### PR TITLE
Initial prototype for handling OT Span's baggage properly.

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
@@ -135,6 +135,15 @@ public final class DefaultSpan implements Span {
     return false;
   }
 
+  @SuppressWarnings("ReturnMissingNullable")
+  @Override
+  public Object getImplObj() {
+    return null;
+  }
+
+  @Override
+  public void setImplObj(Object obj) {}
+
   @Override
   public String toString() {
     return "DefaultSpan";

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -206,6 +206,18 @@ public interface Span {
   boolean isRecordingEvents();
 
   /**
+   * Returns an {@code Object} used for backwards interoperability with either OpenTracing or
+   * OpenCensus. Do not use this object. Scheduled to be removed in the next version.
+   */
+  Object getImplObj();
+
+  /**
+   * Sets an {@code Object} used for backwards interoperability with either OpenTracing or
+   * OpenCensus. Do not use this object. Scheduled to be removed in the next version.
+   */
+  void setImplObj(Object obj);
+
+  /**
    * {@link Builder} is used to construct {@link Span} instances which define arbitrary scopes of
    * code that are sampled for distributed tracing as a single atomic unit.
    *

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/ScopeManagerShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/ScopeManagerShim.java
@@ -37,8 +37,7 @@ final class ScopeManagerShim extends BaseShimObject implements ScopeManager {
       return null;
     }
 
-    // TODO: Properly include the bagagge/distributedContext.
-    return new SpanShim(telemetryInfo(), span);
+    return new SpanShim(telemetryInfo(), span, /*reuseContext= */ true);
   }
 
   @Override

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.opentracingshim;
 
 import io.opentelemetry.distributedcontext.DistributedContext;
-import io.opentelemetry.distributedcontext.EmptyDistributedContext;
 import io.opentelemetry.distributedcontext.Entry;
 import io.opentelemetry.distributedcontext.EntryKey;
 import io.opentelemetry.distributedcontext.EntryMetadata;
@@ -34,7 +33,7 @@ final class SpanContextShim extends BaseShimObject implements SpanContext {
   private final DistributedContext distContext;
 
   public SpanContextShim(TelemetryInfo telemetryInfo, io.opentelemetry.trace.SpanContext context) {
-    this(telemetryInfo, context, EmptyDistributedContext.getInstance());
+    this(telemetryInfo, context, telemetryInfo.contextManager().contextBuilder().build());
   }
 
   public SpanContextShim(

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/TestUtils.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/TestUtils.java
@@ -20,8 +20,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import io.opentelemetry.common.Timestamp;
-import io.opentelemetry.distributedcontext.DefaultDistributedContextManager;
 import io.opentelemetry.opentracingshim.TraceShim;
+import io.opentelemetry.sdk.distributedcontext.DistributedContextManagerSdk;
 import io.opentelemetry.sdk.trace.SpanData;
 import io.opentelemetry.sdk.trace.TracerSdk;
 import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
@@ -50,7 +50,7 @@ public final class TestUtils {
     tracer.addSpanProcessor(SimpleSpansProcessor.newBuilder(exporter).build());
     // TODO - Make SURE that for these tests we don't really need anything special here.
     // (PROBABLY we can already use the SDK portion of the Dist Context).
-    return TraceShim.createTracerShim(tracer, DefaultDistributedContextManager.getInstance());
+    return TraceShim.createTracerShim(tracer, new DistributedContextManagerSdk());
   }
 
   /** Returns the number of finished {@code Span}s in the specified {@code InMemorySpanExporter}. */

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/baggagehandling/BaggageHandlingTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/baggagehandling/BaggageHandlingTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.opentracingshim.testbed.baggagehandling;
+
+import static io.opentelemetry.opentracingshim.testbed.TestUtils.createTracerShim;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import org.junit.Test;
+
+public final class BaggageHandlingTest {
+  private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
+  private final Tracer tracer = createTracerShim(exporter);
+
+  @Test
+  public void test() throws Exception {
+    Span span = tracer.buildSpan("one").start();
+    try (Scope scope = tracer.activateSpan(span)) {
+      SpanContext ctx1 = span.context();
+
+      span.setBaggageItem("key1", "value1");
+      assertEquals(true, span.context().baggageItems().iterator().hasNext());
+      assertEquals(span.getBaggageItem("key1"), "value1");
+      assertEquals(tracer.activeSpan().getBaggageItem("key1"), "value1");
+
+      // The original SpanContext was not modified.
+      assertFalse(ctx1.baggageItems().iterator().hasNext());
+
+      tracer.activeSpan().setBaggageItem("key2", "value2");
+      assertEquals(span.getBaggageItem("key2"), "value2");
+      assertEquals(tracer.activeSpan().getBaggageItem("key2"), "value2");
+    }
+  }
+}

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -433,6 +433,18 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     return true;
   }
 
+  private volatile Object implObj;
+
+  @Override
+  public Object getImplObj() {
+    return implObj;
+  }
+
+  @Override
+  public void setImplObj(Object obj) {
+    implObj = obj;
+  }
+
   void addChild() {
     synchronized (this) {
       if (hasBeenEnded) {


### PR DESCRIPTION
This is a (dirty, but working) prototype for what is described in #547 in general, and this small PR shows the required change in the API side:

```
// Span.java
public Object getImplObj();
public void setImplObj();
```

This methods are expected to be used only by the interoperability layers (OT for sure would make use of this opaque object), and labeled as **do not use, we will remove them in the future**.

As mentioned in the related Issue, this would **greatly** simplify the **SpanContext + Baggage** handling that happens in OT, as otherwise we would have a valid, working shim but potentially a really bad performance. 

Let me know - in any case, I will probably work on the alternative, non-touching API approach for the v02 ;)