### PR TITLE
Test SDK and OpenTracing shim interoperability

### DIFF
--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNull;
 
 import io.opentelemetry.distributedcontext.DefaultDistributedContextManager;
 import io.opentelemetry.opentracingshim.TraceShim;
+import io.opentelemetry.sdk.trace.SpanData;
 import io.opentelemetry.sdk.trace.TracerSdk;
 import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
@@ -58,7 +59,7 @@ public class OpenTelemetryInteroperabilityTest {
     assertEquals(sdk.getCurrentSpan().getClass(), DefaultSpan.class);
     assertNull(otTracer.activeSpan());
 
-    List<io.opentelemetry.proto.trace.v1.Span> finishedSpans = spanExporter.getFinishedSpanItems();
+    List<SpanData> finishedSpans = spanExporter.getFinishedSpanItems();
     assertEquals(2, finishedSpans.size());
     TestUtils.assertSameTrace(finishedSpans);
   }
@@ -75,7 +76,7 @@ public class OpenTelemetryInteroperabilityTest {
     assertEquals(sdk.getCurrentSpan().getClass(), DefaultSpan.class);
     assertNull(otTracer.activeSpan());
 
-    List<io.opentelemetry.proto.trace.v1.Span> finishedSpans = spanExporter.getFinishedSpanItems();
+    List<SpanData> finishedSpans = spanExporter.getFinishedSpanItems();
     assertEquals(2, finishedSpans.size());
     TestUtils.assertSameTrace(finishedSpans);
   }

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
@@ -23,7 +23,7 @@ import io.opentelemetry.distributedcontext.DefaultDistributedContextManager;
 import io.opentelemetry.opentracingshim.TraceShim;
 import io.opentelemetry.sdk.trace.TracerSdk;
 import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
-import io.opentelemetry.sdk.trace.export.SimpleSampledSpansProcessor;
+import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentracing.Scope;
 import io.opentracing.Span;
@@ -39,7 +39,7 @@ public class OpenTelemetryInteroperabilityTest {
       TraceShim.createTracerShim(sdk, DefaultDistributedContextManager.getInstance());
 
   {
-    sdk.addSpanProcessor(SimpleSampledSpansProcessor.newBuilder(spanExporter).build());
+    sdk.addSpanProcessor(SimpleSpansProcessor.newBuilder(spanExporter).build());
   }
 
   @Before

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.opentracingshim.testbed;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import io.opentelemetry.distributedcontext.DefaultDistributedContextManager;
+import io.opentelemetry.opentracingshim.TraceShim;
+import io.opentelemetry.sdk.trace.TracerSdk;
+import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.export.SimpleSampledSpansProcessor;
+import io.opentelemetry.trace.DefaultSpan;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+public class OpenTelemetryInteroperabilityTest {
+  private final TracerSdk sdk = new TracerSdk();
+  private final InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+  private final Tracer otTracer =
+      TraceShim.createTracerShim(sdk, DefaultDistributedContextManager.getInstance());
+
+  {
+    sdk.addSpanProcessor(SimpleSampledSpansProcessor.newBuilder(spanExporter).build());
+  }
+
+  @Before
+  public void before() {
+    spanExporter.reset();
+  }
+
+  @Test
+  public void sdkContinuesOpenTracingTrace() {
+    Span otSpan = otTracer.buildSpan("ot_span").start();
+    try (Scope scope = otTracer.scopeManager().activate(otSpan)) {
+      sdk.spanBuilder("otel_span").startSpan().end();
+    } finally {
+      otSpan.finish();
+    }
+    assertEquals(sdk.getCurrentSpan().getClass(), DefaultSpan.class);
+    assertNull(otTracer.activeSpan());
+
+    List<io.opentelemetry.proto.trace.v1.Span> finishedSpans = spanExporter.getFinishedSpanItems();
+    assertEquals(2, finishedSpans.size());
+    TestUtils.assertSameTrace(finishedSpans);
+  }
+
+  @Test
+  public void openTracingContinuesSdkTrace() {
+    io.opentelemetry.trace.Span otelSpan = sdk.spanBuilder("otel_span").startSpan();
+    try (io.opentelemetry.context.Scope scope = sdk.withSpan(otelSpan)) {
+      otTracer.buildSpan("ot_span").start().finish();
+    } finally {
+      otelSpan.end();
+    }
+
+    assertEquals(sdk.getCurrentSpan().getClass(), DefaultSpan.class);
+    assertNull(otTracer.activeSpan());
+
+    List<io.opentelemetry.proto.trace.v1.Span> finishedSpans = spanExporter.getFinishedSpanItems();
+    assertEquals(2, finishedSpans.size());
+    TestUtils.assertSameTrace(finishedSpans);
+  }
+}


### PR DESCRIPTION
Test that OpenTracing shim can continue trace started by SDK and vice versa.

cc @carlosalberto 

Signed-off-by: Pavol Loffay <ploffay@redhat.com>