### PR TITLE
Properly set TimestampConverter from implicit parent Span.

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -179,7 +179,7 @@ class SpanBuilderSdk implements Span.Builder {
     if (!recordEvents && !samplingDecision.isSampled()) {
       return DefaultSpan.create(spanContext);
     }
-    TimestampConverter timestampConverter = getTimestampConverter(parent);
+    TimestampConverter timestampConverter = getTimestampConverter(parentSpan(parentType, parent));
     return RecordEventsReadableSpan.startSpan(
         spanContext,
         spanName,
@@ -219,6 +219,18 @@ class SpanBuilderSdk implements Span.Builder {
         return remoteParent;
     }
     throw new IllegalStateException("Unknown parent type");
+  }
+
+  @Nullable
+  private static Span parentSpan(ParentType parentType, Span explicitParent) {
+    switch (parentType) {
+      case CURRENT_SPAN:
+        return ContextUtils.getValue();
+      case EXPLICIT_PARENT:
+        return explicitParent;
+      default:
+        return null;
+    }
   }
 
   /**

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -369,4 +369,34 @@ public class SpanBuilderSdkTest {
       span.end();
     }
   }
+
+  @Test
+  public void parent_timestampConverter() {
+    Span parent = tracer.spanBuilder(SPAN_NAME).startSpan();
+    try {
+      RecordEventsReadableSpan span =
+          (RecordEventsReadableSpan) tracer.spanBuilder(SPAN_NAME).setParent(parent).startSpan();
+
+      assertThat(span.getTimestampConverter())
+          .isEqualTo(((RecordEventsReadableSpan) parent).getTimestampConverter());
+    } finally {
+      parent.end();
+    }
+  }
+
+  @Test
+  public void parentCurrentSpan_timestampConverter() {
+    Span parent = tracer.spanBuilder(SPAN_NAME).startSpan();
+    Scope scope = tracer.withSpan(parent);
+    try {
+      RecordEventsReadableSpan span =
+          (RecordEventsReadableSpan) tracer.spanBuilder(SPAN_NAME).startSpan();
+
+      assertThat(span.getTimestampConverter())
+          .isEqualTo(((RecordEventsReadableSpan) parent).getTimestampConverter());
+    } finally {
+      scope.close();
+      parent.end();
+    }
+  }
 }


### PR DESCRIPTION
When using implicit parent `Span`s, we were not properly inheriting/setting their `TimestampConverter` (we were doing that only for explicit parents).

(Wish we had value-based tuples, so we could return parent `Span`/`SpanContext` in a single call ;) )