### PR TITLE
Use emptyDistributedContext if the DistributedContext from parent is unavailable

### DIFF
--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
@@ -210,9 +210,10 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
 
     SpanShim spanShim = new SpanShim(telemetryInfo(), span);
 
-    if (distContext != null && distContext != telemetryInfo().emptyDistributedContext()) {
-      spanContextTable().create(spanShim, distContext);
+    if (distContext == null) {
+      distContext = telemetryInfo().emptyDistributedContext();
     }
+    spanContextTable().create(spanShim, distContext);
 
     return spanShim;
   }


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-java/issues/671 Alt2