### PR TITLE
Initial baggage support for the OT shim.

### DIFF
--- a/opentracing-shim/src/main/java/openconsensus/opentracingshim/Propagation.java
+++ b/opentracing-shim/src/main/java/openconsensus/opentracingshim/Propagation.java
@@ -31,11 +31,11 @@ final class Propagation {
 
   public void injectTextFormat(SpanContextShim contextShim, TextMap carrier) {
     tracerShim
-        .tracer()
+        .getTracer()
         .getTextFormat()
         .inject(contextShim.getSpanContext(), carrier, TextMapSetter.INSTANCE);
     tracerShim
-        .tagger()
+        .getTagger()
         .getTextFormat()
         .inject(contextShim.getTagMap(), carrier, TextMapSetter.INSTANCE);
   }
@@ -47,9 +47,9 @@ final class Propagation {
     }
 
     openconsensus.trace.SpanContext context =
-        tracerShim.tracer().getTextFormat().extract(carrierMap, TextMapGetter.INSTANCE);
+        tracerShim.getTracer().getTextFormat().extract(carrierMap, TextMapGetter.INSTANCE);
     openconsensus.tags.TagMap tagMap =
-        tracerShim.tagger().getTextFormat().extract(carrierMap, TextMapGetter.INSTANCE);
+        tracerShim.getTagger().getTextFormat().extract(carrierMap, TextMapGetter.INSTANCE);
     return new SpanContextShim(tracerShim, context, tagMap);
   }
 
@@ -83,7 +83,7 @@ final class Propagation {
   public void injectBinaryFormat(SpanContextShim context, Binary carrier) {
 
     byte[] contextBuff =
-        tracerShim.tracer().getBinaryFormat().toByteArray(context.getSpanContext());
+        tracerShim.getTracer().getBinaryFormat().toByteArray(context.getSpanContext());
     ByteBuffer byteBuff = carrier.injectionBuffer(contextBuff.length);
     byteBuff.put(contextBuff);
   }
@@ -94,6 +94,6 @@ final class Propagation {
     byte[] buff = new byte[byteBuff.remaining()];
     byteBuff.get(buff);
     return new SpanContextShim(
-        tracerShim, tracerShim.tracer().getBinaryFormat().fromByteArray(buff));
+        tracerShim, tracerShim.getTracer().getBinaryFormat().fromByteArray(buff));
   }
 }

--- a/opentracing-shim/src/main/java/openconsensus/opentracingshim/ScopeManagerShim.java
+++ b/opentracing-shim/src/main/java/openconsensus/opentracingshim/ScopeManagerShim.java
@@ -31,7 +31,7 @@ final class ScopeManagerShim implements ScopeManager {
   @Override
   public Span activeSpan() {
     // TODO - is there a way to cleanly support baggage/tags here?
-    return new SpanShim(tracerShim, tracerShim.tracer().getCurrentSpan());
+    return new SpanShim(tracerShim, tracerShim.getTracer().getCurrentSpan());
   }
 
   @Override
@@ -43,7 +43,7 @@ final class ScopeManagerShim implements ScopeManager {
   @SuppressWarnings("MustBeClosedChecker")
   public Scope activate(Span span) {
     openconsensus.trace.Span actualSpan = getActualSpan(span);
-    return new ScopeShim(tracerShim.tracer().withSpan(actualSpan));
+    return new ScopeShim(tracerShim.getTracer().withSpan(actualSpan));
   }
 
   @Override

--- a/opentracing-shim/src/main/java/openconsensus/opentracingshim/ScopeManagerShim.java
+++ b/opentracing-shim/src/main/java/openconsensus/opentracingshim/ScopeManagerShim.java
@@ -22,15 +22,16 @@ import io.opentracing.Span;
 
 @SuppressWarnings("deprecation")
 final class ScopeManagerShim implements ScopeManager {
-  private final openconsensus.trace.Tracer tracer;
+  private final TracerShim tracerShim;
 
-  public ScopeManagerShim(openconsensus.trace.Tracer tracer) {
-    this.tracer = tracer;
+  public ScopeManagerShim(TracerShim tracerShim) {
+    this.tracerShim = tracerShim;
   }
 
   @Override
   public Span activeSpan() {
-    return new SpanShim(tracer.getCurrentSpan());
+    // TODO - is there a way to cleanly support baggage/tags here?
+    return new SpanShim(tracerShim, tracerShim.tracer().getCurrentSpan());
   }
 
   @Override
@@ -42,7 +43,7 @@ final class ScopeManagerShim implements ScopeManager {
   @SuppressWarnings("MustBeClosedChecker")
   public Scope activate(Span span) {
     openconsensus.trace.Span actualSpan = getActualSpan(span);
-    return new ScopeShim(tracer.withSpan(actualSpan));
+    return new ScopeShim(tracerShim.tracer().withSpan(actualSpan));
   }
 
   @Override

--- a/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanBuilderShim.java
+++ b/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanBuilderShim.java
@@ -31,7 +31,7 @@ import openconsensus.trace.Status;
 
 @SuppressWarnings("deprecation")
 final class SpanBuilderShim implements SpanBuilder {
-  private final openconsensus.trace.Tracer tracer;
+  private final TracerShim tracerShim;
   private final String spanName;
 
   // The parent will be either a Span or a SpanContext.
@@ -45,8 +45,8 @@ final class SpanBuilderShim implements SpanBuilder {
   private Kind spanKind;
   private boolean error;
 
-  public SpanBuilderShim(openconsensus.trace.Tracer tracer, String spanName) {
-    this.tracer = tracer;
+  public SpanBuilderShim(TracerShim tracerShim, String spanName) {
+    this.tracerShim = tracerShim;
     this.spanName = spanName;
   }
 
@@ -186,6 +186,7 @@ final class SpanBuilderShim implements SpanBuilder {
 
   @Override
   public Span start() {
+    openconsensus.trace.Tracer tracer = tracerShim.tracer();
 
     openconsensus.trace.SpanBuilder builder;
     if (ignoreActiveSpan && parentSpan == null && parentSpanContext == null) {
@@ -214,7 +215,7 @@ final class SpanBuilderShim implements SpanBuilder {
       span.setStatus(Status.UNKNOWN);
     }
 
-    return new SpanShim(span);
+    return new SpanShim(tracerShim, span);
   }
 
   @Override

--- a/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanBuilderShim.java
+++ b/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanBuilderShim.java
@@ -186,7 +186,7 @@ final class SpanBuilderShim implements SpanBuilder {
 
   @Override
   public Span start() {
-    openconsensus.trace.Tracer tracer = tracerShim.tracer();
+    openconsensus.trace.Tracer tracer = tracerShim.getTracer();
 
     openconsensus.trace.SpanBuilder builder;
     if (ignoreActiveSpan && parentSpan == null && parentSpanContext == null) {

--- a/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanContextShim.java
+++ b/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanContextShim.java
@@ -35,7 +35,7 @@ final class SpanContextShim implements SpanContext {
   private TagMap tagMap;
 
   public SpanContextShim(TracerShim tracerShim, openconsensus.trace.SpanContext context) {
-    this(tracerShim, context, tracerShim.tagger().empty());
+    this(tracerShim, context, tracerShim.getTagger().empty());
   }
 
   public SpanContextShim(
@@ -81,7 +81,7 @@ final class SpanContextShim implements SpanContext {
 
   void setBaggageItem(String key, String value) {
     synchronized (this) {
-      TagMapBuilder builder = tracerShim.tagger().toBuilder(tagMap);
+      TagMapBuilder builder = tracerShim.getTagger().toBuilder(tagMap);
       builder.put(TagKey.create(key), TagValue.create(value), DEFAULT_TAG_METADATA);
       tagMap = builder.build();
     }

--- a/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanContextShim.java
+++ b/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanContextShim.java
@@ -19,6 +19,7 @@ package openconsensus.opentracingshim;
 import io.opentracing.SpanContext;
 import java.util.Iterator;
 import java.util.Map;
+import openconsensus.tags.EmptyTagMap;
 import openconsensus.tags.Tag;
 import openconsensus.tags.TagKey;
 import openconsensus.tags.TagMap;
@@ -35,7 +36,7 @@ final class SpanContextShim implements SpanContext {
   private TagMap tagMap;
 
   public SpanContextShim(TracerShim tracerShim, openconsensus.trace.SpanContext context) {
-    this(tracerShim, context, tracerShim.getTagger().empty());
+    this(tracerShim, context, EmptyTagMap.INSTANCE);
   }
 
   public SpanContextShim(

--- a/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanShim.java
+++ b/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanShim.java
@@ -22,6 +22,7 @@ import io.opentracing.log.Fields;
 import io.opentracing.tag.Tag;
 import java.util.HashMap;
 import java.util.Map;
+import openconsensus.tags.EmptyTagMap;
 import openconsensus.tags.TagMap;
 import openconsensus.trace.AttributeValue;
 import openconsensus.trace.Status;
@@ -33,7 +34,7 @@ final class SpanShim implements Span {
   private final SpanContextShim contextShim;
 
   public SpanShim(TracerShim tracerShim, openconsensus.trace.Span span) {
-    this(tracerShim, span, tracerShim.getTagger().empty());
+    this(tracerShim, span, EmptyTagMap.INSTANCE);
   }
 
   public SpanShim(TracerShim tracerShim, openconsensus.trace.Span span, TagMap tagMap) {

--- a/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanShim.java
+++ b/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanShim.java
@@ -22,6 +22,7 @@ import io.opentracing.log.Fields;
 import io.opentracing.tag.Tag;
 import java.util.HashMap;
 import java.util.Map;
+import openconsensus.tags.TagMap;
 import openconsensus.trace.AttributeValue;
 import openconsensus.trace.Status;
 
@@ -31,9 +32,13 @@ final class SpanShim implements Span {
   private final openconsensus.trace.Span span;
   private final SpanContextShim contextShim;
 
-  public SpanShim(openconsensus.trace.Span span) {
+  public SpanShim(TracerShim tracerShim, openconsensus.trace.Span span) {
+    this(tracerShim, span, tracerShim.tagger().empty());
+  }
+
+  public SpanShim(TracerShim tracerShim, openconsensus.trace.Span span, TagMap tagMap) {
     this.span = span;
-    this.contextShim = new SpanContextShim(span.getContext());
+    this.contextShim = new SpanContextShim(tracerShim, span.getContext(), tagMap);
   }
 
   openconsensus.trace.Span getSpan() {
@@ -124,10 +129,8 @@ final class SpanShim implements Span {
   }
 
   @Override
-  @SuppressWarnings("ReturnMissingNullable")
   public String getBaggageItem(String key) {
-    // TODO
-    return null;
+    return contextShim.getBaggageItem(key);
   }
 
   @Override

--- a/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanShim.java
+++ b/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanShim.java
@@ -33,7 +33,7 @@ final class SpanShim implements Span {
   private final SpanContextShim contextShim;
 
   public SpanShim(TracerShim tracerShim, openconsensus.trace.Span span) {
-    this(tracerShim, span, tracerShim.tagger().empty());
+    this(tracerShim, span, tracerShim.getTagger().empty());
   }
 
   public SpanShim(TracerShim tracerShim, openconsensus.trace.Span span, TagMap tagMap) {

--- a/opentracing-shim/src/main/java/openconsensus/opentracingshim/TracerShim.java
+++ b/opentracing-shim/src/main/java/openconsensus/opentracingshim/TracerShim.java
@@ -57,11 +57,11 @@ public final class TracerShim implements Tracer {
     this.propagation = new Propagation(this);
   }
 
-  Tagger tagger() {
+  Tagger getTagger() {
     return tagger;
   }
 
-  openconsensus.trace.Tracer tracer() {
+  openconsensus.trace.Tracer getTracer() {
     return tracer;
   }
 


### PR DESCRIPTION
This implements **Baggage** support on top of `openconsensus.tags.TagMap`. 

From a **in-process** perspective, I'm not discarding the `io.opentracing.SpanContext` object(`SpanContextShim` underneath) every time the baggage changes, as usually done in OT. It was mentioned in the past we might not need strict behavior here, but if you guys  (mostly @yurishkuro @tedsuo ) think that we should keep this, let me know.

From a **inter-process** perspective, this means two injection/extraction operations happen: one for the actual `SpanContext`, one for the baggage (`TagMap`). This is fine for `TEXT_MAP`, but *could* become tricky for `BINARY`, as we would be writing/reading `SpanContext` + Baggage consecutively. Also, actual `BINARY` support is not implemented yet (`ByteBuffer` support would be of great help here, to keep state when extraction happens).