### PR TITLE
SDK: Ignore parent if SpanContext.isInvalid() is true.

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -162,6 +162,7 @@ class SpanBuilderSdk implements Span.Builder {
       // New root span.
       traceId = generateRandomTraceId(random);
       // This is a root span so no remote or local parent.
+      parentContext = null;
     } else {
       // New child span.
       traceId = parentContext.getTraceId();

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -327,4 +327,20 @@ public class SpanBuilderSdkTest {
       parent.end();
     }
   }
+
+  @Test
+  public void parent_invalidContext() {
+    Span parent = DefaultSpan.getInvalid();
+
+    RecordEventsReadableSpan span =
+        (RecordEventsReadableSpan)
+            tracer.spanBuilder(SPAN_NAME).setParent(parent.getContext()).startSpan();
+    try {
+      io.opentelemetry.proto.trace.v1.Span spanProto = span.toSpanProto();
+      assertThat(span.getContext().getTraceId()).isNotEqualTo(parent.getContext().getTraceId());
+      assertThat(spanProto.getParentSpanId().isEmpty()).isTrue();
+    } finally {
+      span.end();
+    }
+  }
 }


### PR DESCRIPTION
When setting a parent (implicitly or explicitly), we should ignore it if the related `SpanContext.isInvalid()` value is true.

This showed up as converting `Span`s to protos resulted in `getParentSpanId()` being equal to non-empty values, even if the parent was `DefaultSpan.getInvalid()`, for example.

The only place I can see affected by this change, is samplers **now** getting a `null` parent `SpanId` for this case - would this really be a problem? If that's the case, then this check needs to be refined.

Let me know @bogdandrutu as this is very implementation-related ;)