### PR TITLE
Create a labelset with an arbitrary number of key/value pairs

### DIFF
--- a/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
@@ -20,7 +20,6 @@ import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.internal.Utils;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -29,6 +28,7 @@ import javax.annotation.concurrent.Immutable;
  * @since 0.1.0
  */
 public final class DefaultMeter implements Meter {
+
   private static final DefaultMeter INSTANCE = new DefaultMeter();
 
   /* VisibleForTesting */ static final int NAME_MAX_LENGTH = 255;
@@ -166,7 +166,7 @@ public final class DefaultMeter implements Meter {
   }
 
   @Override
-  public LabelSet createLabelSet(@Nonnull Map<String, String> labels) {
+  public LabelSet createLabelSet(Map<String, String> labels) {
     Utils.checkNotNull(labels, "labels");
     return NoopLabelSet.INSTANCE;
   }
@@ -179,6 +179,7 @@ public final class DefaultMeter implements Meter {
   /** No-op implementation of LongGauge interface. */
   @Immutable
   private static final class NoopLongGauge implements LongGauge {
+
     /** Creates a new {@code NoopBound}. */
     private NoopLongGauge() {}
 
@@ -207,6 +208,7 @@ public final class DefaultMeter implements Meter {
 
     private static final class NoopBuilder extends NoopAbstractGaugeBuilder<Builder, LongGauge>
         implements Builder {
+
       @Override
       protected Builder getThis() {
         return this;
@@ -222,6 +224,7 @@ public final class DefaultMeter implements Meter {
   /** No-op implementation of DoubleGauge interface. */
   @Immutable
   private static final class NoopDoubleGauge implements DoubleGauge {
+
     /** Creates a new {@code NoopBound}. */
     private NoopDoubleGauge() {}
 
@@ -250,6 +253,7 @@ public final class DefaultMeter implements Meter {
 
     private static final class NoopBuilder extends NoopAbstractGaugeBuilder<Builder, DoubleGauge>
         implements Builder {
+
       @Override
       protected Builder getThis() {
         return this;
@@ -265,6 +269,7 @@ public final class DefaultMeter implements Meter {
   /** No-op implementation of DoubleCounter interface. */
   @Immutable
   private static final class NoopDoubleCounter implements DoubleCounter {
+
     /** Creates a new {@code NoopBound}. */
     private NoopDoubleCounter() {}
 
@@ -293,6 +298,7 @@ public final class DefaultMeter implements Meter {
 
     private static final class NoopBuilder
         extends NoopAbstractCounterBuilder<Builder, DoubleCounter> implements Builder {
+
       @Override
       protected Builder getThis() {
         return this;
@@ -308,6 +314,7 @@ public final class DefaultMeter implements Meter {
   /** No-op implementation of CounterLong interface. */
   @Immutable
   private static final class NoopLongCounter implements LongCounter {
+
     /** Creates a new {@code NoopBound}. */
     private NoopLongCounter() {}
 
@@ -336,6 +343,7 @@ public final class DefaultMeter implements Meter {
 
     private static final class NoopBuilder extends NoopAbstractCounterBuilder<Builder, LongCounter>
         implements Builder {
+
       @Override
       protected Builder getThis() {
         return this;
@@ -350,6 +358,7 @@ public final class DefaultMeter implements Meter {
 
   @Immutable
   private static final class NoopDoubleMeasure implements DoubleMeasure {
+
     /** Creates a new {@code NoopDoubleMeasure}. */
     private NoopDoubleMeasure() {}
 
@@ -382,6 +391,7 @@ public final class DefaultMeter implements Meter {
 
     private static final class NoopBuilder
         extends NoopAbstractInstrumentBuilder<Builder, DoubleMeasure> implements Builder {
+
       @Override
       protected Builder getThis() {
         return this;
@@ -396,6 +406,7 @@ public final class DefaultMeter implements Meter {
 
   @Immutable
   private static final class NoopLongMeasure implements LongMeasure {
+
     private NoopLongMeasure() {}
 
     @Override
@@ -427,6 +438,7 @@ public final class DefaultMeter implements Meter {
 
     private static final class NoopBuilder
         extends NoopAbstractInstrumentBuilder<Builder, LongMeasure> implements Builder {
+
       @Override
       protected Builder getThis() {
         return this;
@@ -441,6 +453,7 @@ public final class DefaultMeter implements Meter {
 
   @Immutable
   private static final class NoopDoubleObserver implements DoubleObserver {
+
     private NoopDoubleObserver() {}
 
     @Override
@@ -467,6 +480,7 @@ public final class DefaultMeter implements Meter {
 
     private static final class NoopBuilder
         extends NoopAbstractObserverBuilder<Builder, DoubleObserver> implements Builder {
+
       @Override
       protected Builder getThis() {
         return this;
@@ -481,6 +495,7 @@ public final class DefaultMeter implements Meter {
 
   @Immutable
   private static final class NoopLongObserver implements LongObserver {
+
     private NoopLongObserver() {}
 
     @Override
@@ -507,6 +522,7 @@ public final class DefaultMeter implements Meter {
 
     private static final class NoopBuilder
         extends NoopAbstractObserverBuilder<Builder, LongObserver> implements Builder {
+
       @Override
       protected Builder getThis() {
         return this;
@@ -520,6 +536,7 @@ public final class DefaultMeter implements Meter {
   }
 
   private static final class NoopBatchRecorder implements BatchRecorder {
+
     private NoopBatchRecorder() {}
 
     @Override
@@ -542,6 +559,7 @@ public final class DefaultMeter implements Meter {
 
   private abstract static class NoopAbstractGaugeBuilder<B extends Gauge.Builder<B, V>, V>
       extends NoopAbstractInstrumentBuilder<B, V> implements Gauge.Builder<B, V> {
+
     @Override
     public B setMonotonic(boolean monotonic) {
       return getThis();
@@ -550,6 +568,7 @@ public final class DefaultMeter implements Meter {
 
   private abstract static class NoopAbstractCounterBuilder<B extends Counter.Builder<B, V>, V>
       extends NoopAbstractInstrumentBuilder<B, V> implements Counter.Builder<B, V> {
+
     @Override
     public B setMonotonic(boolean monotonic) {
       return getThis();
@@ -558,6 +577,7 @@ public final class DefaultMeter implements Meter {
 
   private abstract static class NoopAbstractObserverBuilder<B extends Observer.Builder<B, V>, V>
       extends NoopAbstractInstrumentBuilder<B, V> implements Observer.Builder<B, V> {
+
     @Override
     public B setMonotonic(boolean monotonic) {
       return getThis();
@@ -566,6 +586,7 @@ public final class DefaultMeter implements Meter {
 
   private abstract static class NoopAbstractInstrumentBuilder<B extends Instrument.Builder<B, V>, V>
       implements Instrument.Builder<B, V> {
+
     @Override
     public B setDescription(String description) {
       Utils.checkNotNull(description, "description");

--- a/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
@@ -165,6 +165,12 @@ public final class DefaultMeter implements Meter {
   }
 
   @Override
+  public LabelSet createLabelSet(Map<String, String> labels) {
+    Utils.checkNotNull(labels, "labels");
+    return NoopLabelSet.INSTANCE;
+  }
+
+  @Override
   public LabelSet emptyLabelSet() {
     return NoopLabelSet.INSTANCE;
   }

--- a/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
@@ -20,6 +20,7 @@ import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.internal.Utils;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -165,7 +166,7 @@ public final class DefaultMeter implements Meter {
   }
 
   @Override
-  public LabelSet createLabelSet(Map<String, String> labels) {
+  public LabelSet createLabelSet(@Nonnull Map<String, String> labels) {
     Utils.checkNotNull(labels, "labels");
     return NoopLabelSet.INSTANCE;
   }

--- a/api/src/main/java/io/opentelemetry/metrics/Meter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Meter.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.metrics;
 
 import java.util.Map;
-import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -288,7 +287,7 @@ public interface Meter {
    * @return a new {@link LabelSet} with the given labels.
    * @throws NullPointerException if the map is null.
    */
-  LabelSet createLabelSet(@Nonnull Map<String, String> labels);
+  LabelSet createLabelSet(Map<String, String> labels);
 
   /**
    * Returns an empty {@link LabelSet}. The implementation is permitted to have this be a singleton

--- a/api/src/main/java/io/opentelemetry/metrics/Meter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Meter.java
@@ -17,6 +17,7 @@
 package io.opentelemetry.metrics;
 
 import java.util.Map;
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -118,7 +119,7 @@ public interface Meter {
    * Returns a builder for a {@link LongGauge}.
    *
    * @param name the name of the metric. Should be a ASCII string with a length no greater than 255
-   * characters.
+   *     characters.
    * @return a {@code LongGauge.Builder}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
@@ -131,7 +132,7 @@ public interface Meter {
    * Returns a builder for a {@link DoubleGauge}.
    *
    * @param name the name of the metric. Should be a ASCII string with a length no greater than 255
-   * characters.
+   *     characters.
    * @return a {@code DoubleGauge.Builder}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
@@ -144,7 +145,7 @@ public interface Meter {
    * Returns a builder for a {@link DoubleCounter}.
    *
    * @param name the name of the metric. Should be a ASCII string with a length no greater than 255
-   * characters.
+   *     characters.
    * @return a {@code DoubleCounter.Builder}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
@@ -157,7 +158,7 @@ public interface Meter {
    * Returns a builder for a {@link LongCounter}.
    *
    * @param name the name of the metric. Should be a ASCII string with a length no greater than 255
-   * characters.
+   *     characters.
    * @return a {@code LongCounter.Builder}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
@@ -170,7 +171,7 @@ public interface Meter {
    * Returns a new builder for a {@link DoubleMeasure}.
    *
    * @param name Name of measure, as a {@code String}. Should be a ASCII string with a length no
-   * greater than 255 characters.
+   *     greater than 255 characters.
    * @return a new builder for a {@code DoubleMeasure}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
@@ -183,7 +184,7 @@ public interface Meter {
    * Returns a new builder for a {@link LongMeasure}.
    *
    * @param name Name of measure, as a {@code String}. Should be a ASCII string with a length no
-   * greater than 255 characters.
+   *     greater than 255 characters.
    * @return a new builder for a {@code LongMeasure}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
@@ -196,7 +197,7 @@ public interface Meter {
    * Returns a new builder for a {@link DoubleObserver}.
    *
    * @param name Name of observer, as a {@code String}. Should be a ASCII string with a length no
-   * greater than 255 characters.
+   *     greater than 255 characters.
    * @return a new builder for a {@code DoubleObserver}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
@@ -209,7 +210,7 @@ public interface Meter {
    * Returns a new builder for a {@link LongObserver}.
    *
    * @param name Name of observer, as a {@code String}. Should be a ASCII string with a length no
-   * greater than 255 characters.
+   *     greater than 255 characters.
    * @return a new builder for a {@code LongObserver}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
@@ -222,7 +223,7 @@ public interface Meter {
    * Utility method that allows users to atomically record measurements to a set of Measures.
    *
    * @return a {@code MeasureBatchRecorder} that can be use to atomically record a set of
-   * measurements associated with different Measures.
+   *     measurements associated with different Measures.
    * @since 0.1.0
    */
   BatchRecorder newMeasureBatchRecorder();
@@ -285,8 +286,9 @@ public interface Meter {
    *
    * @param labels The key-value pairs to turn into labels.
    * @return a new {@link LabelSet} with the given labels.
+   * @throws NullPointerException if the map is null.
    */
-  LabelSet createLabelSet(Map<String, String> labels);
+  LabelSet createLabelSet(@Nonnull Map<String, String> labels);
 
   /**
    * Returns an empty {@link LabelSet}. The implementation is permitted to have this be a singleton

--- a/api/src/main/java/io/opentelemetry/metrics/Meter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Meter.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.metrics;
 
+import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -117,7 +118,7 @@ public interface Meter {
    * Returns a builder for a {@link LongGauge}.
    *
    * @param name the name of the metric. Should be a ASCII string with a length no greater than 255
-   *     characters.
+   * characters.
    * @return a {@code LongGauge.Builder}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
@@ -130,7 +131,7 @@ public interface Meter {
    * Returns a builder for a {@link DoubleGauge}.
    *
    * @param name the name of the metric. Should be a ASCII string with a length no greater than 255
-   *     characters.
+   * characters.
    * @return a {@code DoubleGauge.Builder}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
@@ -143,7 +144,7 @@ public interface Meter {
    * Returns a builder for a {@link DoubleCounter}.
    *
    * @param name the name of the metric. Should be a ASCII string with a length no greater than 255
-   *     characters.
+   * characters.
    * @return a {@code DoubleCounter.Builder}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
@@ -156,7 +157,7 @@ public interface Meter {
    * Returns a builder for a {@link LongCounter}.
    *
    * @param name the name of the metric. Should be a ASCII string with a length no greater than 255
-   *     characters.
+   * characters.
    * @return a {@code LongCounter.Builder}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
@@ -169,7 +170,7 @@ public interface Meter {
    * Returns a new builder for a {@link DoubleMeasure}.
    *
    * @param name Name of measure, as a {@code String}. Should be a ASCII string with a length no
-   *     greater than 255 characters.
+   * greater than 255 characters.
    * @return a new builder for a {@code DoubleMeasure}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
@@ -182,7 +183,7 @@ public interface Meter {
    * Returns a new builder for a {@link LongMeasure}.
    *
    * @param name Name of measure, as a {@code String}. Should be a ASCII string with a length no
-   *     greater than 255 characters.
+   * greater than 255 characters.
    * @return a new builder for a {@code LongMeasure}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
@@ -195,7 +196,7 @@ public interface Meter {
    * Returns a new builder for a {@link DoubleObserver}.
    *
    * @param name Name of observer, as a {@code String}. Should be a ASCII string with a length no
-   *     greater than 255 characters.
+   * greater than 255 characters.
    * @return a new builder for a {@code DoubleObserver}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
@@ -208,7 +209,7 @@ public interface Meter {
    * Returns a new builder for a {@link LongObserver}.
    *
    * @param name Name of observer, as a {@code String}. Should be a ASCII string with a length no
-   *     greater than 255 characters.
+   * greater than 255 characters.
    * @return a new builder for a {@code LongObserver}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
@@ -221,7 +222,7 @@ public interface Meter {
    * Utility method that allows users to atomically record measurements to a set of Measures.
    *
    * @return a {@code MeasureBatchRecorder} that can be use to atomically record a set of
-   *     measurements associated with different Measures.
+   * measurements associated with different Measures.
    * @since 0.1.0
    */
   BatchRecorder newMeasureBatchRecorder();
@@ -278,6 +279,14 @@ public interface Meter {
    */
   LabelSet createLabelSet(
       String k1, String v1, String k2, String v2, String k3, String v3, String k4, String v4);
+
+  /**
+   * Returns a new {@link LabelSet} with labels built from the keys and values in the provided Map.
+   *
+   * @param labels The key-value pairs to turn into labels.
+   * @return a new {@link LabelSet} with the given labels.
+   */
+  LabelSet createLabelSet(Map<String, String> labels);
 
   /**
    * Returns an empty {@link LabelSet}. The implementation is permitted to have this be a singleton

--- a/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
+++ b/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
@@ -51,6 +51,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.net.URL;
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.BeforeClass;
@@ -390,6 +391,11 @@ public class OpenTelemetryTest {
     @Override
     public LabelSet createLabelSet(
         String k1, String v1, String k2, String v2, String k3, String v3, String k4, String v4) {
+      return null;
+    }
+
+    @Override
+    public LabelSet createLabelSet(Map<String, String> labels) {
       return null;
     }
 

--- a/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
+++ b/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
@@ -52,6 +52,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.net.URL;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.BeforeClass;
@@ -394,8 +395,9 @@ public class OpenTelemetryTest {
       return null;
     }
 
+    @Nullable
     @Override
-    public LabelSet createLabelSet(Map<String, String> labels) {
+    public LabelSet createLabelSet(@Nonnull Map<String, String> labels) {
       return null;
     }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
@@ -31,6 +31,7 @@ import io.opentelemetry.metrics.LongMeasure;
 import io.opentelemetry.metrics.LongObserver;
 import io.opentelemetry.metrics.Meter;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 /** {@link MeterSdk} is SDK implementation of {@link Meter}. */
 public class MeterSdk implements Meter {
@@ -102,7 +103,7 @@ public class MeterSdk implements Meter {
   }
 
   @Override
-  public LabelSet createLabelSet(Map<String, String> labels) {
+  public LabelSet createLabelSet(@Nonnull Map<String, String> labels) {
     throw new UnsupportedOperationException("to be implemented");
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
@@ -104,7 +104,7 @@ public class MeterSdk implements Meter {
 
   @Override
   public LabelSet createLabelSet(@Nonnull Map<String, String> labels) {
-    throw new UnsupportedOperationException("to be implemented");
+    return SdkLabelSet.create(labels);
   }
 
   @Override

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
@@ -31,7 +31,6 @@ import io.opentelemetry.metrics.LongMeasure;
 import io.opentelemetry.metrics.LongObserver;
 import io.opentelemetry.metrics.Meter;
 import java.util.Map;
-import javax.annotation.Nonnull;
 
 /** {@link MeterSdk} is SDK implementation of {@link Meter}. */
 public class MeterSdk implements Meter {
@@ -103,7 +102,7 @@ public class MeterSdk implements Meter {
   }
 
   @Override
-  public LabelSet createLabelSet(@Nonnull Map<String, String> labels) {
+  public LabelSet createLabelSet(Map<String, String> labels) {
     return SdkLabelSet.create(labels);
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
@@ -30,6 +30,7 @@ import io.opentelemetry.metrics.LongGauge;
 import io.opentelemetry.metrics.LongMeasure;
 import io.opentelemetry.metrics.LongObserver;
 import io.opentelemetry.metrics.Meter;
+import java.util.Map;
 
 /** {@link MeterSdk} is SDK implementation of {@link Meter}. */
 public class MeterSdk implements Meter {
@@ -98,6 +99,11 @@ public class MeterSdk implements Meter {
   public LabelSet createLabelSet(
       String k1, String v1, String k2, String v2, String k3, String v3, String k4, String v4) {
     return SdkLabelSet.create(ImmutableMap.of(k1, v1, k2, v2, k3, v3, k4, v4));
+  }
+
+  @Override
+  public LabelSet createLabelSet(Map<String, String> labels) {
+    throw new UnsupportedOperationException("to be implemented");
   }
 
   @Override

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
@@ -17,6 +17,7 @@
 package io.opentelemetry.sdk.metrics;
 
 import static com.google.common.truth.Truth.assertThat;
+import static java.util.Collections.singletonMap;
 
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.metrics.LongCounter;
@@ -53,6 +54,8 @@ public class MeterSdkTest {
     MeterSdk testSdk = new MeterSdk();
 
     assertThat(testSdk.emptyLabelSet()).isSameInstanceAs(testSdk.emptyLabelSet());
+    assertThat(testSdk.emptyLabelSet())
+        .isSameInstanceAs(testSdk.createLabelSet(Collections.<String, String>emptyMap()));
     assertThat(testSdk.createLabelSet("key", "value"))
         .isEqualTo(testSdk.createLabelSet("key", "value"));
     assertThat(testSdk.createLabelSet("k1", "v1", "k2", "v2"))
@@ -61,5 +64,11 @@ public class MeterSdkTest {
         .isEqualTo(testSdk.createLabelSet("k1", "v1", "k2", "v2", "k3", "v3"));
     assertThat(testSdk.createLabelSet("k1", "v1", "k2", "v2", "k3", "v3", "k4", "v4"))
         .isEqualTo(testSdk.createLabelSet("k1", "v1", "k2", "v2", "k3", "v3", "k4", "v4"));
+
+    assertThat(testSdk.createLabelSet("key", "value"))
+        .isEqualTo(testSdk.createLabelSet(singletonMap("key", "value")));
+
+    assertThat(testSdk.createLabelSet("key", "value"))
+        .isNotEqualTo(testSdk.createLabelSet("value", "key"));
   }
 }


### PR DESCRIPTION
Personally, I'd prefer just having one varargs method that takes key/value pairs of Strings, but this will at least let API users add more than 4 labels in a LabelSet.

related to #723 