### PR TITLE
Add a global registry

### DIFF
--- a/api/src/main/java/io/opentelemetry/OpenTelemetry.java
+++ b/api/src/main/java/io/opentelemetry/OpenTelemetry.java
@@ -20,7 +20,6 @@ import io.opentelemetry.spi.TracerProvider;
 import io.opentelemetry.trace.NoopTrace;
 import io.opentelemetry.trace.Trace;
 import io.opentelemetry.trace.Tracer;
-import java.util.Iterator;
 import java.util.ServiceLoader;
 
 /**
@@ -46,9 +45,7 @@ public final class OpenTelemetry {
   private static Tracer loadTracer() {
     String tracerClass = System.getProperty(TracerProvider.class.getName());
     ServiceLoader<TracerProvider> tracers = ServiceLoader.load(TracerProvider.class);
-    Iterator<TracerProvider> tracerIterator = tracers.iterator();
-    while (tracerIterator.hasNext()) {
-      TracerProvider provider = tracerIterator.next();
+    for (TracerProvider provider : tracers) {
       if (tracerClass == null) {
         return provider.create();
       } else if (tracerClass.equals(provider.getClass().getName())) {

--- a/api/src/main/java/io/opentelemetry/OpenTelemetry.java
+++ b/api/src/main/java/io/opentelemetry/OpenTelemetry.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry;
+
+import io.opentelemetry.spi.TracerProvider;
+import io.opentelemetry.trace.NoopTrace;
+import io.opentelemetry.trace.Trace;
+import io.opentelemetry.trace.Tracer;
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+/**
+ * This class provides a static global accessor for telemetry objects {@link Tracer}, {@link
+ * io.opentelemetry.metrics.Meter} and {@link io.opentelemetry.tags.Tagger}.
+ */
+public final class OpenTelemetry {
+
+  private static volatile OpenTelemetry instance;
+
+  private Tracer tracer;
+
+  /**
+   * Returns an instance of a {@link Tracer}.
+   *
+   * @return registered tracer or {@link NoopTrace} singleton via {@link Trace#getTracer()}.
+   * @throws IllegalStateException if a specified tracer (via system properties) could not be find.
+   */
+  public static Tracer getTracer() {
+    return getInstance().tracer;
+  }
+
+  private static Tracer loadTracer() {
+    String tracerClass = System.getProperty(TracerProvider.class.getName());
+    ServiceLoader<TracerProvider> tracers = ServiceLoader.load(TracerProvider.class);
+    Iterator<TracerProvider> tracerIterator = tracers.iterator();
+    while (tracerIterator.hasNext()) {
+      TracerProvider provider = tracerIterator.next();
+      if (tracerClass == null) {
+        return provider.create();
+      } else if (tracerClass.equals(provider.getClass().getName())) {
+        return provider.create();
+      }
+    }
+    if (tracerClass != null) {
+      throw new IllegalStateException(String.format("Tracer %s not found", tracerClass));
+    }
+    return Trace.getTracer();
+  }
+
+  /** Lazy loads an instance. */
+  private static OpenTelemetry getInstance() {
+    if (instance == null) {
+      synchronized (OpenTelemetry.class) {
+        if (instance == null) {
+          instance = new OpenTelemetry();
+        }
+      }
+    }
+    return instance;
+  }
+
+  private OpenTelemetry() {
+    tracer = loadTracer();
+  }
+
+  // for testing
+  static void initialize() {
+    getInstance().tracer = loadTracer();
+  }
+}

--- a/api/src/main/java/io/opentelemetry/spi/TracerProvider.java
+++ b/api/src/main/java/io/opentelemetry/spi/TracerProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.spi;
+
+import io.opentelemetry.trace.Tracer;
+
+/**
+ * TracerProvider is a service provider for {@link Tracer}. Implementation should register
+ * implementation in <code>META-INF/services/io.opentelemetry.spi.TracerProvider</code>. <br>
+ * <br>
+ * A specific implementation can be specified by a system property {@code
+ * io.opentelemetry.spi.TracerProvider} with value of fully qualified class name.
+ */
+public interface TracerProvider {
+
+  /**
+   * Creates a new tracer instance.
+   *
+   * @return a tracer instance.
+   */
+  Tracer create();
+}

--- a/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
+++ b/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.BinaryFormat;
+import io.opentelemetry.context.propagation.HttpTextFormat;
+import io.opentelemetry.resource.Resource;
+import io.opentelemetry.spi.TracerProvider;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.Span.Builder;
+import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.SpanData;
+import io.opentelemetry.trace.Trace;
+import io.opentelemetry.trace.Tracer;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.net.URL;
+import javax.annotation.Nullable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class OpenTelemetryTest {
+
+  @Before
+  public void before() {
+    OpenTelemetry.initialize();
+  }
+
+  @Test
+  public void testDefault() {
+    assertThat(OpenTelemetry.getTracer()).isEqualTo(Trace.getTracer());
+    assertThat(OpenTelemetry.getTracer()).isEqualTo(OpenTelemetry.getTracer());
+  }
+
+  @Test
+  public void testSystemProperty() throws IOException {
+    File serviceFile = createService(TracerProvider.class, FirstTracer.class, SecondTracer.class);
+    System.setProperty(TracerProvider.class.getName(), SecondTracer.class.getName());
+    try {
+      OpenTelemetry.initialize();
+      assertThat(OpenTelemetry.getTracer()).isInstanceOf(SecondTracer.class);
+      assertThat(OpenTelemetry.getTracer()).isEqualTo(OpenTelemetry.getTracer());
+    } finally {
+      serviceFile.delete();
+      System.clearProperty(TracerProvider.class.getCanonicalName());
+    }
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testNotFind() {
+    System.setProperty(TracerProvider.class.getName(), "io.does.not.exists");
+    try {
+      OpenTelemetry.initialize();
+    } finally {
+      System.clearProperty("io.does.not.exists");
+    }
+  }
+
+  private static File createService(Class<?> service, Class<?>... impls) throws IOException {
+    URL location = Tracer.class.getProtectionDomain().getCodeSource().getLocation();
+    File file = new File(location.getPath() + "META-INF/services/" + service.getName());
+    file.getParentFile().mkdirs();
+
+    Writer output = new FileWriter(file);
+    for (Class<?> impl : impls) {
+      output.write(impl.getName());
+      output.write(System.getProperty("line.separator"));
+    }
+    output.close();
+    return file;
+  }
+
+  public static class SecondTracer extends FirstTracer {
+    @Override
+    public Tracer create() {
+      return new SecondTracer();
+    }
+  }
+
+  public static class FirstTracer implements Tracer, TracerProvider {
+    @Override
+    public Tracer create() {
+      return new FirstTracer();
+    }
+
+    @Override
+    public Span getCurrentSpan() {
+      return null;
+    }
+
+    @Override
+    public Scope withSpan(Span span) {
+      return null;
+    }
+
+    @Override
+    public Builder spanBuilder(String spanName) {
+      return null;
+    }
+
+    @Override
+    public Builder spanBuilderWithExplicitParent(String spanName, @Nullable Span parent) {
+      return null;
+    }
+
+    @Override
+    public Builder spanBuilderWithRemoteParent(
+        String spanName, @Nullable SpanContext remoteParentSpanContext) {
+      return null;
+    }
+
+    @Override
+    public void setResource(Resource resource) {}
+
+    @Override
+    public Resource getResource() {
+      return null;
+    }
+
+    @Override
+    public void recordSpanData(SpanData span) {}
+
+    @Override
+    public BinaryFormat<SpanContext> getBinaryFormat() {
+      return null;
+    }
+
+    @Override
+    public HttpTextFormat<SpanContext> getHttpTextFormat() {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Updates #107 

This is an initial draft currently only for tracer object. The design still depends on some questions in #107 e.g. whether we want to support java agents and/or we can assume that app init time can be always used to init the tracer.

This PR introduces a singleton object `OpenConsensus`. It's like a registry for `Tracer`, `Metrics` objects which instrumentation can use when a tracer is not explicitly provided.

The biggest difference to `GlobalTracer` is that it requires initialization of the registry before instrumentation initialization. Developers control application start-time and therefore can first initialize the tracer and then wire in instrumentations. 

The current proposal is that implementation (of a tracer) will set itself to the registry once it is created, I think the cleaner would be to use a service loader this way we can support java agent scenarios.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>