### PR TITLE
Fix comment for Span.end() as there's no overload taking options anymore.

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -190,7 +190,7 @@ public interface Span {
   void updateName(String name);
 
   /**
-   * Marks the end of {@code Span} execution with the default options.
+   * Marks the end of {@code Span} execution.
    *
    * <p>Only the timing of the first end call for a given {@code Span} will be recorded, and
    * implementations are free to ignore all further calls.


### PR DESCRIPTION
Addresses #368 