### PR TITLE
Return DefaultSpan if not recording events. Implement TracerSdk.shutdown().

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
@@ -46,13 +46,17 @@ public final class DefaultSpan implements Span {
   }
 
   /**
-   * Creates an instance of this class.
+   * Creates an instance of this class with the {@link SpanContext}.
    *
-   * <p>Each instance will have unique and valid {@link TraceId} and {@link SpanId}.
-   *
+   * @param spanContext the {@code SpanContext}.
    * @return a {@link DefaultSpan}.
+   * @since 0.1.0
    */
-  static DefaultSpan create() {
+  public static DefaultSpan create(SpanContext spanContext) {
+    return new DefaultSpan(spanContext);
+  }
+
+  static DefaultSpan createRandom() {
     return new DefaultSpan(
         SpanContext.create(
             TraceId.generateRandomId(random),

--- a/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
@@ -95,7 +95,7 @@ public final class DefaultTracer implements Tracer {
 
       return spanContext != null && !SpanContext.getInvalid().equals(spanContext)
           ? new DefaultSpan(spanContext)
-          : DefaultSpan.create();
+          : DefaultSpan.createRandom();
     }
 
     @Override

--- a/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
@@ -28,22 +28,22 @@ import org.junit.runners.JUnit4;
 public class DefaultSpanTest {
   @Test
   public void hasInvalidContextAndDefaultSpanOptions() {
-    SpanContext context = DefaultSpan.create().getContext();
+    SpanContext context = DefaultSpan.createRandom().getContext();
     assertThat(context.getTraceOptions()).isEqualTo(TraceOptions.getDefault());
     assertThat(context.getTracestate()).isEqualTo(Tracestate.getDefault());
   }
 
   @Test
   public void hasUniqueTraceIdAndSpanId() {
-    DefaultSpan span1 = DefaultSpan.create();
-    DefaultSpan span2 = DefaultSpan.create();
+    DefaultSpan span1 = DefaultSpan.createRandom();
+    DefaultSpan span2 = DefaultSpan.createRandom();
     assertThat(span1.getContext().getTraceId()).isNotEqualTo(span2.getContext().getTraceId());
     assertThat(span1.getContext().getSpanId()).isNotEqualTo(span2.getContext().getSpanId());
   }
 
   @Test
   public void doNotCrash() {
-    DefaultSpan span = DefaultSpan.create();
+    DefaultSpan span = DefaultSpan.createRandom();
     span.setAttribute(
         "MyStringAttributeKey", AttributeValue.stringAttributeValue("MyStringAttributeValue"));
     span.setAttribute("MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true));
@@ -63,7 +63,7 @@ public class DefaultSpanTest {
 
   @Test
   public void defaultSpan_ToString() {
-    DefaultSpan span = DefaultSpan.create();
+    DefaultSpan span = DefaultSpan.createRandom();
     assertThat(span.toString()).isEqualTo("DefaultSpan");
   }
 }

--- a/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
@@ -52,7 +52,7 @@ public class DefaultTracerTest {
   @Test
   public void getCurrentSpan_WithSpan() {
     assertThat(defaultTracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
-    Scope ws = defaultTracer.withSpan(DefaultSpan.create());
+    Scope ws = defaultTracer.withSpan(DefaultSpan.createRandom());
     try {
       assertThat(defaultTracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
     } finally {

--- a/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
@@ -37,8 +37,8 @@ public class SpanBuilderTest {
     spanBuilder.setRecordEvents(true);
     spanBuilder.setSampler(Samplers.alwaysSample());
     spanBuilder.setSpanKind(Kind.SERVER);
-    spanBuilder.setParent(DefaultSpan.create());
-    spanBuilder.setParent(DefaultSpan.create().getContext());
+    spanBuilder.setParent(DefaultSpan.createRandom());
+    spanBuilder.setParent(DefaultSpan.createRandom().getContext());
     spanBuilder.setNoParent();
     assertThat(spanBuilder.startSpan()).isInstanceOf(DefaultSpan.class);
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -55,7 +55,6 @@ class SpanBuilderSdk implements Span.Builder {
   private final SpanProcessor spanProcessor;
   private final TraceConfig traceConfig;
   private final Resource resource;
-  private final boolean isStopped;
 
   private final Clock clock;
   // TODO change with ThreadLocal version
@@ -76,8 +75,7 @@ class SpanBuilderSdk implements Span.Builder {
       TraceConfig traceConfig,
       Resource resource,
       Random random,
-      Clock clock,
-      boolean isStopped) {
+      Clock clock) {
     this.spanName = spanName;
     this.spanProcessor = spanProcessor;
     this.traceConfig = traceConfig;
@@ -85,7 +83,6 @@ class SpanBuilderSdk implements Span.Builder {
     this.sampler = traceConfig.getSampler();
     this.random = random;
     this.clock = clock;
-    this.isStopped = isStopped;
   }
 
   @Override
@@ -186,7 +183,7 @@ class SpanBuilderSdk implements Span.Builder {
             samplingDecision.isSampled() ? TRACE_OPTIONS_SAMPLED : TRACE_OPTIONS_NOT_SAMPLED,
             tracestate);
 
-    if (isStopped || (!recordEvents && !samplingDecision.isSampled())) {
+    if (!recordEvents && !samplingDecision.isSampled()) {
       return DefaultSpan.create(spanContext);
     }
     TimestampConverter timestampConverter = getTimestampConverter(parent);

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -22,6 +22,7 @@ import io.opentelemetry.sdk.internal.Clock;
 import io.opentelemetry.sdk.internal.TimestampConverter;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.trace.AttributeValue;
+import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Link;
 import io.opentelemetry.trace.Sampler;
 import io.opentelemetry.trace.Sampler.Decision;
@@ -66,10 +67,7 @@ class SpanBuilderSdk implements Span.Builder {
   @Nullable private List<Link> links;
   private Sampler sampler;
   private ParentType parentType = ParentType.CURRENT_SPAN;
-  // TODO when true return default span
-  // https://github.com/open-telemetry/opentelemetry-java/issues/438
-  @SuppressWarnings("unused")
-  private boolean recordEvents;
+  private boolean recordEvents = true;
 
   SpanBuilderSdk(
       String spanName,
@@ -150,7 +148,7 @@ class SpanBuilderSdk implements Span.Builder {
 
   @Override
   public Span.Builder setRecordEvents(boolean recordEvents) {
-    this.recordEvents = true;
+    this.recordEvents = recordEvents;
     return this;
   }
 
@@ -185,9 +183,10 @@ class SpanBuilderSdk implements Span.Builder {
             samplingDecision.isSampled() ? TRACE_OPTIONS_SAMPLED : TRACE_OPTIONS_NOT_SAMPLED,
             tracestate);
 
+    if (!recordEvents) {
+      return DefaultSpan.create(spanContext);
+    }
     TimestampConverter timestampConverter = getTimestampConverter(parent);
-    // TODO return DefaultSpan if not recording events
-    // https://github.com/open-telemetry/opentelemetry-java/issues/438
     return RecordEventsReadableSpanImpl.startSpan(
         spanContext,
         spanName,

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -67,7 +67,7 @@ class SpanBuilderSdk implements Span.Builder {
   @Nullable private List<Link> links;
   private Sampler sampler;
   private ParentType parentType = ParentType.CURRENT_SPAN;
-  private boolean recordEvents = true;
+  private boolean recordEvents = false;
 
   SpanBuilderSdk(
       String spanName,
@@ -183,7 +183,7 @@ class SpanBuilderSdk implements Span.Builder {
             samplingDecision.isSampled() ? TRACE_OPTIONS_SAMPLED : TRACE_OPTIONS_NOT_SAMPLED,
             tracestate);
 
-    if (!recordEvents) {
+    if (!recordEvents && !samplingDecision.isSampled()) {
       return DefaultSpan.create(spanContext);
     }
     TimestampConverter timestampConverter = getTimestampConverter(parent);

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -55,6 +55,7 @@ class SpanBuilderSdk implements Span.Builder {
   private final SpanProcessor spanProcessor;
   private final TraceConfig traceConfig;
   private final Resource resource;
+  private final boolean isStopped;
 
   private final Clock clock;
   // TODO change with ThreadLocal version
@@ -75,7 +76,8 @@ class SpanBuilderSdk implements Span.Builder {
       TraceConfig traceConfig,
       Resource resource,
       Random random,
-      Clock clock) {
+      Clock clock,
+      boolean isStopped) {
     this.spanName = spanName;
     this.spanProcessor = spanProcessor;
     this.traceConfig = traceConfig;
@@ -83,6 +85,7 @@ class SpanBuilderSdk implements Span.Builder {
     this.sampler = traceConfig.getSampler();
     this.random = random;
     this.clock = clock;
+    this.isStopped = isStopped;
   }
 
   @Override
@@ -183,7 +186,7 @@ class SpanBuilderSdk implements Span.Builder {
             samplingDecision.isSampled() ? TRACE_OPTIONS_SAMPLED : TRACE_OPTIONS_NOT_SAMPLED,
             tracestate);
 
-    if (!recordEvents && !samplingDecision.isSampled()) {
+    if (isStopped || (!recordEvents && !samplingDecision.isSampled())) {
       return DefaultSpan.create(spanContext);
     }
     TimestampConverter timestampConverter = getTimestampConverter(parent);

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.sdk.trace;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.BinaryFormat;
 import io.opentelemetry.context.propagation.BinaryTraceContext;
@@ -34,10 +35,14 @@ import io.opentelemetry.trace.unsafe.ContextUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.concurrent.GuardedBy;
 
 /** {@link TracerSdk} is SDK implementation of {@link Tracer}. */
 public class TracerSdk implements Tracer {
+  private static final Logger logger = Logger.getLogger(TracerSdk.class.getName());
+
   private static final BinaryFormat<SpanContext> BINARY_FORMAT = new BinaryTraceContext();
   private static final HttpTextFormat<SpanContext> HTTP_TEXT_FORMAT = new HttpTraceContext();
   private final Clock clock = MillisClock.getInstance();
@@ -52,6 +57,9 @@ public class TracerSdk implements Tracer {
   @GuardedBy("this")
   private final List<SpanProcessor> registeredSpanProcessors = new ArrayList<>();
 
+  @GuardedBy("this")
+  private boolean isStopped = false;
+
   @Override
   public Span getCurrentSpan() {
     return ContextUtils.getValue();
@@ -64,8 +72,15 @@ public class TracerSdk implements Tracer {
 
   @Override
   public Span.Builder spanBuilder(String spanName) {
-    return new SpanBuilderSdk(
-        spanName, activeSpanProcessor, activeTraceConfig, resource, random, clock);
+    SpanBuilderSdk builderSdk =
+        new SpanBuilderSdk(
+            spanName, activeSpanProcessor, activeTraceConfig, resource, random, clock);
+    synchronized (this) {
+      if (isStopped) {
+        builderSdk.setRecordEvents(false);
+      }
+    }
+    return builderSdk;
   }
 
   @Override
@@ -92,7 +107,26 @@ public class TracerSdk implements Tracer {
    *
    * <p>After this is called all the newly created {@code Span}s will be no-op.
    */
-  public void shutdown() {}
+  public void shutdown() {
+    synchronized (this) {
+      if (isStopped) {
+        logger.log(Level.WARNING, "Calling shutdown() multiple times.");
+        return;
+      }
+      for (SpanProcessor spanProcessor : registeredSpanProcessors) {
+        spanProcessor.shutdown();
+      }
+      isStopped = true;
+    }
+  }
+
+  // Restarts all the activity for this Tracer. Only used for unit testing.
+  @VisibleForTesting
+  void unsafeRestart() {
+    synchronized (this) {
+      isStopped = false;
+    }
+  }
 
   /**
    * Returns the active {@code TraceConfig}.

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
@@ -32,7 +32,6 @@ import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanData;
 import io.opentelemetry.trace.Tracer;
 import io.opentelemetry.trace.unsafe.ContextUtils;
-import io.opentelemetry.trace.util.Samplers;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -72,13 +71,8 @@ public class TracerSdk implements Tracer {
 
   @Override
   public Span.Builder spanBuilder(String spanName) {
-    SpanBuilderSdk builderSdk =
-        new SpanBuilderSdk(
-            spanName, activeSpanProcessor, activeTraceConfig, resource, random, clock);
-    if (isStopped) {
-      builderSdk.setRecordEvents(false).setSampler(Samplers.neverSample());
-    }
-    return builderSdk;
+    return new SpanBuilderSdk(
+        spanName, activeSpanProcessor, activeTraceConfig, resource, random, clock, isStopped);
   }
 
   @Override

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -109,6 +109,22 @@ public class SpanBuilderSdkTest {
   }
 
   @Test
+  public void notSampledButRecordingEvents() {
+    Span span =
+        tracer
+            .spanBuilder(SPAN_NAME)
+            .setSampler(Samplers.neverSample())
+            .setRecordEvents(true)
+            .startSpan();
+    try {
+      assertThat(span.getContext().getTraceOptions().isSampled()).isFalse();
+      assertThat(span.isRecordingEvents()).isTrue();
+    } finally {
+      span.end();
+    }
+  }
+
+  @Test
   public void kind_default() {
     RecordEventsReadableSpanImpl span =
         (RecordEventsReadableSpanImpl) tracer.spanBuilder(SPAN_NAME).startSpan();

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -90,8 +90,7 @@ public class SpanBuilderSdkTest {
 
   @Test
   public void recordEvents_default() {
-    RecordEventsReadableSpanImpl span =
-        (RecordEventsReadableSpanImpl) tracer.spanBuilder(SPAN_NAME).startSpan();
+    Span span = tracer.spanBuilder(SPAN_NAME).startSpan();
     try {
       assertThat(span.isRecordingEvents()).isTrue();
     } finally {
@@ -101,9 +100,7 @@ public class SpanBuilderSdkTest {
 
   @Test
   public void recordEvents_neverSample() {
-    RecordEventsReadableSpanImpl span =
-        (RecordEventsReadableSpanImpl)
-            tracer.spanBuilder(SPAN_NAME).setSampler(Samplers.neverSample()).startSpan();
+    Span span = tracer.spanBuilder(SPAN_NAME).setSampler(Samplers.neverSample()).startSpan();
     try {
       assertThat(span.getContext().getTraceOptions().isSampled()).isFalse();
     } finally {
@@ -136,9 +133,8 @@ public class SpanBuilderSdkTest {
 
   @Test
   public void sampler() {
-    RecordEventsReadableSpanImpl span =
-        (RecordEventsReadableSpanImpl)
-            tracer.spanBuilder(SPAN_NAME).setSampler(Samplers.neverSample()).startSpan();
+    Span span = tracer.spanBuilder(SPAN_NAME).setSampler(Samplers.neverSample()).startSpan();
+
     try {
       assertThat(span.getContext().getTraceOptions().isSampled()).isFalse();
     } finally {
@@ -195,23 +191,15 @@ public class SpanBuilderSdkTest {
 
   @Test
   public void noParent() {
-    RecordEventsReadableSpanImpl parent =
-        (RecordEventsReadableSpanImpl) tracer.spanBuilder(SPAN_NAME).startSpan();
+    Span parent = tracer.spanBuilder(SPAN_NAME).startSpan();
     Scope scope = tracer.withSpan(parent);
     try {
-      RecordEventsReadableSpanImpl span =
-          (RecordEventsReadableSpanImpl) tracer.spanBuilder(SPAN_NAME).setNoParent().startSpan();
+      Span span = tracer.spanBuilder(SPAN_NAME).setNoParent().startSpan();
       try {
         assertThat(span.getContext().getTraceId()).isNotEqualTo(parent.getContext().getTraceId());
 
-        RecordEventsReadableSpanImpl spanNoParent =
-            (RecordEventsReadableSpanImpl)
-                tracer
-                    .spanBuilder(SPAN_NAME)
-                    .setNoParent()
-                    .setParent(parent)
-                    .setNoParent()
-                    .startSpan();
+        Span spanNoParent =
+            tracer.spanBuilder(SPAN_NAME).setNoParent().setParent(parent).setNoParent().startSpan();
         try {
           assertThat(span.getContext().getTraceId()).isNotEqualTo(parent.getContext().getTraceId());
         } finally {
@@ -228,8 +216,7 @@ public class SpanBuilderSdkTest {
 
   @Test
   public void noParent_override() {
-    RecordEventsReadableSpanImpl parent =
-        (RecordEventsReadableSpanImpl) tracer.spanBuilder(SPAN_NAME).startSpan();
+    Span parent = tracer.spanBuilder(SPAN_NAME).startSpan();
     try {
       RecordEventsReadableSpanImpl span =
           (RecordEventsReadableSpanImpl)
@@ -262,8 +249,7 @@ public class SpanBuilderSdkTest {
 
   @Test
   public void overrideNoParent_remoteParent() {
-    RecordEventsReadableSpanImpl parent =
-        (RecordEventsReadableSpanImpl) tracer.spanBuilder(SPAN_NAME).startSpan();
+    Span parent = tracer.spanBuilder(SPAN_NAME).startSpan();
     try {
 
       RecordEventsReadableSpanImpl span =
@@ -288,8 +274,7 @@ public class SpanBuilderSdkTest {
 
   @Test
   public void parentCurrentSpan() {
-    RecordEventsReadableSpanImpl parent =
-        (RecordEventsReadableSpanImpl) tracer.spanBuilder(SPAN_NAME).startSpan();
+    Span parent = tracer.spanBuilder(SPAN_NAME).startSpan();
     Scope scope = tracer.withSpan(parent);
     try {
       RecordEventsReadableSpanImpl span =

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -134,4 +134,26 @@ public class TracerSdkTest {
     tracer.updateActiveTraceConfig(newConfig);
     assertThat(tracer.getActiveTraceConfig()).isEqualTo(newConfig);
   }
+
+  @Test
+  public void shutdown() {
+    try {
+      tracer.shutdown();
+      Mockito.verify(spanProcessor, Mockito.times(1)).shutdown();
+    } finally {
+      tracer.unsafeRestart();
+    }
+  }
+
+  @Test
+  public void returnNoopSpanAfterShutdown() {
+    try {
+      tracer.shutdown();
+      Span span = tracer.spanBuilder("span").startSpan();
+      assertThat(span).isInstanceOf(DefaultSpan.class);
+      span.end();
+    } finally {
+      tracer.unsafeRestart();
+    }
+  }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -149,7 +149,12 @@ public class TracerSdkTest {
   public void returnNoopSpanAfterShutdown() {
     try {
       tracer.shutdown();
-      Span span = tracer.spanBuilder("span").startSpan();
+      Span span =
+          tracer
+              .spanBuilder("span")
+              .setRecordEvents(true)
+              .setSampler(Samplers.alwaysSample())
+              .startSpan();
       assertThat(span).isInstanceOf(DefaultSpan.class);
       span.end();
     } finally {

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -146,6 +146,18 @@ public class TracerSdkTest {
   }
 
   @Test
+  public void shutdownTwice_OnlyFlushSpanProcessorOnce() {
+    try {
+      tracer.shutdown();
+      Mockito.verify(spanProcessor, Mockito.times(1)).shutdown();
+      tracer.shutdown(); // the second call will be ignored
+      Mockito.verify(spanProcessor, Mockito.times(1)).shutdown();
+    } finally {
+      tracer.unsafeRestart();
+    }
+  }
+
+  @Test
   public void returnNoopSpanAfterShutdown() {
     try {
       tracer.shutdown();


### PR DESCRIPTION
Fixes #438.
Fixes #444.