### PR TITLE
Move InMemorySpanExporter to exporters/

### DIFF
--- a/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporter.java
+++ b/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporter.java
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.sdk.trace.export;
+package io.opentelemetry.exporters.inmemory;
 
 import io.opentelemetry.sdk.trace.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryTracing.java
+++ b/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryTracing.java
@@ -19,7 +19,6 @@ package io.opentelemetry.exporters.inmemory;
 import io.opentelemetry.internal.Utils;
 import io.opentelemetry.sdk.trace.SpanData;
 import io.opentelemetry.sdk.trace.TracerSdk;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
 import io.opentelemetry.trace.Tracer;
 import java.util.List;

--- a/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
+++ b/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.sdk.trace.export;
+package io.opentelemetry.exporters.inmemory;
 
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.TestUtils;
 import io.opentelemetry.sdk.trace.TracerSdk;
+import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode;
 import java.util.Collections;
 import java.util.List;
@@ -85,15 +85,27 @@ public class InMemorySpanExporterTest {
 
   @Test
   public void export_ReturnCode() {
-    assertThat(exporter.export(Collections.singletonList(TestUtils.makeBasicSpan())))
+    assertThat(exporter.export(Collections.singletonList(makeBasicSpan())))
         .isEqualTo(ResultCode.SUCCESS);
     exporter.shutdown();
     // After shutdown no more export.
-    assertThat(exporter.export(Collections.singletonList(TestUtils.makeBasicSpan())))
+    assertThat(exporter.export(Collections.singletonList(makeBasicSpan())))
         .isEqualTo(ResultCode.FAILED_NOT_RETRYABLE);
     exporter.reset();
     // Reset does not do anything if already shutdown.
-    assertThat(exporter.export(Collections.singletonList(TestUtils.makeBasicSpan())))
+    assertThat(exporter.export(Collections.singletonList(makeBasicSpan())))
         .isEqualTo(ResultCode.FAILED_NOT_RETRYABLE);
+  }
+
+  static SpanData makeBasicSpan() {
+    return SpanData.newBuilder()
+        .setTraceId(io.opentelemetry.trace.TraceId.getInvalid())
+        .setSpanId(io.opentelemetry.trace.SpanId.getInvalid())
+        .setName("span")
+        .setKind(io.opentelemetry.trace.Span.Kind.SERVER)
+        .setStartTimestamp(io.opentelemetry.common.Timestamp.create(100, 100))
+        .setStatus(io.opentelemetry.trace.Status.OK)
+        .setEndTimestamp(io.opentelemetry.common.Timestamp.create(200, 200))
+        .build();
   }
 }

--- a/opentracing_shim/build.gradle
+++ b/opentracing_shim/build.gradle
@@ -7,6 +7,7 @@ dependencies {
             libraries.opentracing
 
     testImplementation project(':opentelemetry-sdk'),
+            project(':opentelemetry-exporters-inmemory'),
             libraries.protobuf,
             libraries.junit,
             libraries.truth,

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
@@ -20,10 +20,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import io.opentelemetry.distributedcontext.DefaultDistributedContextManager;
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.opentracingshim.TraceShim;
 import io.opentelemetry.sdk.trace.SpanData;
 import io.opentelemetry.sdk.trace.TracerSdk;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentracing.Scope;

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/TestUtils.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/TestUtils.java
@@ -21,10 +21,10 @@ import static org.junit.Assert.assertTrue;
 
 import io.opentelemetry.common.Timestamp;
 import io.opentelemetry.distributedcontext.DefaultDistributedContextManager;
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.opentracingshim.TraceShim;
 import io.opentelemetry.sdk.trace.SpanData;
 import io.opentelemetry.sdk.trace.TracerSdk;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
 import io.opentelemetry.trace.AttributeValue;
 import io.opentelemetry.trace.Span.Kind;

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/activespanreplacement/ActiveSpanReplacementTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/activespanreplacement/ActiveSpanReplacementTest.java
@@ -26,8 +26,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/actorpropagation/ActorPropagationTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/actorpropagation/ActorPropagationTest.java
@@ -21,8 +21,8 @@ import static io.opentelemetry.opentracingshim.testbed.TestUtils.createTracerShi
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.getByKind;
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.getOneByKind;
 
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentracing.Scope;
 import io.opentracing.Span;

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/clientserver/TestClientServerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/clientserver/TestClientServerTest.java
@@ -24,8 +24,8 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentracing.Tracer;
 import java.util.List;

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/concurrentcommonrequesthandler/HandlerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/concurrentcommonrequesthandler/HandlerTest.java
@@ -25,8 +25,8 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentracing.Scope;
 import io.opentracing.Span;

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/errorreporting/ErrorReportingTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/errorreporting/ErrorReportingTest.java
@@ -23,9 +23,9 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SpanData;
 import io.opentelemetry.sdk.trace.SpanData.TimedEvent;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.trace.Status;
 import io.opentracing.Scope;
 import io.opentracing.Span;

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/latespanfinish/LateSpanFinishTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/latespanfinish/LateSpanFinishTest.java
@@ -23,8 +23,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/listenerperrequest/ListenerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/listenerperrequest/ListenerTest.java
@@ -20,8 +20,8 @@ import static io.opentelemetry.opentracingshim.testbed.TestUtils.createTracerShi
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.trace.Span;
 import io.opentracing.Tracer;
 import java.util.List;

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/multiplecallbacks/MultipleCallbacksTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/multiplecallbacks/MultipleCallbacksTest.java
@@ -23,8 +23,8 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/nestedcallbacks/NestedCallbacksTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/nestedcallbacks/NestedCallbacksTest.java
@@ -23,8 +23,8 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.trace.AttributeValue;
 import io.opentracing.Scope;
 import io.opentracing.Span;

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/promisepropagation/PromisePropagationTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/promisepropagation/PromisePropagationTest.java
@@ -20,8 +20,8 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.createTracerShim;
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.getByAttr;
 
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.trace.SpanId;
 import io.opentracing.Scope;
 import io.opentracing.Span;

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/statelesscommonrequesthandler/HandlerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/statelesscommonrequesthandler/HandlerTest.java
@@ -19,8 +19,8 @@ package io.opentelemetry.opentracingshim.testbed.statelesscommonrequesthandler;
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.createTracerShim;
 import static org.junit.Assert.assertEquals;
 
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentracing.Tracer;
 import java.util.List;
 import java.util.concurrent.Future;

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/suspendresumepropagation/SuspendResumePropagationTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/suspendresumepropagation/SuspendResumePropagationTest.java
@@ -19,8 +19,8 @@ package io.opentelemetry.opentracingshim.testbed.suspendresumepropagation;
 import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.createTracerShim;
 
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentracing.Tracer;
 import java.util.List;
 import org.junit.Before;

--- a/sdk_contrib/testbed/build.gradle
+++ b/sdk_contrib/testbed/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     api project(':opentelemetry-api')
 
     implementation project(':opentelemetry-sdk'),
+            project(':opentelemetry-exporters-inmemory'),
             libraries.awaitility,
             libraries.guava
 

--- a/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/TestUtils.java
+++ b/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/TestUtils.java
@@ -19,9 +19,9 @@ package io.opentelemetry.sdk.contrib.trace.testbed;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.common.Timestamp;
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SpanData;
 import io.opentelemetry.sdk.trace.TracerSdk;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
 import io.opentelemetry.trace.AttributeValue;
 import io.opentelemetry.trace.Span.Kind;

--- a/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/activespanreplacement/ActiveSpanReplacementTest.java
+++ b/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/activespanreplacement/ActiveSpanReplacementTest.java
@@ -24,8 +24,8 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanId;

--- a/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/actorpropagation/ActorPropagationTest.java
+++ b/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/actorpropagation/ActorPropagationTest.java
@@ -19,9 +19,9 @@ package io.opentelemetry.sdk.contrib.trace.testbed.actorpropagation;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.contrib.trace.testbed.TestUtils;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Span.Kind;

--- a/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/clientserver/TestClientServerTest.java
+++ b/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/clientserver/TestClientServerTest.java
@@ -21,9 +21,9 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.contrib.trace.testbed.TestUtils;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.Tracer;

--- a/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/concurrentcommonrequesthandler/HandlerTest.java
+++ b/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/concurrentcommonrequesthandler/HandlerTest.java
@@ -19,9 +19,9 @@ package io.opentelemetry.sdk.contrib.trace.testbed.concurrentcommonrequesthandle
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.contrib.trace.testbed.TestUtils;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanId;

--- a/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/errorreporting/ErrorReportingTest.java
+++ b/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/errorreporting/ErrorReportingTest.java
@@ -22,10 +22,10 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.contrib.trace.testbed.TestUtils;
 import io.opentelemetry.sdk.trace.SpanData;
 import io.opentelemetry.sdk.trace.SpanData.TimedEvent;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Status;

--- a/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/latespanfinish/LateSpanFinishTest.java
+++ b/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/latespanfinish/LateSpanFinishTest.java
@@ -19,9 +19,9 @@ package io.opentelemetry.sdk.contrib.trace.testbed.latespanfinish;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.contrib.trace.testbed.TestUtils;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;

--- a/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/listenerperrequest/ListenerTest.java
+++ b/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/listenerperrequest/ListenerTest.java
@@ -18,9 +18,9 @@ package io.opentelemetry.sdk.contrib.trace.testbed.listenerperrequest;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.contrib.trace.testbed.TestUtils;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.Tracer;

--- a/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/multiplecallbacks/MultipleCallbacksTest.java
+++ b/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/multiplecallbacks/MultipleCallbacksTest.java
@@ -21,9 +21,9 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.contrib.trace.testbed.TestUtils;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;

--- a/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/nestedcallbacks/NestedCallbacksTest.java
+++ b/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/nestedcallbacks/NestedCallbacksTest.java
@@ -21,9 +21,9 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.contrib.trace.testbed.TestUtils;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.trace.AttributeValue;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;

--- a/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/promisepropagation/PromisePropagationTest.java
+++ b/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/promisepropagation/PromisePropagationTest.java
@@ -19,9 +19,9 @@ package io.opentelemetry.sdk.contrib.trace.testbed.promisepropagation;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.contrib.trace.testbed.TestUtils;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Tracer;

--- a/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/statelesscommonrequesthandler/HandlerTest.java
+++ b/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/statelesscommonrequesthandler/HandlerTest.java
@@ -19,8 +19,8 @@ package io.opentelemetry.sdk.contrib.trace.testbed.statelesscommonrequesthandler
 import static io.opentelemetry.sdk.contrib.trace.testbed.TestUtils.createTracerShim;
 import static org.junit.Assert.assertEquals;
 
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.trace.Tracer;
 import java.util.List;
 import java.util.concurrent.Future;

--- a/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/suspendresumepropagation/SuspendResumePropagationTest.java
+++ b/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/suspendresumepropagation/SuspendResumePropagationTest.java
@@ -19,8 +19,8 @@ package io.opentelemetry.sdk.contrib.trace.testbed.suspendresumepropagation;
 import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.sdk.contrib.trace.testbed.TestUtils.createTracerShim;
 
+import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.InMemorySpanExporter;
 import io.opentelemetry.trace.Tracer;
 import java.util.List;
 import org.junit.Before;


### PR DESCRIPTION
Remaining part of moving the `InMemory*` bits to `exporters/`, instead of having it in the SDK.