### PR TITLE
Add support to install SpanProcessor and an InMemorySpanExporter for tests.

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -68,6 +68,7 @@ class SpanBuilderSdk implements Span.Builder {
   @Override
   public Span.Builder setParent(SpanContext remoteParent) {
     this.remoteParent = Utils.checkNotNull(remoteParent, "remoteParent");
+    this.parent = null;
     this.parentType = ParentType.EXPLICIT_REMOTE_PARENT;
     return this;
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -61,7 +61,7 @@ class SpanBuilderSdk implements Span.Builder {
   public Span.Builder setParent(Span parent) {
     this.parent = Utils.checkNotNull(parent, "parent");
     this.parent = parent;
-    this.parentType = ParentType.EXPLICIT_REMOTE_PARENT;
+    this.parentType = ParentType.EXPLICIT_PARENT;
     return this;
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -75,6 +75,7 @@ class SpanBuilderSdk implements Span.Builder {
   @Override
   public Span.Builder setNoParent() {
     this.parentType = ParentType.NO_PARENT;
+    this.parent = null;
     this.remoteParent = null;
     return this;
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -59,7 +59,7 @@ class SpanBuilderSdk implements Span.Builder {
 
   @Override
   public Span.Builder setParent(Span parent) {
-    Utils.checkNotNull(parent, "remoteParent");
+    this.parent = Utils.checkNotNull(parent, "parent");
     this.parent = parent;
     this.parentType = ParentType.EXPLICIT_REMOTE_PARENT;
     return this;

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -60,7 +60,7 @@ class SpanBuilderSdk implements Span.Builder {
   @Override
   public Span.Builder setParent(Span parent) {
     this.parent = Utils.checkNotNull(parent, "parent");
-    this.parent = parent;
+    this.remoteParent = null;
     this.parentType = ParentType.EXPLICIT_PARENT;
     return this;
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/InMemorySpanExporter.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/InMemorySpanExporter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.trace.export;
+
+import io.opentelemetry.proto.trace.v1.Span;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class InMemorySpanExporter implements SpanExporter {
+  private final List<Span> finishedSpanDataItems = new ArrayList<>();
+
+  /**
+   * Returns a {@code List} of the finished {@code Span}s, represented by {@code
+   * io.opentelemetry.proto.trace.v1.Span}.
+   */
+  public List<Span> getFinishedSpanItems() {
+    synchronized (this) {
+      return Collections.unmodifiableList(new ArrayList<>(finishedSpanDataItems));
+    }
+  }
+
+  /** Clears the internal {@code List} of finished {@code Span}s. */
+  public void reset() {
+    synchronized (this) {
+      finishedSpanDataItems.clear();
+    }
+  }
+
+  @Override
+  public void export(List<Span> spans) {
+    synchronized (this) {
+      finishedSpanDataItems.addAll(spans);
+    }
+  }
+
+  @Override
+  public void shutdown() {
+    synchronized (this) {
+      finishedSpanDataItems.clear();
+    }
+  }
+}

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/InMemorySpanExporterTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/InMemorySpanExporterTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.trace.export;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.opentelemetry.sdk.trace.TracerSdk;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link InMemorySpanExporter}. */
+@RunWith(JUnit4.class)
+public class InMemorySpanExporterTest {
+  private final TracerSdk tracer = new TracerSdk();
+  private final InMemorySpanExporter exporter = new InMemorySpanExporter();
+
+  @Before
+  public void setup() {
+    tracer.addSpanProcessor(SimpleSampledSpansProcessor.newBuilder(exporter).build());
+  }
+
+  @Test
+  public void getFinishedSpanDataItems() {
+    tracer.spanBuilder("one").startSpan().end();
+    tracer.spanBuilder("two").startSpan().end();
+    tracer.spanBuilder("three").startSpan().end();
+
+    List<io.opentelemetry.proto.trace.v1.Span> spanItems = exporter.getFinishedSpanItems();
+    assertThat(spanItems).isNotNull();
+    assertThat(spanItems.size()).isEqualTo(3);
+    assertThat(spanItems.get(0).getName().getValue()).isEqualTo("one");
+    assertThat(spanItems.get(1).getName().getValue()).isEqualTo("two");
+    assertThat(spanItems.get(2).getName().getValue()).isEqualTo("three");
+  }
+
+  @Test
+  public void reset() {
+    tracer.spanBuilder("one").startSpan().end();
+    tracer.spanBuilder("two").startSpan().end();
+    tracer.spanBuilder("three").startSpan().end();
+    List<io.opentelemetry.proto.trace.v1.Span> spanItems = exporter.getFinishedSpanItems();
+    assertThat(spanItems).isNotNull();
+    assertThat(spanItems.size()).isEqualTo(3);
+    // Reset then expect no items in memory.
+    exporter.reset();
+    spanItems = exporter.getFinishedSpanItems();
+    assertThat(spanItems).isEmpty();
+  }
+}


### PR DESCRIPTION
Implemented support for InMemorySpanExporter, this PR cannot be merged until the SpanBuilderSdk is not finalized (just a hacky implementation for the moment to prove that everything works e2e).

Updates https://github.com/open-telemetry/opentelemetry-java/issues/277
