### PR TITLE
remove protobuf from timestamp converter and friends.

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/internal/Clock.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/internal/Clock.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.internal;
 
-import com.google.protobuf.Timestamp;
+import io.opentelemetry.common.Timestamp;
 
 /**
  * Interface for getting the current time.

--- a/sdk/src/main/java/io/opentelemetry/sdk/internal/MillisClock.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/internal/MillisClock.java
@@ -16,8 +16,7 @@
 
 package io.opentelemetry.sdk.internal;
 
-import com.google.protobuf.Timestamp;
-import com.google.protobuf.util.Timestamps;
+import io.opentelemetry.common.Timestamp;
 import javax.annotation.concurrent.ThreadSafe;
 
 /** A {@link Clock} that uses {@link System#currentTimeMillis()} and {@link System#nanoTime()}. */
@@ -39,7 +38,7 @@ public final class MillisClock implements Clock {
 
   @Override
   public Timestamp now() {
-    return Timestamps.fromMillis(System.currentTimeMillis());
+    return Timestamp.fromMillis(System.currentTimeMillis());
   }
 
   @Override

--- a/sdk/src/main/java/io/opentelemetry/sdk/internal/TimestampConverter.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/internal/TimestampConverter.java
@@ -48,7 +48,7 @@ public class TimestampConverter {
    * @param nanoTime value to convert.
    * @return the {@code Timestamp} representation of the {@code time}.
    */
-  public Timestamp convertNanoTimeProto(long nanoTime) {
+  public Timestamp convertNanoTime(long nanoTime) {
     long deltaNanos = nanoTime - this.nanoTime;
 
     long seconds = timestamp.getSeconds() + (deltaNanos / NANOS_PER_SECOND);
@@ -64,19 +64,5 @@ public class TimestampConverter {
   private TimestampConverter(Timestamp timestamp, long nanoTime) {
     this.timestamp = timestamp;
     this.nanoTime = nanoTime;
-  }
-
-  /**
-   * Converts a {@link System#nanoTime() nanoTime} value to {@link
-   * io.opentelemetry.common.Timestamp}.
-   *
-   * @param nanoTime value to convert.
-   * @return the {@code SpanData.Timestamp} representation of the {@code time}.
-   */
-  public io.opentelemetry.common.Timestamp convertNanoTime(long nanoTime) {
-    // todo: implement this without going through the protobuf intermediary.
-    Timestamp protoVersion = convertNanoTimeProto(nanoTime);
-    return io.opentelemetry.common.Timestamp.create(
-        protoVersion.getSeconds(), protoVersion.getNanos());
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/internal/ClockTestUtil.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/internal/ClockTestUtil.java
@@ -16,14 +16,14 @@
 
 package io.opentelemetry.sdk.internal;
 
-import com.google.protobuf.Timestamp;
+import io.opentelemetry.common.Timestamp;
 
 final class ClockTestUtil {
   static final int NANOS_PER_SECOND = 1000 * 1000 * 1000;
   static final int NANOS_PER_MILLI = 1000 * 1000;
 
   static Timestamp createTimestamp(long seconds, int nanos) {
-    return Timestamp.newBuilder().setSeconds(seconds).setNanos(nanos).build();
+    return Timestamp.create(seconds, nanos);
   }
 
   private ClockTestUtil() {}

--- a/sdk/src/test/java/io/opentelemetry/sdk/internal/TimestampConverterTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/internal/TimestampConverterTest.java
@@ -34,28 +34,28 @@ public class TimestampConverterTest {
   public void now() {
     assertThat(testClock.now()).isEqualTo(timestamp);
     TimestampConverter timeConverter = TimestampConverter.now(testClock);
-    assertThat(timeConverter.convertNanoTimeProto(testClock.nowNanos())).isEqualTo(timestamp);
+    assertThat(timeConverter.convertNanoTime(testClock.nowNanos())).isEqualTo(timestamp);
   }
 
   @Test
   public void convertNanoTime_Positive() {
     TimestampConverter timeConverter = TimestampConverter.now(testClock);
-    assertThat(timeConverter.convertNanoTimeProto(testClock.nowNanos() + 3210))
+    assertThat(timeConverter.convertNanoTime(testClock.nowNanos() + 3210))
         .isEqualTo(createTimestamp(1234, 8888));
-    assertThat(timeConverter.convertNanoTimeProto(testClock.nowNanos() + 1000))
+    assertThat(timeConverter.convertNanoTime(testClock.nowNanos() + 1000))
         .isEqualTo(createTimestamp(1234, 6678));
-    assertThat(timeConverter.convertNanoTimeProto(testClock.nowNanos() + 15_999_994_322L))
+    assertThat(timeConverter.convertNanoTime(testClock.nowNanos() + 15_999_994_322L))
         .isEqualTo(createTimestamp(1250, 0));
   }
 
   @Test
   public void convertNanoTime_Negative() {
     TimestampConverter timeConverter = TimestampConverter.now(testClock);
-    assertThat(timeConverter.convertNanoTimeProto(testClock.nowNanos() - 3456))
+    assertThat(timeConverter.convertNanoTime(testClock.nowNanos() - 3456))
         .isEqualTo(createTimestamp(1234, 2222));
-    assertThat(timeConverter.convertNanoTimeProto(testClock.nowNanos() - 1000))
+    assertThat(timeConverter.convertNanoTime(testClock.nowNanos() - 1000))
         .isEqualTo(createTimestamp(1234, 4678));
-    assertThat(timeConverter.convertNanoTimeProto(testClock.nowNanos() - 14000005678L))
+    assertThat(timeConverter.convertNanoTime(testClock.nowNanos() - 14000005678L))
         .isEqualTo(createTimestamp(1220, 0));
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/internal/TimestampConverterTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/internal/TimestampConverterTest.java
@@ -19,7 +19,7 @@ package io.opentelemetry.sdk.internal;
 import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.sdk.internal.ClockTestUtil.createTimestamp;
 
-import com.google.protobuf.Timestamp;
+import io.opentelemetry.common.Timestamp;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -44,7 +44,7 @@ public class TimestampConverterTest {
         .isEqualTo(createTimestamp(1234, 8888));
     assertThat(timeConverter.convertNanoTimeProto(testClock.nowNanos() + 1000))
         .isEqualTo(createTimestamp(1234, 6678));
-    assertThat(timeConverter.convertNanoTimeProto(testClock.nowNanos() + 15999994322L))
+    assertThat(timeConverter.convertNanoTimeProto(testClock.nowNanos() + 15_999_994_322L))
         .isEqualTo(createTimestamp(1250, 0));
   }
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -66,8 +66,7 @@ public class RecordEventsReadableSpanTest {
   private final SpanId parentSpanId = TestUtils.generateRandomSpanId();
   private final SpanContext spanContext =
       SpanContext.create(traceId, spanId, TraceFlags.getDefault(), Tracestate.getDefault());
-  private final com.google.protobuf.Timestamp startTime =
-      com.google.protobuf.Timestamp.newBuilder().setSeconds(1000).build();
+  private final Timestamp startTime = Timestamp.create(1000, 0);
   private final TestClock testClock = TestClock.create(startTime);
   private final TimestampConverter timestampConverter = TimestampConverter.now(testClock);
   private final Resource resource = Resource.getEmpty();


### PR DESCRIPTION
This relates to #590.

I'm not entirely what scope of cleanup was discussed around #590, but this removes protobufs from `TimestampConverter` and `Clock` while keeping the tests passing.  If there are additional specific cleanups in `TimestampConverter` (etc) that we think should be picked up as part of this, let's figure it out.