### PR TITLE
Remove sync prefix from SpanProcessor interface methods.

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/MultiSpanProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/MultiSpanProcessor.java
@@ -28,16 +28,16 @@ final class MultiSpanProcessor implements SpanProcessor {
   }
 
   @Override
-  public void onStartSync(ReadableSpan readableSpan) {
+  public void onStart(ReadableSpan readableSpan) {
     for (SpanProcessor spanProcessor : spanProcessors) {
-      spanProcessor.onStartSync(readableSpan);
+      spanProcessor.onStart(readableSpan);
     }
   }
 
   @Override
-  public void onEndSync(ReadableSpan readableSpan) {
+  public void onEnd(ReadableSpan readableSpan) {
     for (SpanProcessor spanProcessor : spanProcessors) {
-      spanProcessor.onEndSync(readableSpan);
+      spanProcessor.onEnd(readableSpan);
     }
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/NoopSpanProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/NoopSpanProcessor.java
@@ -24,10 +24,10 @@ final class NoopSpanProcessor implements SpanProcessor {
   }
 
   @Override
-  public void onStartSync(ReadableSpan span) {}
+  public void onStart(ReadableSpan span) {}
 
   @Override
-  public void onEndSync(ReadableSpan span) {}
+  public void onEnd(ReadableSpan span) {}
 
   @Override
   public void shutdown() {}

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -142,7 +142,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
             attributes);
     // Call onStart here instead of calling in the constructor to make sure the span is completely
     // initialized.
-    spanProcessor.onStartSync(span);
+    spanProcessor.onStart(span);
     return span;
   }
 
@@ -382,7 +382,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
       endNanoTime = clock.nowNanos();
       hasBeenEnded = true;
     }
-    spanProcessor.onEndSync(this);
+    spanProcessor.onEnd(this);
   }
 
   @Override

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
@@ -32,7 +32,7 @@ public interface SpanProcessor {
    *
    * @param span the {@code ReadableSpan} that just started.
    */
-  void onStartSync(ReadableSpan span);
+  void onStart(ReadableSpan span);
 
   /**
    * Called when a {@link io.opentelemetry.trace.Span} is ended, if the {@link
@@ -43,8 +43,8 @@ public interface SpanProcessor {
    *
    * @param span the {@code ReadableSpan} that just ended.
    */
-  // TODO: Consider checking whether the given span is processed with onStartSync().
-  void onEndSync(ReadableSpan span);
+  // TODO: Consider checking whether the given span is processed with onStart().
+  void onEnd(ReadableSpan span);
 
   /** Called when {@link TracerSdk#shutdown()} is called. */
   void shutdown();

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
@@ -81,7 +81,7 @@ public class TracerSdk implements Tracer {
 
   @Override
   public void recordSpanData(SpanData spanData) {
-    activeSpanProcessor.onEndSync(ReadableSpanData.create(spanData));
+    activeSpanProcessor.onEnd(ReadableSpanData.create(spanData));
   }
 
   @Override

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/BatchSampledSpansProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/BatchSampledSpansProcessor.java
@@ -59,10 +59,10 @@ public final class BatchSampledSpansProcessor implements SpanProcessor {
   }
 
   @Override
-  public void onStartSync(ReadableSpan span) {}
+  public void onStart(ReadableSpan span) {}
 
   @Override
-  public void onEndSync(ReadableSpan span) {
+  public void onEnd(ReadableSpan span) {
     if (!span.getSpanContext().getTraceOptions().isSampled()) {
       return;
     }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSampledSpansProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSampledSpansProcessor.java
@@ -42,12 +42,12 @@ public final class SimpleSampledSpansProcessor implements SpanProcessor {
   }
 
   @Override
-  public void onStartSync(ReadableSpan span) {
+  public void onStart(ReadableSpan span) {
     // Do nothing.
   }
 
   @Override
-  public void onEndSync(ReadableSpan span) {
+  public void onEnd(ReadableSpan span) {
     if (!span.getSpanContext().getTraceOptions().isSampled()) {
       return;
     }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/MultiSpanProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/MultiSpanProcessorTest.java
@@ -44,8 +44,8 @@ public class MultiSpanProcessorTest {
   public void empty() {
     SpanProcessor multiSpanProcessor =
         MultiSpanProcessor.create(Collections.<SpanProcessor>emptyList());
-    multiSpanProcessor.onStartSync(readableSpan);
-    multiSpanProcessor.onEndSync(readableSpan);
+    multiSpanProcessor.onStart(readableSpan);
+    multiSpanProcessor.onEnd(readableSpan);
     multiSpanProcessor.shutdown();
   }
 
@@ -53,11 +53,11 @@ public class MultiSpanProcessorTest {
   public void oneSpanProcessor() {
     SpanProcessor multiSpanProcessor =
         MultiSpanProcessor.create(Collections.singletonList(spanProcessor1));
-    multiSpanProcessor.onStartSync(readableSpan);
-    verify(spanProcessor1).onStartSync(same(readableSpan));
+    multiSpanProcessor.onStart(readableSpan);
+    verify(spanProcessor1).onStart(same(readableSpan));
 
-    multiSpanProcessor.onEndSync(readableSpan);
-    verify(spanProcessor1).onEndSync(same(readableSpan));
+    multiSpanProcessor.onEnd(readableSpan);
+    verify(spanProcessor1).onEnd(same(readableSpan));
 
     multiSpanProcessor.shutdown();
     verify(spanProcessor1).shutdown();
@@ -67,13 +67,13 @@ public class MultiSpanProcessorTest {
   public void twoSpanProcessor() {
     SpanProcessor multiSpanProcessor =
         MultiSpanProcessor.create(Arrays.asList(spanProcessor1, spanProcessor2));
-    multiSpanProcessor.onStartSync(readableSpan);
-    verify(spanProcessor1).onStartSync(same(readableSpan));
-    verify(spanProcessor2).onStartSync(same(readableSpan));
+    multiSpanProcessor.onStart(readableSpan);
+    verify(spanProcessor1).onStart(same(readableSpan));
+    verify(spanProcessor2).onStart(same(readableSpan));
 
-    multiSpanProcessor.onEndSync(readableSpan);
-    verify(spanProcessor1).onEndSync(same(readableSpan));
-    verify(spanProcessor2).onEndSync(same(readableSpan));
+    multiSpanProcessor.onEnd(readableSpan);
+    verify(spanProcessor1).onEnd(same(readableSpan));
+    verify(spanProcessor2).onEnd(same(readableSpan));
 
     multiSpanProcessor.shutdown();
     verify(spanProcessor1).shutdown();

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/NoopSpanProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/NoopSpanProcessorTest.java
@@ -36,8 +36,8 @@ public class NoopSpanProcessorTest {
   @Test
   public void noCrash() {
     SpanProcessor noopSpanProcessor = NoopSpanProcessor.getInstance();
-    noopSpanProcessor.onStartSync(readableSpan);
-    noopSpanProcessor.onEndSync(readableSpan);
+    noopSpanProcessor.onStart(readableSpan);
+    noopSpanProcessor.onEnd(readableSpan);
     noopSpanProcessor.shutdown();
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -151,7 +151,7 @@ public class RecordEventsReadableSpanTest {
     } finally {
       span.end();
     }
-    Mockito.verify(spanProcessor, Mockito.times(1)).onEndSync(span);
+    Mockito.verify(spanProcessor, Mockito.times(1)).onEnd(span);
     Span spanProto = span.toSpanProto();
     long timeInNanos = (startTime.getSeconds() + 1) * NANOS_PER_SECOND;
     TimedEvent timedEvent = TimedEvent.create(timeInNanos, event);
@@ -506,7 +506,7 @@ public class RecordEventsReadableSpanTest {
             testClock,
             resource,
             attributes);
-    Mockito.verify(spanProcessor, Mockito.times(1)).onStartSync(span);
+    Mockito.verify(spanProcessor, Mockito.times(1)).onStart(span);
     return span;
   }
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -123,7 +123,7 @@ public class TracerSdkTest {
             Status.OK,
             SpanData.Timestamp.create(2, 0));
     tracer.recordSpanData(spanData);
-    Mockito.verify(spanProcessor, Mockito.times(1)).onEndSync(Mockito.any(ReadableSpanData.class));
+    Mockito.verify(spanProcessor, Mockito.times(1)).onEnd(Mockito.any(ReadableSpanData.class));
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSampledSpansProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSampledSpansProcessorTest.java
@@ -66,7 +66,7 @@ public class SimpleSampledSpansProcessorTest {
 
   @Test
   public void onStartSync() {
-    simpleSampledSpansProcessor.onStartSync(readableSpan);
+    simpleSampledSpansProcessor.onStart(readableSpan);
     verifyZeroInteractions(spanExporter);
   }
 
@@ -76,7 +76,7 @@ public class SimpleSampledSpansProcessorTest {
     when(readableSpan.toSpanProto())
         .thenReturn(Span.getDefaultInstance())
         .thenThrow(new RuntimeException());
-    simpleSampledSpansProcessor.onEndSync(readableSpan);
+    simpleSampledSpansProcessor.onEnd(readableSpan);
     verify(spanExporter).export(Collections.singletonList(Span.getDefaultInstance()));
   }
 
@@ -86,7 +86,7 @@ public class SimpleSampledSpansProcessorTest {
     when(readableSpan.toSpanProto())
         .thenReturn(Span.getDefaultInstance())
         .thenThrow(new RuntimeException());
-    simpleSampledSpansProcessor.onEndSync(readableSpan);
+    simpleSampledSpansProcessor.onEnd(readableSpan);
     verifyZeroInteractions(spanExporter);
   }
 
@@ -101,9 +101,9 @@ public class SimpleSampledSpansProcessorTest {
         .doNothing()
         .when(spanExporter)
         .export(ArgumentMatchers.<Span>anyList());
-    simpleSampledSpansProcessor.onEndSync(readableSpan);
+    simpleSampledSpansProcessor.onEnd(readableSpan);
     // Try again, now will no longer return error.
-    simpleSampledSpansProcessor.onEndSync(readableSpan);
+    simpleSampledSpansProcessor.onEnd(readableSpan);
     verify(spanExporter, times(2)).export(Collections.singletonList(Span.getDefaultInstance()));
   }
 


### PR DESCRIPTION
An async `SpanProcessor` will be available as a different implementation of the `SpanProcessor`.