### PR TITLE
Use ThreadLocalRandom instead of Random in DefaultSpan

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
@@ -33,7 +33,6 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public final class DefaultSpan implements Span {
 
-  private static final Random random = ThreadLocalRandom.current();
   private static final DefaultSpan INVALID = new DefaultSpan(SpanContext.getInvalid());
 
   /**
@@ -54,6 +53,7 @@ public final class DefaultSpan implements Span {
    * @return a {@link DefaultSpan}.
    */
   static DefaultSpan create() {
+    final Random random = ThreadLocalRandom.current();
     return new DefaultSpan(
         SpanContext.create(
             TraceId.generateRandomId(random),

--- a/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
@@ -19,6 +19,7 @@ package io.opentelemetry.trace;
 import io.opentelemetry.internal.Utils;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -32,7 +33,7 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public final class DefaultSpan implements Span {
 
-  private static final Random random = new Random();
+  private static final Random random = ThreadLocalRandom.current();
   private static final DefaultSpan INVALID = new DefaultSpan(SpanContext.getInvalid());
 
   /**


### PR DESCRIPTION
From the `java.util.Random` Javadocs:

> Instances of `java.util.Random` are threadsafe. However, the concurrent use of the same `java.util.Random` instance across threads may encounter contention and consequent poor performance. Consider instead using `java.util.concurrent.ThreadLocalRandom` in multithreaded designs.

If we'd rather leave it, I don't mind closing this PR.