### PR TITLE
clean up the equals/hashcode on the BaseBoundInstrument

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/BaseBoundInstrument.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/BaseBoundInstrument.java
@@ -37,11 +37,11 @@ class BaseBoundInstrument {
 
     BaseBoundInstrument that = (BaseBoundInstrument) o;
 
-    return labels != null ? labels.equals(that.labels) : that.labels == null;
+    return labels.equals(that.labels);
   }
 
   @Override
   public int hashCode() {
-    return labels != null ? labels.hashCode() : 0;
+    return labels.hashCode();
   }
 }


### PR DESCRIPTION
@bogdandrutu this gets rid of the null checks on the auto-generated equals/hashcode