### PR TITLE
DISCUSSION: Add SpanWatcherProcessor (spec#373)

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SpanWatcherProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SpanWatcherProcessor.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.trace.export;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import io.opentelemetry.internal.Utils;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SpanData;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.concurrent.GuardedBy;
+
+/**
+ * Implementation of the {@link SpanProcessor} that batches spans exported by the SDK then pushes
+ * them to the exporter pipeline.
+ *
+ * <p>All spans reported by the SDK implementation are first added to a synchronized queue (with a
+ * {@code maxQueueSize} maximum size, after the size is reached spans are dropped) and exported
+ * every {@code scheduleDelayMillis} to the exporter pipeline in batches of {@code
+ * maxExportBatchSize}.
+ *
+ * <p>If the queue gets half full a preemptive notification is sent to the worker thread that
+ * exports the spans to wake up and start a new export cycle.
+ *
+ * <p>This batch {@link SpanProcessor} can cause high contention in a very high traffic service.
+ * TODO: Add a link to the SpanProcessor that uses Disruptor as alternative with low contention.
+ */
+public final class SpanWatcherProcessor implements SpanProcessor {
+  private static final String WORKER_THREAD_NAME =
+      SpanWatcherProcessor.class.getSimpleName() + "_WorkerThread";
+  private final Worker worker;
+  private final Thread workerThread;
+  private final boolean sampled;
+
+  private SpanWatcherProcessor(
+      SpanExporter spanExporter,
+      boolean sampled,
+      long scheduleDelayMillis,
+      int maxQueueSize,
+      int maxExportBatchSize) {
+    this.worker = new Worker(spanExporter, scheduleDelayMillis, maxQueueSize, maxExportBatchSize);
+    this.workerThread = newThread(worker);
+    this.workerThread.start();
+    this.sampled = sampled;
+  }
+
+  @Override
+  public void onStart(ReadableSpan span) {
+    if (sampled && !span.getSpanContext().getTraceFlags().isSampled()) {
+      return;
+    }
+    worker.addSpan(span);
+  }
+
+  @Override
+  public void onEnd(ReadableSpan span) {}
+
+  @Override
+  public void shutdown() {
+    workerThread.interrupt();
+    worker.flush();
+  }
+
+  /**
+   * Returns a new Builder for {@link SpanWatcherProcessor}.
+   *
+   * @param spanExporter the {@code SpanExporter} to where the Spans are pushed.
+   * @return a new {@link SpanWatcherProcessor}.
+   * @throws NullPointerException if the {@code spanExporter} is {@code null}.
+   */
+  public static Builder newBuilder(SpanExporter spanExporter) {
+    return new Builder(spanExporter);
+  }
+
+  /** Builder class for {@link SpanWatcherProcessor}. */
+  public static final class Builder {
+    private static final long SCHEDULE_DELAY_MILLIS = 5000;
+    private static final int MAX_QUEUE_SIZE = 2048;
+    private static final int MAX_EXPORT_BATCH_SIZE = 512;
+    private final SpanExporter spanExporter;
+    private long scheduleDelayMillis = SCHEDULE_DELAY_MILLIS;
+    private int maxQueueSize = MAX_QUEUE_SIZE;
+    private int maxExportBatchSize = MAX_EXPORT_BATCH_SIZE;
+    private boolean sampled = true;
+
+    private Builder(SpanExporter spanExporter) {
+      this.spanExporter = Utils.checkNotNull(spanExporter, "spanExporter");
+    }
+
+    // TODO: Consider to add support for constant Attributes and/or Resource.
+
+    /**
+     * Set whether only sampled spans should be reported.
+     *
+     * @param sampled report only sampled spans.
+     * @return this.
+     */
+    public Builder reportOnlySampled(boolean sampled) {
+      this.sampled = sampled;
+      return this;
+    }
+
+    /**
+     * Sets the delay interval between two consecutive exports. The actual interval may be shorter
+     * if the batch size is getting larger than {@code maxQueuedSpans / 2}.
+     *
+     * <p>Default value is {@code 5000}ms.
+     *
+     * @param scheduleDelayMillis the delay interval between two consecutive exports.
+     * @return this.
+     */
+    public Builder setScheduleDelayMillis(long scheduleDelayMillis) {
+      this.scheduleDelayMillis = scheduleDelayMillis;
+      return this;
+    }
+
+    /**
+     * Sets the maximum number of Spans that are kept in the queue before start dropping.
+     *
+     * <p>See the BatchSampledSpansProcessor class description for a high-level design description
+     * of this class.
+     *
+     * <p>Default value is {@code 2048}.
+     *
+     * @param maxQueueSize the maximum number of Spans that are kept in the queue before start
+     *     dropping.
+     * @return this.
+     */
+    public Builder setMaxQueueSize(int maxQueueSize) {
+      this.maxQueueSize = maxQueueSize;
+      return this;
+    }
+
+    /**
+     * Sets the maximum batch size for every export. This must be smaller or equal to {@code
+     * maxQueuedSpans}.
+     *
+     * <p>Default value is {@code 512}.
+     *
+     * @param maxExportBatchSize the maximum batch size for every export.
+     * @return this.
+     */
+    public Builder setMaxExportBatchSize(int maxExportBatchSize) {
+      Utils.checkArgument(maxExportBatchSize > 0, "maxExportBatchSize must be positive.");
+      this.maxExportBatchSize = maxExportBatchSize;
+      return this;
+    }
+
+    /**
+     * Returns a new {@link SpanWatcherProcessor} that batches, then converts spans to proto and
+     * forwards them to the given {@code spanExporter}.
+     *
+     * @return a new {@link SpanWatcherProcessor}.
+     * @throws NullPointerException if the {@code spanExporter} is {@code null}.
+     */
+    public SpanWatcherProcessor build() {
+      return new SpanWatcherProcessor(
+          spanExporter, sampled, scheduleDelayMillis, maxQueueSize, maxExportBatchSize);
+    }
+  }
+
+  private static Thread newThread(Runnable runnable) {
+    Thread thread = MoreExecutors.platformThreadFactory().newThread(runnable);
+    try {
+      thread.setName(WORKER_THREAD_NAME);
+    } catch (SecurityException e) {
+      // OK if we can't set the name in this environment.
+    }
+    return thread;
+  }
+
+  // Worker is a thread that batches multiple spans and calls the registered SpanExporter to export
+  // the data.
+  //
+  // The list of batched data is protected by an explicit monitor object which ensures full
+  // concurrency.
+  private static final class Worker implements Runnable {
+    private static final Logger logger = Logger.getLogger(Worker.class.getName());
+    private final SpanExporter spanExporter;
+    private final long reportInterval;
+    private final int maxQueueSize;
+    private final int maxExportBatchSize;
+    private final Object monitor = new Object();
+
+    @GuardedBy("monitor")
+    private final List<WeakReference<ReadableSpan>> spansList;
+
+    private Worker(
+        SpanExporter spanExporter, long reportInterval, int maxQueueSize, int maxExportBatchSize) {
+      this.spanExporter = spanExporter;
+      this.reportInterval = reportInterval;
+      this.maxQueueSize = maxQueueSize;
+      this.maxExportBatchSize = maxExportBatchSize;
+      this.spansList = new ArrayList<>(maxQueueSize);
+    }
+
+    private void addSpan(ReadableSpan span) {
+      synchronized (monitor) {
+        if (spansList.size() == maxQueueSize) {
+          // TODO: Record a counter for dropped spans.
+          return;
+        }
+        // TODO: Record a gauge for referenced spans.
+        spansList.add(new WeakReference<>(span));
+      }
+
+      // TODO: We should keep track of spans that have ended but weren't yet removed
+      //  from spanList to clean up if that's the case.
+    }
+
+    @Override
+    public void run() {
+      while (!Thread.currentThread().isInterrupted()) {
+        // Copy all the batched spans in a separate list to release the monitor lock asap to
+        // avoid blocking the producer thread.
+        ArrayList<SpanData> unfinishedSpans;
+        synchronized (monitor) {
+          do {
+            // In the case of a spurious wakeup we export only if we have at least one span in
+            // the batch. It is acceptable because batching is a best effort mechanism here.
+            try {
+              monitor.wait(reportInterval);
+            } catch (InterruptedException ie) {
+              // Preserve the interruption status as per guidance and stop doing any work.
+              Thread.currentThread().interrupt();
+              return;
+            }
+          } while (spansList.isEmpty());
+          unfinishedSpans = getUnfinishedSpans();
+        }
+        // Execute the batch export outside the synchronized to not block all producers.
+        exportBatches(unfinishedSpans);
+      }
+    }
+
+    @GuardedBy("monitor")
+    private ArrayList<SpanData> getUnfinishedSpans() {
+      ArrayList<SpanData> unfinishedSpans = new ArrayList<>();
+      final long curTimeNanos = System.currentTimeMillis() * 1000L * 1000L;
+      for (int i = 0; i < spansList.size(); ) {
+        ReadableSpan span = spansList.get(i).get();
+        if (span == null) {
+          dropSpan(i);
+          continue;
+        }
+        SpanData data = span.toSpanData();
+        if (data.getEndEpochNanos() != 0) {
+          dropSpan(i);
+          continue;
+        }
+        // We could also use the time we add()ed the span, but since only in-band spans are supposed
+        // to be reported,
+        // using the start timestamp makes just as much sense.
+        final long age = curTimeNanos - data.getStartEpochNanos();
+        if (age > reportInterval) {
+          // Many spans will be end()ed so soon that it won't bring much benefit to report them
+          // earlier.
+          unfinishedSpans.add(data);
+        }
+        ++i;
+      }
+      return unfinishedSpans;
+    }
+
+    @GuardedBy("monitor")
+    private void dropSpan(int i) {
+      final int lastIdx = spansList.size() - 1;
+      if (i != lastIdx) {
+        spansList.set(i, spansList.get(lastIdx));
+      }
+      spansList.remove(lastIdx);
+    }
+
+    private void flush() {
+      ArrayList<SpanData> unfinishedSpans;
+      synchronized (monitor) {
+        unfinishedSpans = getUnfinishedSpans();
+      }
+      // Execute the batch export outside the synchronized to not block all producers.
+      exportBatches(unfinishedSpans);
+    }
+
+    private void exportBatches(ArrayList<SpanData> spanList) {
+      // TODO: Record a counter for pushed spans.
+      for (int i = 0; i < spanList.size(); ) {
+        int batchSizeLimit = Math.min(i + maxExportBatchSize, spanList.size());
+        onBatchExport(createSpanDataForExport(spanList, i, batchSizeLimit));
+        i = batchSizeLimit;
+      }
+    }
+
+    private static List<SpanData> createSpanDataForExport(
+        ArrayList<SpanData> spanList, int startIndex, int numberToTake) {
+      List<SpanData> spanDataBuffer = new ArrayList<>(numberToTake);
+      for (int i = startIndex; i < numberToTake; i++) {
+        spanDataBuffer.add(spanList.get(i));
+        // Remove the reference to the SpanData to allow GC to free the memory.
+        spanList.set(i, null);
+      }
+      return Collections.unmodifiableList(spanDataBuffer);
+    }
+
+    // Exports the list of Span protos to all the ServiceHandlers.
+    private void onBatchExport(List<SpanData> spans) {
+      // In case of any exception thrown by the service handlers continue to run.
+      try {
+        spanExporter.export(spans);
+      } catch (Throwable t) {
+        logger.log(Level.WARNING, "Exception thrown by the export.", t);
+      }
+    }
+  }
+}

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SpanWatcherProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SpanWatcherProcessor.java
@@ -266,7 +266,7 @@ public final class SpanWatcherProcessor implements SpanProcessor {
         // We could also use the time we add()ed the span, but since only in-band spans are supposed
         // to be reported,
         // using the start timestamp makes just as much sense.
-        if (span.getLatencyNanos() > reportIntervalMillis) {
+        if (span.getLatencyNanos() > reportIntervalMillis * 1000L * 1000L) {
           // Many spans will be end()ed so soon that it won't bring much benefit to report them
           // earlier.
           unfinishedSpans.add(span);

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SpanWatcherProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SpanWatcherProcessor.java
@@ -258,7 +258,7 @@ public final class SpanWatcherProcessor implements SpanProcessor {
       ArrayList<ReadableSpan> unfinishedSpans = new ArrayList<>();
       for (int i = 0; i < spanWatchlist.size(); ) {
         ReadableSpan span = spanWatchlist.get(i).get();
-        if (span == null || span.hasBeenEnded()) {
+        if (span == null || span.hasEnded()) {
           dropSpan(i);
           continue;
         }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessorTest.java
@@ -28,7 +28,6 @@ import io.opentelemetry.trace.Tracer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import org.junit.After;
 import org.junit.Before;
@@ -341,54 +340,6 @@ public class BatchSpansProcessorTest {
         state = State.UNBLOCKED;
         monitor.notifyAll();
       }
-    }
-  }
-
-  static final class WaitingSpanExporter implements SpanExporter {
-    private final Object monitor = new Object();
-
-    @GuardedBy("monitor")
-    private final List<SpanData> spanDataList = new ArrayList<>();
-
-    /**
-     * Waits until we received numberOfSpans spans to export. Returns the list of exported {@link
-     * SpanData} objects, otherwise {@code null} if the current thread is interrupted.
-     *
-     * @param numberOfSpans the number of minimum spans to be collected.
-     * @return the list of exported {@link SpanData} objects, otherwise {@code null} if the current
-     *     thread is interrupted.
-     */
-    @Nullable
-    List<SpanData> waitForExport(int numberOfSpans) {
-      List<SpanData> ret;
-      synchronized (monitor) {
-        while (spanDataList.size() < numberOfSpans) {
-          try {
-            monitor.wait();
-          } catch (InterruptedException e) {
-            // Preserve the interruption status as per guidance.
-            Thread.currentThread().interrupt();
-            return null;
-          }
-        }
-        ret = new ArrayList<>(spanDataList);
-        spanDataList.clear();
-      }
-      return ret;
-    }
-
-    @Override
-    public ResultCode export(List<SpanData> spans) {
-      synchronized (monitor) {
-        this.spanDataList.addAll(spans);
-        monitor.notifyAll();
-      }
-      return ResultCode.SUCCESS;
-    }
-
-    @Override
-    public void shutdown() {
-      // Do nothing;
     }
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpansProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpansProcessorTest.java
@@ -27,7 +27,6 @@ import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.sdk.trace.SpanData;
 import io.opentelemetry.sdk.trace.TestUtils;
 import io.opentelemetry.sdk.trace.TracerSdkRegistry;
-import io.opentelemetry.sdk.trace.export.BatchSpansProcessorTest.WaitingSpanExporter;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SpanWatcherProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SpanWatcherProcessorTest.java
@@ -87,6 +87,7 @@ public class SpanWatcherProcessorTest {
       if (!actual.addAll(exporter.waitForExport(1))) {
         actual.clear();
       }
+      assertThat(allowed).containsAtLeastElementsIn(actual);
     } while (!actual.containsAll(expected) || actual.size() != expected.size());
     assertThat(actual).containsExactlyElementsIn(expected);
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SpanWatcherProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SpanWatcherProcessorTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.trace.export;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.doThrow;
+
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.Samplers;
+import io.opentelemetry.sdk.trace.SpanData;
+import io.opentelemetry.sdk.trace.TestUtils;
+import io.opentelemetry.sdk.trace.TracerSdkFactory;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.Tracer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** Unit tests for {@link BatchSpansProcessor}. */
+@RunWith(JUnit4.class)
+public class SpanWatcherProcessorTest {
+  private static final String SPAN_NAME_1 = "MySpanName/1";
+  private static final String SPAN_NAME_2 = "MySpanName/2";
+  private static final long MAX_SCHEDULE_DELAY_MILLIS = 500;
+  private final TracerSdkFactory tracerSdkFactory = TracerSdkFactory.create();
+  private final Tracer tracer = tracerSdkFactory.get("BatchSpansProcessorTest");
+  private final WaitingSpanExporter waitingSpanExporter = new WaitingSpanExporter();
+  @Mock private SpanExporter mockServiceHandler;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @After
+  public void cleanup() {
+    tracerSdkFactory.shutdown();
+  }
+
+  private Span createSampledActiveSpan(String spanName) {
+    return TestUtils.startSpanWithSampler(tracerSdkFactory, tracer, spanName, Samplers.alwaysOn())
+        .startSpan();
+  }
+
+  private Span createNotSampledActiveSpan(String spanName) {
+    return TestUtils.startSpanWithSampler(tracerSdkFactory, tracer, spanName, Samplers.alwaysOff())
+        .startSpan();
+  }
+
+  @Test
+  public void testSpanWatcherBasic() {
+    tracerSdkFactory.addSpanProcessor(
+        SpanWatcherProcessor.newBuilder(waitingSpanExporter)
+            .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
+            .build());
+
+    ReadableSpan span1 = (ReadableSpan) createSampledActiveSpan(SPAN_NAME_1);
+    ReadableSpan span2 = (ReadableSpan) createSampledActiveSpan(SPAN_NAME_2);
+    List<SpanData> exported = waitingSpanExporter.waitForExport(2); // Active spans are reported
+    assertThat(exported).containsExactly(span1.toSpanData(), span2.toSpanData());
+    ((Span) span1).setAttribute("foo", "bar");
+    exported = waitingSpanExporter.waitForExport(2); // Attribute changes get reflected
+    assertThat(exported).containsExactly(span1.toSpanData(), span2.toSpanData());
+    ((Span) span1).end();
+    exported = waitingSpanExporter.waitForExport(2); // Inactive spans are not reported
+    assertThat(exported).containsExactly(span2.toSpanData(), span2.toSpanData());
+  }
+
+  @Test
+  public void testUnreferencedSpansAreNotReported() {
+    tracerSdkFactory.addSpanProcessor(
+        SpanWatcherProcessor.newBuilder(waitingSpanExporter)
+            .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
+            .build());
+
+    @SuppressWarnings("unused")
+    ReadableSpan span1 = (ReadableSpan) createSampledActiveSpan(SPAN_NAME_1);
+    ReadableSpan span2 = (ReadableSpan) createSampledActiveSpan(SPAN_NAME_2);
+    List<SpanData> exported = waitingSpanExporter.waitForExport(2); // Active spans are reported
+    assertThat(exported).containsExactly(span1.toSpanData(), span2.toSpanData());
+
+    //noinspection UnusedAssignment
+    span1 = null;
+
+    // Make sure the span is GCd, so the weakref goes stale.
+    System.gc();
+    System.gc();
+    exported = waitingSpanExporter.waitForExport(2);
+    assertThat(exported).containsExactly(span2.toSpanData(), span2.toSpanData());
+  }
+
+  @Test
+  public void exportMoreSpansThanTheBufferSize() {
+    tracerSdkFactory.addSpanProcessor(
+        SpanWatcherProcessor.newBuilder(waitingSpanExporter)
+            .setMaxQueueSize(6)
+            .setMaxExportBatchSize(2)
+            .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
+            .build());
+
+    ReadableSpan span1 = (ReadableSpan) createSampledActiveSpan(SPAN_NAME_1);
+    ReadableSpan span2 = (ReadableSpan) createSampledActiveSpan(SPAN_NAME_2);
+    ReadableSpan span3 = (ReadableSpan) createSampledActiveSpan(SPAN_NAME_1);
+    ReadableSpan span4 = (ReadableSpan) createSampledActiveSpan(SPAN_NAME_1);
+    ReadableSpan span5 = (ReadableSpan) createSampledActiveSpan(SPAN_NAME_1);
+    ReadableSpan span6 = (ReadableSpan) createSampledActiveSpan(SPAN_NAME_1);
+    List<SpanData> exported = waitingSpanExporter.waitForExport(6);
+    assertThat(exported)
+        .containsExactly(
+            span1.toSpanData(),
+            span2.toSpanData(),
+            span3.toSpanData(),
+            span4.toSpanData(),
+            span5.toSpanData(),
+            span6.toSpanData());
+  }
+
+  @Test
+  public void exportSpansToMultipleServices() {
+    io.opentelemetry.sdk.trace.export.WaitingSpanExporter waitingSpanExporter2 =
+        new io.opentelemetry.sdk.trace.export.WaitingSpanExporter();
+    tracerSdkFactory.addSpanProcessor(
+        SpanWatcherProcessor.newBuilder(
+                MultiSpanExporter.create(
+                    Arrays.<SpanExporter>asList(waitingSpanExporter, waitingSpanExporter2)))
+            .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
+            .build());
+
+    ReadableSpan span1 = (ReadableSpan) createSampledActiveSpan(SPAN_NAME_1);
+    ReadableSpan span2 = (ReadableSpan) createSampledActiveSpan(SPAN_NAME_2);
+    List<SpanData> exported1 = waitingSpanExporter.waitForExport(2);
+    List<SpanData> exported2 = waitingSpanExporter2.waitForExport(2);
+    assertThat(exported1).containsExactly(span1.toSpanData(), span2.toSpanData());
+    assertThat(exported2).containsExactly(span1.toSpanData(), span2.toSpanData());
+  }
+
+  @Test
+  public void exportMoreSpansThanTheMaximumLimit() {
+    final int maxQueuedSpans = 8;
+    tracerSdkFactory.addSpanProcessor(
+        SpanWatcherProcessor.newBuilder(waitingSpanExporter)
+            .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
+            .setMaxQueueSize(maxQueuedSpans)
+            .setMaxExportBatchSize(maxQueuedSpans / 2)
+            .build());
+
+    List<ReadableSpan> spansToExport = new ArrayList<>(maxQueuedSpans);
+    // Wait to block the worker thread in the BatchSampledSpansProcessor. This ensures that no items
+    // can be removed from the queue. Need to add a span to trigger the export otherwise the
+    // pipeline is never called.
+    spansToExport.add(((ReadableSpan) createSampledActiveSpan("blocking_span")));
+
+    for (int i = 0; i < maxQueuedSpans - 1; i++) {
+      // First export maxQueuedSpans, the worker thread is blocked so all items should be queued.
+      spansToExport.add((ReadableSpan) createSampledActiveSpan("span_1_" + i));
+    }
+
+    // TODO: assertThat(spanExporter.getReferencedSpans()).isEqualTo(maxQueuedSpans);
+
+    @SuppressWarnings("ModifiedButNotUsed")
+    List<Span> notIncludedSpans = new ArrayList<>();
+    // Now we should start dropping.
+    for (int i = 0; i < 7; i++) {
+      // Keep a strong reference to these spans.
+      notIncludedSpans.add(createSampledActiveSpan("span_2_" + i));
+      // TODO: assertThat(getDroppedSpans()).isEqualTo(i + 1);
+    }
+
+    // TODO: assertThat(getReferencedSpans()).isEqualTo(maxQueuedSpans);
+
+    // While we wait for maxQueuedSpans we ensure that the queue is also empty after this.
+    List<SpanData> exported = waitingSpanExporter.waitForExport(maxQueuedSpans);
+    assertThat(exported).isNotNull();
+    List<SpanData> expected = new ArrayList<>(spansToExport.size());
+    for (ReadableSpan readableSpan : spansToExport) {
+      expected.add(readableSpan.toSpanData());
+    }
+    assertThat(exported).containsExactlyElementsIn(expected);
+    exported.clear();
+
+    // We cannot compare with maxReferencedSpans here because the worker thread may get
+    // unscheduled immediately after exporting, but before updating the pushed spans, if that is
+    // the case at most bufferSize spans will miss.
+    // TODO: assertThat(getPushedSpans()).isAtLeast((long) maxQueuedSpans - maxBatchSize);
+
+    for (int i = 0; i < spansToExport.size() - 1; ++i) {
+      ((Span) spansToExport.get(i)).end();
+    }
+
+    assertThat(waitingSpanExporter.waitForExport(1))
+        .containsExactly(expected.get(expected.size() - 1));
+
+    expected.clear();
+
+    for (int i = 0; i < maxQueuedSpans - 1; i++) {
+      spansToExport.set(i, ((ReadableSpan) createSampledActiveSpan("span_3_" + i)));
+      // No more dropped spans.
+      // TODO: assertThat(getDroppedSpans()).isEqualTo(7);
+    }
+
+    for (ReadableSpan readableSpan : spansToExport) {
+      expected.add(readableSpan.toSpanData());
+    }
+    exported = waitingSpanExporter.waitForExport(maxQueuedSpans);
+    assertThat(exported).isNotNull();
+    assertThat(exported).containsExactlyElementsIn(expected);
+  }
+
+  @Test
+  public void serviceHandlerThrowsException() {
+    doThrow(new IllegalArgumentException("No export for you."))
+        .when(mockServiceHandler)
+        .export(ArgumentMatchers.<SpanData>anyList());
+
+    tracerSdkFactory.addSpanProcessor(
+        SpanWatcherProcessor.newBuilder(
+                MultiSpanExporter.create(Arrays.asList(mockServiceHandler, waitingSpanExporter)))
+            .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
+            .build());
+    ReadableSpan span1 = (ReadableSpan) createSampledActiveSpan(SPAN_NAME_1);
+    List<SpanData> exported = waitingSpanExporter.waitForExport(1);
+    assertThat(exported).containsExactly(span1.toSpanData());
+    ((Span) span1).end();
+
+    // Continue to export after the exception was received.
+    ReadableSpan span2 = (ReadableSpan) createSampledActiveSpan(SPAN_NAME_2);
+    exported = waitingSpanExporter.waitForExport(1);
+    assertThat(exported).containsExactly(span2.toSpanData());
+  }
+
+  @Test
+  public void exportNotSampledSpans() {
+    tracerSdkFactory.addSpanProcessor(
+        SpanWatcherProcessor.newBuilder(waitingSpanExporter)
+            .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
+            .build());
+
+    @SuppressWarnings("unused")
+    Span s1 = createNotSampledActiveSpan(SPAN_NAME_1);
+
+    @SuppressWarnings("unused")
+    Span s2 = createNotSampledActiveSpan(SPAN_NAME_2);
+    ReadableSpan span3 = (ReadableSpan) createSampledActiveSpan(SPAN_NAME_2);
+    // Spans are recorded and exported in the same order as they are ended, we test that a non
+    // sampled span is not exported by creating and ending a sampled span after a non sampled span
+    // and checking that the first exported span is the sampled span (the non sampled did not get
+    // exported).
+    List<SpanData> exported = waitingSpanExporter.waitForExport(2);
+    assertThat(exported).containsExactly(span3.toSpanData(), span3.toSpanData());
+  }
+}

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SpanWatcherProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SpanWatcherProcessorTest.java
@@ -80,7 +80,8 @@ public class SpanWatcherProcessorTest {
   }
 
   // Wait for all the expected Spans and no more to be in the watchlist of exporter.
-  private static void waitForSpans(List<SpanData> expected, List<SpanData> allowed, WaitingSpanExporter exporter) {
+  private static void waitForSpans(
+      List<SpanData> expected, List<SpanData> allowed, WaitingSpanExporter exporter) {
     Set<SpanData> actual = new HashSet<>(expected.size());
     do {
       if (!actual.addAll(exporter.waitForExport(1))) {

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/WaitingSpanExporter.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/WaitingSpanExporter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.trace.export;
+
+import io.opentelemetry.sdk.trace.SpanData;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
+final class WaitingSpanExporter implements SpanExporter {
+  private final Object monitor = new Object();
+
+  @GuardedBy("monitor")
+  private final List<SpanData> spanDataList = new ArrayList<>();
+
+  /**
+   * Waits until we received numberOfSpans spans to export. Returns the list of exported {@link
+   * SpanData} objects, otherwise {@code null} if the current thread is interrupted.
+   *
+   * @param numberOfSpans the number of minimum spans to be collected.
+   * @return the list of exported {@link SpanData} objects, otherwise {@code null} if the current
+   *     thread is interrupted.
+   */
+  @Nullable
+  List<SpanData> waitForExport(int numberOfSpans) {
+    List<SpanData> ret;
+    synchronized (monitor) {
+      while (spanDataList.size() < numberOfSpans) {
+        try {
+          monitor.wait();
+        } catch (InterruptedException e) {
+          // Preserve the interruption status as per guidance.
+          Thread.currentThread().interrupt();
+          return null;
+        }
+      }
+      ret = new ArrayList<>(spanDataList);
+      spanDataList.clear();
+    }
+    return ret;
+  }
+
+  @Override
+  public ResultCode export(List<SpanData> spans) {
+    synchronized (monitor) {
+      this.spanDataList.addAll(spans);
+      monitor.notifyAll();
+    }
+    return ResultCode.SUCCESS;
+  }
+
+  @Override
+  public void shutdown() {
+    // Do nothing;
+  }
+}


### PR DESCRIPTION
This is an example implementation of open-telemetry/opentelemetry-specification#373. It depends on #693 to detect ended spans.

The SpanWatcherProcessor is 80% a copy of the BatchSpansProcessor. It uses a list of weak references to detect Spans that were dropped by the user without ending them, as to not cause memory leaks.

It is probably rather slow since it has to use `toSpanData` on every span. To detect whether it was ended already, an alternative would be to use the `onEnd` callback, but then the spans would have to be stored in a map structure and some locking would have to take place there. Having an `isEnded` property on `ReadableSpan` would be more efficient. The age of the span (getStartEpochNanos) can also only be calculated with the SpanData. Assuming that most spans in applications have a duration of less than the reportInterval of the SpanWatcherProcessor, having just one of hasEnded or getStartEpochNanos exposed on the ReadableSpan should already bring a good improvement.