### PR TITLE
Add hasEnded to ReadableSpan and SpanData (split from #693)

### DIFF
--- a/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
+++ b/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
@@ -101,6 +101,7 @@ public class InMemorySpanExporterTest {
 
   static SpanData makeBasicSpan() {
     return SpanData.newBuilder()
+        .setHasBeenEnded(true)
         .setTraceId(io.opentelemetry.trace.TraceId.getInvalid())
         .setSpanId(io.opentelemetry.trace.SpanId.getInvalid())
         .setName("span")

--- a/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
+++ b/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
@@ -101,7 +101,7 @@ public class InMemorySpanExporterTest {
 
   static SpanData makeBasicSpan() {
     return SpanData.newBuilder()
-        .setHasBeenEnded(true)
+        .setHasEnded(true)
         .setTraceId(io.opentelemetry.trace.TraceId.getInvalid())
         .setSpanId(io.opentelemetry.trace.SpanId.getInvalid())
         .setName("span")

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
@@ -218,7 +218,7 @@ public class AdapterTest {
     long endMs = startMs + 900;
     SpanData span =
         SpanData.newBuilder()
-            .setHasBeenEnded(true)
+            .setHasEnded(true)
             .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
             .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
             .setName("GET /api/endpoint")
@@ -245,7 +245,7 @@ public class AdapterTest {
     Link link = SpanData.Link.create(createSpanContext(LINK_TRACE_ID, LINK_SPAN_ID), attributes);
 
     return SpanData.newBuilder()
-        .setHasBeenEnded(true)
+        .setHasEnded(true)
         .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
         .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
         .setParentSpanId(SpanId.fromLowerBase16(PARENT_SPAN_ID, 0))

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
@@ -218,6 +218,7 @@ public class AdapterTest {
     long endMs = startMs + 900;
     SpanData span =
         SpanData.newBuilder()
+            .setHasBeenEnded(true)
             .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
             .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
             .setName("GET /api/endpoint")
@@ -244,6 +245,7 @@ public class AdapterTest {
     Link link = SpanData.Link.create(createSpanContext(LINK_TRACE_ID, LINK_SPAN_ID), attributes);
 
     return SpanData.newBuilder()
+        .setHasBeenEnded(true)
         .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
         .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
         .setParentSpanId(SpanId.fromLowerBase16(PARENT_SPAN_ID, 0))

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporterTest.java
@@ -79,7 +79,7 @@ public class JaegerGrpcSpanExporterTest {
     long endMs = startMs + duration;
     SpanData span =
         SpanData.newBuilder()
-            .setHasBeenEnded(true)
+            .setHasEnded(true)
             .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
             .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
             .setName("GET /api/endpoint")

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporterTest.java
@@ -79,6 +79,7 @@ public class JaegerGrpcSpanExporterTest {
     long endMs = startMs + duration;
     SpanData span =
         SpanData.newBuilder()
+            .setHasBeenEnded(true)
             .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
             .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
             .setName("GET /api/endpoint")

--- a/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingExporterTest.java
@@ -37,7 +37,7 @@ public class LoggingExporterTest {
     long epochNanos = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
     SpanData spanData =
         SpanData.newBuilder()
-            .setHasBeenEnded(true)
+            .setHasEnded(true)
             .setTraceId(new TraceId(1234L, 6789L))
             .setSpanId(new SpanId(9876L))
             .setStartEpochNanos(epochNanos)

--- a/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingExporterTest.java
@@ -37,6 +37,7 @@ public class LoggingExporterTest {
     long epochNanos = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
     SpanData spanData =
         SpanData.newBuilder()
+            .setHasBeenEnded(true)
             .setTraceId(new TraceId(1234L, 6789L))
             .setSpanId(new SpanId(9876L))
             .setStartEpochNanos(epochNanos)

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
@@ -67,5 +67,5 @@ public interface ReadableSpan {
    * @return {@code true} if the span has already been ended, {@code false} if not.
    * @since 0.4.0
    */
-  boolean hasBeenEnded();
+  boolean hasEnded();
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
@@ -60,4 +60,12 @@ public interface ReadableSpan {
    *     library
    */
   InstrumentationLibraryInfo getInstrumentationLibraryInfo();
+
+  /**
+   * Returns whether this Span has already been ended.
+   *
+   * @return {@code true} if the span has already been ended, {@code false} if not.
+   * @since 0.4.0
+   */
+  boolean hasBeenEnded();
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -179,6 +179,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     // Copy remainder within synchronized
     synchronized (lock) {
       return builder
+          .setHasBeenEnded(hasBeenEnded)
           .setAttributes(attributes)
           .setEndEpochNanos(getEndEpochNanos())
           .setStatus(getStatusWithDefault())

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -310,7 +310,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   // Use getEndNanoTimeInternal to avoid over-locking.
   @GuardedBy("lock")
   private long getEndNanoTimeInternal() {
-    return hasBeenEnded ? endEpochNanos : clock.now();
+    return hasEnded ? endEpochNanos : clock.now();
   }
 
   /**

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -201,6 +201,13 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   }
 
   @Override
+  public boolean hasBeenEnded() {
+    synchronized (lock) {
+      return hasBeenEnded;
+    }
+  }
+
+  @Override
   public SpanContext getSpanContext() {
     return getContext();
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -98,7 +98,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   private long endEpochNanos;
   // True if the span is ended.
   @GuardedBy("lock")
-  private boolean hasBeenEnded;
+  private boolean hasEnded;
 
   /**
    * Creates and starts a span with the given configuration.
@@ -179,7 +179,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     // Copy remainder within synchronized
     synchronized (lock) {
       return builder
-          .setHasBeenEnded(hasBeenEnded)
+          .setHasEnded(hasEnded)
           .setAttributes(attributes)
           .setEndEpochNanos(getEndEpochNanos())
           .setStatus(getStatusWithDefault())
@@ -202,9 +202,9 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   }
 
   @Override
-  public boolean hasBeenEnded() {
+  public boolean hasEnded() {
     synchronized (lock) {
-      return hasBeenEnded;
+      return hasEnded;
     }
   }
 
@@ -367,7 +367,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     Preconditions.checkNotNull(key, "key");
     Preconditions.checkNotNull(value, "value");
     synchronized (lock) {
-      if (hasBeenEnded) {
+      if (hasEnded) {
         logger.log(Level.FINE, "Calling setAttribute() on an ended Span.");
         return;
       }
@@ -407,7 +407,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
 
   private void addTimedEvent(TimedEvent timedEvent) {
     synchronized (lock) {
-      if (hasBeenEnded) {
+      if (hasEnded) {
         logger.log(Level.FINE, "Calling addEvent() on an ended Span.");
         return;
       }
@@ -420,7 +420,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   public void setStatus(Status status) {
     Preconditions.checkNotNull(status, "status");
     synchronized (lock) {
-      if (hasBeenEnded) {
+      if (hasEnded) {
         logger.log(Level.FINE, "Calling setStatus() on an ended Span.");
         return;
       }
@@ -432,7 +432,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   public void updateName(String name) {
     Preconditions.checkNotNull(name, "name");
     synchronized (lock) {
-      if (hasBeenEnded) {
+      if (hasEnded) {
         logger.log(Level.FINE, "Calling updateName() on an ended Span.");
         return;
       }
@@ -453,12 +453,12 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
 
   private void endInternal(long endEpochNanos) {
     synchronized (lock) {
-      if (hasBeenEnded) {
+      if (hasEnded) {
         logger.log(Level.FINE, "Calling end() on an ended Span.");
         return;
       }
       this.endEpochNanos = endEpochNanos;
-      hasBeenEnded = true;
+      hasEnded = true;
     }
     spanProcessor.onEnd(this);
   }
@@ -475,7 +475,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
 
   void addChild() {
     synchronized (lock) {
-      if (hasBeenEnded) {
+      if (hasEnded) {
         logger.log(Level.FINE, "Calling end() on an ended Span.");
         return;
       }
@@ -515,7 +515,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     this.kind = kind;
     this.spanProcessor = spanProcessor;
     this.resource = resource;
-    this.hasBeenEnded = false;
+    this.hasEnded = false;
     this.numberOfChildren = 0;
     this.clock = clock;
     this.startEpochNanos = startEpochNanos;
@@ -527,7 +527,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   @Override
   protected void finalize() throws Throwable {
     synchronized (lock) {
-      if (!hasBeenEnded) {
+      if (!hasEnded) {
         logger.log(Level.SEVERE, "Span " + name + " is GC'ed without being ended.");
       }
     }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanData.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanData.java
@@ -178,7 +178,7 @@ public abstract class SpanData {
    * @return {@code true} if the span has already been ended, {@code false} if not.
    * @since 0.4.0
    */
-  public abstract boolean getHasBeenEnded();
+  public abstract boolean getHasEnded();
 
   /**
    * An immutable implementation of {@link Link}.
@@ -454,10 +454,10 @@ public abstract class SpanData {
     /**
      * Sets to true if the span has been ended.
      *
-     * @param hasBeenEnded A boolean indicating if the span has been ended.
+     * @param hasEnded A boolean indicating if the span has been ended.
      * @return this
      * @since 0.4.0
      */
-    public abstract Builder setHasBeenEnded(boolean hasBeenEnded);
+    public abstract Builder setHasEnded(boolean hasEnded);
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanData.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanData.java
@@ -173,6 +173,14 @@ public abstract class SpanData {
   public abstract boolean getHasRemoteParent();
 
   /**
+   * Returns whether this Span has already been ended.
+   *
+   * @return {@code true} if the span has already been ended, {@code false} if not.
+   * @since 0.4.0
+   */
+  public abstract boolean getHasBeenEnded();
+
+  /**
    * An immutable implementation of {@link Link}.
    *
    * @since 0.1.0
@@ -442,5 +450,14 @@ public abstract class SpanData {
      * @since 0.3.0
      */
     public abstract Builder setHasRemoteParent(boolean hasRemoteParent);
+
+    /**
+     * Sets to true if the span has been ended.
+     *
+     * @param hasBeenEnded A boolean indicating if the span has been ended.
+     * @return this
+     * @since 0.4.0
+     */
+    public abstract Builder setHasBeenEnded(boolean hasBeenEnded);
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -110,7 +110,8 @@ public class RecordEventsReadableSpanTest {
         SPAN_NAME,
         startEpochNanos,
         startEpochNanos,
-        Status.OK);
+        Status.OK,
+        /*hasEnded=*/ true);
   }
 
   @Test
@@ -143,7 +144,8 @@ public class RecordEventsReadableSpanTest {
           SPAN_NEW_NAME,
           startEpochNanos,
           testClock.now(),
-          Status.OK);
+          Status.OK,
+          /*hasEnded=*/ false);
       assertThat(span.hasEnded()).isFalse();
     } finally {
       span.end();
@@ -174,7 +176,8 @@ public class RecordEventsReadableSpanTest {
         SPAN_NEW_NAME,
         startEpochNanos,
         testClock.now(),
-        Status.CANCELLED);
+        Status.CANCELLED,
+        /*hasEnded=*/ true);
   }
 
   @Test
@@ -514,7 +517,8 @@ public class RecordEventsReadableSpanTest {
       String spanName,
       long startEpochNanos,
       long endEpochNanos,
-      Status status) {
+      Status status,
+      boolean hasEnded) {
     assertThat(spanData.getTraceId()).isEqualTo(traceId);
     assertThat(spanData.getSpanId()).isEqualTo(spanId);
     assertThat(spanData.getParentSpanId()).isEqualTo(parentSpanId);
@@ -529,6 +533,7 @@ public class RecordEventsReadableSpanTest {
     assertThat(spanData.getStartEpochNanos()).isEqualTo(startEpochNanos);
     assertThat(spanData.getEndEpochNanos()).isEqualTo(endEpochNanos);
     assertThat(spanData.getStatus().getCanonicalCode()).isEqualTo(status.getCanonicalCode());
+    assertThat(spanData.getHasEnded()).isEqualTo(hasEnded);
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -116,14 +116,18 @@ public class RecordEventsReadableSpanTest {
   @Test
   public void endSpanTwice_DoNotCrash() {
     RecordEventsReadableSpan span = createTestSpan(Kind.INTERNAL);
+    assertThat(span.hasBeenEnded()).isFalse();
     span.end();
+    assertThat(span.hasBeenEnded()).isTrue();
     span.end();
+    assertThat(span.hasBeenEnded()).isTrue();
   }
 
   @Test
   public void toSpanData_ActiveSpan() {
     RecordEventsReadableSpan span = createTestSpan(Kind.INTERNAL);
     try {
+      assertThat(span.hasBeenEnded()).isFalse();
       spanDoWork(span, null);
       SpanData spanData = span.toSpanData();
       SpanData.TimedEvent timedEvent =
@@ -140,9 +144,11 @@ public class RecordEventsReadableSpanTest {
           startEpochNanos,
           testClock.now(),
           Status.OK);
+      assertThat(span.hasBeenEnded()).isFalse();
     } finally {
       span.end();
     }
+    assertThat(span.hasBeenEnded()).isTrue();
   }
 
   @Test
@@ -578,6 +584,7 @@ public class RecordEventsReadableSpanTest {
 
     SpanData expected =
         SpanData.newBuilder()
+            .setHasBeenEnded(true)
             .setName(name)
             .setInstrumentationLibraryInfo(instrumentationLibraryInfo)
             .setKind(kind)

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -116,18 +116,18 @@ public class RecordEventsReadableSpanTest {
   @Test
   public void endSpanTwice_DoNotCrash() {
     RecordEventsReadableSpan span = createTestSpan(Kind.INTERNAL);
-    assertThat(span.hasBeenEnded()).isFalse();
+    assertThat(span.hasEnded()).isFalse();
     span.end();
-    assertThat(span.hasBeenEnded()).isTrue();
+    assertThat(span.hasEnded()).isTrue();
     span.end();
-    assertThat(span.hasBeenEnded()).isTrue();
+    assertThat(span.hasEnded()).isTrue();
   }
 
   @Test
   public void toSpanData_ActiveSpan() {
     RecordEventsReadableSpan span = createTestSpan(Kind.INTERNAL);
     try {
-      assertThat(span.hasBeenEnded()).isFalse();
+      assertThat(span.hasEnded()).isFalse();
       spanDoWork(span, null);
       SpanData spanData = span.toSpanData();
       SpanData.TimedEvent timedEvent =
@@ -144,11 +144,11 @@ public class RecordEventsReadableSpanTest {
           startEpochNanos,
           testClock.now(),
           Status.OK);
-      assertThat(span.hasBeenEnded()).isFalse();
+      assertThat(span.hasEnded()).isFalse();
     } finally {
       span.end();
     }
-    assertThat(span.hasBeenEnded()).isTrue();
+    assertThat(span.hasEnded()).isTrue();
   }
 
   @Test
@@ -584,7 +584,7 @@ public class RecordEventsReadableSpanTest {
 
     SpanData expected =
         SpanData.newBuilder()
-            .setHasBeenEnded(true)
+            .setHasEnded(true)
             .setName(name)
             .setInstrumentationLibraryInfo(instrumentationLibraryInfo)
             .setKind(kind)

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanDataTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanDataTest.java
@@ -105,7 +105,7 @@ public class SpanDataTest {
 
   private static SpanData.Builder createBasicSpanBuilder() {
     return SpanData.newBuilder()
-        .setHasBeenEnded(true)
+        .setHasEnded(true)
         .setSpanId(SpanId.getInvalid())
         .setTraceId(TraceId.getInvalid())
         .setName("spanName")

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanDataTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanDataTest.java
@@ -105,6 +105,7 @@ public class SpanDataTest {
 
   private static SpanData.Builder createBasicSpanBuilder() {
     return SpanData.newBuilder()
+        .setHasBeenEnded(true)
         .setSpanId(SpanId.getInvalid())
         .setTraceId(TraceId.getInvalid())
         .setName("spanName")

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
@@ -55,6 +55,7 @@ public final class TestUtils {
    */
   public static SpanData makeBasicSpan() {
     return SpanData.newBuilder()
+        .setHasBeenEnded(true)
         .setTraceId(TraceId.getInvalid())
         .setSpanId(SpanId.getInvalid())
         .setName("span")

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
@@ -55,7 +55,7 @@ public final class TestUtils {
    */
   public static SpanData makeBasicSpan() {
     return SpanData.newBuilder()
-        .setHasBeenEnded(true)
+        .setHasEnded(true)
         .setTraceId(TraceId.getInvalid())
         .setSpanId(SpanId.getInvalid())
         .setName("span")


### PR DESCRIPTION
This PR was split from #693 at the request of @bogdandrutu. It just renames the internal `boolean hasBeenEnded` of `RecordEventsReadableSpan` to `hasEnded`, makes it public on the `ReadableSpan` interface and also adds it to `SpanData`.