### PR TITLE
Remove trace config and shutdown from TracerSdk

### DIFF
--- a/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryTracing.java
+++ b/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryTracing.java
@@ -18,9 +18,8 @@ package io.opentelemetry.exporters.inmemory;
 
 import io.opentelemetry.internal.Utils;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.TracerSdk;
+import io.opentelemetry.sdk.trace.TracerSdkFactory;
 import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
-import io.opentelemetry.trace.Tracer;
 import java.util.List;
 
 /**
@@ -45,7 +44,7 @@ import java.util.List;
  * @since 0.1.0
  */
 public final class InMemoryTracing {
-  private final TracerSdk tracer;
+  private final TracerSdkFactory tracerSdkFactory;
   private final InMemorySpanExporter exporter;
 
   /**
@@ -54,22 +53,22 @@ public final class InMemoryTracing {
    * @since 0.1.0
    */
   public InMemoryTracing() {
-    this(new TracerSdk());
+    this(new TracerSdkFactory());
   }
 
   /**
    * Creates a new {@code InMemoryTracing} with the specified {@code TracerSdk}.
    *
-   * @param tracer the {@code TracerSdk} to be used.
+   * @param tracerSdkFactory the {@code TracerSdkFactory} to be used.
    * @throws NullPointerException if {@code tracer} is {@code null}.
    * @since 0.1.0
    */
-  public InMemoryTracing(TracerSdk tracer) {
-    Utils.checkNotNull(tracer, "tracer");
+  public InMemoryTracing(TracerSdkFactory tracerSdkFactory) {
+    Utils.checkNotNull(tracerSdkFactory, "tracerSdkFactory");
 
-    this.tracer = tracer;
+    this.tracerSdkFactory = tracerSdkFactory;
     this.exporter = InMemorySpanExporter.create();
-    tracer.addSpanProcessor(SimpleSpansProcessor.newBuilder(exporter).build());
+    tracerSdkFactory.addSpanProcessor(SimpleSpansProcessor.newBuilder(exporter).build());
   }
 
   /**
@@ -79,8 +78,8 @@ public final class InMemoryTracing {
    * @return the {@code Tracer} to be used to create {@code Span}s.
    * @since 0.1.0
    */
-  public Tracer getTracer() {
-    return tracer;
+  public TracerSdkFactory getTracerFactory() {
+    return tracerSdkFactory;
   }
 
   /**
@@ -109,6 +108,6 @@ public final class InMemoryTracing {
    * @since 0.1.0
    */
   public void shutdown() {
-    tracer.shutdown();
+    tracerSdkFactory.shutdown();
   }
 }

--- a/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemoryTracingTest.java
+++ b/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemoryTracingTest.java
@@ -20,8 +20,9 @@ import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.TracerSdk;
+import io.opentelemetry.sdk.trace.TracerSdkFactory;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
+import io.opentelemetry.trace.Tracer;
 import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,13 +34,9 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class InMemoryTracingTest {
   private final InMemoryTracing tracing = new InMemoryTracing();
+  private final Tracer tracer = tracing.getTracerFactory().get("InMemoryTracing");
 
   @Rule public final ExpectedException thrown = ExpectedException.none();
-
-  @Test
-  public void defaultTracer() {
-    assertThat(tracing.getTracer()).isInstanceOf(TracerSdk.class);
-  }
 
   @Test
   public void defaultFinishedSpanItems() {
@@ -48,9 +45,9 @@ public class InMemoryTracingTest {
 
   @Test
   public void ctor_tracer() {
-    TracerSdk tracer = new TracerSdk();
-    InMemoryTracing tracing = new InMemoryTracing(tracer);
-    assertThat(tracing.getTracer()).isSameInstanceAs(tracer);
+    TracerSdkFactory tracerSdkFactory = new TracerSdkFactory();
+    InMemoryTracing tracing = new InMemoryTracing(tracerSdkFactory);
+    assertThat(tracing.getTracerFactory()).isSameInstanceAs(tracerSdkFactory);
   }
 
   @Test
@@ -61,8 +58,8 @@ public class InMemoryTracingTest {
 
   @Test
   public void getFinishedSpanItems() {
-    tracing.getTracer().spanBuilder("A").startSpan().end();
-    tracing.getTracer().spanBuilder("B").startSpan().end();
+    tracer.spanBuilder("A").startSpan().end();
+    tracer.spanBuilder("B").startSpan().end();
 
     List<SpanData> finishedSpanItems = tracing.getFinishedSpanItems();
     assertThat(finishedSpanItems.get(0).getName()).isEqualTo("A");
@@ -71,15 +68,15 @@ public class InMemoryTracingTest {
 
   @Test
   public void getFinishedSpanItems_sampled() {
-    tracing.getTracer().spanBuilder("A").startSpan().end();
-    TracerSdk tracerSdk = (TracerSdk) tracing.getTracer();
-    TraceConfig originalConfig = tracerSdk.getActiveTraceConfig();
-    tracerSdk.updateActiveTraceConfig(
+    tracer.spanBuilder("A").startSpan().end();
+    TracerSdkFactory tracerSdkFactory = tracing.getTracerFactory();
+    TraceConfig originalConfig = tracerSdkFactory.getActiveTraceConfig();
+    tracerSdkFactory.updateActiveTraceConfig(
         originalConfig.toBuilder().setSampler(Samplers.alwaysOff()).build());
     try {
-      tracing.getTracer().spanBuilder("B").startSpan().end();
+      tracer.spanBuilder("B").startSpan().end();
     } finally {
-      tracerSdk.updateActiveTraceConfig(originalConfig);
+      tracerSdkFactory.updateActiveTraceConfig(originalConfig);
     }
 
     List<SpanData> finishedSpanItems = tracing.getFinishedSpanItems();
@@ -89,8 +86,8 @@ public class InMemoryTracingTest {
 
   @Test
   public void reset() {
-    tracing.getTracer().spanBuilder("A").startSpan();
-    tracing.getTracer().spanBuilder("B").startSpan();
+    tracer.spanBuilder("A").startSpan();
+    tracer.spanBuilder("B").startSpan();
     tracing.reset();
     assertThat(tracing.getFinishedSpanItems().size()).isEqualTo(0);
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
@@ -46,6 +46,6 @@ public interface SpanProcessor {
   // TODO: Consider checking whether the given span is processed with onStart().
   void onEnd(ReadableSpan span);
 
-  /** Called when {@link TracerSdk#shutdown()} is called. */
+  /** Called when {@link TracerSdkFactory#shutdown()} is called. */
   void shutdown();
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
@@ -80,9 +80,4 @@ public class TracerSdk implements Tracer {
   public void addSpanProcessor(SpanProcessor spanProcessor) {
     sharedState.addSpanProcessor(spanProcessor);
   }
-
-  /** TODO: Remove this when all tests are changed to use the factory. */
-  public void shutdown() {
-    sharedState.stop();
-  }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
@@ -19,7 +19,6 @@ package io.opentelemetry.sdk.trace;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.BinaryFormat;
 import io.opentelemetry.context.propagation.HttpTextFormat;
-import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.trace.DefaultTracer;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
@@ -75,16 +74,6 @@ public class TracerSdk implements Tracer {
   @Override
   public HttpTextFormat<SpanContext> getHttpTextFormat() {
     return HTTP_TEXT_FORMAT;
-  }
-
-  /** TODO: Remove this when all tests are changed to use the factory. */
-  public TraceConfig getActiveTraceConfig() {
-    return sharedState.getActiveTraceConfig();
-  }
-
-  /** TODO: Remove this when all tests are changed to use the factory. */
-  public void updateActiveTraceConfig(TraceConfig traceConfig) {
-    sharedState.updateActiveTraceConfig(traceConfig);
   }
 
   /** TODO: Remove this when all tests are changed to use the factory. */

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SpanExporter.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SpanExporter.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.sdk.trace.export;
 
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.TracerSdk;
 import java.util.List;
 
 /**
@@ -55,8 +54,8 @@ public interface SpanExporter {
   ResultCode export(List<SpanData> spans);
 
   /**
-   * Called when {@link TracerSdk#shutdown()} is called, if this {@code SpanExporter} is register to
-   * a {@code TracerSdk} object.
+   * Called when {@link io.opentelemetry.sdk.trace.TracerSdkFactory#shutdown()} is called, if this
+   * {@code SpanExporter} is register to a {@code TracerSdkFactory} object.
    */
   void shutdown();
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -53,32 +53,33 @@ public class SpanBuilderSdkTest {
           TraceFlags.builder().setIsSampled(true).build(),
           Tracestate.getDefault());
 
-  private final TracerSdk tracer = new TracerSdk();
+  private final TracerSdkFactory tracerSdkFactory = new TracerSdkFactory();
+  private final TracerSdk tracerSdk = tracerSdkFactory.get("SpanBuilderSdkTest");
 
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void setSpanKind_null() {
     thrown.expect(NullPointerException.class);
-    tracer.spanBuilder(SPAN_NAME).setSpanKind(null);
+    tracerSdk.spanBuilder(SPAN_NAME).setSpanKind(null);
   }
 
   @Test
   public void setParent_null() {
     thrown.expect(NullPointerException.class);
-    tracer.spanBuilder(SPAN_NAME).setParent((Span) null);
+    tracerSdk.spanBuilder(SPAN_NAME).setParent((Span) null);
   }
 
   @Test
   public void setRemoteParent_null() {
     thrown.expect(NullPointerException.class);
-    tracer.spanBuilder(SPAN_NAME).setParent((SpanContext) null);
+    tracerSdk.spanBuilder(SPAN_NAME).setParent((SpanContext) null);
   }
 
   @Test
   public void addLink() {
     // Verify methods do not crash.
-    Span.Builder spanBuilder = tracer.spanBuilder(SPAN_NAME);
+    Span.Builder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
     spanBuilder.addLink(SpanData.Link.create(DefaultSpan.getInvalid().getContext()));
     spanBuilder.addLink(DefaultSpan.getInvalid().getContext());
     spanBuilder.addLink(
@@ -96,10 +97,14 @@ public class SpanBuilderSdkTest {
   public void truncateLink() {
     final int maxNumberOfLinks = 8;
     TraceConfig traceConfig =
-        TraceConfig.getDefault().toBuilder().setMaxNumberOfLinks(maxNumberOfLinks).build();
-    tracer.updateActiveTraceConfig(traceConfig);
+        tracerSdkFactory
+            .getActiveTraceConfig()
+            .toBuilder()
+            .setMaxNumberOfLinks(maxNumberOfLinks)
+            .build();
+    tracerSdkFactory.updateActiveTraceConfig(traceConfig);
     // Verify methods do not crash.
-    Span.Builder spanBuilder = tracer.spanBuilder(SPAN_NAME);
+    Span.Builder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
     for (int i = 0; i < 2 * maxNumberOfLinks; i++) {
       spanBuilder.addLink(sampledSpanContext);
     }
@@ -112,37 +117,37 @@ public class SpanBuilderSdkTest {
       }
     } finally {
       span.end();
-      tracer.updateActiveTraceConfig(TraceConfig.getDefault());
+      tracerSdkFactory.updateActiveTraceConfig(TraceConfig.getDefault());
     }
   }
 
   @Test
   public void addLink_null() {
     thrown.expect(NullPointerException.class);
-    tracer.spanBuilder(SPAN_NAME).addLink((Link) null);
+    tracerSdk.spanBuilder(SPAN_NAME).addLink((Link) null);
   }
 
   @Test
   public void addLinkSpanContext_null() {
     thrown.expect(NullPointerException.class);
-    tracer.spanBuilder(SPAN_NAME).addLink((SpanContext) null);
+    tracerSdk.spanBuilder(SPAN_NAME).addLink((SpanContext) null);
   }
 
   @Test
   public void addLinkSpanContextAttributes_nullContext() {
     thrown.expect(NullPointerException.class);
-    tracer.spanBuilder(SPAN_NAME).addLink(null, Collections.<String, AttributeValue>emptyMap());
+    tracerSdk.spanBuilder(SPAN_NAME).addLink(null, Collections.<String, AttributeValue>emptyMap());
   }
 
   @Test
   public void addLinkSpanContextAttributes_nullAttributes() {
     thrown.expect(NullPointerException.class);
-    tracer.spanBuilder(SPAN_NAME).addLink(DefaultSpan.getInvalid().getContext(), null);
+    tracerSdk.spanBuilder(SPAN_NAME).addLink(DefaultSpan.getInvalid().getContext(), null);
   }
 
   @Test
   public void recordEvents_default() {
-    Span span = tracer.spanBuilder(SPAN_NAME).startSpan();
+    Span span = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
     try {
       assertThat(span.isRecording()).isTrue();
     } finally {
@@ -153,7 +158,7 @@ public class SpanBuilderSdkTest {
   @Test
   public void kind_default() {
     RecordEventsReadableSpan span =
-        (RecordEventsReadableSpan) tracer.spanBuilder(SPAN_NAME).startSpan();
+        (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).startSpan();
     try {
       assertThat(span.getKind()).isEqualTo(Kind.INTERNAL);
     } finally {
@@ -165,7 +170,7 @@ public class SpanBuilderSdkTest {
   public void kind() {
     RecordEventsReadableSpan span =
         (RecordEventsReadableSpan)
-            tracer.spanBuilder(SPAN_NAME).setSpanKind(Kind.CONSUMER).startSpan();
+            tracerSdk.spanBuilder(SPAN_NAME).setSpanKind(Kind.CONSUMER).startSpan();
     try {
       assertThat(span.getKind()).isEqualTo(Kind.CONSUMER);
     } finally {
@@ -175,7 +180,9 @@ public class SpanBuilderSdkTest {
 
   @Test
   public void sampler() {
-    Span span = TestUtils.startSpanWithSampler(tracer, SPAN_NAME, Samplers.alwaysOff()).startSpan();
+    Span span =
+        TestUtils.startSpanWithSampler(tracerSdkFactory, tracerSdk, SPAN_NAME, Samplers.alwaysOff())
+            .startSpan();
     try {
       assertThat(span.getContext().getTraceFlags().isSampled()).isFalse();
     } finally {
@@ -188,7 +195,8 @@ public class SpanBuilderSdkTest {
     RecordEventsReadableSpan span =
         (RecordEventsReadableSpan)
             TestUtils.startSpanWithSampler(
-                    tracer,
+                    tracerSdkFactory,
+                    tracerSdk,
                     SPAN_NAME,
                     new Sampler() {
                       @Override
@@ -233,7 +241,8 @@ public class SpanBuilderSdkTest {
   public void sampledViaParentLinks() {
     RecordEventsReadableSpan span =
         (RecordEventsReadableSpan)
-            TestUtils.startSpanWithSampler(tracer, SPAN_NAME, Samplers.probability(0.0))
+            TestUtils.startSpanWithSampler(
+                    tracerSdkFactory, tracerSdk, SPAN_NAME, Samplers.probability(0.0))
                 .addLink(sampledSpanContext)
                 .startSpan();
     try {
@@ -247,15 +256,20 @@ public class SpanBuilderSdkTest {
 
   @Test
   public void noParent() {
-    Span parent = tracer.spanBuilder(SPAN_NAME).startSpan();
-    Scope scope = tracer.withSpan(parent);
+    Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
+    Scope scope = tracerSdk.withSpan(parent);
     try {
-      Span span = tracer.spanBuilder(SPAN_NAME).setNoParent().startSpan();
+      Span span = tracerSdk.spanBuilder(SPAN_NAME).setNoParent().startSpan();
       try {
         assertThat(span.getContext().getTraceId()).isNotEqualTo(parent.getContext().getTraceId());
 
         Span spanNoParent =
-            tracer.spanBuilder(SPAN_NAME).setNoParent().setParent(parent).setNoParent().startSpan();
+            tracerSdk
+                .spanBuilder(SPAN_NAME)
+                .setNoParent()
+                .setParent(parent)
+                .setNoParent()
+                .startSpan();
         try {
           assertThat(span.getContext().getTraceId()).isNotEqualTo(parent.getContext().getTraceId());
         } finally {
@@ -272,18 +286,18 @@ public class SpanBuilderSdkTest {
 
   @Test
   public void noParent_override() {
-    Span parent = tracer.spanBuilder(SPAN_NAME).startSpan();
+    Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
     try {
       RecordEventsReadableSpan span =
           (RecordEventsReadableSpan)
-              tracer.spanBuilder(SPAN_NAME).setNoParent().setParent(parent).startSpan();
+              tracerSdk.spanBuilder(SPAN_NAME).setNoParent().setParent(parent).startSpan();
       try {
         assertThat(span.getContext().getTraceId()).isEqualTo(parent.getContext().getTraceId());
         assertThat(span.getParentSpanId()).isEqualTo(parent.getContext().getSpanId());
 
         RecordEventsReadableSpan span2 =
             (RecordEventsReadableSpan)
-                tracer
+                tracerSdk
                     .spanBuilder(SPAN_NAME)
                     .setNoParent()
                     .setParent(parent.getContext())
@@ -303,12 +317,12 @@ public class SpanBuilderSdkTest {
 
   @Test
   public void overrideNoParent_remoteParent() {
-    Span parent = tracer.spanBuilder(SPAN_NAME).startSpan();
+    Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
     try {
 
       RecordEventsReadableSpan span =
           (RecordEventsReadableSpan)
-              tracer
+              tracerSdk
                   .spanBuilder(SPAN_NAME)
                   .setNoParent()
                   .setParent(parent.getContext())
@@ -326,11 +340,11 @@ public class SpanBuilderSdkTest {
 
   @Test
   public void parentCurrentSpan() {
-    Span parent = tracer.spanBuilder(SPAN_NAME).startSpan();
-    Scope scope = tracer.withSpan(parent);
+    Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
+    Scope scope = tracerSdk.withSpan(parent);
     try {
       RecordEventsReadableSpan span =
-          (RecordEventsReadableSpan) tracer.spanBuilder(SPAN_NAME).startSpan();
+          (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).startSpan();
       try {
         assertThat(span.getContext().getTraceId()).isEqualTo(parent.getContext().getTraceId());
         assertThat(span.getParentSpanId()).isEqualTo(parent.getContext().getSpanId());
@@ -349,7 +363,7 @@ public class SpanBuilderSdkTest {
 
     RecordEventsReadableSpan span =
         (RecordEventsReadableSpan)
-            tracer.spanBuilder(SPAN_NAME).setParent(parent.getContext()).startSpan();
+            tracerSdk.spanBuilder(SPAN_NAME).setParent(parent.getContext()).startSpan();
     try {
       assertThat(span.getContext().getTraceId()).isNotEqualTo(parent.getContext().getTraceId());
       assertFalse(span.getParentSpanId().isValid());
@@ -360,10 +374,10 @@ public class SpanBuilderSdkTest {
 
   @Test
   public void parent_timestampConverter() {
-    Span parent = tracer.spanBuilder(SPAN_NAME).startSpan();
+    Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
     try {
       RecordEventsReadableSpan span =
-          (RecordEventsReadableSpan) tracer.spanBuilder(SPAN_NAME).setParent(parent).startSpan();
+          (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).setParent(parent).startSpan();
 
       assertThat(span.getClock()).isEqualTo(((RecordEventsReadableSpan) parent).getClock());
     } finally {
@@ -373,11 +387,11 @@ public class SpanBuilderSdkTest {
 
   @Test
   public void parentCurrentSpan_timestampConverter() {
-    Span parent = tracer.spanBuilder(SPAN_NAME).startSpan();
-    Scope scope = tracer.withSpan(parent);
+    Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
+    Scope scope = tracerSdk.withSpan(parent);
     try {
       RecordEventsReadableSpan span =
-          (RecordEventsReadableSpan) tracer.spanBuilder(SPAN_NAME).startSpan();
+          (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).startSpan();
 
       assertThat(span.getClock()).isEqualTo(((RecordEventsReadableSpan) parent).getClock());
     } finally {
@@ -390,6 +404,6 @@ public class SpanBuilderSdkTest {
   public void startTimestamp_null() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Negative startTimestamp");
-    tracer.spanBuilder(SPAN_NAME).setStartTimestamp(-1);
+    tracerSdk.spanBuilder(SPAN_NAME).setStartTimestamp(-1);
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
@@ -70,13 +70,14 @@ public final class TestUtils {
    * @return A SpanData instance.
    */
   public static Span.Builder startSpanWithSampler(
-      TracerSdk tracerSdk, String spanName, Sampler sampler) {
-    TraceConfig originalConfig = tracerSdk.getActiveTraceConfig();
-    tracerSdk.updateActiveTraceConfig(originalConfig.toBuilder().setSampler(sampler).build());
+      TracerSdkFactory tracerSdkFactory, TracerSdk tracerSdk, String spanName, Sampler sampler) {
+    TraceConfig originalConfig = tracerSdkFactory.getActiveTraceConfig();
+    tracerSdkFactory.updateActiveTraceConfig(
+        originalConfig.toBuilder().setSampler(sampler).build());
     try {
       return tracerSdk.spanBuilder(spanName);
     } finally {
-      tracerSdk.updateActiveTraceConfig(originalConfig);
+      tracerSdkFactory.updateActiveTraceConfig(originalConfig);
     }
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessorTest.java
@@ -58,7 +58,7 @@ public class BatchSpansProcessorTest {
 
   @After
   public void cleanup() {
-    tracerSdk.shutdown();
+    tracerSdkFactory.shutdown();
   }
 
   private ReadableSpan createSampledEndedSpan(String spanName) {
@@ -87,7 +87,7 @@ public class BatchSpansProcessorTest {
 
   @Test
   public void exportDifferentSampledSpans() {
-    tracerSdk.addSpanProcessor(
+    tracerSdkFactory.addSpanProcessor(
         BatchSpansProcessor.newBuilder(waitingSpanExporter)
             .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
             .build());
@@ -100,7 +100,7 @@ public class BatchSpansProcessorTest {
 
   @Test
   public void exportMoreSpansThanTheBufferSize() {
-    tracerSdk.addSpanProcessor(
+    tracerSdkFactory.addSpanProcessor(
         BatchSpansProcessor.newBuilder(waitingSpanExporter)
             .setMaxQueueSize(6)
             .setMaxExportBatchSize(2)
@@ -127,7 +127,7 @@ public class BatchSpansProcessorTest {
   @Test
   public void exportSpansToMultipleServices() {
     WaitingSpanExporter waitingSpanExporter2 = new WaitingSpanExporter();
-    tracerSdk.addSpanProcessor(
+    tracerSdkFactory.addSpanProcessor(
         BatchSpansProcessor.newBuilder(
                 MultiSpanExporter.create(
                     Arrays.<SpanExporter>asList(waitingSpanExporter, waitingSpanExporter2)))
@@ -145,7 +145,7 @@ public class BatchSpansProcessorTest {
   @Test
   public void exportMoreSpansThanTheMaximumLimit() {
     final int maxQueuedSpans = 8;
-    tracerSdk.addSpanProcessor(
+    tracerSdkFactory.addSpanProcessor(
         BatchSpansProcessor.newBuilder(
                 MultiSpanExporter.create(Arrays.asList(blockingSpanExporter, waitingSpanExporter)))
             .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
@@ -207,7 +207,7 @@ public class BatchSpansProcessorTest {
         .when(mockServiceHandler)
         .export(ArgumentMatchers.<SpanData>anyList());
 
-    tracerSdk.addSpanProcessor(
+    tracerSdkFactory.addSpanProcessor(
         BatchSpansProcessor.newBuilder(
                 MultiSpanExporter.create(Arrays.asList(mockServiceHandler, waitingSpanExporter)))
             .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
@@ -224,7 +224,7 @@ public class BatchSpansProcessorTest {
 
   @Test
   public void exportNotSampledSpans() {
-    tracerSdk.addSpanProcessor(
+    tracerSdkFactory.addSpanProcessor(
         BatchSpansProcessor.newBuilder(waitingSpanExporter)
             .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
             .build());
@@ -246,7 +246,7 @@ public class BatchSpansProcessorTest {
   public void exportNotSampledSpans_recordingEvents() {
     // TODO(bdrutu): Fix this when Sampler return RECORD option.
     /*
-    tracerSdk.addSpanProcessor(
+    tracerSdkFactory.addSpanProcessor(
         BatchSpansProcessor.newBuilder(waitingSpanExporter)
             .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
             .reportOnlySampled(false)
@@ -262,7 +262,7 @@ public class BatchSpansProcessorTest {
   public void exportNotSampledSpans_reportOnlySampled() {
     // TODO(bdrutu): Fix this when Sampler return RECORD option.
     /*
-    tracerSdk.addSpanProcessor(
+    tracerSdkFactory.addSpanProcessor(
         BatchSpansProcessor.newBuilder(waitingSpanExporter)
             .reportOnlySampled(true)
             .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
@@ -278,13 +278,13 @@ public class BatchSpansProcessorTest {
   @Test(timeout = 10000L)
   public void shutdownFlushes() {
     // Set the export delay to zero, for no timeout, in order to confirm the #flush() below works
-    tracerSdk.addSpanProcessor(
+    tracerSdkFactory.addSpanProcessor(
         BatchSpansProcessor.newBuilder(waitingSpanExporter).setScheduleDelayMillis(0).build());
 
     ReadableSpan span2 = createSampledEndedSpan(SPAN_NAME_2);
 
     // Force a shutdown, without this, the #waitForExport() call below would block indefinitely.
-    tracerSdk.shutdown();
+    tracerSdkFactory.shutdown();
 
     List<SpanData> exported = waitingSpanExporter.waitForExport(1);
     assertThat(exported).containsExactly(span2.toSpanData());

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessorTest.java
@@ -24,6 +24,7 @@ import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.sdk.trace.SpanData;
 import io.opentelemetry.sdk.trace.TestUtils;
 import io.opentelemetry.sdk.trace.TracerSdk;
+import io.opentelemetry.sdk.trace.TracerSdkFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -44,7 +45,8 @@ public class BatchSpansProcessorTest {
   private static final String SPAN_NAME_1 = "MySpanName/1";
   private static final String SPAN_NAME_2 = "MySpanName/2";
   private static final long MAX_SCHEDULE_DELAY_MILLIS = 500;
-  private final TracerSdk tracerSdk = new TracerSdk();
+  private final TracerSdkFactory tracerSdkFactory = new TracerSdkFactory();
+  private final TracerSdk tracerSdk = tracerSdkFactory.get("BatchSpansProcessorTest");
   private final WaitingSpanExporter waitingSpanExporter = new WaitingSpanExporter();
   private final BlockingSpanExporter blockingSpanExporter = new BlockingSpanExporter();
   @Mock private SpanExporter mockServiceHandler;
@@ -61,7 +63,8 @@ public class BatchSpansProcessorTest {
 
   private ReadableSpan createSampledEndedSpan(String spanName) {
     io.opentelemetry.trace.Span span =
-        TestUtils.startSpanWithSampler(tracerSdk, spanName, Samplers.alwaysOn()).startSpan();
+        TestUtils.startSpanWithSampler(tracerSdkFactory, tracerSdk, spanName, Samplers.alwaysOn())
+            .startSpan();
     span.end();
     return (ReadableSpan) span;
   }
@@ -77,7 +80,9 @@ public class BatchSpansProcessorTest {
   */
 
   private void createNotSampledEndedSpan(String spanName) {
-    TestUtils.startSpanWithSampler(tracerSdk, spanName, Samplers.alwaysOff()).startSpan().end();
+    TestUtils.startSpanWithSampler(tracerSdkFactory, tracerSdk, spanName, Samplers.alwaysOff())
+        .startSpan()
+        .end();
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpansProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpansProcessorTest.java
@@ -27,6 +27,7 @@ import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.sdk.trace.SpanData;
 import io.opentelemetry.sdk.trace.TestUtils;
 import io.opentelemetry.sdk.trace.TracerSdk;
+import io.opentelemetry.sdk.trace.TracerSdkFactory;
 import io.opentelemetry.sdk.trace.export.BatchSpansProcessorTest.WaitingSpanExporter;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
@@ -49,7 +50,8 @@ public class SimpleSpansProcessorTest {
   private static final String SPAN_NAME = "MySpanName";
   @Mock private ReadableSpan readableSpan;
   @Mock private SpanExporter spanExporter;
-  private final TracerSdk tracerSdk = new TracerSdk();
+  private final TracerSdkFactory tracerSdkFactory = new TracerSdkFactory();
+  private final TracerSdk tracerSdk = tracerSdkFactory.get("SimpleSpansProcessor");
   private final WaitingSpanExporter waitingSpanExporter = new WaitingSpanExporter();
   private static final SpanContext SAMPLED_SPAN_CONTEXT =
       SpanContext.create(
@@ -125,8 +127,12 @@ public class SimpleSpansProcessorTest {
             .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
             .build());
 
-    TestUtils.startSpanWithSampler(tracerSdk, SPAN_NAME, Samplers.alwaysOff()).startSpan().end();
-    TestUtils.startSpanWithSampler(tracerSdk, SPAN_NAME, Samplers.alwaysOff()).startSpan().end();
+    TestUtils.startSpanWithSampler(tracerSdkFactory, tracerSdk, SPAN_NAME, Samplers.alwaysOff())
+        .startSpan()
+        .end();
+    TestUtils.startSpanWithSampler(tracerSdkFactory, tracerSdk, SPAN_NAME, Samplers.alwaysOff())
+        .startSpan()
+        .end();
 
     io.opentelemetry.trace.Span span = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
     span.end();


### PR DESCRIPTION
Getting or updating the active configuration was moved to the TracerSdkFactory.