### PR TITLE
Rename Blank SpanContext to Invalid.

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
@@ -93,7 +93,7 @@ public final class DefaultTracer implements Tracer {
         spanContext = tracer.getCurrentSpan().getContext();
       }
 
-      return spanContext != null && !SpanContext.getBlank().equals(spanContext)
+      return spanContext != null && !SpanContext.getInvalid().equals(spanContext)
           ? new DefaultSpan(spanContext)
           : DefaultSpan.create();
     }
@@ -167,7 +167,7 @@ public final class DefaultTracer implements Tracer {
     @Override
     public SpanContext fromByteArray(byte[] bytes) {
       Utils.checkNotNull(bytes, "bytes");
-      return SpanContext.getBlank();
+      return SpanContext.getInvalid();
     }
 
     private NoopBinaryFormat() {}

--- a/api/src/main/java/io/opentelemetry/trace/SpanContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanContext.java
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public final class SpanContext {
 
-  private static final SpanContext BLANK =
+  private static final SpanContext INVALID =
       new SpanContext(
           TraceId.getInvalid(),
           SpanId.getInvalid(),
@@ -44,13 +44,13 @@ public final class SpanContext {
   private final Tracestate tracestate;
 
   /**
-   * Returns the blank {@code SpanContext} that can be used for no-op operations.
+   * Returns the invalid {@code SpanContext} that can be used for no-op operations.
    *
-   * @return the blank {@code SpanContext}.
+   * @return the invalid {@code SpanContext}.
    * @since 0.1.0
    */
-  public static SpanContext getBlank() {
-    return BLANK;
+  public static SpanContext getInvalid() {
+    return INVALID;
   }
 
   /**

--- a/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
@@ -56,9 +56,9 @@ public class DefaultSpanTest {
         Collections.singletonMap(
             "MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true)));
     span.addEvent(SpanData.Event.create("event"));
-    span.addLink(SpanContext.getBlank());
-    span.addLink(SpanContext.getBlank(), Collections.<String, AttributeValue>emptyMap());
-    span.addLink(Link.create(SpanContext.getBlank()));
+    span.addLink(SpanContext.getInvalid());
+    span.addLink(SpanContext.getInvalid(), Collections.<String, AttributeValue>emptyMap());
+    span.addLink(Link.create(SpanContext.getInvalid()));
     span.setStatus(Status.OK);
     span.end();
   }

--- a/api/src/test/java/io/opentelemetry/trace/LinkTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/LinkTest.java
@@ -59,7 +59,7 @@ public class LinkTest {
     EqualsTester tester = new EqualsTester();
     tester
         .addEqualityGroup(Link.create(spanContext), Link.create(spanContext))
-        .addEqualityGroup(Link.create(SpanContext.getBlank()))
+        .addEqualityGroup(Link.create(SpanContext.getInvalid()))
         .addEqualityGroup(
             Link.create(spanContext, attributesMap), Link.create(spanContext, attributesMap));
     tester.testEquals();

--- a/api/src/test/java/io/opentelemetry/trace/SpanContextTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanContextTest.java
@@ -50,14 +50,14 @@ public class SpanContextTest {
 
   @Test
   public void invalidSpanContext() {
-    assertThat(SpanContext.getBlank().getTraceId()).isEqualTo(TraceId.getInvalid());
-    assertThat(SpanContext.getBlank().getSpanId()).isEqualTo(SpanId.getInvalid());
-    assertThat(SpanContext.getBlank().getTraceOptions()).isEqualTo(TraceOptions.getDefault());
+    assertThat(SpanContext.getInvalid().getTraceId()).isEqualTo(TraceId.getInvalid());
+    assertThat(SpanContext.getInvalid().getSpanId()).isEqualTo(SpanId.getInvalid());
+    assertThat(SpanContext.getInvalid().getTraceOptions()).isEqualTo(TraceOptions.getDefault());
   }
 
   @Test
   public void isValid() {
-    assertThat(SpanContext.getBlank().isValid()).isFalse();
+    assertThat(SpanContext.getInvalid().isValid()).isFalse();
     assertThat(
             SpanContext.create(
                     TraceId.fromBytes(firstTraceIdBytes, 0),


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-java/issues/380.