### PR TITLE
[Do not merge] Initial prototype for context-prop overhaul.

### DIFF
--- a/api/src/main/java/io/opentelemetry/OpenTelemetry.java
+++ b/api/src/main/java/io/opentelemetry/OpenTelemetry.java
@@ -18,8 +18,7 @@ package io.opentelemetry;
 
 import io.opentelemetry.context.propagation.DefaultHttpExtractor;
 import io.opentelemetry.context.propagation.DefaultHttpInjector;
-import io.opentelemetry.context.propagation.HttpExtractor;
-import io.opentelemetry.context.propagation.HttpInjector;
+import io.opentelemetry.context.propagation.Propagators;
 import io.opentelemetry.distributedcontext.CorrelationContextManager;
 import io.opentelemetry.distributedcontext.DefaultCorrelationContextManager;
 import io.opentelemetry.distributedcontext.spi.CorrelationContextManagerProvider;
@@ -53,29 +52,8 @@ public final class OpenTelemetry {
   private final TracerFactory tracerFactory;
   private final Meter meter;
   private final CorrelationContextManager contextManager;
-
-  public static final class Propagators {
-    private static volatile HttpInjector httpInjector = new DefaultHttpInjector();
-    private static volatile HttpExtractor httpExtractor = new DefaultHttpExtractor();
-
-    public static HttpExtractor getHttpExtractor() {
-      return httpExtractor;
-    }
-
-    public static void setHttpExtractor(HttpExtractor httpExtractor) {
-      Propagators.httpExtractor = httpExtractor;
-    }
-
-    public static HttpInjector getHttpInjector() {
-      return httpInjector;
-    }
-
-    public static void setHttpInjector(HttpInjector httpInjector) {
-      Propagators.httpInjector = httpInjector;
-    }
-
-    private Propagators() {}
-  }
+  private volatile Propagators propagators =
+      Propagators.create(new DefaultHttpInjector(), new DefaultHttpExtractor());
 
   /**
    * Returns a singleton {@link TracerFactory}.
@@ -111,6 +89,14 @@ public final class OpenTelemetry {
    */
   public static CorrelationContextManager getCorrelationContextManager() {
     return getInstance().contextManager;
+  }
+
+  public static Propagators getPropagators() {
+    return getInstance().propagators;
+  }
+
+  public static void setPropagators(Propagators propagators) {
+    getInstance().propagators = propagators;
   }
 
   /** Lazy loads an instance. */

--- a/api/src/main/java/io/opentelemetry/OpenTelemetry.java
+++ b/api/src/main/java/io/opentelemetry/OpenTelemetry.java
@@ -16,9 +16,9 @@
 
 package io.opentelemetry;
 
-import io.opentelemetry.distributedcontext.DefaultDistributedContextManager;
-import io.opentelemetry.distributedcontext.DistributedContextManager;
-import io.opentelemetry.distributedcontext.spi.DistributedContextManagerProvider;
+import io.opentelemetry.distributedcontext.CorrelationContextManager;
+import io.opentelemetry.distributedcontext.DefaultCorrelationContextManager;
+import io.opentelemetry.distributedcontext.spi.CorrelationContextManagerProvider;
 import io.opentelemetry.metrics.DefaultMeter;
 import io.opentelemetry.metrics.Meter;
 import io.opentelemetry.metrics.spi.MeterProvider;
@@ -33,13 +33,13 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * This class provides a static global accessor for telemetry objects {@link Tracer}, {@link Meter}
- * and {@link DistributedContextManager}.
+ * and {@link CorrelationContextManager}.
  *
  * <p>The telemetry objects are lazy-loaded singletons resolved via {@link ServiceLoader} mechanism.
  *
  * @see TracerFactory
  * @see MeterProvider
- * @see DistributedContextManagerProvider
+ * @see CorrelationContextManagerProvider
  */
 @ThreadSafe
 public final class OpenTelemetry {
@@ -48,7 +48,7 @@ public final class OpenTelemetry {
 
   private final TracerFactory tracerFactory;
   private final Meter meter;
-  private final DistributedContextManager contextManager;
+  private final CorrelationContextManager contextManager;
 
   /**
    * Returns a singleton {@link TracerFactory}.
@@ -74,15 +74,15 @@ public final class OpenTelemetry {
   }
 
   /**
-   * Returns a singleton {@link DistributedContextManager}.
+   * Returns a singleton {@link CorrelationContextManager}.
    *
    * @return registered manager or default via {@link
-   *     DefaultDistributedContextManager#getInstance()}.
+   *     DefaultCorrelationContextManager#getInstance()}.
    * @throws IllegalStateException if a specified manager (via system properties) could not be
    *     found.
    * @since 0.1.0
    */
-  public static DistributedContextManager getDistributedContextManager() {
+  public static CorrelationContextManager getDistributedContextManager() {
     return getInstance().contextManager;
   }
 
@@ -107,12 +107,12 @@ public final class OpenTelemetry {
 
     MeterProvider meterProvider = loadSpi(MeterProvider.class);
     meter = meterProvider != null ? meterProvider.create() : DefaultMeter.getInstance();
-    DistributedContextManagerProvider contextManagerProvider =
-        loadSpi(DistributedContextManagerProvider.class);
+    CorrelationContextManagerProvider contextManagerProvider =
+        loadSpi(CorrelationContextManagerProvider.class);
     contextManager =
         contextManagerProvider != null
             ? contextManagerProvider.create()
-            : DefaultDistributedContextManager.getInstance();
+            : DefaultCorrelationContextManager.getInstance();
   }
 
   /**

--- a/api/src/main/java/io/opentelemetry/OpenTelemetry.java
+++ b/api/src/main/java/io/opentelemetry/OpenTelemetry.java
@@ -16,6 +16,10 @@
 
 package io.opentelemetry;
 
+import io.opentelemetry.context.propagation.DefaultHttpExtractor;
+import io.opentelemetry.context.propagation.DefaultHttpInjector;
+import io.opentelemetry.context.propagation.HttpExtractor;
+import io.opentelemetry.context.propagation.HttpInjector;
 import io.opentelemetry.distributedcontext.CorrelationContextManager;
 import io.opentelemetry.distributedcontext.DefaultCorrelationContextManager;
 import io.opentelemetry.distributedcontext.spi.CorrelationContextManagerProvider;
@@ -49,6 +53,29 @@ public final class OpenTelemetry {
   private final TracerFactory tracerFactory;
   private final Meter meter;
   private final CorrelationContextManager contextManager;
+
+  public static final class Propagators {
+    private static volatile HttpInjector httpInjector = new DefaultHttpInjector();
+    private static volatile HttpExtractor httpExtractor = new DefaultHttpExtractor();
+
+    public static HttpExtractor getHttpExtractor() {
+      return httpExtractor;
+    }
+
+    public static void setHttpExtractor(HttpExtractor httpExtractor) {
+      Propagators.httpExtractor = httpExtractor;
+    }
+
+    public static HttpInjector getHttpInjector() {
+      return httpInjector;
+    }
+
+    public static void setHttpInjector(HttpInjector httpInjector) {
+      Propagators.httpInjector = httpInjector;
+    }
+
+    private Propagators() {}
+  }
 
   /**
    * Returns a singleton {@link TracerFactory}.

--- a/api/src/main/java/io/opentelemetry/OpenTelemetry.java
+++ b/api/src/main/java/io/opentelemetry/OpenTelemetry.java
@@ -82,7 +82,7 @@ public final class OpenTelemetry {
    *     found.
    * @since 0.1.0
    */
-  public static CorrelationContextManager getDistributedContextManager() {
+  public static CorrelationContextManager getCorrelationContextManager() {
     return getInstance().contextManager;
   }
 

--- a/api/src/main/java/io/opentelemetry/baggage/BaggageManager.java
+++ b/api/src/main/java/io/opentelemetry/baggage/BaggageManager.java
@@ -14,47 +14,22 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.distributedcontext;
+package io.opentelemetry.baggage;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.HttpExtractor;
 import io.opentelemetry.context.propagation.HttpInjector;
-import javax.annotation.Nullable;
 
-public final class DefaultBaggageManager implements BaggageManager {
+public interface BaggageManager {
+  public Context setValue(Context ctx, String key, String value);
 
-  @Override
-  public Context setValue(Context ctx, String key, String value) {
-    return ctx;
-  }
+  public String getValue(Context ctx, String key);
 
-  @Nullable
-  @Override
-  public String getValue(Context ctx, String key) {
-    return null;
-  }
+  public Context removeValue(Context ctx, String key);
 
-  @Override
-  public Context removeValue(Context ctx, String key) {
-    return ctx;
-  }
+  public Context clear(Context ctx);
 
-  @Override
-  public Context clear(Context ctx) {
-    return ctx;
-  }
+  public HttpInjector getHttpInjector();
 
-  @Nullable
-  @Override
-  public HttpInjector getHttpInjector() {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public HttpExtractor getHttpExtractor() {
-    return null;
-  }
-
-  // TODO - define noop propagators (expose them?)
+  public HttpExtractor getHttpExtractor();
 }

--- a/api/src/main/java/io/opentelemetry/baggage/DefaultBaggageManager.java
+++ b/api/src/main/java/io/opentelemetry/baggage/DefaultBaggageManager.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.baggage;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.HttpExtractor;
+import io.opentelemetry.context.propagation.HttpInjector;
+import javax.annotation.Nullable;
+
+public final class DefaultBaggageManager implements BaggageManager {
+
+  @Override
+  public Context setValue(Context ctx, String key, String value) {
+    return ctx;
+  }
+
+  @Nullable
+  @Override
+  public String getValue(Context ctx, String key) {
+    return null;
+  }
+
+  @Override
+  public Context removeValue(Context ctx, String key) {
+    return ctx;
+  }
+
+  @Override
+  public Context clear(Context ctx) {
+    return ctx;
+  }
+
+  @Nullable
+  @Override
+  public HttpInjector getHttpInjector() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public HttpExtractor getHttpExtractor() {
+    return null;
+  }
+
+  // TODO - define noop propagators (expose them?)
+}

--- a/api/src/main/java/io/opentelemetry/baggage/DefaultBaggageManager.java
+++ b/api/src/main/java/io/opentelemetry/baggage/DefaultBaggageManager.java
@@ -22,6 +22,11 @@ import io.opentelemetry.context.propagation.HttpInjector;
 import javax.annotation.Nullable;
 
 public final class DefaultBaggageManager implements BaggageManager {
+  private static final DefaultBaggageManager INSTANCE = new DefaultBaggageManager();
+
+  public static DefaultBaggageManager getInstance() {
+    return INSTANCE;
+  }
 
   @Override
   public Context setValue(Context ctx, String key, String value) {

--- a/api/src/main/java/io/opentelemetry/baggage/propagation/ContextKeys.java
+++ b/api/src/main/java/io/opentelemetry/baggage/propagation/ContextKeys.java
@@ -14,22 +14,16 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.distributedcontext;
+package io.opentelemetry.baggage.propagation;
 
 import io.opentelemetry.context.Context;
-import io.opentelemetry.context.propagation.HttpExtractor;
-import io.opentelemetry.context.propagation.HttpInjector;
 
-public interface BaggageManager {
-  public Context setValue(Context ctx, String key, String value);
+public final class ContextKeys {
+  private static final Context.Key<Object> BAGGAGE_KEY = Context.createKey("baggage");
 
-  public String getValue(Context ctx, String key);
+  public static Context.Key<Object> getSpanContextKey() {
+    return BAGGAGE_KEY;
+  }
 
-  public Context removeValue(Context ctx, String key);
-
-  public Context clear(Context ctx);
-
-  public HttpInjector getHttpInjector();
-
-  public HttpExtractor getHttpExtractor();
+  private ContextKeys() {}
 }

--- a/api/src/main/java/io/opentelemetry/baggage/propagation/DefaultBaggageExtractor.java
+++ b/api/src/main/java/io/opentelemetry/baggage/propagation/DefaultBaggageExtractor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.baggage.propagation;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.HttpExtractor;
+
+public final class DefaultBaggageExtractor implements HttpExtractor {
+  @Override
+  public <C> Context extract(Context ctx, C carrier, Getter<C> getter) {
+    // TODO - Implement (outside the bounds of this prototype).
+    return ctx;
+  }
+}

--- a/api/src/main/java/io/opentelemetry/baggage/propagation/DefaultBaggageInjector.java
+++ b/api/src/main/java/io/opentelemetry/baggage/propagation/DefaultBaggageInjector.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.baggage.propagation;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.HttpInjector;
+
+public final class DefaultBaggageInjector implements HttpInjector {
+  @Override
+  public <C> void inject(Context ctx, C carrier, Setter<C> getter) {
+    // TODO - Implement (outside the bounds of this prototype).
+  }
+}

--- a/api/src/main/java/io/opentelemetry/context/Context.java
+++ b/api/src/main/java/io/opentelemetry/context/Context.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.context;
+
+public final class Context {
+  private final io.grpc.Context ctx;
+
+  private Context(io.grpc.Context ctx) {
+    this.ctx = ctx;
+  }
+
+  public static Context current() {
+    return new Context(io.grpc.Context.current());
+  }
+
+  public static Scope setCurrent(Context ctx) {
+    return new ScopeImpl(ctx);
+  }
+
+  public static <T> Context.Key<T> createKey(String name) {
+    return new Key<T>(io.grpc.Context.<T>key(name));
+  }
+
+  public <T> T getValue(Context.Key<T> key) {
+    return key.key().get(ctx);
+  }
+
+  public <T> Context setValue(Context.Key<T> key, T value) {
+    return new Context(ctx.withValue(key.key(), value));
+  }
+
+  public static final class Key<T> {
+    io.grpc.Context.Key<T> key;
+
+    private Key(io.grpc.Context.Key<T> key) {
+      this.key = key;
+    }
+
+    io.grpc.Context.Key<T> key() {
+      return key;
+    }
+  }
+
+  static final class ScopeImpl implements Scope {
+    private final io.grpc.Context ctx;
+    private final io.grpc.Context prevCtx;
+
+    public ScopeImpl(Context ctx) {
+      this.ctx = ctx.ctx;
+      this.prevCtx = ctx.ctx.attach();
+    }
+
+    @Override
+    public void close() {
+      ctx.detach(prevCtx);
+    }
+  }
+}

--- a/api/src/main/java/io/opentelemetry/context/propagation/ChainedPropagators.java
+++ b/api/src/main/java/io/opentelemetry/context/propagation/ChainedPropagators.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.context.propagation;
+
+import io.opentelemetry.context.Context;
+
+// import javax.annotation.Nullable;
+
+public final class ChainedPropagators {
+  public HttpInjector chainInjectors(HttpInjector injector1, HttpInjector injector2) {
+    return new ChainedHttpInjector(injector1, injector2);
+  }
+
+  public HttpExtractor chainExtractors(HttpExtractor extractor1, HttpExtractor extractor2) {
+    return new ChainedHttpExtractor(extractor1, extractor2);
+  }
+
+  private ChainedPropagators() {}
+
+  static final class ChainedHttpInjector implements HttpInjector {
+    private final HttpInjector injector1;
+    private final HttpInjector injector2;
+
+    ChainedHttpInjector(HttpInjector injector1, HttpInjector injector2) {
+      this.injector1 = injector1;
+      this.injector2 = injector2;
+    }
+
+    @Override
+    public <C> void inject(Context ctx, C carrier, Setter<C> setter) {
+      injector1.inject(ctx, carrier, setter);
+      injector2.inject(ctx, carrier, setter);
+    }
+  }
+
+  static final class ChainedHttpExtractor implements HttpExtractor {
+    private final HttpExtractor extractor1;
+    private final HttpExtractor extractor2;
+
+    ChainedHttpExtractor(HttpExtractor extractor1, HttpExtractor extractor2) {
+      this.extractor1 = extractor1;
+      this.extractor2 = extractor2;
+    }
+
+    @Override
+    public <C> Context extract(Context ctx, C carrier, Getter<C> getter) {
+      ctx = extractor1.extract(ctx, carrier, getter);
+      ctx = extractor2.extract(ctx, carrier, getter);
+      return ctx;
+    }
+  }
+}

--- a/api/src/main/java/io/opentelemetry/context/propagation/ChainedPropagators.java
+++ b/api/src/main/java/io/opentelemetry/context/propagation/ChainedPropagators.java
@@ -19,11 +19,11 @@ package io.opentelemetry.context.propagation;
 import io.opentelemetry.context.Context;
 
 public final class ChainedPropagators {
-  public HttpInjector chainInjectors(HttpInjector injector1, HttpInjector injector2) {
+  public static HttpInjector chain(HttpInjector injector1, HttpInjector injector2) {
     return new ChainedHttpInjector(injector1, injector2);
   }
 
-  public HttpExtractor chainExtractors(HttpExtractor extractor1, HttpExtractor extractor2) {
+  public static HttpExtractor chain(HttpExtractor extractor1, HttpExtractor extractor2) {
     return new ChainedHttpExtractor(extractor1, extractor2);
   }
 

--- a/api/src/main/java/io/opentelemetry/context/propagation/ChainedPropagators.java
+++ b/api/src/main/java/io/opentelemetry/context/propagation/ChainedPropagators.java
@@ -18,8 +18,6 @@ package io.opentelemetry.context.propagation;
 
 import io.opentelemetry.context.Context;
 
-// import javax.annotation.Nullable;
-
 public final class ChainedPropagators {
   public HttpInjector chainInjectors(HttpInjector injector1, HttpInjector injector2) {
     return new ChainedHttpInjector(injector1, injector2);

--- a/api/src/main/java/io/opentelemetry/context/propagation/DefaultHttpExtractor.java
+++ b/api/src/main/java/io/opentelemetry/context/propagation/DefaultHttpExtractor.java
@@ -19,11 +19,17 @@ package io.opentelemetry.context.propagation;
 import io.opentelemetry.context.Context;
 import javax.annotation.Nullable;
 
-public interface HttpExtractor {
-  <C> Context extract(Context ctx, C carrier, Getter<C> getter);
+public final class DefaultHttpExtractor implements HttpExtractor {
+  @Override
+  public <C> Context extract(Context ctx, C carrier, Getter<C> getter) {
+    return ctx;
+  }
 
-  interface Getter<C> {
+  static final class DefaultGetter<C> implements Getter<C> {
     @Nullable
-    String get(C carrier, String key);
+    @Override
+    public String get(C carrier, String key) {
+      return null;
+    }
   }
 }

--- a/api/src/main/java/io/opentelemetry/context/propagation/DefaultHttpInjector.java
+++ b/api/src/main/java/io/opentelemetry/context/propagation/DefaultHttpInjector.java
@@ -17,13 +17,13 @@
 package io.opentelemetry.context.propagation;
 
 import io.opentelemetry.context.Context;
-import javax.annotation.Nullable;
 
-public interface HttpExtractor {
-  <C> Context extract(Context ctx, C carrier, Getter<C> getter);
+public final class DefaultHttpInjector implements HttpInjector {
+  @Override
+  public <C> void inject(Context ctx, C carrier, Setter<C> setter) {}
 
-  interface Getter<C> {
-    @Nullable
-    String get(C carrier, String key);
+  static final class DefaultSetter<C> implements Setter<C> {
+    @Override
+    public void put(C carrier, String key, String value) {}
   }
 }

--- a/api/src/main/java/io/opentelemetry/context/propagation/HttpExtractor.java
+++ b/api/src/main/java/io/opentelemetry/context/propagation/HttpExtractor.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.context.propagation;
+
+import io.opentelemetry.context.Context;
+import javax.annotation.Nullable;
+
+public interface HttpExtractor {
+  <C> Context extract(Context ctx, Getter<C> getter);
+
+  interface Getter<C> {
+    @Nullable
+    String get(C carrier, String key);
+  }
+}

--- a/api/src/main/java/io/opentelemetry/context/propagation/HttpInjector.java
+++ b/api/src/main/java/io/opentelemetry/context/propagation/HttpInjector.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.context.propagation;
+
+import io.opentelemetry.context.Context;
+
+public interface HttpInjector {
+  <C> void inject(Context ctx, C carrier, Setter<C> setter);
+
+  interface Setter<C> {
+    void put(C carrier, String key, String value);
+  }
+}

--- a/api/src/main/java/io/opentelemetry/context/propagation/Propagators.java
+++ b/api/src/main/java/io/opentelemetry/context/propagation/Propagators.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.context.propagation;
+
+public final class Propagators {
+  private final HttpInjector injector;
+  private final HttpExtractor extractor;
+
+  public static Propagators create(HttpInjector injector, HttpExtractor extractor) {
+    return new Propagators(injector, extractor);
+  }
+
+  private Propagators(HttpInjector injector, HttpExtractor extractor) {
+    this.injector = injector;
+    this.extractor = extractor;
+  }
+
+  public HttpExtractor getHttpExtractor() {
+    return extractor;
+  }
+
+  public HttpInjector getHttpInjector() {
+    return injector;
+  }
+}

--- a/api/src/main/java/io/opentelemetry/distributedcontext/BaggageManager.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/BaggageManager.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.distributedcontext;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.HttpExtractor;
+import io.opentelemetry.context.propagation.HttpInjector;
+
+public interface BaggageManager {
+  public Context setValue(Context ctx, String key, String value);
+
+  public String getValue(Context ctx, String key);
+
+  public void removeValue(Context ctx, String key);
+
+  public void clear(Context ctx);
+
+  public HttpInjector getHttpInjector();
+
+  public HttpExtractor getHttpExtractor();
+}

--- a/api/src/main/java/io/opentelemetry/distributedcontext/CorrelationContext.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/CorrelationContext.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * A map from {@link EntryKey} to {@link EntryValue} and {@link EntryMetadata} that can be used to
+ * A map from {@link LabelKey} to {@link LabelValue} and {@link LabelMetadata} that can be used to
  * label anything that is associated with a specific operation.
  *
  * <p>For example, {@code DistributedContext}s can be used to label stats, log messages, or
@@ -30,7 +30,7 @@ import javax.annotation.concurrent.Immutable;
  * @since 0.1.0
  */
 @Immutable
-public interface DistributedContext {
+public interface CorrelationContext {
   /**
    * Returns an immutable collection of the entries in this {@code DistributedContext}. Order of
    * entries is not guaranteed.
@@ -38,7 +38,7 @@ public interface DistributedContext {
    * @return an immutable collection of the entries in this {@code DistributedContext}.
    * @since 0.1.0
    */
-  Collection<Entry> getEntries();
+  Collection<Label> getEntries();
 
   /**
    * Returns the {@code EntryValue} associated with the given {@code EntryKey}.
@@ -48,36 +48,36 @@ public interface DistributedContext {
    *     no {@code Entry} with the given {@code entryKey} is in this {@code DistributedContext}.
    */
   @Nullable
-  EntryValue getEntryValue(EntryKey entryKey);
+  LabelValue getEntryValue(LabelKey entryKey);
 
   /**
-   * Builder for the {@link DistributedContext} class.
+   * Builder for the {@link CorrelationContext} class.
    *
    * @since 0.1.0
    */
   interface Builder {
     /**
-     * Sets the parent {@link DistributedContext} to use. If no parent is provided, the value of
-     * {@link DistributedContextManager#getCurrentContext()} at {@link #build()} time will be used
+     * Sets the parent {@link CorrelationContext} to use. If no parent is provided, the value of
+     * {@link CorrelationContextManager#getCurrentContext()} at {@link #build()} time will be used
      * as parent, unless {@link #setNoParent()} was called.
      *
-     * <p>This <b>must</b> be used to create a {@link DistributedContext} when manual Context
+     * <p>This <b>must</b> be used to create a {@link CorrelationContext} when manual Context
      * propagation is used.
      *
      * <p>If called multiple times, only the last specified value will be used.
      *
-     * @param parent the {@link DistributedContext} used as parent, not null.
+     * @param parent the {@link CorrelationContext} used as parent, not null.
      * @return this.
      * @throws NullPointerException if {@code parent} is {@code null}.
      * @see #setNoParent()
      * @since 0.1.0
      */
-    Builder setParent(DistributedContext parent);
+    Builder setParent(CorrelationContext parent);
 
     /**
-     * Sets the option to become a root {@link DistributedContext} with no parent. If <b>not</b>
-     * called, the value provided using {@link #setParent(DistributedContext)} or otherwise {@link
-     * DistributedContextManager#getCurrentContext()} at {@link #build()} time will be used as
+     * Sets the option to become a root {@link CorrelationContext} with no parent. If <b>not</b>
+     * called, the value provided using {@link #setParent(CorrelationContext)} or otherwise {@link
+     * CorrelationContextManager#getCurrentContext()} at {@link #build()} time will be used as
      * parent.
      *
      * @return this.
@@ -90,11 +90,11 @@ public interface DistributedContext {
      *
      * @param key the {@code EntryKey} which will be set.
      * @param value the {@code EntryValue} to set for the given key.
-     * @param entryMetadata the {@code EntryMetadata} associated with this {@link Entry}.
+     * @param entryMetadata the {@code EntryMetadata} associated with this {@link Label}.
      * @return this
      * @since 0.1.0
      */
-    Builder put(EntryKey key, EntryValue value, EntryMetadata entryMetadata);
+    Builder put(LabelKey key, LabelValue value, LabelMetadata entryMetadata);
 
     /**
      * Removes the key if it exists.
@@ -103,7 +103,7 @@ public interface DistributedContext {
      * @return this
      * @since 0.1.0
      */
-    Builder remove(EntryKey key);
+    Builder remove(LabelKey key);
 
     /**
      * Creates a {@code DistributedContext} from this builder.
@@ -111,6 +111,6 @@ public interface DistributedContext {
      * @return a {@code DistributedContext} with the same entries as this builder.
      * @since 0.1.0
      */
-    DistributedContext build();
+    CorrelationContext build();
   }
 }

--- a/api/src/main/java/io/opentelemetry/distributedcontext/CorrelationContextManager.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/CorrelationContextManager.java
@@ -22,20 +22,20 @@ import io.opentelemetry.context.propagation.HttpTextFormat;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * Object for creating new {@link DistributedContext}s and {@code DistributedContext}s based on the
+ * Object for creating new {@link CorrelationContext}s and {@code DistributedContext}s based on the
  * current context.
  *
- * <p>This class returns {@link DistributedContext.Builder builders} that can be used to create the
- * implementation-dependent {@link DistributedContext}s.
+ * <p>This class returns {@link CorrelationContext.Builder builders} that can be used to create the
+ * implementation-dependent {@link CorrelationContext}s.
  *
  * <p>Implementations may have different constraints and are free to convert entry contexts to their
  * own subtypes. This means callers cannot assume the {@link #getCurrentContext() current context}
- * is the same instance as the one {@link #withContext(DistributedContext) placed into scope}.
+ * is the same instance as the one {@link #withContext(CorrelationContext) placed into scope}.
  *
  * @since 0.1.0
  */
 @ThreadSafe
-public interface DistributedContextManager {
+public interface CorrelationContextManager {
 
   /**
    * Returns the current {@code DistributedContext}.
@@ -43,7 +43,7 @@ public interface DistributedContextManager {
    * @return the current {@code DistributedContext}.
    * @since 0.1.0
    */
-  DistributedContext getCurrentContext();
+  CorrelationContext getCurrentContext();
 
   /**
    * Returns a new {@code Builder}.
@@ -51,7 +51,7 @@ public interface DistributedContextManager {
    * @return a new {@code Builder}.
    * @since 0.1.0
    */
-  DistributedContext.Builder contextBuilder();
+  CorrelationContext.Builder contextBuilder();
 
   /**
    * Enters the scope of code where the given {@code DistributedContext} is in the current context
@@ -63,7 +63,7 @@ public interface DistributedContextManager {
    *     current context.
    * @since 0.1.0
    */
-  Scope withContext(DistributedContext distContext);
+  Scope withContext(CorrelationContext distContext);
 
   /**
    * Returns the {@link BinaryFormat} for this implementation.
@@ -102,7 +102,7 @@ public interface DistributedContextManager {
    * @return the {@code BinaryFormat} for this implementation.
    * @since 0.1.0
    */
-  BinaryFormat<DistributedContext> getBinaryFormat();
+  BinaryFormat<CorrelationContext> getBinaryFormat();
 
   /**
    * Returns the {@link HttpTextFormat} for this implementation.
@@ -151,5 +151,5 @@ public interface DistributedContextManager {
    * @return the {@code HttpTextFormat} for this implementation.
    * @since 0.1.0
    */
-  HttpTextFormat<DistributedContext> getHttpTextFormat();
+  HttpTextFormat<CorrelationContext> getHttpTextFormat();
 }

--- a/api/src/main/java/io/opentelemetry/distributedcontext/CorrelationsManager.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/CorrelationsManager.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.distributedcontext;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.HttpExtractor;
+import io.opentelemetry.context.propagation.HttpInjector;
+import java.util.List;
+
+public interface CorrelationsManager {
+  public Context setValue(Context ctx, CorrelationLabel label, HopLimit hopLimit);
+
+  public Context setValues(Context ctx, List<CorrelationLabel> labels, HopLimit hopLimit);
+
+  public interface CorrelationLabel {
+    public String key();
+
+    public String value();
+  }
+
+  public enum HopLimit {
+    NO_PROPAGATION,
+    UNLIMITED_PROPAGATION
+  }
+
+  public HttpInjector getHttpInjector();
+
+  public HttpExtractor getHttpExtractor();
+}

--- a/api/src/main/java/io/opentelemetry/distributedcontext/DefaultBaggageManager.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/DefaultBaggageManager.java
@@ -19,17 +19,42 @@ package io.opentelemetry.distributedcontext;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.HttpExtractor;
 import io.opentelemetry.context.propagation.HttpInjector;
+import javax.annotation.Nullable;
 
-public interface BaggageManager {
-  public Context setValue(Context ctx, String key, String value);
+public final class DefaultBaggageManager implements BaggageManager {
 
-  public String getValue(Context ctx, String key);
+  @Override
+  public Context setValue(Context ctx, String key, String value) {
+    return ctx;
+  }
 
-  public Context removeValue(Context ctx, String key);
+  @Nullable
+  @Override
+  public String getValue(Context ctx, String key) {
+    return null;
+  }
 
-  public Context clear(Context ctx);
+  @Override
+  public Context removeValue(Context ctx, String key) {
+    return ctx;
+  }
 
-  public HttpInjector getHttpInjector();
+  @Override
+  public Context clear(Context ctx) {
+    return ctx;
+  }
 
-  public HttpExtractor getHttpExtractor();
+  @Nullable
+  @Override
+  public HttpInjector getHttpInjector() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public HttpExtractor getHttpExtractor() {
+    return null;
+  }
+
+  // TODO - define noop propagators (expose them?)
 }

--- a/api/src/main/java/io/opentelemetry/distributedcontext/DefaultCorrelationContextManager.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/DefaultCorrelationContextManager.java
@@ -27,71 +27,71 @@ import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * No-op implementations of {@link DistributedContextManager}.
+ * No-op implementations of {@link CorrelationContextManager}.
  *
  * @since 0.1.0
  */
 @ThreadSafe
-public final class DefaultDistributedContextManager implements DistributedContextManager {
-  private static final DefaultDistributedContextManager INSTANCE =
-      new DefaultDistributedContextManager();
-  private static final BinaryFormat<DistributedContext> BINARY_FORMAT = new NoopBinaryFormat();
-  private static final HttpTextFormat<DistributedContext> HTTP_TEXT_FORMAT =
+public final class DefaultCorrelationContextManager implements CorrelationContextManager {
+  private static final DefaultCorrelationContextManager INSTANCE =
+      new DefaultCorrelationContextManager();
+  private static final BinaryFormat<CorrelationContext> BINARY_FORMAT = new NoopBinaryFormat();
+  private static final HttpTextFormat<CorrelationContext> HTTP_TEXT_FORMAT =
       new NoopHttpTextFormat();
 
   /**
    * Returns a {@code DistributedContextManager} singleton that is the default implementation for
-   * {@link DistributedContextManager}.
+   * {@link CorrelationContextManager}.
    *
    * @return a {@code DistributedContextManager} singleton that is the default implementation for
-   *     {@link DistributedContextManager}.
+   *     {@link CorrelationContextManager}.
    * @since 0.1.0
    */
-  public static DistributedContextManager getInstance() {
+  public static CorrelationContextManager getInstance() {
     return INSTANCE;
   }
 
   @Override
-  public DistributedContext getCurrentContext() {
+  public CorrelationContext getCurrentContext() {
     return ContextUtils.getValue();
   }
 
   @Override
-  public DistributedContext.Builder contextBuilder() {
+  public CorrelationContext.Builder contextBuilder() {
     return new NoopDistributedContextBuilder();
   }
 
   @Override
-  public Scope withContext(DistributedContext distContext) {
+  public Scope withContext(CorrelationContext distContext) {
     return ContextUtils.withDistributedContext(distContext);
   }
 
   @Override
-  public BinaryFormat<DistributedContext> getBinaryFormat() {
+  public BinaryFormat<CorrelationContext> getBinaryFormat() {
     return BINARY_FORMAT;
   }
 
   @Override
-  public HttpTextFormat<DistributedContext> getHttpTextFormat() {
+  public HttpTextFormat<CorrelationContext> getHttpTextFormat() {
     return HTTP_TEXT_FORMAT;
   }
 
   @Immutable
-  private static final class NoopDistributedContextBuilder implements DistributedContext.Builder {
+  private static final class NoopDistributedContextBuilder implements CorrelationContext.Builder {
     @Override
-    public DistributedContext.Builder setParent(DistributedContext parent) {
+    public CorrelationContext.Builder setParent(CorrelationContext parent) {
       Utils.checkNotNull(parent, "parent");
       return this;
     }
 
     @Override
-    public DistributedContext.Builder setNoParent() {
+    public CorrelationContext.Builder setNoParent() {
       return this;
     }
 
     @Override
-    public DistributedContext.Builder put(
-        EntryKey key, EntryValue value, EntryMetadata tagMetadata) {
+    public CorrelationContext.Builder put(
+        LabelKey key, LabelValue value, LabelMetadata tagMetadata) {
       Utils.checkNotNull(key, "key");
       Utils.checkNotNull(value, "value");
       Utils.checkNotNull(tagMetadata, "tagMetadata");
@@ -99,53 +99,53 @@ public final class DefaultDistributedContextManager implements DistributedContex
     }
 
     @Override
-    public DistributedContext.Builder remove(EntryKey key) {
+    public CorrelationContext.Builder remove(LabelKey key) {
       Utils.checkNotNull(key, "key");
       return this;
     }
 
     @Override
-    public DistributedContext build() {
-      return EmptyDistributedContext.getInstance();
+    public CorrelationContext build() {
+      return EmptyCorrelationContext.getInstance();
     }
   }
 
   @Immutable
-  private static final class NoopBinaryFormat implements BinaryFormat<DistributedContext> {
+  private static final class NoopBinaryFormat implements BinaryFormat<CorrelationContext> {
     static final byte[] EMPTY_BYTE_ARRAY = {};
 
     @Override
-    public byte[] toByteArray(DistributedContext distContext) {
+    public byte[] toByteArray(CorrelationContext distContext) {
       Utils.checkNotNull(distContext, "distContext");
       return EMPTY_BYTE_ARRAY;
     }
 
     @Override
-    public DistributedContext fromByteArray(byte[] bytes) {
+    public CorrelationContext fromByteArray(byte[] bytes) {
       Utils.checkNotNull(bytes, "bytes");
-      return EmptyDistributedContext.getInstance();
+      return EmptyCorrelationContext.getInstance();
     }
   }
 
   @Immutable
-  private static final class NoopHttpTextFormat implements HttpTextFormat<DistributedContext> {
+  private static final class NoopHttpTextFormat implements HttpTextFormat<CorrelationContext> {
     @Override
     public List<String> fields() {
       return Collections.emptyList();
     }
 
     @Override
-    public <C> void inject(DistributedContext distContext, C carrier, Setter<C> setter) {
+    public <C> void inject(CorrelationContext distContext, C carrier, Setter<C> setter) {
       Utils.checkNotNull(distContext, "distContext");
       Utils.checkNotNull(carrier, "carrier");
       Utils.checkNotNull(setter, "setter");
     }
 
     @Override
-    public <C> DistributedContext extract(C carrier, Getter<C> getter) {
+    public <C> CorrelationContext extract(C carrier, Getter<C> getter) {
       Utils.checkNotNull(carrier, "carrier");
       Utils.checkNotNull(getter, "getter");
-      return EmptyDistributedContext.getInstance();
+      return EmptyCorrelationContext.getInstance();
     }
   }
 }

--- a/api/src/main/java/io/opentelemetry/distributedcontext/EmptyCorrelationContext.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/EmptyCorrelationContext.java
@@ -22,34 +22,34 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * An immutable implementation of the {@link DistributedContext} that does not contain any entries.
+ * An immutable implementation of the {@link CorrelationContext} that does not contain any entries.
  */
 @Immutable
-public class EmptyDistributedContext implements DistributedContext {
-  private static final Collection<Entry> EMPTY_COLLECTION = Collections.emptyList();
+public class EmptyCorrelationContext implements CorrelationContext {
+  private static final Collection<Label> EMPTY_COLLECTION = Collections.emptyList();
 
   /**
-   * Returns the single instance of the {@link EmptyDistributedContext} class.
+   * Returns the single instance of the {@link EmptyCorrelationContext} class.
    *
    * @return the single instance of the {@code EmptyDistributedContext} class.
    * @since 0.1.0
    */
-  public static DistributedContext getInstance() {
+  public static CorrelationContext getInstance() {
     return INSTANCE;
   }
 
-  private static final DistributedContext INSTANCE = new EmptyDistributedContext();
+  private static final CorrelationContext INSTANCE = new EmptyCorrelationContext();
 
   @Override
-  public Collection<Entry> getEntries() {
+  public Collection<Label> getEntries() {
     return EMPTY_COLLECTION;
   }
 
   @Nullable
   @Override
-  public EntryValue getEntryValue(EntryKey entryKey) {
+  public LabelValue getEntryValue(LabelKey entryKey) {
     return null;
   }
 
-  private EmptyDistributedContext() {}
+  private EmptyCorrelationContext() {}
 }

--- a/api/src/main/java/io/opentelemetry/distributedcontext/Label.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/Label.java
@@ -17,23 +17,23 @@
 package io.opentelemetry.distributedcontext;
 
 import com.google.auto.value.AutoValue;
-import io.opentelemetry.distributedcontext.EntryMetadata.EntryTtl;
+import io.opentelemetry.distributedcontext.LabelMetadata.HopLimit;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * {@link EntryKey} paired with a {@link EntryValue}.
+ * {@link LabelKey} paired with a {@link LabelValue}.
  *
  * @since 0.1.0
  */
 @Immutable
 @AutoValue
-public abstract class Entry {
+public abstract class Label {
 
   /** Default propagation metadata - unlimited propagation. */
-  public static final EntryMetadata METADATA_UNLIMITED_PROPAGATION =
-      EntryMetadata.create(EntryTtl.UNLIMITED_PROPAGATION);
+  public static final LabelMetadata METADATA_UNLIMITED_PROPAGATION =
+      LabelMetadata.create(HopLimit.UNLIMITED_PROPAGATION);
 
-  Entry() {}
+  Label() {}
 
   /**
    * Creates an {@code Entry} from the given key, value and metadata.
@@ -44,8 +44,8 @@ public abstract class Entry {
    * @return a {@code Entry}.
    * @since 0.1.0
    */
-  public static Entry create(EntryKey key, EntryValue value, EntryMetadata entryMetadata) {
-    return new AutoValue_Entry(key, value, entryMetadata);
+  public static Label create(LabelKey key, LabelValue value, LabelMetadata entryMetadata) {
+    return new AutoValue_Label(key, value, entryMetadata);
   }
 
   /**
@@ -54,7 +54,7 @@ public abstract class Entry {
    * @return the entry's key.
    * @since 0.1.0
    */
-  public abstract EntryKey getKey();
+  public abstract LabelKey getKey();
 
   /**
    * Returns the entry's value.
@@ -62,13 +62,13 @@ public abstract class Entry {
    * @return the entry's value.
    * @since 0.1.0
    */
-  public abstract EntryValue getValue();
+  public abstract LabelValue getValue();
 
   /**
-   * Returns the {@link EntryMetadata} associated with this {@link Entry}.
+   * Returns the {@link LabelMetadata} associated with this {@link Label}.
    *
    * @return the {@code EntryMetadata}.
    * @since 0.1.0
    */
-  public abstract EntryMetadata getEntryMetadata();
+  public abstract LabelMetadata getEntryMetadata();
 }

--- a/api/src/main/java/io/opentelemetry/distributedcontext/LabelKey.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/LabelKey.java
@@ -22,7 +22,7 @@ import io.opentelemetry.internal.Utils;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * A key to a value stored in a {@link DistributedContext}.
+ * A key to a value stored in a {@link CorrelationContext}.
  *
  * <p>Each {@code EntryKey} has a {@code String} name. Names have a maximum length of {@link
  * #MAX_LENGTH} and contain only printable ASCII characters.
@@ -34,7 +34,7 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 @AutoValue
-public abstract class EntryKey {
+public abstract class LabelKey {
   /**
    * The maximum length for an entry key name. The value is {@value #MAX_LENGTH}.
    *
@@ -42,7 +42,7 @@ public abstract class EntryKey {
    */
   public static final int MAX_LENGTH = 255;
 
-  EntryKey() {}
+  LabelKey() {}
 
   /**
    * Constructs an {@code EntryKey} with the given name.
@@ -59,9 +59,9 @@ public abstract class EntryKey {
    * @throws IllegalArgumentException if the name is not valid.
    * @since 0.1.0
    */
-  public static EntryKey create(String name) {
+  public static LabelKey create(String name) {
     Utils.checkArgument(isValid(name), "Invalid EntryKey name: %s", name);
-    return new AutoValue_EntryKey(name);
+    return new AutoValue_LabelKey(name);
   }
 
   /**

--- a/api/src/main/java/io/opentelemetry/distributedcontext/LabelMetadata.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/LabelMetadata.java
@@ -20,40 +20,40 @@ import com.google.auto.value.AutoValue;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * {@link EntryMetadata} contains properties associated with an {@link Entry}.
+ * {@link LabelMetadata} contains properties associated with an {@link Label}.
  *
- * <p>For now only the property {@link EntryTtl} is defined. In future, additional properties may be
+ * <p>For now only the property {@link HopLimit} is defined. In future, additional properties may be
  * added to address specific situations.
  *
  * @since 0.1.0
  */
 @Immutable
 @AutoValue
-public abstract class EntryMetadata {
+public abstract class LabelMetadata {
 
-  EntryMetadata() {}
+  LabelMetadata() {}
 
   /**
-   * Creates an {@link EntryMetadata} with the given {@link EntryTtl}.
+   * Creates an {@link LabelMetadata} with the given {@link HopLimit}.
    *
    * @param entryTtl TTL of an {@code Entry}.
    * @return an {@code EntryMetadata}.
    * @since 0.1.0
    */
-  public static EntryMetadata create(EntryTtl entryTtl) {
-    return new AutoValue_EntryMetadata(entryTtl);
+  public static LabelMetadata create(HopLimit entryTtl) {
+    return new AutoValue_LabelMetadata(entryTtl);
   }
 
   /**
-   * Returns the {@link EntryTtl} of this {@link EntryMetadata}.
+   * Returns the {@link HopLimit} of this {@link LabelMetadata}.
    *
    * @return the {@code EntryTtl}.
    * @since 0.1.0
    */
-  public abstract EntryTtl getEntryTtl();
+  public abstract HopLimit getEntryTtl();
 
   /**
-   * {@link EntryTtl} is an integer that represents number of hops an entry can propagate.
+   * {@link HopLimit} is an integer that represents number of hops an entry can propagate.
    *
    * <p>Anytime a sender serializes a entry, sends it over the wire and receiver deserializes the
    * entry then the entry is considered to have travelled one hop.
@@ -61,11 +61,11 @@ public abstract class EntryMetadata {
    * <p>There could be one or more proxy(ies) between sender and receiver. Proxies are treated as
    * transparent entities and they are not counted as hops.
    *
-   * <p>For now, only special values of {@link EntryTtl} are supported.
+   * <p>For now, only special values of {@link HopLimit} are supported.
    *
    * @since 0.1.0
    */
-  public enum EntryTtl {
+  public enum HopLimit {
 
     /**
      * An {@link Entry} with {@link EntryTtl#NO_PROPAGATION} is considered to have local scope and
@@ -73,7 +73,7 @@ public abstract class EntryMetadata {
      *
      * @since 0.1.0
      */
-    NO_PROPAGATION(0),
+    NO_PROPAGATION,
 
     /**
      * An {@link Entry} with {@link EntryTtl#UNLIMITED_PROPAGATION} can propagate unlimited hops.
@@ -85,16 +85,6 @@ public abstract class EntryMetadata {
      *
      * @since 0.1.0
      */
-    UNLIMITED_PROPAGATION(-1);
-
-    private final int hops;
-
-    EntryTtl(int hops) {
-      this.hops = hops;
-    }
-
-    int getHops() {
-      return hops;
-    }
+    UNLIMITED_PROPAGATION;
   }
 }

--- a/api/src/main/java/io/opentelemetry/distributedcontext/LabelValue.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/LabelValue.java
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 @AutoValue
-public abstract class EntryValue {
+public abstract class LabelValue {
   /**
    * The maximum length for a entry value. The value is {@value #MAX_LENGTH}.
    *
@@ -39,7 +39,7 @@ public abstract class EntryValue {
    */
   public static final int MAX_LENGTH = 255;
 
-  EntryValue() {}
+  LabelValue() {}
 
   /**
    * Constructs an {@code EntryValue} from the given string. The string must meet the following
@@ -55,9 +55,9 @@ public abstract class EntryValue {
    * @throws IllegalArgumentException if the {@code String} is not valid.
    * @since 0.1.0
    */
-  public static EntryValue create(String value) {
+  public static LabelValue create(String value) {
     Utils.checkArgument(isValid(value), "Invalid EntryValue: %s", value);
-    return new AutoValue_EntryValue(value);
+    return new AutoValue_LabelValue(value);
   }
 
   /**

--- a/api/src/main/java/io/opentelemetry/distributedcontext/package-info.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/package-info.java
@@ -21,10 +21,10 @@
  * to label anything that is associated with a specific operation. For example, the {@code
  * opentelemetry.stats} package labels all stats with the current entries.
  *
- * <p>{@link io.opentelemetry.distributedcontext.Entry Entrys} are key-value pairs. The {@link
- * io.opentelemetry.distributedcontext.EntryKey keys} and {@link
- * io.opentelemetry.distributedcontext.EntryValue values} are wrapped {@code String}s. They are
- * stored as a map in a {@link io.opentelemetry.distributedcontext.DistributedContext}.
+ * <p>{@link io.opentelemetry.distributedcontext.Label Entrys} are key-value pairs. The {@link
+ * io.opentelemetry.distributedcontext.LabelKey keys} and {@link
+ * io.opentelemetry.distributedcontext.LabelValue values} are wrapped {@code String}s. They are
+ * stored as a map in a {@link io.opentelemetry.distributedcontext.CorrelationContext}.
  *
  * <p>Note that entries are independent of the tracing data that is propagated in the {@code
  * io.grpc.Context}, such as trace ID.

--- a/api/src/main/java/io/opentelemetry/distributedcontext/propagation/ContextKeys.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/propagation/ContextKeys.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.distributedcontext.propagation;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.distributedcontext.CorrelationContext;
+
+public final class ContextKeys {
+  private static final Context.Key<CorrelationContext> CORRELATION_CONTEXT_KEY =
+      Context.createKey("correlation-context");
+
+  public static Context.Key<CorrelationContext> getSpanContextKey() {
+    return CORRELATION_CONTEXT_KEY;
+  }
+
+  private ContextKeys() {}
+}

--- a/api/src/main/java/io/opentelemetry/distributedcontext/propagation/DefaultCorrelationContextExtractor.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/propagation/DefaultCorrelationContextExtractor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.distributedcontext.propagation;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.HttpExtractor;
+
+public final class DefaultCorrelationContextExtractor implements HttpExtractor {
+  @Override
+  public <C> Context extract(Context ctx, C carrier, Getter<C> getter) {
+    // TODO - Implement (outside the bounds of this prototype).
+    return ctx;
+  }
+}

--- a/api/src/main/java/io/opentelemetry/distributedcontext/propagation/DefaultCorrelationContextInjector.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/propagation/DefaultCorrelationContextInjector.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.distributedcontext.propagation;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.HttpInjector;
+
+public final class DefaultCorrelationContextInjector implements HttpInjector {
+  @Override
+  public <C> void inject(Context ctx, C carrier, Setter<C> getter) {
+    // TODO - Implement (outside the bounds of this prototype).
+  }
+}

--- a/api/src/main/java/io/opentelemetry/distributedcontext/spi/CorrelationContextManagerProvider.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/spi/CorrelationContextManagerProvider.java
@@ -16,11 +16,11 @@
 
 package io.opentelemetry.distributedcontext.spi;
 
-import io.opentelemetry.distributedcontext.DistributedContextManager;
+import io.opentelemetry.distributedcontext.CorrelationContextManager;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * DistributedContextManagerProvider is a service provider for {@link DistributedContextManager}.
+ * DistributedContextManagerProvider is a service provider for {@link CorrelationContextManager}.
  * Fully qualified class name of the implementation should be registered in {@code
  * META-INF/services/io.opentelemetry.distributedcontext.spi.DistributedContextManagerProvider}.
  * <br>
@@ -32,7 +32,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * @see io.opentelemetry.OpenTelemetry
  */
 @ThreadSafe
-public interface DistributedContextManagerProvider {
+public interface CorrelationContextManagerProvider {
 
   /**
    * Creates a new {@code DistributedContextManager} instance.
@@ -40,5 +40,5 @@ public interface DistributedContextManagerProvider {
    * @return a {@code DistributedContextManager} instance.
    * @since 0.1.0
    */
-  DistributedContextManager create();
+  CorrelationContextManager create();
 }

--- a/api/src/main/java/io/opentelemetry/distributedcontext/unsafe/ContextUtils.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/unsafe/ContextUtils.java
@@ -18,24 +18,24 @@ package io.opentelemetry.distributedcontext.unsafe;
 
 import io.grpc.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.distributedcontext.DistributedContext;
-import io.opentelemetry.distributedcontext.EmptyDistributedContext;
+import io.opentelemetry.distributedcontext.CorrelationContext;
+import io.opentelemetry.distributedcontext.EmptyCorrelationContext;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * Utility methods for accessing the {@link DistributedContext} contained in the {@link
+ * Utility methods for accessing the {@link CorrelationContext} contained in the {@link
  * io.grpc.Context}.
  *
  * <p>Most code should interact with the current context via the public APIs in {@link
- * DistributedContext} and avoid accessing this class directly.
+ * CorrelationContext} and avoid accessing this class directly.
  *
  * @since 0.1.0
  */
 @Immutable
 public final class ContextUtils {
-  private static final Context.Key<DistributedContext> DIST_CONTEXT_KEY =
+  private static final Context.Key<CorrelationContext> DIST_CONTEXT_KEY =
       Context.keyWithDefault(
-          "opentelemetry-dist-context-key", EmptyDistributedContext.getInstance());
+          "opentelemetry-dist-context-key", EmptyCorrelationContext.getInstance());
 
   /**
    * Creates a new {@code Context} with the given value set.
@@ -44,7 +44,7 @@ public final class ContextUtils {
    * @return a new context with the given value set.
    * @since 0.1.0
    */
-  public static Context withValue(DistributedContext distContext) {
+  public static Context withValue(CorrelationContext distContext) {
     return Context.current().withValue(DIST_CONTEXT_KEY, distContext);
   }
 
@@ -56,7 +56,7 @@ public final class ContextUtils {
    * @return a new context with the given value set.
    * @since 0.1.0
    */
-  public static Context withValue(DistributedContext distContext, Context context) {
+  public static Context withValue(CorrelationContext distContext, Context context) {
     return context.withValue(DIST_CONTEXT_KEY, distContext);
   }
 
@@ -66,7 +66,7 @@ public final class ContextUtils {
    * @return the value from the specified {@code Context}.
    * @since 0.1.0
    */
-  public static DistributedContext getValue() {
+  public static CorrelationContext getValue() {
     return DIST_CONTEXT_KEY.get();
   }
 
@@ -77,7 +77,7 @@ public final class ContextUtils {
    * @return the value from the specified {@code Context}.
    * @since 0.1.0
    */
-  public static DistributedContext getValue(Context context) {
+  public static CorrelationContext getValue(Context context) {
     return DIST_CONTEXT_KEY.get(context);
   }
 
@@ -89,7 +89,7 @@ public final class ContextUtils {
    * @return the {@link Scope} for the updated {@code Context}.
    * @since 0.1.0
    */
-  public static Scope withDistributedContext(DistributedContext distContext) {
+  public static Scope withDistributedContext(CorrelationContext distContext) {
     return DistributedContextInScope.create(distContext);
   }
 

--- a/api/src/main/java/io/opentelemetry/distributedcontext/unsafe/DistributedContextInScope.java
+++ b/api/src/main/java/io/opentelemetry/distributedcontext/unsafe/DistributedContextInScope.java
@@ -18,17 +18,17 @@ package io.opentelemetry.distributedcontext.unsafe;
 
 import io.grpc.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.distributedcontext.DistributedContext;
+import io.opentelemetry.distributedcontext.CorrelationContext;
 
 /**
- * A scope that manages the {@link Context} for a {@link DistributedContext}.
+ * A scope that manages the {@link Context} for a {@link CorrelationContext}.
  *
  * @since 0.1.0
  */
 final class DistributedContextInScope implements Scope {
   private final Context orig;
 
-  private DistributedContextInScope(DistributedContext distContext) {
+  private DistributedContextInScope(CorrelationContext distContext) {
     orig = ContextUtils.withValue(distContext).attach();
   }
 
@@ -38,7 +38,7 @@ final class DistributedContextInScope implements Scope {
    * @param distContext the {@code DistributedContext} to be added to the current {@code Context}.
    * @since 0.1.0
    */
-  static DistributedContextInScope create(DistributedContext distContext) {
+  static DistributedContextInScope create(CorrelationContext distContext) {
     return new DistributedContextInScope(distContext);
   }
 

--- a/api/src/main/java/io/opentelemetry/trace/propagation/ContextKeys.java
+++ b/api/src/main/java/io/opentelemetry/trace/propagation/ContextKeys.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.trace.propagation;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.trace.SpanContext;
+
+public final class ContextKeys {
+  private static final Context.Key<SpanContext> SPAN_CONTEXT_KEY =
+      Context.createKey("span-context");
+
+  public static Context.Key<SpanContext> getSpanContextKey() {
+    return SPAN_CONTEXT_KEY;
+  }
+
+  private ContextKeys() {}
+}

--- a/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContextExtractor.java
+++ b/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContextExtractor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.trace.propagation;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.HttpExtractor;
+import io.opentelemetry.context.propagation.HttpTextFormat;
+import io.opentelemetry.trace.SpanContext;
+import javax.annotation.Nullable;
+
+public final class HttpTraceContextExtractor implements HttpExtractor {
+  private static final HttpTraceContext PROPAGATOR = new HttpTraceContext();
+
+  @Override
+  public <C> Context extract(Context ctx, C carrier, Getter<C> getter) {
+    SpanContext spanCtx = PROPAGATOR.extract(carrier, new GetterImpl<C>(getter));
+    return ctx.setValue(ContextKeys.getSpanContextKey(), spanCtx);
+  }
+
+  // Utility class, not relevant.
+  static final class GetterImpl<C> implements HttpTextFormat.Getter<C> {
+    Getter<C> wrapped;
+
+    GetterImpl(Getter<C> wrapped) {
+      this.wrapped = wrapped;
+    }
+
+    @Nullable
+    @Override
+    public String get(C carrier, String key) {
+      return wrapped.get(carrier, key);
+    }
+  }
+}

--- a/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContextInjector.java
+++ b/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContextInjector.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.trace.propagation;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.HttpInjector;
+import io.opentelemetry.context.propagation.HttpTextFormat;
+import io.opentelemetry.trace.SpanContext;
+
+public final class HttpTraceContextInjector implements HttpInjector {
+  private static final HttpTraceContext PROPAGATOR = new HttpTraceContext();
+
+  @Override
+  public <C> void inject(Context ctx, C carrier, Setter<C> setter) {
+    SpanContext spanCtx = ctx.getValue(ContextKeys.getSpanContextKey());
+    if (spanCtx == null) {
+      return;
+    }
+
+    PROPAGATOR.inject(spanCtx, carrier, new SetterImpl<C>(setter));
+  }
+
+  // Utility class, not relevant.
+  static final class SetterImpl<C> implements HttpTextFormat.Setter<C> {
+    Setter<C> wrapped;
+
+    SetterImpl(Setter<C> wrapped) {
+      this.wrapped = wrapped;
+    }
+
+    @Override
+    public void put(C carrier, String key, String value) {
+      wrapped.put(carrier, key, value);
+    }
+  }
+}

--- a/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
+++ b/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
@@ -84,10 +84,10 @@ public class OpenTelemetryTest {
         .isEqualTo(OpenTelemetry.getTracerFactory().get("testTracer"));
     assertThat(OpenTelemetry.getMeter()).isInstanceOf(DefaultMeter.getInstance().getClass());
     assertThat(OpenTelemetry.getMeter()).isEqualTo(OpenTelemetry.getMeter());
-    assertThat(OpenTelemetry.getDistributedContextManager())
+    assertThat(OpenTelemetry.getCorrelationContextManager())
         .isInstanceOf(DefaultCorrelationContextManager.getInstance().getClass());
-    assertThat(OpenTelemetry.getDistributedContextManager())
-        .isEqualTo(OpenTelemetry.getDistributedContextManager());
+    assertThat(OpenTelemetry.getCorrelationContextManager())
+        .isEqualTo(OpenTelemetry.getCorrelationContextManager());
   }
 
   @Test
@@ -165,11 +165,11 @@ public class OpenTelemetryTest {
             SecondDistributedContextManager.class);
     try {
       assertTrue(
-          (OpenTelemetry.getDistributedContextManager() instanceof FirstDistributedContextManager)
-              || (OpenTelemetry.getDistributedContextManager()
+          (OpenTelemetry.getCorrelationContextManager() instanceof FirstDistributedContextManager)
+              || (OpenTelemetry.getCorrelationContextManager()
                   instanceof SecondDistributedContextManager));
-      assertThat(OpenTelemetry.getDistributedContextManager())
-          .isEqualTo(OpenTelemetry.getDistributedContextManager());
+      assertThat(OpenTelemetry.getCorrelationContextManager())
+          .isEqualTo(OpenTelemetry.getCorrelationContextManager());
     } finally {
       serviceFile.delete();
     }
@@ -186,10 +186,10 @@ public class OpenTelemetryTest {
         CorrelationContextManagerProvider.class.getName(),
         SecondDistributedContextManager.class.getName());
     try {
-      assertThat(OpenTelemetry.getDistributedContextManager())
+      assertThat(OpenTelemetry.getCorrelationContextManager())
           .isInstanceOf(SecondDistributedContextManager.class);
-      assertThat(OpenTelemetry.getDistributedContextManager())
-          .isEqualTo(OpenTelemetry.getDistributedContextManager());
+      assertThat(OpenTelemetry.getCorrelationContextManager())
+          .isEqualTo(OpenTelemetry.getCorrelationContextManager());
     } finally {
       serviceFile.delete();
     }
@@ -199,7 +199,7 @@ public class OpenTelemetryTest {
   public void testDistributedContextManagerNotFound() {
     System.setProperty(CorrelationContextManagerProvider.class.getName(), "io.does.not.exists");
     thrown.expect(IllegalStateException.class);
-    OpenTelemetry.getDistributedContextManager();
+    OpenTelemetry.getCorrelationContextManager();
   }
 
   private static File createService(Class<?> service, Class<?>... impls) throws IOException {

--- a/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
+++ b/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
@@ -22,10 +22,10 @@ import static org.junit.Assert.assertTrue;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.BinaryFormat;
 import io.opentelemetry.context.propagation.HttpTextFormat;
-import io.opentelemetry.distributedcontext.DefaultDistributedContextManager;
-import io.opentelemetry.distributedcontext.DistributedContext;
-import io.opentelemetry.distributedcontext.DistributedContextManager;
-import io.opentelemetry.distributedcontext.spi.DistributedContextManagerProvider;
+import io.opentelemetry.distributedcontext.CorrelationContext;
+import io.opentelemetry.distributedcontext.CorrelationContextManager;
+import io.opentelemetry.distributedcontext.DefaultCorrelationContextManager;
+import io.opentelemetry.distributedcontext.spi.CorrelationContextManagerProvider;
 import io.opentelemetry.metrics.CounterDouble;
 import io.opentelemetry.metrics.CounterLong;
 import io.opentelemetry.metrics.DefaultMeter;
@@ -73,7 +73,7 @@ public class OpenTelemetryTest {
     OpenTelemetry.reset();
     System.clearProperty(TracerFactoryProvider.class.getName());
     System.clearProperty(MeterProvider.class.getName());
-    System.clearProperty(DistributedContextManagerProvider.class.getName());
+    System.clearProperty(CorrelationContextManagerProvider.class.getName());
   }
 
   @Test
@@ -85,7 +85,7 @@ public class OpenTelemetryTest {
     assertThat(OpenTelemetry.getMeter()).isInstanceOf(DefaultMeter.getInstance().getClass());
     assertThat(OpenTelemetry.getMeter()).isEqualTo(OpenTelemetry.getMeter());
     assertThat(OpenTelemetry.getDistributedContextManager())
-        .isInstanceOf(DefaultDistributedContextManager.getInstance().getClass());
+        .isInstanceOf(DefaultCorrelationContextManager.getInstance().getClass());
     assertThat(OpenTelemetry.getDistributedContextManager())
         .isEqualTo(OpenTelemetry.getDistributedContextManager());
   }
@@ -160,7 +160,7 @@ public class OpenTelemetryTest {
   public void testDistributedContextManagerLoadArbitrary() throws IOException {
     File serviceFile =
         createService(
-            DistributedContextManagerProvider.class,
+            CorrelationContextManagerProvider.class,
             FirstDistributedContextManager.class,
             SecondDistributedContextManager.class);
     try {
@@ -179,11 +179,11 @@ public class OpenTelemetryTest {
   public void testDistributedContextManagerSystemProperty() throws IOException {
     File serviceFile =
         createService(
-            DistributedContextManagerProvider.class,
+            CorrelationContextManagerProvider.class,
             FirstDistributedContextManager.class,
             SecondDistributedContextManager.class);
     System.setProperty(
-        DistributedContextManagerProvider.class.getName(),
+        CorrelationContextManagerProvider.class.getName(),
         SecondDistributedContextManager.class.getName());
     try {
       assertThat(OpenTelemetry.getDistributedContextManager())
@@ -197,7 +197,7 @@ public class OpenTelemetryTest {
 
   @Test
   public void testDistributedContextManagerNotFound() {
-    System.setProperty(DistributedContextManagerProvider.class.getName(), "io.does.not.exists");
+    System.setProperty(CorrelationContextManagerProvider.class.getName(), "io.does.not.exists");
     thrown.expect(IllegalStateException.class);
     OpenTelemetry.getDistributedContextManager();
   }
@@ -351,45 +351,45 @@ public class OpenTelemetryTest {
 
   public static class SecondDistributedContextManager extends FirstDistributedContextManager {
     @Override
-    public DistributedContextManager create() {
+    public CorrelationContextManager create() {
       return new SecondDistributedContextManager();
     }
   }
 
   public static class FirstDistributedContextManager
-      implements DistributedContextManager, DistributedContextManagerProvider {
+      implements CorrelationContextManager, CorrelationContextManagerProvider {
     @Override
-    public DistributedContextManager create() {
+    public CorrelationContextManager create() {
       return new FirstDistributedContextManager();
     }
 
     @Nullable
     @Override
-    public DistributedContext getCurrentContext() {
+    public CorrelationContext getCurrentContext() {
       return null;
     }
 
     @Nullable
     @Override
-    public DistributedContext.Builder contextBuilder() {
+    public CorrelationContext.Builder contextBuilder() {
       return null;
     }
 
     @Nullable
     @Override
-    public Scope withContext(DistributedContext distContext) {
+    public Scope withContext(CorrelationContext distContext) {
       return null;
     }
 
     @Nullable
     @Override
-    public BinaryFormat<DistributedContext> getBinaryFormat() {
+    public BinaryFormat<CorrelationContext> getBinaryFormat() {
       return null;
     }
 
     @Nullable
     @Override
-    public HttpTextFormat<DistributedContext> getHttpTextFormat() {
+    public HttpTextFormat<CorrelationContext> getHttpTextFormat() {
       return null;
     }
   }

--- a/api/src/test/java/io/opentelemetry/contextprop/PropagatorsTest.java
+++ b/api/src/test/java/io/opentelemetry/contextprop/PropagatorsTest.java
@@ -70,15 +70,15 @@ public class PropagatorsTest {
 
         // Implicit style (do not pass Context, use specific interface/object).
         CorrelationContext corrCtx =
-            OpenTelemetry.getDistributedContextManager()
+            OpenTelemetry.getCorrelationContextManager()
                 .contextBuilder()
-                .setParent(OpenTelemetry.getDistributedContextManager().getCurrentContext())
+                .setParent(OpenTelemetry.getCorrelationContextManager().getCurrentContext())
                 .put(
                     LabelKey.create("key1"),
                     LabelValue.create("label1"),
                     LabelMetadata.create(LabelMetadata.HopLimit.UNLIMITED_PROPAGATION))
                 .build();
-        try (Scope corrScope = OpenTelemetry.getDistributedContextManager().withContext(corrCtx)) {
+        try (Scope corrScope = OpenTelemetry.getCorrelationContextManager().withContext(corrCtx)) {
 
           // Inject everything that is active at this point.
           Map<String, String> outboundCarrier = new HashMap<>();

--- a/api/src/test/java/io/opentelemetry/contextprop/PropagatorsTest.java
+++ b/api/src/test/java/io/opentelemetry/contextprop/PropagatorsTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contextprop;
+
+import io.opentelemetry.OpenTelemetry;
+import io.opentelemetry.baggage.DefaultBaggageManager;
+import io.opentelemetry.baggage.propagation.DefaultBaggageExtractor;
+import io.opentelemetry.baggage.propagation.DefaultBaggageInjector;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.ChainedPropagators;
+import io.opentelemetry.context.propagation.HttpExtractor;
+import io.opentelemetry.context.propagation.HttpInjector;
+import io.opentelemetry.distributedcontext.CorrelationContext;
+import io.opentelemetry.distributedcontext.LabelKey;
+import io.opentelemetry.distributedcontext.LabelMetadata;
+import io.opentelemetry.distributedcontext.LabelValue;
+import io.opentelemetry.distributedcontext.propagation.DefaultCorrelationContextExtractor;
+import io.opentelemetry.distributedcontext.propagation.DefaultCorrelationContextInjector;
+import io.opentelemetry.trace.propagation.HttpTraceContextExtractor;
+import io.opentelemetry.trace.propagation.HttpTraceContextInjector;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class PropagatorsTest {
+  @Test
+  public void testSimpleRequest() {
+    Map<String, String> inboundCarrier = new HashMap<>();
+
+    // Chain the extractors.
+    HttpExtractor extractor =
+        ChainedPropagators.chain(
+            ChainedPropagators.chain(
+                new HttpTraceContextExtractor(), new DefaultCorrelationContextExtractor()),
+            new DefaultBaggageExtractor());
+
+    // Chain the injectors.
+    HttpInjector injector =
+        ChainedPropagators.chain(
+            ChainedPropagators.chain(
+                new HttpTraceContextInjector(), new DefaultCorrelationContextInjector()),
+            new DefaultBaggageInjector());
+
+    // Extract.
+    Context ctx = extractor.extract(Context.current(), inboundCarrier, new MapGetter());
+
+    try (Scope scope = Context.setCurrent(ctx)) {
+      // Explicit style (pass Context, use opaque object underneath).
+      Context newCtx =
+          DefaultBaggageManager.getInstance().setValue(Context.current(), "mykey", "myvalue");
+      try (Scope bagScope = Context.setCurrent(newCtx)) {
+
+        // Implicit style (do not pass Context, use specific interface/object).
+        CorrelationContext corrCtx =
+            OpenTelemetry.getDistributedContextManager()
+                .contextBuilder()
+                .setParent(OpenTelemetry.getDistributedContextManager().getCurrentContext())
+                .put(
+                    LabelKey.create("key1"),
+                    LabelValue.create("label1"),
+                    LabelMetadata.create(LabelMetadata.HopLimit.UNLIMITED_PROPAGATION))
+                .build();
+        try (Scope corrScope = OpenTelemetry.getDistributedContextManager().withContext(corrCtx)) {
+
+          // Inject everything that is active at this point.
+          Map<String, String> outboundCarrier = new HashMap<>();
+          injector.inject(Context.current(), outboundCarrier, new MapSetter());
+        }
+      }
+    }
+  }
+
+  static final class MapGetter implements HttpExtractor.Getter<Map<String, String>> {
+    @Override
+    public String get(Map<String, String> carrier, String key) {
+      return carrier.get(key);
+    }
+  }
+
+  static final class MapSetter implements HttpInjector.Setter<Map<String, String>> {
+    @Override
+    public void put(Map<String, String> carrier, String key, String value) {
+      carrier.put(key, value);
+    }
+  }
+}

--- a/api/src/test/java/io/opentelemetry/distributedcontext/DefaultDistributedContextManagerTest.java
+++ b/api/src/test/java/io/opentelemetry/distributedcontext/DefaultDistributedContextManagerTest.java
@@ -30,25 +30,25 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link DefaultDistributedContextManager}. */
+/** Unit tests for {@link DefaultCorrelationContextManager}. */
 @RunWith(JUnit4.class)
 public final class DefaultDistributedContextManagerTest {
-  private static final DistributedContextManager defaultDistributedContextManager =
-      DefaultDistributedContextManager.getInstance();
-  private static final EntryKey KEY = EntryKey.create("key");
-  private static final EntryValue VALUE = EntryValue.create("value");
+  private static final CorrelationContextManager defaultDistributedContextManager =
+      DefaultCorrelationContextManager.getInstance();
+  private static final LabelKey KEY = LabelKey.create("key");
+  private static final LabelValue VALUE = LabelValue.create("value");
 
-  private static final DistributedContext DIST_CONTEXT =
-      new DistributedContext() {
+  private static final CorrelationContext DIST_CONTEXT =
+      new CorrelationContext() {
 
         @Override
-        public Collection<Entry> getEntries() {
-          return Arrays.asList(Entry.create(KEY, VALUE, Entry.METADATA_UNLIMITED_PROPAGATION));
+        public Collection<Label> getEntries() {
+          return Arrays.asList(Label.create(KEY, VALUE, Label.METADATA_UNLIMITED_PROPAGATION));
         }
 
         @Nullable
         @Override
-        public EntryValue getEntryValue(EntryKey entryKey) {
+        public LabelValue getEntryValue(LabelKey entryKey) {
           return VALUE;
         }
       };
@@ -63,14 +63,14 @@ public final class DefaultDistributedContextManagerTest {
   @Test
   public void getCurrentContext_DefaultContext() {
     assertThat(defaultDistributedContextManager.getCurrentContext())
-        .isSameInstanceAs(EmptyDistributedContext.getInstance());
+        .isSameInstanceAs(EmptyCorrelationContext.getInstance());
   }
 
   @Test
   public void getCurrentContext_ContextSetToNull() {
     Context orig = ContextUtils.withValue(null).attach();
     try {
-      DistributedContext distContext = defaultDistributedContextManager.getCurrentContext();
+      CorrelationContext distContext = defaultDistributedContextManager.getCurrentContext();
       assertThat(distContext).isNotNull();
       assertThat(distContext.getEntries()).isEmpty();
     } finally {
@@ -81,7 +81,7 @@ public final class DefaultDistributedContextManagerTest {
   @Test
   public void withContext() {
     assertThat(defaultDistributedContextManager.getCurrentContext())
-        .isSameInstanceAs(EmptyDistributedContext.getInstance());
+        .isSameInstanceAs(EmptyCorrelationContext.getInstance());
     Scope wtm = defaultDistributedContextManager.withContext(DIST_CONTEXT);
     try {
       assertThat(defaultDistributedContextManager.getCurrentContext())
@@ -90,22 +90,22 @@ public final class DefaultDistributedContextManagerTest {
       wtm.close();
     }
     assertThat(defaultDistributedContextManager.getCurrentContext())
-        .isSameInstanceAs(EmptyDistributedContext.getInstance());
+        .isSameInstanceAs(EmptyCorrelationContext.getInstance());
   }
 
   @Test
   public void withContext_nullContext() {
     assertThat(defaultDistributedContextManager.getCurrentContext())
-        .isSameInstanceAs(EmptyDistributedContext.getInstance());
+        .isSameInstanceAs(EmptyCorrelationContext.getInstance());
     Scope wtm = defaultDistributedContextManager.withContext(null);
     try {
       assertThat(defaultDistributedContextManager.getCurrentContext())
-          .isSameInstanceAs(EmptyDistributedContext.getInstance());
+          .isSameInstanceAs(EmptyCorrelationContext.getInstance());
     } finally {
       wtm.close();
     }
     assertThat(defaultDistributedContextManager.getCurrentContext())
-        .isSameInstanceAs(EmptyDistributedContext.getInstance());
+        .isSameInstanceAs(EmptyCorrelationContext.getInstance());
   }
 
   @Test
@@ -129,42 +129,42 @@ public final class DefaultDistributedContextManagerTest {
       wtm.close();
     }
     assertThat(defaultDistributedContextManager.getCurrentContext())
-        .isSameInstanceAs(EmptyDistributedContext.getInstance());
+        .isSameInstanceAs(EmptyCorrelationContext.getInstance());
     // When we run the runnable we will have the DistributedContext in the current Context.
     runnable.run();
   }
 
   @Test
   public void noopContextBuilder_SetParent_DisallowsNullParent() {
-    DistributedContext.Builder noopBuilder = defaultDistributedContextManager.contextBuilder();
+    CorrelationContext.Builder noopBuilder = defaultDistributedContextManager.contextBuilder();
     thrown.expect(NullPointerException.class);
     noopBuilder.setParent(null);
   }
 
   @Test
   public void noopContextBuilder_Put_DisallowsNullKey() {
-    DistributedContext.Builder noopBuilder = defaultDistributedContextManager.contextBuilder();
+    CorrelationContext.Builder noopBuilder = defaultDistributedContextManager.contextBuilder();
     thrown.expect(NullPointerException.class);
-    noopBuilder.put(null, VALUE, Entry.METADATA_UNLIMITED_PROPAGATION);
+    noopBuilder.put(null, VALUE, Label.METADATA_UNLIMITED_PROPAGATION);
   }
 
   @Test
   public void noopContextBuilder_Put_DisallowsNullValue() {
-    DistributedContext.Builder noopBuilder = defaultDistributedContextManager.contextBuilder();
+    CorrelationContext.Builder noopBuilder = defaultDistributedContextManager.contextBuilder();
     thrown.expect(NullPointerException.class);
-    noopBuilder.put(KEY, null, Entry.METADATA_UNLIMITED_PROPAGATION);
+    noopBuilder.put(KEY, null, Label.METADATA_UNLIMITED_PROPAGATION);
   }
 
   @Test
   public void noopContextBuilder_Put_DisallowsNullEntryMetadata() {
-    DistributedContext.Builder noopBuilder = defaultDistributedContextManager.contextBuilder();
+    CorrelationContext.Builder noopBuilder = defaultDistributedContextManager.contextBuilder();
     thrown.expect(NullPointerException.class);
     noopBuilder.put(KEY, VALUE, null);
   }
 
   @Test
   public void noopContextBuilder_Remove_DisallowsNullKey() {
-    DistributedContext.Builder noopBuilder = defaultDistributedContextManager.contextBuilder();
+    CorrelationContext.Builder noopBuilder = defaultDistributedContextManager.contextBuilder();
     thrown.expect(NullPointerException.class);
     noopBuilder.remove(null);
   }

--- a/api/src/test/java/io/opentelemetry/distributedcontext/EntryKeyTest.java
+++ b/api/src/test/java/io/opentelemetry/distributedcontext/EntryKeyTest.java
@@ -26,55 +26,55 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for {@link EntryKey}. */
+/** Tests for {@link LabelKey}. */
 @RunWith(JUnit4.class)
 public final class EntryKeyTest {
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void testMaxLength() {
-    assertThat(EntryKey.MAX_LENGTH).isEqualTo(255);
+    assertThat(LabelKey.MAX_LENGTH).isEqualTo(255);
   }
 
   @Test
   public void testGetName() {
-    assertThat(EntryKey.create("foo").getName()).isEqualTo("foo");
+    assertThat(LabelKey.create("foo").getName()).isEqualTo("foo");
   }
 
   @Test
   public void create_AllowEntryKeyNameWithMaxLength() {
-    char[] chars = new char[EntryKey.MAX_LENGTH];
+    char[] chars = new char[LabelKey.MAX_LENGTH];
     Arrays.fill(chars, 'k');
     String key = new String(chars);
-    assertThat(EntryKey.create(key).getName()).isEqualTo(key);
+    assertThat(LabelKey.create(key).getName()).isEqualTo(key);
   }
 
   @Test
   public void create_DisallowEntryKeyNameOverMaxLength() {
-    char[] chars = new char[EntryKey.MAX_LENGTH + 1];
+    char[] chars = new char[LabelKey.MAX_LENGTH + 1];
     Arrays.fill(chars, 'k');
     String key = new String(chars);
     thrown.expect(IllegalArgumentException.class);
-    EntryKey.create(key);
+    LabelKey.create(key);
   }
 
   @Test
   public void create_DisallowUnprintableChars() {
     thrown.expect(IllegalArgumentException.class);
-    EntryKey.create("\2ab\3cd");
+    LabelKey.create("\2ab\3cd");
   }
 
   @Test
   public void createString_DisallowEmpty() {
     thrown.expect(IllegalArgumentException.class);
-    EntryKey.create("");
+    LabelKey.create("");
   }
 
   @Test
   public void testEntryKeyEquals() {
     new EqualsTester()
-        .addEqualityGroup(EntryKey.create("foo"), EntryKey.create("foo"))
-        .addEqualityGroup(EntryKey.create("bar"))
+        .addEqualityGroup(LabelKey.create("foo"), LabelKey.create("foo"))
+        .addEqualityGroup(LabelKey.create("bar"))
         .testEquals();
   }
 }

--- a/api/src/test/java/io/opentelemetry/distributedcontext/EntryMetadataTest.java
+++ b/api/src/test/java/io/opentelemetry/distributedcontext/EntryMetadataTest.java
@@ -19,28 +19,28 @@ package io.opentelemetry.distributedcontext;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import io.opentelemetry.distributedcontext.EntryMetadata.EntryTtl;
+import io.opentelemetry.distributedcontext.LabelMetadata.HopLimit;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for {@link EntryMetadata}. */
+/** Tests for {@link LabelMetadata}. */
 @RunWith(JUnit4.class)
 public class EntryMetadataTest {
 
   @Test
   public void testGetEntryTtl() {
-    EntryMetadata entryMetadata = EntryMetadata.create(EntryTtl.NO_PROPAGATION);
-    assertThat(entryMetadata.getEntryTtl()).isEqualTo(EntryTtl.NO_PROPAGATION);
+    LabelMetadata entryMetadata = LabelMetadata.create(HopLimit.NO_PROPAGATION);
+    assertThat(entryMetadata.getEntryTtl()).isEqualTo(HopLimit.NO_PROPAGATION);
   }
 
   @Test
   public void testEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            EntryMetadata.create(EntryTtl.NO_PROPAGATION),
-            EntryMetadata.create(EntryTtl.NO_PROPAGATION))
-        .addEqualityGroup(EntryMetadata.create(EntryTtl.UNLIMITED_PROPAGATION))
+            LabelMetadata.create(HopLimit.NO_PROPAGATION),
+            LabelMetadata.create(HopLimit.NO_PROPAGATION))
+        .addEqualityGroup(LabelMetadata.create(HopLimit.UNLIMITED_PROPAGATION))
         .testEquals();
   }
 }

--- a/api/src/test/java/io/opentelemetry/distributedcontext/EntryTest.java
+++ b/api/src/test/java/io/opentelemetry/distributedcontext/EntryTest.java
@@ -19,32 +19,32 @@ package io.opentelemetry.distributedcontext;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import io.opentelemetry.distributedcontext.EntryMetadata.EntryTtl;
+import io.opentelemetry.distributedcontext.LabelMetadata.HopLimit;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for {@link Entry}. */
+/** Tests for {@link Label}. */
 @RunWith(JUnit4.class)
 public final class EntryTest {
 
-  private static final EntryKey KEY = EntryKey.create("KEY");
-  private static final EntryKey KEY_2 = EntryKey.create("KEY2");
-  private static final EntryValue VALUE = EntryValue.create("VALUE");
-  private static final EntryValue VALUE_2 = EntryValue.create("VALUE2");
-  private static final EntryMetadata METADATA_UNLIMITED_PROPAGATION =
-      EntryMetadata.create(EntryTtl.UNLIMITED_PROPAGATION);
-  private static final EntryMetadata METADATA_NO_PROPAGATION =
-      EntryMetadata.create(EntryTtl.NO_PROPAGATION);
+  private static final LabelKey KEY = LabelKey.create("KEY");
+  private static final LabelKey KEY_2 = LabelKey.create("KEY2");
+  private static final LabelValue VALUE = LabelValue.create("VALUE");
+  private static final LabelValue VALUE_2 = LabelValue.create("VALUE2");
+  private static final LabelMetadata METADATA_UNLIMITED_PROPAGATION =
+      LabelMetadata.create(HopLimit.UNLIMITED_PROPAGATION);
+  private static final LabelMetadata METADATA_NO_PROPAGATION =
+      LabelMetadata.create(HopLimit.NO_PROPAGATION);
 
   @Test
   public void testGetKey() {
-    assertThat(Entry.create(KEY, VALUE, METADATA_UNLIMITED_PROPAGATION).getKey()).isEqualTo(KEY);
+    assertThat(Label.create(KEY, VALUE, METADATA_UNLIMITED_PROPAGATION).getKey()).isEqualTo(KEY);
   }
 
   @Test
   public void testGetEntryMetadata() {
-    assertThat(Entry.create(KEY, VALUE, METADATA_NO_PROPAGATION).getEntryMetadata())
+    assertThat(Label.create(KEY, VALUE, METADATA_NO_PROPAGATION).getEntryMetadata())
         .isEqualTo(METADATA_NO_PROPAGATION);
   }
 
@@ -52,11 +52,11 @@ public final class EntryTest {
   public void testEntryEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            Entry.create(KEY, VALUE, METADATA_UNLIMITED_PROPAGATION),
-            Entry.create(KEY, VALUE, METADATA_UNLIMITED_PROPAGATION))
-        .addEqualityGroup(Entry.create(KEY, VALUE_2, METADATA_UNLIMITED_PROPAGATION))
-        .addEqualityGroup(Entry.create(KEY_2, VALUE, METADATA_UNLIMITED_PROPAGATION))
-        .addEqualityGroup(Entry.create(KEY, VALUE, METADATA_NO_PROPAGATION))
+            Label.create(KEY, VALUE, METADATA_UNLIMITED_PROPAGATION),
+            Label.create(KEY, VALUE, METADATA_UNLIMITED_PROPAGATION))
+        .addEqualityGroup(Label.create(KEY, VALUE_2, METADATA_UNLIMITED_PROPAGATION))
+        .addEqualityGroup(Label.create(KEY_2, VALUE, METADATA_UNLIMITED_PROPAGATION))
+        .addEqualityGroup(Label.create(KEY, VALUE, METADATA_NO_PROPAGATION))
         .testEquals();
   }
 }

--- a/api/src/test/java/io/opentelemetry/distributedcontext/EntryValueTest.java
+++ b/api/src/test/java/io/opentelemetry/distributedcontext/EntryValueTest.java
@@ -26,50 +26,50 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for {@link EntryValue}. */
+/** Tests for {@link LabelValue}. */
 @RunWith(JUnit4.class)
 public final class EntryValueTest {
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void testMaxLength() {
-    assertThat(EntryValue.MAX_LENGTH).isEqualTo(255);
+    assertThat(LabelValue.MAX_LENGTH).isEqualTo(255);
   }
 
   @Test
   public void testAsString() {
-    assertThat(EntryValue.create("foo").asString()).isEqualTo("foo");
+    assertThat(LabelValue.create("foo").asString()).isEqualTo("foo");
   }
 
   @Test
   public void create_AllowEntryValueWithMaxLength() {
-    char[] chars = new char[EntryValue.MAX_LENGTH];
+    char[] chars = new char[LabelValue.MAX_LENGTH];
     Arrays.fill(chars, 'v');
     String value = new String(chars);
-    assertThat(EntryValue.create(value).asString()).isEqualTo(value);
+    assertThat(LabelValue.create(value).asString()).isEqualTo(value);
   }
 
   @Test
   public void create_DisallowEntryValueOverMaxLength() {
-    char[] chars = new char[EntryValue.MAX_LENGTH + 1];
+    char[] chars = new char[LabelValue.MAX_LENGTH + 1];
     Arrays.fill(chars, 'v');
     String value = new String(chars);
     thrown.expect(IllegalArgumentException.class);
-    EntryValue.create(value);
+    LabelValue.create(value);
   }
 
   @Test
   public void disallowEntryValueWithUnprintableChars() {
     String value = "\2ab\3cd";
     thrown.expect(IllegalArgumentException.class);
-    EntryValue.create(value);
+    LabelValue.create(value);
   }
 
   @Test
   public void testEntryValueEquals() {
     new EqualsTester()
-        .addEqualityGroup(EntryValue.create("foo"), EntryValue.create("foo"))
-        .addEqualityGroup(EntryValue.create("bar"))
+        .addEqualityGroup(LabelValue.create("foo"), LabelValue.create("foo"))
+        .addEqualityGroup(LabelValue.create("bar"))
         .testEquals();
   }
 }

--- a/api/src/test/java/io/opentelemetry/distributedcontext/unsafe/ContextUtilsTest.java
+++ b/api/src/test/java/io/opentelemetry/distributedcontext/unsafe/ContextUtilsTest.java
@@ -19,7 +19,7 @@ package io.opentelemetry.distributedcontext.unsafe;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.grpc.Context;
-import io.opentelemetry.distributedcontext.DistributedContext;
+import io.opentelemetry.distributedcontext.CorrelationContext;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -29,14 +29,14 @@ import org.junit.runners.JUnit4;
 public final class ContextUtilsTest {
   @Test
   public void testGetCurrentDistributedContex_DefaultContext() {
-    DistributedContext distContext = ContextUtils.getValue(Context.current());
+    CorrelationContext distContext = ContextUtils.getValue(Context.current());
     assertThat(distContext).isNotNull();
     assertThat(distContext.getEntries()).isEmpty();
   }
 
   @Test
   public void testGetCurrentDistributedContex_DefaultContext_WithoutExplicitContext() {
-    DistributedContext distContext = ContextUtils.getValue();
+    CorrelationContext distContext = ContextUtils.getValue();
     assertThat(distContext).isNotNull();
     assertThat(distContext.getEntries()).isEmpty();
   }
@@ -45,7 +45,7 @@ public final class ContextUtilsTest {
   public void testGetCurrentDistributedContex_ContextSetToNull() {
     Context orig = ContextUtils.withValue(null, Context.current()).attach();
     try {
-      DistributedContext distContext = ContextUtils.getValue(Context.current());
+      CorrelationContext distContext = ContextUtils.getValue(Context.current());
       assertThat(distContext).isNotNull();
       assertThat(distContext.getEntries()).isEmpty();
     } finally {
@@ -57,7 +57,7 @@ public final class ContextUtilsTest {
   public void testGetCurrentDistributedContex_ContextSetToNull_WithoutExplicitContext() {
     Context orig = ContextUtils.withValue(null).attach();
     try {
-      DistributedContext distContext = ContextUtils.getValue();
+      CorrelationContext distContext = ContextUtils.getValue();
       assertThat(distContext).isNotNull();
       assertThat(distContext.getEntries()).isEmpty();
     } finally {

--- a/contrib/web_servlet_filter/build.gradle
+++ b/contrib/web_servlet_filter/build.gradle
@@ -1,0 +1,10 @@
+description = 'OpenTelemetry Contrib Web Servlet Filter'
+
+dependencies {
+    api project(':opentelemetry-api')
+
+    implementation "javax.servlet:javax.servlet-api:3.1.0"
+
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
+}

--- a/contrib/web_servlet_filter/src/main/java/io/opentelemetry/contrib/web/servlet/filter/HttpServletRequestGetter.java
+++ b/contrib/web_servlet_filter/src/main/java/io/opentelemetry/contrib/web/servlet/filter/HttpServletRequestGetter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.web.servlet.filter;
+
+import io.opentelemetry.context.propagation.HttpExtractor;
+import javax.servlet.http.HttpServletRequest;
+
+/** Tracer extract adapter for {@link HttpServletRequest}. */
+public final class HttpServletRequestGetter implements HttpExtractor.Getter<HttpServletRequest> {
+  private static final HttpServletRequestGetter INSTANCE = new HttpServletRequestGetter();
+
+  public static HttpServletRequestGetter getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public String get(HttpServletRequest carrier, String key) {
+    return carrier.getHeader(key);
+  }
+
+  private HttpServletRequestGetter() {}
+}

--- a/contrib/web_servlet_filter/src/main/java/io/opentelemetry/contrib/web/servlet/filter/ServletFilterSpanDecorator.java
+++ b/contrib/web_servlet_filter/src/main/java/io/opentelemetry/contrib/web/servlet/filter/ServletFilterSpanDecorator.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.web.servlet.filter;
+
+import io.opentelemetry.trace.AttributeValue;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.Status;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.AsyncEvent;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * SpanDecorator to decorate span at different stages in filter processing (before
+ * filterChain.doFilter(), after and if exception is thrown).
+ *
+ * @author Pavol Loffay
+ */
+public interface ServletFilterSpanDecorator {
+
+  /**
+   * Decorate span before {@link javax.servlet.Filter#doFilter(ServletRequest, ServletResponse,
+   * FilterChain)} is called. This is called right after span in created. Span is already present in
+   * request attributes with name {@link TracingFilter#SERVER_SPAN_CONTEXT}.
+   *
+   * @param httpServletRequest request
+   * @param span span to decorate
+   */
+  void onRequest(HttpServletRequest httpServletRequest, Span span);
+
+  /**
+   * Decorate span after {@link javax.servlet.Filter#doFilter(ServletRequest, ServletResponse,
+   * FilterChain)}. When it is an async request this will be called in {@link
+   * javax.servlet.AsyncListener#onComplete(AsyncEvent)}.
+   *
+   * @param httpServletRequest request
+   * @param httpServletResponse response
+   * @param span span to decorate
+   */
+  void onResponse(
+      HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Span span);
+
+  /**
+   * Decorate span when an exception is thrown during processing in {@link
+   * javax.servlet.Filter#doFilter(ServletRequest, ServletResponse, FilterChain)}. This is also
+   * called in {@link javax.servlet.AsyncListener#onError(AsyncEvent)}.
+   *
+   * @param httpServletRequest request
+   * @param exception exception
+   * @param span span to decorate
+   */
+  void onError(
+      HttpServletRequest httpServletRequest,
+      HttpServletResponse httpServletResponse,
+      Throwable exception,
+      Span span);
+
+  /**
+   * Decorate span on asynchronous request timeout. It is called in {@link
+   * javax.servlet.AsyncListener#onTimeout(AsyncEvent)}.
+   *
+   * @param httpServletRequest request
+   * @param httpServletResponse response
+   * @param timeout timeout
+   * @param span span to decorate
+   */
+  void onTimeout(
+      HttpServletRequest httpServletRequest,
+      HttpServletResponse httpServletResponse,
+      long timeout,
+      Span span);
+
+  /**
+   * Adds standard tags to span. {@link Tags#HTTP_URL}, {@link Tags#HTTP_STATUS}, {@link
+   * Tags#HTTP_METHOD} and {@link Tags#COMPONENT}. If an exception during {@link
+   * javax.servlet.Filter#doFilter(ServletRequest, ServletResponse, FilterChain)} is thrown tag
+   * {@link Tags#ERROR} is added and {@link Tags#HTTP_STATUS} not because at this point it is not
+   * known.
+   */
+  ServletFilterSpanDecorator STANDARD_TAGS =
+      new ServletFilterSpanDecorator() {
+        @Override
+        public void onRequest(HttpServletRequest httpServletRequest, Span span) {
+          span.setAttribute("component", "java-web-servlet");
+
+          span.setAttribute("http.method", httpServletRequest.getMethod());
+
+          // without query params
+          span.setAttribute("http.url", httpServletRequest.getRequestURL().toString());
+        }
+
+        @Override
+        public void onResponse(
+            HttpServletRequest httpServletRequest,
+            HttpServletResponse httpServletResponse,
+            Span span) {
+          span.setAttribute("http.status", httpServletResponse.getStatus());
+        }
+
+        @Override
+        public void onError(
+            HttpServletRequest httpServletRequest,
+            HttpServletResponse httpServletResponse,
+            Throwable exception,
+            Span span) {
+          span.setStatus(Status.UNKNOWN);
+
+          if (httpServletResponse.getStatus() == HttpServletResponse.SC_OK) {
+            // exception is thrown in filter chain, but status code is incorrect
+            span.setAttribute("http.status", 500);
+          }
+        }
+
+        @Override
+        public void onTimeout(
+            HttpServletRequest httpServletRequest,
+            HttpServletResponse httpServletResponse,
+            long timeout,
+            Span span) {
+          Map<String, AttributeValue> timeoutLogs = new HashMap<>(2);
+          timeoutLogs.put("timeout", AttributeValue.longAttributeValue(timeout));
+          span.addEvent("timeout", timeoutLogs);
+        }
+      };
+}

--- a/contrib/web_servlet_filter/src/main/java/io/opentelemetry/contrib/web/servlet/filter/TracingFilter.java
+++ b/contrib/web_servlet_filter/src/main/java/io/opentelemetry/contrib/web/servlet/filter/TracingFilter.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.web.servlet.filter;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.Tracer;
+import io.opentelemetry.trace.propagation.ContextKeys;
+import io.opentelemetry.trace.propagation.HttpTraceContextExtractor;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import javax.servlet.AsyncEvent;
+import javax.servlet.AsyncListener;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Tracing servlet filter.
+ *
+ * <p>Filter can be programmatically added to {@link ServletContext} or initialized via web.xml.
+ *
+ * <p>Following code examples show possible initialization:
+ *
+ * <pre>{@code
+ * TracingFilter filter = new TracingFilter(tracer);
+ *  servletContext.addFilter("tracingFilter", filter);
+ * }</pre>
+ *
+ * Or include filter in web.xml and:
+ *
+ * <pre>{@code
+ * GlobalTracer.register(tracer);
+ * servletContext.setAttribute({@link TracingFilter#SPAN_DECORATORS}, listOfDecorators); // optional, if no present ServletFilterSpanDecorator.STANDARD_TAGS is applied
+ * }</pre>
+ *
+ * Current server span context is accessible via {@link HttpServletRequest#getAttribute(String)}
+ * with name {@link TracingFilter#SERVER_SPAN_CONTEXT}.
+ *
+ * @author Pavol Loffay
+ */
+public class TracingFilter implements Filter {
+  private static final Logger log = Logger.getLogger(TracingFilter.class.getName());
+
+  /** Use as a key of {@link ServletContext#setAttribute(String, Object)} to set span decorators */
+  public static final String SPAN_DECORATORS = TracingFilter.class.getName() + ".spanDecorators";
+  /** Use as a key of {@link ServletContext#setAttribute(String, Object)} to skip pattern */
+  public static final String SKIP_PATTERN = TracingFilter.class.getName() + ".skipPattern";
+
+  /**
+   * Used as a key of {@link HttpServletRequest#setAttribute(String, Object)} to inject server span
+   * context
+   */
+  public static final String SERVER_SPAN_CONTEXT =
+      TracingFilter.class.getName() + ".activeSpanContext";
+
+  protected Tracer tracer;
+  private List<ServletFilterSpanDecorator> spanDecorators;
+  private Pattern skipPattern;
+
+  /** @param tracer */
+  public TracingFilter(Tracer tracer) {
+    this(tracer, Collections.singletonList(ServletFilterSpanDecorator.STANDARD_TAGS), null);
+  }
+
+  /**
+   * @param tracer tracer
+   * @param spanDecorators decorators
+   * @param skipPattern null or pattern to exclude certain paths from tracing e.g. "/health"
+   */
+  public TracingFilter(
+      Tracer tracer, List<ServletFilterSpanDecorator> spanDecorators, Pattern skipPattern) {
+    this.tracer = tracer;
+    this.spanDecorators = new ArrayList<>(spanDecorators);
+    this.spanDecorators.removeAll(Collections.singleton(null));
+    this.skipPattern = skipPattern;
+  }
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+    ServletContext servletContext = filterConfig.getServletContext();
+
+    // Check whether the servlet context provides a tracer
+    Object tracerObj = servletContext.getAttribute(Tracer.class.getName());
+    if (tracerObj instanceof Tracer) {
+      tracer = (Tracer) tracerObj;
+    } else {
+      // Add current tracer to servlet context, so available to webapp
+      servletContext.setAttribute(Tracer.class.getName(), tracer);
+    }
+
+    // use decorators from context attributes
+    Object contextAttribute = servletContext.getAttribute(SPAN_DECORATORS);
+    if (contextAttribute instanceof Collection) {
+      List<ServletFilterSpanDecorator> decorators = new ArrayList<>();
+      for (Object decorator : (Collection) contextAttribute) {
+        if (decorator instanceof ServletFilterSpanDecorator) {
+          decorators.add((ServletFilterSpanDecorator) decorator);
+        } else {
+          log.severe(decorator + " is not an instance of " + ServletFilterSpanDecorator.class);
+        }
+      }
+      this.spanDecorators = decorators.size() > 0 ? decorators : this.spanDecorators;
+    }
+
+    contextAttribute = servletContext.getAttribute(SKIP_PATTERN);
+    if (contextAttribute instanceof Pattern) {
+      skipPattern = (Pattern) contextAttribute;
+    }
+  }
+
+  @Override
+  public void doFilter(
+      ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain)
+      throws IOException, ServletException {
+
+    HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
+    HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
+
+    if (!isTraced(httpRequest, httpResponse)) {
+      chain.doFilter(httpRequest, httpResponse);
+      return;
+    }
+
+    /** If request is traced then do not start new span. */
+    if (servletRequest.getAttribute(SERVER_SPAN_CONTEXT) != null) {
+      chain.doFilter(servletRequest, servletResponse);
+    } else {
+      /* In a real world scenario, a single instance would be shared/used. */
+      HttpTraceContextExtractor extractor = new HttpTraceContextExtractor();
+
+      /**
+       * SpanContext *and* other members (such as correlationcontext) would be extracted here, and
+       * make it available in the returned Context object.
+       * 
+       * For further consumption, the returned Context object would need to be explicitly passed
+       * to DistributedContext/Baggage handlers, or else set it automatically as the current instance.
+       */
+      Context ctx =
+          extractor.extract(Context.current(), httpRequest, HttpServletRequestGetter.getInstance());
+      SpanContext extractedContext = ctx.getValue(ContextKeys.getSpanContextKey());
+
+      final Span span =
+          tracer
+              .spanBuilder(httpRequest.getMethod())
+              .setParent(extractedContext)
+              .setSpanKind(Span.Kind.SERVER)
+              .startSpan();
+
+      httpRequest.setAttribute(SERVER_SPAN_CONTEXT, span.getContext());
+
+      for (ServletFilterSpanDecorator spanDecorator : spanDecorators) {
+        spanDecorator.onRequest(httpRequest, span);
+      }
+
+      try (Scope scope = tracer.withSpan(span)) {
+        chain.doFilter(servletRequest, servletResponse);
+        if (!httpRequest.isAsyncStarted()) {
+          for (ServletFilterSpanDecorator spanDecorator : spanDecorators) {
+            spanDecorator.onResponse(httpRequest, httpResponse, span);
+          }
+        }
+        // catch all exceptions (e.g. RuntimeException, ServletException...)
+      } catch (Throwable ex) {
+        for (ServletFilterSpanDecorator spanDecorator : spanDecorators) {
+          spanDecorator.onError(httpRequest, httpResponse, ex, span);
+        }
+        throw ex;
+      } finally {
+        if (httpRequest.isAsyncStarted()) {
+          // what if async is already finished? This would not be called
+          httpRequest
+              .getAsyncContext()
+              .addListener(
+                  new AsyncListener() {
+                    @Override
+                    public void onComplete(AsyncEvent event) throws IOException {
+                      HttpServletRequest httpRequest =
+                          (HttpServletRequest) event.getSuppliedRequest();
+                      HttpServletResponse httpResponse =
+                          (HttpServletResponse) event.getSuppliedResponse();
+                      for (ServletFilterSpanDecorator spanDecorator : spanDecorators) {
+                        spanDecorator.onResponse(httpRequest, httpResponse, span);
+                      }
+                      span.end();
+                    }
+
+                    @Override
+                    public void onTimeout(AsyncEvent event) throws IOException {
+                      HttpServletRequest httpRequest =
+                          (HttpServletRequest) event.getSuppliedRequest();
+                      HttpServletResponse httpResponse =
+                          (HttpServletResponse) event.getSuppliedResponse();
+                      for (ServletFilterSpanDecorator spanDecorator : spanDecorators) {
+                        spanDecorator.onTimeout(
+                            httpRequest, httpResponse, event.getAsyncContext().getTimeout(), span);
+                      }
+                    }
+
+                    @Override
+                    public void onError(AsyncEvent event) throws IOException {
+                      HttpServletRequest httpRequest =
+                          (HttpServletRequest) event.getSuppliedRequest();
+                      HttpServletResponse httpResponse =
+                          (HttpServletResponse) event.getSuppliedResponse();
+                      for (ServletFilterSpanDecorator spanDecorator : spanDecorators) {
+                        spanDecorator.onError(
+                            httpRequest, httpResponse, event.getThrowable(), span);
+                      }
+                    }
+
+                    @Override
+                    public void onStartAsync(AsyncEvent event) throws IOException {}
+                  });
+        } else {
+          // If not async, then need to explicitly finish the span associated with the scope.
+          // This is necessary, as we don't know whether this request is being handled
+          // asynchronously until after the scope has already been started.
+          span.end();
+        }
+      }
+    }
+  }
+
+  @Override
+  public void destroy() {}
+
+  /**
+   * It checks whether a request should be traced or not.
+   *
+   * @param httpServletRequest request
+   * @param httpServletResponse response
+   * @return whether request should be traced or not
+   */
+  protected boolean isTraced(
+      HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+    // skip URLs matching skip pattern
+    // e.g. pattern is defined as '/health|/status' then URL 'http://localhost:5000/context/health'
+    // won't be traced
+    if (skipPattern != null) {
+      String url =
+          httpServletRequest
+              .getRequestURI()
+              .substring(httpServletRequest.getContextPath().length());
+      return !skipPattern.matcher(url).matches();
+    }
+
+    return true;
+  }
+
+  /**
+   * Get context of server span.
+   *
+   * @param servletRequest request
+   * @return server span context
+   */
+  public static SpanContext serverSpanContext(ServletRequest servletRequest) {
+    return (SpanContext) servletRequest.getAttribute(SERVER_SPAN_CONTEXT);
+  }
+}

--- a/contrib/web_servlet_filter/src/main/java/io/opentelemetry/contrib/web/servlet/filter/decorator/ServletFilterHeaderSpanDecorator.java
+++ b/contrib/web_servlet_filter/src/main/java/io/opentelemetry/contrib/web/servlet/filter/decorator/ServletFilterHeaderSpanDecorator.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.web.servlet.filter.decorator;
+
+import io.opentelemetry.contrib.web.servlet.filter.ServletFilterSpanDecorator;
+import io.opentelemetry.trace.Span;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * ServletFilterHeaderSpanDecorator will decorate the span based on incoming HTTP headers. Incoming
+ * are compared to the list of {@link #allowedHeaders}, if the header is part of the provided list,
+ * they will be added as {@link StringTag}. The tag format will be a concatenation of {@link
+ * #prefix} and {@link HeaderEntry#tag}
+ */
+public class ServletFilterHeaderSpanDecorator implements ServletFilterSpanDecorator {
+
+  @Nullable private final String prefix;
+  private final List<HeaderEntry> allowedHeaders;
+
+  /**
+   * Constructor of ServletFilterHeaderSpanDecorator with a default prefix of "http.header."
+   *
+   * @param allowedHeaders list of {@link HeaderEntry} to extract from the incoming request
+   */
+  public ServletFilterHeaderSpanDecorator(List<HeaderEntry> allowedHeaders) {
+    this(allowedHeaders, "http.header.");
+  }
+
+  /**
+   * Constructor of ServletFilterHeaderSpanDecorator
+   *
+   * @param allowedHeaders list of {@link HeaderEntry} to extract from the incoming request
+   * @param prefix the prefix to prepend on each @{@link StringTag}. Can be null is not prefix is
+   *     desired
+   */
+  public ServletFilterHeaderSpanDecorator(List<HeaderEntry> allowedHeaders, String prefix) {
+    this.allowedHeaders = new ArrayList<>(allowedHeaders);
+    this.prefix = (prefix != null && !prefix.isEmpty()) ? prefix : null;
+  }
+
+  @Override
+  public void onRequest(HttpServletRequest httpServletRequest, Span span) {
+    for (HeaderEntry headerEntry : allowedHeaders) {
+      String headerValue = httpServletRequest.getHeader(headerEntry.getHeader());
+      if (headerValue != null && !headerValue.isEmpty()) {
+        span.setAttribute(buildAttrKey(headerEntry.getTag()), headerValue);
+      }
+    }
+  }
+
+  @Override
+  public void onResponse(
+      HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Span span) {}
+
+  @Override
+  public void onError(
+      HttpServletRequest httpServletRequest,
+      HttpServletResponse httpServletResponse,
+      Throwable exception,
+      Span span) {}
+
+  @Override
+  public void onTimeout(
+      HttpServletRequest httpServletRequest,
+      HttpServletResponse httpServletResponse,
+      long timeout,
+      Span span) {}
+
+  private String buildAttrKey(String tag) {
+    if (prefix == null) {
+      return tag;
+    }
+    return prefix + tag;
+  }
+
+  @Nullable
+  public String getPrefix() {
+    return this.prefix;
+  }
+
+  public List<HeaderEntry> getAllowedHeaders() {
+    return this.allowedHeaders;
+  }
+
+  /**
+   * HeaderEntry is used to configure {@link ServletFilterHeaderSpanDecorator} {@link #header} is
+   * used to check if the header exists using {@link HttpServletRequest#getHeader(String)} {@link
+   * #tag} will be used as a {@link StringTag} if {@link #header} is found on the incoming request
+   */
+  public static class HeaderEntry {
+    private final String header;
+    private final String tag;
+
+    /**
+     * @param header Header on the {@link HttpServletRequest}
+     * @param tag Tag to be used if {@link #header} is found
+     */
+    public HeaderEntry(String header, String tag) {
+      this.header = header;
+      this.tag = tag;
+    }
+
+    public String getHeader() {
+      return this.header;
+    }
+
+    public String getTag() {
+      return this.tag;
+    }
+  }
+}

--- a/contrib/web_servlet_filter/src/main/java/io/opentelemetry/contrib/web/servlet/filter/decorator/ServletFilterHeaderSpanDecorator.java
+++ b/contrib/web_servlet_filter/src/main/java/io/opentelemetry/contrib/web/servlet/filter/decorator/ServletFilterHeaderSpanDecorator.java
@@ -45,7 +45,7 @@ public class ServletFilterHeaderSpanDecorator implements ServletFilterSpanDecora
   }
 
   /**
-   * Constructor of ServletFilterHeaderSpanDecorator
+   * Constructor of ServletFilterHeaderSpanDecorator.
    *
    * @param allowedHeaders list of {@link HeaderEntry} to extract from the incoming request
    * @param prefix the prefix to prepend on each @{@link StringTag}. Can be null is not prefix is
@@ -103,13 +103,15 @@ public class ServletFilterHeaderSpanDecorator implements ServletFilterSpanDecora
   /**
    * HeaderEntry is used to configure {@link ServletFilterHeaderSpanDecorator} {@link #header} is
    * used to check if the header exists using {@link HttpServletRequest#getHeader(String)} {@link
-   * #tag} will be used as a {@link StringTag} if {@link #header} is found on the incoming request
+   * #tag} will be used as a {@link StringTag} if {@link #header} is found on the incoming request.
    */
   public static class HeaderEntry {
     private final String header;
     private final String tag;
 
     /**
+     * Summary.
+     *
      * @param header Header on the {@link HttpServletRequest}
      * @param tag Tag to be used if {@link #header} is found
      */

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/BaseShimObject.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/BaseShimObject.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.opentracingshim;
 
-import io.opentelemetry.distributedcontext.DistributedContextManager;
+import io.opentelemetry.distributedcontext.CorrelationContextManager;
 import io.opentelemetry.trace.Tracer;
 
 abstract class BaseShimObject {
@@ -34,7 +34,7 @@ abstract class BaseShimObject {
     return telemetryInfo.tracer();
   }
 
-  DistributedContextManager contextManager() {
+  CorrelationContextManager contextManager() {
     return telemetryInfo.contextManager();
   }
 }

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/Propagation.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/Propagation.java
@@ -46,7 +46,7 @@ final class Propagation extends BaseShimObject {
 
     io.opentelemetry.trace.SpanContext context =
         tracer().getHttpTextFormat().extract(carrierMap, TextMapGetter.INSTANCE);
-    io.opentelemetry.distributedcontext.DistributedContext distContext =
+    io.opentelemetry.distributedcontext.CorrelationContext distContext =
         contextManager().getHttpTextFormat().extract(carrierMap, TextMapGetter.INSTANCE);
 
     return new SpanContextShim(telemetryInfo, context, distContext);

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/TelemetryInfo.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/TelemetryInfo.java
@@ -16,8 +16,8 @@
 
 package io.opentelemetry.opentracingshim;
 
-import io.opentelemetry.distributedcontext.DistributedContext;
-import io.opentelemetry.distributedcontext.DistributedContextManager;
+import io.opentelemetry.distributedcontext.CorrelationContext;
+import io.opentelemetry.distributedcontext.CorrelationContextManager;
 import io.opentelemetry.trace.Tracer;
 
 /**
@@ -26,11 +26,11 @@ import io.opentelemetry.trace.Tracer;
  */
 final class TelemetryInfo {
   private final Tracer tracer;
-  private final DistributedContextManager contextManager;
-  private final DistributedContext emptyDistributedContext;
+  private final CorrelationContextManager contextManager;
+  private final CorrelationContext emptyDistributedContext;
   private final SpanContextShimTable spanContextShimTable;
 
-  TelemetryInfo(Tracer tracer, DistributedContextManager contextManager) {
+  TelemetryInfo(Tracer tracer, CorrelationContextManager contextManager) {
     this.tracer = tracer;
     this.contextManager = contextManager;
     this.emptyDistributedContext = contextManager.contextBuilder().build();
@@ -41,7 +41,7 @@ final class TelemetryInfo {
     return tracer;
   }
 
-  DistributedContextManager contextManager() {
+  CorrelationContextManager contextManager() {
     return contextManager;
   }
 
@@ -49,7 +49,7 @@ final class TelemetryInfo {
     return spanContextShimTable;
   }
 
-  DistributedContext emptyDistributedContext() {
+  CorrelationContext emptyDistributedContext() {
     return emptyDistributedContext;
   }
 }

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/TraceShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/TraceShim.java
@@ -17,7 +17,7 @@
 package io.opentelemetry.opentracingshim;
 
 import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.distributedcontext.DistributedContextManager;
+import io.opentelemetry.distributedcontext.CorrelationContextManager;
 import io.opentelemetry.internal.Utils;
 import io.opentelemetry.trace.Tracer;
 
@@ -48,7 +48,7 @@ public final class TraceShim {
    * @since 0.1.0
    */
   public static io.opentracing.Tracer createTracerShim(
-      Tracer tracer, DistributedContextManager contextManager) {
+      Tracer tracer, CorrelationContextManager contextManager) {
     Utils.checkNotNull(tracer, "tracer");
     Utils.checkNotNull(contextManager, "contextManager");
     return new TracerShim(new TelemetryInfo(tracer, contextManager));

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/TraceShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/TraceShim.java
@@ -35,7 +35,7 @@ public final class TraceShim {
     return new TracerShim(
         new TelemetryInfo(
             OpenTelemetry.getTracerFactory().get("opentracingshim"),
-            OpenTelemetry.getDistributedContextManager()));
+            OpenTelemetry.getCorrelationContextManager()));
   }
 
   /**

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import io.opentelemetry.sdk.distributedcontext.DistributedContextManagerSdk;
+import io.opentelemetry.sdk.distributedcontext.CorrelationContextManagerSdk;
 import io.opentelemetry.sdk.trace.TracerSdk;
 import java.util.HashMap;
 import java.util.Map;
@@ -38,7 +38,7 @@ public class SpanShimTest {
 
   @Before
   public void setUp() {
-    telemetryInfo = new TelemetryInfo(new TracerSdk(), new DistributedContextManagerSdk());
+    telemetryInfo = new TelemetryInfo(new TracerSdk(), new CorrelationContextManagerSdk());
     span = telemetryInfo.tracer().spanBuilder(SPAN_NAME).startSpan();
   }
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/TraceShimTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/TraceShimTest.java
@@ -29,12 +29,12 @@ public class TraceShimTest {
   public void createTracerShim_default() {
     TracerShim tracerShim = (TracerShim) TraceShim.createTracerShim();
     assertEquals(OpenTelemetry.getTracerFactory().get("opentracingshim"), tracerShim.tracer());
-    assertEquals(OpenTelemetry.getDistributedContextManager(), tracerShim.contextManager());
+    assertEquals(OpenTelemetry.getCorrelationContextManager(), tracerShim.contextManager());
   }
 
   @Test(expected = NullPointerException.class)
   public void createTracerShim_nullTracer() {
-    TraceShim.createTracerShim(null, OpenTelemetry.getDistributedContextManager());
+    TraceShim.createTracerShim(null, OpenTelemetry.getCorrelationContextManager());
   }
 
   @Test(expected = NullPointerException.class)

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/TraceShimTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/TraceShimTest.java
@@ -19,7 +19,7 @@ package io.opentelemetry.opentracingshim;
 import static org.junit.Assert.assertEquals;
 
 import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.sdk.distributedcontext.DistributedContextManagerSdk;
+import io.opentelemetry.sdk.distributedcontext.CorrelationContextManagerSdk;
 import io.opentelemetry.sdk.trace.TracerSdk;
 import org.junit.Test;
 
@@ -45,7 +45,7 @@ public class TraceShimTest {
   @Test
   public void createTracerShim() {
     TracerSdk tracer = new TracerSdk();
-    DistributedContextManagerSdk contextManager = new DistributedContextManagerSdk();
+    CorrelationContextManagerSdk contextManager = new CorrelationContextManagerSdk();
     TracerShim tracerShim = (TracerShim) TraceShim.createTracerShim(tracer, contextManager);
     assertEquals(tracer, tracerShim.tracer());
     assertEquals(contextManager, tracerShim.contextManager());

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/TracerShimTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/TracerShimTest.java
@@ -41,7 +41,7 @@ public class TracerShimTest {
         new TracerShim(
             new TelemetryInfo(
                 OpenTelemetry.getTracerFactory().get("opentracingshim"),
-                OpenTelemetry.getDistributedContextManager()));
+                OpenTelemetry.getCorrelationContextManager()));
   }
 
   @Test

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
@@ -19,7 +19,7 @@ package io.opentelemetry.opentracingshim.testbed;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import io.opentelemetry.distributedcontext.DefaultDistributedContextManager;
+import io.opentelemetry.distributedcontext.DefaultCorrelationContextManager;
 import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.opentracingshim.TraceShim;
 import io.opentelemetry.sdk.trace.SpanData;
@@ -37,7 +37,7 @@ public class OpenTelemetryInteroperabilityTest {
   private final TracerSdk sdk = new TracerSdk();
   private final InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
   private final Tracer otTracer =
-      TraceShim.createTracerShim(sdk, DefaultDistributedContextManager.getInstance());
+      TraceShim.createTracerShim(sdk, DefaultCorrelationContextManager.getInstance());
 
   {
     sdk.addSpanProcessor(SimpleSpansProcessor.newBuilder(spanExporter).build());

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/TestUtils.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/TestUtils.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertTrue;
 
 import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;
 import io.opentelemetry.opentracingshim.TraceShim;
-import io.opentelemetry.sdk.distributedcontext.DistributedContextManagerSdk;
+import io.opentelemetry.sdk.distributedcontext.CorrelationContextManagerSdk;
 import io.opentelemetry.sdk.trace.SpanData;
 import io.opentelemetry.sdk.trace.TracerSdk;
 import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
@@ -47,7 +47,7 @@ public final class TestUtils {
   public static Tracer createTracerShim(InMemorySpanExporter exporter) {
     TracerSdk tracer = new TracerSdk();
     tracer.addSpanProcessor(SimpleSpansProcessor.newBuilder(exporter).build());
-    return TraceShim.createTracerShim(tracer, new DistributedContextManagerSdk());
+    return TraceShim.createTracerShim(tracer, new CorrelationContextManagerSdk());
   }
 
   /** Returns the number of finished {@code Span}s in the specified {@code InMemorySpanExporter}. */

--- a/sdk/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -57,11 +57,11 @@ public final class OpenTelemetrySdk {
   /**
    * Returns a {@link CorrelationContextManagerSdk}.
    *
-   * @return context manager returned by {@link OpenTelemetry#getDistributedContextManager()}.
+   * @return context manager returned by {@link OpenTelemetry#getCorrelationContextManager()}.
    * @since 0.1.0
    */
   public static CorrelationContextManagerSdk getDistributedContextManager() {
-    return (CorrelationContextManagerSdk) OpenTelemetry.getDistributedContextManager();
+    return (CorrelationContextManagerSdk) OpenTelemetry.getCorrelationContextManager();
   }
 
   private OpenTelemetrySdk() {}

--- a/sdk/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -17,7 +17,7 @@
 package io.opentelemetry.sdk;
 
 import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.sdk.distributedcontext.DistributedContextManagerSdk;
+import io.opentelemetry.sdk.distributedcontext.CorrelationContextManagerSdk;
 import io.opentelemetry.sdk.metrics.MeterSdk;
 import io.opentelemetry.sdk.trace.TracerSdk;
 import io.opentelemetry.sdk.trace.TracerSdkFactory;
@@ -25,7 +25,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * This class provides a static global accessor for SDK telemetry objects {@link TracerSdk}, {@link
- * MeterSdk} and {@link DistributedContextManagerSdk}.
+ * MeterSdk} and {@link CorrelationContextManagerSdk}.
  *
  * <p>This is a convenience class getting and casting the telemetry objects from {@link
  * OpenTelemetry}.
@@ -55,13 +55,13 @@ public final class OpenTelemetrySdk {
   }
 
   /**
-   * Returns a {@link DistributedContextManagerSdk}.
+   * Returns a {@link CorrelationContextManagerSdk}.
    *
    * @return context manager returned by {@link OpenTelemetry#getDistributedContextManager()}.
    * @since 0.1.0
    */
-  public static DistributedContextManagerSdk getDistributedContextManager() {
-    return (DistributedContextManagerSdk) OpenTelemetry.getDistributedContextManager();
+  public static CorrelationContextManagerSdk getDistributedContextManager() {
+    return (CorrelationContextManagerSdk) OpenTelemetry.getDistributedContextManager();
   }
 
   private OpenTelemetrySdk() {}

--- a/sdk/src/main/java/io/opentelemetry/sdk/distributedcontext/CorrelationContextManagerSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/distributedcontext/CorrelationContextManagerSdk.java
@@ -19,40 +19,40 @@ package io.opentelemetry.sdk.distributedcontext;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.BinaryFormat;
 import io.opentelemetry.context.propagation.HttpTextFormat;
-import io.opentelemetry.distributedcontext.DefaultDistributedContextManager;
-import io.opentelemetry.distributedcontext.DistributedContext;
-import io.opentelemetry.distributedcontext.DistributedContextManager;
+import io.opentelemetry.distributedcontext.CorrelationContext;
+import io.opentelemetry.distributedcontext.CorrelationContextManager;
+import io.opentelemetry.distributedcontext.DefaultCorrelationContextManager;
 import io.opentelemetry.distributedcontext.unsafe.ContextUtils;
 
 /**
- * {@link DistributedContextManagerSdk} is SDK implementation of {@link DistributedContextManager}.
+ * {@link CorrelationContextManagerSdk} is SDK implementation of {@link CorrelationContextManager}.
  */
-public class DistributedContextManagerSdk implements DistributedContextManager {
+public class CorrelationContextManagerSdk implements CorrelationContextManager {
 
   @Override
-  public DistributedContext getCurrentContext() {
+  public CorrelationContext getCurrentContext() {
     return ContextUtils.getValue();
   }
 
   @Override
-  public DistributedContext.Builder contextBuilder() {
-    return new DistributedContextSdk.Builder();
+  public CorrelationContext.Builder contextBuilder() {
+    return new CorrelationContextSdk.Builder();
   }
 
   @Override
-  public Scope withContext(DistributedContext distContext) {
+  public Scope withContext(CorrelationContext distContext) {
     return ContextUtils.withDistributedContext(distContext);
   }
 
   @Override
-  public BinaryFormat<DistributedContext> getBinaryFormat() {
+  public BinaryFormat<CorrelationContext> getBinaryFormat() {
     // TODO: Implement this.
-    return DefaultDistributedContextManager.getInstance().getBinaryFormat();
+    return DefaultCorrelationContextManager.getInstance().getBinaryFormat();
   }
 
   @Override
-  public HttpTextFormat<DistributedContext> getHttpTextFormat() {
+  public HttpTextFormat<CorrelationContext> getHttpTextFormat() {
     // TODO: Implement this.
-    return DefaultDistributedContextManager.getInstance().getHttpTextFormat();
+    return DefaultCorrelationContextManager.getInstance().getHttpTextFormat();
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/distributedcontext/CorrelationContextManagerSdkProvider.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/distributedcontext/CorrelationContextManagerSdkProvider.java
@@ -16,20 +16,20 @@
 
 package io.opentelemetry.sdk.distributedcontext;
 
-import io.opentelemetry.distributedcontext.DistributedContextManager;
-import io.opentelemetry.distributedcontext.spi.DistributedContextManagerProvider;
+import io.opentelemetry.distributedcontext.CorrelationContextManager;
+import io.opentelemetry.distributedcontext.spi.CorrelationContextManagerProvider;
 
 /**
  * {@code DistributedContextManager} provider implementation for {@link
- * io.opentelemetry.distributedcontext.spi.DistributedContextManagerProvider}.
+ * io.opentelemetry.distributedcontext.spi.CorrelationContextManagerProvider}.
  *
  * <p>This class is not intended to be used in application code and it is used only by {@link
  * io.opentelemetry.OpenTelemetry}.
  */
-public class DistributedContextManagerSdkProvider implements DistributedContextManagerProvider {
+public class CorrelationContextManagerSdkProvider implements CorrelationContextManagerProvider {
 
   @Override
-  public DistributedContextManager create() {
-    return new DistributedContextManagerSdk();
+  public CorrelationContextManager create() {
+    return new CorrelationContextManagerSdk();
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/distributedcontext/CorrelationContextSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/distributedcontext/CorrelationContextSdk.java
@@ -156,7 +156,7 @@ class CorrelationContextSdk implements CorrelationContext {
     @Override
     public CorrelationContextSdk build() {
       if (parent == null && !noImplicitParent) {
-        parent = OpenTelemetry.getDistributedContextManager().getCurrentContext();
+        parent = OpenTelemetry.getCorrelationContextManager().getCurrentContext();
       }
       return new CorrelationContextSdk(entries, parent);
     }

--- a/sdk/src/main/resources/META-INF/services/io.opentelemetry.distributedcontext.spi.CorrelationContextManagerProvider
+++ b/sdk/src/main/resources/META-INF/services/io.opentelemetry.distributedcontext.spi.CorrelationContextManagerProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.sdk.distributedcontext.CorrelationContextManagerSdkProvider

--- a/sdk/src/main/resources/META-INF/services/io.opentelemetry.distributedcontext.spi.DistributedContextManagerProvider
+++ b/sdk/src/main/resources/META-INF/services/io.opentelemetry.distributedcontext.spi.DistributedContextManagerProvider
@@ -1,1 +1,0 @@
-io.opentelemetry.sdk.distributedcontext.DistributedContextManagerSdkProvider

--- a/sdk/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -31,7 +31,7 @@ public class OpenTelemetrySdkTest {
     assertThat(OpenTelemetrySdk.getTracerFactory())
         .isSameInstanceAs(OpenTelemetry.getTracerFactory());
     assertThat(OpenTelemetrySdk.getDistributedContextManager())
-        .isSameInstanceAs(OpenTelemetry.getDistributedContextManager());
+        .isSameInstanceAs(OpenTelemetry.getCorrelationContextManager());
     assertThat(OpenTelemetrySdk.getMeter()).isSameInstanceAs(OpenTelemetry.getMeter());
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/distributedcontext/DistributedContextManagerSdkProviderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/distributedcontext/DistributedContextManagerSdkProviderTest.java
@@ -27,7 +27,7 @@ public class DistributedContextManagerSdkProviderTest {
 
   @Test
   public void testDefault() {
-    assertThat(new DistributedContextManagerSdkProvider().create())
-        .isInstanceOf(DistributedContextManagerSdk.class);
+    assertThat(new CorrelationContextManagerSdkProvider().create())
+        .isInstanceOf(CorrelationContextManagerSdk.class);
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/distributedcontext/DistributedContextManagerSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/distributedcontext/DistributedContextManagerSdkTest.java
@@ -20,8 +20,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 import io.grpc.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.distributedcontext.DistributedContext;
-import io.opentelemetry.distributedcontext.EmptyDistributedContext;
+import io.opentelemetry.distributedcontext.CorrelationContext;
+import io.opentelemetry.distributedcontext.EmptyCorrelationContext;
 import io.opentelemetry.distributedcontext.unsafe.ContextUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,14 +30,14 @@ import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-/** Unit tests for {@link DistributedContextManagerSdk}. */
+/** Unit tests for {@link CorrelationContextManagerSdk}. */
 @RunWith(JUnit4.class)
 // Need to suppress warnings for MustBeClosed because Android 14 does not support
 // try-with-resources.
 @SuppressWarnings("MustBeClosedChecker")
 public class DistributedContextManagerSdkTest {
-  @Mock private DistributedContext distContext;
-  private final DistributedContextManagerSdk contextManager = new DistributedContextManagerSdk();
+  @Mock private CorrelationContext distContext;
+  private final CorrelationContextManagerSdk contextManager = new CorrelationContextManagerSdk();
 
   @Before
   public void setUp() {
@@ -47,14 +47,14 @@ public class DistributedContextManagerSdkTest {
   @Test
   public void testGetCurrentContext_DefaultContext() {
     assertThat(contextManager.getCurrentContext())
-        .isSameInstanceAs(EmptyDistributedContext.getInstance());
+        .isSameInstanceAs(EmptyCorrelationContext.getInstance());
   }
 
   @Test
   public void testGetCurrentContext_ContextSetToNull() {
     Context orig = ContextUtils.withValue(null).attach();
     try {
-      DistributedContext distContext = contextManager.getCurrentContext();
+      CorrelationContext distContext = contextManager.getCurrentContext();
       assertThat(distContext).isNotNull();
       assertThat(distContext.getEntries()).isEmpty();
     } finally {
@@ -65,7 +65,7 @@ public class DistributedContextManagerSdkTest {
   @Test
   public void testWithDistributedContext() {
     assertThat(contextManager.getCurrentContext())
-        .isSameInstanceAs(EmptyDistributedContext.getInstance());
+        .isSameInstanceAs(EmptyCorrelationContext.getInstance());
     Scope wtm = contextManager.withContext(distContext);
     try {
       assertThat(contextManager.getCurrentContext()).isSameInstanceAs(distContext);
@@ -73,7 +73,7 @@ public class DistributedContextManagerSdkTest {
       wtm.close();
     }
     assertThat(contextManager.getCurrentContext())
-        .isSameInstanceAs(EmptyDistributedContext.getInstance());
+        .isSameInstanceAs(EmptyCorrelationContext.getInstance());
   }
 
   @Test
@@ -95,7 +95,7 @@ public class DistributedContextManagerSdkTest {
       wtm.close();
     }
     assertThat(contextManager.getCurrentContext())
-        .isSameInstanceAs(EmptyDistributedContext.getInstance());
+        .isSameInstanceAs(EmptyCorrelationContext.getInstance());
     // When we run the runnable we will have the DistributedContext in the current Context.
     runnable.run();
   }

--- a/sdk/src/test/java/io/opentelemetry/sdk/distributedcontext/DistributedContextTestUtil.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/distributedcontext/DistributedContextTestUtil.java
@@ -16,19 +16,19 @@
 
 package io.opentelemetry.sdk.distributedcontext;
 
-import io.opentelemetry.distributedcontext.Entry;
+import io.opentelemetry.distributedcontext.Label;
 import java.util.Arrays;
 import java.util.List;
 
 class DistributedContextTestUtil {
 
-  static DistributedContextSdk listToDistributedContext(Entry... entries) {
+  static CorrelationContextSdk listToDistributedContext(Label... entries) {
     return listToDistributedContext(Arrays.asList(entries));
   }
 
-  static DistributedContextSdk listToDistributedContext(List<Entry> entries) {
-    DistributedContextSdk.Builder builder = new DistributedContextSdk.Builder();
-    for (Entry entry : entries) {
+  static CorrelationContextSdk listToDistributedContext(List<Label> entries) {
+    CorrelationContextSdk.Builder builder = new CorrelationContextSdk.Builder();
+    for (Label entry : entries) {
       builder.put(entry.getKey(), entry.getValue(), entry.getEntryMetadata());
     }
     return builder.build();

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,9 @@ include ":opentelemetry-sdk"
 include ":opentelemetry-sdk-contrib-async-processor"
 include ":opentelemetry-sdk-contrib-testbed"
 
+// context-prop prototype
+include ":opentelemetry-contrib-web-servlet-filter"
+
 project(':opentelemetry-all').projectDir = "$rootDir/all" as File
 project(':opentelemetry-api').projectDir = "$rootDir/api" as File
 project(':opentelemetry-proto').projectDir = "$rootDir/proto" as File
@@ -36,3 +39,7 @@ project(':opentelemetry-sdk-contrib-async-processor').projectDir =
         "$rootDir/sdk_contrib/async_processor" as File
 project(':opentelemetry-sdk-contrib-testbed').projectDir =
         "$rootDir/sdk_contrib/testbed" as File
+
+// context-prop prototype
+project(':opentelemetry-contrib-web-servlet-filter').projectDir =
+        "$rootDir/contrib/web_servlet_filter" as File


### PR DESCRIPTION
This is an initial prototype for the [context-prop](https://github.com/open-telemetry/oteps/pull/42) changes - below is a summary of the changes, in addition to a possible alternative approach for this (also, this prototype is meant to be reviewed by non-Javaers, in order to validate the contest-prop proposal).

Observe that the main code is not touched, and only the new classes have been added (I had intended to re-adjust the entire code base, which I'd be happy to do once we decide the path to take).

Also, `DistributedContext` and its related class would be removed under this initial protoype.

## Summary

### Context

The current effort makes `Context` an explicit parameter for all related operations - with the help of `Context.current()`, which makes the current instance available **all time**. This `Context` class acts as layer on top of `io.grpc.Context`, in case we/some vendor want to replace with something else (while also hiding advanced features, such as cancellation). 

```java
Context ctx = OpenTelemetry.baggageManager().setValue(Context.current(), "val1", "key1");
try (Scope scope = Context.setCurrent(ctx)) {
   OpenTelemetry.baggageManager().getValue(Context.current(), "val1");
}
```

Actual top-level objects (active `Span`, the container for baggage, the container for correlations, etc) all live in its own bucket within `Context`, which can be set/accessed through a key object, which is kept privately by each owner (and accessible to the `Injector`/`Extractor` in turn):

```java
class TracerSdk {
    static final Context.Key currentSpanKey = Context.createKey("activeSpan");
    Span getCurrentSpan() {
        return Context.current().getValue(currentSpanKey);
    }
```

Simple string keys cannot be used to access the underlying object, as a limitation imposed by `io.grpc.Context`. But direct access to the objects in `Context` could be offered (as opposed to have convenience methods such as `Tracer.getCurrentSpan()`), through exposing a set of predefined keys:

```java
CURRENT_SPAN_KEY = Context.createKey("currentSpan");
CURRENT_CORRELATIONS_KEY = Context.createKey("currentCorrelations");
...
    span = Context.current().getValue(CURRENT_SPAN_KEY);
```

**Question:** Should we make this interface, and make it pluggable as part of the `OpenTelemetry` object? Then it could be accessed through `OpenTelemetry.getContextManager().current()`.

### Baggage/Correlation managers

No direct access would exist to the baggage/correlation containers, and such values would have to be fetched through their respective managers:

```java
ctx = OpenTelemetry.baggageManager().setValue(Context.current(), "key1", "val1");
ctx = OpenTelemetry.correlationManager().setValue(Context.current(),
                       label, HopLimit.NO_PROPAGATION);

String val = OpenTelemetry.baggageManager().getValue(ctx, "key1");
```

### Propagators

Injectors/extractors would work directly with a `Context` object, fetching each own the bucket they want and work with it:

```java
import static com.myimplementation.InternalContextKeys.BAGGAGE_KEY; 

class HttpInjectorSdk implements HttpInjector {
    @Override
    public <C> void inject(Context ctx, C carrier, Setter<C> setter) {
        BaggageSdk baggageSdk = (BaggageSdk) ctx.getValue(BAGGAGE_KEY);
        ....
    }
}
```

## Alternative approach

During playing with the approach above, I though about an alternative approach:

- Make `Context` an explicit component (just like above) which works mostly **behind the scenes**.
- Rename `DistributedContext` to `CorrelationContext` and adjust the operations (remove `getEntryValue()`, etc).
- Create a new `BaggageContext` object, with the set/clear operations (`BagaggeContext.removeValue()`, for example).
- Have operations such as `Tracer.getCurrentSpan()` and `CorrelationContext.setCurrent()` stay, which would work with `Context` behind the scenes, implicitly (so the user does not have to think of the context all the time). `Context` could, however, be accessed **all the time** as an advanced feature.
- Propagators would be the only component using `Context` directly, so **Injection/Extraction** can be done in a single step.

Code with this design would look like this:

```java
Context ctx = extractor.extract(...);
try (Scope scope = Context.setCurrent(ctx)) {
   // Do work
   // ...
   try (Span span = tracer.setCurrent(span)) {
       // Context.current() would hold the current Span behind the scenes.
       // ...
      injector.inject(Context.current(), ...);
   }
}
```