### PR TITLE
Fix that disruptor does not accept events after shutdown.

### DIFF
--- a/sdk_contrib/async_processor/src/main/java/io/opentelemetry/sdk/contrib/trace/export/DisruptorEventQueue.java
+++ b/sdk_contrib/async_processor/src/main/java/io/opentelemetry/sdk/contrib/trace/export/DisruptorEventQueue.java
@@ -97,6 +97,7 @@ final class DisruptorEventQueue {
       if (!loggedShutdownMessage.getAndSet(true)) {
         logger.info("Attempted to enqueue entry after Disruptor shutdown.");
       }
+      return;
     }
 
     if (blocking) {


### PR DESCRIPTION
This also fixes a flaky test in the disruptor implementation `incrementAfterShutdown`.