### PR TITLE
[On Hold] Improve behavior of un-ended ReadableSpan

### DIFF
--- a/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
+++ b/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
@@ -101,6 +101,7 @@ public class InMemorySpanExporterTest {
 
   static SpanData makeBasicSpan() {
     return SpanData.newBuilder()
+        .setHasBeenEnded(true)
         .setTraceId(io.opentelemetry.trace.TraceId.getInvalid())
         .setSpanId(io.opentelemetry.trace.SpanId.getInvalid())
         .setName("span")

--- a/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
+++ b/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
@@ -101,7 +101,7 @@ public class InMemorySpanExporterTest {
 
   static SpanData makeBasicSpan() {
     return SpanData.newBuilder()
-        .setHasBeenEnded(true)
+        .setHasEnded(true)
         .setTraceId(io.opentelemetry.trace.TraceId.getInvalid())
         .setSpanId(io.opentelemetry.trace.SpanId.getInvalid())
         .setName("span")

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
@@ -218,7 +218,7 @@ public class AdapterTest {
     long endMs = startMs + 900;
     SpanData span =
         SpanData.newBuilder()
-            .setHasBeenEnded(true)
+            .setHasEnded(true)
             .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
             .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
             .setName("GET /api/endpoint")
@@ -245,7 +245,7 @@ public class AdapterTest {
     Link link = SpanData.Link.create(createSpanContext(LINK_TRACE_ID, LINK_SPAN_ID), attributes);
 
     return SpanData.newBuilder()
-        .setHasBeenEnded(true)
+        .setHasEnded(true)
         .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
         .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
         .setParentSpanId(SpanId.fromLowerBase16(PARENT_SPAN_ID, 0))

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
@@ -218,6 +218,7 @@ public class AdapterTest {
     long endMs = startMs + 900;
     SpanData span =
         SpanData.newBuilder()
+            .setHasBeenEnded(true)
             .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
             .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
             .setName("GET /api/endpoint")
@@ -244,6 +245,7 @@ public class AdapterTest {
     Link link = SpanData.Link.create(createSpanContext(LINK_TRACE_ID, LINK_SPAN_ID), attributes);
 
     return SpanData.newBuilder()
+        .setHasBeenEnded(true)
         .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
         .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
         .setParentSpanId(SpanId.fromLowerBase16(PARENT_SPAN_ID, 0))

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporterTest.java
@@ -79,7 +79,7 @@ public class JaegerGrpcSpanExporterTest {
     long endMs = startMs + duration;
     SpanData span =
         SpanData.newBuilder()
-            .setHasBeenEnded(true)
+            .setHasEnded(true)
             .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
             .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
             .setName("GET /api/endpoint")

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporterTest.java
@@ -79,6 +79,7 @@ public class JaegerGrpcSpanExporterTest {
     long endMs = startMs + duration;
     SpanData span =
         SpanData.newBuilder()
+            .setHasBeenEnded(true)
             .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
             .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
             .setName("GET /api/endpoint")

--- a/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingExporterTest.java
@@ -37,7 +37,7 @@ public class LoggingExporterTest {
     long epochNanos = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
     SpanData spanData =
         SpanData.newBuilder()
-            .setHasBeenEnded(true)
+            .setHasEnded(true)
             .setTraceId(new TraceId(1234L, 6789L))
             .setSpanId(new SpanId(9876L))
             .setStartEpochNanos(epochNanos)

--- a/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingExporterTest.java
@@ -37,6 +37,7 @@ public class LoggingExporterTest {
     long epochNanos = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
     SpanData spanData =
         SpanData.newBuilder()
+            .setHasBeenEnded(true)
             .setTraceId(new TraceId(1234L, 6789L))
             .setSpanId(new SpanId(9876L))
             .setStartEpochNanos(epochNanos)

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
@@ -62,6 +62,14 @@ public interface ReadableSpan {
   InstrumentationLibraryInfo getInstrumentationLibraryInfo();
 
   /**
+   * Returns whether this Span has already been ended.
+   *
+   * @return {@code true} if the span has already been ended, {@code false} if not.
+   * @since 0.4.0
+   */
+  boolean hasBeenEnded();
+
+  /**
    * Returns the latency of the {@code Span} in nanos. If still active then returns now() - start
    * time.
    *

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
@@ -60,4 +60,13 @@ public interface ReadableSpan {
    *     library
    */
   InstrumentationLibraryInfo getInstrumentationLibraryInfo();
+
+  /**
+   * Returns the latency of the {@code Span} in nanos. If still active then returns now() - start
+   * time.
+   *
+   * @return the latency of the {@code Span} in nanos.
+   * @since 0.4.0
+   */
+  long getLatencyNs();
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
@@ -68,5 +68,5 @@ public interface ReadableSpan {
    * @return the latency of the {@code Span} in nanos.
    * @since 0.4.0
    */
-  long getLatencyNs();
+  long getLatencyNanos();
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
@@ -67,7 +67,7 @@ public interface ReadableSpan {
    * @return {@code true} if the span has already been ended, {@code false} if not.
    * @since 0.4.0
    */
-  boolean hasBeenEnded();
+  boolean hasEnded();
 
   /**
    * Returns the latency of the {@code Span} in nanos. If still active then returns now() - start

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -296,6 +296,19 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   }
 
   /**
+   * Returns the latency of the {@code Span} in nanos. If still active then returns now() - start
+   * time.
+   *
+   * @return the latency of the {@code Span} in nanos.
+   */
+  @Override
+  public long getLatencyNs() {
+    synchronized (lock) {
+      return (hasBeenEnded ? endEpochNanos : clock.now()) - startEpochNanos;
+    }
+  }
+
+  /**
    * Returns the kind of this {@code Span}.
    *
    * @return the kind of this {@code Span}.

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -34,7 +34,6 @@ import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.Tracer;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -160,31 +159,26 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   @Override
   public SpanData toSpanData() {
     SpanContext spanContext = getSpanContext();
-    // Set immutable info outside the lock.
-    SpanData.Builder builder =
-        SpanData.newBuilder()
-            .setInstrumentationLibraryInfo(instrumentationLibraryInfo)
-            .setTraceId(spanContext.getTraceId())
-            .setSpanId(spanContext.getSpanId())
-            .setTraceFlags(spanContext.getTraceFlags())
-            .setTracestate(spanContext.getTracestate())
-            .setStartEpochNanos(startEpochNanos)
-            .setKind(kind)
-            .setLinks(getLinks())
-            .setParentSpanId(parentSpanId)
-            .setHasRemoteParent(hasRemoteParent)
-            .setResource(resource);
-    synchronized (lock) {
-      builder
-          .setHasEnded(hasEnded)
-          .setName(getName())
-          .setAttributes(hasEnded ? attributes : new HashMap<>(attributes))
-          .setEndEpochNanos(getEndEpochNanos())
-          .setLatencyNanos(getLatencyNanos())
-          .setStatus(getStatus())
-          .setTimedEvents(adaptTimedEvents());
-    }
-    return builder.build();
+    return SpanData.newBuilder()
+        .setName(getName())
+        .setInstrumentationLibraryInfo(instrumentationLibraryInfo)
+        .setTraceId(spanContext.getTraceId())
+        .setSpanId(spanContext.getSpanId())
+        .setTraceFlags(spanContext.getTraceFlags())
+        .setTracestate(spanContext.getTracestate())
+        .setAttributes(getAttributes())
+        .setStartEpochNanos(startEpochNanos)
+        .setEndEpochNanos(getEndEpochNanos())
+        .setLatencyNanos(getLatencyNanos())
+        .setKind(kind)
+        .setLinks(getLinks())
+        .setParentSpanId(parentSpanId)
+        .setHasRemoteParent(hasRemoteParent)
+        .setResource(resource)
+        .setStatus(getStatus())
+        .setTimedEvents(adaptTimedEvents())
+        .setHasEnded(hasEnded())
+        .build();
   }
 
   private List<SpanData.TimedEvent> adaptTimedEvents() {
@@ -276,20 +270,22 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
    */
   @VisibleForTesting
   List<Link> getLinks() {
-    if (links == null) {
-      return Collections.emptyList();
-    }
-    List<Link> result = new ArrayList<>(links.size());
-    for (Link link : links) {
-      Link newLink = link;
-      if (!(link instanceof SpanData.Link)) {
-        // Make a copy because the given Link may not be immutable and we may reference a lot of
-        // memory.
-        newLink = SpanData.Link.create(link.getContext(), link.getAttributes());
+    synchronized (lock) {
+      if (links == null) {
+        return Collections.emptyList();
       }
-      result.add(newLink);
+      List<Link> result = new ArrayList<>(links.size());
+      for (Link link : links) {
+        Link newLink = link;
+        if (!(link instanceof SpanData.Link)) {
+          // Make a copy because the given Link may not be immutable and we may reference a lot of
+          // memory.
+          newLink = SpanData.Link.create(link.getContext(), link.getAttributes());
+        }
+        result.add(newLink);
+      }
+      return Collections.unmodifiableList(result);
     }
-    return Collections.unmodifiableList(result);
   }
 
   /**

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -220,14 +220,14 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   }
 
   /**
-   * Returns the end nano time (see {@link System#nanoTime()}). If the current {@code Span} is not
-   * ended then returns {@link Clock#nanoTime()}.
+   * Returns the end nano time (see {@link System#nanoTime()}) or zero if the current {@code Span}
+   * is not ended.
    *
    * @return the end nano time.
    */
   private long getEndEpochNanos() {
     synchronized (lock) {
-      return getEndNanoTimeInternal();
+      return endEpochNanos;
     }
   }
 
@@ -289,24 +289,6 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     synchronized (lock) {
       return Collections.unmodifiableMap(attributes);
     }
-  }
-
-  /**
-   * Returns the latency of the {@code Span} in nanos. If still active then returns now() - start
-   * time.
-   *
-   * @return the latency of the {@code Span} in nanos.
-   */
-  long getLatencyNs() {
-    synchronized (lock) {
-      return getEndNanoTimeInternal() - startEpochNanos;
-    }
-  }
-
-  // Use getEndNanoTimeInternal to avoid over-locking.
-  @GuardedBy("lock")
-  private long getEndNanoTimeInternal() {
-    return hasBeenEnded ? endEpochNanos : clock.now();
   }
 
   /**

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -180,6 +180,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
           .setName(getName())
           .setAttributes(hasBeenEnded ? attributes : new HashMap<>(attributes))
           .setEndEpochNanos(getEndEpochNanos())
+          .setLatencyNanos(getLatencyNanos())
           .setStatus(getStatus())
           .setTimedEvents(adaptTimedEvents());
     }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -197,6 +197,13 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   }
 
   @Override
+  public boolean hasBeenEnded() {
+    synchronized (lock) {
+      return hasBeenEnded;
+    }
+  }
+
+  @Override
   public SpanContext getSpanContext() {
     return getContext();
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -302,7 +302,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
    * @return the latency of the {@code Span} in nanos.
    */
   @Override
-  public long getLatencyNs() {
+  public long getLatencyNanos() {
     synchronized (lock) {
       return (hasBeenEnded ? endEpochNanos : clock.now()) - startEpochNanos;
     }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -176,6 +176,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
             .setResource(resource);
     synchronized (lock) {
       builder
+          .setHasBeenEnded(hasBeenEnded)
           .setName(getName())
           .setAttributes(hasBeenEnded ? attributes : new HashMap<>(attributes))
           .setEndEpochNanos(getEndEpochNanos())

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanData.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanData.java
@@ -179,7 +179,7 @@ public abstract class SpanData {
    * @return {@code true} if the span has already been ended, {@code false} if not.
    * @since 0.4.0
    */
-  public abstract boolean getHasBeenEnded();
+  public abstract boolean getHasEnded();
 
   /**
    * Returns the latency of the {@code Span} in nanos. If still active then returns now() - start
@@ -478,11 +478,11 @@ public abstract class SpanData {
     /**
      * Sets to true if the span has been ended.
      *
-     * @param hasBeenEnded A boolean indicating if the span has been ended.
+     * @param hasEnded A boolean indicating if the span has been ended.
      * @return this
      * @since 0.4.0
      */
-    public abstract Builder setHasBeenEnded(boolean hasBeenEnded);
+    public abstract Builder setHasEnded(boolean hasEnded);
 
     /**
      * Sets to true if the span has been ended.

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanData.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanData.java
@@ -173,6 +173,14 @@ public abstract class SpanData {
   public abstract boolean getHasRemoteParent();
 
   /**
+   * Returns whether this Span has already been ended.
+   *
+   * @return {@code true} if the span has already been ended, {@code false} if not.
+   * @since 0.4.0
+   */
+  public abstract boolean getHasBeenEnded();
+
+  /**
    * An immutable implementation of {@link Link}.
    *
    * @since 0.1.0
@@ -442,5 +450,14 @@ public abstract class SpanData {
      * @since 0.3.0
      */
     public abstract Builder setHasRemoteParent(boolean hasRemoteParent);
+
+    /**
+     * Sets to true if the span has been ended.
+     *
+     * @param hasBeenEnded A boolean indicating if the span has been ended.
+     * @return this
+     * @since 0.4.0
+     */
+    public abstract Builder setHasBeenEnded(boolean hasBeenEnded);
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -244,6 +244,32 @@ public class RecordEventsReadableSpanTest {
   }
 
   @Test
+  public void getLatencyNs_ActiveSpan() {
+    RecordEventsReadableSpan span = createTestSpan(Kind.INTERNAL);
+    try {
+      testClock.advanceMillis(MILLIS_PER_SECOND);
+      long elapsedTimeNanos1 = testClock.now() - startEpochNanos;
+      assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos1);
+      testClock.advanceMillis(MILLIS_PER_SECOND);
+      long elapsedTimeNanos2 = testClock.now() - startEpochNanos;
+      assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos2);
+    } finally {
+      span.end();
+    }
+  }
+
+  @Test
+  public void getLatencyNs_EndedSpan() {
+    RecordEventsReadableSpan span = createTestSpan(Kind.INTERNAL);
+    testClock.advanceMillis(MILLIS_PER_SECOND);
+    span.end();
+    long elapsedTimeNanos = testClock.now() - startEpochNanos;
+    assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos);
+    testClock.advanceMillis(MILLIS_PER_SECOND);
+    assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos);
+  }
+
+  @Test
   public void setAttribute() {
     RecordEventsReadableSpan span = createTestRootSpan();
     try {

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -106,7 +106,8 @@ public class RecordEventsReadableSpanTest {
         SPAN_NAME,
         startEpochNanos,
         startEpochNanos,
-        Status.OK);
+        Status.OK,
+        /*hasEnded=*/ true);
   }
 
   @Test
@@ -139,7 +140,8 @@ public class RecordEventsReadableSpanTest {
           SPAN_NEW_NAME,
           startEpochNanos,
           0,
-          Status.OK);
+          Status.OK,
+          /*hasEnded=*/ false);
       assertThat(span.hasEnded()).isFalse();
     } finally {
       span.end();
@@ -170,7 +172,8 @@ public class RecordEventsReadableSpanTest {
         SPAN_NEW_NAME,
         startEpochNanos,
         testClock.now(),
-        Status.CANCELLED);
+        Status.CANCELLED,
+        /*hasEnded=*/ true);
   }
 
   @Test
@@ -510,7 +513,8 @@ public class RecordEventsReadableSpanTest {
       String spanName,
       long startEpochNanos,
       long endEpochNanos,
-      Status status) {
+      Status status,
+      boolean hasEnded) {
     assertThat(spanData.getTraceId()).isEqualTo(traceId);
     assertThat(spanData.getSpanId()).isEqualTo(spanId);
     assertThat(spanData.getParentSpanId()).isEqualTo(parentSpanId);
@@ -525,6 +529,7 @@ public class RecordEventsReadableSpanTest {
     assertThat(spanData.getStartEpochNanos()).isEqualTo(startEpochNanos);
     assertThat(spanData.getEndEpochNanos()).isEqualTo(endEpochNanos);
     assertThat(spanData.getStatus().getCanonicalCode()).isEqualTo(status.getCanonicalCode());
+    assertThat(spanData.getHasEnded()).isEqualTo(hasEnded);
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -134,7 +134,7 @@ public class RecordEventsReadableSpanTest {
           Collections.singletonList(link),
           SPAN_NEW_NAME,
           startEpochNanos,
-          testClock.now(),
+          0,
           Status.OK);
     } finally {
       span.end();
@@ -241,32 +241,6 @@ public class RecordEventsReadableSpanTest {
     } finally {
       span.end();
     }
-  }
-
-  @Test
-  public void getLatencyNs_ActiveSpan() {
-    RecordEventsReadableSpan span = createTestSpan(Kind.INTERNAL);
-    try {
-      testClock.advanceMillis(MILLIS_PER_SECOND);
-      long elapsedTimeNanos1 = testClock.now() - startEpochNanos;
-      assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos1);
-      testClock.advanceMillis(MILLIS_PER_SECOND);
-      long elapsedTimeNanos2 = testClock.now() - startEpochNanos;
-      assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos2);
-    } finally {
-      span.end();
-    }
-  }
-
-  @Test
-  public void getLatencyNs_EndedSpan() {
-    RecordEventsReadableSpan span = createTestSpan(Kind.INTERNAL);
-    testClock.advanceMillis(MILLIS_PER_SECOND);
-    span.end();
-    long elapsedTimeNanos = testClock.now() - startEpochNanos;
-    assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos);
-    testClock.advanceMillis(MILLIS_PER_SECOND);
-    assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos);
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -112,14 +112,18 @@ public class RecordEventsReadableSpanTest {
   @Test
   public void endSpanTwice_DoNotCrash() {
     RecordEventsReadableSpan span = createTestSpan(Kind.INTERNAL);
+    assertThat(span.hasBeenEnded()).isFalse();
     span.end();
+    assertThat(span.hasBeenEnded()).isTrue();
     span.end();
+    assertThat(span.hasBeenEnded()).isTrue();
   }
 
   @Test
   public void toSpanData_ActiveSpan() {
     RecordEventsReadableSpan span = createTestSpan(Kind.INTERNAL);
     try {
+      assertThat(span.hasBeenEnded()).isFalse();
       spanDoWork(span, null);
       SpanData spanData = span.toSpanData();
       SpanData.TimedEvent timedEvent =
@@ -136,9 +140,11 @@ public class RecordEventsReadableSpanTest {
           startEpochNanos,
           0,
           Status.OK);
+      assertThat(span.hasBeenEnded()).isFalse();
     } finally {
       span.end();
     }
+    assertThat(span.hasBeenEnded()).isTrue();
   }
 
   @Test
@@ -574,6 +580,7 @@ public class RecordEventsReadableSpanTest {
 
     SpanData expected =
         SpanData.newBuilder()
+            .setHasBeenEnded(true)
             .setName(name)
             .setInstrumentationLibraryInfo(instrumentationLibraryInfo)
             .setKind(kind)

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -108,6 +108,7 @@ public class RecordEventsReadableSpanTest {
         startEpochNanos,
         Status.OK,
         /*hasEnded=*/ true);
+    assertThat(spanData.getLatencyNanos()).isEqualTo(0);
   }
 
   @Test
@@ -132,6 +133,7 @@ public class RecordEventsReadableSpanTest {
               startEpochNanos + NANOS_PER_SECOND,
               "event2",
               Collections.<String, AttributeValue>emptyMap());
+      long prevLatencyNanos = span.getLatencyNanos();
       verifySpanData(
           spanData,
           expectedAttributes,
@@ -142,6 +144,8 @@ public class RecordEventsReadableSpanTest {
           0,
           Status.OK,
           /*hasEnded=*/ false);
+      assertThat(spanData.getLatencyNanos()).isAtLeast(prevLatencyNanos);
+      assertThat(spanData.getLatencyNanos()).isAtMost(span.getLatencyNanos());
       assertThat(span.hasEnded()).isFalse();
     } finally {
       span.end();
@@ -174,6 +178,7 @@ public class RecordEventsReadableSpanTest {
         testClock.now(),
         Status.CANCELLED,
         /*hasEnded=*/ true);
+    assertThat(spanData.getLatencyNanos()).isEqualTo(testClock.now() - startEpochNanos);
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -112,18 +112,18 @@ public class RecordEventsReadableSpanTest {
   @Test
   public void endSpanTwice_DoNotCrash() {
     RecordEventsReadableSpan span = createTestSpan(Kind.INTERNAL);
-    assertThat(span.hasBeenEnded()).isFalse();
+    assertThat(span.hasEnded()).isFalse();
     span.end();
-    assertThat(span.hasBeenEnded()).isTrue();
+    assertThat(span.hasEnded()).isTrue();
     span.end();
-    assertThat(span.hasBeenEnded()).isTrue();
+    assertThat(span.hasEnded()).isTrue();
   }
 
   @Test
   public void toSpanData_ActiveSpan() {
     RecordEventsReadableSpan span = createTestSpan(Kind.INTERNAL);
     try {
-      assertThat(span.hasBeenEnded()).isFalse();
+      assertThat(span.hasEnded()).isFalse();
       spanDoWork(span, null);
       SpanData spanData = span.toSpanData();
       SpanData.TimedEvent timedEvent =
@@ -140,11 +140,11 @@ public class RecordEventsReadableSpanTest {
           startEpochNanos,
           0,
           Status.OK);
-      assertThat(span.hasBeenEnded()).isFalse();
+      assertThat(span.hasEnded()).isFalse();
     } finally {
       span.end();
     }
-    assertThat(span.hasBeenEnded()).isTrue();
+    assertThat(span.hasEnded()).isTrue();
   }
 
   @Test
@@ -580,7 +580,7 @@ public class RecordEventsReadableSpanTest {
 
     SpanData expected =
         SpanData.newBuilder()
-            .setHasBeenEnded(true)
+            .setHasEnded(true)
             .setName(name)
             .setInstrumentationLibraryInfo(instrumentationLibraryInfo)
             .setKind(kind)

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -249,10 +249,10 @@ public class RecordEventsReadableSpanTest {
     try {
       testClock.advanceMillis(MILLIS_PER_SECOND);
       long elapsedTimeNanos1 = testClock.now() - startEpochNanos;
-      assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos1);
+      assertThat(span.getLatencyNanos()).isEqualTo(elapsedTimeNanos1);
       testClock.advanceMillis(MILLIS_PER_SECOND);
       long elapsedTimeNanos2 = testClock.now() - startEpochNanos;
-      assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos2);
+      assertThat(span.getLatencyNanos()).isEqualTo(elapsedTimeNanos2);
     } finally {
       span.end();
     }
@@ -264,9 +264,9 @@ public class RecordEventsReadableSpanTest {
     testClock.advanceMillis(MILLIS_PER_SECOND);
     span.end();
     long elapsedTimeNanos = testClock.now() - startEpochNanos;
-    assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos);
+    assertThat(span.getLatencyNanos()).isEqualTo(elapsedTimeNanos);
     testClock.advanceMillis(MILLIS_PER_SECOND);
-    assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos);
+    assertThat(span.getLatencyNanos()).isEqualTo(elapsedTimeNanos);
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanDataTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanDataTest.java
@@ -105,7 +105,7 @@ public class SpanDataTest {
 
   private static SpanData.Builder createBasicSpanBuilder() {
     return SpanData.newBuilder()
-        .setHasBeenEnded(true)
+        .setHasEnded(true)
         .setSpanId(SpanId.getInvalid())
         .setTraceId(TraceId.getInvalid())
         .setName("spanName")

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanDataTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanDataTest.java
@@ -105,6 +105,7 @@ public class SpanDataTest {
 
   private static SpanData.Builder createBasicSpanBuilder() {
     return SpanData.newBuilder()
+        .setHasBeenEnded(true)
         .setSpanId(SpanId.getInvalid())
         .setTraceId(TraceId.getInvalid())
         .setName("spanName")

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
@@ -55,6 +55,7 @@ public final class TestUtils {
    */
   public static SpanData makeBasicSpan() {
     return SpanData.newBuilder()
+        .setHasBeenEnded(true)
         .setTraceId(TraceId.getInvalid())
         .setSpanId(SpanId.getInvalid())
         .setName("span")

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
@@ -55,7 +55,7 @@ public final class TestUtils {
    */
   public static SpanData makeBasicSpan() {
     return SpanData.newBuilder()
-        .setHasBeenEnded(true)
+        .setHasEnded(true)
         .setTraceId(TraceId.getInvalid())
         .setSpanId(SpanId.getInvalid())
         .setName("span")


### PR DESCRIPTION
Original title: Simplify span end time. 

The only reason to have now() returned in getEndEpochNanos seems to be
that it kinda makes sense for getLatencyMs, but that method is
package-private and never used.

See also
https://github.com/open-telemetry/opentelemetry-specification/issues/373#issuecomment-564939980.