### PR TITLE
Add W3C tracecontext propagation

### DIFF
--- a/api/src/main/java/io/opentelemetry/context/propagation/TraceContextFormat.java
+++ b/api/src/main/java/io/opentelemetry/context/propagation/TraceContextFormat.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.context.propagation;
+
+import static io.opentelemetry.internal.Utils.checkArgument;
+import static io.opentelemetry.internal.Utils.checkNotNull;
+
+import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceId;
+import io.opentelemetry.trace.TraceOptions;
+import io.opentelemetry.trace.Tracestate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Implementation of the TraceContext propagation protocol. See <a
+ * href=https://github.com/w3c/distributed-tracing>w3c/distributed-tracing</a>.
+ */
+public class TraceContextFormat implements HttpTextFormat<SpanContext> {
+  private static final Tracestate TRACESTATE_DEFAULT = Tracestate.builder().build();
+  static final String TRACEPARENT = "traceparent";
+  static final String TRACESTATE = "tracestate";
+  private static final List<String> FIELDS =
+      Collections.unmodifiableList(Arrays.asList(TRACEPARENT, TRACESTATE));
+
+  private static final String VERSION = "00";
+  private static final int VERSION_SIZE = 2;
+  private static final char TRACEPARENT_DELIMITER = '-';
+  private static final int TRACEPARENT_DELIMITER_SIZE = 1;
+  private static final int TRACE_ID_HEX_SIZE = 2 * TraceId.SIZE;
+  private static final int SPAN_ID_HEX_SIZE = 2 * SpanId.SIZE;
+  private static final int TRACE_OPTION_HEX_SIZE = 2 * TraceOptions.SIZE;
+  private static final int TRACE_ID_OFFSET = VERSION_SIZE + TRACEPARENT_DELIMITER_SIZE;
+  private static final int SPAN_ID_OFFSET =
+      TRACE_ID_OFFSET + TRACE_ID_HEX_SIZE + TRACEPARENT_DELIMITER_SIZE;
+  private static final int TRACE_OPTION_OFFSET =
+      SPAN_ID_OFFSET + SPAN_ID_HEX_SIZE + TRACEPARENT_DELIMITER_SIZE;
+  private static final int TRACEPARENT_HEADER_SIZE = TRACE_OPTION_OFFSET + TRACE_OPTION_HEX_SIZE;
+  private static final int TRACESTATE_MAX_SIZE = 512;
+  private static final int TRACESTATE_MAX_MEMBERS = 32;
+  private static final char TRACESTATE_KEY_VALUE_DELIMITER = '=';
+  private static final char TRACESTATE_ENTRY_DELIMITER = ',';
+  private static final Pattern TRACESTATE_ENTRY_DELIMITER_SPLIT_PATTERN =
+      Pattern.compile("[ \t]*" + TRACESTATE_ENTRY_DELIMITER + "[ \t]*");
+
+  @Override
+  public List<String> fields() {
+    return FIELDS;
+  }
+
+  @Override
+  public <C> void inject(SpanContext spanContext, C carrier, Setter<C> setter) {
+
+    checkNotNull(spanContext, "spanContext");
+    checkNotNull(setter, "setter");
+    checkNotNull(carrier, "carrier");
+    char[] chars = new char[TRACEPARENT_HEADER_SIZE];
+    chars[0] = VERSION.charAt(0);
+    chars[1] = VERSION.charAt(1);
+    chars[2] = TRACEPARENT_DELIMITER;
+    spanContext.getTraceId().copyLowerBase16To(chars, TRACE_ID_OFFSET);
+    chars[SPAN_ID_OFFSET - 1] = TRACEPARENT_DELIMITER;
+    spanContext.getSpanId().copyLowerBase16To(chars, SPAN_ID_OFFSET);
+    chars[TRACE_OPTION_OFFSET - 1] = TRACEPARENT_DELIMITER;
+    spanContext.getTraceOptions().copyLowerBase16To(chars, TRACE_OPTION_OFFSET);
+    setter.put(carrier, TRACEPARENT, new String(chars));
+    List<Tracestate.Entry> entries = spanContext.getTracestate().getEntries();
+    if (entries.isEmpty()) {
+      // No need to add an empty "tracestate" header.
+      return;
+    }
+    StringBuilder stringBuilder = new StringBuilder(TRACESTATE_MAX_SIZE);
+    for (Tracestate.Entry entry : entries) {
+      if (stringBuilder.length() != 0) {
+        stringBuilder.append(TRACESTATE_ENTRY_DELIMITER);
+      }
+      stringBuilder
+          .append(entry.getKey())
+          .append(TRACESTATE_KEY_VALUE_DELIMITER)
+          .append(entry.getValue());
+    }
+    setter.put(carrier, TRACESTATE, stringBuilder.toString());
+  }
+
+  @Override
+  public <C /*>>> extends @NonNull Object*/> SpanContext extract(C carrier, Getter<C> getter)
+      throws IllegalArgumentException {
+    checkNotNull(carrier, "carrier");
+    checkNotNull(getter, "getter");
+    TraceId traceId;
+    SpanId spanId;
+    TraceOptions traceOptions;
+    String traceparent = getter.get(carrier, TRACEPARENT);
+    if (traceparent == null) {
+      throw new IllegalArgumentException("Traceparent not present");
+    }
+    try {
+      // TODO(bdrutu): Do we need to verify that version is hex and that for the version
+      // the length is the expected one?
+      checkArgument(
+          traceparent.charAt(TRACE_OPTION_OFFSET - 1) == TRACEPARENT_DELIMITER
+              && (traceparent.length() == TRACEPARENT_HEADER_SIZE
+                  || (traceparent.length() > TRACEPARENT_HEADER_SIZE
+                      && traceparent.charAt(TRACEPARENT_HEADER_SIZE) == TRACEPARENT_DELIMITER))
+              && traceparent.charAt(SPAN_ID_OFFSET - 1) == TRACEPARENT_DELIMITER
+              && traceparent.charAt(TRACE_OPTION_OFFSET - 1) == TRACEPARENT_DELIMITER,
+          "Missing or malformed TRACEPARENT.");
+
+      traceId = TraceId.fromLowerBase16(traceparent, TRACE_ID_OFFSET);
+      spanId = SpanId.fromLowerBase16(traceparent, SPAN_ID_OFFSET);
+      traceOptions = TraceOptions.fromLowerBase16(traceparent, TRACE_OPTION_OFFSET);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Invalid traceparent: " + traceparent, e);
+    }
+
+    String tracestate = getter.get(carrier, TRACESTATE);
+    try {
+      if (tracestate == null || tracestate.isEmpty()) {
+        return SpanContext.create(traceId, spanId, traceOptions, TRACESTATE_DEFAULT);
+      }
+      Tracestate.Builder tracestateBuilder = Tracestate.builder();
+      String[] listMembers = TRACESTATE_ENTRY_DELIMITER_SPLIT_PATTERN.split(tracestate);
+      checkArgument(
+          listMembers.length <= TRACESTATE_MAX_MEMBERS, "Tracestate has too many elements.");
+      // Iterate in reverse order because when call builder set the elements is added in the
+      // front of the list.
+      for (int i = listMembers.length - 1; i >= 0; i--) {
+        String listMember = listMembers[i];
+        int index = listMember.indexOf(TRACESTATE_KEY_VALUE_DELIMITER);
+        checkArgument(index != -1, "Invalid tracestate list-member format.");
+        tracestateBuilder.set(
+            listMember.substring(0, index), listMember.substring(index + 1, listMember.length()));
+      }
+      return SpanContext.create(traceId, spanId, traceOptions, tracestateBuilder.build());
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Invalid tracestate: " + tracestate, e);
+    }
+  }
+}

--- a/api/src/main/java/io/opentelemetry/context/propagation/TraceContextFormat.java
+++ b/api/src/main/java/io/opentelemetry/context/propagation/TraceContextFormat.java
@@ -67,7 +67,6 @@ public class TraceContextFormat implements HttpTextFormat<SpanContext> {
 
   @Override
   public <C> void inject(SpanContext spanContext, C carrier, Setter<C> setter) {
-
     checkNotNull(spanContext, "spanContext");
     checkNotNull(setter, "setter");
     checkNotNull(carrier, "carrier");

--- a/api/src/test/java/io/opentelemetry/context/propagation/TraceContextFormatTest.java
+++ b/api/src/test/java/io/opentelemetry/context/propagation/TraceContextFormatTest.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.context.propagation;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.opentelemetry.context.propagation.TraceContextFormat.TRACEPARENT;
+import static io.opentelemetry.context.propagation.TraceContextFormat.TRACESTATE;
+
+import io.opentelemetry.context.propagation.HttpTextFormat.Getter;
+import io.opentelemetry.context.propagation.HttpTextFormat.Setter;
+import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceId;
+import io.opentelemetry.trace.TraceOptions;
+import io.opentelemetry.trace.Tracestate;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link TraceContextFormat}. */
+@RunWith(JUnit4.class)
+public class TraceContextFormatTest {
+
+  private static final Tracestate TRACESTATE_DEFAULT = Tracestate.builder().build();
+  private static final Tracestate TRACESTATE_NOT_DEFAULT =
+      Tracestate.builder().set("foo", "bar").set("bar", "baz").build();
+  private static final String TRACE_ID_BASE16 = "ff000000000000000000000000000041";
+  private static final TraceId TRACE_ID = TraceId.fromLowerBase16(TRACE_ID_BASE16, 0);
+  private static final String SPAN_ID_BASE16 = "ff00000000000041";
+  private static final SpanId SPAN_ID = SpanId.fromLowerBase16(SPAN_ID_BASE16, 0);
+  private static final byte SAMPLED_TRACE_OPTIONS_BYTES = 1;
+  private static final TraceOptions SAMPLED_TRACE_OPTIONS =
+      TraceOptions.fromByte(SAMPLED_TRACE_OPTIONS_BYTES);
+  private static final String TRACEPARENT_HEADER_SAMPLED =
+      "00-" + TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-01";
+  private static final String TRACEPARENT_HEADER_NOT_SAMPLED =
+      "00-" + TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-00";
+  private static final Setter<Map<String, String>> setter =
+      new Setter<Map<String, String>>() {
+        @Override
+        public void put(Map<String, String> carrier, String key, String value) {
+          carrier.put(key, value);
+        }
+      };
+  private static final Getter<Map<String, String>> getter =
+      new Getter<Map<String, String>>() {
+        @Nullable
+        @Override
+        public String get(Map<String, String> carrier, String key) {
+          return carrier.get(key);
+        }
+      };
+  // Encoding preserves the order which is the reverse order of adding.
+  private static final String TRACESTATE_NOT_DEFAULT_ENCODING = "bar=baz,foo=bar";
+  private final TraceContextFormat traceContextFormat = new TraceContextFormat();
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void inject_SampledContext() {
+    Map<String, String> carrier = new LinkedHashMap<String, String>();
+    traceContextFormat.inject(
+        SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACESTATE_DEFAULT),
+        carrier,
+        setter);
+    assertThat(carrier).containsExactly(TRACEPARENT, TRACEPARENT_HEADER_SAMPLED);
+  }
+
+  @Test
+  public void inject_NotSampledContext() {
+    Map<String, String> carrier = new LinkedHashMap<String, String>();
+    traceContextFormat.inject(
+        SpanContext.create(TRACE_ID, SPAN_ID, TraceOptions.DEFAULT, TRACESTATE_DEFAULT),
+        carrier,
+        setter);
+    assertThat(carrier).containsExactly(TRACEPARENT, TRACEPARENT_HEADER_NOT_SAMPLED);
+  }
+
+  @Test
+  public void inject_SampledContext_WithTraceState() {
+    Map<String, String> carrier = new LinkedHashMap<String, String>();
+    traceContextFormat.inject(
+        SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACESTATE_NOT_DEFAULT),
+        carrier,
+        setter);
+    assertThat(carrier)
+        .containsExactly(
+            TRACEPARENT, TRACEPARENT_HEADER_SAMPLED, TRACESTATE, TRACESTATE_NOT_DEFAULT_ENCODING);
+  }
+
+  @Test
+  public void inject_NotSampledContext_WithTraceState() {
+    Map<String, String> carrier = new LinkedHashMap<String, String>();
+    traceContextFormat.inject(
+        SpanContext.create(TRACE_ID, SPAN_ID, TraceOptions.DEFAULT, TRACESTATE_NOT_DEFAULT),
+        carrier,
+        setter);
+    assertThat(carrier)
+        .containsExactly(
+            TRACEPARENT,
+            TRACEPARENT_HEADER_NOT_SAMPLED,
+            TRACESTATE,
+            TRACESTATE_NOT_DEFAULT_ENCODING);
+  }
+
+  @Test
+  public void extract_SampledContext() {
+    Map<String, String> carrier = new LinkedHashMap<String, String>();
+    carrier.put(TRACEPARENT, TRACEPARENT_HEADER_SAMPLED);
+    assertThat(traceContextFormat.extract(carrier, getter))
+        .isEqualTo(
+            SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACESTATE_DEFAULT));
+  }
+
+  @Test
+  public void extract_NotSampledContext() {
+    Map<String, String> carrier = new LinkedHashMap<String, String>();
+    carrier.put(TRACEPARENT, TRACEPARENT_HEADER_NOT_SAMPLED);
+    assertThat(traceContextFormat.extract(carrier, getter))
+        .isEqualTo(SpanContext.create(TRACE_ID, SPAN_ID, TraceOptions.DEFAULT, TRACESTATE_DEFAULT));
+  }
+
+  @Test
+  public void extract_SampledContext_WithTraceState() {
+    Map<String, String> carrier = new LinkedHashMap<String, String>();
+    carrier.put(TRACEPARENT, TRACEPARENT_HEADER_SAMPLED);
+    carrier.put(TRACESTATE, TRACESTATE_NOT_DEFAULT_ENCODING);
+    assertThat(traceContextFormat.extract(carrier, getter))
+        .isEqualTo(
+            SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACESTATE_NOT_DEFAULT));
+  }
+
+  @Test
+  public void extract_NotSampledContext_WithTraceState() {
+    Map<String, String> carrier = new LinkedHashMap<String, String>();
+    carrier.put(TRACEPARENT, TRACEPARENT_HEADER_NOT_SAMPLED);
+    carrier.put(TRACESTATE, TRACESTATE_NOT_DEFAULT_ENCODING);
+    assertThat(traceContextFormat.extract(carrier, getter))
+        .isEqualTo(
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceOptions.DEFAULT, TRACESTATE_NOT_DEFAULT));
+  }
+
+  @Test
+  public void extract_NotSampledContext_NextVersion() {
+    Map<String, String> carrier = new LinkedHashMap<String, String>();
+    carrier.put(TRACEPARENT, "01-" + TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-00-02");
+    assertThat(traceContextFormat.extract(carrier, getter))
+        .isEqualTo(SpanContext.create(TRACE_ID, SPAN_ID, TraceOptions.DEFAULT, TRACESTATE_DEFAULT));
+  }
+
+  @Test
+  public void extract_NotSampledContext_EmptyTraceState() {
+    Map<String, String> carrier = new LinkedHashMap<String, String>();
+    carrier.put(TRACEPARENT, TRACEPARENT_HEADER_NOT_SAMPLED);
+    carrier.put(TRACESTATE, "");
+    assertThat(traceContextFormat.extract(carrier, getter))
+        .isEqualTo(SpanContext.create(TRACE_ID, SPAN_ID, TraceOptions.DEFAULT, TRACESTATE_DEFAULT));
+  }
+
+  @Test
+  public void extract_NotSampledContext_TraceStateWithSpaces() {
+    Map<String, String> carrier = new LinkedHashMap<String, String>();
+    carrier.put(TRACEPARENT, TRACEPARENT_HEADER_NOT_SAMPLED);
+    carrier.put(TRACESTATE, "foo=bar   ,    bar=baz");
+    assertThat(traceContextFormat.extract(carrier, getter))
+        .isEqualTo(
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceOptions.DEFAULT, TRACESTATE_NOT_DEFAULT));
+  }
+
+  @Test
+  public void extract_InvalidTraceId() {
+    Map<String, String> invalidHeaders = new LinkedHashMap<String, String>();
+    invalidHeaders.put(
+        TRACEPARENT, "00-" + "abcdefghijklmnopabcdefghijklmnop" + "-" + SPAN_ID_BASE16 + "-01");
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(
+        "Invalid traceparent: "
+            + "00-"
+            + "abcdefghijklmnopabcdefghijklmnop"
+            + "-"
+            + SPAN_ID_BASE16
+            + "-01");
+    traceContextFormat.extract(invalidHeaders, getter);
+  }
+
+  @Test
+  public void extract_InvalidTraceId_Size() {
+    Map<String, String> invalidHeaders = new LinkedHashMap<String, String>();
+    invalidHeaders.put(TRACEPARENT, "00-" + TRACE_ID_BASE16 + "00-" + SPAN_ID_BASE16 + "-01");
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(
+        "Invalid traceparent: " + "00-" + TRACE_ID_BASE16 + "00-" + SPAN_ID_BASE16 + "-01");
+    traceContextFormat.extract(invalidHeaders, getter);
+  }
+
+  @Test
+  public void extract_InvalidSpanId() {
+    Map<String, String> invalidHeaders = new HashMap<String, String>();
+    invalidHeaders.put(TRACEPARENT, "00-" + TRACE_ID_BASE16 + "-" + "abcdefghijklmnop" + "-01");
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(
+        "Invalid traceparent: " + "00-" + TRACE_ID_BASE16 + "-" + "abcdefghijklmnop" + "-01");
+    traceContextFormat.extract(invalidHeaders, getter);
+  }
+
+  @Test
+  public void extract_InvalidSpanId_Size() {
+    Map<String, String> invalidHeaders = new HashMap<String, String>();
+    invalidHeaders.put(TRACEPARENT, "00-" + TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "00-01");
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(
+        "Invalid traceparent: " + "00-" + TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "00-01");
+    traceContextFormat.extract(invalidHeaders, getter);
+  }
+
+  @Test
+  public void extract_InvalidTraceOptions() {
+    Map<String, String> invalidHeaders = new HashMap<String, String>();
+    invalidHeaders.put(TRACEPARENT, "00-" + TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-gh");
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(
+        "Invalid traceparent: " + "00-" + TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-gh");
+    traceContextFormat.extract(invalidHeaders, getter);
+  }
+
+  @Test
+  public void extract_InvalidTraceOptions_Size() {
+    Map<String, String> invalidHeaders = new HashMap<String, String>();
+    invalidHeaders.put(TRACEPARENT, "00-" + TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-0100");
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(
+        "Invalid traceparent: " + "00-" + TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-0100");
+    traceContextFormat.extract(invalidHeaders, getter);
+  }
+
+  @Test
+  public void extract_InvalidTracestate_EntriesDelimiter() {
+    Map<String, String> invalidHeaders = new HashMap<String, String>();
+    invalidHeaders.put(TRACEPARENT, "00-" + TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-01");
+    invalidHeaders.put(TRACESTATE, "foo=bar;test=test");
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Invalid tracestate: " + "foo=bar;test=test");
+    traceContextFormat.extract(invalidHeaders, getter);
+  }
+
+  @Test
+  public void extract_InvalidTracestate_KeyValueDelimiter() {
+    Map<String, String> invalidHeaders = new HashMap<String, String>();
+    invalidHeaders.put(TRACEPARENT, "00-" + TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-01");
+    invalidHeaders.put(TRACESTATE, "foo=bar,test-test");
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Invalid tracestate: " + "foo=bar,test-test");
+    traceContextFormat.extract(invalidHeaders, getter);
+  }
+
+  @Test
+  public void extract_InvalidTracestate_OneString() {
+    Map<String, String> invalidHeaders = new HashMap<String, String>();
+    invalidHeaders.put(TRACEPARENT, "00-" + TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-01");
+    invalidHeaders.put(TRACESTATE, "test-test");
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Invalid tracestate: " + "test-test");
+    traceContextFormat.extract(invalidHeaders, getter);
+  }
+
+  @Test
+  public void fieldsList() {
+    assertThat(traceContextFormat.fields()).containsExactly(TRACEPARENT, TRACESTATE);
+  }
+
+  @Test
+  public void headerNames() {
+    assertThat(TRACEPARENT).isEqualTo("traceparent");
+    assertThat(TRACESTATE).isEqualTo("tracestate");
+  }
+}


### PR DESCRIPTION
Updates #118 
Related to #258 

The implementation is ported from OpenCensus https://github.com/census-instrumentation/opencensus-java/blob/master/impl_core/src/main/java/io/opencensus/implcore/trace/propagation/TraceContextFormat.java

Signed-off-by: Pavol Loffay <ploffay@redhat.com>