### PR TITLE
Remove TruncatableString from proto to sync with ot-proto.

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanImpl.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanImpl.java
@@ -20,7 +20,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.EvictingQueue;
 import com.google.protobuf.UInt32Value;
-import io.opentelemetry.proto.trace.v1.TruncatableString;
 import io.opentelemetry.resources.Resource;
 import io.opentelemetry.sdk.internal.Clock;
 import io.opentelemetry.sdk.internal.TimestampConverter;
@@ -173,7 +172,7 @@ final class RecordEventsReadableSpanImpl implements ReadableSpan, Span {
               .setSpanId(TraceProtoUtils.toProtoSpanId(context.getSpanId()))
               .setTracestate(TraceProtoUtils.toProtoTracestate(context.getTracestate()))
               .setResource(TraceProtoUtils.toProtoResource(resource))
-              .setName(TruncatableString.newBuilder().setValue(name).build())
+              .setName(name)
               .setKind(TraceProtoUtils.toProtoKind(kind))
               .setStartTime(timestampConverter.convertNanoTime(startNanoTime))
               .setEndTime(timestampConverter.convertNanoTime(getEndNanoTime()))

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TraceProtoUtils.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TraceProtoUtils.java
@@ -23,7 +23,6 @@ import io.opentelemetry.proto.trace.v1.Span.Attributes;
 import io.opentelemetry.proto.trace.v1.Span.Links;
 import io.opentelemetry.proto.trace.v1.Span.SpanKind;
 import io.opentelemetry.proto.trace.v1.Span.TimedEvents;
-import io.opentelemetry.proto.trace.v1.TruncatableString;
 import io.opentelemetry.resources.Resource;
 import io.opentelemetry.sdk.internal.TimestampConverter;
 import io.opentelemetry.trace.AttributeValue;
@@ -113,8 +112,7 @@ final class TraceProtoUtils {
         builder.setIntValue(attributeValue.getLongValue());
         break;
       case STRING:
-        builder.setStringValue(
-            TruncatableString.newBuilder().setValue(attributeValue.getStringValue()).build());
+        builder.setStringValue(attributeValue.getStringValue());
     }
     return builder.build();
   }
@@ -135,7 +133,7 @@ final class TraceProtoUtils {
     builder.setTime(converter.convertNanoTime(timedEvent.getNanotime()));
     builder.setEvent(
         Span.TimedEvent.Event.newBuilder()
-            .setName(TruncatableString.newBuilder().setValue(timedEvent.getName()).build())
+            .setName(timedEvent.getName())
             .setAttributes(toProtoAttributes(timedEvent.getAttributes(), 0))
             .build());
     return builder.build();

--- a/sdk/src/main/proto/trace/v1/trace.proto
+++ b/sdk/src/main/proto/trace/v1/trace.proto
@@ -100,7 +100,7 @@ message Span {
   // receiver to fix the empty span name.
   //
   // This field is required.
-  TruncatableString name = 6;
+  string name = 6;
 
   // Type of span. Can be used to specify additional relationships between spans
   // in addition to a parent/child relationship.
@@ -189,7 +189,7 @@ message Span {
     // A text annotation with a set of attributes.
     message Event {
       // A user-supplied name describing the event.
-      TruncatableString name = 1;
+      string name = 1;
 
       // A set of attributes on the event.
       Attributes attributes = 2;
@@ -275,7 +275,7 @@ message AttributeValue {
   // The type of the value.
   oneof value {
     // A string up to 256 bytes long.
-    TruncatableString string_value = 1;
+    string string_value = 1;
     // A 64-bit signed integer.
     int64 int_value = 2;
     // A Boolean value represented by `true` or `false`.
@@ -283,19 +283,4 @@ message AttributeValue {
     // A double value.
     double double_value = 4;
   }
-}
-
-// A string that might be shortened to a specified length.
-message TruncatableString {
-  // The shortened string. For example, if the original string was 500 bytes long and
-  // the limit of the string was 128 bytes, then this value contains the first 128
-  // bytes of the 500-byte string. Note that truncation always happens on a
-  // character boundary, to ensure that a truncated string is still valid UTF-8.
-  // Because it may contain multi-byte characters, the size of the truncated string
-  // may be less than the truncation limit.
-  string value = 1;
-
-  // The number of bytes removed from the original string. If this
-  // value is 0, then the string was not shortened.
-  int32 truncated_byte_count = 2;
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TraceProtoUtilsTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TraceProtoUtilsTest.java
@@ -27,7 +27,6 @@ import io.opentelemetry.proto.trace.v1.Span.Attributes;
 import io.opentelemetry.proto.trace.v1.Span.Links;
 import io.opentelemetry.proto.trace.v1.Span.SpanKind;
 import io.opentelemetry.proto.trace.v1.Span.TimedEvents;
-import io.opentelemetry.proto.trace.v1.TruncatableString;
 import io.opentelemetry.resources.Resource;
 import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.internal.TimestampConverter;
@@ -150,7 +149,7 @@ public class TraceProtoUtilsTest {
                     .setEvent(
                         Span.TimedEvent.Event.newBuilder()
                             .setAttributes(Attributes.getDefaultInstance())
-                            .setName(TruncatableString.newBuilder().setValue("event"))))
+                            .setName("event")))
             .build();
     assertThat(
             TraceProtoUtils.toProtoTimedEvents(

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/InMemorySpanExporterTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/InMemorySpanExporterTest.java
@@ -45,9 +45,9 @@ public class InMemorySpanExporterTest {
     List<io.opentelemetry.proto.trace.v1.Span> spanItems = exporter.getFinishedSpanItems();
     assertThat(spanItems).isNotNull();
     assertThat(spanItems.size()).isEqualTo(3);
-    assertThat(spanItems.get(0).getName().getValue()).isEqualTo("one");
-    assertThat(spanItems.get(1).getName().getValue()).isEqualTo("two");
-    assertThat(spanItems.get(2).getName().getValue()).isEqualTo("three");
+    assertThat(spanItems.get(0).getName()).isEqualTo("one");
+    assertThat(spanItems.get(1).getName()).isEqualTo("two");
+    assertThat(spanItems.get(2).getName()).isEqualTo("three");
   }
 
   @Test


### PR DESCRIPTION
Fixes a bunch of places where Spans are created but not ended in tests. This is a good practice because test code will definitely be copied by others.