### PR TITLE
Add NoRecordEventsSpanImpl to SDK.

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/NoRecordEventsSpanImpl.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/NoRecordEventsSpanImpl.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.trace;
+
+import com.google.common.base.Preconditions;
+import io.opentelemetry.trace.AttributeValue;
+import io.opentelemetry.trace.Event;
+import io.opentelemetry.trace.Link;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.Status;
+import java.util.Map;
+
+/** Implementation for the {@link Span} class that does not record trace events. */
+final class NoRecordEventsSpanImpl implements Span {
+
+  // Contains the identifiers associated with this Span.
+  private final SpanContext context;
+
+  private NoRecordEventsSpanImpl(SpanContext context) {
+    this.context = context;
+  }
+
+  static NoRecordEventsSpanImpl create(SpanContext context) {
+    return new NoRecordEventsSpanImpl(context);
+  }
+
+  @Override
+  public void setAttribute(String key, String value) {
+    Preconditions.checkNotNull(key, "key");
+    Preconditions.checkNotNull(value, "value");
+  }
+
+  @Override
+  public void setAttribute(String key, long value) {
+    Preconditions.checkNotNull(key, "key");
+  }
+
+  @Override
+  public void setAttribute(String key, double value) {
+    Preconditions.checkNotNull(key, "key");
+  }
+
+  @Override
+  public void setAttribute(String key, boolean value) {
+    Preconditions.checkNotNull(key, "key");
+  }
+
+  @Override
+  public void setAttribute(String key, AttributeValue value) {
+    Preconditions.checkNotNull(key, "key");
+    Preconditions.checkNotNull(value, "value");
+  }
+
+  @Override
+  public void addEvent(String name) {
+    Preconditions.checkNotNull(name, "name");
+  }
+
+  @Override
+  public void addEvent(String name, Map<String, AttributeValue> attributes) {
+    Preconditions.checkNotNull(name, "name");
+    Preconditions.checkNotNull(attributes, "attributes");
+  }
+
+  @Override
+  public void addEvent(Event event) {
+    Preconditions.checkNotNull(event, "event");
+  }
+
+  @Override
+  public void addLink(Link link) {
+    Preconditions.checkNotNull(link, link);
+  }
+
+  @Override
+  public void setStatus(Status status) {
+    Preconditions.checkNotNull(status, "status");
+  }
+
+  @Override
+  public void updateName(String name) {
+    Preconditions.checkNotNull(name, "name");
+  }
+
+  @Override
+  public void end() {}
+
+  @Override
+  public SpanContext getContext() {
+    return context;
+  }
+
+  @Override
+  public boolean isRecordingEvents() {
+    return false;
+  }
+}

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/NoRecordEventsSpanImplTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/NoRecordEventsSpanImplTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.trace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.opentelemetry.trace.AttributeValue;
+import io.opentelemetry.trace.Event;
+import io.opentelemetry.trace.Link;
+import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.Status;
+import io.opentelemetry.trace.TraceId;
+import io.opentelemetry.trace.TraceOptions;
+import io.opentelemetry.trace.Tracestate;
+import java.util.Collections;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link NoRecordEventsSpanImpl}. */
+@RunWith(JUnit4.class)
+public class NoRecordEventsSpanImplTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  private static final SpanContext spanContext =
+      SpanContext.create(
+          TestUtils.generateRandomTraceId(),
+          TestUtils.generateRandomSpanId(),
+          TraceOptions.DEFAULT,
+          Tracestate.builder().build());
+  private static final SpanContext BLANK =
+      SpanContext.create(
+          TraceId.INVALID, SpanId.INVALID, TraceOptions.DEFAULT, Tracestate.builder().build());
+  private final NoRecordEventsSpanImpl noRecordEventsSpan =
+      NoRecordEventsSpanImpl.create(spanContext);
+
+  @Test
+  public void propagatesSpanContext() {
+    assertThat(noRecordEventsSpan.getContext()).isEqualTo(spanContext);
+  }
+
+  @Test
+  public void notRecordingEvents() {
+    assertThat(noRecordEventsSpan.isRecordingEvents()).isFalse();
+  }
+
+  @Test
+  public void disallowNullAttributeKey() {
+    thrown.expect(NullPointerException.class);
+    noRecordEventsSpan.setAttribute(null, 0);
+  }
+
+  @Test
+  public void disallowNullAttributeValue() {
+    thrown.expect(NullPointerException.class);
+    noRecordEventsSpan.setAttribute("key", (AttributeValue) null);
+  }
+
+  @Test
+  public void disallowNullEvent() {
+    thrown.expect(NullPointerException.class);
+    noRecordEventsSpan.addEvent((Event) null);
+  }
+
+  @Test
+  public void disallowNullEventName() {
+    thrown.expect(NullPointerException.class);
+    noRecordEventsSpan.addEvent(null, Collections.<String, AttributeValue>emptyMap());
+  }
+
+  @Test
+  public void disallowNullEventAttributes() {
+    thrown.expect(NullPointerException.class);
+    noRecordEventsSpan.addEvent("name", null);
+  }
+
+  @Test
+  public void disallowNullLink() {
+    thrown.expect(NullPointerException.class);
+    noRecordEventsSpan.addLink(null);
+  }
+
+  @Test
+  public void disallowNullName() {
+    thrown.expect(NullPointerException.class);
+    noRecordEventsSpan.updateName(null);
+  }
+
+  @Test
+  public void disallowNullStatus() {
+    thrown.expect(NullPointerException.class);
+    noRecordEventsSpan.setStatus(null);
+  }
+
+  @Test
+  public void doNotCrash() {
+    // Tests only that all the methods are not crashing/throwing errors.
+    noRecordEventsSpan.setAttribute("MyStringAttributeKey", "MyStringAttributeValue");
+    noRecordEventsSpan.setAttribute("MyBooleanAttributeKey", true);
+    noRecordEventsSpan.setAttribute("MyLongAttributeKey", 123);
+    noRecordEventsSpan.setAttribute(
+        "MyStringAttributeKey2", AttributeValue.stringAttributeValue("MyStringAttributeValue2"));
+    noRecordEventsSpan.addEvent("event1");
+    noRecordEventsSpan.addEvent("event2", Collections.<String, AttributeValue>emptyMap());
+    noRecordEventsSpan.addLink(Link.create(BLANK));
+    noRecordEventsSpan.updateName("name");
+    noRecordEventsSpan.setStatus(Status.OK);
+    noRecordEventsSpan.end();
+  }
+}

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.trace;
+
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceId;
+import java.util.UUID;
+
+/** Common utilities for unit tests. */
+public final class TestUtils {
+
+  /**
+   * Returns a random {@link TraceId}.
+   *
+   * @return a random {@link TraceId}.
+   */
+  public static TraceId generateRandomTraceId() {
+    return TraceId.fromLowerBase16(UUID.randomUUID().toString().replace("-", ""), 0);
+  }
+
+  /**
+   * Returns a random {@link SpanId}.
+   *
+   * @return a random {@link SpanId}.
+   */
+  public static SpanId generateRandomSpanId() {
+    return SpanId.fromLowerBase16(UUID.randomUUID().toString().replace("-", ""), 0);
+  }
+
+  private TestUtils() {}
+}


### PR DESCRIPTION
First part of https://github.com/open-telemetry/opentelemetry-java/issues/279.

Pretty much a copy-and-paste of https://github.com/census-instrumentation/opencensus-java/blob/master/impl_core/src/main/java/io/opencensus/implcore/trace/NoRecordEventsSpanImpl.java and https://github.com/census-instrumentation/opencensus-java/blob/master/impl_core/src/test/java/io/opencensus/implcore/trace/NoRecordEventsSpanImplTest.java.

/cc @dinooliva