### PR TITLE
Add LabelSet to the Meter API and change GetHandle to use it.

### DIFF
--- a/api/src/main/java/io/opentelemetry/metrics/CounterDouble.java
+++ b/api/src/main/java/io/opentelemetry/metrics/CounterDouble.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.metrics;
 
 import io.opentelemetry.metrics.CounterDouble.Handle;
-import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -54,7 +53,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface CounterDouble extends Counter<Handle> {
 
   @Override
-  Handle getHandle(List<String> labelValues);
+  Handle getHandle(LabelSet labelSet);
 
   @Override
   Handle getDefaultHandle();

--- a/api/src/main/java/io/opentelemetry/metrics/CounterLong.java
+++ b/api/src/main/java/io/opentelemetry/metrics/CounterLong.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.metrics;
 
 import io.opentelemetry.metrics.CounterLong.Handle;
-import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -54,7 +53,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface CounterLong extends Metric<Handle> {
 
   @Override
-  Handle getHandle(List<String> labelValues);
+  Handle getHandle(LabelSet labelSet);
 
   @Override
   Handle getDefaultHandle();

--- a/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
@@ -126,7 +126,7 @@ public final class DefaultMeter implements Meter {
   @Override
   public LabelSet createLabelSet(String k1, String v1) {
     Utils.checkNotNull(k1, "k1");
-    Utils.checkNotNull(v1, "k1");
+    Utils.checkNotNull(v1, "v1");
     return NoopLabelSet.INSTANCE;
   }
 

--- a/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
@@ -133,7 +133,7 @@ public final class DefaultMeter implements Meter {
   @Override
   public LabelSet createLabelSet(String k1, String v1, String k2, String v2) {
     Utils.checkNotNull(k1, "k1");
-    Utils.checkNotNull(v1, "k1");
+    Utils.checkNotNull(v1, "v1");
     Utils.checkNotNull(k2, "k2");
     Utils.checkNotNull(v2, "v2");
     return NoopLabelSet.INSTANCE;

--- a/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
@@ -142,7 +142,7 @@ public final class DefaultMeter implements Meter {
   @Override
   public LabelSet createLabelSet(String k1, String v1, String k2, String v2, String k3, String v3) {
     Utils.checkNotNull(k1, "k1");
-    Utils.checkNotNull(v1, "k1");
+    Utils.checkNotNull(v1, "v1");
     Utils.checkNotNull(k2, "k2");
     Utils.checkNotNull(v2, "v2");
     Utils.checkNotNull(k3, "k3");

--- a/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
@@ -123,38 +123,73 @@ public final class DefaultMeter implements Meter {
     return new NoopBatchRecorder();
   }
 
+  @Override
+  public LabelSet createLabelSet(String k1, String v1) {
+    Utils.checkNotNull(k1, "k1");
+    Utils.checkNotNull(v1, "k1");
+    return NoopLabelSet.INSTANCE;
+  }
+
+  @Override
+  public LabelSet createLabelSet(String k1, String v1, String k2, String v2) {
+    Utils.checkNotNull(k1, "k1");
+    Utils.checkNotNull(v1, "k1");
+    Utils.checkNotNull(k2, "k2");
+    Utils.checkNotNull(v2, "v2");
+    return NoopLabelSet.INSTANCE;
+  }
+
+  @Override
+  public LabelSet createLabelSet(String k1, String v1, String k2, String v2, String k3, String v3) {
+    Utils.checkNotNull(k1, "k1");
+    Utils.checkNotNull(v1, "k1");
+    Utils.checkNotNull(k2, "k2");
+    Utils.checkNotNull(v2, "v2");
+    Utils.checkNotNull(k3, "k3");
+    Utils.checkNotNull(v3, "v3");
+    return NoopLabelSet.INSTANCE;
+  }
+
+  @Override
+  public LabelSet createLabelSet(
+      String k1, String v1, String k2, String v2, String k3, String v3, String k4, String v4) {
+    Utils.checkNotNull(k1, "k1");
+    Utils.checkNotNull(v1, "k1");
+    Utils.checkNotNull(k2, "k2");
+    Utils.checkNotNull(v2, "v2");
+    Utils.checkNotNull(k3, "k3");
+    Utils.checkNotNull(v3, "v3");
+    Utils.checkNotNull(k4, "k4");
+    Utils.checkNotNull(v4, "v4");
+    return NoopLabelSet.INSTANCE;
+  }
+
   /** No-op implementations of GaugeLong class. */
   @Immutable
   private static final class NoopGaugeLong implements GaugeLong {
-    private final int labelKeysSize;
-
     /** Creates a new {@code NoopHandle}. */
-    private NoopGaugeLong(int labelKeysSize) {
-      this.labelKeysSize = labelKeysSize;
-    }
+    private NoopGaugeLong() {}
 
     @Override
-    public NoopHandle getHandle(List<String> labelValues) {
-      Utils.checkNotNull(labelValues, "labelValues");
-      Utils.checkArgument(
-          labelKeysSize == labelValues.size(), "Label Keys and Label Values don't have same size.");
-      return new NoopHandle();
+    public NoopHandle getHandle(LabelSet labelSet) {
+      Utils.checkNotNull(labelSet, "labelSet");
+      return NoopHandle.INSTANCE;
     }
 
     @Override
     public NoopHandle getDefaultHandle() {
-      return new NoopHandle();
+      return NoopHandle.INSTANCE;
     }
 
     @Override
-    public void removeHandle(List<String> labelValues) {
-      Utils.checkNotNull(labelValues, "labelValues");
+    public void removeHandle(Handle handle) {
+      Utils.checkNotNull(handle, "handle");
     }
 
     /** No-op implementations of Handle class. */
     @Immutable
-    private static final class NoopHandle implements Handle {
-      private NoopHandle() {}
+    private enum NoopHandle implements Handle {
+      INSTANCE;
 
       @Override
       public void set(long val) {}
@@ -169,7 +204,7 @@ public final class DefaultMeter implements Meter {
 
       @Override
       public GaugeLong build() {
-        return new NoopGaugeLong(labelKeysSize);
+        return new NoopGaugeLong();
       }
     }
   }
@@ -177,35 +212,29 @@ public final class DefaultMeter implements Meter {
   /** No-op implementations of GaugeDouble class. */
   @Immutable
   private static final class NoopGaugeDouble implements GaugeDouble {
-    private final int labelKeysSize;
-
     /** Creates a new {@code NoopHandle}. */
-    private NoopGaugeDouble(int labelKeysSize) {
-      this.labelKeysSize = labelKeysSize;
-    }
+    private NoopGaugeDouble() {}
 
     @Override
-    public NoopHandle getHandle(List<String> labelValues) {
-      Utils.checkNotNull(labelValues, "labelValues");
-      Utils.checkArgument(
-          labelKeysSize == labelValues.size(), "Label Keys and Label Values don't have same size.");
-      return new NoopHandle();
+    public NoopHandle getHandle(LabelSet labelSet) {
+      Utils.checkNotNull(labelSet, "labelSet");
+      return NoopHandle.INSTANCE;
     }
 
     @Override
     public NoopHandle getDefaultHandle() {
-      return new NoopHandle();
+      return NoopHandle.INSTANCE;
     }
 
     @Override
-    public void removeHandle(List<String> labelValues) {
-      Utils.checkNotNull(labelValues, "labelValues");
+    public void removeHandle(Handle handle) {
+      Utils.checkNotNull(handle, "handle");
     }
 
     /** No-op implementations of Handle class. */
     @Immutable
-    private static final class NoopHandle implements Handle {
-      private NoopHandle() {}
+    private enum NoopHandle implements Handle {
+      INSTANCE;
 
       @Override
       public void set(double val) {}
@@ -220,7 +249,7 @@ public final class DefaultMeter implements Meter {
 
       @Override
       public GaugeDouble build() {
-        return new NoopGaugeDouble(labelKeysSize);
+        return new NoopGaugeDouble();
       }
     }
   }
@@ -228,18 +257,12 @@ public final class DefaultMeter implements Meter {
   /** No-op implementations of CounterDouble class. */
   @Immutable
   private static final class NoopCounterDouble implements CounterDouble {
-    private final int labelKeysSize;
-
     /** Creates a new {@code NoopHandle}. */
-    private NoopCounterDouble(int labelKeysSize) {
-      this.labelKeysSize = labelKeysSize;
-    }
+    private NoopCounterDouble() {}
 
     @Override
-    public NoopHandle getHandle(List<String> labelValues) {
-      Utils.checkNotNull(labelValues, "labelValues");
-      Utils.checkArgument(
-          labelKeysSize == labelValues.size(), "Label Keys and Label Values don't have same size.");
+    public NoopHandle getHandle(LabelSet labelSet) {
+      Utils.checkNotNull(labelSet, "labelSet");
       return NoopHandle.INSTANCE;
     }
 
@@ -249,16 +272,14 @@ public final class DefaultMeter implements Meter {
     }
 
     @Override
-    public void removeHandle(List<String> labelValues) {
-      Utils.checkNotNull(labelValues, "labelValues");
+    public void removeHandle(Handle handle) {
+      Utils.checkNotNull(handle, "handle");
     }
 
     /** No-op implementations of Handle class. */
     @Immutable
-    private static final class NoopHandle implements Handle {
-      private static final NoopHandle INSTANCE = new NoopHandle();
-
-      private NoopHandle() {}
+    private enum NoopHandle implements Handle {
+      INSTANCE;
 
       @Override
       public void add(double delta) {}
@@ -273,7 +294,7 @@ public final class DefaultMeter implements Meter {
 
       @Override
       public CounterDouble build() {
-        return new NoopCounterDouble(labelKeysSize);
+        return new NoopCounterDouble();
       }
     }
   }
@@ -281,18 +302,12 @@ public final class DefaultMeter implements Meter {
   /** No-op implementations of CounterLong class. */
   @Immutable
   private static final class NoopCounterLong implements CounterLong {
-    private final int labelKeysSize;
-
     /** Creates a new {@code NoopHandle}. */
-    private NoopCounterLong(int labelKeysSize) {
-      this.labelKeysSize = labelKeysSize;
-    }
+    private NoopCounterLong() {}
 
     @Override
-    public NoopHandle getHandle(List<String> labelValues) {
-      Utils.checkNotNull(labelValues, "labelValues");
-      Utils.checkArgument(
-          labelKeysSize == labelValues.size(), "Label Keys and Label Values don't have same size.");
+    public NoopHandle getHandle(LabelSet labelSet) {
+      Utils.checkNotNull(labelSet, "labelSet");
       return NoopHandle.INSTANCE;
     }
 
@@ -302,16 +317,14 @@ public final class DefaultMeter implements Meter {
     }
 
     @Override
-    public void removeHandle(List<String> labelValues) {
-      Utils.checkNotNull(labelValues, "labelValues");
+    public void removeHandle(Handle handle) {
+      Utils.checkNotNull(handle, "handle");
     }
 
     /** No-op implementations of Handle class. */
     @Immutable
-    private static final class NoopHandle implements Handle {
-      private static final NoopHandle INSTANCE = new NoopHandle();
-
-      private NoopHandle() {}
+    private enum NoopHandle implements Handle {
+      INSTANCE;
 
       @Override
       public void add(long delta) {}
@@ -326,25 +339,19 @@ public final class DefaultMeter implements Meter {
 
       @Override
       public CounterLong build() {
-        return new NoopCounterLong(labelKeysSize);
+        return new NoopCounterLong();
       }
     }
   }
 
   @Immutable
   private static final class NoopMeasureDouble implements MeasureDouble {
-    private final int labelKeysSize;
-
     /** Creates a new {@code NoopHandle}. */
-    private NoopMeasureDouble(int labelKeysSize) {
-      this.labelKeysSize = labelKeysSize;
-    }
+    private NoopMeasureDouble() {}
 
     @Override
-    public NoopHandle getHandle(List<String> labelValues) {
-      Utils.checkNotNull(labelValues, "labelValues");
-      Utils.checkArgument(
-          labelKeysSize == labelValues.size(), "Label Keys and Label Values don't have same size.");
+    public NoopHandle getHandle(LabelSet labelSet) {
+      Utils.checkNotNull(labelSet, "labelSet");
       return NoopHandle.INSTANCE;
     }
 
@@ -354,14 +361,14 @@ public final class DefaultMeter implements Meter {
     }
 
     @Override
-    public void removeHandle(List<String> labelValues) {
-      Utils.checkNotNull(labelValues, "labelValues");
+    public void removeHandle(Handle handle) {
+      Utils.checkNotNull(handle, "handle");
     }
 
     /** No-op implementations of Handle class. */
     @Immutable
-    private static final class NoopHandle implements Handle {
-      private static final NoopHandle INSTANCE = new NoopHandle();
+    private enum NoopHandle implements Handle {
+      INSTANCE;
 
       @Override
       public void record(double value) {
@@ -378,24 +385,18 @@ public final class DefaultMeter implements Meter {
 
       @Override
       public MeasureDouble build() {
-        return new NoopMeasureDouble(labelKeysSize);
+        return new NoopMeasureDouble();
       }
     }
   }
 
   @Immutable
   private static final class NoopMeasureLong implements MeasureLong {
-    private final int labelKeysSize;
-
-    private NoopMeasureLong(int labelKeysSize) {
-      this.labelKeysSize = labelKeysSize;
-    }
+    private NoopMeasureLong() {}
 
     @Override
-    public NoopHandle getHandle(List<String> labelValues) {
-      Utils.checkNotNull(labelValues, "labelValues");
-      Utils.checkArgument(
-          labelKeysSize == labelValues.size(), "Label Keys and Label Values don't have same size.");
+    public NoopHandle getHandle(LabelSet labelSet) {
+      Utils.checkNotNull(labelSet, "labelSet");
       return NoopHandle.INSTANCE;
     }
 
@@ -405,14 +406,14 @@ public final class DefaultMeter implements Meter {
     }
 
     @Override
-    public void removeHandle(List<String> labelValues) {
-      Utils.checkNotNull(labelValues, "labelValues");
+    public void removeHandle(Handle handle) {
+      Utils.checkNotNull(handle, "handle");
     }
 
     /** No-op implementations of Handle class. */
     @Immutable
-    private static final class NoopHandle implements Handle {
-      private static final NoopHandle INSTANCE = new NoopHandle();
+    private enum NoopHandle implements Handle {
+      INSTANCE;
 
       @Override
       public void record(long value) {
@@ -429,24 +430,18 @@ public final class DefaultMeter implements Meter {
 
       @Override
       public MeasureLong build() {
-        return new NoopMeasureLong(labelKeysSize);
+        return new NoopMeasureLong();
       }
     }
   }
 
   @Immutable
   private static final class NoopObserverDouble implements ObserverDouble {
-    private final int labelKeysSize;
-
-    private NoopObserverDouble(int labelKeysSize) {
-      this.labelKeysSize = labelKeysSize;
-    }
+    private NoopObserverDouble() {}
 
     @Override
-    public NoopHandle getHandle(List<String> labelValues) {
-      Utils.checkNotNull(labelValues, "labelValues");
-      Utils.checkArgument(
-          labelKeysSize == labelValues.size(), "Label Keys and Label Values don't have same size.");
+    public NoopHandle getHandle(LabelSet labelSet) {
+      Utils.checkNotNull(labelSet, "labelSet");
       return NoopHandle.INSTANCE;
     }
 
@@ -456,8 +451,8 @@ public final class DefaultMeter implements Meter {
     }
 
     @Override
-    public void removeHandle(List<String> labelValues) {
-      Utils.checkNotNull(labelValues, "labelValues");
+    public void removeHandle(Handle handle) {
+      Utils.checkNotNull(handle, "handle");
     }
 
     @Override
@@ -467,8 +462,8 @@ public final class DefaultMeter implements Meter {
 
     /** No-op implementations of Handle class. */
     @Immutable
-    private static final class NoopHandle implements Handle {
-      private static final NoopHandle INSTANCE = new NoopHandle();
+    private enum NoopHandle implements Handle {
+      INSTANCE
     }
 
     private static final class NoopBuilder
@@ -480,24 +475,18 @@ public final class DefaultMeter implements Meter {
 
       @Override
       public ObserverDouble build() {
-        return new NoopObserverDouble(labelKeysSize);
+        return new NoopObserverDouble();
       }
     }
   }
 
   @Immutable
   private static final class NoopObserverLong implements ObserverLong {
-    private final int labelKeysSize;
-
-    private NoopObserverLong(int labelKeysSize) {
-      this.labelKeysSize = labelKeysSize;
-    }
+    private NoopObserverLong() {}
 
     @Override
-    public NoopHandle getHandle(List<String> labelValues) {
-      Utils.checkNotNull(labelValues, "labelValues");
-      Utils.checkArgument(
-          labelKeysSize == labelValues.size(), "Label Keys and Label Values don't have same size.");
+    public NoopHandle getHandle(LabelSet labelSet) {
+      Utils.checkNotNull(labelSet, "labelSet");
       return NoopHandle.INSTANCE;
     }
 
@@ -507,8 +496,8 @@ public final class DefaultMeter implements Meter {
     }
 
     @Override
-    public void removeHandle(List<String> labelValues) {
-      Utils.checkNotNull(labelValues, "labelValues");
+    public void removeHandle(Handle handle) {
+      Utils.checkNotNull(handle, "handle");
     }
 
     @Override
@@ -518,8 +507,8 @@ public final class DefaultMeter implements Meter {
 
     /** No-op implementations of Handle class. */
     @Immutable
-    private static final class NoopHandle implements Handle {
-      private static final NoopHandle INSTANCE = new NoopHandle();
+    private enum NoopHandle implements Handle {
+      INSTANCE
     }
 
     private static final class NoopBuilder
@@ -531,7 +520,7 @@ public final class DefaultMeter implements Meter {
 
       @Override
       public ObserverLong build() {
-        return new NoopObserverLong(labelKeysSize);
+        return new NoopObserverLong();
       }
     }
   }
@@ -583,8 +572,6 @@ public final class DefaultMeter implements Meter {
 
   private abstract static class NoopAbstractMetricBuilder<B extends Metric.Builder<B, V>, V>
       implements Metric.Builder<B, V> {
-    int labelKeysSize = 0;
-
     @Override
     public B setDescription(String description) {
       Utils.checkNotNull(description, "description");
@@ -600,7 +587,6 @@ public final class DefaultMeter implements Meter {
     @Override
     public B setLabelKeys(List<String> labelKeys) {
       Utils.checkListElementNotNull(Utils.checkNotNull(labelKeys, "labelKeys"), "labelKey");
-      labelKeysSize = labelKeys.size();
       return getThis();
     }
 
@@ -612,5 +598,9 @@ public final class DefaultMeter implements Meter {
     }
 
     protected abstract B getThis();
+  }
+
+  private enum NoopLabelSet implements LabelSet {
+    INSTANCE
   }
 }

--- a/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
@@ -154,7 +154,7 @@ public final class DefaultMeter implements Meter {
   public LabelSet createLabelSet(
       String k1, String v1, String k2, String v2, String k3, String v3, String k4, String v4) {
     Utils.checkNotNull(k1, "k1");
-    Utils.checkNotNull(v1, "k1");
+    Utils.checkNotNull(v1, "v1");
     Utils.checkNotNull(k2, "k2");
     Utils.checkNotNull(v2, "v2");
     Utils.checkNotNull(k3, "k3");

--- a/api/src/main/java/io/opentelemetry/metrics/GaugeDouble.java
+++ b/api/src/main/java/io/opentelemetry/metrics/GaugeDouble.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.metrics;
 
 import io.opentelemetry.metrics.GaugeDouble.Handle;
-import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -55,7 +54,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface GaugeDouble extends Gauge<Handle> {
 
   @Override
-  Handle getHandle(List<String> labelValues);
+  Handle getHandle(LabelSet labelSet);
 
   @Override
   Handle getDefaultHandle();

--- a/api/src/main/java/io/opentelemetry/metrics/GaugeLong.java
+++ b/api/src/main/java/io/opentelemetry/metrics/GaugeLong.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.metrics;
 
 import io.opentelemetry.metrics.GaugeLong.Handle;
-import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -55,7 +54,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface GaugeLong extends Gauge<Handle> {
 
   @Override
-  Handle getHandle(List<String> labelValues);
+  Handle getHandle(LabelSet labelSet);
 
   @Override
   Handle getDefaultHandle();

--- a/api/src/main/java/io/opentelemetry/metrics/LabelSet.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LabelSet.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.metrics;
+
+/**
+ * LabelSet is an implementation-level interface that represents a set of Labels for use as
+ * pre-defined labels in the metrics API.
+ */
+public interface LabelSet {}

--- a/api/src/main/java/io/opentelemetry/metrics/LabelSet.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LabelSet.java
@@ -19,5 +19,7 @@ package io.opentelemetry.metrics;
 /**
  * LabelSet is an implementation-level interface that represents a set of Labels for use as
  * pre-defined labels in the metrics API.
+ *
+ * <p>LabelSets that have the same key/value pairs should have the same equals/hashcode.
  */
 public interface LabelSet {}

--- a/api/src/main/java/io/opentelemetry/metrics/Meter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Meter.java
@@ -225,4 +225,57 @@ public interface Meter {
    * @since 0.1.0
    */
   BatchRecorder newMeasureBatchRecorder();
+
+  /**
+   * Returns a new {@link LabelSet} with the given label.
+   *
+   * @param k1 first key.
+   * @param v1 first value.
+   * @return a new {@link LabelSet} with the given label.
+   * @throws NullPointerException if any provided value is null.
+   */
+  LabelSet createLabelSet(String k1, String v1);
+
+  /**
+   * Returns a new {@link LabelSet} with the given labels.
+   *
+   * @param k1 first key.
+   * @param v1 first value.
+   * @param k2 second key.
+   * @param v2 second value.
+   * @return a new {@link LabelSet} with the given labels.
+   * @throws NullPointerException if any provided value is null.
+   */
+  LabelSet createLabelSet(String k1, String v1, String k2, String v2);
+
+  /**
+   * Returns a new {@link LabelSet} with the given labels.
+   *
+   * @param k1 first key.
+   * @param v1 first value.
+   * @param k2 second key.
+   * @param v2 second value.
+   * @param k3 third key.
+   * @param v3 third value.
+   * @return a new {@link LabelSet} with the given labels.
+   * @throws NullPointerException if any provided value is null.
+   */
+  LabelSet createLabelSet(String k1, String v1, String k2, String v2, String k3, String v3);
+
+  /**
+   * Returns a new {@link LabelSet} with the given labels.
+   *
+   * @param k1 first key.
+   * @param v1 first value.
+   * @param k2 second key.
+   * @param v2 second value.
+   * @param k3 third key.
+   * @param v3 third value.
+   * @param k4 fourth key.
+   * @param v4 fourth value.
+   * @return a new {@link LabelSet} with the given labels.
+   * @throws NullPointerException if any provided value is null.
+   */
+  LabelSet createLabelSet(
+      String k1, String v1, String k2, String v2, String k3, String v3, String k4, String v4);
 }

--- a/api/src/main/java/io/opentelemetry/metrics/Metric.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Metric.java
@@ -30,22 +30,18 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public interface Metric<H> {
   /**
-   * Returns a {@code Handle} with associated with specified {@code labelValues}. Multiples requests
-   * with the same {@code labelValues} may return the same {@code Handle}.
+   * Returns a {@code Handle} with associated with specified {@code labelSet}. Multiples requests
+   * with the same {@code labelSet} may return the same {@code Handle}.
    *
    * <p>It is recommended to keep a reference to the Handle instead of always calling this method
    * for every operations.
    *
-   * @param labelValues the list of label values. The number of label values must be the same to
-   *     that of the label keys passed to {@link GaugeDouble.Builder#setLabelKeys(List)}.
+   * @param labelSet the set of labels.
    * @return a {@code Handle} the value of single gauge.
-   * @throws NullPointerException if {@code labelValues} is null OR any element of {@code
-   *     labelValues} is null.
-   * @throws IllegalArgumentException if number of {@code labelValues}s are not equal to the label
-   *     keys.
+   * @throws NullPointerException if {@code labelValues} is null.
    * @since 0.1.0
    */
-  H getHandle(List<String> labelValues);
+  H getHandle(LabelSet labelSet);
 
   /**
    * Returns a {@code Handle} for a metric with all labels not set.
@@ -56,15 +52,13 @@ public interface Metric<H> {
   H getDefaultHandle();
 
   /**
-   * Removes the {@code Handle} from the metric, if it is present. i.e. references to previous
-   * {@code Handle} are invalid (not part of the metric).
+   * Removes the {@code Handle} from the metric. i.e. references to previous {@code Handle} are
+   * invalid (not part of the metric).
    *
-   * <p>If value is missing for one of the predefined keys {@code null} must be used for that value.
-   *
-   * @param labelValues the list of label values.
+   * @param handle the {@code Handle} to be removed.
    * @since 0.1.0
    */
-  void removeHandle(List<String> labelValues);
+  void removeHandle(H handle);
 
   /**
    * The {@code Builder} class for the {@code Metric}.

--- a/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
+++ b/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
@@ -32,6 +32,7 @@ import io.opentelemetry.metrics.CounterLong;
 import io.opentelemetry.metrics.DefaultMeterFactory;
 import io.opentelemetry.metrics.GaugeDouble;
 import io.opentelemetry.metrics.GaugeLong;
+import io.opentelemetry.metrics.LabelSet;
 import io.opentelemetry.metrics.MeasureDouble;
 import io.opentelemetry.metrics.MeasureLong;
 import io.opentelemetry.metrics.Meter;
@@ -361,6 +362,32 @@ public class OpenTelemetryTest {
     @Nullable
     @Override
     public BatchRecorder newMeasureBatchRecorder() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public LabelSet createLabelSet(String k1, String v1) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public LabelSet createLabelSet(String k1, String v1, String k2, String v2) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public LabelSet createLabelSet(
+        String k1, String v1, String k2, String v2, String k3, String v3) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public LabelSet createLabelSet(
+        String k1, String v1, String k2, String v2, String k3, String v3, String k4, String v4) {
       return null;
     }
 

--- a/api/src/test/java/io/opentelemetry/metrics/CounterDoubleTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/CounterDoubleTest.java
@@ -35,7 +35,6 @@ public class CounterDoubleTest {
   private static final String DESCRIPTION = "description";
   private static final String UNIT = "1";
   private static final List<String> LABEL_KEY = Collections.singletonList("key");
-  private static final List<String> EMPTY_LABEL_VALUES = Collections.emptyList();
 
   private final Meter meter = OpenTelemetry.getMeterFactory().get("counter_double_test");
 
@@ -95,7 +94,7 @@ public class CounterDoubleTest {
   }
 
   @Test
-  public void noopGetHandle_WithNullLabelValues() {
+  public void noopGetHandle_WithNullLabelSet() {
     CounterDouble counterDouble =
         meter
             .counterDoubleBuilder(NAME)
@@ -104,26 +103,12 @@ public class CounterDoubleTest {
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("labelValues");
+    thrown.expectMessage("labelSet");
     counterDouble.getHandle(null);
   }
 
   @Test
-  public void noopGetHandle_WithInvalidLabelSize() {
-    CounterDouble counterDouble =
-        meter
-            .counterDoubleBuilder(NAME)
-            .setDescription(DESCRIPTION)
-            .setLabelKeys(LABEL_KEY)
-            .setUnit(UNIT)
-            .build();
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Label Keys and Label Values don't have same size.");
-    counterDouble.getHandle(EMPTY_LABEL_VALUES);
-  }
-
-  @Test
-  public void noopRemoveHandle_WithNullLabelValues() {
+  public void noopRemoveHandle_WithNullHandle() {
     CounterDouble counterDouble =
         meter
             .counterDoubleBuilder(NAME)
@@ -132,7 +117,7 @@ public class CounterDoubleTest {
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("labelValues");
+    thrown.expectMessage("handle");
     counterDouble.removeHandle(null);
   }
 

--- a/api/src/test/java/io/opentelemetry/metrics/CounterLongTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/CounterLongTest.java
@@ -35,7 +35,6 @@ public class CounterLongTest {
   private static final String DESCRIPTION = "description";
   private static final String UNIT = "1";
   private static final List<String> LABEL_KEY = Collections.singletonList("key");
-  private static final List<String> EMPTY_LABEL_VALUES = Collections.emptyList();
 
   private final Meter meter = OpenTelemetry.getMeterFactory().get("counter_long_test");
 
@@ -94,7 +93,7 @@ public class CounterLongTest {
   }
 
   @Test
-  public void noopGetHandle_WithNullLabelValues() {
+  public void noopGetHandle_WithNullLabelSet() {
     CounterLong counterLong =
         meter
             .counterLongBuilder(NAME)
@@ -103,26 +102,12 @@ public class CounterLongTest {
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("labelValues");
+    thrown.expectMessage("labelSet");
     counterLong.getHandle(null);
   }
 
   @Test
-  public void noopGetHandle_WithInvalidLabelSize() {
-    CounterLong counterLong =
-        meter
-            .counterLongBuilder(NAME)
-            .setDescription(DESCRIPTION)
-            .setLabelKeys(LABEL_KEY)
-            .setUnit(UNIT)
-            .build();
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Label Keys and Label Values don't have same size.");
-    counterLong.getHandle(EMPTY_LABEL_VALUES);
-  }
-
-  @Test
-  public void noopRemoveHandle_WithNullLabelValues() {
+  public void noopRemoveHandle_WithNullHandle() {
     CounterLong counterLong =
         meter
             .counterLongBuilder(NAME)
@@ -131,7 +116,7 @@ public class CounterLongTest {
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("labelValues");
+    thrown.expectMessage("handle");
     counterLong.removeHandle(null);
   }
 

--- a/api/src/test/java/io/opentelemetry/metrics/GaugeDoubleTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/GaugeDoubleTest.java
@@ -35,7 +35,6 @@ public class GaugeDoubleTest {
   private static final String DESCRIPTION = "description";
   private static final String UNIT = "1";
   private static final List<String> LABEL_KEY = Collections.singletonList("key");
-  private static final List<String> EMPTY_LABEL_VALUES = Collections.emptyList();
 
   private final Meter meter = OpenTelemetry.getMeterFactory().get("gauge_double_test");
 
@@ -94,7 +93,7 @@ public class GaugeDoubleTest {
   }
 
   @Test
-  public void noopGetHandle_WithNullLabelValues() {
+  public void noopGetHandle_WithNullLabelSet() {
     GaugeDouble gaugeDouble =
         meter
             .gaugeDoubleBuilder(NAME)
@@ -103,26 +102,12 @@ public class GaugeDoubleTest {
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("labelValues");
+    thrown.expectMessage("labelSet");
     gaugeDouble.getHandle(null);
   }
 
   @Test
-  public void noopGetHandle_WithInvalidLabelSize() {
-    GaugeDouble gaugeDouble =
-        meter
-            .gaugeDoubleBuilder(NAME)
-            .setDescription(DESCRIPTION)
-            .setLabelKeys(LABEL_KEY)
-            .setUnit(UNIT)
-            .build();
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Label Keys and Label Values don't have same size.");
-    gaugeDouble.getHandle(EMPTY_LABEL_VALUES);
-  }
-
-  @Test
-  public void noopRemoveHandle_WithNullLabelValues() {
+  public void noopRemoveHandle_WithNullHandle() {
     GaugeDouble gaugeDouble =
         meter
             .gaugeDoubleBuilder(NAME)
@@ -131,7 +116,7 @@ public class GaugeDoubleTest {
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("labelValues");
+    thrown.expectMessage("handle");
     gaugeDouble.removeHandle(null);
   }
 

--- a/api/src/test/java/io/opentelemetry/metrics/GaugeLongTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/GaugeLongTest.java
@@ -35,7 +35,6 @@ public class GaugeLongTest {
   private static final String DESCRIPTION = "description";
   private static final String UNIT = "1";
   private static final List<String> LABEL_KEY = Collections.singletonList("key");
-  private static final List<String> EMPTY_LABEL_VALUES = Collections.emptyList();
 
   private final Meter meter = OpenTelemetry.getMeterFactory().get("gauge_long_test");
 
@@ -91,7 +90,7 @@ public class GaugeLongTest {
   }
 
   @Test
-  public void noopGetHandle_WithNullLabelValues() {
+  public void noopGetHandle_WithNullLabelSet() {
     GaugeLong gaugeLong =
         meter
             .gaugeLongBuilder(NAME)
@@ -100,26 +99,12 @@ public class GaugeLongTest {
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("labelValues");
+    thrown.expectMessage("labelSet");
     gaugeLong.getHandle(null);
   }
 
   @Test
-  public void noopGetHandle_WithInvalidLabelSize() {
-    GaugeLong gaugeLong =
-        meter
-            .gaugeLongBuilder(NAME)
-            .setDescription(DESCRIPTION)
-            .setLabelKeys(LABEL_KEY)
-            .setUnit(UNIT)
-            .build();
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Label Keys and Label Values don't have same size.");
-    gaugeLong.getHandle(EMPTY_LABEL_VALUES);
-  }
-
-  @Test
-  public void noopRemoveHandle_WithNullLabelValues() {
+  public void noopRemoveHandle_WithNullHandle() {
     GaugeLong gaugeLong =
         meter
             .gaugeLongBuilder(NAME)
@@ -128,7 +113,7 @@ public class GaugeLongTest {
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("labelValues");
+    thrown.expectMessage("handle");
     gaugeLong.removeHandle(null);
   }
 

--- a/api/src/test/java/io/opentelemetry/metrics/MeasureLongTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/MeasureLongTest.java
@@ -28,7 +28,6 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public final class MeasureLongTest {
   private static final Meter meter = DefaultMeter.getInstance();
-
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   @Test

--- a/api/src/test/java/io/opentelemetry/metrics/ObserverDoubleTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/ObserverDoubleTest.java
@@ -35,7 +35,6 @@ public class ObserverDoubleTest {
   private static final String DESCRIPTION = "description";
   private static final String UNIT = "1";
   private static final List<String> LABEL_KEY = Collections.singletonList("key");
-  private static final List<String> EMPTY_LABEL_VALUES = Collections.emptyList();
 
   private final Meter meter = OpenTelemetry.getMeterFactory().get("observer_double_test");
 
@@ -94,7 +93,7 @@ public class ObserverDoubleTest {
   }
 
   @Test
-  public void noopGetHandle_WithNullLabelValues() {
+  public void noopGetHandle_WithNullLabelSet() {
     ObserverDouble observerDouble =
         meter
             .observerDoubleBuilder(NAME)
@@ -103,26 +102,12 @@ public class ObserverDoubleTest {
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("labelValues");
+    thrown.expectMessage("labelSet");
     observerDouble.getHandle(null);
   }
 
   @Test
-  public void noopGetHandle_WithInvalidLabelSize() {
-    ObserverDouble observerDouble =
-        meter
-            .observerDoubleBuilder(NAME)
-            .setDescription(DESCRIPTION)
-            .setLabelKeys(LABEL_KEY)
-            .setUnit(UNIT)
-            .build();
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Label Keys and Label Values don't have same size.");
-    observerDouble.getHandle(EMPTY_LABEL_VALUES);
-  }
-
-  @Test
-  public void noopRemoveHandle_WithNullLabelValues() {
+  public void noopRemoveHandle_WithNullHandle() {
     ObserverDouble gaugeDouble =
         meter
             .observerDoubleBuilder(NAME)
@@ -131,7 +116,7 @@ public class ObserverDoubleTest {
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("labelValues");
+    thrown.expectMessage("handle");
     gaugeDouble.removeHandle(null);
   }
 }

--- a/api/src/test/java/io/opentelemetry/metrics/ObserverLongTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/ObserverLongTest.java
@@ -35,7 +35,6 @@ public class ObserverLongTest {
   private static final String DESCRIPTION = "description";
   private static final String UNIT = "1";
   private static final List<String> LABEL_KEY = Collections.singletonList("key");
-  private static final List<String> EMPTY_LABEL_VALUES = Collections.emptyList();
 
   private final Meter meter = OpenTelemetry.getMeterFactory().get("observer_long_test");
 
@@ -94,7 +93,7 @@ public class ObserverLongTest {
   }
 
   @Test
-  public void noopGetHandle_WithNullLabelValues() {
+  public void noopGetHandle_WithNullLabelSet() {
     ObserverLong observerLong =
         meter
             .observerLongBuilder(NAME)
@@ -103,26 +102,12 @@ public class ObserverLongTest {
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("labelValues");
+    thrown.expectMessage("labelSet");
     observerLong.getHandle(null);
   }
 
   @Test
-  public void noopGetHandle_WithInvalidLabelSize() {
-    ObserverLong observerLong =
-        meter
-            .observerLongBuilder(NAME)
-            .setDescription(DESCRIPTION)
-            .setLabelKeys(LABEL_KEY)
-            .setUnit(UNIT)
-            .build();
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Label Keys and Label Values don't have same size.");
-    observerLong.getHandle(EMPTY_LABEL_VALUES);
-  }
-
-  @Test
-  public void noopRemoveHandle_WithNullLabelValues() {
+  public void noopRemoveHandle_WithNullHandle() {
     ObserverLong observerLong =
         meter
             .observerLongBuilder(NAME)
@@ -131,7 +116,7 @@ public class ObserverLongTest {
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("labelValues");
+    thrown.expectMessage("handle");
     observerLong.removeHandle(null);
   }
 }

--- a/contrib/runtime_metrics/src/main/java/io/opentelemetry/contrib/metrics/runtime/GarbageCollector.java
+++ b/contrib/runtime_metrics/src/main/java/io/opentelemetry/contrib/metrics/runtime/GarbageCollector.java
@@ -17,6 +17,7 @@
 package io.opentelemetry.contrib.metrics.runtime;
 
 import io.opentelemetry.OpenTelemetry;
+import io.opentelemetry.metrics.LabelSet;
 import io.opentelemetry.metrics.Meter;
 import io.opentelemetry.metrics.Observer.Callback;
 import io.opentelemetry.metrics.ObserverLong;
@@ -66,7 +67,8 @@ public final class GarbageCollector {
             .build();
     final List<ObserverLong.Handle> handles = new ArrayList<>(garbageCollectors.size());
     for (final GarbageCollectorMXBean gc : garbageCollectors) {
-      handles.add(gcMetric.getHandle(Collections.singletonList(gc.getName())));
+      LabelSet labelSet = meter.createLabelSet(GC_LABEL_KEY, gc.getName());
+      handles.add(gcMetric.getHandle(labelSet));
     }
 
     gcMetric.setCallback(

--- a/contrib/runtime_metrics/src/main/java/io/opentelemetry/contrib/metrics/runtime/MemoryPools.java
+++ b/contrib/runtime_metrics/src/main/java/io/opentelemetry/contrib/metrics/runtime/MemoryPools.java
@@ -79,13 +79,20 @@ public final class MemoryPools {
             .setLabelKeys(Arrays.asList(TYPE_LABEL_KEY, AREA_LABEL_KEY))
             .setMonotonic(false)
             .build();
-    final Handle usedHeap = areaMetric.getHandle(Arrays.asList(USED, HEAP));
-    final Handle usedNonHeap = areaMetric.getHandle(Arrays.asList(USED, NON_HEAP));
-    final Handle committedHeap = areaMetric.getHandle(Arrays.asList(COMMITTED, HEAP));
-    final Handle committedNonHeap = areaMetric.getHandle(Arrays.asList(COMMITTED, NON_HEAP));
+    final Handle usedHeap =
+        areaMetric.getHandle(meter.createLabelSet(TYPE_LABEL_KEY, USED, AREA_LABEL_KEY, HEAP));
+    final Handle usedNonHeap =
+        areaMetric.getHandle(meter.createLabelSet(TYPE_LABEL_KEY, USED, AREA_LABEL_KEY, NON_HEAP));
+    final Handle committedHeap =
+        areaMetric.getHandle(meter.createLabelSet(TYPE_LABEL_KEY, COMMITTED, AREA_LABEL_KEY, HEAP));
+    final Handle committedNonHeap =
+        areaMetric.getHandle(
+            meter.createLabelSet(TYPE_LABEL_KEY, COMMITTED, AREA_LABEL_KEY, NON_HEAP));
     // TODO: Decide if max is needed or not. May be derived with some approximation from max(used).
-    final Handle maxHeap = areaMetric.getHandle(Arrays.asList(MAX, HEAP));
-    final Handle maxNonHeap = areaMetric.getHandle(Arrays.asList(MAX, NON_HEAP));
+    final Handle maxHeap =
+        areaMetric.getHandle(meter.createLabelSet(TYPE_LABEL_KEY, MAX, AREA_LABEL_KEY, HEAP));
+    final Handle maxNonHeap =
+        areaMetric.getHandle(meter.createLabelSet(TYPE_LABEL_KEY, MAX, AREA_LABEL_KEY, NON_HEAP));
     areaMetric.setCallback(
         new ObserverLong.Callback<Result>() {
           @Override
@@ -117,9 +124,15 @@ public final class MemoryPools {
     final List<Handle> committedHandles = new ArrayList<>(poolBeans.size());
     final List<Handle> maxHandles = new ArrayList<>(poolBeans.size());
     for (final MemoryPoolMXBean pool : poolBeans) {
-      usedHandles.add(poolMetric.getHandle(Arrays.asList(USED, pool.getName())));
-      committedHandles.add(poolMetric.getHandle(Arrays.asList(COMMITTED, pool.getName())));
-      maxHandles.add(poolMetric.getHandle(Arrays.asList(MAX, pool.getName())));
+      usedHandles.add(
+          poolMetric.getHandle(
+              meter.createLabelSet(TYPE_LABEL_KEY, USED, POOL_LABEL_KEY, pool.getName())));
+      committedHandles.add(
+          poolMetric.getHandle(
+              meter.createLabelSet(TYPE_LABEL_KEY, COMMITTED, POOL_LABEL_KEY, pool.getName())));
+      maxHandles.add(
+          poolMetric.getHandle(
+              meter.createLabelSet(TYPE_LABEL_KEY, MAX, POOL_LABEL_KEY, pool.getName())));
     }
     poolMetric.setCallback(
         new Callback<Result>() {

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
@@ -21,6 +21,7 @@ import io.opentelemetry.metrics.CounterDouble;
 import io.opentelemetry.metrics.CounterLong;
 import io.opentelemetry.metrics.GaugeDouble;
 import io.opentelemetry.metrics.GaugeLong;
+import io.opentelemetry.metrics.LabelSet;
 import io.opentelemetry.metrics.MeasureDouble;
 import io.opentelemetry.metrics.MeasureLong;
 import io.opentelemetry.metrics.Meter;
@@ -72,6 +73,27 @@ public class MeterSdk implements Meter {
 
   @Override
   public BatchRecorder newMeasureBatchRecorder() {
+    throw new UnsupportedOperationException("to be implemented");
+  }
+
+  @Override
+  public LabelSet createLabelSet(String k1, String v1) {
+    throw new UnsupportedOperationException("to be implemented");
+  }
+
+  @Override
+  public LabelSet createLabelSet(String k1, String v1, String k2, String v2) {
+    throw new UnsupportedOperationException("to be implemented");
+  }
+
+  @Override
+  public LabelSet createLabelSet(String k1, String v1, String k2, String v2, String k3, String v3) {
+    throw new UnsupportedOperationException("to be implemented");
+  }
+
+  @Override
+  public LabelSet createLabelSet(
+      String k1, String v1, String k2, String v2, String k3, String v3, String k4, String v4) {
     throw new UnsupportedOperationException("to be implemented");
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractCounterBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractCounterBuilderTest.java
@@ -19,7 +19,7 @@ package io.opentelemetry.sdk.metrics;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.metrics.Counter;
-import java.util.List;
+import io.opentelemetry.metrics.LabelSet;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -78,7 +78,7 @@ public class AbstractCounterBuilderTest {
     private static final TestHandle HANDLE = new TestHandle();
 
     @Override
-    public TestHandle getHandle(List<String> labelValues) {
+    public TestHandle getHandle(LabelSet labelSet) {
       return HANDLE;
     }
 
@@ -88,7 +88,7 @@ public class AbstractCounterBuilderTest {
     }
 
     @Override
-    public void removeHandle(List<String> labelValues) {}
+    public void removeHandle(TestHandle handle) {}
   }
 
   private static final class TestHandle {}

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractGaugeBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractGaugeBuilderTest.java
@@ -19,7 +19,7 @@ package io.opentelemetry.sdk.metrics;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.metrics.Gauge;
-import java.util.List;
+import io.opentelemetry.metrics.LabelSet;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -78,7 +78,7 @@ public class AbstractGaugeBuilderTest {
     private static final TestHandle HANDLE = new TestHandle();
 
     @Override
-    public TestHandle getHandle(List<String> labelValues) {
+    public TestHandle getHandle(LabelSet labelSet) {
       return HANDLE;
     }
 
@@ -88,7 +88,7 @@ public class AbstractGaugeBuilderTest {
     }
 
     @Override
-    public void removeHandle(List<String> labelValues) {}
+    public void removeHandle(TestHandle handle) {}
   }
 
   private static final class TestHandle {}

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractMetricBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractMetricBuilderTest.java
@@ -18,6 +18,7 @@ package io.opentelemetry.sdk.metrics;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import io.opentelemetry.metrics.LabelSet;
 import io.opentelemetry.metrics.Metric;
 import java.util.Arrays;
 import java.util.Collections;
@@ -151,7 +152,7 @@ public class AbstractMetricBuilderTest {
     private static final TestHandle HANDLE = new TestHandle();
 
     @Override
-    public TestHandle getHandle(List<String> labelValues) {
+    public TestHandle getHandle(LabelSet labelSet) {
       return HANDLE;
     }
 
@@ -161,7 +162,7 @@ public class AbstractMetricBuilderTest {
     }
 
     @Override
-    public void removeHandle(List<String> labelValues) {}
+    public void removeHandle(TestHandle handle) {}
   }
 
   private static final class TestHandle {}

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractObserverBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractObserverBuilderTest.java
@@ -18,9 +18,9 @@ package io.opentelemetry.sdk.metrics;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import io.opentelemetry.metrics.LabelSet;
 import io.opentelemetry.metrics.Observer;
 import io.opentelemetry.metrics.ObserverDouble;
-import java.util.List;
 import javax.annotation.Nullable;
 import org.junit.Rule;
 import org.junit.Test;
@@ -80,7 +80,7 @@ public class AbstractObserverBuilderTest {
 
     @Nullable
     @Override
-    public Observer.Handle getHandle(List<String> labelValues) {
+    public Observer.Handle getHandle(LabelSet labelSet) {
       return null;
     }
 
@@ -91,7 +91,7 @@ public class AbstractObserverBuilderTest {
     }
 
     @Override
-    public void removeHandle(List<String> labelValues) {}
+    public void removeHandle(Observer.Handle handle) {}
 
     @Override
     public void setCallback(Callback<ObserverDouble.Result> metricUpdater) {}


### PR DESCRIPTION
Except changes in Meter and DefaultMeter all the other changes are mechanical. 

Filed https://github.com/open-telemetry/opentelemetry-java/issues/683 to track the creation of LabelSet objects APIs.