### PR TITLE
Provide a builder for the TracerSdkRegistry, for ultimate configurability

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/resources/EnvVarResource.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/resources/EnvVarResource.java
@@ -30,12 +30,12 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class EnvVarResource {
-  private static final String OC_RESOURCE_LABELS_ENV = "OC_RESOURCE_LABELS";
+  private static final String OTEL_RESOURCE_LABELS_ENV = "OTEL_RESOURCE_LABELS";
   private static final String LABEL_LIST_SPLITTER = ",";
   private static final String LABEL_KEY_VALUE_SPLITTER = "=";
 
   private static final Resource ENV_VAR_RESOURCE =
-      Resource.create(parseResourceLabels(System.getenv(OC_RESOURCE_LABELS_ENV)));
+      Resource.create(parseResourceLabels(System.getenv(OTEL_RESOURCE_LABELS_ENV)));
 
   private EnvVarResource() {}
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdkFactoryBuilder.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdkFactoryBuilder.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.trace;
+
+import io.opentelemetry.sdk.common.Clock;
+import io.opentelemetry.sdk.internal.MillisClock;
+import io.opentelemetry.sdk.resources.EnvVarResource;
+import io.opentelemetry.sdk.resources.Resource;
+import java.security.SecureRandom;
+
+/**
+ * Builder class for the TracerSdkFactory. Has fully functional default implementations of all three
+ * required interfaces.
+ *
+ * @since 0.4.0
+ */
+public class TracerSdkFactoryBuilder {
+
+  private Clock clock = MillisClock.getInstance();
+  private IdsGenerator idsGenerator = new RandomIdsGenerator(new SecureRandom());
+  private Resource resource = EnvVarResource.getResource();
+
+  /**
+   * Assign a {@link Clock}.
+   *
+   * @param clock The clock to use for all temporal needs.
+   * @return this
+   */
+  public TracerSdkFactoryBuilder setClock(Clock clock) {
+    this.clock = clock;
+    return this;
+  }
+
+  /**
+   * Assign an {@link IdsGenerator}.
+   *
+   * @param idsGenerator A generator for trace and span ids. Note: this should be thread-safe and as
+   *     contention free as possible.
+   * @return this
+   */
+  public TracerSdkFactoryBuilder setIdsGenerator(IdsGenerator idsGenerator) {
+    this.idsGenerator = idsGenerator;
+    return this;
+  }
+
+  /**
+   * Assign a {@link Resource} to be attached to all Spans created by Tracers.
+   *
+   * @param resource A Resource implementation.
+   * @return this
+   */
+  public TracerSdkFactoryBuilder setResource(Resource resource) {
+    this.resource = resource;
+    return this;
+  }
+
+  /**
+   * Create a new TracerSdkFactory instance.
+   *
+   * @return An initialized TracerSdkFactory.
+   */
+  public TracerSdkFactory build() {
+    return new TracerSdkFactory(clock, idsGenerator, resource);
+  }
+}

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdkRegistry.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdkRegistry.java
@@ -18,8 +18,6 @@ package io.opentelemetry.sdk.trace;
 
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.internal.MillisClock;
-import io.opentelemetry.sdk.resources.EnvVarResource;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.trace.Tracer;
@@ -33,7 +31,8 @@ import java.util.logging.Logger;
  * {@code Tracer} provider implementation for {@link TracerRegistry}.
  *
  * <p>This class is not intended to be used in application code and it is used only by {@link
- * io.opentelemetry.OpenTelemetry}.
+ * io.opentelemetry.OpenTelemetry}. However, if you need a custom implementation of the factory, you
+ * can create one as needed.
  */
 public class TracerSdkRegistry implements TracerRegistry {
   private final Object lock = new Object();
@@ -49,11 +48,14 @@ public class TracerSdkRegistry implements TracerRegistry {
    * @return a new {@link TracerSdkRegistry} with default configs.
    */
   public static TracerSdkRegistry create() {
-    return new TracerSdkRegistry(
-        MillisClock.getInstance(), new RandomIdsGenerator(), EnvVarResource.getResource());
+    return builder().build();
   }
 
-  private TracerSdkRegistry(Clock clock, IdsGenerator idsGenerator, Resource resource) {
+  public static TracerSdkRegistryBuilder builder() {
+    return new TracerSdkRegistryBuilder();
+  }
+
+  TracerSdkRegistry(Clock clock, IdsGenerator idsGenerator, Resource resource) {
     this.sharedState = new TracerSharedState(clock, idsGenerator, resource);
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdkRegistryBuilder.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdkRegistryBuilder.java
@@ -16,11 +16,13 @@
 
 package io.opentelemetry.sdk.trace;
 
+import io.opentelemetry.internal.Utils;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.internal.MillisClock;
 import io.opentelemetry.sdk.resources.EnvVarResource;
 import io.opentelemetry.sdk.resources.Resource;
 import java.security.SecureRandom;
+import javax.annotation.Nonnull;
 
 /**
  * Builder class for the TracerSdkFactory. Has fully functional default implementations of all three
@@ -28,7 +30,7 @@ import java.security.SecureRandom;
  *
  * @since 0.4.0
  */
-public class TracerSdkFactoryBuilder {
+public class TracerSdkRegistryBuilder {
 
   private Clock clock = MillisClock.getInstance();
   private IdsGenerator idsGenerator = new RandomIdsGenerator(new SecureRandom());
@@ -40,7 +42,8 @@ public class TracerSdkFactoryBuilder {
    * @param clock The clock to use for all temporal needs.
    * @return this
    */
-  public TracerSdkFactoryBuilder setClock(Clock clock) {
+  public TracerSdkRegistryBuilder setClock(@Nonnull Clock clock) {
+    Utils.checkNotNull(clock, "The Clock must be non-null");
     this.clock = clock;
     return this;
   }
@@ -52,7 +55,8 @@ public class TracerSdkFactoryBuilder {
    *     contention free as possible.
    * @return this
    */
-  public TracerSdkFactoryBuilder setIdsGenerator(IdsGenerator idsGenerator) {
+  public TracerSdkRegistryBuilder setIdsGenerator(@Nonnull IdsGenerator idsGenerator) {
+    Utils.checkNotNull(idsGenerator, "The IdsGenerator must be non-null");
     this.idsGenerator = idsGenerator;
     return this;
   }
@@ -63,7 +67,8 @@ public class TracerSdkFactoryBuilder {
    * @param resource A Resource implementation.
    * @return this
    */
-  public TracerSdkFactoryBuilder setResource(Resource resource) {
+  public TracerSdkRegistryBuilder setResource(@Nonnull Resource resource) {
+    Utils.checkNotNull(resource, "The Resource must be non-null");
     this.resource = resource;
     return this;
   }
@@ -73,7 +78,7 @@ public class TracerSdkFactoryBuilder {
    *
    * @return An initialized TracerSdkFactory.
    */
-  public TracerSdkFactory build() {
-    return new TracerSdkFactory(clock, idsGenerator, resource);
+  public TracerSdkRegistry build() {
+    return new TracerSdkRegistry(clock, idsGenerator, resource);
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdkRegistryBuilder.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdkRegistryBuilder.java
@@ -21,7 +21,6 @@ import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.internal.MillisClock;
 import io.opentelemetry.sdk.resources.EnvVarResource;
 import io.opentelemetry.sdk.resources.Resource;
-import java.security.SecureRandom;
 import javax.annotation.Nonnull;
 
 /**
@@ -33,7 +32,7 @@ import javax.annotation.Nonnull;
 public class TracerSdkRegistryBuilder {
 
   private Clock clock = MillisClock.getInstance();
-  private IdsGenerator idsGenerator = new RandomIdsGenerator(new SecureRandom());
+  private IdsGenerator idsGenerator = new RandomIdsGenerator();
   private Resource resource = EnvVarResource.getResource();
 
   /**

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdkRegistryProvider.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdkRegistryProvider.java
@@ -23,6 +23,6 @@ import io.opentelemetry.trace.spi.TracerRegistryProvider;
 public class TracerSdkRegistryProvider implements TracerRegistryProvider {
   @Override
   public TracerRegistry create() {
-    return TracerSdkRegistry.create();
+    return TracerSdkRegistry.builder().build();
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkRegistryBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkRegistryBuilderTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.trace;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+import io.opentelemetry.sdk.common.Clock;
+import io.opentelemetry.sdk.resources.Resource;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class TracerSdkRegistryBuilderTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testHappyPath() {
+    TracerSdkRegistry registry =
+        TracerSdkRegistry.builder()
+            .setClock(mock(Clock.class))
+            .setResource(mock(Resource.class))
+            .setIdsGenerator(mock(IdsGenerator.class))
+            .build();
+    assertNotNull(registry);
+  }
+
+  @Test
+  public void testNullClock() {
+    thrown.expect(NullPointerException.class);
+    TracerSdkRegistry.builder().setClock(null);
+  }
+
+  @Test
+  public void testNullResource() {
+    thrown.expect(NullPointerException.class);
+    TracerSdkRegistry.builder().setResource(null);
+  }
+
+  @Test
+  public void testNullIdsGenerator() {
+    thrown.expect(NullPointerException.class);
+    TracerSdkRegistry.builder().setIdsGenerator(null);
+  }
+}


### PR DESCRIPTION
I think this should at least partially resolve #518, in that it will enable building arbitrary service providers for the TracerSdkFactory.

resolves #735 