### PR TITLE
Rename TraceContextFormat to HttpTraceContext.

### DIFF
--- a/api/src/main/java/io/opentelemetry/context/propagation/HttpTraceContext.java
+++ b/api/src/main/java/io/opentelemetry/context/propagation/HttpTraceContext.java
@@ -33,7 +33,7 @@ import java.util.regex.Pattern;
  * Implementation of the TraceContext propagation protocol. See <a
  * href=https://github.com/w3c/distributed-tracing>w3c/distributed-tracing</a>.
  */
-public class TraceContextFormat implements HttpTextFormat<SpanContext> {
+public class HttpTraceContext implements HttpTextFormat<SpanContext> {
   private static final Tracestate TRACESTATE_DEFAULT = Tracestate.builder().build();
   static final String TRACEPARENT = "traceparent";
   static final String TRACESTATE = "tracestate";

--- a/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
@@ -19,7 +19,7 @@ package io.opentelemetry.trace;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.BinaryFormat;
 import io.opentelemetry.context.propagation.HttpTextFormat;
-import io.opentelemetry.context.propagation.TraceContextFormat;
+import io.opentelemetry.context.propagation.HttpTraceContext;
 import io.opentelemetry.internal.Utils;
 import io.opentelemetry.trace.unsafe.ContextUtils;
 import java.util.Map;
@@ -33,7 +33,7 @@ import javax.annotation.Nullable;
 public final class DefaultTracer implements Tracer {
   private static final DefaultTracer INSTANCE = new DefaultTracer();
   private static final BinaryFormat<SpanContext> BINARY_FORMAT = new NoopBinaryFormat();
-  private static final HttpTextFormat<SpanContext> HTTP_TEXT_FORMAT = new TraceContextFormat();
+  private static final HttpTextFormat<SpanContext> HTTP_TEXT_FORMAT = new HttpTraceContext();
 
   /**
    * Returns a {@code Tracer} singleton that is the default implementations for {@link Tracer}.

--- a/api/src/main/java/io/opentelemetry/trace/Tracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/Tracer.java
@@ -20,6 +20,7 @@ import com.google.errorprone.annotations.MustBeClosed;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.BinaryFormat;
 import io.opentelemetry.context.propagation.HttpTextFormat;
+import io.opentelemetry.context.propagation.HttpTraceContext;
 
 /**
  * Tracer is a simple, interface for {@link Span} creation and in-process context interaction.
@@ -215,8 +216,8 @@ public interface Tracer {
    * Returns the {@link HttpTextFormat} for this tracer implementation.
    *
    * <p>If no tracer implementation is provided, this defaults to the W3C Trace Context HTTP text
-   * format ({@link io.opentelemetry.context.propagation.TraceContextFormat}). For more details see
-   * <a href="https://w3c.github.io/trace-context/">W3C Trace Context</a>.
+   * format ({@link HttpTraceContext}). For more details see <a
+   * href="https://w3c.github.io/trace-context/">W3C Trace Context</a>.
    *
    * <p>Example of usage on the client:
    *

--- a/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
@@ -19,7 +19,7 @@ package io.opentelemetry.trace;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.context.propagation.TraceContextFormat;
+import io.opentelemetry.context.propagation.HttpTraceContext;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -74,7 +74,7 @@ public class DefaultTracerTest {
 
   @Test
   public void defaultHttpTextFormat() {
-    assertThat(defaultTracer.getHttpTextFormat()).isInstanceOf(TraceContextFormat.class);
+    assertThat(defaultTracer.getHttpTextFormat()).isInstanceOf(HttpTraceContext.class);
   }
 
   @Test

--- a/opentracing-shim/src/main/java/io/opentelemetry/inmemorytrace/InMemoryTracer.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/inmemorytrace/InMemoryTracer.java
@@ -20,7 +20,7 @@ import io.grpc.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.BinaryFormat;
 import io.opentelemetry.context.propagation.HttpTextFormat;
-import io.opentelemetry.context.propagation.TraceContextFormat;
+import io.opentelemetry.context.propagation.HttpTraceContext;
 import io.opentelemetry.resources.Resource;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
@@ -33,7 +33,7 @@ import java.util.List;
 // TODO - Use the Nullable annotation everywhere.
 final class InMemoryTracer implements Tracer {
   private final List<SpanData> finishedSpanDataItems = new ArrayList<>();
-  private final HttpTextFormat<SpanContext> textFormat = new TraceContextFormat();
+  private final HttpTextFormat<SpanContext> textFormat = new HttpTraceContext();
   private final Resource resource;
 
   public InMemoryTracer() {

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
@@ -20,7 +20,7 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.BinaryFormat;
 import io.opentelemetry.context.propagation.BinaryTraceContext;
 import io.opentelemetry.context.propagation.HttpTextFormat;
-import io.opentelemetry.context.propagation.TraceContextFormat;
+import io.opentelemetry.context.propagation.HttpTraceContext;
 import io.opentelemetry.resources.Resource;
 import io.opentelemetry.sdk.internal.Clock;
 import io.opentelemetry.sdk.internal.MillisClock;
@@ -38,8 +38,8 @@ import javax.annotation.concurrent.GuardedBy;
 
 /** {@link TracerSdk} is SDK implementation of {@link Tracer}. */
 public class TracerSdk implements Tracer {
-  private static final HttpTextFormat<SpanContext> HTTP_TEXT_FORMAT = new TraceContextFormat();
   private static final BinaryFormat<SpanContext> BINARY_FORMAT = new BinaryTraceContext();
+  private static final HttpTextFormat<SpanContext> HTTP_TEXT_FORMAT = new HttpTraceContext();
   private final Clock clock = MillisClock.getInstance();
   private final Random random = new Random();
   private final Resource resource = EnvVarResource.getResource();

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -21,7 +21,7 @@ import static com.google.common.truth.Truth.assertThat;
 import io.grpc.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.BinaryTraceContext;
-import io.opentelemetry.context.propagation.TraceContextFormat;
+import io.opentelemetry.context.propagation.HttpTraceContext;
 import io.opentelemetry.resources.Resource;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.trace.AttributeValue;
@@ -68,7 +68,7 @@ public class TracerSdkTest {
 
   @Test
   public void defaultHttpTextFormat() {
-    assertThat(tracer.getHttpTextFormat()).isInstanceOf(TraceContextFormat.class);
+    assertThat(tracer.getHttpTextFormat()).isInstanceOf(HttpTraceContext.class);
   }
 
   @Test


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-java/pull/446#discussion_r298641472.

Next: move HTTP and binary formats to `api.trace.propagation` to avoid circular dependency.