### PR TITLE
Implementation of a Span Exporter that sends data to the New Relic Trace API

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/SpanId.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanId.java
@@ -108,6 +108,21 @@ public final class SpanId implements Comparable<SpanId> {
   }
 
   /**
+   * Transforms a byte[] representation of a span id (eg. from a protobuf) and returns a base 16
+   * representation of the same.
+   *
+   * @param bytes The byte array containing the span id.
+   * @return A base 16 representation of the span id.
+   * @since 0.1.0
+   */
+  public static String asLowerBase16(byte[] bytes) {
+    long longId = BigendianEncoding.longFromByteArray(bytes, 0);
+    char[] chars = new char[BASE16_SIZE];
+    BigendianEncoding.longToBase16String(longId, chars, 0);
+    return new String(chars);
+  }
+
+  /**
    * Copies the byte array representations of the {@code SpanId} into the {@code dest} beginning at
    * the {@code destOffset} offset.
    *

--- a/api/src/main/java/io/opentelemetry/trace/TraceId.java
+++ b/api/src/main/java/io/opentelemetry/trace/TraceId.java
@@ -151,6 +151,23 @@ public final class TraceId implements Comparable<TraceId> {
   }
 
   /**
+   * Transforms a byte[] representation of a trace id (eg. from a protobuf) and returns a base 16
+   * representation of the same.
+   *
+   * @param bytes The byte array containing the trace id.
+   * @return A base 16 representation of the trace id.
+   * @since 0.1.0
+   */
+  public static String asLowerBase16(byte[] bytes) {
+    long idHi = BigendianEncoding.longFromByteArray(bytes, 0);
+    long idLo = BigendianEncoding.longFromByteArray(bytes, SIZE / 2);
+    char[] chars = new char[BASE16_SIZE];
+    BigendianEncoding.longToBase16String(idHi, chars, 0);
+    BigendianEncoding.longToBase16String(idLo, chars, BASE16_SIZE / 2);
+    return new String(chars);
+  }
+
+  /**
    * Copies the lowercase base16 representations of the {@code TraceId} into the {@code dest}
    * beginning at the {@code destOffset} offset.
    *

--- a/api/src/test/java/io/opentelemetry/trace/SpanIdTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanIdTest.java
@@ -62,6 +62,14 @@ public class SpanIdTest {
   }
 
   @Test
+  public void asLowerBase16() {
+    SpanId spanId = new SpanId(43L);
+    byte[] idAsBytes = new byte[8];
+    spanId.copyBytesTo(idAsBytes, 0);
+    assertThat(SpanId.asLowerBase16(idAsBytes)).isEqualTo("000000000000002b");
+  }
+
+  @Test
   public void spanId_CompareTo() {
     assertThat(first.compareTo(second)).isGreaterThan(0);
     assertThat(second.compareTo(first)).isLessThan(0);

--- a/api/src/test/java/io/opentelemetry/trace/TraceIdTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TraceIdTest.java
@@ -73,6 +73,14 @@ public class TraceIdTest {
   }
 
   @Test
+  public void asLowerBase16() {
+    TraceId traceId = new TraceId(43L, 109L);
+    byte[] idAsBytes = new byte[16];
+    traceId.copyBytesTo(idAsBytes, 0);
+    assertThat(TraceId.asLowerBase16(idAsBytes)).isEqualTo("000000000000002b000000000000006d");
+  }
+
+  @Test
   public void toLowerBase16() {
     assertThat(TraceId.getInvalid().toLowerBase16()).isEqualTo("00000000000000000000000000000000");
     assertThat(first.toLowerBase16()).isEqualTo("00000000000000000000000000000061");

--- a/exporters/newrelic/README.md
+++ b/exporters/newrelic/README.md
@@ -1,0 +1,88 @@
+# OpenTelemetry - New Relic Exporter For Spans
+
+A New Relic exporter for sending Open Telemetry spans to New Relic using the New Relic Java Telemetry SDK. For details on how Open Telemetry spans are mapped to New Relic spans, please visit the exporter specs documentation repo. 
+
+# How To Use
+
+`build.gradle`
+
+```
+compile("com.newrelic.telemetry:telemetry-http-okhttp:0.3.1")
+compile("com.newrelic.telemetry:telemetry-core:0.3.1")
+```
+
+or if you're using kotlin build gradle...
+
+`build.gradle.kts`
+
+```
+implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.3.1")
+implementation("com.newrelic.telemetry:telemetry-core:0.3.1")
+```
+
+##### Remove OkHttp
+
+You can remove the dependency on telemetry-http-okhttp, but you will need to construct a MetricBatchSender instance using its builder and provide your own implementation of the com.newrelic.telemetry.http.HttpPoster interface.
+
+`MetricBatchSender sender = MetricBatchSender.builder().httpPoster(<your implementation>);`
+
+Note: to use the sample code below, you will need the telemetry-http-okhttp library mentioned above. It provides implementations communicating via HTTP using the okhttp libraries, respectively.
+
+## Create and configure the tracer for New Relic
+
+```
+
+public Tracer buildNewRelicEnabledTracer(String newRelicInsertKey) {
+    SpanExporter spanExporter = NewRelicSpanExporter.newBuilder().apiKey(newRelicInsertKey).build(); 
+    SpanProcessor spanProcessor = BatchSampledSpansProcessor.newBuilder(exporter).build();
+    TracerSdk tracerSdk = new TracerSdk();
+    tracerSdk.addSpanProcessor(spanProcessor);
+    return tracerSdk;
+  }
+```
+
+The NewRelicSpanExporter takes a SpanBatchSender from the New Relic Telemetry SDK. We provide [many more examples](https://github.com/newrelic/newrelic-telemetry-sdk-java/tree/master/telemetry_examples) of how a SpanBatchSender is built and used in the Telemetry SDK. 
+
+## How To Trace 
+
+With the tracer, trace a parent and child method. 
+
+```
+public String mySpanMethod(){
+
+  //Create a new parent span for this operation
+  Span span = tracer.spanBuilder("my Span Method")
+                                .setNoParent()
+                                .startSpan();
+  
+  try {
+        return withSpan(span, true, () -> {
+          myChildSpanMethod(span);
+        });
+      } catch (Exception e) {
+        if (e instanceof RuntimeException) {
+          throw (RuntimeException) e;
+        }
+        throw new RuntimeException(e);
+      }                  
+}
+
+public String myChildSpanMethod(Span parentSpan){
+
+ //Create a new span for this child operation
+ Span childSpan = tracerSdk.spanBuilder("my Child Span Method")
+                               .setParent(parentSpan)
+                               .startSpan();
+ 
+ try {
+       return withSpan(childSpan, true, () -> {
+         //your business logic for myChildMethod goes here
+       });
+     } catch (Exception e) {
+       if (e instanceof RuntimeException) {
+         throw (RuntimeException) e;
+       }
+       throw new RuntimeException(e);
+     }                  
+}
+```

--- a/exporters/newrelic/build.gradle
+++ b/exporters/newrelic/build.gradle
@@ -1,0 +1,17 @@
+description = 'OpenTelemetry - New Relic Exporter'
+
+test {
+    useJUnitPlatform()
+}
+
+dependencies {
+    api project(':opentelemetry-sdk')
+    compile("com.newrelic.telemetry:telemetry:0.3.1")
+    compile("com.newrelic.telemetry:telemetry-http-okhttp:0.3.1")
+
+    testRuntimeOnly("org.slf4j:slf4j-simple:1.7.26")
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.4.2'
+    testImplementation("org.mockito:mockito-core:3.0.0")
+    testImplementation("org.mockito:mockito-junit-jupiter:3.0.0")
+}

--- a/exporters/newrelic/src/main/java/io/opentelemetry/exporters/newrelic/NewRelicSpanExporter.java
+++ b/exporters/newrelic/src/main/java/io/opentelemetry/exporters/newrelic/NewRelicSpanExporter.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.exporters.newrelic;
+
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.SimpleSpanBatchSender;
+import com.newrelic.telemetry.exceptions.ResponseException;
+import com.newrelic.telemetry.exceptions.RetryWithBackoffException;
+import com.newrelic.telemetry.exceptions.RetryWithRequestedWaitException;
+import com.newrelic.telemetry.spans.SpanBatch;
+import com.newrelic.telemetry.spans.SpanBatchSender;
+import com.newrelic.telemetry.spans.SpanBatchSenderBuilder;
+import io.opentelemetry.proto.trace.v1.Span;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.util.List;
+
+/**
+ * The NewRelicSpanExporter takes a list of Span objects, converts them into a New Relic SpanBatch
+ * instance and then sends it to the New Relic trace ingest API via a SpanBatchSender.
+ *
+ * @since 0.1.0
+ */
+public class NewRelicSpanExporter implements SpanExporter {
+
+  private final SpanBatchAdapter adapter;
+  private final SpanBatchSender spanBatchSender;
+
+  /**
+   * Constructor for the NewRelicSpanExporter.
+   *
+   * @param adapter An instance of SpanBatchAdapter that can turn list of open telemetry spans into
+   *     New Relic SpanBatch.
+   * @param spanBatchSender An instance that sends a SpanBatch to the New Relic trace ingest API
+   * @since 0.1.0
+   */
+  NewRelicSpanExporter(SpanBatchAdapter adapter, SpanBatchSender spanBatchSender) {
+    if (spanBatchSender == null) {
+      throw new IllegalArgumentException("You must provide a non-null SpanBatchSender");
+    }
+    this.adapter = adapter;
+    this.spanBatchSender = spanBatchSender;
+  }
+
+  /**
+   * export() is the primary interface action method of all SpanExporters.
+   *
+   * @param openTracingSpans A list of spans to export to New Relic trace ingest API
+   * @return A ResultCode that indicates the execution status of the export operation
+   */
+  @Override
+  public ResultCode export(List<Span> openTracingSpans) {
+    try {
+      SpanBatch spanBatch = adapter.adaptToSpanBatch(openTracingSpans);
+      spanBatchSender.sendBatch(spanBatch);
+      return ResultCode.SUCCESS;
+    } catch (RetryWithRequestedWaitException | RetryWithBackoffException e) {
+      return ResultCode.FAILED_RETRYABLE;
+    } catch (ResponseException e) {
+      return ResultCode.FAILED_NOT_RETRYABLE;
+    }
+  }
+
+  @Override
+  public void shutdown() {}
+
+  /**
+   * Creates a new builder instance.
+   *
+   * @return a new instance builder for this exporter.
+   */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder utility for this exporter. At the very minimum, you need to provide your New Relic
+   * Insert API Key for this to work.
+   *
+   * @since 0.1.0
+   */
+  public static class Builder {
+
+    private Attributes commonAttributes = new Attributes();
+    private SpanBatchSender spanBatchSender;
+    private String apiKey;
+    private boolean enableAuditLogging = false;
+
+    /**
+     * A SpanBatchSender from the New Relic Telemetry SDK. This allows you to provide your own
+     * custom-built SpanBatchSender (for instance, if you need to enable proxies, etc).
+     *
+     * @param spanBatchSender the sender to use.
+     * @return this builder's instance
+     */
+    public Builder spanBatchSender(SpanBatchSender spanBatchSender) {
+      this.spanBatchSender = spanBatchSender;
+      return this;
+    }
+
+    /**
+     * Set your New Relic Insert Key.
+     *
+     * @param apiKey your New Relic Insert Key.
+     * @return this builder's instance
+     */
+    public Builder apiKey(String apiKey) {
+      this.apiKey = apiKey;
+      return this;
+    }
+
+    /**
+     * Turn on Audit Logging for the New Relic Telemetry SDK. This will provide additional logging
+     * of the data being sent to the New Relic Trace API at DEBUG logging level.
+     *
+     * <p>WARNING: If there is sensitive data in your Traces, this will cause that data to be
+     * exposed to wherever your logs are being sent.
+     *
+     * @return this builder's instance
+     */
+    public Builder enableAuditLogging() {
+      enableAuditLogging = true;
+      return this;
+    }
+
+    /**
+     * A set of attributes that should be attached to all Spans that are sent to New Relic.
+     *
+     * @param commonAttributes the attributes to attach
+     * @return this builder's instance
+     */
+    public Builder commonAttributes(Attributes commonAttributes) {
+      this.commonAttributes = commonAttributes;
+      return this;
+    }
+
+    /**
+     * Constructs a new instance of the exporter based on the builder's values.
+     *
+     * @return a new NewRelicSpanExporter instance
+     */
+    public NewRelicSpanExporter build() {
+      if (spanBatchSender == null) {
+        SpanBatchSenderBuilder builder = SimpleSpanBatchSender.builder(apiKey);
+        if (enableAuditLogging) {
+          builder.enableAuditLogging();
+        }
+        spanBatchSender = builder.build();
+      }
+      return new NewRelicSpanExporter(new SpanBatchAdapter(commonAttributes), spanBatchSender);
+    }
+  }
+}

--- a/exporters/newrelic/src/main/java/io/opentelemetry/exporters/newrelic/SpanBatchAdapter.java
+++ b/exporters/newrelic/src/main/java/io/opentelemetry/exporters/newrelic/SpanBatchAdapter.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.exporters.newrelic;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.spans.Span.SpanBuilder;
+import com.newrelic.telemetry.spans.SpanBatch;
+import io.opentelemetry.proto.resource.v1.Resource;
+import io.opentelemetry.proto.trace.v1.AttributeValue;
+import io.opentelemetry.proto.trace.v1.Span;
+import io.opentelemetry.proto.trace.v1.Status;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceId;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import javax.annotation.Nullable;
+
+class SpanBatchAdapter {
+
+  private final Attributes commonAttributes;
+
+  SpanBatchAdapter(Attributes commonAttributes) {
+    this.commonAttributes = commonAttributes;
+  }
+
+  SpanBatch adaptToSpanBatch(List<Span> openTracingSpans) {
+    Collection<com.newrelic.telemetry.spans.Span> newRelicSpans = new HashSet<>();
+    for (Span openTracingSpan : openTracingSpans) {
+      newRelicSpans.add(makeNewRelicSpan(openTracingSpan));
+    }
+    return new SpanBatch(newRelicSpans, commonAttributes);
+  }
+
+  private static com.newrelic.telemetry.spans.Span makeNewRelicSpan(Span span) {
+    SpanBuilder spanBuilder =
+        com.newrelic.telemetry.spans.Span.builder(makeSpanId(span.getSpanId()))
+            .name(span.getName().isEmpty() ? null : span.getName())
+            .parentId(makeSpanId(span.getParentSpanId()))
+            .traceId(makeTraceId(span.getTraceId()))
+            .attributes(generateSpanAttributes(span));
+
+    if (span.hasStartTime()) {
+      spanBuilder.timestamp(calculateTimestampMillis(span));
+    }
+
+    Double duration = calculateDuration(span);
+    if (duration != null) {
+      spanBuilder.durationMs(duration);
+    }
+    return spanBuilder.build();
+  }
+
+  private static Attributes generateSpanAttributes(Span span) {
+    Attributes attributes = createIntrinsicAttributes(span);
+    attributes = addPossibleErrorAttribute(span, attributes);
+    return addResourceAttributes(span, attributes);
+  }
+
+  private static Attributes createIntrinsicAttributes(Span span) {
+    Attributes attributes = new Attributes();
+    Span.Attributes originalAttributes = span.getAttributes();
+    Map<String, AttributeValue> attributeMap = originalAttributes.getAttributeMapMap();
+    for (Entry<String, AttributeValue> stringAttributeValueEntry : attributeMap.entrySet()) {
+      AttributeValue value = stringAttributeValueEntry.getValue();
+      switch (value.getValueCase()) {
+        case STRING_VALUE:
+          attributes.put(stringAttributeValueEntry.getKey(), value.getStringValue());
+          break;
+        case INT_VALUE:
+          attributes.put(stringAttributeValueEntry.getKey(), value.getIntValue());
+          break;
+        case BOOL_VALUE:
+          attributes.put(stringAttributeValueEntry.getKey(), value.getBoolValue());
+          break;
+        case DOUBLE_VALUE:
+          attributes.put(stringAttributeValueEntry.getKey(), value.getDoubleValue());
+          break;
+        case VALUE_NOT_SET:
+          // ignore this. NR doesn't support valueless attributes.
+          break;
+      }
+    }
+    return attributes;
+  }
+
+  private static Attributes addPossibleErrorAttribute(Span span, Attributes attributes) {
+    if (span.hasStatus()) {
+      Status status = span.getStatus();
+      if (status.getMessage() != null && !status.getMessage().isEmpty()) {
+        attributes.put("error.message", status.getMessage());
+      }
+    }
+    return attributes;
+  }
+
+  private static Attributes addResourceAttributes(Span span, Attributes attributes) {
+    Resource resource = span.getResource();
+    if (resource != null) {
+      Map<String, String> labelsMap = resource.getLabelsMap();
+      for (Entry<String, String> resourceLabel : labelsMap.entrySet()) {
+        attributes.put(resourceLabel.getKey(), resourceLabel.getValue());
+      }
+    }
+    return attributes;
+  }
+
+  @Nullable
+  private static Double calculateDuration(Span span) {
+    if (!span.hasEndTime() || !span.hasStartTime()) {
+      return null;
+    }
+    Timestamp startTime = span.getStartTime();
+    Timestamp endTime = span.getEndTime();
+
+    Duration duration = Timestamps.between(startTime, endTime);
+    double nanoPart = duration.getNanos() / 1000000d;
+    return nanoPart + SECONDS.toMillis(duration.getSeconds());
+  }
+
+  @Nullable
+  private static String makeTraceId(ByteString byteString) {
+    if (byteString.isEmpty()) {
+      return null;
+    }
+    return TraceId.asLowerBase16(byteString.toByteArray());
+  }
+
+  @Nullable
+  private static String makeSpanId(ByteString byteString) {
+    if (byteString.isEmpty()) {
+      return null;
+    }
+    return SpanId.asLowerBase16(byteString.toByteArray());
+  }
+
+  private static long calculateTimestampMillis(Span span) {
+    Timestamp spanStartTime = span.getStartTime();
+    long millis = NANOSECONDS.toMillis(spanStartTime.getNanos());
+    long seconds = SECONDS.toMillis(spanStartTime.getSeconds());
+    return seconds + millis;
+  }
+}

--- a/exporters/newrelic/src/test/java/io/opentelemetry/exporters/newrelic/NewRelicSpanExporterTest.java
+++ b/exporters/newrelic/src/test/java/io/opentelemetry/exporters/newrelic/NewRelicSpanExporterTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.exporters.newrelic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.when;
+
+import com.google.common.primitives.Longs;
+import com.google.protobuf.ByteString;
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.exceptions.DiscardBatchException;
+import com.newrelic.telemetry.exceptions.ResponseException;
+import com.newrelic.telemetry.exceptions.RetryWithBackoffException;
+import com.newrelic.telemetry.exceptions.RetryWithRequestedWaitException;
+import com.newrelic.telemetry.exceptions.RetryWithSplitException;
+import com.newrelic.telemetry.spans.SpanBatch;
+import com.newrelic.telemetry.spans.SpanBatchSender;
+import io.opentelemetry.proto.trace.v1.Span;
+import io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NewRelicSpanExporterTest {
+
+  @Mock private SpanBatchSender sender;
+  @Mock private SpanBatchAdapter adapter;
+
+  @Test
+  void testExportHappyPath() {
+    NewRelicSpanExporter testClass = new NewRelicSpanExporter(adapter, sender);
+
+    Span inputSpan =
+        Span.newBuilder().setSpanId(ByteString.copyFrom(Longs.toByteArray(1234565L))).build();
+    List<Span> spans = Collections.singletonList(inputSpan);
+    SpanBatch batch =
+        new SpanBatch(Collections.<com.newrelic.telemetry.spans.Span>emptyList(), new Attributes());
+    when(adapter.adaptToSpanBatch(spans)).thenReturn(batch);
+
+    ResultCode result = testClass.export(spans);
+    assertEquals(ResultCode.SUCCESS, result);
+  }
+
+  @Test
+  void testDiscardBatchException() throws Exception {
+    checkResponseCodeProducesException(
+        ResultCode.FAILED_NOT_RETRYABLE, DiscardBatchException.class);
+  }
+
+  @Test
+  void testRetryWithSplitException() throws Exception {
+    checkResponseCodeProducesException(
+        ResultCode.FAILED_NOT_RETRYABLE, RetryWithSplitException.class);
+  }
+
+  @Test
+  void testRetryWithBackOffException() throws Exception {
+    checkResponseCodeProducesException(
+        ResultCode.FAILED_RETRYABLE, RetryWithBackoffException.class);
+  }
+
+  @Test
+  void testRetryWithRequestedWaitException() throws Exception {
+    checkResponseCodeProducesException(
+        ResultCode.FAILED_RETRYABLE, RetryWithRequestedWaitException.class);
+  }
+
+  private void checkResponseCodeProducesException(
+      ResultCode resultCode, Class<? extends ResponseException> exceptionClass)
+      throws ResponseException {
+    com.newrelic.telemetry.spans.Span span =
+        com.newrelic.telemetry.spans.Span.builder("000000000012d685").build();
+    SpanBatch spanBatch = new SpanBatch(Collections.singleton(span), new Attributes());
+
+    NewRelicSpanExporter testClass = new NewRelicSpanExporter(adapter, sender);
+
+    Span inputSpan =
+        Span.newBuilder().setSpanId(ByteString.copyFrom(Longs.toByteArray(1234565L))).build();
+
+    when(adapter.adaptToSpanBatch(ArgumentMatchers.<Span>anyList())).thenReturn(spanBatch);
+    when(sender.sendBatch(isA(SpanBatch.class))).thenThrow(exceptionClass);
+
+    ResultCode result = testClass.export(Collections.singletonList(inputSpan));
+    assertEquals(resultCode, result);
+  }
+}

--- a/exporters/newrelic/src/test/java/io/opentelemetry/exporters/newrelic/SpanBatchAdapterTest.java
+++ b/exporters/newrelic/src/test/java/io/opentelemetry/exporters/newrelic/SpanBatchAdapterTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.exporters.newrelic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.common.primitives.Longs;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Timestamp;
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.spans.SpanBatch;
+import io.opentelemetry.proto.resource.v1.Resource;
+import io.opentelemetry.proto.trace.v1.AttributeValue;
+import io.opentelemetry.proto.trace.v1.Span;
+import io.opentelemetry.proto.trace.v1.Status;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class SpanBatchAdapterTest {
+
+  @Test
+  void testSendBatchWithSingleSpan() {
+    byte[] spanIdBytes = Longs.toByteArray(1234565L);
+    byte[] bigTraceId = new byte[16];
+    System.arraycopy(Longs.toByteArray(6543215L), 0, bigTraceId, 0, 8);
+    System.arraycopy(Longs.toByteArray(939393939L), 0, bigTraceId, 8, 8);
+    byte[] parentSpanIdBytes = Longs.toByteArray(777666777L);
+
+    com.newrelic.telemetry.spans.Span span1 =
+        com.newrelic.telemetry.spans.Span.builder("000000000012d685")
+            .traceId("000000000063d76f0000000037fe0393")
+            .timestamp(1000456)
+            .name("spanName")
+            .parentId("000000002e5a40d9")
+            .durationMs(1333.020111d)
+            .attributes(new Attributes().put("host", "bar").put("datacenter", "boo"))
+            .build();
+    SpanBatch expected = new SpanBatch(Collections.singleton(span1), new Attributes());
+
+    SpanBatchAdapter testClass = new SpanBatchAdapter(new Attributes());
+
+    Resource inputResource =
+        Resource.newBuilder().putLabels("host", "bar").putLabels("datacenter", "boo").build();
+    Span inputSpan =
+        Span.newBuilder()
+            .setSpanId(ByteString.copyFrom(spanIdBytes))
+            .setTraceId(ByteString.copyFrom(bigTraceId))
+            .setStartTime(Timestamp.newBuilder().setSeconds(1000).setNanos(456_000_000).build())
+            .setParentSpanId(ByteString.copyFrom(parentSpanIdBytes))
+            .setEndTime(Timestamp.newBuilder().setSeconds(1001).setNanos(789_020_111).build())
+            .setName("spanName")
+            .setStatus(Status.newBuilder().setCode(200).build())
+            .setResource(inputResource)
+            .build();
+
+    SpanBatch result = testClass.adaptToSpanBatch(Collections.singletonList(inputSpan));
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testAttributes() {
+    byte[] spanIdBytes = Longs.toByteArray(1234565L);
+    com.newrelic.telemetry.spans.Span span1 =
+        com.newrelic.telemetry.spans.Span.builder("000000000012d685")
+            .timestamp(1000456)
+            .attributes(
+                new Attributes()
+                    .put("myBooleanKey", true)
+                    .put("myIntKey", 123L)
+                    .put("myStringKey", "attrValue")
+                    .put("myDoubleKey", 123.45d))
+            .build();
+
+    SpanBatch expected = new SpanBatch(Collections.singleton(span1), new Attributes());
+
+    SpanBatchAdapter testClass = new SpanBatchAdapter(new Attributes());
+
+    Span inputSpan =
+        Span.newBuilder()
+            .setSpanId(ByteString.copyFrom(spanIdBytes))
+            .setStartTime(Timestamp.newBuilder().setSeconds(1000).setNanos(456_000_000).build())
+            .setAttributes(
+                Span.Attributes.newBuilder()
+                    .putAttributeMap(
+                        "myBooleanKey", AttributeValue.newBuilder().setBoolValue(true).build())
+                    .putAttributeMap(
+                        "myIntKey", AttributeValue.newBuilder().setIntValue(123).build())
+                    .putAttributeMap(
+                        "myStringKey",
+                        AttributeValue.newBuilder().setStringValue("attrValue").build())
+                    .putAttributeMap(
+                        "myDoubleKey", AttributeValue.newBuilder().setDoubleValue(123.45d).build()))
+            .build();
+
+    SpanBatch result = testClass.adaptToSpanBatch(Collections.singletonList(inputSpan));
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testMinimalData() {
+    byte[] spanIdBytes = Longs.toByteArray(1234565L);
+    SpanBatchAdapter testClass = new SpanBatchAdapter(new Attributes());
+
+    Span inputSpan = Span.newBuilder().setSpanId(ByteString.copyFrom(spanIdBytes)).build();
+    SpanBatch result = testClass.adaptToSpanBatch(Collections.singletonList(inputSpan));
+
+    assertEquals(1, result.getTelemetry().size());
+  }
+
+  @Test
+  void testErrors() {
+    byte[] spanIdBytes = Longs.toByteArray(1234565L);
+    com.newrelic.telemetry.spans.Span span1 =
+        com.newrelic.telemetry.spans.Span.builder("000000000012d685")
+            .timestamp(1000456)
+            .attributes(new Attributes().put("error.message", "it's broken"))
+            .build();
+    SpanBatch expected =
+        new SpanBatch(Collections.singleton(span1), new Attributes().put("host", "localhost"));
+
+    SpanBatchAdapter testClass = new SpanBatchAdapter(new Attributes().put("host", "localhost"));
+
+    Span inputSpan =
+        Span.newBuilder()
+            .setSpanId(ByteString.copyFrom(spanIdBytes))
+            .setStartTime(Timestamp.newBuilder().setSeconds(1000).setNanos(456_000_000).build())
+            .setStatus(Status.newBuilder().setMessage("it's broken"))
+            .build();
+    SpanBatch result = testClass.adaptToSpanBatch(Collections.singletonList(inputSpan));
+
+    assertEquals(expected, result);
+  }
+}

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SpanExporter.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SpanExporter.java
@@ -24,7 +24,7 @@ import java.util.List;
  * An interface that allows different tracing services to export recorded data for sampled spans in
  * their own format.
  *
- * <p>To export data this MUST be register to the {@code TracerSdk} using a {@link
+ * <p>To export data this MUST be registered to the {@code TracerSdk} using a {@link
  * SimpleSampledSpansProcessor} or a {@code BatchSampledSpansProcessor}.
  */
 // TODO: Change {@code BatchSampledSpansExporter} to {@link BatchSampledSpansExporter} when the

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,7 @@ include ":opentelemetry-api"
 include ":opentelemetry-contrib-runtime-metrics"
 include ":opentelemetry-contrib-trace-utils"
 include ":opentelemetry-exporters-jaeger"
+include ":opentelemetry-exporters-newrelic"
 include ":opentelemetry-opentracing-shim"
 include ":opentelemetry-proto"
 include ":opentelemetry-sdk"
@@ -19,6 +20,7 @@ project(':opentelemetry-contrib-runtime-metrics').projectDir =
         "$rootDir/contrib/runtime_metrics" as File
 project(':opentelemetry-contrib-trace-utils').projectDir = "$rootDir/contrib/trace_utils" as File
 project(':opentelemetry-exporters-jaeger').projectDir = "$rootDir/exporters/jaeger" as File
+project(':opentelemetry-exporters-newrelic').projectDir = "$rootDir/exporters/newrelic" as File
 project(':opentelemetry-opentracing-shim').projectDir = "$rootDir/opentracing_shim" as File
 project(':opentelemetry-sdk').projectDir = "$rootDir/sdk" as File
 project(':opentelemetry-sdk-contrib-async-processor').projectDir =


### PR DESCRIPTION
This also adds methods to `SpanId` and `TradeId` to make it easier to make hex ids out of the binary keys in the protobufs.