### PR TITLE
Readme add modules desc

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ project.
 
 This project contains the following top level components:
 
-* [api](api/): The OpenTelemetry API, including tracing, metrics and tags.
+* [api](api/): The OpenTelemetry API.
+  * [trace](api/src/main/java/io/opentelemetry/trace/): The tracing api. Includes `Tracer`, `Span` and `SpanContext`.
+  * [tags](api/src/main/java/io/opentelemetry/tags/): Key-value pairs of data that can be propagated to provide contextual information.
+  * [context](api/src/main/java/io/opentelemetry/context/): In-process and inter-process propagation layer.
+  * [metrics](api/src/main/java/io/opentelemetry/metrics/): Metrics layer.
 * [sdk](sdk/): The reference implementation complying to the OpenTelemetry API.
 * [OpenTracing shim](opentracing-shim/): A bridge layer from OpenTelemetry to the OpenTracing API.
 * [OpenCensus shim](opencensus-shim): A bridge layer from OpenTelemetry to the OpenCensus API.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@
 OpenTelemetry is a working name of a combined OpenCensus and OpenTracing
 project.
 
+This project contains the following top level components:
+
+* [api](api/): The OpenTelemetry API, including tracing, metrics and tags.
+* [sdk](sdk/): The reference implementation complying to the OpenTelemetry API.
+* [OpenTracing shim](opentracing-shim/): A bridge layer from OpenTelemetry to the OpenTracing API.
+* [OpenCensus shim](opencensus-shim): A bridge layer from OpenTelemetry to the OpenCensus API.
+
 ## This codebase will be ready for review April 24th, 2019. 
 
 ## Please note that this is a temorary repository, and we cannot accept PRs until the project is moved to its offical home, where it can be covered by the CNCF CLA.


### PR DESCRIPTION
Addresses #186 

I left out `stats` (as it will likely be merged to `metrics`) as well as `resource` and the new `spi`, as they are more of advanced components.