### PR TITLE
Add instrumentation library resource to named tracers

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/TracerFactory.java
+++ b/api/src/main/java/io/opentelemetry/trace/TracerFactory.java
@@ -32,7 +32,7 @@ public interface TracerFactory {
    * Gets or creates a named tracer instance.
    *
    * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library.
+   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.
    * @return a tracer instance.
    * @since 0.1.0
    */
@@ -42,8 +42,9 @@ public interface TracerFactory {
    * Gets or creates a named and versioned tracer instance.
    *
    * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library.
-   * @param instrumentationVersion The version of the instrumentation library.
+   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.
+   * @param instrumentationVersion The version of the instrumentation library (e.g.,
+   *     "semver:1.0.0").
    * @return a tracer instance.
    * @since 0.1.0
    */

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/InstrumentationLibraryInfo.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/InstrumentationLibraryInfo.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.trace;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.internal.Utils;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * Holds information about the instrumentation library specified when creating an instance of {@link
+ * TracerSdk} using {@link TracerSdkFactory}.
+ */
+@AutoValue
+@Immutable
+abstract class InstrumentationLibraryInfo {
+
+  static final InstrumentationLibraryInfo EMPTY = create("", null);
+
+  /**
+   * Creates a new instance of {@link InstrumentationLibraryInfo}.
+   *
+   * @param name name of the instrumentation library (e.g., "io.opentelemetry.contrib.mongodb"),
+   *     must not be null
+   * @param version version of the instrumentation library (e.g., "semver:1.0.0"), might be null
+   * @return the new instance
+   */
+  static InstrumentationLibraryInfo create(String name, @Nullable String version) {
+    Utils.checkNotNull(name, "name");
+    return new AutoValue_InstrumentationLibraryInfo(name, version);
+  }
+
+  abstract String name();
+
+  @Nullable
+  abstract String version();
+}

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
@@ -16,7 +16,6 @@
 
 package io.opentelemetry.sdk.trace;
 
-import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
 
@@ -56,7 +55,8 @@ public interface ReadableSpan {
    * Returns the instrumentation library specified when creating the tracer which produced this
    * span.
    *
-   * @return a resource describing the instrumentation library
+   * @return an instance of {@link InstrumentationLibraryInfo} describing the instrumentation
+   *     library
    */
-  Resource getLibraryResource();
+  InstrumentationLibraryInfo getInstrumentationLibraryInfo();
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.sdk.trace;
 
+import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
 
@@ -50,4 +51,12 @@ public interface ReadableSpan {
    * @since 0.1.0
    */
   SpanData toSpanData();
+
+  /**
+   * Returns the instrumentation library specified when creating the tracer which produced this
+   * span.
+   *
+   * @return a resource describing the instrumentation library
+   */
+  Resource getLibraryResource();
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -71,6 +71,8 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   private final Clock clock;
   // The resource associated with this span.
   private final Resource resource;
+  // library resource of the named tracer which created this span
+  private final Resource instrumentationLibrary;
   // The start time of the span.
   private final long startEpochNanos;
   // Set of recorded attributes. DO NOT CALL any other method that changes the ordering of events.
@@ -122,6 +124,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
       SpanProcessor spanProcessor,
       Clock clock,
       Resource resource,
+      Resource instrumentationLibrary,
       Map<String, AttributeValue> attributes,
       List<Link> links,
       int totalRecordedLinks,
@@ -136,6 +139,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
             spanProcessor,
             clock,
             resource,
+            instrumentationLibrary,
             attributes,
             links,
             totalRecordedLinks,
@@ -162,6 +166,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
         .setLinks(getLinks())
         .setParentSpanId(parentSpanId)
         .setResource(resource)
+        .setLibraryResource(instrumentationLibrary)
         .setStatus(getStatus())
         .setTimedEvents(adaptTimedEvents())
         .build();
@@ -193,6 +198,17 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     synchronized (lock) {
       return name;
     }
+  }
+
+  /**
+   * Returns the instrumentation library specified when creating the tracer which produced this
+   * span.
+   *
+   * @return a resource describing the instrumentation library
+   */
+  @Override
+  public Resource getLibraryResource() {
+    return instrumentationLibrary;
   }
 
   /**
@@ -508,6 +524,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
       SpanProcessor spanProcessor,
       Clock clock,
       Resource resource,
+      Resource instrumentationLibrary,
       Map<String, AttributeValue> attributes,
       List<Link> links,
       int totalRecordedLinks,
@@ -520,6 +537,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     this.kind = kind;
     this.spanProcessor = spanProcessor;
     this.resource = resource;
+    this.instrumentationLibrary = instrumentationLibrary;
     this.hasBeenEnded = false;
     this.numberOfChildren = 0;
     this.clock = clock;

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -51,6 +51,7 @@ class SpanBuilderSdk implements Span.Builder {
   private final TraceConfig traceConfig;
   private final Resource resource;
   private final IdsGenerator idsGenerator;
+  private final Resource instrumentationLibrary;
   private final Clock clock;
 
   @Nullable private Span parent;
@@ -65,12 +66,14 @@ class SpanBuilderSdk implements Span.Builder {
       SpanProcessor spanProcessor,
       TraceConfig traceConfig,
       Resource resource,
+      Resource instrumentationLibrary,
       IdsGenerator idsGenerator,
       Clock clock) {
     this.spanName = spanName;
     this.spanProcessor = spanProcessor;
     this.traceConfig = traceConfig;
     this.resource = resource;
+    this.instrumentationLibrary = instrumentationLibrary;
     this.links = Collections.emptyList();
     this.idsGenerator = idsGenerator;
     this.clock = clock;
@@ -174,6 +177,7 @@ class SpanBuilderSdk implements Span.Builder {
         spanProcessor,
         getClock(parentSpan(parentType, parent), clock),
         resource,
+        instrumentationLibrary,
         samplingDecision.attributes(),
         truncatedLinks(),
         links.size(),

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -47,11 +47,11 @@ class SpanBuilderSdk implements Span.Builder {
       TraceFlags.builder().setIsSampled(false).build();
 
   private final String spanName;
+  private final InstrumentationLibraryInfo instrumentationLibraryInfo;
   private final SpanProcessor spanProcessor;
   private final TraceConfig traceConfig;
   private final Resource resource;
   private final IdsGenerator idsGenerator;
-  private final Resource instrumentationLibrary;
   private final Clock clock;
 
   @Nullable private Span parent;
@@ -63,17 +63,17 @@ class SpanBuilderSdk implements Span.Builder {
 
   SpanBuilderSdk(
       String spanName,
+      InstrumentationLibraryInfo instrumentationLibraryInfo,
       SpanProcessor spanProcessor,
       TraceConfig traceConfig,
       Resource resource,
-      Resource instrumentationLibrary,
       IdsGenerator idsGenerator,
       Clock clock) {
     this.spanName = spanName;
+    this.instrumentationLibraryInfo = instrumentationLibraryInfo;
     this.spanProcessor = spanProcessor;
     this.traceConfig = traceConfig;
     this.resource = resource;
-    this.instrumentationLibrary = instrumentationLibrary;
     this.links = Collections.emptyList();
     this.idsGenerator = idsGenerator;
     this.clock = clock;
@@ -171,13 +171,13 @@ class SpanBuilderSdk implements Span.Builder {
     return RecordEventsReadableSpan.startSpan(
         spanContext,
         spanName,
+        instrumentationLibraryInfo,
         spanKind,
         parentContext != null ? parentContext.getSpanId() : null,
         traceConfig,
         spanProcessor,
         getClock(parentSpan(parentType, parent), clock),
         resource,
-        instrumentationLibrary,
         samplingDecision.attributes(),
         truncatedLinks(),
         links.size(),

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanData.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanData.java
@@ -90,6 +90,14 @@ public abstract class SpanData {
   public abstract Resource getResource();
 
   /**
+   * Returns the instrumentation library specified when creating the tracer which produced this
+   * {@code Span}.
+   *
+   * @return a resource describing the instrumentation library
+   */
+  public abstract Resource getLibraryResource();
+
+  /**
    * Returns the name of this {@code Span}.
    *
    * @return the name of this {@code Span}.
@@ -239,6 +247,7 @@ public abstract class SpanData {
         .setAttributes(Collections.<String, AttributeValue>emptyMap())
         .setTimedEvents(Collections.<TimedEvent>emptyList())
         .setResource(Resource.getEmpty())
+        .setLibraryResource(Resource.getEmpty())
         .setTracestate(Tracestate.getDefault())
         .setTraceFlags(TraceFlags.getDefault());
   }
@@ -324,6 +333,17 @@ public abstract class SpanData {
      * @since 0.1.0
      */
     public abstract Builder setResource(Resource resource);
+
+    /**
+     * Set the instrumentation library of the tracer which created this span. Must not be null.
+     *
+     * @param instrumentationLibrary the instrumentation library of the tracer which created this
+     *     span.
+     * @return this
+     * @see Resource
+     * @since 0.2.0
+     */
+    public abstract Builder setLibraryResource(Resource instrumentationLibrary);
 
     /**
      * Set the name of the span. Must not be null.

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanData.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanData.java
@@ -93,9 +93,9 @@ public abstract class SpanData {
    * Returns the instrumentation library specified when creating the tracer which produced this
    * {@code Span}.
    *
-   * @return a resource describing the instrumentation library
+   * @return an instance of {@link InstrumentationLibraryInfo}
    */
-  public abstract Resource getLibraryResource();
+  public abstract InstrumentationLibraryInfo getInstrumentationLibraryInfo();
 
   /**
    * Returns the name of this {@code Span}.
@@ -243,11 +243,11 @@ public abstract class SpanData {
   public static Builder newBuilder() {
     return new AutoValue_SpanData.Builder()
         .setParentSpanId(SpanId.getInvalid())
+        .setInstrumentationLibraryInfo(InstrumentationLibraryInfo.EMPTY)
         .setLinks(Collections.<io.opentelemetry.trace.Link>emptyList())
         .setAttributes(Collections.<String, AttributeValue>emptyMap())
         .setTimedEvents(Collections.<TimedEvent>emptyList())
         .setResource(Resource.getEmpty())
-        .setLibraryResource(Resource.getEmpty())
         .setTracestate(Tracestate.getDefault())
         .setTraceFlags(TraceFlags.getDefault());
   }
@@ -335,15 +335,16 @@ public abstract class SpanData {
     public abstract Builder setResource(Resource resource);
 
     /**
-     * Set the instrumentation library of the tracer which created this span. Must not be null.
+     * Sets the instrumentation library of the tracer which created this span. Must not be null.
      *
-     * @param instrumentationLibrary the instrumentation library of the tracer which created this
-     *     span.
+     * @param instrumentationLibraryInfo the instrumentation library of the tracer which created
+     *     this span.
      * @return this
-     * @see Resource
+     * @see InstrumentationLibraryInfo
      * @since 0.2.0
      */
-    public abstract Builder setLibraryResource(Resource instrumentationLibrary);
+    public abstract Builder setInstrumentationLibraryInfo(
+        InstrumentationLibraryInfo instrumentationLibraryInfo);
 
     /**
      * Set the name of the span. Must not be null.

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
@@ -19,6 +19,7 @@ package io.opentelemetry.sdk.trace;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.BinaryFormat;
 import io.opentelemetry.context.propagation.HttpTextFormat;
+import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.trace.DefaultTracer;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
@@ -32,9 +33,11 @@ public class TracerSdk implements Tracer {
   private static final BinaryFormat<SpanContext> BINARY_FORMAT = new BinaryTraceContext();
   private static final HttpTextFormat<SpanContext> HTTP_TEXT_FORMAT = new HttpTraceContext();
   private final TracerSharedState sharedState;
+  private final Resource instrumentationLibrary;
 
-  TracerSdk(TracerSharedState sharedState) {
+  TracerSdk(TracerSharedState sharedState, Resource instrumentationLibrary) {
     this.sharedState = sharedState;
+    this.instrumentationLibrary = instrumentationLibrary;
   }
 
   @Override
@@ -57,6 +60,7 @@ public class TracerSdk implements Tracer {
         sharedState.getActiveSpanProcessor(),
         sharedState.getActiveTraceConfig(),
         sharedState.getResource(),
+        instrumentationLibrary,
         sharedState.getIdsGenerator(),
         sharedState.getClock());
   }
@@ -69,5 +73,15 @@ public class TracerSdk implements Tracer {
   @Override
   public HttpTextFormat<SpanContext> getHttpTextFormat() {
     return HTTP_TEXT_FORMAT;
+  }
+
+  /**
+   * Returns the instrumentation library specified when creating the tracer using {@link
+   * TracerSdkFactory}.
+   *
+   * @return a resource describing the instrumentation library
+   */
+  public Resource getLibraryResource() {
+    return instrumentationLibrary;
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
@@ -30,6 +30,8 @@ import io.opentelemetry.trace.unsafe.ContextUtils;
 
 /** {@link TracerSdk} is SDK implementation of {@link Tracer}. */
 public class TracerSdk implements Tracer {
+  public static final String INSTRUMENTATION_LIBRARY_RESOURCE_LABEL_NAME = "name";
+  public static final String INSTRUMENTATION_LIBRARY_RESOURCE_LABEL_VERSION = "version";
   private static final BinaryFormat<SpanContext> BINARY_FORMAT = new BinaryTraceContext();
   private static final HttpTextFormat<SpanContext> HTTP_TEXT_FORMAT = new HttpTraceContext();
   private final TracerSharedState sharedState;

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
@@ -19,7 +19,6 @@ package io.opentelemetry.sdk.trace;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.BinaryFormat;
 import io.opentelemetry.context.propagation.HttpTextFormat;
-import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.trace.DefaultTracer;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
@@ -30,16 +29,14 @@ import io.opentelemetry.trace.unsafe.ContextUtils;
 
 /** {@link TracerSdk} is SDK implementation of {@link Tracer}. */
 public class TracerSdk implements Tracer {
-  public static final String INSTRUMENTATION_LIBRARY_RESOURCE_LABEL_NAME = "name";
-  public static final String INSTRUMENTATION_LIBRARY_RESOURCE_LABEL_VERSION = "version";
   private static final BinaryFormat<SpanContext> BINARY_FORMAT = new BinaryTraceContext();
   private static final HttpTextFormat<SpanContext> HTTP_TEXT_FORMAT = new HttpTraceContext();
   private final TracerSharedState sharedState;
-  private final Resource instrumentationLibrary;
+  private final InstrumentationLibraryInfo instrumentationLibraryInfo;
 
-  TracerSdk(TracerSharedState sharedState, Resource instrumentationLibrary) {
+  TracerSdk(TracerSharedState sharedState, InstrumentationLibraryInfo instrumentationLibraryInfo) {
     this.sharedState = sharedState;
-    this.instrumentationLibrary = instrumentationLibrary;
+    this.instrumentationLibraryInfo = instrumentationLibraryInfo;
   }
 
   @Override
@@ -59,10 +56,10 @@ public class TracerSdk implements Tracer {
     }
     return new SpanBuilderSdk(
         spanName,
+        instrumentationLibraryInfo,
         sharedState.getActiveSpanProcessor(),
         sharedState.getActiveTraceConfig(),
         sharedState.getResource(),
-        instrumentationLibrary,
         sharedState.getIdsGenerator(),
         sharedState.getClock());
   }
@@ -81,9 +78,9 @@ public class TracerSdk implements Tracer {
    * Returns the instrumentation library specified when creating the tracer using {@link
    * TracerSdkFactory}.
    *
-   * @return a resource describing the instrumentation library
+   * @return an instance of {@link InstrumentationLibraryInfo}
    */
-  public Resource getLibraryResource() {
-    return instrumentationLibrary;
+  public InstrumentationLibraryInfo getInstrumentationLibraryInfo() {
+    return instrumentationLibraryInfo;
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdkFactory.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdkFactory.java
@@ -92,9 +92,10 @@ public class TracerSdkFactory implements TracerFactory {
       String instrumentationName, String instrumentationVersion) {
     Utils.checkNotNull(instrumentationName, "instrumentationName");
     Map<String, String> libraryLabels = new HashMap<>();
-    libraryLabels.put("name", instrumentationName);
+    libraryLabels.put(TracerSdk.INSTRUMENTATION_LIBRARY_RESOURCE_LABEL_NAME, instrumentationName);
     if (instrumentationVersion != null) {
-      libraryLabels.put("version", instrumentationVersion);
+      libraryLabels.put(
+          TracerSdk.INSTRUMENTATION_LIBRARY_RESOURCE_LABEL_VERSION, instrumentationVersion);
     }
     return Resource.create(libraryLabels);
   }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -68,7 +68,9 @@ public class RecordEventsReadableSpanTest {
   private final TestClock testClock = TestClock.create(startEpochNanos);
   private final Resource resource = Resource.getEmpty();
   private final Resource instrumentationLibrary =
-      Resource.create(Collections.singletonMap("name", "theName"));
+      Resource.create(
+          Collections.singletonMap(
+              TracerSdk.INSTRUMENTATION_LIBRARY_RESOURCE_LABEL_NAME, "theName"));
   private final Map<String, AttributeValue> attributes = new HashMap<>();
   private final Map<String, AttributeValue> expectedAttributes = new HashMap<>();
   private final Link link = SpanData.Link.create(spanContext);

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -67,6 +67,8 @@ public class RecordEventsReadableSpanTest {
   private final long startEpochNanos = 1000_123_789_654L;
   private final TestClock testClock = TestClock.create(startEpochNanos);
   private final Resource resource = Resource.getEmpty();
+  private final Resource instrumentationLibrary =
+      Resource.create(Collections.singletonMap("name", "theName"));
   private final Map<String, AttributeValue> attributes = new HashMap<>();
   private final Map<String, AttributeValue> expectedAttributes = new HashMap<>();
   private final Link link = SpanData.Link.create(spanContext);
@@ -202,6 +204,16 @@ public class RecordEventsReadableSpanTest {
     RecordEventsReadableSpan span = createTestSpan(Kind.SERVER);
     try {
       assertThat(span.getKind()).isEqualTo(Kind.SERVER);
+    } finally {
+      span.end();
+    }
+  }
+
+  @Test
+  public void getLibraryResource() {
+    RecordEventsReadableSpan span = createTestSpan(Kind.CLIENT);
+    try {
+      assertThat(span.getLibraryResource()).isEqualTo(instrumentationLibrary);
     } finally {
       span.end();
     }
@@ -441,6 +453,7 @@ public class RecordEventsReadableSpanTest {
             spanProcessor,
             testClock,
             resource,
+            instrumentationLibrary,
             attributes,
             Collections.singletonList(link),
             1,
@@ -480,6 +493,7 @@ public class RecordEventsReadableSpanTest {
     assertThat(spanData.getParentSpanId()).isEqualTo(parentSpanId);
     assertThat(spanData.getTracestate()).isEqualTo(Tracestate.getDefault());
     assertThat(spanData.getResource()).isEqualTo(resource);
+    assertThat(spanData.getLibraryResource()).isEqualTo(instrumentationLibrary);
     assertThat(spanData.getName()).isEqualTo(spanName);
     assertThat(spanData.getAttributes()).isEqualTo(attributes);
     assertThat(spanData.getTimedEvents()).isEqualTo(timedEvents);
@@ -520,6 +534,7 @@ public class RecordEventsReadableSpanTest {
             spanProcessor,
             clock,
             resource,
+            instrumentationLibrary,
             attributes,
             links,
             1,
@@ -548,6 +563,7 @@ public class RecordEventsReadableSpanTest {
                     SpanData.TimedEvent.create(firstEventEpochNanos, "event1", event1Attributes),
                     SpanData.TimedEvent.create(secondEventTimeNanos, "event2", event2Attributes)))
             .setResource(resource)
+            .setLibraryResource(instrumentationLibrary)
             .setParentSpanId(parentSpanId)
             .setLinks(links)
             .setTraceId(traceId)

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -67,10 +67,8 @@ public class RecordEventsReadableSpanTest {
   private final long startEpochNanos = 1000_123_789_654L;
   private final TestClock testClock = TestClock.create(startEpochNanos);
   private final Resource resource = Resource.getEmpty();
-  private final Resource instrumentationLibrary =
-      Resource.create(
-          Collections.singletonMap(
-              TracerSdk.INSTRUMENTATION_LIBRARY_RESOURCE_LABEL_NAME, "theName"));
+  private final InstrumentationLibraryInfo instrumentationLibraryInfo =
+      InstrumentationLibraryInfo.create("theName", null);
   private final Map<String, AttributeValue> attributes = new HashMap<>();
   private final Map<String, AttributeValue> expectedAttributes = new HashMap<>();
   private final Link link = SpanData.Link.create(spanContext);
@@ -212,10 +210,10 @@ public class RecordEventsReadableSpanTest {
   }
 
   @Test
-  public void getLibraryResource() {
+  public void getInstrumentationLibraryInfo() {
     RecordEventsReadableSpan span = createTestSpan(Kind.CLIENT);
     try {
-      assertThat(span.getLibraryResource()).isEqualTo(instrumentationLibrary);
+      assertThat(span.getInstrumentationLibraryInfo()).isEqualTo(instrumentationLibraryInfo);
     } finally {
       span.end();
     }
@@ -449,13 +447,13 @@ public class RecordEventsReadableSpanTest {
         RecordEventsReadableSpan.startSpan(
             spanContext,
             SPAN_NAME,
+            instrumentationLibraryInfo,
             kind,
             parentSpanId,
             config,
             spanProcessor,
             testClock,
             resource,
-            instrumentationLibrary,
             attributes,
             Collections.singletonList(link),
             1,
@@ -495,7 +493,7 @@ public class RecordEventsReadableSpanTest {
     assertThat(spanData.getParentSpanId()).isEqualTo(parentSpanId);
     assertThat(spanData.getTracestate()).isEqualTo(Tracestate.getDefault());
     assertThat(spanData.getResource()).isEqualTo(resource);
-    assertThat(spanData.getLibraryResource()).isEqualTo(instrumentationLibrary);
+    assertThat(spanData.getInstrumentationLibraryInfo()).isEqualTo(instrumentationLibraryInfo);
     assertThat(spanData.getName()).isEqualTo(spanName);
     assertThat(spanData.getAttributes()).isEqualTo(attributes);
     assertThat(spanData.getTimedEvents()).isEqualTo(timedEvents);
@@ -530,13 +528,13 @@ public class RecordEventsReadableSpanTest {
         RecordEventsReadableSpan.startSpan(
             context,
             name,
+            instrumentationLibraryInfo,
             kind,
             parentSpanId,
             traceConfig,
             spanProcessor,
             clock,
             resource,
-            instrumentationLibrary,
             attributes,
             links,
             1,
@@ -556,6 +554,7 @@ public class RecordEventsReadableSpanTest {
     SpanData expected =
         SpanData.newBuilder()
             .setName(name)
+            .setInstrumentationLibraryInfo(instrumentationLibraryInfo)
             .setKind(kind)
             .setStatus(Status.OK)
             .setStartEpochNanos(startEpochNanos)
@@ -565,7 +564,6 @@ public class RecordEventsReadableSpanTest {
                     SpanData.TimedEvent.create(firstEventEpochNanos, "event1", event1Attributes),
                     SpanData.TimedEvent.create(secondEventTimeNanos, "event2", event2Attributes)))
             .setResource(resource)
-            .setLibraryResource(instrumentationLibrary)
             .setParentSpanId(parentSpanId)
             .setLinks(links)
             .setTraceId(traceId)

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanDataTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanDataTest.java
@@ -20,6 +20,7 @@ import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SpanData.TimedEvent;
 import io.opentelemetry.trace.AttributeValue;
 import io.opentelemetry.trace.Link;
@@ -55,6 +56,7 @@ public class SpanDataTest {
     assertEquals(Collections.<String, AttributeValue>emptyMap(), spanData.getAttributes());
     assertEquals(emptyList(), spanData.getTimedEvents());
     assertEquals(emptyList(), spanData.getLinks());
+    assertEquals(Resource.getEmpty(), spanData.getLibraryResource());
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanDataTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanDataTest.java
@@ -20,7 +20,6 @@ import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SpanData.TimedEvent;
 import io.opentelemetry.trace.AttributeValue;
 import io.opentelemetry.trace.Link;
@@ -56,7 +55,7 @@ public class SpanDataTest {
     assertEquals(Collections.<String, AttributeValue>emptyMap(), spanData.getAttributes());
     assertEquals(emptyList(), spanData.getTimedEvents());
     assertEquals(emptyList(), spanData.getLinks());
-    assertEquals(Resource.getEmpty(), spanData.getLibraryResource());
+    assertEquals(InstrumentationLibraryInfo.EMPTY, spanData.getInstrumentationLibraryInfo());
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkFactoryTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkFactoryTest.java
@@ -21,7 +21,6 @@ import static com.google.common.truth.Truth.assertThat;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
-import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,6 +52,11 @@ public class TracerSdkFactoryTest {
   }
 
   @Test
+  public void libraryVersion_AllowsNull() {
+    assertThat(tracerFactory.get("name", null)).isNotNull();
+  }
+
+  @Test
   public void getSameInstanceForSameName_WithoutVersion() {
     assertThat(tracerFactory.get("test")).isSameInstanceAs(tracerFactory.get("test"));
     assertThat(tracerFactory.get("test")).isSameInstanceAs(tracerFactory.get("test", null));
@@ -77,13 +81,11 @@ public class TracerSdkFactoryTest {
   }
 
   @Test
-  public void propagatesLibraryResourceToTracer() {
-    TracerSdk tracer = tracerFactory.get("theName", "theVersion");
-    Map<String, String> labels = tracer.getLibraryResource().getLabels();
-    assertThat(labels.get(TracerSdk.INSTRUMENTATION_LIBRARY_RESOURCE_LABEL_NAME))
-        .isEqualTo("theName");
-    assertThat(labels.get(TracerSdk.INSTRUMENTATION_LIBRARY_RESOURCE_LABEL_VERSION))
-        .isEqualTo("theVersion");
+  public void propagatesInstrumentationLibraryInfoToTracer() {
+    InstrumentationLibraryInfo expected =
+        InstrumentationLibraryInfo.create("theName", "theVersion");
+    TracerSdk tracer = tracerFactory.get(expected.name(), expected.version());
+    assertThat(tracer.getInstrumentationLibraryInfo()).isEqualTo(expected);
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkFactoryTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkFactoryTest.java
@@ -80,8 +80,10 @@ public class TracerSdkFactoryTest {
   public void propagatesLibraryResourceToTracer() {
     TracerSdk tracer = tracerFactory.get("theName", "theVersion");
     Map<String, String> labels = tracer.getLibraryResource().getLabels();
-    assertThat(labels.get("name")).isEqualTo("theName");
-    assertThat(labels.get("version")).isEqualTo("theVersion");
+    assertThat(labels.get(TracerSdk.INSTRUMENTATION_LIBRARY_RESOURCE_LABEL_NAME))
+        .isEqualTo("theName");
+    assertThat(labels.get(TracerSdk.INSTRUMENTATION_LIBRARY_RESOURCE_LABEL_VERSION))
+        .isEqualTo("theVersion");
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkFactoryTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkFactoryTest.java
@@ -21,6 +21,7 @@ import static com.google.common.truth.Truth.assertThat;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,6 +47,11 @@ public class TracerSdkFactoryTest {
     assertThat(tracerFactory.get("test")).isInstanceOf(TracerSdk.class);
   }
 
+  @Test(expected = NullPointerException.class)
+  public void libraryName_MustNotBeNull() {
+    tracerFactory.get(null);
+  }
+
   @Test
   public void getSameInstanceForSameName_WithoutVersion() {
     assertThat(tracerFactory.get("test")).isSameInstanceAs(tracerFactory.get("test"));
@@ -56,6 +62,26 @@ public class TracerSdkFactoryTest {
   public void getSameInstanceForSameName_WithVersion() {
     assertThat(tracerFactory.get("test", "version"))
         .isSameInstanceAs(tracerFactory.get("test", "version"));
+  }
+
+  @Test
+  public void getDifferentInstancesForDifferentNames() {
+    assertThat(tracerFactory.get("test1", null))
+        .isNotSameInstanceAs(tracerFactory.get("test2", null));
+  }
+
+  @Test
+  public void getDifferentInstancesForDifferentVersions() {
+    assertThat(tracerFactory.get("test", "version1"))
+        .isNotSameInstanceAs(tracerFactory.get("test", "version2"));
+  }
+
+  @Test
+  public void propagatesLibraryResourceToTracer() {
+    TracerSdk tracer = tracerFactory.get("theName", "theVersion");
+    Map<String, String> labels = tracer.getLibraryResource().getLabels();
+    assertThat(labels.get("name")).isEqualTo("theName");
+    assertThat(labels.get("version")).isEqualTo("theVersion");
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -25,8 +25,6 @@ import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.propagation.BinaryTraceContext;
 import io.opentelemetry.trace.propagation.HttpTraceContext;
 import io.opentelemetry.trace.unsafe.ContextUtils;
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,17 +42,15 @@ public class TracerSdkTest {
   private static final String INSTRUMENTATION_LIBRARY_NAME =
       "io.opentelemetry.sdk.trace.TracerSdkTest";
   private static final String INSTRUMENTATION_LIBRARY_VERSION = "semver:0.2.0";
-  private final Map<String, String> instrumentationLibraryLabels = new HashMap<>();
+  private static final InstrumentationLibraryInfo instrumentationLibraryInfo =
+      InstrumentationLibraryInfo.create(
+          INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION);
   @Mock private Span span;
   private final TracerSdk tracer =
       TracerSdkFactory.create().get(INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION);
 
   @Before
   public void setUp() {
-    instrumentationLibraryLabels.put(
-        TracerSdk.INSTRUMENTATION_LIBRARY_RESOURCE_LABEL_NAME, INSTRUMENTATION_LIBRARY_NAME);
-    instrumentationLibraryLabels.put(
-        TracerSdk.INSTRUMENTATION_LIBRARY_RESOURCE_LABEL_VERSION, INSTRUMENTATION_LIBRARY_VERSION);
     MockitoAnnotations.initMocks(this);
   }
 
@@ -116,14 +112,13 @@ public class TracerSdkTest {
   }
 
   @Test
-  public void getLibraryResource() {
-    assertThat(tracer.getLibraryResource().getLabels()).isEqualTo(instrumentationLibraryLabels);
+  public void getInstrumentationLibraryInfo() {
+    assertThat(tracer.getInstrumentationLibraryInfo()).isEqualTo(instrumentationLibraryInfo);
   }
 
   @Test
-  public void propagatesLibraryResourceToSpan() {
+  public void propagatesInstrumentationLibraryInfoToSpan() {
     ReadableSpan readableSpan = (ReadableSpan) tracer.spanBuilder("spanName").startSpan();
-    assertThat(readableSpan.getLibraryResource().getLabels())
-        .isEqualTo(instrumentationLibraryLabels);
+    assertThat(readableSpan.getInstrumentationLibraryInfo()).isEqualTo(instrumentationLibraryInfo);
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -51,8 +51,10 @@ public class TracerSdkTest {
 
   @Before
   public void setUp() {
-    instrumentationLibraryLabels.put("name", INSTRUMENTATION_LIBRARY_NAME);
-    instrumentationLibraryLabels.put("version", INSTRUMENTATION_LIBRARY_VERSION);
+    instrumentationLibraryLabels.put(
+        TracerSdk.INSTRUMENTATION_LIBRARY_RESOURCE_LABEL_NAME, INSTRUMENTATION_LIBRARY_NAME);
+    instrumentationLibraryLabels.put(
+        TracerSdk.INSTRUMENTATION_LIBRARY_RESOURCE_LABEL_VERSION, INSTRUMENTATION_LIBRARY_VERSION);
     MockitoAnnotations.initMocks(this);
   }
 


### PR DESCRIPTION
This implements the instrumentation library resource for named tracers and makes it available to `SpanProcessor`s (via `ReadableSpan`) and `SpanExporter`s (via `SpanData`).

Resolves #617