### PR TITLE
Change DistributedContextSdk.Builder to use current dctx as implicit parent

### DIFF
--- a/api/src/main/java/io/opentelemetry/distributedcontext/DistributedContext.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/DistributedContext.java
@@ -57,9 +57,9 @@ public interface DistributedContext {
    */
   interface Builder {
     /**
-     * Sets the parent {@link DistributedContext} to use. If not set, the value of {@link
-     * DistributedContextManager#getCurrentContext()} at {@link #build()} time will be used as
-     * parent.
+     * Sets the parent {@link DistributedContext} to use. If no parent (or {@code null}) is
+     * provided, the value of {@link DistributedContextManager#getCurrentContext()} at {@link
+     * #build()} time will be used as parent, unless {@link #setNoParent()} was called.
      *
      * <p>This <b>must</b> be used to create a {@link DistributedContext} when manual Context
      * propagation is used.
@@ -75,7 +75,10 @@ public interface DistributedContext {
     Builder setParent(DistributedContext parent);
 
     /**
-     * Sets the option to become a root {@link DistributedContext} with no parent.
+     * Sets the option to become a root {@link DistributedContext} with no parent. If <b>not</b>
+     * called, the value provided using {@link #setParent(DistributedContext)} or otherwise {@link
+     * DistributedContextManager#getCurrentContext()} at {@link #build()} time will be used as
+     * parent.
      *
      * @return this.
      * @since 0.1.0

--- a/api/src/main/java/io/opentelemetry/distributedcontext/DistributedContext.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/DistributedContext.java
@@ -57,16 +57,16 @@ public interface DistributedContext {
    */
   interface Builder {
     /**
-     * Sets the parent {@link DistributedContext} to use. If no parent (or {@code null}) is
-     * provided, the value of {@link DistributedContextManager#getCurrentContext()} at {@link
-     * #build()} time will be used as parent, unless {@link #setNoParent()} was called.
+     * Sets the parent {@link DistributedContext} to use. If no parent is provided, the value of
+     * {@link DistributedContextManager#getCurrentContext()} at {@link #build()} time will be used
+     * as parent, unless {@link #setNoParent()} was called.
      *
      * <p>This <b>must</b> be used to create a {@link DistributedContext} when manual Context
      * propagation is used.
      *
      * <p>If called multiple times, only the last specified value will be used.
      *
-     * @param parent the {@link DistributedContext} used as parent.
+     * @param parent the {@link DistributedContext} used as parent, not null.
      * @return this.
      * @throws NullPointerException if {@code parent} is {@code null}.
      * @see #setNoParent()

--- a/api/src/main/java/io/opentelemetry/distributedcontext/DistributedContext.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/DistributedContext.java
@@ -75,9 +75,7 @@ public interface DistributedContext {
     Builder setParent(DistributedContext parent);
 
     /**
-     * Sets the option to become a {@link DistributedContext} with no parent. If not set, the value
-     * of {@link DistributedContextManager#getCurrentContext()} at {@link #build()} time will be
-     * used as parent.
+     * Sets the option to become a root {@link DistributedContext} with no parent.
      *
      * @return this.
      * @since 0.1.0

--- a/api/src/test/java/io/opentelemetry/distributedcontext/DefaultDistributedContextManagerTest.java
+++ b/api/src/test/java/io/opentelemetry/distributedcontext/DefaultDistributedContextManagerTest.java
@@ -135,7 +135,7 @@ public final class DefaultDistributedContextManagerTest {
   }
 
   @Test
-  public void noopContextBuilder_SetParent_DisallowsNullKey() {
+  public void noopContextBuilder_SetParent_DisallowsNullParent() {
     DistributedContext.Builder noopBuilder = defaultDistributedContextManager.contextBuilder();
     thrown.expect(NullPointerException.class);
     noopBuilder.setParent(null);

--- a/sdk/src/main/java/io/opentelemetry/sdk/distributedcontext/DistributedContextSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/distributedcontext/DistributedContextSdk.java
@@ -112,6 +112,7 @@ class DistributedContextSdk implements DistributedContext {
   // @AutoValue.Builder
   static class Builder implements DistributedContext.Builder {
     @Nullable private DistributedContext parent;
+    private boolean noImplicitParent;
     private final Map<EntryKey, Entry> entries;
 
     /** Create a new empty DistributedContext builder. */
@@ -127,7 +128,8 @@ class DistributedContextSdk implements DistributedContext {
 
     @Override
     public DistributedContext.Builder setNoParent() {
-      parent = null;
+      this.parent = null;
+      noImplicitParent = true;
       return this;
     }
 
@@ -152,7 +154,7 @@ class DistributedContextSdk implements DistributedContext {
 
     @Override
     public DistributedContextSdk build() {
-      if (parent == null) {
+      if (parent == null && !noImplicitParent) {
         parent = OpenTelemetry.getDistributedContextManager().getCurrentContext();
       }
       return new DistributedContextSdk(entries, parent);

--- a/sdk/src/main/java/io/opentelemetry/sdk/distributedcontext/DistributedContextSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/distributedcontext/DistributedContextSdk.java
@@ -18,6 +18,7 @@ package io.opentelemetry.sdk.distributedcontext;
 
 import static io.opentelemetry.internal.Utils.checkNotNull;
 
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.distributedcontext.DistributedContext;
 import io.opentelemetry.distributedcontext.Entry;
 import io.opentelemetry.distributedcontext.EntryKey;
@@ -151,7 +152,9 @@ class DistributedContextSdk implements DistributedContext {
 
     @Override
     public DistributedContextSdk build() {
-      // TODO if (parent == null) parent = DistributedContextManager.getCurrentContext();
+      if (parent == null) {
+        parent = OpenTelemetry.getDistributedContextManager().getCurrentContext();
+      }
       return new DistributedContextSdk(entries, parent);
     }
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/distributedcontext/DistributedContextSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/distributedcontext/DistributedContextSdk.java
@@ -24,6 +24,7 @@ import io.opentelemetry.distributedcontext.Entry;
 import io.opentelemetry.distributedcontext.EntryKey;
 import io.opentelemetry.distributedcontext.EntryMetadata;
 import io.opentelemetry.distributedcontext.EntryValue;
+import io.opentelemetry.internal.Utils;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -122,7 +123,7 @@ class DistributedContextSdk implements DistributedContext {
 
     @Override
     public DistributedContext.Builder setParent(DistributedContext parent) {
-      this.parent = parent;
+      this.parent = Utils.checkNotNull(parent, "parent");
       return this;
     }
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/distributedcontext/DistributedContextSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/distributedcontext/DistributedContextSdkTest.java
@@ -128,9 +128,8 @@ public class DistributedContextSdkTest {
   @Test
   public void setParent_nullValue() {
     DistributedContextSdk parent = listToDistributedContext(T1);
-    DistributedContext distContext =
-        contextManager.contextBuilder().setParent(parent).setParent(null).build();
-    assertThat(distContext.getEntries()).isEmpty();
+    thrown.expect(NullPointerException.class);
+    contextManager.contextBuilder().setParent(parent).setParent(null).build();
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/distributedcontext/ScopedDistributedContextTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/distributedcontext/ScopedDistributedContextTest.java
@@ -78,7 +78,6 @@ public class ScopedDistributedContextTest {
       DistributedContext newEntries =
           contextManager
               .contextBuilder()
-              .setParent(contextManager.getCurrentContext())
               .put(KEY_2, VALUE_2, METADATA_UNLIMITED_PROPAGATION)
               .build();
       assertThat(newEntries.getEntries())
@@ -110,7 +109,6 @@ public class ScopedDistributedContextTest {
       DistributedContext innerDistContext =
           contextManager
               .contextBuilder()
-              .setParent(contextManager.getCurrentContext())
               .put(KEY_2, VALUE_2, METADATA_UNLIMITED_PROPAGATION)
               .build();
       try (Scope scope2 = contextManager.withContext(innerDistContext)) {
@@ -136,7 +134,6 @@ public class ScopedDistributedContextTest {
       DistributedContext innerDistContext =
           contextManager
               .contextBuilder()
-              .setParent(contextManager.getCurrentContext())
               .put(KEY_3, VALUE_3, METADATA_NO_PROPAGATION)
               .put(KEY_2, VALUE_4, METADATA_NO_PROPAGATION)
               .build();

--- a/sdk/src/test/java/io/opentelemetry/sdk/distributedcontext/ScopedDistributedContextTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/distributedcontext/ScopedDistributedContextTest.java
@@ -148,4 +148,22 @@ public class ScopedDistributedContextTest {
       assertThat(contextManager.getCurrentContext()).isSameInstanceAs(scopedDistContext);
     }
   }
+
+  @Test
+  public void setNoParent_doesNotInheritContext() {
+    assertThat(distContextToList(contextManager.getCurrentContext())).isEmpty();
+    DistributedContext scopedDistContext =
+        contextManager.contextBuilder().put(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION).build();
+    try (Scope scope = contextManager.withContext(scopedDistContext)) {
+      DistributedContext innerDistContext =
+          contextManager
+              .contextBuilder()
+              .setNoParent()
+              .put(KEY_2, VALUE_2, METADATA_UNLIMITED_PROPAGATION)
+              .build();
+      assertThat(distContextToList(innerDistContext))
+          .containsExactly(Entry.create(KEY_2, VALUE_2, METADATA_UNLIMITED_PROPAGATION));
+    }
+    assertThat(distContextToList(contextManager.getCurrentContext())).isEmpty();
+  }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/distributedcontext/ScopedDistributedContextTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/distributedcontext/ScopedDistributedContextTest.java
@@ -151,7 +151,7 @@ public class ScopedDistributedContextTest {
 
   @Test
   public void setNoParent_doesNotInheritContext() {
-    assertThat(distContextToList(contextManager.getCurrentContext())).isEmpty();
+    assertThat(contextManager.getCurrentContext().getEntries()).isEmpty();
     DistributedContext scopedDistContext =
         contextManager.contextBuilder().put(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION).build();
     try (Scope scope = contextManager.withContext(scopedDistContext)) {
@@ -161,9 +161,9 @@ public class ScopedDistributedContextTest {
               .setNoParent()
               .put(KEY_2, VALUE_2, METADATA_UNLIMITED_PROPAGATION)
               .build();
-      assertThat(distContextToList(innerDistContext))
+      assertThat(innerDistContext.getEntries())
           .containsExactly(Entry.create(KEY_2, VALUE_2, METADATA_UNLIMITED_PROPAGATION));
     }
-    assertThat(distContextToList(contextManager.getCurrentContext())).isEmpty();
+    assertThat(contextManager.getCurrentContext().getEntries()).isEmpty();
   }
 }


### PR DESCRIPTION
Fixes #436

API definition:
https://github.com/open-telemetry/opentelemetry-java/blob/ed42237b6c71052bbffe4d849647c53fae81b246/api/src/main/java/io/opentelemetry/distributedcontext/DistributedContext.java#L57-L61