### PR TITLE
Add AWS-specific support to SDK

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/resources/ResourceConstants.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/resources/ResourceConstants.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.resources;
+
+/**
+ * Provides constants for resource semantic conventions defined by the OpenTelemetry specification.
+ *
+ * @see <a
+ *     href="https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-resource-semantic-conventions.md">Resource
+ *     Conventions</a>
+ */
+public class ResourceConstants {
+
+  /**
+   * Logical name of the service. MUST be the same for all instances of horizontally scaled
+   * services.
+   */
+  public static final String SERVICE_NAME = "service.name";
+  /**
+   * A namespace for `service.name`. A string value having a meaning that helps to distinguish a
+   * group of services,
+   */
+  public static final String SERVICE_NAMESPACE = "service.namespace";
+  /**
+   * The string ID of the service instance. MUST be unique for each instance of the same
+   * `service.namespace,service.name` pair.
+   */
+  public static final String SERVICE_INSTANCE = "service.instance.id";
+  /** The version string of the service API or implementation. */
+  public static final String SERVICE_VERSION = "service.version";
+  /** The name of the telemetry library. */
+  public static final String LIBRARY_NAME = "library.name";
+  /** The language of telemetry library and of the code instrumented with it. */
+  public static final String LIBRARY_LANGUAGE = "library.language";
+  /** The version string of the library. */
+  public static final String LIBRARY_VERSION = "library.version";
+  /** Container name. */
+  public static final String CONTAINER_NAME = "container.name";
+  /** Name of the image the container was built on. */
+  public static final String CONTAINER_IMAGE_NAME = "container.image.name";
+  /** Container image tag. */
+  public static final String CONTAINER_IMAGE_TAG = "container.image.tag";
+  /** The name of the cluster that the pod is running in. */
+  public static final String K8S_CLUSTER = "k8s.cluster.name";
+  /** The name of the namespace that the pod is running in. */
+  public static final String K8S_NAMESPACE = "k8s.namespace.name";
+  /** The name of the pod. */
+  public static final String K8S_POD = "k8s.pod.name";
+  /** The name of the deployment. */
+  public static final String K8S_DEPLOYMENT = "k8s.deployment.name";
+  /** Hostname of the host. It contains what the `hostname` command returns on the host machine. */
+  public static final String HOST_HOSTNAME = "host.hostname";
+  /** Unique host id. For Cloud this must be the instance_id assigned by the cloud provider. */
+  public static final String HOST_ID = "host.id";
+  /**
+   * Name of the host. It may contain what `hostname` returns on Unix systems, the fully qualified,
+   * or a name specified by the user.
+   */
+  public static final String HOST_NAME = "host.name";
+  /** Type of host. For Cloud this must be the machine type. */
+  public static final String HOST_TYPE = "host.type";
+  /** Name of the cloud provider. */
+  public static final String CLOUD_PROVIDER = "cloud.provider";
+  /** The cloud account id used to identify different entities. */
+  public static final String CLOUD_ACCOUNT = "cloud.account.id";
+  /** A specific geographical location where different entities can run. */
+  public static final String CLOUD_REGION = "cloud.region";
+  /** Zones are a sub set of the region connected through low-latency links. */
+  public static final String CLOUD_ZONE = "cloud.zone";
+
+  private ResourceConstants() {}
+}

--- a/sdk_contrib/aws_support/build.gradle
+++ b/sdk_contrib/aws_support/build.gradle
@@ -12,6 +12,8 @@ dependencies {
 
     implementation 'com.amazonaws:aws-xray-recorder-sdk-core:2.4.0'
     implementation 'com.amazonaws:aws-java-sdk-core:1.11.701'
+    implementation 'com.amazonaws:aws-java-sdk-ec2:1.11.701'
+    implementation 'com.amazonaws:aws-java-sdk-cloudformation:1.11.701'
 
     signature "org.codehaus.mojo.signature:java18:1.0@signature"
 }

--- a/sdk_contrib/aws_support/build.gradle
+++ b/sdk_contrib/aws_support/build.gradle
@@ -1,0 +1,17 @@
+description = 'OpenTelemetry SDK AWS Support'
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+dependencies {
+    api project(':opentelemetry-api'),
+            project(':opentelemetry-sdk')
+
+    implementation libraries.guava,
+            libraries.disruptor
+
+    implementation 'com.amazonaws:aws-xray-recorder-sdk-core:2.4.0'
+    implementation 'com.amazonaws:aws-java-sdk-core:1.11.701'
+
+    signature "org.codehaus.mojo.signature:java18:1.0@signature"
+}

--- a/sdk_contrib/aws_support/src/main/java/io/opentelemetry/sdk/contrib/trace/aws/AwsXRayIdsGenerator.java
+++ b/sdk_contrib/aws_support/src/main/java/io/opentelemetry/sdk/contrib/trace/aws/AwsXRayIdsGenerator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.contrib.trace.aws;
+
+import com.amazonaws.xray.ThreadLocalStorage;
+import com.amazonaws.xray.entities.TraceID;
+import io.opentelemetry.sdk.trace.IdsGenerator;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceId;
+
+/**
+ * Generates tracing ids compatible with the AWS X-Ray tracing service. In the X-Ray system the
+ * first 32 bits of the trace id are the Unix epoch time in secords. Spans (AWS calls them segments)
+ * submit with trace id timestamps outside of the last 30 days are rejected.
+ *
+ * @see <a
+ *     href="https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html#xray-api-traceids">Generating
+ *     Trace IDs</a>
+ */
+public class AwsXRayIdsGenerator implements IdsGenerator {
+
+  @Override
+  public SpanId generateSpanId() {
+    String awsIdStr = generateId();
+    return SpanId.fromLowerBase16(awsIdStr, 0);
+  }
+
+  @Override
+  public TraceId generateTraceId() {
+    String traceIdStr = new TraceID().toString();
+    return TraceId.fromLowerBase16(traceIdStr.substring(2, 10) + traceIdStr.substring(11, 35), 0);
+  }
+
+  // Copied from com.amazonaws.xray.entities.Entity
+  private static String generateId() {
+    String id = Long.toString(ThreadLocalStorage.getRandom().nextLong() >>> 1, 16);
+    while (id.length() < 16) {
+      id = '0' + id;
+    }
+    return id;
+  }
+}

--- a/sdk_contrib/aws_support/src/main/java/io/opentelemetry/sdk/contrib/trace/aws/Ec2Resource.java
+++ b/sdk_contrib/aws_support/src/main/java/io/opentelemetry/sdk/contrib/trace/aws/Ec2Resource.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.contrib.trace.aws;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+import com.amazonaws.util.EC2MetadataUtils;
+import com.amazonaws.util.EC2MetadataUtils.InstanceInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.resources.ResourceConstants;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Provides for lookup and population of {@link Resource} labels when running on AWS EC2. */
+public class Ec2Resource {
+
+  /** OpenTelemetry semantic convention identifier for AWS cloud. */
+  public static final String CLOUD_PROVIDER_AWS = "aws";
+
+  /**
+   * Returns a resource with all host and cloud labels populated with the information obtained from
+   * the EC2 metadata endpoint.
+   *
+   * @return the resource
+   */
+  public static Resource getResource() {
+    Map<String, String> labels = new HashMap<>();
+    labels.put(ResourceConstants.CLOUD_PROVIDER, CLOUD_PROVIDER_AWS);
+    addEc2InstanceData(labels);
+    return Resource.create(labels);
+  }
+
+  private static void addEc2InstanceData(Map<String, String> labels) {
+    InstanceInfo info = EC2MetadataUtils.getInstanceInfo();
+    if (info != null) {
+      labels.put(ResourceConstants.CLOUD_ACCOUNT, info.getAccountId());
+      labels.put(ResourceConstants.CLOUD_REGION, info.getRegion());
+      labels.put(ResourceConstants.CLOUD_ZONE, info.getAvailabilityZone());
+      labels.put(ResourceConstants.HOST_ID, info.getInstanceId());
+      labels.put(ResourceConstants.HOST_NAME, info.getPrivateIp());
+      labels.put(ResourceConstants.HOST_TYPE, info.getInstanceType());
+    }
+    String hostname = EC2MetadataUtils.getLocalHostName();
+    if (!isNullOrEmpty(hostname)) {
+      labels.put(ResourceConstants.HOST_HOSTNAME, hostname);
+    }
+  }
+
+  private Ec2Resource() {}
+}

--- a/sdk_contrib/aws_support/src/main/java/io/opentelemetry/sdk/contrib/trace/aws/package-info.java
+++ b/sdk_contrib/aws_support/src/main/java/io/opentelemetry/sdk/contrib/trace/aws/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Provides implementations of SDK interfaces which integrate natively with AWS infrastructure. */
+package io.opentelemetry.sdk.contrib.trace.aws;

--- a/sdk_contrib/aws_support/src/test/java/io/opentelemetry/sdk/contrib/trace/aws/AwsXRayIdsGeneratorTest.java
+++ b/sdk_contrib/aws_support/src/test/java/io/opentelemetry/sdk/contrib/trace/aws/AwsXRayIdsGeneratorTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.contrib.trace.aws;
+
+import static org.junit.Assert.assertTrue;
+
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceId;
+import org.junit.Test;
+
+/** Unit tests for {@link AwsXRayIdsGenerator}. */
+public class AwsXRayIdsGeneratorTest {
+
+  @Test
+  public void shouldGenerateValidIds() {
+    AwsXRayIdsGenerator generator = new AwsXRayIdsGenerator();
+    TraceId traceId = generator.generateTraceId();
+    assertTrue(traceId.isValid());
+    SpanId spanId = generator.generateSpanId();
+    assertTrue(spanId.isValid());
+  }
+
+  @Test
+  public void shouldGenerateTraceIdsWithTimestampsWithAllowedXrayTimeRange() {
+    AwsXRayIdsGenerator generator = new AwsXRayIdsGenerator();
+    TraceId traceId = generator.generateTraceId();
+    Long unixSeconds = Long.valueOf(traceId.toLowerBase16().substring(0, 8), 16);
+    long ts = unixSeconds.longValue() * 1000L;
+    long currentTs = System.currentTimeMillis();
+    assertTrue(ts <= currentTs);
+    long month = 86400000L * 30L;
+    assertTrue(ts > currentTs - month);
+  }
+}

--- a/sdk_contrib/aws_support/src/test/java/io/opentelemetry/sdk/contrib/trace/aws/Ec2ResourceTest.java
+++ b/sdk_contrib/aws_support/src/test/java/io/opentelemetry/sdk/contrib/trace/aws/Ec2ResourceTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.contrib.trace.aws;
+
+import static org.junit.Assert.assertEquals;
+
+import io.opentelemetry.sdk.resources.Resource;
+import org.junit.Test;
+
+public class Ec2ResourceTest {
+
+  @Test
+  public void shouldReturnResourceWithOnlyCloudProviderLabelIfNotRunningOnEc2() {
+    Resource resource = Ec2Resource.getResource();
+    assertEquals(1, resource.getLabels().size());
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,7 @@ include ":opentelemetry-all",
         ":opentelemetry-proto",
         ":opentelemetry-sdk",
         ":opentelemetry-sdk-contrib-async-processor",
+        ":opentelemetry-sdk-contrib-aws-support",
         ":opentelemetry-sdk-contrib-testbed"
 
 project(':opentelemetry-all').projectDir = "$rootDir/all" as File
@@ -34,5 +35,7 @@ project(':opentelemetry-opentracing-shim').projectDir =
 project(':opentelemetry-sdk').projectDir = "$rootDir/sdk" as File
 project(':opentelemetry-sdk-contrib-async-processor').projectDir =
         "$rootDir/sdk_contrib/async_processor" as File
+project(':opentelemetry-sdk-contrib-aws-support').projectDir =
+        "$rootDir/sdk_contrib/aws_support" as File
 project(':opentelemetry-sdk-contrib-testbed').projectDir =
         "$rootDir/sdk_contrib/testbed" as File


### PR DESCRIPTION
Provides Resource label population using the EC2 metadata endpoint. Provides IDs generator compatible with AWS X-Ray.
