### PR TITLE
Decouple the getter methods for the Span in a different class.

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
@@ -17,9 +17,19 @@
 package io.opentelemetry.sdk.trace;
 
 import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.SpanContext;
 
 /** The extend Span interface used by the SDK. */
-public interface SpanSdk extends Span {
+public interface ReadableSpan {
+
+  /**
+   * Returns the {@link SpanContext} of the {@code Span}.
+   *
+   * <p>Equivalent with {@link Span#getContext()}.
+   *
+   * @return the {@link SpanContext} of the {@code Span}.
+   */
+  SpanContext getSpanContext();
 
   /**
    * Returns the name of the {@code Span}.

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanImpl.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanImpl.java
@@ -43,7 +43,7 @@ import javax.annotation.concurrent.ThreadSafe;
 /** Implementation for the {@link Span} class that records trace events. */
 @ThreadSafe
 @SuppressWarnings("unused") // TODO(songya): remove this annotation after finishing implementation
-final class RecordEventsSpanImpl implements SpanSdk {
+final class RecordEventsReadableSpanImpl implements ReadableSpan, Span {
   private static final Logger logger = Logger.getLogger(Tracer.class.getName());
 
   // Contains the identifiers associated with this Span.
@@ -115,7 +115,7 @@ final class RecordEventsSpanImpl implements SpanSdk {
    * @return a new and started span.
    */
   @VisibleForTesting
-  static RecordEventsSpanImpl startSpan(
+  static RecordEventsReadableSpanImpl startSpan(
       SpanContext context,
       String name,
       Kind kind,
@@ -125,8 +125,8 @@ final class RecordEventsSpanImpl implements SpanSdk {
       @Nullable TimestampConverter timestampConverter,
       Clock clock,
       Resource resource) {
-    RecordEventsSpanImpl span =
-        new RecordEventsSpanImpl(
+    RecordEventsReadableSpanImpl span =
+        new RecordEventsReadableSpanImpl(
             context,
             name,
             kind,
@@ -140,6 +140,11 @@ final class RecordEventsSpanImpl implements SpanSdk {
     // initialized.
     spanProcessor.onStartSync(span);
     return span;
+  }
+
+  @Override
+  public SpanContext getSpanContext() {
+    return getContext();
   }
 
   /**
@@ -419,7 +424,7 @@ final class RecordEventsSpanImpl implements SpanSdk {
     }
   }
 
-  private RecordEventsSpanImpl(
+  private RecordEventsReadableSpanImpl(
       SpanContext context,
       String name,
       Kind kind,

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -110,7 +110,7 @@ class SpanBuilderSdk implements Span.Builder {
   }
 
   @Override
-  public SpanSdk startSpan() {
+  public Span startSpan() {
     // TODO get parent span from the context if noParent=false and parent/remoteParents are null
     throw new UnsupportedOperationException("to be implemented");
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
@@ -30,9 +30,9 @@ public interface SpanProcessor {
    * <p>This method is called synchronously on the execution thread, should not throw or block the
    * execution thread.
    *
-   * @param span the {@code SpanSdk} that just started.
+   * @param span the {@code ReadableSpan} that just started.
    */
-  void onStartSync(SpanSdk span);
+  void onStartSync(ReadableSpan span);
 
   /**
    * Called when a {@link io.opentelemetry.trace.Span} is ended, if the {@link
@@ -41,9 +41,9 @@ public interface SpanProcessor {
    * <p>This method is called synchronously on the execution thread, should not throw or block the
    * execution thread.
    *
-   * @param span the {@code SpanSdk} that just ended.
+   * @param span the {@code ReadableSpan} that just ended.
    */
-  void onEndSync(SpanSdk span);
+  void onEndSync(ReadableSpan span);
 
   /** Called when {@link TracerSdk#shutdown()} is called. */
   void shutdown();

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSampledSpansProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSampledSpansProcessor.java
@@ -17,15 +17,15 @@
 package io.opentelemetry.sdk.trace.export;
 
 import io.opentelemetry.internal.Utils;
+import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
-import io.opentelemetry.sdk.trace.SpanSdk;
 import io.opentelemetry.trace.TraceOptions;
 import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * An implementation of the {@link SpanProcessor} that converts the {@link SpanSdk} to {@link
+ * An implementation of the {@link SpanProcessor} that converts the {@link ReadableSpan} to {@link
  * io.opentelemetry.proto.trace.v1.Span} and passes it to the configured exporter.
  *
  * <p>Only spans that are sampled are converted, {@link TraceOptions#isSampled()} must return {@code
@@ -42,13 +42,13 @@ public final class SimpleSampledSpansProcessor implements SpanProcessor {
   }
 
   @Override
-  public void onStartSync(SpanSdk span) {
+  public void onStartSync(ReadableSpan span) {
     // Do nothing.
   }
 
   @Override
-  public void onEndSync(SpanSdk span) {
-    if (!span.getContext().getTraceOptions().isSampled()) {
+  public void onEndSync(ReadableSpan span) {
+    if (!span.getSpanContext().getTraceOptions().isSampled()) {
       return;
     }
     try {

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsSpanImplTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsSpanImplTest.java
@@ -47,7 +47,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-/** Unit tests for {@link RecordEventsSpanImpl}. */
+/** Unit tests for {@link RecordEventsReadableSpanImpl}. */
 @RunWith(JUnit4.class)
 public class RecordEventsSpanImplTest {
   private static final String SPAN_NAME = "MySpanName";
@@ -81,8 +81,8 @@ public class RecordEventsSpanImplTest {
 
   @Test
   public void noEventsRecordedAfterEnd() {
-    RecordEventsSpanImpl span =
-        RecordEventsSpanImpl.startSpan(
+    RecordEventsReadableSpanImpl span =
+        RecordEventsReadableSpanImpl.startSpan(
             spanContext,
             SPAN_NAME,
             Kind.INTERNAL,
@@ -110,8 +110,8 @@ public class RecordEventsSpanImplTest {
 
   @Test
   public void toSpanData_EndedSpan() {
-    RecordEventsSpanImpl span =
-        RecordEventsSpanImpl.startSpan(
+    RecordEventsReadableSpanImpl span =
+        RecordEventsReadableSpanImpl.startSpan(
             spanContext,
             SPAN_NAME,
             Kind.INTERNAL,
@@ -141,8 +141,8 @@ public class RecordEventsSpanImplTest {
 
   @Test
   public void status_ViaSetStatus() {
-    RecordEventsSpanImpl span =
-        RecordEventsSpanImpl.startSpan(
+    RecordEventsReadableSpanImpl span =
+        RecordEventsReadableSpanImpl.startSpan(
             spanContext,
             SPAN_NAME,
             Kind.INTERNAL,
@@ -163,8 +163,8 @@ public class RecordEventsSpanImplTest {
 
   @Test
   public void getSpanKind() {
-    RecordEventsSpanImpl span =
-        RecordEventsSpanImpl.startSpan(
+    RecordEventsReadableSpanImpl span =
+        RecordEventsReadableSpanImpl.startSpan(
             spanContext,
             SPAN_NAME,
             Kind.SERVER,

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSampledSpansProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSampledSpansProcessorTest.java
@@ -72,7 +72,7 @@ public class SimpleSampledSpansProcessorTest {
 
   @Test
   public void onEndSync_SampledSpan() {
-    when(readableSpan.getContext()).thenReturn(SAMPLED_SPAN_CONTEXT);
+    when(readableSpan.getSpanContext()).thenReturn(SAMPLED_SPAN_CONTEXT);
     when(readableSpan.toSpanProto())
         .thenReturn(Span.getDefaultInstance())
         .thenThrow(new RuntimeException());
@@ -82,7 +82,7 @@ public class SimpleSampledSpansProcessorTest {
 
   @Test
   public void onEndSync_NotSampledSpan() {
-    when(readableSpan.getContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
+    when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
     when(readableSpan.toSpanProto())
         .thenReturn(Span.getDefaultInstance())
         .thenThrow(new RuntimeException());
@@ -92,7 +92,7 @@ public class SimpleSampledSpansProcessorTest {
 
   @Test
   public void onEndSync_ExporterReturnError() {
-    when(readableSpan.getContext()).thenReturn(SAMPLED_SPAN_CONTEXT);
+    when(readableSpan.getSpanContext()).thenReturn(SAMPLED_SPAN_CONTEXT);
     when(readableSpan.toSpanProto())
         .thenReturn(Span.getDefaultInstance())
         .thenReturn(Span.getDefaultInstance())

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSampledSpansProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSampledSpansProcessorTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 import io.opentelemetry.proto.trace.v1.Span;
-import io.opentelemetry.sdk.trace.SpanSdk;
+import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceId;
@@ -41,7 +41,7 @@ import org.mockito.MockitoAnnotations;
 /** Unit tests for {@link SimpleSampledSpansProcessor}. */
 @RunWith(JUnit4.class)
 public class SimpleSampledSpansProcessorTest {
-  @Mock private SpanSdk spanSdk;
+  @Mock private ReadableSpan readableSpan;
   @Mock private SpanExporter spanExporter;
   private static final SpanContext SAMPLED_SPAN_CONTEXT =
       SpanContext.create(
@@ -66,34 +66,34 @@ public class SimpleSampledSpansProcessorTest {
 
   @Test
   public void onStartSync() {
-    simpleSampledSpansProcessor.onStartSync(spanSdk);
+    simpleSampledSpansProcessor.onStartSync(readableSpan);
     verifyZeroInteractions(spanExporter);
   }
 
   @Test
   public void onEndSync_SampledSpan() {
-    when(spanSdk.getContext()).thenReturn(SAMPLED_SPAN_CONTEXT);
-    when(spanSdk.toSpanProto())
+    when(readableSpan.getContext()).thenReturn(SAMPLED_SPAN_CONTEXT);
+    when(readableSpan.toSpanProto())
         .thenReturn(Span.getDefaultInstance())
         .thenThrow(new RuntimeException());
-    simpleSampledSpansProcessor.onEndSync(spanSdk);
+    simpleSampledSpansProcessor.onEndSync(readableSpan);
     verify(spanExporter).export(Collections.singletonList(Span.getDefaultInstance()));
   }
 
   @Test
   public void onEndSync_NotSampledSpan() {
-    when(spanSdk.getContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
-    when(spanSdk.toSpanProto())
+    when(readableSpan.getContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
+    when(readableSpan.toSpanProto())
         .thenReturn(Span.getDefaultInstance())
         .thenThrow(new RuntimeException());
-    simpleSampledSpansProcessor.onEndSync(spanSdk);
+    simpleSampledSpansProcessor.onEndSync(readableSpan);
     verifyZeroInteractions(spanExporter);
   }
 
   @Test
   public void onEndSync_ExporterReturnError() {
-    when(spanSdk.getContext()).thenReturn(SAMPLED_SPAN_CONTEXT);
-    when(spanSdk.toSpanProto())
+    when(readableSpan.getContext()).thenReturn(SAMPLED_SPAN_CONTEXT);
+    when(readableSpan.toSpanProto())
         .thenReturn(Span.getDefaultInstance())
         .thenReturn(Span.getDefaultInstance())
         .thenThrow(new RuntimeException());
@@ -101,9 +101,9 @@ public class SimpleSampledSpansProcessorTest {
         .doNothing()
         .when(spanExporter)
         .export(ArgumentMatchers.<Span>anyList());
-    simpleSampledSpansProcessor.onEndSync(spanSdk);
+    simpleSampledSpansProcessor.onEndSync(readableSpan);
     // Try again, now will no longer return error.
-    simpleSampledSpansProcessor.onEndSync(spanSdk);
+    simpleSampledSpansProcessor.onEndSync(readableSpan);
     verify(spanExporter, times(2)).export(Collections.singletonList(Span.getDefaultInstance()));
   }
 


### PR DESCRIPTION
This allows to use the SpanProcessor and exporters with SpanData or other source of Spans (not only via the Span object from the API).