### PR TITLE
Allow recording attributes in Span.Builder

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
@@ -132,6 +132,38 @@ public final class DefaultTracer implements Tracer {
     }
 
     @Override
+    public NoopSpanBuilder setAttribute(String key, String value) {
+      Utils.checkNotNull(key, "key");
+      Utils.checkNotNull(value, "value");
+      return this;
+    }
+
+    @Override
+    public NoopSpanBuilder setAttribute(String key, long value) {
+      Utils.checkNotNull(key, "key");
+      return this;
+    }
+
+    @Override
+    public NoopSpanBuilder setAttribute(String key, double value) {
+      Utils.checkNotNull(key, "key");
+      return this;
+    }
+
+    @Override
+    public NoopSpanBuilder setAttribute(String key, boolean value) {
+      Utils.checkNotNull(key, "key");
+      return this;
+    }
+
+    @Override
+    public NoopSpanBuilder setAttribute(String key, AttributeValue value) {
+      Utils.checkNotNull(key, "key");
+      Utils.checkNotNull(value, "value");
+      return this;
+    }
+
+    @Override
     public NoopSpanBuilder setSpanKind(Span.Kind spanKind) {
       return this;
     }

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -469,7 +469,7 @@ public interface Span {
      * @param value the value for this attribute.
      * @return this.
      * @throws NullPointerException if {@code key} is {@code null}.
-     * @since 0.1.0
+     * @since 0.3.0
      */
     Builder setAttribute(String key, long value);
 
@@ -481,7 +481,7 @@ public interface Span {
      * @param value the value for this attribute.
      * @return this.
      * @throws NullPointerException if {@code key} is {@code null}.
-     * @since 0.1.0
+     * @since 0.3.0
      */
     Builder setAttribute(String key, double value);
 
@@ -493,7 +493,7 @@ public interface Span {
      * @param value the value for this attribute.
      * @return this.
      * @throws NullPointerException if {@code key} is {@code null}.
-     * @since 0.1.0
+     * @since 0.3.0
      */
     Builder setAttribute(String key, boolean value);
 
@@ -506,7 +506,7 @@ public interface Span {
      * @return this.
      * @throws NullPointerException if {@code key} is {@code null}.
      * @throws NullPointerException if {@code value} is {@code null}.
-     * @since 0.1.0
+     * @since 0.3.0
      */
     Builder setAttribute(String key, AttributeValue value);
 

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -474,7 +474,7 @@ public interface Span {
     Builder setAttribute(String key, long value);
 
     /**
-     * Sets an attribute to the newly created {@code Span}. If {@code Span} previously contained a
+     * Sets an attribute to the newly created {@code Span}. If {@code Span.Builder} previously
      * mapping for the key, the old value is replaced by the specified value.
      *
      * @param key the key for this attribute.

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -457,7 +457,7 @@ public interface Span {
      * @return this.
      * @throws NullPointerException if {@code key} is {@code null}.
      * @throws NullPointerException if {@code value} is {@code null}.
-     * @since 0.1.0
+     * @since 0.3.0
      */
     Builder setAttribute(String key, String value);
 

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -449,6 +449,68 @@ public interface Span {
     Builder addLink(Link link);
 
     /**
+     * Sets an attribute to the newly created {@code Span}. If {@code Span.Builder} previously
+     * contained a mapping for the key, the old value is replaced by the specified value.
+     *
+     * @param key the key for this attribute.
+     * @param value the value for this attribute.
+     * @return this.
+     * @throws NullPointerException if {@code key} is {@code null}.
+     * @throws NullPointerException if {@code value} is {@code null}.
+     * @since 0.1.0
+     */
+    Builder setAttribute(String key, String value);
+
+    /**
+     * Sets an attribute to the newly created {@code Span}. If {@code Span.Builder} previously
+     * contained a mapping for the key, the old value is replaced by the specified value.
+     *
+     * @param key the key for this attribute.
+     * @param value the value for this attribute.
+     * @return this.
+     * @throws NullPointerException if {@code key} is {@code null}.
+     * @since 0.1.0
+     */
+    Builder setAttribute(String key, long value);
+
+    /**
+     * Sets an attribute to the newly created {@code Span}. If {@code Span} previously contained a
+     * mapping for the key, the old value is replaced by the specified value.
+     *
+     * @param key the key for this attribute.
+     * @param value the value for this attribute.
+     * @return this.
+     * @throws NullPointerException if {@code key} is {@code null}.
+     * @since 0.1.0
+     */
+    Builder setAttribute(String key, double value);
+
+    /**
+     * Sets an attribute to the newly created {@code Span}. If {@code Span.Builder} previously
+     * contained a mapping for the key, the old value is replaced by the specified value.
+     *
+     * @param key the key for this attribute.
+     * @param value the value for this attribute.
+     * @return this.
+     * @throws NullPointerException if {@code key} is {@code null}.
+     * @since 0.1.0
+     */
+    Builder setAttribute(String key, boolean value);
+
+    /**
+     * Sets an attribute to the newly created {@code Span}. If {@code Span.Builder} previously
+     * contained a mapping for the key, the old value is replaced by the specified value.
+     *
+     * @param key the key for this attribute.
+     * @param value the value for this attribute.
+     * @return this.
+     * @throws NullPointerException if {@code key} is {@code null}.
+     * @throws NullPointerException if {@code value} is {@code null}.
+     * @since 0.1.0
+     */
+    Builder setAttribute(String key, AttributeValue value);
+
+    /**
      * Sets the {@link Span.Kind} for the newly created {@code Span}. If not called, the
      * implementation will provide a default value {@link Span.Kind#INTERNAL}.
      *

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -475,7 +475,7 @@ public interface Span {
 
     /**
      * Sets an attribute to the newly created {@code Span}. If {@code Span.Builder} previously
-     * mapping for the key, the old value is replaced by the specified value.
+     * contained a mapping for the key, the old value is replaced by the specified value.
      *
      * @param key the key for this attribute.
      * @param value the value for this attribute.

--- a/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
@@ -56,6 +56,11 @@ public class SpanBuilderTest {
             return Collections.emptyMap();
           }
         });
+    spanBuilder.setAttribute("key", "value");
+    spanBuilder.setAttribute("key", 12345L);
+    spanBuilder.setAttribute("key", .12345);
+    spanBuilder.setAttribute("key", true);
+    spanBuilder.setAttribute("key", AttributeValue.stringAttributeValue("value"));
     spanBuilder.setStartTimestamp(12345L);
     assertThat(spanBuilder.startSpan()).isInstanceOf(DefaultSpan.class);
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/AttributesWithCapacity.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/AttributesWithCapacity.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.trace;
+
+import io.opentelemetry.trace.AttributeValue;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+// A map implementation with a fixed capacity that drops events when the map gets full. Eviction
+// is based on the access order.
+final class AttributesWithCapacity extends LinkedHashMap<String, AttributeValue> {
+
+  private final long capacity;
+  private int totalRecordedAttributes = 0;
+  // Here because -Werror complains about this: [serial] serializable class AttributesWithCapacity
+  // has no definition of serialVersionUID. This class shouldn't be serialized.
+  private static final long serialVersionUID = 42L;
+
+  AttributesWithCapacity(long capacity) {
+    // Capacity of the map is capacity + 1 to avoid resizing because removeEldestEntry is invoked
+    // by put and putAll after inserting a new entry into the map. The loadFactor is set to 1
+    // to avoid resizing because. The accessOrder is set to true.
+    super((int) capacity + 1, 1, /*accessOrder=*/ true);
+    this.capacity = capacity;
+  }
+
+  // Users must call this method instead of put to keep count of the total number of entries
+  // inserted.
+  void putAttribute(String key, AttributeValue value) {
+    totalRecordedAttributes += 1;
+    put(key, value);
+  }
+
+  int getNumberOfDroppedAttributes() {
+    return totalRecordedAttributes - size();
+  }
+
+  // It is called after each put or putAll call in order to determine if the eldest inserted
+  // entry should be removed or not.
+  @Override
+  protected boolean removeEldestEntry(Map.Entry<String, AttributeValue> eldest) {
+    return size() > this.capacity;
+  }
+}

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/AttributesWithCapacity.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/AttributesWithCapacity.java
@@ -45,6 +45,12 @@ final class AttributesWithCapacity extends LinkedHashMap<String, AttributeValue>
     put(key, value);
   }
 
+  void putAllAttributes(Map<String, AttributeValue> m) {
+    for (Map.Entry<String, AttributeValue> entry : m.entrySet()) {
+      putAttribute(entry.getKey(), entry.getValue());
+    }
+  }
+
   int getNumberOfDroppedAttributes() {
     return totalRecordedAttributes - size();
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -33,7 +33,6 @@ import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.Tracer;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -130,7 +129,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
       SpanProcessor spanProcessor,
       Clock clock,
       Resource resource,
-      Map<String, AttributeValue> attributes,
+      AttributesWithCapacity attributes,
       List<Link> links,
       int totalRecordedLinks,
       long startEpochNanos) {
@@ -486,43 +485,6 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     }
   }
 
-  // A map implementation with a fixed capacity that drops events when the map gets full. Eviction
-  // is based on the access order.
-  static final class AttributesWithCapacity extends LinkedHashMap<String, AttributeValue> {
-
-    private final long capacity;
-    private int totalRecordedAttributes = 0;
-    // Here because -Werror complains about this: [serial] serializable class AttributesWithCapacity
-    // has no definition of serialVersionUID. This class shouldn't be serialized.
-    private static final long serialVersionUID = 42L;
-
-    private AttributesWithCapacity(long capacity) {
-      // Capacity of the map is capacity + 1 to avoid resizing because removeEldestEntry is invoked
-      // by put and putAll after inserting a new entry into the map. The loadFactor is set to 1
-      // to avoid resizing because. The accessOrder is set to true.
-      super((int) capacity + 1, 1, /*accessOrder=*/ true);
-      this.capacity = capacity;
-    }
-
-    // Users must call this method instead of put to keep count of the total number of entries
-    // inserted.
-    private void putAttribute(String key, AttributeValue value) {
-      totalRecordedAttributes += 1;
-      put(key, value);
-    }
-
-    int getNumberOfDroppedAttributes() {
-      return totalRecordedAttributes - size();
-    }
-
-    // It is called after each put or putAll call in order to determine if the eldest inserted
-    // entry should be removed or not.
-    @Override
-    protected boolean removeEldestEntry(Map.Entry<String, AttributeValue> eldest) {
-      return size() > this.capacity;
-    }
-  }
-
   private RecordEventsReadableSpan(
       SpanContext context,
       String name,
@@ -534,7 +496,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
       SpanProcessor spanProcessor,
       Clock clock,
       Resource resource,
-      Map<String, AttributeValue> attributes,
+      AttributesWithCapacity attributes,
       List<Link> links,
       int totalRecordedLinks,
       long startEpochNanos) {
@@ -552,8 +514,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     this.numberOfChildren = 0;
     this.clock = clock;
     this.startEpochNanos = startEpochNanos;
-    this.attributes = new AttributesWithCapacity(traceConfig.getMaxNumberOfAttributes());
-    this.attributes.putAll(attributes);
+    this.attributes = attributes;
     this.events = EvictingQueue.create(traceConfig.getMaxNumberOfEvents());
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -199,7 +199,7 @@ class SpanBuilderSdk implements Span.Builder {
       return DefaultSpan.create(spanContext);
     }
 
-    attributes.putAll(samplingDecision.attributes());
+    attributes.putAllAttributes(samplingDecision.attributes());
 
     return RecordEventsReadableSpan.startSpan(
         spanContext,

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -57,6 +57,7 @@ class SpanBuilderSdk implements Span.Builder {
   @Nullable private Span parent;
   @Nullable private SpanContext remoteParent;
   private Kind spanKind = Kind.INTERNAL;
+  private final AttributesWithCapacity attributes;
   private List<Link> links;
   private ParentType parentType = ParentType.CURRENT_SPAN;
   private long startEpochNanos = 0;
@@ -74,6 +75,7 @@ class SpanBuilderSdk implements Span.Builder {
     this.spanProcessor = spanProcessor;
     this.traceConfig = traceConfig;
     this.resource = resource;
+    this.attributes = new AttributesWithCapacity(traceConfig.getMaxNumberOfAttributes());
     this.links = Collections.emptyList();
     this.idsGenerator = idsGenerator;
     this.clock = clock;
@@ -133,6 +135,34 @@ class SpanBuilderSdk implements Span.Builder {
   }
 
   @Override
+  public Span.Builder setAttribute(String key, String value) {
+    return setAttribute(key, AttributeValue.stringAttributeValue(value));
+  }
+
+  @Override
+  public Span.Builder setAttribute(String key, long value) {
+    return setAttribute(key, AttributeValue.longAttributeValue(value));
+  }
+
+  @Override
+  public Span.Builder setAttribute(String key, double value) {
+    return setAttribute(key, AttributeValue.doubleAttributeValue(value));
+  }
+
+  @Override
+  public Span.Builder setAttribute(String key, boolean value) {
+    return setAttribute(key, AttributeValue.booleanAttributeValue(value));
+  }
+
+  @Override
+  public Span.Builder setAttribute(String key, AttributeValue value) {
+    Utils.checkNotNull(key, "key");
+    Utils.checkNotNull(value, "value");
+    attributes.putAttribute(key, value);
+    return this;
+  }
+
+  @Override
   public Span.Builder setStartTimestamp(long startTimestamp) {
     Utils.checkArgument(startTimestamp >= 0, "Negative startTimestamp");
     startEpochNanos = startTimestamp;
@@ -169,6 +199,8 @@ class SpanBuilderSdk implements Span.Builder {
       return DefaultSpan.create(spanContext);
     }
 
+    attributes.putAll(samplingDecision.attributes());
+
     return RecordEventsReadableSpan.startSpan(
         spanContext,
         spanName,
@@ -180,7 +212,7 @@ class SpanBuilderSdk implements Span.Builder {
         spanProcessor,
         getClock(parentSpan(parentType, parent), clock),
         resource,
-        samplingDecision.attributes(),
+        attributes,
         truncatedLinks(),
         links.size(),
         startEpochNanos);

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -454,6 +454,10 @@ public class RecordEventsReadableSpanTest {
       TraceConfig config,
       @Nullable SpanId parentSpanId,
       Map<String, AttributeValue> attributes) {
+    AttributesWithCapacity attributesWithCapacity =
+        new AttributesWithCapacity(config.getMaxNumberOfAttributes());
+    attributesWithCapacity.putAll(attributes);
+
     RecordEventsReadableSpan span =
         RecordEventsReadableSpan.startSpan(
             spanContext,
@@ -466,7 +470,7 @@ public class RecordEventsReadableSpanTest {
             spanProcessor,
             testClock,
             resource,
-            attributes,
+            attributesWithCapacity,
             Collections.singletonList(link),
             1,
             0);
@@ -530,6 +534,8 @@ public class RecordEventsReadableSpanTest {
     labels.put("foo", "bar");
     Resource resource = Resource.create(labels);
     Map<String, AttributeValue> attributes = TestUtils.generateRandomAttributes();
+    AttributesWithCapacity attributesWithCapacity = new AttributesWithCapacity(32);
+    attributesWithCapacity.putAll(attributes);
     Map<String, AttributeValue> event1Attributes = TestUtils.generateRandomAttributes();
     Map<String, AttributeValue> event2Attributes = TestUtils.generateRandomAttributes();
     SpanContext context =
@@ -549,7 +555,7 @@ public class RecordEventsReadableSpanTest {
             spanProcessor,
             clock,
             resource,
-            attributes,
+            attributesWithCapacity,
             links,
             1,
             0);

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -456,7 +456,7 @@ public class RecordEventsReadableSpanTest {
       Map<String, AttributeValue> attributes) {
     AttributesWithCapacity attributesWithCapacity =
         new AttributesWithCapacity(config.getMaxNumberOfAttributes());
-    attributesWithCapacity.putAll(attributes);
+    attributesWithCapacity.putAllAttributes(attributes);
 
     RecordEventsReadableSpan span =
         RecordEventsReadableSpan.startSpan(
@@ -535,7 +535,7 @@ public class RecordEventsReadableSpanTest {
     Resource resource = Resource.create(labels);
     Map<String, AttributeValue> attributes = TestUtils.generateRandomAttributes();
     AttributesWithCapacity attributesWithCapacity = new AttributesWithCapacity(32);
-    attributesWithCapacity.putAll(attributes);
+    attributesWithCapacity.putAllAttributes(attributes);
     Map<String, AttributeValue> event1Attributes = TestUtils.generateRandomAttributes();
     Map<String, AttributeValue> event2Attributes = TestUtils.generateRandomAttributes();
     SpanContext context =

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -146,6 +146,55 @@ public class SpanBuilderSdkTest {
   }
 
   @Test
+  public void setAttribute() {
+    Span.Builder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
+    spanBuilder.setAttribute("string", "value");
+    spanBuilder.setAttribute("long", 12345L);
+    spanBuilder.setAttribute("double", .12345);
+    spanBuilder.setAttribute("boolean", true);
+
+    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    try {
+      Map<String, AttributeValue> attrs = span.getAttributes();
+      assertThat(attrs).hasSize(4);
+      assertThat(attrs.get("string")).isEqualTo(AttributeValue.stringAttributeValue("value"));
+      assertThat(attrs.get("long")).isEqualTo(AttributeValue.longAttributeValue(12345L));
+      assertThat(attrs.get("double")).isEqualTo(AttributeValue.doubleAttributeValue(.12345));
+      assertThat(attrs.get("boolean")).isEqualTo(AttributeValue.booleanAttributeValue(true));
+    } finally {
+      span.end();
+    }
+  }
+
+  @Test
+  public void droppingAttributes() {
+    final int maxNumberOfAttrs = 8;
+    TraceConfig traceConfig =
+        tracerSdkFactory
+            .getActiveTraceConfig()
+            .toBuilder()
+            .setMaxNumberOfAttributes(maxNumberOfAttrs)
+            .build();
+    tracerSdkFactory.updateActiveTraceConfig(traceConfig);
+    Span.Builder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
+    for (int i = 0; i < 2 * maxNumberOfAttrs; i++) {
+      spanBuilder.setAttribute("key" + i, i);
+    }
+    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    try {
+      Map<String, AttributeValue> attrs = span.getAttributes();
+      assertThat(attrs.size()).isEqualTo(maxNumberOfAttrs);
+      for (int i = 0; i < maxNumberOfAttrs; i++) {
+        assertThat(attrs.get("key" + (i + maxNumberOfAttrs)))
+            .isEqualTo(AttributeValue.longAttributeValue(i + maxNumberOfAttrs));
+      }
+    } finally {
+      span.end();
+      tracerSdkFactory.updateActiveTraceConfig(TraceConfig.getDefault());
+    }
+  }
+
+  @Test
   public void recordEvents_default() {
     Span span = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
     try {
@@ -192,6 +241,7 @@ public class SpanBuilderSdkTest {
 
   @Test
   public void sampler_decisionAttributes() {
+    final String samplerAttributeName = "sampler-attribute";
     RecordEventsReadableSpan span =
         (RecordEventsReadableSpan)
             TestUtils.startSpanWithSampler(
@@ -216,7 +266,7 @@ public class SpanBuilderSdkTest {
                           public Map<String, AttributeValue> attributes() {
                             Map<String, AttributeValue> attributes = new LinkedHashMap<>();
                             attributes.put(
-                                "sampler-attribute", AttributeValue.stringAttributeValue("bar"));
+                                samplerAttributeName, AttributeValue.stringAttributeValue("bar"));
                             return attributes;
                           }
                         };
@@ -226,11 +276,13 @@ public class SpanBuilderSdkTest {
                       public String getDescription() {
                         return "test sampler";
                       }
-                    })
+                    },
+                    Collections.<String, AttributeValue>singletonMap(
+                        samplerAttributeName, AttributeValue.stringAttributeValue("none")))
                 .startSpan();
     try {
       assertThat(span.getContext().getTraceFlags().isSampled()).isTrue();
-      assertThat(span.getAttributes()).containsKey("sampler-attribute");
+      assertThat(span.getAttributes()).containsKey(samplerAttributeName);
     } finally {
       span.end();
     }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -152,15 +152,18 @@ public class SpanBuilderSdkTest {
     spanBuilder.setAttribute("long", 12345L);
     spanBuilder.setAttribute("double", .12345);
     spanBuilder.setAttribute("boolean", true);
+    spanBuilder.setAttribute("stringAttribute", AttributeValue.stringAttributeValue("attrvalue"));
 
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     try {
       Map<String, AttributeValue> attrs = span.getAttributes();
-      assertThat(attrs).hasSize(4);
+      assertThat(attrs).hasSize(5);
       assertThat(attrs.get("string")).isEqualTo(AttributeValue.stringAttributeValue("value"));
       assertThat(attrs.get("long")).isEqualTo(AttributeValue.longAttributeValue(12345L));
       assertThat(attrs.get("double")).isEqualTo(AttributeValue.doubleAttributeValue(.12345));
       assertThat(attrs.get("boolean")).isEqualTo(AttributeValue.booleanAttributeValue(true));
+      assertThat(attrs.get("stringAttribute"))
+          .isEqualTo(AttributeValue.stringAttributeValue("attrvalue"));
     } finally {
       span.end();
     }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
@@ -24,6 +24,7 @@ import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.Tracer;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -72,11 +73,36 @@ public final class TestUtils {
    */
   public static Span.Builder startSpanWithSampler(
       TracerSdkFactory tracerSdkFactory, Tracer tracer, String spanName, Sampler sampler) {
+    return startSpanWithSampler(
+        tracerSdkFactory,
+        tracer,
+        spanName,
+        sampler,
+        Collections.<String, AttributeValue>emptyMap());
+  }
+
+  /**
+   * Create a very basic SpanData instance, suitable for testing. It has the bare minimum viable
+   * data.
+   *
+   * @return A SpanData instance.
+   */
+  public static Span.Builder startSpanWithSampler(
+      TracerSdkFactory tracerSdkFactory,
+      Tracer tracer,
+      String spanName,
+      Sampler sampler,
+      Map<String, AttributeValue> attributes) {
     TraceConfig originalConfig = tracerSdkFactory.getActiveTraceConfig();
     tracerSdkFactory.updateActiveTraceConfig(
         originalConfig.toBuilder().setSampler(sampler).build());
     try {
-      return tracer.spanBuilder(spanName);
+      Span.Builder builder = tracer.spanBuilder(spanName);
+      for (Map.Entry<String, AttributeValue> entry : attributes.entrySet()) {
+        builder.setAttribute(entry.getKey(), entry.getValue());
+      }
+
+      return builder;
     } finally {
       tracerSdkFactory.updateActiveTraceConfig(originalConfig);
     }


### PR DESCRIPTION
Fixes #660 

PS - I've used `AttributesWithCapacity` from the `Span.Builder` implementation itself, to keep the very same logic that `Span` uses to discard them when the max count is reached.