### PR TITLE
API: Have TraceId/SpanId constructors taking long values.

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/SpanId.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanId.java
@@ -48,7 +48,13 @@ public final class SpanId implements Comparable<SpanId> {
   // The internal representation of the SpanId.
   private final long id;
 
-  private SpanId(long id) {
+  /**
+   * Constructs a {@code SpanId} whose representation is specified by a long value.
+   *
+   * @param id the long represenation of the {@code TraceId}.
+   * @since 0.1.0
+   */
+  public SpanId(long id) {
     this.id = id;
   }
 

--- a/api/src/main/java/io/opentelemetry/trace/SpanId.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanId.java
@@ -55,6 +55,9 @@ public final class SpanId implements Comparable<SpanId> {
    * rules applying to {@code SpanId}. Specifying 0 for this value will effectively make the new
    * {@code SpanId} invalid.
    *
+   * <p>This is equivalent to calling {@link #fromBytes(byte[], int)} with the specified value
+   * stored as big-endian.
+   *
    * @param id the long represenation of the {@code TraceId}.
    * @since 0.1.0
    */

--- a/api/src/main/java/io/opentelemetry/trace/SpanId.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanId.java
@@ -51,6 +51,10 @@ public final class SpanId implements Comparable<SpanId> {
   /**
    * Constructs a {@code SpanId} whose representation is specified by a long value.
    *
+   * <p>There is no restriction on the specified value, other than the already established validity
+   * rules applying to {@code SpanId}. Specifying 0 for this value will effectively make the new
+   * {@code SpanId} invalid.
+   *
    * @param id the long represenation of the {@code TraceId}.
    * @since 0.1.0
    */

--- a/api/src/main/java/io/opentelemetry/trace/TraceId.java
+++ b/api/src/main/java/io/opentelemetry/trace/TraceId.java
@@ -49,7 +49,15 @@ public final class TraceId implements Comparable<TraceId> {
   private final long idHi;
   private final long idLo;
 
-  private TraceId(long idHi, long idLo) {
+  /**
+   * Constructs a {@code TraceId} whose representation is specified by two long values representing
+   * the lower and higher parts.
+   *
+   * @param idHi the higher part of the {@code TraceId}.
+   * @param idLo the lower part of the {@code TraceId}.
+   * @since 0.1.0
+   */
+  public TraceId(long idHi, long idLo) {
     this.idHi = idHi;
     this.idLo = idLo;
   }

--- a/api/src/main/java/io/opentelemetry/trace/TraceId.java
+++ b/api/src/main/java/io/opentelemetry/trace/TraceId.java
@@ -53,6 +53,10 @@ public final class TraceId implements Comparable<TraceId> {
    * Constructs a {@code TraceId} whose representation is specified by two long values representing
    * the lower and higher parts.
    *
+   * <p>There is no restriction on the specified values, other than the already established validity
+   * rules applying to {@code TraceId}. Specifying 0 for both values will effectively make the new
+   * {@code TraceId} invalid.
+   *
    * @param idHi the higher part of the {@code TraceId}.
    * @param idLo the lower part of the {@code TraceId}.
    * @since 0.1.0

--- a/api/src/main/java/io/opentelemetry/trace/TraceId.java
+++ b/api/src/main/java/io/opentelemetry/trace/TraceId.java
@@ -57,6 +57,9 @@ public final class TraceId implements Comparable<TraceId> {
    * rules applying to {@code TraceId}. Specifying 0 for both values will effectively make the new
    * {@code TraceId} invalid.
    *
+   * <p>This is equivalent to calling {@link #fromBytes(byte[], int)} with the specified values
+   * stored as big-endian.
+   *
    * @param idHi the higher part of the {@code TraceId}.
    * @param idLo the lower part of the {@code TraceId}.
    * @since 0.1.0

--- a/api/src/test/java/io/opentelemetry/trace/SpanIdTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanIdTest.java
@@ -19,6 +19,7 @@ package io.opentelemetry.trace;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.EqualsTester;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,7 +30,7 @@ import org.junit.runners.JUnit4;
 public class SpanIdTest {
   private static final byte[] firstBytes = new byte[] {0, 0, 0, 0, 0, 0, 0, 'a'};
   private static final byte[] secondBytes = new byte[] {(byte) 0xFF, 0, 0, 0, 0, 0, 0, 'A'};
-  private static final SpanId first = SpanId.fromBytes(firstBytes, 0);
+  private static final SpanId first = new SpanId(ByteBuffer.wrap(firstBytes).getLong());
   private static final SpanId second = SpanId.fromBytes(secondBytes, 0);
 
   @Test

--- a/api/src/test/java/io/opentelemetry/trace/TraceIdTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TraceIdTest.java
@@ -19,6 +19,7 @@ package io.opentelemetry.trace;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.EqualsTester;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,7 +33,9 @@ public class TraceIdTest {
   private static final byte[] secondBytes =
       new byte[] {(byte) 0xFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'A'};
   private static final TraceId first = TraceId.fromBytes(firstBytes, 0);
-  private static final TraceId second = TraceId.fromBytes(secondBytes, 0);
+  private static final TraceId second =
+      new TraceId(
+          ByteBuffer.wrap(secondBytes).getLong(), ByteBuffer.wrap(secondBytes, 8, 8).getLong());
 
   @Test
   public void invalidTraceId() {


### PR DESCRIPTION
Exposed the constructors taking `long`, as proposed in a recent call.

I re-used the existing tests, btw. Hope that is fine too ;)