### PR TITLE
OT Shim: Add a super basic InMemoryTracer.

### DIFF
--- a/opentracing-shim/src/main/java/io/opentelemetry/inmemorytrace/Check.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/inmemorytrace/Check.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.inmemorytrace;
+
+final class Check {
+  private Check() {}
+
+  public static void isNotNull(Object value, String valueName) {
+    if (value == null) {
+      throw new NullPointerException(valueName);
+    }
+  }
+}

--- a/opentracing-shim/src/main/java/io/opentelemetry/inmemorytrace/InMemorySpan.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/inmemorytrace/InMemorySpan.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.inmemorytrace;
+
+import io.opentelemetry.resources.Resource;
+import io.opentelemetry.trace.AttributeValue;
+import io.opentelemetry.trace.Event;
+import io.opentelemetry.trace.Link;
+import io.opentelemetry.trace.Sampler;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.Span.Kind;
+import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.SpanData;
+import io.opentelemetry.trace.SpanData.TimedEvent;
+import io.opentelemetry.trace.SpanData.Timestamp;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.Status;
+import io.opentelemetry.trace.TraceId;
+import io.opentelemetry.trace.TraceOptions;
+import io.opentelemetry.trace.Tracestate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import javax.annotation.Nullable;
+
+// TODO - Use sampler to create TraceOptions.
+final class InMemorySpan implements Span {
+  private String name;
+  private final InMemoryTracer tracer;
+  private final SpanContext context;
+  private final SpanId parentSpanId;
+  private final Resource resource;
+  private final Kind kind;
+  private final Timestamp startTimestamp;
+  private final Map<String, AttributeValue> attributes = new HashMap<>();
+  private final List<TimedEvent> timedEvents = new ArrayList<>();
+  private final List<Link> links;
+  private Status status = Status.OK;
+  private boolean ended;
+
+  InMemorySpan(
+      InMemoryTracer tracer,
+      SpanContext context,
+      SpanId parentSpanId,
+      Resource resource,
+      String name,
+      Kind kind,
+      Timestamp startTimestamp,
+      List<Link> links) {
+    this.tracer = tracer;
+    this.context = context;
+    this.parentSpanId = parentSpanId;
+    this.resource = resource;
+    this.name = name;
+    this.kind = kind;
+    this.startTimestamp = startTimestamp;
+    this.links = links;
+  }
+
+  @Override
+  public void setAttribute(String key, String value) {
+    setAttribute(key, AttributeValue.stringAttributeValue(value));
+  }
+
+  @Override
+  public void setAttribute(String key, long value) {
+    setAttribute(key, AttributeValue.longAttributeValue(value));
+  }
+
+  @Override
+  public void setAttribute(String key, double value) {
+    setAttribute(key, AttributeValue.doubleAttributeValue(value));
+  }
+
+  @Override
+  public void setAttribute(String key, boolean value) {
+    setAttribute(key, AttributeValue.booleanAttributeValue(value));
+  }
+
+  @Override
+  public void setAttribute(String key, AttributeValue value) {
+    Check.isNotNull(key, "key");
+    Check.isNotNull(value, "value");
+
+    synchronized (this) {
+      endedCheck();
+      attributes.put(key, value);
+    }
+  }
+
+  @Override
+  public void addEvent(String name) {
+    addEvent(SpanData.Event.create(name));
+  }
+
+  @Override
+  public void addEvent(String name, Map<String, AttributeValue> attributes) {
+    addEvent(SpanData.Event.create(name, attributes));
+  }
+
+  @Override
+  public void addEvent(Event event) {
+    Check.isNotNull(event, "event");
+
+    synchronized (this) {
+      endedCheck();
+      Timestamp tstamp = Timestamp.fromMillis(System.currentTimeMillis());
+      timedEvents.add(TimedEvent.create(tstamp, event));
+    }
+  }
+
+  @Override
+  public void addLink(SpanContext spanContext) {
+    addLink(SpanData.Link.create(spanContext));
+  }
+
+  @Override
+  public void addLink(SpanContext spanContext, Map<String, AttributeValue> attributes) {
+    addLink(SpanData.Link.create(spanContext, attributes));
+  }
+
+  @Override
+  public void addLink(Link link) {
+    Check.isNotNull(link, "link");
+
+    synchronized (this) {
+      endedCheck();
+      links.add(link);
+    }
+  }
+
+  @Override
+  public void setStatus(Status status) {
+    Check.isNotNull(status, "status");
+
+    synchronized (this) {
+      endedCheck();
+      this.status = status;
+    }
+  }
+
+  @Override
+  public void updateName(String name) {
+    Check.isNotNull(name, "name");
+
+    synchronized (this) {
+      endedCheck();
+      this.name = name;
+    }
+  }
+
+  @Override
+  public void end() {
+    synchronized (this) {
+      endedCheck();
+      tracer.recordSpanData(
+          SpanData.create(
+              context,
+              parentSpanId,
+              resource,
+              name,
+              kind,
+              startTimestamp,
+              attributes,
+              timedEvents,
+              links,
+              status,
+              Timestamp.fromMillis(System.currentTimeMillis())));
+      ended = true;
+    }
+  }
+
+  @Override
+  public SpanContext getContext() {
+    return context;
+  }
+
+  @Override
+  public boolean isRecordingEvents() {
+    return true;
+  }
+
+  private void endedCheck() {
+    if (ended) {
+      throw new IllegalStateException("Span is already ended.");
+    }
+  }
+
+  // TODO - Use recordEvents and sampler.
+  static final class Builder implements Span.Builder {
+    final InMemoryTracer tracer;
+    final String name;
+    final List<Link> links = new ArrayList<>();
+    @Nullable SpanContext explicitParent;
+    ParentType parentType = ParentType.CURRENT;
+    Kind kind = Kind.INTERNAL;
+
+    static final Random random = new Random();
+
+    Builder(InMemoryTracer tracer, String name) {
+      this.tracer = tracer;
+      this.name = name;
+    }
+
+    @Override
+    public Builder setParent(Span parent) {
+      Check.isNotNull(parent, "parent");
+
+      explicitParent = parent.getContext();
+      parentType = ParentType.EXPLICIT;
+      return this;
+    }
+
+    @Override
+    public Builder setParent(SpanContext remoteParent) {
+      Check.isNotNull(remoteParent, "remoteParent");
+
+      explicitParent = remoteParent;
+      parentType = ParentType.EXPLICIT;
+      return this;
+    }
+
+    @Override
+    public Builder setNoParent() {
+      explicitParent = null;
+      parentType = ParentType.NONE;
+      return this;
+    }
+
+    @Override
+    public Builder setSampler(Sampler sampler) {
+      return this;
+    }
+
+    @Override
+    public Builder addLink(SpanContext spanContext) {
+      links.add(SpanData.Link.create(spanContext));
+      return this;
+    }
+
+    @Override
+    public Builder addLink(SpanContext spanContext, Map<String, AttributeValue> attributes) {
+      links.add(SpanData.Link.create(spanContext, attributes));
+      return this;
+    }
+
+    @Override
+    public Builder addLink(Link link) {
+      Check.isNotNull(link, "link");
+
+      links.add(link);
+      return this;
+    }
+
+    @Override
+    public Builder setRecordEvents(boolean recordEvents) {
+      return this;
+    }
+
+    @Override
+    public Builder setSpanKind(Kind kind) {
+      Check.isNotNull(kind, "kind");
+
+      this.kind = kind;
+      return this;
+    }
+
+    @Override
+    public Span startSpan() {
+      SpanContext parentContext = null;
+
+      switch (parentType) {
+        case CURRENT:
+          parentContext = tracer.getCurrentSpan().getContext();
+          break;
+        case NONE:
+          parentContext = null;
+          break;
+        case EXPLICIT:
+          parentContext = explicitParent;
+          break;
+      }
+
+      TraceId traceId = null;
+      SpanId parentSpanId = null;
+
+      if (parentContext != null) {
+        traceId = parentContext.getTraceId();
+        parentSpanId = parentContext.getSpanId();
+      }
+
+      if (traceId == null || TraceId.getInvalid().equals(traceId)) {
+        traceId = createTraceId();
+        parentSpanId = null;
+      }
+
+      // TODO - Create properly the remaining SpanContext members.
+      SpanContext context =
+          SpanContext.create(
+              traceId, createSpanId(), TraceOptions.getDefault(), Tracestate.getDefault());
+      return new InMemorySpan(
+          tracer,
+          context,
+          parentSpanId,
+          tracer.getResource(),
+          name,
+          kind,
+          Timestamp.fromMillis(System.currentTimeMillis()),
+          links);
+    }
+
+    static SpanId createSpanId() {
+      long id;
+      do {
+        id = random.nextLong();
+      } while (id == 0);
+
+      return new SpanId(id);
+    }
+
+    static TraceId createTraceId() {
+      long idHi;
+      long idLo;
+      do {
+        idHi = random.nextLong();
+        idLo = random.nextLong();
+      } while (idHi == 0 && idLo == 0);
+
+      return new TraceId(idHi, idLo);
+    }
+
+    enum ParentType {
+      CURRENT,
+      EXPLICIT,
+      NONE,
+    }
+  }
+}

--- a/opentracing-shim/src/main/java/io/opentelemetry/inmemorytrace/InMemoryTracer.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/inmemorytrace/InMemoryTracer.java
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 // TODO - Use the Nullable annotation everywhere.
-public final class InMemoryTracer implements Tracer {
+final class InMemoryTracer implements Tracer {
   private final List<SpanData> finishedSpanDataItems = new ArrayList<>();
   private final HttpTextFormat<SpanContext> textFormat = new TraceContextFormat();
   private final Resource resource;

--- a/opentracing-shim/src/main/java/io/opentelemetry/inmemorytrace/InMemoryTracer.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/inmemorytrace/InMemoryTracer.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.inmemorytrace;
+
+import io.grpc.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.BinaryFormat;
+import io.opentelemetry.context.propagation.HttpTextFormat;
+import io.opentelemetry.context.propagation.TraceContextFormat;
+import io.opentelemetry.resources.Resource;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.SpanData;
+import io.opentelemetry.trace.Tracer;
+import io.opentelemetry.trace.unsafe.ContextUtils;
+import java.util.ArrayList;
+import java.util.List;
+
+// TODO - Use the Nullable annotation everywhere.
+public final class InMemoryTracer implements Tracer {
+  private final List<SpanData> finishedSpanDataItems = new ArrayList<>();
+  private final HttpTextFormat<SpanContext> textFormat = new TraceContextFormat();
+  private final Resource resource;
+
+  public InMemoryTracer() {
+    this(Resource.getEmpty());
+  }
+
+  public InMemoryTracer(Resource resource) {
+    Check.isNotNull(resource, "resource");
+    this.resource = resource;
+  }
+
+  static final class InMemoryScope implements Scope {
+    final Context context;
+    final Context prevContext;
+
+    public InMemoryScope(Context context) {
+      this.context = context;
+      this.prevContext = context.attach();
+    }
+
+    @Override
+    public void close() {
+      context.detach(prevContext);
+    }
+  }
+
+  Resource getResource() {
+    return resource;
+  }
+
+  @Override
+  public Span getCurrentSpan() {
+    return ContextUtils.getValue(Context.current());
+  }
+
+  @Override
+  public Scope withSpan(Span span) {
+    Check.isNotNull(span, "span");
+
+    Context context = ContextUtils.withValue(span, Context.current());
+    return new InMemoryScope(context);
+  }
+
+  @Override
+  public Span.Builder spanBuilder(String spanName) {
+    Check.isNotNull(spanName, "spanName");
+
+    return new InMemorySpan.Builder(this, spanName);
+  }
+
+  @Override
+  public void recordSpanData(SpanData spanData) {
+    Check.isNotNull(spanData, "spanData");
+
+    synchronized (this) {
+      finishedSpanDataItems.add(spanData);
+    }
+  }
+
+  @Override
+  @SuppressWarnings("ReturnMissingNullable")
+  public BinaryFormat<SpanContext> getBinaryFormat() {
+    // TODO
+    return null;
+  }
+
+  @Override
+  public HttpTextFormat<SpanContext> getHttpTextFormat() {
+    return textFormat;
+  }
+
+  /** Returns a {@code List} of the finished {@code Span}s, represented by {@code SpanData}. */
+  public List<SpanData> getFinishedSpanDataItems() {
+    synchronized (this) {
+      return new ArrayList<>(finishedSpanDataItems);
+    }
+  }
+
+  /** Clears the internal {@code List} of finished {@code Span}s. */
+  public void reset() {
+    synchronized (this) {
+      finishedSpanDataItems.clear();
+    }
+  }
+}

--- a/opentracing-shim/src/test/java/io/opentelemetry/inmemorytrace/InMemoryTracerTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/inmemorytrace/InMemoryTracerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.inmemorytrace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.opentelemetry.trace.DefaultSpan;
+import io.opentelemetry.trace.SpanData;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link InMemoryTracer}. */
+@RunWith(JUnit4.class)
+public class InMemoryTracerTest {
+  @Test
+  public void defaultCtor() {
+    InMemoryTracer tracer = new InMemoryTracer();
+    assertThat(tracer.getCurrentSpan()).isEqualTo(DefaultSpan.getInvalid());
+    assertThat(tracer.spanBuilder("one")).isNotNull();
+    assertThat(tracer.getResource()).isNotNull();
+    assertThat(tracer.getHttpTextFormat()).isNotNull();
+    assertThat(tracer.getFinishedSpanDataItems()).isNotNull();
+    assertThat(tracer.getFinishedSpanDataItems().size()).isEqualTo(0);
+  }
+
+  @Test
+  public void getFinishedSpanDataItems() {
+    InMemoryTracer tracer = new InMemoryTracer();
+    tracer.spanBuilder("one").startSpan().end();
+    tracer.spanBuilder("two").startSpan().end();
+    tracer.spanBuilder("three").startSpan().end();
+
+    List<SpanData> spanItems = tracer.getFinishedSpanDataItems();
+    assertThat(spanItems).isNotNull();
+    assertThat(spanItems.size()).isEqualTo(3);
+    assertThat(spanItems.get(0).getName()).isEqualTo("one");
+    assertThat(spanItems.get(1).getName()).isEqualTo("two");
+    assertThat(spanItems.get(2).getName()).isEqualTo("three");
+  }
+
+  @Test
+  public void reset() {
+    InMemoryTracer tracer = new InMemoryTracer();
+    tracer.spanBuilder("one").startSpan().end();
+    tracer.spanBuilder("two").startSpan().end();
+    tracer.spanBuilder("three").startSpan().end();
+    tracer.reset();
+
+    List<SpanData> spanItems = tracer.getFinishedSpanDataItems();
+    assertThat(spanItems).isNotNull();
+    assertThat(spanItems.size()).isEqualTo(0);
+  }
+}


### PR DESCRIPTION
Adds a basic in-memory `Tracer` that we can later leverage for the OT shim tests (including the `testbed` examples).

Originated from #408 