### PR TITLE
Add explicit timestamp for Span events in the API.

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
@@ -102,14 +102,33 @@ public final class DefaultSpan implements Span {
   public void addEvent(String name) {}
 
   @Override
+  public void addEvent(String name, long timestamp) {
+    Utils.checkNotNull(name, "name");
+    Utils.checkArgument(timestamp >= 0, "Negative timestamp");
+  }
+
+  @Override
   public void addEvent(String name, Map<String, AttributeValue> attributes) {
     Utils.checkNotNull(name, "name");
     Utils.checkNotNull(attributes, "attributes");
   }
 
   @Override
+  public void addEvent(String name, Map<String, AttributeValue> attributes, long timestamp) {
+    Utils.checkNotNull(name, "name");
+    Utils.checkNotNull(attributes, "attributes");
+    Utils.checkArgument(timestamp >= 0, "Negative timestamp");
+  }
+
+  @Override
   public void addEvent(Event event) {
     Utils.checkNotNull(event, "event");
+  }
+
+  @Override
+  public void addEvent(Event event, long timestamp) {
+    Utils.checkNotNull(event, "event");
+    Utils.checkArgument(timestamp >= 0, "Negative timestamp");
   }
 
   @Override

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -138,6 +138,20 @@ public interface Span {
   /**
    * Adds an event to the {@code Span}.
    *
+   * <p>Use this method to specify an explicit event timestamp. If not called, the implementation
+   * will use the current timestamp value, which should be the default case.
+   *
+   * <p>Important: this is NOT equivalent with System.nanoTime().
+   *
+   * @param name the name of the event.
+   * @param timestamp the explicit event timestamp in nanos since epoch.
+   * @since 0.1.0
+   */
+  void addEvent(String name, long timestamp);
+
+  /**
+   * Adds an event to the {@code Span}.
+   *
    * @param name the name of the event.
    * @param attributes the attributes that will be added; these are associated with this event, not
    *     the {@code Span} as for {@code setAttribute()}.
@@ -148,10 +162,40 @@ public interface Span {
   /**
    * Adds an event to the {@code Span}.
    *
+   * <p>Use this method to specify an explicit event timestamp. If not called, the implementation
+   * will use the current timestamp value, which should be the default case.
+   *
+   * <p>Important: this is NOT equivalent with System.nanoTime().
+   *
+   * @param name the name of the event.
+   * @param attributes the attributes that will be added; these are associated with this event, not
+   *     the {@code Span} as for {@code setAttribute()}.
+   * @param timestamp the explicit event timestamp in nanos since epoch.
+   * @since 0.1.0
+   */
+  void addEvent(String name, Map<String, AttributeValue> attributes, long timestamp);
+
+  /**
+   * Adds an event to the {@code Span}.
+   *
    * @param event the event to add.
    * @since 0.1.0
    */
   void addEvent(Event event);
+
+  /**
+   * Adds an event to the {@code Span}.
+   *
+   * <p>Use this method to specify an explicit event timestamp. If not alled, the implementation
+   * will use the current timestamp value, which should be the default case.
+   *
+   * <p>Important: this is NOT equivalent with System.nanoTime().
+   *
+   * @param event the event to add.
+   * @param timestamp the explicit event timestamp in nanos since epoch.
+   * @since 0.1.0
+   */
+  void addEvent(Event event, long timestamp);
 
   /**
    * Sets the {@link Status} to the {@code Span}.

--- a/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
@@ -54,22 +54,18 @@ public class DefaultSpanTest {
     span.setAttribute("MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true));
     span.setAttribute("MyLongAttributeKey", AttributeValue.longAttributeValue(123));
     span.addEvent("event");
+    span.addEvent("event", 0);
     span.addEvent(
         "event",
         Collections.singletonMap(
             "MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true)));
     span.addEvent(
-        new Event() {
-          @Override
-          public String getName() {
-            return "name";
-          }
-
-          @Override
-          public Map<String, AttributeValue> getAttributes() {
-            return Collections.emptyMap();
-          }
-        });
+        "event",
+        Collections.singletonMap(
+            "MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true)),
+        0);
+    span.addEvent(new TestEvent());
+    span.addEvent(new TestEvent(), 0);
     span.setStatus(Status.OK);
     span.end();
     span.end(EndSpanOptions.getDefault());
@@ -86,5 +82,17 @@ public class DefaultSpanTest {
     DefaultSpan span = DefaultSpan.getInvalid();
     thrown.expect(NullPointerException.class);
     span.end(null);
+  }
+
+  static final class TestEvent implements Event {
+    @Override
+    public String getName() {
+      return "name";
+    }
+
+    @Override
+    public Map<String, AttributeValue> getAttributes() {
+      return Collections.emptyMap();
+    }
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -368,13 +368,31 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     addTimedEvent(TimedEvent.create(clock.nowNanos(), name));
   }
 
+  // TODO: Use timestamp.
+  @Override
+  public void addEvent(String name, long timestamp) {
+    addTimedEvent(TimedEvent.create(clock.nowNanos(), name));
+  }
+
   @Override
   public void addEvent(String name, Map<String, AttributeValue> attributes) {
     addTimedEvent(TimedEvent.create(clock.nowNanos(), name, attributes));
   }
 
+  // TODO: Use timestamp.
+  @Override
+  public void addEvent(String name, Map<String, AttributeValue> attributes, long timestamp) {
+    addTimedEvent(TimedEvent.create(clock.nowNanos(), name, attributes));
+  }
+
   @Override
   public void addEvent(Event event) {
+    addTimedEvent(TimedEvent.create(clock.nowNanos(), event));
+  }
+
+  // TODO: Use timestamp.
+  @Override
+  public void addEvent(Event event, long timestamp) {
     addTimedEvent(TimedEvent.create(clock.nowNanos(), event));
   }
 


### PR DESCRIPTION
Add explicit timestamp for all the `Span.addEvent()` overloads in the API (no implementation, that is).

I had wanted to only add this for `addEvent(Event event)`, to prevent the overload 'explosion' ;)