### PR TITLE
Expose the global telemetry objects as sdk ones.

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk;
+
+import io.opentelemetry.OpenTelemetry;
+import io.opentelemetry.sdk.distributedcontext.DistributedContextManagerSdk;
+import io.opentelemetry.sdk.metrics.MeterSdk;
+import io.opentelemetry.sdk.trace.TracerSdk;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * This class provides a static global accessor for SDK telemetry objects {@link TracerSdk}, {@link
+ * MeterSdk} and {@link DistributedContextManagerSdk}.
+ *
+ * <p>This is a convenience class getting and casting the telemetry objects from {@link
+ * OpenTelemetry}.
+ *
+ * @see OpenTelemetry
+ */
+@ThreadSafe
+public final class OpenTelemetrySdk {
+  /**
+   * Returns a {@link TracerSdk}.
+   *
+   * @return tracer returned by {@link OpenTelemetry#getTracer()}.
+   * @since 0.1.0
+   */
+  public static TracerSdk getTracer() {
+    return (TracerSdk) OpenTelemetry.getTracer();
+  }
+
+  /**
+   * Returns a {@link MeterSdk}.
+   *
+   * @return meter returned by {@link OpenTelemetry#getMeter()}.
+   * @since 0.1.0
+   */
+  public static MeterSdk getMeter() {
+    return (MeterSdk) OpenTelemetry.getMeter();
+  }
+
+  /**
+   * Returns a {@link DistributedContextManagerSdk}.
+   *
+   * @return context manager returned by {@link OpenTelemetry#getDistributedContextManager()}.
+   * @since 0.1.0
+   */
+  public static DistributedContextManagerSdk getDistributedContextManager() {
+    return (DistributedContextManagerSdk) OpenTelemetry.getDistributedContextManager();
+  }
+
+  private OpenTelemetrySdk() {}
+}

--- a/sdk/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -19,21 +19,18 @@ package io.opentelemetry.sdk;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.sdk.distributedcontext.DistributedContextManagerSdk;
-import io.opentelemetry.sdk.metrics.MeterSdk;
-import io.opentelemetry.sdk.trace.TracerSdk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class OpenTelemetryTest {
+public class OpenTelemetrySdkTest {
 
   @Test
   public void testDefault() {
-    assertThat(OpenTelemetry.getTracer()).isInstanceOf(TracerSdk.class);
-    assertThat(OpenTelemetry.getDistributedContextManager())
-        .isInstanceOf(DistributedContextManagerSdk.class);
-    assertThat(OpenTelemetry.getMeter()).isInstanceOf(MeterSdk.class);
+    assertThat(OpenTelemetrySdk.getTracer()).isSameInstanceAs(OpenTelemetry.getTracer());
+    assertThat(OpenTelemetrySdk.getDistributedContextManager())
+        .isSameInstanceAs(OpenTelemetry.getDistributedContextManager());
+    assertThat(OpenTelemetrySdk.getMeter()).isSameInstanceAs(OpenTelemetry.getMeter());
   }
 }


### PR DESCRIPTION
I remember @bogdandrutu asking for convenience getters this in the past.