### PR TITLE
Move utils/Samplers from API to SDK Samplers

### DIFF
--- a/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
@@ -20,7 +20,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.common.Timestamp;
 import io.opentelemetry.trace.Span.Kind;
-import io.opentelemetry.trace.util.Samplers;
+import java.util.Collections;
+import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -35,11 +36,27 @@ public class SpanBuilderTest {
   @Test
   public void doNotCrash_NoopImplementation() {
     Span.Builder spanBuilder = tracer.spanBuilder("MySpanName");
-    spanBuilder.setSampler(Samplers.alwaysSample());
     spanBuilder.setSpanKind(Kind.SERVER);
     spanBuilder.setParent(DefaultSpan.createRandom());
     spanBuilder.setParent(DefaultSpan.createRandom().getContext());
     spanBuilder.setNoParent();
+    spanBuilder.addLink(DefaultSpan.createRandom().getContext());
+    spanBuilder.addLink(
+        DefaultSpan.createRandom().getContext(), Collections.<String, AttributeValue>emptyMap());
+    spanBuilder.addLink(
+        new Link() {
+          private final SpanContext spanContext = DefaultSpan.createRandom().getContext();
+
+          @Override
+          public SpanContext getContext() {
+            return spanContext;
+          }
+
+          @Override
+          public Map<String, AttributeValue> getAttributes() {
+            return Collections.emptyMap();
+          }
+        });
     spanBuilder.setStartTimestamp(Timestamp.create(0, 1));
     assertThat(spanBuilder.startSpan()).isInstanceOf(DefaultSpan.class);
   }

--- a/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemoryTracingTest.java
+++ b/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemoryTracingTest.java
@@ -18,9 +18,9 @@ package io.opentelemetry.exporters.inmemory;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.sdk.trace.SpanData;
 import io.opentelemetry.sdk.trace.TracerSdk;
-import io.opentelemetry.trace.util.Samplers;
 import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
@@ -71,7 +71,7 @@ public class InMemoryTracingTest {
   @Test
   public void getFinishedSpanItems_sampled() {
     tracing.getTracer().spanBuilder("A").startSpan().end();
-    tracing.getTracer().spanBuilder("B").setSampler(Samplers.neverSample()).startSpan().end();
+    tracing.getTracer().spanBuilder("B").setSampler(Samplers.alwaysOff()).startSpan().end();
 
     List<SpanData> finishedSpanItems = tracing.getFinishedSpanItems();
     assertThat(finishedSpanItems.size()).isEqualTo(1);

--- a/exporters/otprotocol/src/main/java/io/opentelemetry/exporters/otprotocol/TraceProtoUtils.java
+++ b/exporters/otprotocol/src/main/java/io/opentelemetry/exporters/otprotocol/TraceProtoUtils.java
@@ -19,11 +19,11 @@ package io.opentelemetry.exporters.otprotocol;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
 import io.opentelemetry.proto.trace.v1.ConstantSampler;
+import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.trace.Sampler;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceId;
-import io.opentelemetry.trace.util.Samplers;
 
 /** Utilities for converting various objects to protobuf representations. */
 public class TraceProtoUtils {
@@ -92,9 +92,9 @@ public class TraceProtoUtils {
       ConstantSampler constantSampler = traceConfigProto.getConstantSampler();
       switch (constantSampler.getDecision()) {
         case ALWAYS_ON:
-          return Samplers.alwaysSample();
+          return Samplers.alwaysOn();
         case ALWAYS_OFF:
-          return Samplers.neverSample();
+          return Samplers.alwaysOff();
         case ALWAYS_PARENT:
           // TODO: add support.
         case UNRECOGNIZED:

--- a/exporters/otprotocol/src/test/java/io/opentelemetry/exporters/otprotocol/TraceProtoUtilsTest.java
+++ b/exporters/otprotocol/src/test/java/io/opentelemetry/exporters/otprotocol/TraceProtoUtilsTest.java
@@ -21,10 +21,10 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.protobuf.ByteString;
 import io.opentelemetry.proto.trace.v1.ConstantSampler;
 import io.opentelemetry.proto.trace.v1.ConstantSampler.ConstantDecision;
+import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceId;
-import io.opentelemetry.trace.util.Samplers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -64,7 +64,7 @@ public class TraceProtoUtilsTest {
   @Test
   public void traceConfigFromProto() {
     TraceConfig traceConfig = TraceProtoUtils.traceConfigFromProto(TRACE_CONFIG_PROTO);
-    assertThat(traceConfig.getSampler()).isEqualTo(Samplers.neverSample());
+    assertThat(traceConfig.getSampler()).isEqualTo(Samplers.alwaysOff());
     assertThat(traceConfig.getMaxNumberOfAttributes()).isEqualTo(10);
     assertThat(traceConfig.getMaxNumberOfEvents()).isEqualTo(9);
     assertThat(traceConfig.getMaxNumberOfLinks()).isEqualTo(8);

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.trace.util;
+package io.opentelemetry.sdk.trace;
 
 import io.opentelemetry.trace.AttributeValue;
 import io.opentelemetry.trace.Link;
@@ -37,8 +37,8 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public final class Samplers {
-  private static final Sampler ALWAYS_SAMPLE = new AlwaysSampleSampler();
-  private static final Sampler NEVER_SAMPLE = new NeverSampleSampler();
+  private static final Sampler ALWAYS_ON = new AlwaysOnSampler();
+  private static final Sampler ALWAYS_OFF = new AlwaysOffSampler();
   private static final Decision ALWAYS_ON_DECISION = new SimpleDecision(/* decision= */ true);
   private static final Decision ALWAYS_OFF_DECISION = new SimpleDecision(/* decision= */ false);
 
@@ -51,8 +51,8 @@ public final class Samplers {
    * @return a {@code Sampler} that always makes a "yes" decision on {@code Span} sampling.
    * @since 0.1.0
    */
-  public static Sampler alwaysSample() {
-    return ALWAYS_SAMPLE;
+  public static Sampler alwaysOn() {
+    return ALWAYS_ON;
   }
 
   /**
@@ -61,13 +61,13 @@ public final class Samplers {
    * @return a {@code Sampler} that always makes a "no" decision on {@code Span} sampling.
    * @since 0.1.0
    */
-  public static Sampler neverSample() {
-    return NEVER_SAMPLE;
+  public static Sampler alwaysOff() {
+    return ALWAYS_OFF;
   }
 
   @Immutable
-  private static final class AlwaysSampleSampler implements Sampler {
-    AlwaysSampleSampler() {}
+  private static final class AlwaysOnSampler implements Sampler {
+    AlwaysOnSampler() {}
 
     // Returns always makes a "yes" decision on {@link Span} sampling.
     @Override
@@ -88,13 +88,13 @@ public final class Samplers {
 
     @Override
     public String toString() {
-      return "AlwaysSampleSampler";
+      return "AlwaysOnSampler";
     }
   }
 
   @Immutable
-  private static final class NeverSampleSampler implements Sampler {
-    NeverSampleSampler() {}
+  private static final class AlwaysOffSampler implements Sampler {
+    AlwaysOffSampler() {}
 
     // Returns always makes a "no" decision on {@link Span} sampling.
     @Override
@@ -115,7 +115,7 @@ public final class Samplers {
 
     @Override
     public String toString() {
-      return "NeverSampleSampler";
+      return "AlwaysOffSampler";
     }
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
@@ -18,11 +18,11 @@ package io.opentelemetry.sdk.trace.config;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
+import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.trace.Event;
 import io.opentelemetry.trace.Link;
 import io.opentelemetry.trace.Sampler;
 import io.opentelemetry.trace.Span;
-import io.opentelemetry.trace.util.Samplers;
 import javax.annotation.concurrent.Immutable;
 
 /** Class that holds global trace parameters. */
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.Immutable;
 public abstract class TraceConfig {
   // These values are the default values for all the global parameters.
   // TODO: decide which default sampler to use
-  private static final Sampler DEFAULT_SAMPLER = Samplers.alwaysSample();
+  private static final Sampler DEFAULT_SAMPLER = Samplers.alwaysOn();
   private static final int DEFAULT_SPAN_MAX_NUM_ATTRIBUTES = 32;
   private static final int DEFAULT_SPAN_MAX_NUM_EVENTS = 128;
   private static final int DEFAULT_SPAN_MAX_NUM_LINKS = 32;

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.trace.util;
-
-import static io.opentelemetry.trace.TestUtils.generateRandomSpanId;
-import static io.opentelemetry.trace.TestUtils.generateRandomTraceId;
+package io.opentelemetry.sdk.trace;
 
 import com.google.common.truth.Truth;
 import io.opentelemetry.trace.Link;
@@ -27,7 +24,6 @@ import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.Tracestate;
 import java.util.Collections;
-import java.util.Random;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -35,10 +31,9 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link Samplers}. */
 @RunWith(JUnit4.class)
 public class SamplersTest {
-  private final Random random = new Random(1234);
-  private final TraceId traceId = generateRandomTraceId(random);
-  private final SpanId parentSpanId = generateRandomSpanId(random);
-  private final SpanId spanId = generateRandomSpanId(random);
+  private final TraceId traceId = TestUtils.generateRandomTraceId();
+  private final SpanId parentSpanId = TestUtils.generateRandomSpanId();
+  private final SpanId spanId = TestUtils.generateRandomSpanId();
   private final Tracestate tracestate = Tracestate.builder().build();
   private final SpanContext sampledSpanContext =
       SpanContext.create(
@@ -47,10 +42,10 @@ public class SamplersTest {
       SpanContext.create(traceId, parentSpanId, TraceFlags.getDefault(), tracestate);
 
   @Test
-  public void alwaysSampleSampler_AlwaysReturnTrue() {
+  public void alwaysOnSampler_AlwaysReturnTrue() {
     // Sampled parent.
     Truth.assertThat(
-            Samplers.alwaysSample()
+            Samplers.alwaysOn()
                 .shouldSample(
                     sampledSpanContext,
                     false,
@@ -62,7 +57,7 @@ public class SamplersTest {
         .isTrue();
     // Not sampled parent.
     Truth.assertThat(
-            Samplers.alwaysSample()
+            Samplers.alwaysOn()
                 .shouldSample(
                     notSampledSpanContext,
                     false,
@@ -75,15 +70,15 @@ public class SamplersTest {
   }
 
   @Test
-  public void alwaysSampleSampler_ToString() {
-    Truth.assertThat(Samplers.alwaysSample().toString()).isEqualTo("AlwaysSampleSampler");
+  public void alwaysOnSampler_ToString() {
+    Truth.assertThat(Samplers.alwaysOn().toString()).isEqualTo("AlwaysOnSampler");
   }
 
   @Test
-  public void neverSampleSampler_AlwaysReturnFalse() {
+  public void alwaysOffSampler_AlwaysReturnFalse() {
     // Sampled parent.
     Truth.assertThat(
-            Samplers.neverSample()
+            Samplers.alwaysOff()
                 .shouldSample(
                     sampledSpanContext,
                     false,
@@ -95,7 +90,7 @@ public class SamplersTest {
         .isFalse();
     // Not sampled parent.
     Truth.assertThat(
-            Samplers.neverSample()
+            Samplers.alwaysOff()
                 .shouldSample(
                     notSampledSpanContext,
                     false,
@@ -108,7 +103,7 @@ public class SamplersTest {
   }
 
   @Test
-  public void neverSampleSampler_ToString() {
-    Truth.assertThat(Samplers.neverSample().toString()).isEqualTo("NeverSampleSampler");
+  public void alwaysOffSampler_ToString() {
+    Truth.assertThat(Samplers.alwaysOff().toString()).isEqualTo("AlwaysOffSampler");
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -34,7 +34,6 @@ import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.Tracestate;
 import io.opentelemetry.trace.util.Links;
-import io.opentelemetry.trace.util.Samplers;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -164,7 +163,7 @@ public class SpanBuilderSdkTest {
 
   @Test
   public void recordEvents_neverSample() {
-    Span span = tracer.spanBuilder(SPAN_NAME).setSampler(Samplers.neverSample()).startSpan();
+    Span span = tracer.spanBuilder(SPAN_NAME).setSampler(Samplers.alwaysOff()).startSpan();
     try {
       assertThat(span.getContext().getTraceFlags().isSampled()).isFalse();
     } finally {
@@ -197,7 +196,7 @@ public class SpanBuilderSdkTest {
 
   @Test
   public void sampler() {
-    Span span = tracer.spanBuilder(SPAN_NAME).setSampler(Samplers.neverSample()).startSpan();
+    Span span = tracer.spanBuilder(SPAN_NAME).setSampler(Samplers.alwaysOff()).startSpan();
 
     try {
       assertThat(span.getContext().getTraceFlags().isSampled()).isFalse();

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -26,7 +26,6 @@ import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.propagation.BinaryTraceContext;
 import io.opentelemetry.trace.propagation.HttpTraceContext;
 import io.opentelemetry.trace.unsafe.ContextUtils;
-import io.opentelemetry.trace.util.Samplers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -113,7 +112,7 @@ public class TracerSdkTest {
   public void updateActiveTraceConfig() {
     assertThat(tracer.getActiveTraceConfig()).isEqualTo(TraceConfig.getDefault());
     TraceConfig newConfig =
-        TraceConfig.getDefault().toBuilder().setSampler(Samplers.neverSample()).build();
+        TraceConfig.getDefault().toBuilder().setSampler(Samplers.alwaysOff()).build();
     tracer.updateActiveTraceConfig(newConfig);
     assertThat(tracer.getActiveTraceConfig()).isEqualTo(newConfig);
   }
@@ -144,7 +143,7 @@ public class TracerSdkTest {
   public void returnNoopSpanAfterShutdown() {
     try {
       tracer.shutdown();
-      Span span = tracer.spanBuilder("span").setSampler(Samplers.alwaysSample()).startSpan();
+      Span span = tracer.spanBuilder("span").setSampler(Samplers.alwaysOn()).startSpan();
       assertThat(span).isInstanceOf(DefaultSpan.class);
       span.end();
     } finally {

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
@@ -18,7 +18,7 @@ package io.opentelemetry.sdk.trace.config;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import io.opentelemetry.trace.util.Samplers;
+import io.opentelemetry.sdk.trace.Samplers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -32,7 +32,7 @@ public class TraceConfigTest {
 
   @Test
   public void defaultTraceConfig() {
-    assertThat(TraceConfig.getDefault().getSampler()).isEqualTo(Samplers.alwaysSample());
+    assertThat(TraceConfig.getDefault().getSampler()).isEqualTo(Samplers.alwaysOn());
     assertThat(TraceConfig.getDefault().getMaxNumberOfAttributes()).isEqualTo(32);
     assertThat(TraceConfig.getDefault().getMaxNumberOfEvents()).isEqualTo(128);
     assertThat(TraceConfig.getDefault().getMaxNumberOfLinks()).isEqualTo(32);
@@ -81,14 +81,14 @@ public class TraceConfigTest {
     TraceConfig traceConfig =
         TraceConfig.getDefault()
             .toBuilder()
-            .setSampler(Samplers.neverSample())
+            .setSampler(Samplers.alwaysOff())
             .setMaxNumberOfAttributes(8)
             .setMaxNumberOfEvents(10)
             .setMaxNumberOfLinks(11)
             .setMaxNumberOfAttributesPerEvent(1)
             .setMaxNumberOfAttributesPerLink(2)
             .build();
-    assertThat(traceConfig.getSampler()).isEqualTo(Samplers.neverSample());
+    assertThat(traceConfig.getSampler()).isEqualTo(Samplers.alwaysOff());
     assertThat(traceConfig.getMaxNumberOfAttributes()).isEqualTo(8);
     assertThat(traceConfig.getMaxNumberOfEvents()).isEqualTo(10);
     assertThat(traceConfig.getMaxNumberOfLinks()).isEqualTo(11);

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessorTest.java
@@ -20,9 +20,9 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.doThrow;
 
 import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.sdk.trace.SpanData;
 import io.opentelemetry.sdk.trace.TracerSdk;
-import io.opentelemetry.trace.util.Samplers;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -60,7 +60,7 @@ public class BatchSpansProcessorTest {
 
   private ReadableSpan createSampledEndedSpan(String spanName) {
     io.opentelemetry.trace.Span span =
-        tracerSdk.spanBuilder(spanName).setSampler(Samplers.alwaysSample()).startSpan();
+        tracerSdk.spanBuilder(spanName).setSampler(Samplers.alwaysOn()).startSpan();
     span.end();
     return (ReadableSpan) span;
   }
@@ -77,7 +77,7 @@ public class BatchSpansProcessorTest {
 
   private void createNotSampledEndedSpan(String spanName) {
     io.opentelemetry.trace.Span span =
-        tracerSdk.spanBuilder(spanName).setSampler(Samplers.neverSample()).startSpan();
+        tracerSdk.spanBuilder(spanName).setSampler(Samplers.alwaysOff()).startSpan();
     span.end();
   }
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpansProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpansProcessorTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.sdk.trace.SpanData;
 import io.opentelemetry.sdk.trace.TestUtils;
 import io.opentelemetry.sdk.trace.TracerSdk;
@@ -32,7 +33,6 @@ import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.Tracestate;
-import io.opentelemetry.trace.util.Samplers;
 import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
@@ -125,11 +125,11 @@ public class SimpleSpansProcessorTest {
             .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
             .build());
 
-    tracerSdk.spanBuilder(SPAN_NAME).setSampler(Samplers.neverSample()).startSpan().end();
-    tracerSdk.spanBuilder(SPAN_NAME).setSampler(Samplers.neverSample()).startSpan().end();
+    tracerSdk.spanBuilder(SPAN_NAME).setSampler(Samplers.alwaysOff()).startSpan().end();
+    tracerSdk.spanBuilder(SPAN_NAME).setSampler(Samplers.alwaysOff()).startSpan().end();
 
     io.opentelemetry.trace.Span span =
-        tracerSdk.spanBuilder(SPAN_NAME).setSampler(Samplers.alwaysSample()).startSpan();
+        tracerSdk.spanBuilder(SPAN_NAME).setSampler(Samplers.alwaysOn()).startSpan();
     span.end();
 
     // Spans are recorded and exported in the same order as they are ended, we test that a non


### PR DESCRIPTION
First PR from a series of PRs to move the Sampler interface to the SDK to implement https://github.com/open-telemetry/opentelemetry-specification/pull/257

Also rename:
alwaysSample -> alwaysOn
neverSample -> alwaysOff