### PR TITLE
Sort finished Spans by either start/finish time in OT testbed.

### DIFF
--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/latespanfinish/LateSpanFinishTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/latespanfinish/LateSpanFinishTest.java
@@ -21,6 +21,7 @@ import static io.opentelemetry.opentracingshim.testbed.TestUtils.createTracerShi
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.sleep;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentracing.Scope;
@@ -51,10 +52,11 @@ public final class LateSpanFinishTest {
     // Late-finish the parent Span now
     parentSpan.finish();
 
+    // Children finish order is not guaranteed, but parent should finish *last*.
     List<io.opentelemetry.proto.trace.v1.Span> spans = exporter.getFinishedSpanItems();
     assertEquals(3, spans.size());
-    assertEquals("task1", spans.get(0).getName());
-    assertEquals("task2", spans.get(1).getName());
+    assertTrue(spans.get(0).getName().startsWith("task"));
+    assertTrue(spans.get(1).getName().startsWith("task"));
     assertEquals("parent", spans.get(2).getName());
 
     assertSameTrace(spans);

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/multiplecallbacks/MultipleCallbacksTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/multiplecallbacks/MultipleCallbacksTest.java
@@ -18,6 +18,7 @@ package io.opentelemetry.opentracingshim.testbed.multiplecallbacks;
 
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.createTracerShim;
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.finishedSpansSize;
+import static io.opentelemetry.opentracingshim.testbed.TestUtils.sortByStartTime;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
@@ -50,7 +51,9 @@ public class MultipleCallbacksTest {
 
     await().atMost(15, TimeUnit.SECONDS).until(finishedSpansSize(exporter), equalTo(4));
 
+    // Finish order is not guaranteed, so we rely on *start time* to fetch the parent.
     List<io.opentelemetry.proto.trace.v1.Span> spans = exporter.getFinishedSpanItems();
+    spans = sortByStartTime(spans);
     assertEquals(4, spans.size());
     assertEquals("parent", spans.get(0).getName());
 


### PR DESCRIPTION
Order the Spans in latespanfinish/ and multiplecallbacks/ cases
to *make sure* the invariant is enforced (prior to do assert
the conditions).

Fixes #487 
Fixes #490 