### PR TITLE
Random ids gen cleanup

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
@@ -32,21 +32,22 @@ final class RandomIdsGenerator implements IdsGenerator {
 
   @Override
   public SpanId generateSpanId() {
-    long id;
-    do {
-      id = random.nextLong();
-    } while (id == INVALID_ID);
+    long id = generateValidId();
     return new SpanId(id);
   }
 
   @Override
   public TraceId generateTraceId() {
-    long idHi;
-    long idLo;
-    do {
-      idHi = random.nextLong();
-      idLo = random.nextLong();
-    } while (idHi == INVALID_ID && idLo == INVALID_ID);
+    long idHi = generateValidId();
+    long idLo = generateValidId();
     return new TraceId(idHi, idLo);
+  }
+
+  private long generateValidId() {
+    long id;
+    do {
+      id = random.nextLong();
+    } while (id == INVALID_ID);
+    return id;
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
@@ -22,8 +22,6 @@ import java.util.Random;
 
 final class RandomIdsGenerator implements IdsGenerator {
   private static final long INVALID_ID = 0;
-  // TODO change with ThreadLocal version
-  // https://github.com/open-telemetry/opentelemetry-java/issues/406
   private final Random random;
 
   RandomIdsGenerator(Random random) {


### PR DESCRIPTION
This resolves #642 

Note: ThreadLocalRandom was added in android api 21 and we need to support down to 14?  Removed to comment as a result.