### PR TITLE
Remove capability to set a resource for metrics construction

### DIFF
--- a/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
@@ -19,7 +19,6 @@ package io.opentelemetry.metrics;
 import io.opentelemetry.distributedcontext.DistributedContext;
 import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.internal.Utils;
-import io.opentelemetry.resources.Resource;
 import io.opentelemetry.trace.SpanContext;
 import java.util.List;
 import java.util.Map;
@@ -175,12 +174,6 @@ public final class DefaultMeter implements Meter {
       }
 
       @Override
-      public Builder setResource(Resource resource) {
-        Utils.checkNotNull(resource, "resource");
-        return this;
-      }
-
-      @Override
       public GaugeLong build() {
         return new NoopGaugeLong(labelKeysSize);
       }
@@ -262,12 +255,6 @@ public final class DefaultMeter implements Meter {
       @Override
       public Builder setComponent(String component) {
         Utils.checkNotNull(component, "component");
-        return this;
-      }
-
-      @Override
-      public Builder setResource(Resource resource) {
-        Utils.checkNotNull(resource, "resource");
         return this;
       }
 
@@ -359,12 +346,6 @@ public final class DefaultMeter implements Meter {
       }
 
       @Override
-      public Builder setResource(Resource resource) {
-        Utils.checkNotNull(resource, "resource");
-        return this;
-      }
-
-      @Override
       public CounterDouble build() {
         return new NoopCounterDouble(labelKeysSize);
       }
@@ -448,12 +429,6 @@ public final class DefaultMeter implements Meter {
       @Override
       public Builder setComponent(String component) {
         Utils.checkNotNull(component, "component");
-        return this;
-      }
-
-      @Override
-      public Builder setResource(Resource resource) {
-        Utils.checkNotNull(resource, "resource");
         return this;
       }
 

--- a/api/src/main/java/io/opentelemetry/metrics/Metric.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Metric.java
@@ -16,7 +16,6 @@
 
 package io.opentelemetry.metrics;
 
-import io.opentelemetry.resources.Resource;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -131,18 +130,6 @@ public interface Metric<T> {
      * @return this.
      */
     B setComponent(String component);
-
-    /**
-     * Sets the {@code Resource} associated with this {@code Metric}.
-     *
-     * <p>This should be set only when reporting out-of-band metrics, otherwise the implementation
-     * will set the {@code Resource} for in-process metrics (or user can do that when initialize the
-     * {@code Meter}).
-     *
-     * @param resource the {@code Resource} associated with this {@code Metric}.
-     * @return this.
-     */
-    B setResource(Resource resource);
 
     /**
      * Builds and returns a {@code Metric} with the desired options.


### PR DESCRIPTION
Some of the reasons are listed in the https://github.com/open-telemetry/oteps/pull/26, and also it confuses users.

Few reasons:
* The user that writes the instrumentation does not know the `resource` that produces the telemetry.
* If needed to support a custom resource we should support configuring the `resource` similar to the proposed named tracer https://github.com/open-telemetry/oteps/pull/16