### PR TITLE
Remove default bound

### DIFF
--- a/api/src/main/java/io/opentelemetry/metrics/CounterDouble.java
+++ b/api/src/main/java/io/opentelemetry/metrics/CounterDouble.java
@@ -56,9 +56,6 @@ public interface CounterDouble extends Counter<BoundDoubleCounter> {
   BoundDoubleCounter bind(LabelSet labelSet);
 
   @Override
-  BoundDoubleCounter getDefaultBound();
-
-  @Override
   void unbind(BoundDoubleCounter bound);
 
   /**

--- a/api/src/main/java/io/opentelemetry/metrics/CounterLong.java
+++ b/api/src/main/java/io/opentelemetry/metrics/CounterLong.java
@@ -56,9 +56,6 @@ public interface CounterLong extends Metric<BoundLongCounter> {
   BoundLongCounter bind(LabelSet labelSet);
 
   @Override
-  BoundLongCounter getDefaultBound();
-
-  @Override
   void unbind(BoundLongCounter bound);
 
   /**

--- a/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
@@ -177,11 +177,6 @@ public final class DefaultMeter implements Meter {
     }
 
     @Override
-    public NoopBoundLongGauge getDefaultBound() {
-      return NoopBoundLongGauge.INSTANCE;
-    }
-
-    @Override
     public void unbind(BoundLongGauge boundLongGauge) {
       Utils.checkNotNull(boundLongGauge, "boundLongGauge");
     }
@@ -218,11 +213,6 @@ public final class DefaultMeter implements Meter {
     @Override
     public NoopBoundDoubleGauge bind(LabelSet labelSet) {
       Utils.checkNotNull(labelSet, "labelSet");
-      return NoopBoundDoubleGauge.INSTANCE;
-    }
-
-    @Override
-    public NoopBoundDoubleGauge getDefaultBound() {
       return NoopBoundDoubleGauge.INSTANCE;
     }
 
@@ -267,11 +257,6 @@ public final class DefaultMeter implements Meter {
     }
 
     @Override
-    public NoopBoundDoubleCounter getDefaultBound() {
-      return NoopBoundDoubleCounter.INSTANCE;
-    }
-
-    @Override
     public void unbind(BoundDoubleCounter boundDoubleCounter) {
       Utils.checkNotNull(boundDoubleCounter, "boundDoubleCounter");
     }
@@ -312,11 +297,6 @@ public final class DefaultMeter implements Meter {
     }
 
     @Override
-    public NoopBoundLongCounter getDefaultBound() {
-      return NoopBoundLongCounter.INSTANCE;
-    }
-
-    @Override
     public void unbind(BoundLongCounter boundLongCounter) {
       Utils.checkNotNull(boundLongCounter, "boundLongCounter");
     }
@@ -352,11 +332,6 @@ public final class DefaultMeter implements Meter {
     @Override
     public NoopBoundDoubleMeasure bind(LabelSet labelSet) {
       Utils.checkNotNull(labelSet, "labelSet");
-      return NoopBoundDoubleMeasure.INSTANCE;
-    }
-
-    @Override
-    public NoopBoundDoubleMeasure getDefaultBound() {
       return NoopBoundDoubleMeasure.INSTANCE;
     }
 
@@ -401,11 +376,6 @@ public final class DefaultMeter implements Meter {
     }
 
     @Override
-    public NoopBoundLongMeasure getDefaultBound() {
-      return NoopBoundLongMeasure.INSTANCE;
-    }
-
-    @Override
     public void unbind(BoundLongMeasure boundLongMeasure) {
       Utils.checkNotNull(boundLongMeasure, "boundLongMeasure");
     }
@@ -446,11 +416,6 @@ public final class DefaultMeter implements Meter {
     }
 
     @Override
-    public NoopBoundDoubleObserver getDefaultBound() {
-      return NoopBoundDoubleObserver.INSTANCE;
-    }
-
-    @Override
     public void unbind(BoundDoubleObserver boundDoubleObserver) {
       Utils.checkNotNull(boundDoubleObserver, "boundDoubleObserver");
     }
@@ -487,11 +452,6 @@ public final class DefaultMeter implements Meter {
     @Override
     public NoopBoundLongObserver bind(LabelSet labelSet) {
       Utils.checkNotNull(labelSet, "labelSet");
-      return NoopBoundLongObserver.INSTANCE;
-    }
-
-    @Override
-    public NoopBoundLongObserver getDefaultBound() {
       return NoopBoundLongObserver.INSTANCE;
     }
 

--- a/api/src/main/java/io/opentelemetry/metrics/GaugeDouble.java
+++ b/api/src/main/java/io/opentelemetry/metrics/GaugeDouble.java
@@ -56,9 +56,6 @@ public interface GaugeDouble extends Gauge<BoundDoubleGauge> {
   BoundDoubleGauge bind(LabelSet labelSet);
 
   @Override
-  BoundDoubleGauge getDefaultBound();
-
-  @Override
   void unbind(BoundDoubleGauge bound);
 
   /**

--- a/api/src/main/java/io/opentelemetry/metrics/GaugeLong.java
+++ b/api/src/main/java/io/opentelemetry/metrics/GaugeLong.java
@@ -57,9 +57,6 @@ public interface GaugeLong extends Gauge<BoundLongGauge> {
   BoundLongGauge bind(LabelSet labelSet);
 
   @Override
-  BoundLongGauge getDefaultBound();
-
-  @Override
   void unbind(BoundLongGauge bound);
 
   /**

--- a/api/src/main/java/io/opentelemetry/metrics/MeasureDouble.java
+++ b/api/src/main/java/io/opentelemetry/metrics/MeasureDouble.java
@@ -34,12 +34,12 @@ import javax.annotation.concurrent.ThreadSafe;
  *           .setDescription("gRPC Latency")
  *           .setUnit("ms")
  *           .build();
- *   private static final BoundDoubleMeasure defaultBound = measure.getDefaultBound();
+ *   private static final BoundDoubleMeasure boundMeasure = measure.bind(labelset);
  *
  *   void doWork() {
  *      long startTime = System.nanoTime();
  *      // Your code here.
- *      defaultBound.record((System.nanoTime() - startTime) / 1e6);
+ *      boundMeasure.record((System.nanoTime() - startTime) / 1e6);
  *   }
  * }
  * }</pre>
@@ -50,9 +50,6 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface MeasureDouble extends Measure<BoundDoubleMeasure> {
   @Override
   BoundDoubleMeasure bind(LabelSet labelSet);
-
-  @Override
-  BoundDoubleMeasure getDefaultBound();
 
   @Override
   void unbind(BoundDoubleMeasure bound);

--- a/api/src/main/java/io/opentelemetry/metrics/MeasureLong.java
+++ b/api/src/main/java/io/opentelemetry/metrics/MeasureLong.java
@@ -34,12 +34,12 @@ import javax.annotation.concurrent.ThreadSafe;
  *           .setDescription("gRPC Latency")
  *           .setUnit("ns")
  *           .build();
- *   private static final MeasureLong.Bound defaultBound = measure.getDefaultBound();
+ *   private static final MeasureLong.BoundLongMeasure boundMeasure = measure.bind(labelset);
  *
  *   void doWork() {
  *      long startTime = System.nanoTime();
  *      // Your code here.
- *      defaultBound.record(System.nanoTime() - startTime);
+ *      boundMeasure.record(System.nanoTime() - startTime);
  *   }
  * }
  * }</pre>
@@ -50,9 +50,6 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface MeasureLong extends Measure<BoundLongMeasure> {
   @Override
   BoundLongMeasure bind(LabelSet labelSet);
-
-  @Override
-  BoundLongMeasure getDefaultBound();
 
   @Override
   void unbind(BoundLongMeasure bound);

--- a/api/src/main/java/io/opentelemetry/metrics/Metric.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Metric.java
@@ -44,14 +44,6 @@ public interface Metric<B> {
   B bind(LabelSet labelSet);
 
   /**
-   * Returns a {@code Bound} for a metric with all labels not set.
-   *
-   * @return a {@code Bound} for a metric with all labels not set.
-   * @since 0.1.0
-   */
-  B getDefaultBound();
-
-  /**
    * Removes the {@code Bound} from the metric. i.e. references to previous {@code Bound} are
    * invalid (not part of the metric).
    *

--- a/api/src/main/java/io/opentelemetry/metrics/ObserverDouble.java
+++ b/api/src/main/java/io/opentelemetry/metrics/ObserverDouble.java
@@ -42,7 +42,7 @@ import javax.annotation.concurrent.ThreadSafe;
  *           final AtomicInteger count = new AtomicInteger(0);
  *          {@literal @}Override
  *           public void update(Result result) {
- *             result.put(observer.getDefaultBound(), 0.8 * count.addAndGet(1));
+ *             result.put(observer.bind(labelSet), 0.8 * count.addAndGet(1));
  *           }
  *         });
  *   }
@@ -55,9 +55,6 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface ObserverDouble extends Observer<ResultDoubleObserver, BoundDoubleObserver> {
   @Override
   BoundDoubleObserver bind(LabelSet labelSet);
-
-  @Override
-  BoundDoubleObserver getDefaultBound();
 
   @Override
   void unbind(BoundDoubleObserver bound);

--- a/api/src/main/java/io/opentelemetry/metrics/ObserverLong.java
+++ b/api/src/main/java/io/opentelemetry/metrics/ObserverLong.java
@@ -42,7 +42,7 @@ import javax.annotation.concurrent.ThreadSafe;
  *           final AtomicInteger count = new AtomicInteger(0);
  *          {@literal @}Override
  *           public void update(ResultLongObserver result) {
- *             result.put(observer.getDefaultBound(), count.addAndGet(1));
+ *             result.put(observer.bind(labelset), count.addAndGet(1));
  *           }
  *         });
  *   }
@@ -55,9 +55,6 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface ObserverLong extends Observer<ResultLongObserver, BoundLongObserver> {
   @Override
   BoundLongObserver bind(LabelSet labelSet);
-
-  @Override
-  BoundLongObserver getDefaultBound();
 
   @Override
   void unbind(BoundLongObserver bound);

--- a/api/src/test/java/io/opentelemetry/metrics/CounterDoubleTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/CounterDoubleTest.java
@@ -130,6 +130,6 @@ public class CounterDoubleTest {
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
-    counterDouble.getDefaultBound().add(1.0);
+    counterDouble.bind(meter.createLabelSet("key", "value")).add(1.0);
   }
 }

--- a/api/src/test/java/io/opentelemetry/metrics/CounterDoubleTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/CounterDoubleTest.java
@@ -130,6 +130,6 @@ public class CounterDoubleTest {
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
-    counterDouble.bind(meter.createLabelSet("key", "value")).add(1.0);
+    counterDouble.bind(TestLabelSet.empty()).add(1.0);
   }
 }

--- a/api/src/test/java/io/opentelemetry/metrics/CounterLongTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/CounterLongTest.java
@@ -129,6 +129,6 @@ public class CounterLongTest {
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
-    counterLong.getDefaultBound().add(1);
+    counterLong.bind(meter.createLabelSet("key", "value")).add(1);
   }
 }

--- a/api/src/test/java/io/opentelemetry/metrics/CounterLongTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/CounterLongTest.java
@@ -129,6 +129,6 @@ public class CounterLongTest {
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
-    counterLong.bind(meter.createLabelSet("key", "value")).add(1);
+    counterLong.bind(TestLabelSet.empty()).add(1);
   }
 }

--- a/api/src/test/java/io/opentelemetry/metrics/GaugeDoubleTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/GaugeDoubleTest.java
@@ -129,6 +129,6 @@ public class GaugeDoubleTest {
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
-    gaugeDouble.getDefaultBound().set(5.0);
+    gaugeDouble.bind(meter.createLabelSet("key", "value")).set(5.0);
   }
 }

--- a/api/src/test/java/io/opentelemetry/metrics/GaugeDoubleTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/GaugeDoubleTest.java
@@ -129,6 +129,6 @@ public class GaugeDoubleTest {
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
-    gaugeDouble.bind(meter.createLabelSet("key", "value")).set(5.0);
+    gaugeDouble.bind(TestLabelSet.empty()).set(5.0);
   }
 }

--- a/api/src/test/java/io/opentelemetry/metrics/GaugeLongTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/GaugeLongTest.java
@@ -126,6 +126,6 @@ public class GaugeLongTest {
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
-    gaugeLong.bind(meter.createLabelSet("key", "value")).set(5);
+    gaugeLong.bind(TestLabelSet.empty()).set(5);
   }
 }

--- a/api/src/test/java/io/opentelemetry/metrics/GaugeLongTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/GaugeLongTest.java
@@ -126,6 +126,6 @@ public class GaugeLongTest {
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
-    gaugeLong.getDefaultBound().set(5);
+    gaugeLong.bind(meter.createLabelSet("key", "value")).set(5);
   }
 }

--- a/api/src/test/java/io/opentelemetry/metrics/MeasureDoubleTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/MeasureDoubleTest.java
@@ -90,12 +90,12 @@ public final class MeasureDoubleTest {
     MeasureDouble myMeasure = meter.measureDoubleBuilder("MyMeasure").build();
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Unsupported negative values");
-    myMeasure.getDefaultBound().record(-5.0);
+    myMeasure.bind(meter.createLabelSet("key", "value")).record(-5.0);
   }
 
   @Test
   public void doesNotThrow() {
     MeasureDouble myMeasure = meter.measureDoubleBuilder("MyMeasure").build();
-    myMeasure.getDefaultBound().record(5.0);
+    myMeasure.bind(meter.createLabelSet("key", "value")).record(5.0);
   }
 }

--- a/api/src/test/java/io/opentelemetry/metrics/MeasureDoubleTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/MeasureDoubleTest.java
@@ -90,12 +90,12 @@ public final class MeasureDoubleTest {
     MeasureDouble myMeasure = meter.measureDoubleBuilder("MyMeasure").build();
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Unsupported negative values");
-    myMeasure.bind(meter.createLabelSet("key", "value")).record(-5.0);
+    myMeasure.bind(TestLabelSet.empty()).record(-5.0);
   }
 
   @Test
   public void doesNotThrow() {
     MeasureDouble myMeasure = meter.measureDoubleBuilder("MyMeasure").build();
-    myMeasure.bind(meter.createLabelSet("key", "value")).record(5.0);
+    myMeasure.bind(TestLabelSet.empty()).record(5.0);
   }
 }

--- a/api/src/test/java/io/opentelemetry/metrics/MeasureLongTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/MeasureLongTest.java
@@ -90,12 +90,12 @@ public final class MeasureLongTest {
     MeasureLong myMeasure = meter.measureLongBuilder("MyMeasure").build();
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Unsupported negative values");
-    myMeasure.getDefaultBound().record(-5);
+    myMeasure.bind(meter.createLabelSet("key", "value")).record(-5);
   }
 
   @Test
   public void doesNotThrow() {
     MeasureLong myMeasure = meter.measureLongBuilder("MyMeasure").build();
-    myMeasure.getDefaultBound().record(5);
+    myMeasure.bind(meter.createLabelSet("key", "value")).record(5);
   }
 }

--- a/api/src/test/java/io/opentelemetry/metrics/MeasureLongTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/MeasureLongTest.java
@@ -90,12 +90,12 @@ public final class MeasureLongTest {
     MeasureLong myMeasure = meter.measureLongBuilder("MyMeasure").build();
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Unsupported negative values");
-    myMeasure.bind(meter.createLabelSet("key", "value")).record(-5);
+    myMeasure.bind(TestLabelSet.empty()).record(-5);
   }
 
   @Test
   public void doesNotThrow() {
     MeasureLong myMeasure = meter.measureLongBuilder("MyMeasure").build();
-    myMeasure.bind(meter.createLabelSet("key", "value")).record(5);
+    myMeasure.bind(TestLabelSet.empty()).record(5);
   }
 }

--- a/api/src/test/java/io/opentelemetry/metrics/TestLabelSet.java
+++ b/api/src/test/java/io/opentelemetry/metrics/TestLabelSet.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.metrics;
+
+/**
+ * Empty implementation of a LabelSet, for testing where you need one, but you don't care what's in
+ * it.
+ */
+public final class TestLabelSet implements LabelSet {
+  public static LabelSet empty() {
+    return new TestLabelSet();
+  }
+}

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractCounterBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractCounterBuilderTest.java
@@ -83,11 +83,6 @@ public class AbstractCounterBuilderTest {
     }
 
     @Override
-    public TestBound getDefaultBound() {
-      return HANDLE;
-    }
-
-    @Override
     public void unbind(TestBound handle) {}
   }
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractGaugeBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractGaugeBuilderTest.java
@@ -83,11 +83,6 @@ public class AbstractGaugeBuilderTest {
     }
 
     @Override
-    public TestBound getDefaultBound() {
-      return HANDLE;
-    }
-
-    @Override
     public void unbind(TestBound handle) {}
   }
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractMetricBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractMetricBuilderTest.java
@@ -157,11 +157,6 @@ public class AbstractMetricBuilderTest {
     }
 
     @Override
-    public TestBound getDefaultBound() {
-      return HANDLE;
-    }
-
-    @Override
     public void unbind(TestBound handle) {}
   }
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractObserverBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractObserverBuilderTest.java
@@ -83,12 +83,6 @@ public class AbstractObserverBuilderTest {
       return null;
     }
 
-    @Nullable
-    @Override
-    public TestBound getDefaultBound() {
-      return null;
-    }
-
     @Override
     public void unbind(TestBound handle) {}
 


### PR DESCRIPTION
Resolves #701 

This leaves the API without the ability to create a bound instrument with an empty LabelSet. Is that something that we should support?