### PR TITLE
 Fail the build on warnings with '-Werror'.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,10 @@ subprojects {
         it.options.compilerArgs += ["-XepExcludedPaths:.*/sdk/build/generated/source/proto/.*"]
 
         // Enforce errorprone warnings to be errors.
-        it.options.compilerArgs += ["-Werror"]
+        if (!JavaVersion.current().isJava9() && !JavaVersion.current().isJava10()) {
+            // TODO: Enable -Werror for Java 9+
+            it.options.compilerArgs += ["-Werror"]
+        }
     }
 
     compileTestJava {

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,9 @@ subprojects {
 
         // Ignore warnings for protobuf generated files.
         it.options.compilerArgs += ["-XepExcludedPaths:.*/sdk/build/generated/source/proto/.*"]
+
+        // Enforce errorprone warnings to be errors.
+        it.options.compilerArgs += ["-Werror"]
     }
 
     compileTestJava {

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsSpanImpl.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsSpanImpl.java
@@ -42,6 +42,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /** Implementation for the {@link Span} class that records trace events. */
 @ThreadSafe
+@SuppressWarnings("unused") // TODO(songya): remove this annotation after finishing implementation
 final class RecordEventsSpanImpl implements SpanSdk {
   private static final Logger logger = Logger.getLogger(Tracer.class.getName());
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsSpanImplTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsSpanImplTest.java
@@ -130,8 +130,6 @@ public class RecordEventsSpanImplTest {
     }
     testClock.advanceMillis(1000);
     Event event = new SimpleEvent("event2", Collections.<String, AttributeValue>emptyMap());
-    Event expectdEvent =
-        SpanData.Event.create("event2", Collections.<String, AttributeValue>emptyMap());
     span.addEvent(event);
     Link link = SpanData.Link.create(spanContext);
     span.addLink(link);


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-java/issues/375.

Only enabled for Java 8 and lower. For Java 9+, I got a lot of warnings like
```bash
warning: /modules/java.base/java/lang/SuppressWarnings.class: major version 54 is newer than 53, the highest major version supported by this compiler.
  It is recommended that the compiler be upgraded.
...
warning: Supported source version 'RELEASE_5' from annotation processor 'com.google.auto.value.extension.memoized.processor.MemoizedValidator' less than -source '1.7'
```

Seems to be related to AutoValue.