### PR TITLE
organize build directions in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,15 +70,17 @@ $ git commit -m "Update javadoc for API."
 Continuous integration builds the project, runs the tests, and runs multiple
 types of static analysis.
 
-Before running the build init repository dependencies by running `make init-git-submodules`.
+1. From the root project directory, initialize repository dependencies
 
-Run the following commands to build, run tests and most static analysis, and
+   `make init-git-submodules`
+
+2. Run the following commands to build, run tests and most static analysis, and
 check formatting:
 
-### OS X or Linux
+    ##### OS X or Linux
 
-`make test verify-format`
+    `make test verify-format`
 
-### Windows
+    ##### Windows
 
-`gradlew.bat clean assemble check verGJF`
+    `gradlew.bat clean assemble check verGJF`

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ This project contains the following top level components:
 
 We would love to hear from the larger community: please provide feedback proactively.
 
+## Project setup and contribute
+
+Please refer to the [contribution guide](https://github.com/newrelic-forks/opentelemetry-java/blob/master/CONTRIBUTING.md)
+on how to setup and contribute!
+
 ## Plan
 
 [Please review the roadmap here](https://medium.com/opentracing/a-roadmap-to-convergence-b074e5815289).


### PR DESCRIPTION
I closed a previous update docs PR after finding the information I needed in the current docs. The purpose of this PR is to organize the build directions a bit differently and call them out more. I think it would be easier for new contributors to find the information they need to quickly build. 