### PR TITLE
Handle null parent's SpanContextShim in the OT Shim.

### DIFF
--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
@@ -183,7 +183,8 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
       builder.setNoParent();
     } else if (parentSpan != null) {
       builder.setParent(parentSpan.getSpan());
-      distContext = spanContextTable().get(parentSpan).getDistributedContext();
+      SpanContextShim contextShim = spanContextTable().get(parentSpan);
+      distContext = contextShim == null ? null : contextShim.getDistributedContext();
     } else if (parentSpanContext != null) {
       builder.setParent(parentSpanContext.getSpanContext());
       distContext = parentSpanContext.getDistributedContext();

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/SpanBuilderShimTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/SpanBuilderShimTest.java
@@ -18,6 +18,7 @@ package io.opentelemetry.opentracingshim;
 
 import static io.opentelemetry.opentracingshim.TestUtils.getBaggageMap;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import io.opentelemetry.sdk.distributedcontext.DistributedContextManagerSdk;
 import io.opentelemetry.sdk.trace.TracerSdkFactory;
@@ -67,6 +68,24 @@ public class SpanBuilderShimTest {
         assertEquals(
             getBaggageMap(childSpan.context().baggageItems()),
             getBaggageMap(parentSpan.context().baggageItems()));
+      } finally {
+        childSpan.finish();
+      }
+    } finally {
+      parentSpan.finish();
+    }
+  }
+
+  @Test
+  public void parent_NullContextShim() {
+    /* SpanContextShim is null until Span.context() or Span.getBaggageItem() are called.
+     * Verify a null SpanContextShim in the parent is handled properly. */
+    SpanShim parentSpan = (SpanShim) new SpanBuilderShim(telemetryInfo, SPAN_NAME).start();
+    try {
+      SpanShim childSpan =
+          (SpanShim) new SpanBuilderShim(telemetryInfo, SPAN_NAME).asChildOf(parentSpan).start();
+      try {
+        assertFalse(childSpan.context().baggageItems().iterator().hasNext());
       } finally {
         childSpan.finish();
       }


### PR DESCRIPTION
SpanContextShim objects are created on demand,
as it's an expensive operation because of a global
write lock, hence we need to handle the case
of starting a Span whose parent has no SpanContextShim
yet.

Fixes #671 