### PR TITLE
Rework latency/duration/endTime of Span

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
@@ -68,4 +68,13 @@ public interface ReadableSpan {
    * @since 0.4.0
    */
   boolean hasEnded();
+
+  /**
+   * Returns the latency of the {@code Span} in nanos. If still active then returns now() - start
+   * time.
+   *
+   * @return the latency of the {@code Span} in nanos.
+   * @since 0.4.0
+   */
+  long getLatencyNs();
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
@@ -76,5 +76,5 @@ public interface ReadableSpan {
    * @return the latency of the {@code Span} in nanos.
    * @since 0.4.0
    */
-  long getLatencyNs();
+  long getLatencyNanos();
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -296,6 +296,19 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   }
 
   /**
+   * Returns the latency of the {@code Span} in nanos. If still active then returns now() - start
+   * time.
+   *
+   * @return the latency of the {@code Span} in nanos.
+   */
+  @Override
+  public long getLatencyNs() {
+    synchronized (lock) {
+      return (hasEnded ? endEpochNanos : clock.now()) - startEpochNanos;
+    }
+  }
+
+  /**
    * Returns the kind of this {@code Span}.
    *
    * @return the kind of this {@code Span}.

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -238,14 +238,14 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   }
 
   /**
-   * Returns the end nano time (see {@link System#nanoTime()}). If the current {@code Span} is not
-   * ended then returns {@link Clock#nanoTime()}.
+   * Returns the end nano time (see {@link System#nanoTime()}) or zero if the current {@code Span}
+   * is not ended.
    *
    * @return the end nano time.
    */
   private long getEndEpochNanos() {
     synchronized (lock) {
-      return getEndNanoTimeInternal();
+      return endEpochNanos;
     }
   }
 
@@ -293,24 +293,6 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   @GuardedBy("lock")
   Map<String, AttributeValue> getAttributes() {
     return Collections.unmodifiableMap(attributes);
-  }
-
-  /**
-   * Returns the latency of the {@code Span} in nanos. If still active then returns now() - start
-   * time.
-   *
-   * @return the latency of the {@code Span} in nanos.
-   */
-  long getLatencyNs() {
-    synchronized (lock) {
-      return getEndNanoTimeInternal() - startEpochNanos;
-    }
-  }
-
-  // Use getEndNanoTimeInternal to avoid over-locking.
-  @GuardedBy("lock")
-  private long getEndNanoTimeInternal() {
-    return hasEnded ? endEpochNanos : clock.now();
   }
 
   /**

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -302,7 +302,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
    * @return the latency of the {@code Span} in nanos.
    */
   @Override
-  public long getLatencyNs() {
+  public long getLatencyNanos() {
     synchronized (lock) {
       return (hasEnded ? endEpochNanos : clock.now()) - startEpochNanos;
     }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -256,6 +256,32 @@ public class RecordEventsReadableSpanTest {
   }
 
   @Test
+  public void getLatencyNs_ActiveSpan() {
+    RecordEventsReadableSpan span = createTestSpan(Kind.INTERNAL);
+    try {
+      testClock.advanceMillis(MILLIS_PER_SECOND);
+      long elapsedTimeNanos1 = testClock.now() - startEpochNanos;
+      assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos1);
+      testClock.advanceMillis(MILLIS_PER_SECOND);
+      long elapsedTimeNanos2 = testClock.now() - startEpochNanos;
+      assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos2);
+    } finally {
+      span.end();
+    }
+  }
+
+  @Test
+  public void getLatencyNs_EndedSpan() {
+    RecordEventsReadableSpan span = createTestSpan(Kind.INTERNAL);
+    testClock.advanceMillis(MILLIS_PER_SECOND);
+    span.end();
+    long elapsedTimeNanos = testClock.now() - startEpochNanos;
+    assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos);
+    testClock.advanceMillis(MILLIS_PER_SECOND);
+    assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos);
+  }
+
+  @Test
   public void setAttribute() {
     RecordEventsReadableSpan span = createTestRootSpan();
     try {

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -261,10 +261,10 @@ public class RecordEventsReadableSpanTest {
     try {
       testClock.advanceMillis(MILLIS_PER_SECOND);
       long elapsedTimeNanos1 = testClock.now() - startEpochNanos;
-      assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos1);
+      assertThat(span.getLatencyNanos()).isEqualTo(elapsedTimeNanos1);
       testClock.advanceMillis(MILLIS_PER_SECOND);
       long elapsedTimeNanos2 = testClock.now() - startEpochNanos;
-      assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos2);
+      assertThat(span.getLatencyNanos()).isEqualTo(elapsedTimeNanos2);
     } finally {
       span.end();
     }
@@ -276,9 +276,9 @@ public class RecordEventsReadableSpanTest {
     testClock.advanceMillis(MILLIS_PER_SECOND);
     span.end();
     long elapsedTimeNanos = testClock.now() - startEpochNanos;
-    assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos);
+    assertThat(span.getLatencyNanos()).isEqualTo(elapsedTimeNanos);
     testClock.advanceMillis(MILLIS_PER_SECOND);
-    assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos);
+    assertThat(span.getLatencyNanos()).isEqualTo(elapsedTimeNanos);
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -142,7 +142,7 @@ public class RecordEventsReadableSpanTest {
           Collections.singletonList(link),
           SPAN_NEW_NAME,
           startEpochNanos,
-          testClock.now(),
+          0,
           Status.OK,
           /*hasEnded=*/ false);
       assertThat(span.hasEnded()).isFalse();
@@ -253,32 +253,6 @@ public class RecordEventsReadableSpanTest {
     } finally {
       span.end();
     }
-  }
-
-  @Test
-  public void getLatencyNs_ActiveSpan() {
-    RecordEventsReadableSpan span = createTestSpan(Kind.INTERNAL);
-    try {
-      testClock.advanceMillis(MILLIS_PER_SECOND);
-      long elapsedTimeNanos1 = testClock.now() - startEpochNanos;
-      assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos1);
-      testClock.advanceMillis(MILLIS_PER_SECOND);
-      long elapsedTimeNanos2 = testClock.now() - startEpochNanos;
-      assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos2);
-    } finally {
-      span.end();
-    }
-  }
-
-  @Test
-  public void getLatencyNs_EndedSpan() {
-    RecordEventsReadableSpan span = createTestSpan(Kind.INTERNAL);
-    testClock.advanceMillis(MILLIS_PER_SECOND);
-    span.end();
-    long elapsedTimeNanos = testClock.now() - startEpochNanos;
-    assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos);
-    testClock.advanceMillis(MILLIS_PER_SECOND);
-    assertThat(span.getLatencyNs()).isEqualTo(elapsedTimeNanos);
   }
 
   @Test


### PR DESCRIPTION
Split & rebased from #693. The only difference to #693 is that the latency/duration is not added to SpanData, only ReadableSpan.

In effect, this PR:
- Changes the end time of active spans to return zero instead of the current duration/latency if the span has not been ended yet.
- Add a public getter for a ReadableSpan's latency/duration.
- In contrast to #693, this does *not* add the latency property to SpanData (I think this was a bad idea anyway).