### PR TITLE
Make Span.Builder properly set the Links in the Span.

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -34,6 +34,7 @@ import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.Tracer;
 import io.opentelemetry.trace.util.Links;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -127,7 +128,8 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
       @Nullable TimestampConverter timestampConverter,
       Clock clock,
       Resource resource,
-      Map<String, AttributeValue> attributes) {
+      Map<String, AttributeValue> attributes,
+      List<Link> links) {
     RecordEventsReadableSpan span =
         new RecordEventsReadableSpan(
             context,
@@ -139,7 +141,8 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
             timestampConverter,
             clock,
             resource,
-            attributes);
+            attributes,
+            links);
     // Call onStart here instead of calling in the constructor to make sure the span is completely
     // initialized.
     spanProcessor.onStart(span);
@@ -480,7 +483,8 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
       @Nullable TimestampConverter timestampConverter,
       Clock clock,
       Resource resource,
-      Map<String, AttributeValue> attributes) {
+      Map<String, AttributeValue> attributes,
+      List<Link> links) {
     this.context = context;
     this.parentSpanId = parentSpanId;
     this.name = name;
@@ -496,6 +500,9 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     startNanoTime = clock.nowNanos();
     if (!attributes.isEmpty()) {
       getInitializedAttributes().putAll(attributes);
+    }
+    if (!links.isEmpty()) {
+      getInitializedLinks().addAll(links);
     }
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -36,6 +36,7 @@ import io.opentelemetry.trace.Tracestate;
 import io.opentelemetry.trace.unsafe.ContextUtils;
 import io.opentelemetry.trace.util.Links;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -190,7 +191,8 @@ class SpanBuilderSdk implements Span.Builder {
         timestampConverter,
         clock,
         resource,
-        samplingDecision.attributes());
+        samplingDecision.attributes(),
+        links != null ? links : Collections.<Link>emptyList());
   }
 
   @Nullable

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -505,7 +505,8 @@ public class RecordEventsReadableSpanTest {
             timestampConverter,
             testClock,
             resource,
-            attributes);
+            attributes,
+            Collections.<Link>emptyList());
     Mockito.verify(spanProcessor, Mockito.times(1)).onStart(span);
     return span;
   }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -91,6 +91,14 @@ public class SpanBuilderSdkTest {
     spanBuilder.addLink(DefaultSpan.getInvalid().getContext());
     spanBuilder.addLink(
         DefaultSpan.getInvalid().getContext(), Collections.<String, AttributeValue>emptyMap());
+
+    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    io.opentelemetry.proto.trace.v1.Span protoSpan = span.toSpanProto();
+    try {
+      assertThat(protoSpan.getLinks().getLinkList()).hasSize(3);
+    } finally {
+      span.end();
+    }
   }
 
   @Test


### PR DESCRIPTION
Before this, we had forgotten to properly carry the Links from `Span.Builder` to `Span`.