### PR TITLE
Update the InMemorySpanExporter creation calls from the testbed.

### DIFF
--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/activespanreplacement/ActiveSpanReplacementTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/activespanreplacement/ActiveSpanReplacementTest.java
@@ -39,7 +39,7 @@ import org.junit.Test;
 @SuppressWarnings("FutureReturnValueIgnored")
 public class ActiveSpanReplacementTest {
 
-  private final InMemorySpanExporter exporter = new InMemorySpanExporter();
+  private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
   private final Tracer tracer = createTracerShim(exporter);
   private final ExecutorService executor = Executors.newCachedThreadPool();
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/actorpropagation/ActorPropagationTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/actorpropagation/ActorPropagationTest.java
@@ -45,7 +45,7 @@ import org.junit.Test;
  */
 @SuppressWarnings("FutureReturnValueIgnored")
 public class ActorPropagationTest {
-  private final InMemorySpanExporter exporter = new InMemorySpanExporter();
+  private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
   private final Tracer tracer = createTracerShim(exporter);
   private Phaser phaser;
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/clientserver/TestClientServerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/clientserver/TestClientServerTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 
 public class TestClientServerTest {
 
-  private final InMemorySpanExporter exporter = new InMemorySpanExporter();
+  private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
   private final Tracer tracer = createTracerShim(exporter);
   private final ArrayBlockingQueue<Message> queue = new ArrayBlockingQueue<>(10);
   private Server server;

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/concurrentcommonrequesthandler/HandlerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/concurrentcommonrequesthandler/HandlerTest.java
@@ -43,7 +43,7 @@ import org.junit.Test;
  */
 public class HandlerTest {
 
-  private final InMemorySpanExporter exporter = new InMemorySpanExporter();
+  private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
   private final Tracer tracer = createTracerShim(exporter);
   private final Client client = new Client(new RequestHandler(tracer));
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/errorreporting/ErrorReportingTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/errorreporting/ErrorReportingTest.java
@@ -41,7 +41,7 @@ import org.junit.Test;
 @SuppressWarnings("FutureReturnValueIgnored")
 public final class ErrorReportingTest {
 
-  private final InMemorySpanExporter exporter = new InMemorySpanExporter();
+  private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
   private final Tracer tracer = createTracerShim(exporter);
   private final ExecutorService executor = Executors.newCachedThreadPool();
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/latespanfinish/LateSpanFinishTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/latespanfinish/LateSpanFinishTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 
 @SuppressWarnings("FutureReturnValueIgnored")
 public final class LateSpanFinishTest {
-  private final InMemorySpanExporter exporter = new InMemorySpanExporter();
+  private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
   private final Tracer tracer = createTracerShim(exporter);
   private final ExecutorService executor = Executors.newCachedThreadPool();
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/listenerperrequest/ListenerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/listenerperrequest/ListenerTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 /** Each request has own instance of ResponseListener. */
 public class ListenerTest {
-  private final InMemorySpanExporter exporter = new InMemorySpanExporter();
+  private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
   private final Tracer tracer = createTracerShim(exporter);
 
   @Test

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/multiplecallbacks/MultipleCallbacksTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/multiplecallbacks/MultipleCallbacksTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 
 @SuppressWarnings("FutureReturnValueIgnored")
 public class MultipleCallbacksTest {
-  private final InMemorySpanExporter exporter = new InMemorySpanExporter();
+  private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
   private final Tracer tracer = createTracerShim(exporter);
 
   @Test

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/nestedcallbacks/NestedCallbacksTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/nestedcallbacks/NestedCallbacksTest.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 @SuppressWarnings("FutureReturnValueIgnored")
 public final class NestedCallbacksTest {
 
-  private final InMemorySpanExporter exporter = new InMemorySpanExporter();
+  private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
   private final Tracer tracer = createTracerShim(exporter);
   private final ExecutorService executor = Executors.newCachedThreadPool();
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/promisepropagation/PromisePropagationTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/promisepropagation/PromisePropagationTest.java
@@ -43,7 +43,7 @@ import org.junit.Test;
  * @author tylerbenson
  */
 public class PromisePropagationTest {
-  private final InMemorySpanExporter exporter = new InMemorySpanExporter();
+  private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
   private final Tracer tracer = createTracerShim(exporter);
   private Phaser phaser;
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/statelesscommonrequesthandler/HandlerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/statelesscommonrequesthandler/HandlerTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
  */
 public final class HandlerTest {
 
-  private final InMemorySpanExporter exporter = new InMemorySpanExporter();
+  private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
   private final Tracer tracer = createTracerShim(exporter);
   private final Client client = new Client(new RequestHandler(tracer));
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/suspendresumepropagation/SuspendResumePropagationTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/suspendresumepropagation/SuspendResumePropagationTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
  * @author tylerbenson
  */
 public class SuspendResumePropagationTest {
-  private final InMemorySpanExporter exporter = new InMemorySpanExporter();
+  private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
   private final Tracer tracer = createTracerShim(exporter);
 
   @Before


### PR DESCRIPTION
Hadn't realized `InMemorySpanExporter` had restricted its creation. Updating this to get the master branch green again.