### PR TITLE
Rename BlankSpan to DefaultSpan.

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
@@ -21,11 +21,11 @@ import java.util.Map;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * The {@code BlankSpan} is the default {@link Span} that is used when no {@code Span}
+ * The {@code DefaultSpan} is the default {@link Span} that is used when no {@code Span}
  * implementation is available. All operations are no-op except context propagation.
  *
  * <p>When no valid context ({@code null} or {@link SpanContext#BLANK}) is available then
- * implementation propagates {@link BlankSpan#INSTANCE} which encapsulates {@link
+ * implementation propagates {@link DefaultSpan#INSTANCE} which encapsulates {@link
  * SpanContext#BLANK}.
  *
  * <p>Used also to stop tracing, see {@link Tracer#withSpan}.
@@ -33,18 +33,18 @@ import javax.annotation.concurrent.Immutable;
  * @since 0.1.0
  */
 @Immutable
-public final class BlankSpan implements Span {
+public final class DefaultSpan implements Span {
   /**
    * An instance of this class. If there is no {@code SpanContext} or {@link SpanContext#BLANK} to
    * propagate this instance is used.
    *
    * @since 0.1.0
    */
-  public static final Span INSTANCE = new BlankSpan(SpanContext.BLANK);
+  public static final Span INSTANCE = new DefaultSpan(SpanContext.BLANK);
 
   private final SpanContext spanContext;
 
-  BlankSpan(SpanContext spanContext) {
+  DefaultSpan(SpanContext spanContext) {
     this.spanContext = spanContext;
   }
 
@@ -119,6 +119,6 @@ public final class BlankSpan implements Span {
 
   @Override
   public String toString() {
-    return "BlankSpan";
+    return "DefaultSpan";
   }
 }

--- a/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
@@ -105,8 +105,8 @@ public final class DefaultTracer implements Tracer {
       }
 
       return spanContext != null && !SpanContext.BLANK.equals(spanContext)
-          ? new BlankSpan(spanContext)
-          : BlankSpan.INSTANCE;
+          ? new DefaultSpan(spanContext)
+          : DefaultSpan.INSTANCE;
     }
 
     @Override

--- a/api/src/main/java/io/opentelemetry/trace/Tracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/Tracer.java
@@ -93,7 +93,7 @@ public interface Tracer {
    *
    * <p>Supports try-with-resource idiom.
    *
-   * <p>Can be called with {@link BlankSpan} to enter a scope of code where tracing is stopped.
+   * <p>Can be called with {@link DefaultSpan} to enter a scope of code where tracing is stopped.
    *
    * <p>Example of usage:
    *

--- a/api/src/main/java/io/opentelemetry/trace/unsafe/ContextUtils.java
+++ b/api/src/main/java/io/opentelemetry/trace/unsafe/ContextUtils.java
@@ -18,7 +18,7 @@ package io.opentelemetry.trace.unsafe;
 
 import io.grpc.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.trace.BlankSpan;
+import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
 
@@ -32,7 +32,7 @@ import io.opentelemetry.trace.Tracer;
  */
 public final class ContextUtils {
   private static final Context.Key<Span> CONTEXT_SPAN_KEY =
-      Context.keyWithDefault("opentelemetry-trace-span-key", BlankSpan.INSTANCE);
+      Context.keyWithDefault("opentelemetry-trace-span-key", DefaultSpan.INSTANCE);
 
   /**
    * Creates a new {@code Context} with the given value set.

--- a/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
@@ -23,34 +23,34 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link BlankSpan}. */
+/** Unit tests for {@link DefaultSpan}. */
 @RunWith(JUnit4.class)
-public class BlankSpanTest {
+public class DefaultSpanTest {
   @Test
   public void hasInvalidContextAndDefaultSpanOptions() {
-    assertThat(BlankSpan.INSTANCE.getContext()).isEqualTo(SpanContext.BLANK);
+    assertThat(DefaultSpan.INSTANCE.getContext()).isEqualTo(SpanContext.BLANK);
   }
 
   @Test
   public void doNotCrash() {
-    BlankSpan.INSTANCE.setAttribute(
+    DefaultSpan.INSTANCE.setAttribute(
         "MyStringAttributeKey", AttributeValue.stringAttributeValue("MyStringAttributeValue"));
-    BlankSpan.INSTANCE.setAttribute(
+    DefaultSpan.INSTANCE.setAttribute(
         "MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true));
-    BlankSpan.INSTANCE.setAttribute("MyLongAttributeKey", AttributeValue.longAttributeValue(123));
-    BlankSpan.INSTANCE.addEvent("event");
-    BlankSpan.INSTANCE.addEvent(
+    DefaultSpan.INSTANCE.setAttribute("MyLongAttributeKey", AttributeValue.longAttributeValue(123));
+    DefaultSpan.INSTANCE.addEvent("event");
+    DefaultSpan.INSTANCE.addEvent(
         "event",
         Collections.singletonMap(
             "MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true)));
-    BlankSpan.INSTANCE.addEvent(SpanData.Event.create("event"));
-    BlankSpan.INSTANCE.addLink(Link.create(SpanContext.BLANK));
-    BlankSpan.INSTANCE.setStatus(Status.OK);
-    BlankSpan.INSTANCE.end();
+    DefaultSpan.INSTANCE.addEvent(SpanData.Event.create("event"));
+    DefaultSpan.INSTANCE.addLink(Link.create(SpanContext.BLANK));
+    DefaultSpan.INSTANCE.setStatus(Status.OK);
+    DefaultSpan.INSTANCE.end();
   }
 
   @Test
   public void blankSpan_ToString() {
-    assertThat(BlankSpan.INSTANCE.toString()).isEqualTo("BlankSpan");
+    assertThat(DefaultSpan.INSTANCE.toString()).isEqualTo("DefaultSpan");
   }
 }

--- a/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
@@ -42,19 +42,19 @@ public class DefaultTracerTest {
 
   @Test
   public void defaultGetCurrentSpan() {
-    assertThat(defaultTracer.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
+    assertThat(defaultTracer.getCurrentSpan()).isEqualTo(DefaultSpan.INSTANCE);
   }
 
   @Test
   public void getCurrentSpan_WithSpan() {
-    assertThat(defaultTracer.getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
-    Scope ws = defaultTracer.withSpan(BlankSpan.INSTANCE);
+    assertThat(defaultTracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
+    Scope ws = defaultTracer.withSpan(DefaultSpan.INSTANCE);
     try {
-      assertThat(defaultTracer.getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+      assertThat(defaultTracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
     } finally {
       ws.close();
     }
-    assertThat(defaultTracer.getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(defaultTracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
   }
 
   @Test(expected = NullPointerException.class)
@@ -65,7 +65,7 @@ public class DefaultTracerTest {
   @Test
   public void defaultSpanBuilderWithName() {
     assertThat(defaultTracer.spanBuilder(SPAN_NAME).startSpan())
-        .isSameInstanceAs(BlankSpan.INSTANCE);
+        .isSameInstanceAs(DefaultSpan.INSTANCE);
   }
 
   @Test
@@ -91,7 +91,7 @@ public class DefaultTracerTest {
     } finally {
       scope.close();
     }
-    assertThat(defaultTracer.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
+    assertThat(defaultTracer.getCurrentSpan()).isEqualTo(DefaultSpan.INSTANCE);
   }
 
   @Test
@@ -102,7 +102,7 @@ public class DefaultTracerTest {
 
   @Test
   public void testSpanContextPropagation() {
-    BlankSpan parent = new BlankSpan(spanContext);
+    DefaultSpan parent = new DefaultSpan(spanContext);
 
     Span span = defaultTracer.spanBuilder(SPAN_NAME).setParent(parent).startSpan();
     assertThat(span.getContext()).isSameInstanceAs(spanContext);
@@ -110,7 +110,7 @@ public class DefaultTracerTest {
 
   @Test
   public void testSpanContextPropagationCurrentSpan() {
-    BlankSpan parent = new BlankSpan(spanContext);
+    DefaultSpan parent = new DefaultSpan(spanContext);
     Scope scope = defaultTracer.withSpan(parent);
     try {
       Span span = defaultTracer.spanBuilder(SPAN_NAME).startSpan();

--- a/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
@@ -37,10 +37,10 @@ public class SpanBuilderTest {
     spanBuilder.setRecordEvents(true);
     spanBuilder.setSampler(Samplers.alwaysSample());
     spanBuilder.setSpanKind(Kind.SERVER);
-    spanBuilder.setParent(BlankSpan.INSTANCE);
-    spanBuilder.setParent(BlankSpan.INSTANCE.getContext());
+    spanBuilder.setParent(DefaultSpan.INSTANCE);
+    spanBuilder.setParent(DefaultSpan.INSTANCE.getContext());
     spanBuilder.setNoParent();
-    assertThat(spanBuilder.startSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(spanBuilder.startSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
   }
 
   @Rule public final ExpectedException thrown = ExpectedException.none();

--- a/api/src/test/java/io/opentelemetry/trace/unsafe/ContextUtilsTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/unsafe/ContextUtilsTest.java
@@ -19,7 +19,7 @@ package io.opentelemetry.trace.unsafe;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.grpc.Context;
-import io.opentelemetry.trace.BlankSpan;
+import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,14 +32,14 @@ public final class ContextUtilsTest {
   public void testGetCurrentSpan_DefaultContext() {
     Span span = ContextUtils.getValue(Context.current());
     assertThat(span).isNotNull();
-    assertThat(span).isInstanceOf(BlankSpan.class);
+    assertThat(span).isInstanceOf(DefaultSpan.class);
   }
 
   @Test
   public void testGetCurrentSpan_DefaultContext_WithoutExplicitContext() {
     Span span = ContextUtils.getValue();
     assertThat(span).isNotNull();
-    assertThat(span).isInstanceOf(BlankSpan.class);
+    assertThat(span).isInstanceOf(DefaultSpan.class);
   }
 
   @Test
@@ -48,7 +48,7 @@ public final class ContextUtilsTest {
     try {
       Span span = ContextUtils.getValue(Context.current());
       assertThat(span).isNotNull();
-      assertThat(span).isInstanceOf(BlankSpan.class);
+      assertThat(span).isInstanceOf(DefaultSpan.class);
     } finally {
       Context.current().detach(orig);
     }
@@ -60,7 +60,7 @@ public final class ContextUtilsTest {
     try {
       Span span = ContextUtils.getValue(Context.current());
       assertThat(span).isNotNull();
-      assertThat(span).isInstanceOf(BlankSpan.class);
+      assertThat(span).isInstanceOf(DefaultSpan.class);
     } finally {
       Context.current().detach(orig);
     }

--- a/contrib/src/test/java/io/opentelemetry/contrib/trace/CurrentSpanUtilsTest.java
+++ b/contrib/src/test/java/io/opentelemetry/contrib/trace/CurrentSpanUtilsTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 import io.grpc.Context;
-import io.opentelemetry.trace.BlankSpan;
+import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.unsafe.ContextUtils;
@@ -69,7 +69,7 @@ public class CurrentSpanUtilsTest {
 
   @Test
   public void withSpanRunnable() {
-    assertThat(getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
     Runnable runnable =
         new Runnable() {
           @Override
@@ -80,12 +80,12 @@ public class CurrentSpanUtilsTest {
         };
     CurrentSpanUtils.withSpan(span, false, runnable).run();
     verifyZeroInteractions(span);
-    assertThat(getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
   }
 
   @Test
   public void withSpanRunnable_EndSpan() {
-    assertThat(getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
     Runnable runnable =
         new Runnable() {
           @Override
@@ -96,13 +96,13 @@ public class CurrentSpanUtilsTest {
         };
     CurrentSpanUtils.withSpan(span, true, runnable).run();
     verify(span).end();
-    assertThat(getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
   }
 
   @Test
   public void withSpanRunnable_WithError() {
     final AssertionError error = new AssertionError("MyError");
-    assertThat(getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
     Runnable runnable =
         new Runnable() {
           @Override
@@ -115,13 +115,13 @@ public class CurrentSpanUtilsTest {
     executeRunnableAndExpectError(runnable, error);
     verify(span).setStatus(Status.UNKNOWN.withDescription("MyError"));
     verify(span).end();
-    assertThat(getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
   }
 
   @Test
   public void withSpanRunnable_WithErrorNoMessage() {
     final AssertionError error = new AssertionError();
-    assertThat(getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
     Runnable runnable =
         new Runnable() {
           @Override
@@ -134,13 +134,13 @@ public class CurrentSpanUtilsTest {
     executeRunnableAndExpectError(runnable, error);
     verify(span).setStatus(Status.UNKNOWN.withDescription("AssertionError"));
     verify(span).end();
-    assertThat(getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
   }
 
   @Test
   public void withSpanCallable() throws Exception {
     final Object ret = new Object();
-    assertThat(getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
     Callable<Object> callable =
         new Callable<Object>() {
           @Override
@@ -152,13 +152,13 @@ public class CurrentSpanUtilsTest {
         };
     assertThat(CurrentSpanUtils.withSpan(span, false, callable).call()).isEqualTo(ret);
     verifyZeroInteractions(span);
-    assertThat(getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
   }
 
   @Test
   public void withSpanCallable_EndSpan() throws Exception {
     final Object ret = new Object();
-    assertThat(getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
     Callable<Object> callable =
         new Callable<Object>() {
           @Override
@@ -170,13 +170,13 @@ public class CurrentSpanUtilsTest {
         };
     assertThat(CurrentSpanUtils.withSpan(span, true, callable).call()).isEqualTo(ret);
     verify(span).end();
-    assertThat(getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
   }
 
   @Test
   public void withSpanCallable_WithException() {
     final Exception exception = new Exception("MyException");
-    assertThat(getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
     Callable<Object> callable =
         new Callable<Object>() {
           @Override
@@ -189,13 +189,13 @@ public class CurrentSpanUtilsTest {
     executeCallableAndExpectError(callable, exception);
     verify(span).setStatus(Status.UNKNOWN.withDescription("MyException"));
     verify(span).end();
-    assertThat(getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
   }
 
   @Test
   public void withSpanCallable_WithExceptionNoMessage() {
     final Exception exception = new Exception();
-    assertThat(getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
     Callable<Object> callable =
         new Callable<Object>() {
           @Override
@@ -208,13 +208,13 @@ public class CurrentSpanUtilsTest {
     executeCallableAndExpectError(callable, exception);
     verify(span).setStatus(Status.UNKNOWN.withDescription("Exception"));
     verify(span).end();
-    assertThat(getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
   }
 
   @Test
   public void withSpanCallable_WithError() {
     final AssertionError error = new AssertionError("MyError");
-    assertThat(getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
     Callable<Object> callable =
         new Callable<Object>() {
           @Override
@@ -227,13 +227,13 @@ public class CurrentSpanUtilsTest {
     executeCallableAndExpectError(callable, error);
     verify(span).setStatus(Status.UNKNOWN.withDescription("MyError"));
     verify(span).end();
-    assertThat(getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
   }
 
   @Test
   public void withSpanCallable_WithErrorNoMessage() {
     final AssertionError error = new AssertionError();
-    assertThat(getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
     Callable<Object> callable =
         new Callable<Object>() {
           @Override
@@ -246,7 +246,7 @@ public class CurrentSpanUtilsTest {
     executeCallableAndExpectError(callable, error);
     verify(span).setStatus(Status.UNKNOWN.withDescription("AssertionError"));
     verify(span).end();
-    assertThat(getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
   }
 
   private static Span getCurrentSpan() {

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -21,7 +21,7 @@ import static com.google.common.truth.Truth.assertThat;
 import io.grpc.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TraceContextFormat;
-import io.opentelemetry.trace.BlankSpan;
+import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.unsafe.ContextUtils;
 import org.junit.Before;
@@ -44,7 +44,7 @@ public class TracerSdkTest {
 
   @Test
   public void defaultGetCurrentSpan() {
-    assertThat(tracer.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
+    assertThat(tracer.getCurrentSpan()).isEqualTo(DefaultSpan.INSTANCE);
   }
 
   @Test
@@ -54,7 +54,7 @@ public class TracerSdkTest {
 
   @Test
   public void getCurrentSpan() {
-    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
     Context origContext = ContextUtils.withValue(span).attach();
     // Make sure context is detached even if test fails.
     try {
@@ -62,24 +62,24 @@ public class TracerSdkTest {
     } finally {
       Context.current().detach(origContext);
     }
-    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
   }
 
   @Test
   public void withSpan_NullSpan() {
-    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
     try (Scope ws = tracer.withSpan(null)) {
-      assertThat(tracer.getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+      assertThat(tracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
     }
-    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
   }
 
   @Test
   public void getCurrentSpan_WithSpan() {
-    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
     try (Scope ws = tracer.withSpan(span)) {
       assertThat(tracer.getCurrentSpan()).isSameInstanceAs(span);
     }
-    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(BlankSpan.INSTANCE);
+    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.INSTANCE);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-java/issues/310.

Followed @SergeyKanzhelev's suggestion in https://github.com/open-telemetry/opentelemetry-java/issues/310#issuecomment-498797101:

> - So we will call it `Default` span. 
> - `Default` will generate a new span ID. There will be built-in random algorithm.

Note invalid span is not yet included in this PR.