### PR TITLE
Fix the warning that occurs when a code is used in a code tag

### DIFF
--- a/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporter.java
+++ b/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporter.java
@@ -41,7 +41,7 @@ import java.util.List;
  *   public void getFinishedSpanData() {
  *     tracer.spanBuilder("span").startSpan().end();
  *
- *     {@code List<Span> spanItems} = exporter.getFinishedSpanItems();
+ *     List&lt;Span&gt; spanItems = exporter.getFinishedSpanItems();
  *     assertThat(spanItems).isNotNull();
  *     assertThat(spanItems.size()).isEqualTo(1);
  *     assertThat(spanItems.get(0).getName()).isEqualTo("span");

--- a/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryTracing.java
+++ b/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryTracing.java
@@ -35,7 +35,7 @@ import java.util.List;
  *     Tracer tracer = tracing.getTracer();
  *     tracer.spanBuilder("span").startSpan().end();
  *
- *     {@code List<io.opentelemetry.sdk.trace.SpanData>} spans = tracing.getFinishedSpanItems();
+ *     List&lt;io.opentelemetry.sdk.trace.SpanData&gt; spans = tracing.getFinishedSpanItems();
  *     assertThat(spans.size()).isEqualTo(1);
  *     assertThat(spans.get(0).getName()).isEqualTo("span");
  *   }


### PR DESCRIPTION
## Problem

```shell
$ make test verify-format
./gradlew clean assemble check --stacktrace

> Task :opentelemetry-all:javadoc
/Users/a14689/oss/opentelemetry-java/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporter.java:44: Warning: <code> in {@code}
 *     {@code List<Span> spanItems} = exporter.getFinishedSpanItems();
       ^
/Users/a14689/oss/opentelemetry-java/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryTracing.java:38: Warning: <code> in {@code}
 *     {@code List<io.opentelemetry.sdk.trace.SpanData>} spans = tracing.getFinishedSpanItems();
       ^

> Task :opentelemetry-exporters-inmemory:javadoc
/Users/a14689/oss/opentelemetry-java/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporter.java:44: Warning: <code> in {@code}
 *     {@code List<Span> spanItems} = exporter.getFinishedSpanItems();
       ^
/Users/a14689/oss/opentelemetry-java/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryTracing.java:38: Warning: <code> in {@code}
 *     {@code List<io.opentelemetry.sdk.trace.SpanData>} spans = tracing.getFinishedSpanItems();
       ^
```

## Solution

- Replace `<`, `>` with `&lt;`, `%gt;`.
- Remove a `@code` tag in a `<code>` tag.