### PR TITLE
Extract trace id generator in an interface to allow different implementations

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/IdsGenerator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/IdsGenerator.java
@@ -25,16 +25,16 @@ import io.opentelemetry.trace.TraceId;
  */
 public interface IdsGenerator {
   /**
-   * Generates a new random {@code SpanId}.
+   * Generates a new valid {@code SpanId}.
    *
-   * @return a valid new {@code SpanId}.
+   * @return a new valid {@code SpanId}.
    */
   SpanId generateSpanId();
 
   /**
-   * Generates a new random {@code TraceIde}.
+   * Generates a new valid {@code TraceId}.
    *
-   * @return a valid new {@code TraceId}.
+   * @return a new valid {@code TraceId}.
    */
   TraceId generateTraceId();
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/IdsGenerator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/IdsGenerator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.trace;
+
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceId;
+
+/**
+ * Interface that is used by the {@link TracerSdk} to generate new {@link SpanId} and {@link
+ * TraceId}.
+ */
+public interface IdsGenerator {
+  /**
+   * Generates a new random {@code SpanId}.
+   *
+   * @return a valid new {@code SpanId}.
+   */
+  SpanId generateSpanId();
+
+  /**
+   * Generates a new random {@code TraceIde}.
+   *
+   * @return a valid new {@code TraceId}.
+   */
+  TraceId generateTraceId();
+}

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.trace;
+
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceId;
+import java.util.Random;
+
+final class RandomIdsGenerator implements IdsGenerator {
+  private static final long INVALID_ID = 0;
+  // TODO change with ThreadLocal version
+  // https://github.com/open-telemetry/opentelemetry-java/issues/406
+  private final Random random;
+
+  RandomIdsGenerator(Random random) {
+    this.random = random;
+  }
+
+  @Override
+  public SpanId generateSpanId() {
+    long id;
+    do {
+      id = random.nextLong();
+    } while (id == INVALID_ID);
+    return new SpanId(id);
+  }
+
+  @Override
+  public TraceId generateTraceId() {
+    long idHi;
+    long idLo;
+    do {
+      idHi = random.nextLong();
+      idLo = random.nextLong();
+    } while (idHi == INVALID_ID && idLo == INVALID_ID);
+    return new TraceId(idHi, idLo);
+  }
+}

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
@@ -46,7 +46,7 @@ public class TracerSdk implements Tracer {
   private static final BinaryFormat<SpanContext> BINARY_FORMAT = new BinaryTraceContext();
   private static final HttpTextFormat<SpanContext> HTTP_TEXT_FORMAT = new HttpTraceContext();
   private final Clock clock = MillisClock.getInstance();
-  private final Random random = new Random();
+  private final IdsGenerator idsGenerator = new RandomIdsGenerator(new Random());
   private final Resource resource = EnvVarResource.getResource();
 
   // Reads and writes are atomic for reference variables. Use volatile to ensure that these
@@ -75,7 +75,7 @@ public class TracerSdk implements Tracer {
       return DefaultTracer.getInstance().spanBuilder(spanName);
     }
     return new SpanBuilderSdk(
-        spanName, activeSpanProcessor, activeTraceConfig, resource, random, clock);
+        spanName, activeSpanProcessor, activeTraceConfig, resource, idsGenerator, clock);
   }
 
   @Override

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.junit.Before;
@@ -59,9 +60,10 @@ public class RecordEventsReadableSpanTest {
   private static final String SPAN_NEW_NAME = "NewName";
   private static final long NANOS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);
   private static final long MILLIS_PER_SECOND = TimeUnit.SECONDS.toMillis(1);
-  private final TraceId traceId = TestUtils.generateRandomTraceId();
-  private final SpanId spanId = TestUtils.generateRandomSpanId();
-  private final SpanId parentSpanId = TestUtils.generateRandomSpanId();
+  private final IdsGenerator idsGenerator = new RandomIdsGenerator(new Random(1234));
+  private final TraceId traceId = idsGenerator.generateTraceId();
+  private final SpanId spanId = idsGenerator.generateSpanId();
+  private final SpanId parentSpanId = idsGenerator.generateSpanId();
   private final SpanContext spanContext =
       SpanContext.create(traceId, spanId, TraceFlags.getDefault(), Tracestate.getDefault());
   private final long startEpochNanos = 1000_123_789_654L;
@@ -494,9 +496,9 @@ public class RecordEventsReadableSpanTest {
   public void testAsSpanData() {
     String name = "GreatSpan";
     Kind kind = Kind.SERVER;
-    TraceId traceId = TestUtils.generateRandomTraceId();
-    SpanId spanId = TestUtils.generateRandomSpanId();
-    SpanId parentSpanId = TestUtils.generateRandomSpanId();
+    TraceId traceId = idsGenerator.generateTraceId();
+    SpanId spanId = idsGenerator.generateSpanId();
+    SpanId parentSpanId = idsGenerator.generateSpanId();
     TraceConfig traceConfig = TraceConfig.getDefault();
     SpanProcessor spanProcessor = NoopSpanProcessor.getInstance();
     TestClock clock = TestClock.create();

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -17,8 +17,6 @@
 package io.opentelemetry.sdk.trace;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.opentelemetry.sdk.trace.TestUtils.generateRandomSpanId;
-import static io.opentelemetry.sdk.trace.TestUtils.generateRandomTraceId;
 
 import com.google.common.truth.Truth;
 import io.opentelemetry.sdk.trace.Sampler.Decision;
@@ -30,6 +28,7 @@ import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.Tracestate;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -41,9 +40,10 @@ import org.junit.runners.JUnit4;
 public class SamplersTest {
   private static final String SPAN_NAME = "MySpanName";
   private static final int NUM_SAMPLE_TRIES = 1000;
-  private final TraceId traceId = TestUtils.generateRandomTraceId();
-  private final SpanId parentSpanId = TestUtils.generateRandomSpanId();
-  private final SpanId spanId = TestUtils.generateRandomSpanId();
+  private final IdsGenerator idsGenerator = new RandomIdsGenerator(new Random(1234));
+  private final TraceId traceId = idsGenerator.generateTraceId();
+  private final SpanId spanId = idsGenerator.generateSpanId();
+  private final SpanId parentSpanId = idsGenerator.generateSpanId();
   private final Tracestate tracestate = Tracestate.builder().build();
   private final SpanContext sampledSpanContext =
       SpanContext.create(
@@ -156,7 +156,7 @@ public class SamplersTest {
   }
 
   // Applies the given sampler to NUM_SAMPLE_TRIES random traceId/spanId pairs.
-  private static void assertSamplerSamplesWithProbability(
+  private void assertSamplerSamplesWithProbability(
       Sampler sampler, SpanContext parent, List<Link> parentLinks, double probability) {
     int count = 0; // Count of spans with sampling enabled
     for (int i = 0; i < NUM_SAMPLE_TRIES; i++) {
@@ -164,8 +164,8 @@ public class SamplersTest {
           .shouldSample(
               parent,
               false,
-              generateRandomTraceId(),
-              generateRandomSpanId(),
+              idsGenerator.generateTraceId(),
+              idsGenerator.generateSpanId(),
               SPAN_NAME,
               parentLinks)
           .isSampled()) {
@@ -254,7 +254,7 @@ public class SamplersTest {
             null,
             false,
             notSampledtraceId,
-            generateRandomSpanId(),
+            idsGenerator.generateSpanId(),
             SPAN_NAME,
             Collections.<Link>emptyList());
     assertThat(decision1.isSampled()).isFalse();
@@ -287,7 +287,7 @@ public class SamplersTest {
             null,
             false,
             sampledtraceId,
-            generateRandomSpanId(),
+            idsGenerator.generateSpanId(),
             SPAN_NAME,
             Collections.<Link>emptyList());
     assertThat(decision2.isSampled()).isTrue();

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
@@ -34,24 +34,6 @@ public final class TestUtils {
   private TestUtils() {}
 
   /**
-   * Returns a random {@link TraceId}.
-   *
-   * @return a random {@link TraceId}.
-   */
-  public static TraceId generateRandomTraceId() {
-    return TraceId.fromLowerBase16(UUID.randomUUID().toString().replace("-", ""), 0);
-  }
-
-  /**
-   * Returns a random {@link SpanId}.
-   *
-   * @return a random {@link SpanId}.
-   */
-  public static SpanId generateRandomSpanId() {
-    return SpanId.fromLowerBase16(UUID.randomUUID().toString().replace("-", ""), 0);
-  }
-
-  /**
    * Generates some random attributes used for testing.
    *
    * @return a map of String to AttributeValues


### PR DESCRIPTION
Currently the mechanism to inject a different ids generator is not implemented, but soon we will implement for clock, resource, etc.