### PR TITLE
Per spec change, allow start digit and @.  

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/Tracestate.java
+++ b/api/src/main/java/io/opentelemetry/trace/Tracestate.java
@@ -253,7 +253,7 @@ public abstract class Tracestate {
           && c != '/') {
         return false;
       }
-      if((c == '@') && (++atSeenCount > 1)){
+      if ((c == '@') && (++atSeenCount > 1)) {
         return false;
       }
     }

--- a/api/src/main/java/io/opentelemetry/trace/Tracestate.java
+++ b/api/src/main/java/io/opentelemetry/trace/Tracestate.java
@@ -238,19 +238,13 @@ public abstract class Tracestate {
   // forward slashes /.  For multi-tenant vendor scenarios, an at sign (@) can be used to prefix the
   // vendor name.
   private static boolean validateKey(String key) {
-    if (key.length() > KEY_MAX_SIZE || key.isEmpty() || !isNumberOrDigit(key.charAt(0))) {
+    if (key.length() > KEY_MAX_SIZE || key.isEmpty() || isNotNumberOrDigit(key.charAt(0))) {
       return false;
     }
     int atSeenCount = 0;
     for (int i = 1; i < key.length(); i++) {
       char c = key.charAt(i);
-      if (!isNumberOrDigit(c)
-          && !(c >= '0' && c <= '9')
-          && c != '_'
-          && c != '-'
-          && c != '@'
-          && c != '*'
-          && c != '/') {
+      if (isNotNumberOrDigit(c) && c != '_' && c != '-' && c != '@' && c != '*' && c != '/') {
         return false;
       }
       if ((c == '@') && (++atSeenCount > 1)) {
@@ -260,8 +254,8 @@ public abstract class Tracestate {
     return true;
   }
 
-  private static boolean isNumberOrDigit(char ch) {
-    return (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9');
+  private static boolean isNotNumberOrDigit(char ch) {
+    return (ch < 'a' || ch > 'z') && (ch < '0' || ch > '9');
   }
 
   // Value is opaque string up to 256 characters printable ASCII RFC0020 characters (i.e., the range

--- a/api/src/main/java/io/opentelemetry/trace/Tracestate.java
+++ b/api/src/main/java/io/opentelemetry/trace/Tracestate.java
@@ -237,7 +237,7 @@ public abstract class Tracestate {
   // can only contain lowercase letters a-z, digits 0-9, underscores _, dashes -, asterisks *, and
   // forward slashes /.  For multi-tenant vendor scenarios, an at sign (@) can be used to prefix the
   // vendor name.
-  //todo: benchmark this implementation
+  // todo: benchmark this implementation
   private static boolean validateKey(String key) {
     if (key.length() > KEY_MAX_SIZE || key.isEmpty() || !isNumberOrDigit(key.charAt(0))) {
       return false;

--- a/api/src/main/java/io/opentelemetry/trace/Tracestate.java
+++ b/api/src/main/java/io/opentelemetry/trace/Tracestate.java
@@ -235,11 +235,13 @@ public abstract class Tracestate {
 
   // Key is opaque string up to 256 characters printable. It MUST begin with a lowercase letter, and
   // can only contain lowercase letters a-z, digits 0-9, underscores _, dashes -, asterisks *, and
-  // forward slashes /.
+  // forward slashes /.  For multi-tenant vendor scenarios, an at sign (@) can be used to prefix the
+  // vendor name.
   private static boolean validateKey(String key) {
     if (key.length() > KEY_MAX_SIZE || key.isEmpty() || !isNumberOrDigit(key.charAt(0))) {
       return false;
     }
+    int atSeenCount = 0;
     for (int i = 1; i < key.length(); i++) {
       char c = key.charAt(i);
       if (!isNumberOrDigit(c)
@@ -249,6 +251,9 @@ public abstract class Tracestate {
           && c != '@'
           && c != '*'
           && c != '/') {
+        return false;
+      }
+      if((c == '@') && (++atSeenCount > 1)){
         return false;
       }
     }

--- a/api/src/main/java/io/opentelemetry/trace/Tracestate.java
+++ b/api/src/main/java/io/opentelemetry/trace/Tracestate.java
@@ -238,13 +238,13 @@ public abstract class Tracestate {
   // forward slashes /.  For multi-tenant vendor scenarios, an at sign (@) can be used to prefix the
   // vendor name.
   private static boolean validateKey(String key) {
-    if (key.length() > KEY_MAX_SIZE || key.isEmpty() || isNotNumberOrDigit(key.charAt(0))) {
+    if (key.length() > KEY_MAX_SIZE || key.isEmpty() || !isNumberOrDigit(key.charAt(0))) {
       return false;
     }
     int atSeenCount = 0;
     for (int i = 1; i < key.length(); i++) {
       char c = key.charAt(i);
-      if (isNotNumberOrDigit(c) && c != '_' && c != '-' && c != '@' && c != '*' && c != '/') {
+      if (!isNumberOrDigit(c) && c != '_' && c != '-' && c != '@' && c != '*' && c != '/') {
         return false;
       }
       if ((c == '@') && (++atSeenCount > 1)) {
@@ -254,8 +254,8 @@ public abstract class Tracestate {
     return true;
   }
 
-  private static boolean isNotNumberOrDigit(char ch) {
-    return (ch < 'a' || ch > 'z') && (ch < '0' || ch > '9');
+  private static boolean isNumberOrDigit(char ch) {
+    return (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9');
   }
 
   // Value is opaque string up to 256 characters printable ASCII RFC0020 characters (i.e., the range

--- a/api/src/main/java/io/opentelemetry/trace/Tracestate.java
+++ b/api/src/main/java/io/opentelemetry/trace/Tracestate.java
@@ -237,24 +237,26 @@ public abstract class Tracestate {
   // can only contain lowercase letters a-z, digits 0-9, underscores _, dashes -, asterisks *, and
   // forward slashes /.
   private static boolean validateKey(String key) {
-    if (key.length() > KEY_MAX_SIZE
-        || key.isEmpty()
-        || key.charAt(0) < 'a'
-        || key.charAt(0) > 'z') {
+    if (key.length() > KEY_MAX_SIZE || key.isEmpty() || !isNumberOrDigit(key.charAt(0))) {
       return false;
     }
     for (int i = 1; i < key.length(); i++) {
       char c = key.charAt(i);
-      if (!(c >= 'a' && c <= 'z')
+      if (!isNumberOrDigit(c)
           && !(c >= '0' && c <= '9')
           && c != '_'
           && c != '-'
+          && c != '@'
           && c != '*'
           && c != '/') {
         return false;
       }
     }
     return true;
+  }
+
+  private static boolean isNumberOrDigit(char ch) {
+    return (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9');
   }
 
   // Value is opaque string up to 256 characters printable ASCII RFC0020 characters (i.e., the range

--- a/api/src/main/java/io/opentelemetry/trace/Tracestate.java
+++ b/api/src/main/java/io/opentelemetry/trace/Tracestate.java
@@ -237,6 +237,7 @@ public abstract class Tracestate {
   // can only contain lowercase letters a-z, digits 0-9, underscores _, dashes -, asterisks *, and
   // forward slashes /.  For multi-tenant vendor scenarios, an at sign (@) can be used to prefix the
   // vendor name.
+  //todo: benchmark this implementation
   private static boolean validateKey(String key) {
     if (key.length() > KEY_MAX_SIZE || key.isEmpty() || !isNumberOrDigit(key.charAt(0))) {
       return false;

--- a/api/src/test/java/io/opentelemetry/trace/TracestateTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TracestateTest.java
@@ -71,13 +71,25 @@ public class TracestateTest {
   @Test
   public void invalidFirstKeyCharacter() {
     thrown.expect(IllegalArgumentException.class);
-    EMPTY.toBuilder().set("1_key", FIRST_VALUE).build();
+    EMPTY.toBuilder().set("$_key", FIRST_VALUE).build();
+  }
+
+  @Test
+  public void firstKeyCharacterDigitIsAllowed() {
+    Tracestate result = EMPTY.toBuilder().set("1_key", FIRST_VALUE).build();
+    assertThat(result).isNotNull();
   }
 
   @Test
   public void invalidKeyCharacters() {
     thrown.expect(IllegalArgumentException.class);
     EMPTY.toBuilder().set("kEy_1", FIRST_VALUE).build();
+  }
+
+  @Test
+  public void testValidAtSignVendorNamePrefix() {
+    Tracestate result = EMPTY.toBuilder().set("1@nr", FIRST_VALUE).build();
+    assertThat(result).isNotNull();
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/trace/TracestateTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TracestateTest.java
@@ -77,7 +77,7 @@ public class TracestateTest {
   @Test
   public void firstKeyCharacterDigitIsAllowed() {
     Tracestate result = EMPTY.toBuilder().set("1_key", FIRST_VALUE).build();
-    assertThat(result).isNotNull();
+    assertThat(result.get("1_key")).isEqualTo(FIRST_VALUE);
   }
 
   @Test
@@ -89,7 +89,13 @@ public class TracestateTest {
   @Test
   public void testValidAtSignVendorNamePrefix() {
     Tracestate result = EMPTY.toBuilder().set("1@nr", FIRST_VALUE).build();
-    assertThat(result).isNotNull();
+    assertThat(result.get("1@nr")).isEqualTo(FIRST_VALUE);
+  }
+
+  @Test
+  public void testMultipleAtSignNotAllowed() {
+    thrown.expect(IllegalArgumentException.class);
+    EMPTY.toBuilder().set("1@n@r@", FIRST_VALUE).build();
   }
 
   @Test


### PR DESCRIPTION
Fixes #562

Note: This also adds support for `@` vendor prefix inside the key.