### PR TITLE
Add methods to SpanId and TraceId to make conversion to hex strings easier

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/SpanId.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanId.java
@@ -108,6 +108,21 @@ public final class SpanId implements Comparable<SpanId> {
   }
 
   /**
+   * Transforms a byte[] representation of a span id (eg. from a protobuf) and returns a base 16
+   * representation of the same.
+   *
+   * @param bytes The byte array containing the span id.
+   * @return A base 16 representation of the span id.
+   * @since 0.1.0
+   */
+  public static String asLowerBase16(byte[] bytes) {
+    long longId = BigendianEncoding.longFromByteArray(bytes, 0);
+    char[] chars = new char[BASE16_SIZE];
+    BigendianEncoding.longToBase16String(longId, chars, 0);
+    return new String(chars);
+  }
+
+  /**
    * Copies the byte array representations of the {@code SpanId} into the {@code dest} beginning at
    * the {@code destOffset} offset.
    *

--- a/api/src/main/java/io/opentelemetry/trace/TraceId.java
+++ b/api/src/main/java/io/opentelemetry/trace/TraceId.java
@@ -151,6 +151,23 @@ public final class TraceId implements Comparable<TraceId> {
   }
 
   /**
+   * Transforms a byte[] representation of a trace id (eg. from a protobuf) and returns a base 16
+   * representation of the same.
+   *
+   * @param bytes The byte array containing the trace id.
+   * @return A base 16 representation of the trace id.
+   * @since 0.1.0
+   */
+  public static String asLowerBase16(byte[] bytes) {
+    long idHi = BigendianEncoding.longFromByteArray(bytes, 0);
+    long idLo = BigendianEncoding.longFromByteArray(bytes, SIZE / 2);
+    char[] chars = new char[BASE16_SIZE];
+    BigendianEncoding.longToBase16String(idHi, chars, 0);
+    BigendianEncoding.longToBase16String(idLo, chars, BASE16_SIZE / 2);
+    return new String(chars);
+  }
+
+  /**
    * Copies the lowercase base16 representations of the {@code TraceId} into the {@code dest}
    * beginning at the {@code destOffset} offset.
    *

--- a/api/src/test/java/io/opentelemetry/trace/SpanIdTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanIdTest.java
@@ -62,6 +62,14 @@ public class SpanIdTest {
   }
 
   @Test
+  public void asLowerBase16() {
+    SpanId spanId = new SpanId(43L);
+    byte[] idAsBytes = new byte[8];
+    spanId.copyBytesTo(idAsBytes, 0);
+    assertThat(SpanId.asLowerBase16(idAsBytes)).isEqualTo("000000000000002b");
+  }
+
+  @Test
   public void spanId_CompareTo() {
     assertThat(first.compareTo(second)).isGreaterThan(0);
     assertThat(second.compareTo(first)).isLessThan(0);

--- a/api/src/test/java/io/opentelemetry/trace/TraceIdTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TraceIdTest.java
@@ -80,6 +80,14 @@ public class TraceIdTest {
   }
 
   @Test
+  public void asLowerBase16() {
+    TraceId traceId = new TraceId(43L, 109L);
+    byte[] idAsBytes = new byte[16];
+    traceId.copyBytesTo(idAsBytes, 0);
+    assertThat(TraceId.asLowerBase16(idAsBytes)).isEqualTo("000000000000002b000000000000006d");
+  }
+
+  @Test
   public void traceId_CompareTo() {
     assertThat(first.compareTo(second)).isGreaterThan(0);
     assertThat(second.compareTo(first)).isLessThan(0);


### PR DESCRIPTION
While building our exporter, we ran into issues trying to make the binary protobuf ids into a json friendly format. These methods were very useful in converting the ids into hexadecimal strings.