### PR TITLE
Add a small artifact that joins TracerSdk and InMemorySpanExporter.

### DIFF
--- a/inmemory/build.gradle
+++ b/inmemory/build.gradle
@@ -1,0 +1,9 @@
+description = 'OpenTelemetry InMemory Utility'
+
+def protobufVersion = '3.7.1'
+
+dependencies {
+    api project(':opentelemetry-sdk')
+
+    testImplementation "com.google.protobuf:protobuf-java:${protobufVersion}"
+}

--- a/inmemory/src/main/java/io/opentelemetry/inmemory/trace/InMemoryTracing.java
+++ b/inmemory/src/main/java/io/opentelemetry/inmemory/trace/InMemoryTracing.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.inmemory.trace;
+
+import io.opentelemetry.internal.Utils;
+import io.opentelemetry.proto.trace.v1.Span;
+import io.opentelemetry.sdk.trace.TracerSdk;
+import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.export.SimpleSampledSpansProcessor;
+import io.opentelemetry.trace.Tracer;
+import java.util.List;
+
+/**
+ * InMemoryTracing is an utility class that uses a {@code TracerSdk} to create {@code Span}s and
+ * later expose the finished items in memory. Can be used to test OpenTelemetry integration.
+ *
+ * <p>Example usage:
+ *
+ * <pre><code>
+ *   {@literal @}Test
+ *   public void testCondition() {
+ *     InMemoryTracing tracing = new InMemoryTracing();
+ *     Tracer tracer = tracing.getTracer();
+ *     tracer.spanBuilder("span").startSpan().end();
+ *
+ *     {@code List<io.opentelemetry.proto.trace.v1.Span>} spans = tracing.getFinishedSpanItems();
+ *     assertThat(spans.size()).isEqualTo(1);
+ *     assertThat(spans.get(0).getName()).isEqualTo("span");
+ *   }
+ * </code></pre>
+ *
+ * @since 0.1.0
+ */
+public final class InMemoryTracing {
+  private final TracerSdk tracer;
+  private final InMemorySpanExporter exporter;
+
+  /**
+   * Creates a new {@code InMemoryTracing} with a new {@code TracerSdk}.
+   *
+   * @since 0.1.0
+   */
+  public InMemoryTracing() {
+    this(new TracerSdk());
+  }
+
+  /**
+   * Creates a new {@code InMemoryTracing} with the specified {@code TracerSdk}.
+   *
+   * @param tracer the {@code TracerSdk} to be used.
+   * @throws NullPointerException if {@code tracer} is {@code null}.
+   * @since 0.1.0
+   */
+  public InMemoryTracing(TracerSdk tracer) {
+    Utils.checkNotNull(tracer, "tracer");
+
+    this.tracer = tracer;
+    this.exporter = InMemorySpanExporter.create();
+    tracer.addSpanProcessor(SimpleSampledSpansProcessor.newBuilder(exporter).build());
+  }
+
+  /**
+   * Returns a {@code Tracer} that can be used to create {@code Span}s and later recovered through
+   * {@link #getFinishedSpanItems()}.
+   *
+   * @return the {@code Tracer} to be used to create {@code Span}s.
+   * @since 0.1.0
+   */
+  public Tracer getTracer() {
+    return tracer;
+  }
+
+  /**
+   * Clears the internal {@code List} of finished {@code Span}s.
+   *
+   * @since 0.1.0
+   */
+  public void reset() {
+    exporter.reset();
+  }
+
+  /**
+   * Returns a copy {@code List} of the finished {@code Span}s, represented by {@code
+   * io.opentelemetry.proto.trace.v1.Span}.
+   *
+   * @return a {@code List} of the finished {@code Span}s.
+   * @since 0.1.0
+   */
+  public List<Span> getFinishedSpanItems() {
+    return exporter.getFinishedSpanItems();
+  }
+
+  /**
+   * Attemps to stop all activity for the underlying tracer by calling {@code TracerSdk.shutdown()}.
+   *
+   * @since 0.1.0
+   */
+  public void shutdown() {
+    tracer.shutdown();
+  }
+}

--- a/inmemory/src/test/java/io/opentelemetry/inmemory/trace/InMemoryTracingTest.java
+++ b/inmemory/src/test/java/io/opentelemetry/inmemory/trace/InMemoryTracingTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.inmemory.trace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.opentelemetry.proto.trace.v1.Span;
+import io.opentelemetry.sdk.trace.TracerSdk;
+import io.opentelemetry.trace.util.Samplers;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link InMemoryTracing}. */
+@RunWith(JUnit4.class)
+public class InMemoryTracingTest {
+  InMemoryTracing tracing = new InMemoryTracing();
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void defaultTracer() {
+    assertThat(tracing.getTracer()).isInstanceOf(TracerSdk.class);
+  }
+
+  @Test
+  public void defaultFinishedSpanItems() {
+    assertThat(tracing.getFinishedSpanItems().size()).isEqualTo(0);
+  }
+
+  @Test
+  public void ctor_tracer() {
+    TracerSdk tracer = new TracerSdk();
+    InMemoryTracing tracing = new InMemoryTracing(tracer);
+    assertThat(tracing.getTracer()).isSameInstanceAs(tracer);
+  }
+
+  @Test
+  public void ctor_nullTracer() {
+    thrown.expect(NullPointerException.class);
+    new InMemoryTracing(null);
+  }
+
+  @Test
+  public void getFinishedSpanItems() {
+    tracing.getTracer().spanBuilder("A").startSpan().end();
+    tracing.getTracer().spanBuilder("B").startSpan().end();
+
+    List<Span> finishedSpanItems = tracing.getFinishedSpanItems();
+    assertThat(finishedSpanItems.get(0).getName()).isEqualTo("A");
+    assertThat(finishedSpanItems.get(1).getName()).isEqualTo("B");
+  }
+
+  @Test
+  public void getFinishedSpanItems_sampled() {
+    tracing.getTracer().spanBuilder("A").startSpan().end();
+    tracing.getTracer().spanBuilder("B").setSampler(Samplers.neverSample()).startSpan().end();
+
+    List<Span> finishedSpanItems = tracing.getFinishedSpanItems();
+    assertThat(finishedSpanItems.size()).isEqualTo(1);
+    assertThat(finishedSpanItems.get(0).getName()).isEqualTo("A");
+  }
+
+  @Test
+  public void reset() {
+    tracing.getTracer().spanBuilder("A").startSpan();
+    tracing.getTracer().spanBuilder("B").startSpan();
+    tracing.reset();
+    assertThat(tracing.getFinishedSpanItems().size()).isEqualTo(0);
+
+    tracing.reset();
+    assertThat(tracing.getFinishedSpanItems().size()).isEqualTo(0);
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,7 @@ include ":opentelemetry-contrib-runtime-metrics"
 include ":opentelemetry-contrib-trace-utils"
 include ":opentelemetry-opentracing-shim"
 include ":opentelemetry-sdk"
+include ":opentelemetry-inmemory"
 
 project(':opentelemetry-all').projectDir = "$rootDir/all" as File
 project(':opentelemetry-api').projectDir = "$rootDir/api" as File
@@ -14,3 +15,4 @@ project(':opentelemetry-contrib-runtime-metrics').projectDir =
 project(':opentelemetry-contrib-trace-utils').projectDir = "$rootDir/contrib/trace_utils" as File
 project(':opentelemetry-opentracing-shim').projectDir = "$rootDir/opentracing_shim" as File
 project(':opentelemetry-sdk').projectDir = "$rootDir/sdk" as File
+project(':opentelemetry-inmemory').projectDir = "$rootDir/inmemory" as File


### PR DESCRIPTION
Used for OpenTelemetry integration testing.

This exposes the mentioned artifact to make testing easier by exposing a `TracerSdk` along with an `InMemorySpanExporter` (and we can use this to have some actual examples, similar to the OT Shim testbed cases).

The current design keeps the hierarchy used the the API/SDK (which means we can add a `InMemoryMetrics` or similar later on). 

I had been wrapping the proto `Span` objects in a friendlier class, but dropped that for now, while we the `SpanData` issue is solved (so I can either use that or not for this layer).

Also, I'm not totally married with the `inmemory` name (alternative was `sdk-testing` or `sdk-inmemory`), so I'm open to suggestions ;)