### PR TITLE
Add pavolloffay to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
  # For anything not explicitly taken by someone else:
-*               @bogdandrutu @carlosalberto @SergeyKanzhelev @songy23 @yurishkuro
+*               @bogdandrutu @carlosalberto @pavolloffay @SergeyKanzhelev @songy23 @yurishkuro


### PR DESCRIPTION
Per @bogdandrutu request on gitter

Signed-off-by: Pavol Loffay <ploffay@redhat.com>