### PR TITLE
Leverage a private object monitor lock instead of synchronizing on "this".

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -440,7 +440,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   }
 
   private void endInternal() {
-    synchronized (this) {
+    synchronized (lock) {
       if (hasBeenEnded) {
         logger.log(Level.FINE, "Calling end() on an ended Span.");
         return;

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -226,7 +226,9 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
    */
   @VisibleForTesting
   Status getStatus() {
-    return getStatusWithDefault();
+    synchronized (lock) {
+      return getStatusWithDefault();
+    }
   }
 
   /**
@@ -469,6 +471,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     }
   }
 
+  @GuardedBy("lock")
   private Status getStatusWithDefault() {
     synchronized (lock) {
       return status == null ? Status.OK : status;

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -202,7 +202,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
    */
   @Override
   public String getName() {
-    synchronized(lock) {
+    synchronized (lock) {
       return name;
     }
   }
@@ -214,7 +214,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
    * @return the end nano time.
    */
   private long getEndNanoTime() {
-    synchronized(lock) {
+    synchronized (lock) {
       return getEndNanoTimeInternal();
     }
   }
@@ -235,7 +235,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
    * @return The TimedEvents for this span.
    */
   private List<TimedEvent> getTimedEvents() {
-    synchronized(lock) {
+    synchronized (lock) {
       return new ArrayList<>(events);
     }
   }
@@ -247,7 +247,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
    */
   @VisibleForTesting
   List<Link> getLinks() {
-    synchronized(lock) {
+    synchronized (lock) {
       if (links == null) {
         return Collections.emptyList();
       }
@@ -272,7 +272,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
    */
   @VisibleForTesting
   Map<String, AttributeValue> getAttributes() {
-    synchronized(lock) {
+    synchronized (lock) {
       return Collections.unmodifiableMap(attributes);
     }
   }
@@ -284,7 +284,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
    * @return the latency of the {@code Span} in nanos.
    */
   long getLatencyNs() {
-    synchronized(lock) {
+    synchronized (lock) {
       return getEndNanoTimeInternal() - startNanoTime;
     }
   }
@@ -292,7 +292,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   // Use getEndNanoTimeInternal to avoid over-locking.
   @GuardedBy("lock")
   private long getEndNanoTimeInternal() {
-    synchronized(lock) {
+    synchronized (lock) {
       return hasBeenEnded ? endNanoTime : clock.nanoTime();
     }
   }
@@ -351,7 +351,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   public void setAttribute(String key, AttributeValue value) {
     Preconditions.checkNotNull(key, "key");
     Preconditions.checkNotNull(value, "value");
-    synchronized(lock) {
+    synchronized (lock) {
       if (hasBeenEnded) {
         logger.log(Level.FINE, "Calling setAttribute() on an ended Span.");
         return;
@@ -391,7 +391,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   }
 
   private void addTimedEvent(TimedEvent timedEvent) {
-    synchronized(lock) {
+    synchronized (lock) {
       if (hasBeenEnded) {
         logger.log(Level.FINE, "Calling addEvent() on an ended Span.");
         return;
@@ -404,7 +404,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   @Override
   public void setStatus(Status status) {
     Preconditions.checkNotNull(status, "status");
-    synchronized(lock) {
+    synchronized (lock) {
       if (hasBeenEnded) {
         logger.log(Level.FINE, "Calling setStatus() on an ended Span.");
         return;
@@ -416,7 +416,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   @Override
   public void updateName(String name) {
     Preconditions.checkNotNull(name, "name");
-    synchronized(lock) {
+    synchronized (lock) {
       if (hasBeenEnded) {
         logger.log(Level.FINE, "Calling updateName() on an ended Span.");
         return;
@@ -460,7 +460,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   }
 
   void addChild() {
-    synchronized(lock) {
+    synchronized (lock) {
       if (hasBeenEnded) {
         logger.log(Level.FINE, "Calling end() on an ended Span.");
         return;
@@ -469,9 +469,8 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     }
   }
 
-  @GuardedBy("lock")
   private Status getStatusWithDefault() {
-    synchronized(lock) {
+    synchronized (lock) {
       return status == null ? Status.OK : status;
     }
   }
@@ -548,7 +547,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   @SuppressWarnings("NoFinalizer")
   @Override
   protected void finalize() throws Throwable {
-    synchronized(lock) {
+    synchronized (lock) {
       if (!hasBeenEnded) {
         logger.log(Level.SEVERE, "Span " + name + " is GC'ed without being ended.");
       }
@@ -568,14 +567,14 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
 
   @VisibleForTesting
   int getNumberOfChildren() {
-    synchronized(lock) {
+    synchronized (lock) {
       return numberOfChildren;
     }
   }
 
   @VisibleForTesting
   int getTotalRecordedEvents() {
-    synchronized(lock) {
+    synchronized (lock) {
       return totalRecordedEvents;
     }
   }


### PR DESCRIPTION
This addresses #585 .

Using `synchronized(this)` is generally considered unsafe because any other object that has a reference to the instance in question can share the monitor can can potentially cause a deadlock.  This change uses a reentrant read/write lock which is fully private/encapsulated and prevents this deadlock potential.

Should also note that this removes lazy init for the events and attributes, which allows the fields to be final, removes concerns around nullability, and allows us to no longer hold a reference to the `TraceConfig` instance.