### PR TITLE
Change LabelSet creation to use varargs, rather than overloaded k/v methods.

### DIFF
--- a/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
@@ -129,7 +129,7 @@ public final class DefaultMeter implements Meter {
     Utils.checkArgument(
         keyValuePairs.length % 2 == 0,
         "You must provide an even number of key/value pair arguments.");
-    for (int i = 0; i < keyValuePairs.length; i+=2) {
+    for (int i = 0; i < keyValuePairs.length; i += 2) {
       String argument = keyValuePairs[i];
       Utils.checkNotNull(argument, "You cannot provide null keys for LabelSet creation.");
     }

--- a/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
@@ -143,11 +143,6 @@ public final class DefaultMeter implements Meter {
     return NoopLabelSet.INSTANCE;
   }
 
-  @Override
-  public LabelSet emptyLabelSet() {
-    return NoopLabelSet.INSTANCE;
-  }
-
   /** No-op implementation of LongGauge interface. */
   @Immutable
   private static final class NoopLongGauge implements LongGauge {

--- a/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
@@ -130,8 +130,8 @@ public final class DefaultMeter implements Meter {
         keyValuePairs.length % 2 == 0,
         "You must provide an even number of key/value pair arguments.");
     for (int i = 0; i < keyValuePairs.length; i += 2) {
-      String argument = keyValuePairs[i];
-      Utils.checkNotNull(argument, "You cannot provide null keys for LabelSet creation.");
+      String key = keyValuePairs[i];
+      Utils.checkNotNull(key, "You cannot provide null keys for LabelSet creation.");
     }
     return NoopLabelSet.INSTANCE;
   }

--- a/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
@@ -125,49 +125,21 @@ public final class DefaultMeter implements Meter {
   }
 
   @Override
-  public LabelSet createLabelSet(String k1, String v1) {
-    Utils.checkNotNull(k1, "k1");
-    Utils.checkNotNull(v1, "v1");
-    return NoopLabelSet.INSTANCE;
-  }
-
-  @Override
-  public LabelSet createLabelSet(String k1, String v1, String k2, String v2) {
-    Utils.checkNotNull(k1, "k1");
-    Utils.checkNotNull(v1, "v1");
-    Utils.checkNotNull(k2, "k2");
-    Utils.checkNotNull(v2, "v2");
-    return NoopLabelSet.INSTANCE;
-  }
-
-  @Override
-  public LabelSet createLabelSet(String k1, String v1, String k2, String v2, String k3, String v3) {
-    Utils.checkNotNull(k1, "k1");
-    Utils.checkNotNull(v1, "v1");
-    Utils.checkNotNull(k2, "k2");
-    Utils.checkNotNull(v2, "v2");
-    Utils.checkNotNull(k3, "k3");
-    Utils.checkNotNull(v3, "v3");
-    return NoopLabelSet.INSTANCE;
-  }
-
-  @Override
-  public LabelSet createLabelSet(
-      String k1, String v1, String k2, String v2, String k3, String v3, String k4, String v4) {
-    Utils.checkNotNull(k1, "k1");
-    Utils.checkNotNull(v1, "v1");
-    Utils.checkNotNull(k2, "k2");
-    Utils.checkNotNull(v2, "v2");
-    Utils.checkNotNull(k3, "k3");
-    Utils.checkNotNull(v3, "v3");
-    Utils.checkNotNull(k4, "k4");
-    Utils.checkNotNull(v4, "v4");
+  public LabelSet createLabelSet(String... keyValuePairs) {
+    Utils.checkArgument(
+        keyValuePairs.length % 2 == 0,
+        "You must provide an even number of key/value pair arguments.");
+    for (int i = 0; i < keyValuePairs.length; i+=2) {
+      String argument = keyValuePairs[i];
+      Utils.checkNotNull(argument, "You cannot provide null keys for LabelSet creation.");
+    }
     return NoopLabelSet.INSTANCE;
   }
 
   @Override
   public LabelSet createLabelSet(Map<String, String> labels) {
     Utils.checkNotNull(labels, "labels");
+    Utils.checkMapKeysNotNull(labels, "Null map keys are not allowed for LabelSet creation");
     return NoopLabelSet.INSTANCE;
   }
 

--- a/api/src/main/java/io/opentelemetry/metrics/Meter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Meter.java
@@ -248,12 +248,4 @@ public interface Meter {
    * @throws NullPointerException if the map is null.
    */
   LabelSet createLabelSet(Map<String, String> labels);
-
-  /**
-   * Returns an empty {@link LabelSet}. The implementation is permitted to have this be a singleton
-   * instance.
-   *
-   * @return an empty {@link LabelSet}
-   */
-  LabelSet emptyLabelSet();
 }

--- a/api/src/main/java/io/opentelemetry/metrics/Meter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Meter.java
@@ -228,57 +228,17 @@ public interface Meter {
   BatchRecorder newMeasureBatchRecorder();
 
   /**
-   * Returns a new {@link LabelSet} with the given label.
-   *
-   * @param k1 first key.
-   * @param v1 first value.
-   * @return a new {@link LabelSet} with the given label.
-   * @throws NullPointerException if any provided value is null.
-   */
-  LabelSet createLabelSet(String k1, String v1);
-
-  /**
    * Returns a new {@link LabelSet} with the given labels.
    *
-   * @param k1 first key.
-   * @param v1 first value.
-   * @param k2 second key.
-   * @param v2 second value.
-   * @return a new {@link LabelSet} with the given labels.
-   * @throws NullPointerException if any provided value is null.
-   */
-  LabelSet createLabelSet(String k1, String v1, String k2, String v2);
-
-  /**
-   * Returns a new {@link LabelSet} with the given labels.
+   * <p>The arguments must are in key, value pairs, so an even number of arguments are required.
    *
-   * @param k1 first key.
-   * @param v1 first value.
-   * @param k2 second key.
-   * @param v2 second value.
-   * @param k3 third key.
-   * @param v3 third value.
-   * @return a new {@link LabelSet} with the given labels.
-   * @throws NullPointerException if any provided value is null.
-   */
-  LabelSet createLabelSet(String k1, String v1, String k2, String v2, String k3, String v3);
-
-  /**
-   * Returns a new {@link LabelSet} with the given labels.
+   * <p>If no arguments are provided, the resulting LabelSet will be the empty one.
    *
-   * @param k1 first key.
-   * @param v1 first value.
-   * @param k2 second key.
-   * @param v2 second value.
-   * @param k3 third key.
-   * @param v3 third value.
-   * @param k4 fourth key.
-   * @param v4 fourth value.
+   * @param keyValuePairs pairs of keys and values for the labels.
    * @return a new {@link LabelSet} with the given labels.
-   * @throws NullPointerException if any provided value is null.
+   * @throws IllegalArgumentException if there aren't an even number of arguments.
    */
-  LabelSet createLabelSet(
-      String k1, String v1, String k2, String v2, String k3, String v3, String k4, String v4);
+  LabelSet createLabelSet(String... keyValuePairs);
 
   /**
    * Returns a new {@link LabelSet} with labels built from the keys and values in the provided Map.

--- a/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
+++ b/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
@@ -381,12 +381,6 @@ public class OpenTelemetryTest {
       return null;
     }
 
-    @Nullable
-    @Override
-    public LabelSet emptyLabelSet() {
-      return null;
-    }
-
     @Override
     public Meter get(String instrumentationName) {
       return new FirstMeterRegistry();

--- a/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
+++ b/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
@@ -371,27 +371,7 @@ public class OpenTelemetryTest {
 
     @Nullable
     @Override
-    public LabelSet createLabelSet(String k1, String v1) {
-      return null;
-    }
-
-    @Nullable
-    @Override
-    public LabelSet createLabelSet(String k1, String v1, String k2, String v2) {
-      return null;
-    }
-
-    @Nullable
-    @Override
-    public LabelSet createLabelSet(
-        String k1, String v1, String k2, String v2, String k3, String v3) {
-      return null;
-    }
-
-    @Nullable
-    @Override
-    public LabelSet createLabelSet(
-        String k1, String v1, String k2, String v2, String k3, String v3, String k4, String v4) {
+    public LabelSet createLabelSet(String... keyValuePairs) {
       return null;
     }
 

--- a/api/src/test/java/io/opentelemetry/metrics/DefaultMeterTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/DefaultMeterTest.java
@@ -16,11 +16,15 @@
 
 package io.opentelemetry.metrics;
 
+import java.util.Arrays;
+import java.util.Collection;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 /** Unit tests for {@link DefaultMeter}. */
 @RunWith(JUnit4.class)
@@ -69,4 +73,19 @@ public final class DefaultMeterTest {
     thrown.expectMessage("name");
     defaultMeter.longMeasureBuilder(null);
   }
+
+  @Test
+  public void testVarargsLabelSetValidation_UnmatchedKeysAndValues() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("even");
+    defaultMeter.createLabelSet("key");
+  }
+
+  @Test
+  public void testVarargsLabelSetValidation_NullKey() throws Exception {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("null");
+    defaultMeter.createLabelSet(null, "value");
+  }
+
 }

--- a/api/src/test/java/io/opentelemetry/metrics/DefaultMeterTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/DefaultMeterTest.java
@@ -16,15 +16,11 @@
 
 package io.opentelemetry.metrics;
 
-import java.util.Arrays;
-import java.util.Collection;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 /** Unit tests for {@link DefaultMeter}. */
 @RunWith(JUnit4.class)
@@ -87,5 +83,4 @@ public final class DefaultMeterTest {
     thrown.expectMessage("null");
     defaultMeter.createLabelSet(null, "value");
   }
-
 }

--- a/api/src/test/java/io/opentelemetry/metrics/DoubleCounterTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/DoubleCounterTest.java
@@ -130,6 +130,6 @@ public class DoubleCounterTest {
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
-    doubleCounter.bind(meter.emptyLabelSet()).add(1.0);
+    doubleCounter.bind(meter.createLabelSet()).add(1.0);
   }
 }

--- a/api/src/test/java/io/opentelemetry/metrics/DoubleGaugeTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/DoubleGaugeTest.java
@@ -129,6 +129,6 @@ public class DoubleGaugeTest {
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
-    doubleGauge.bind(meter.emptyLabelSet()).set(5.0);
+    doubleGauge.bind(meter.createLabelSet()).set(5.0);
   }
 }

--- a/api/src/test/java/io/opentelemetry/metrics/DoubleMeasureTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/DoubleMeasureTest.java
@@ -90,12 +90,12 @@ public final class DoubleMeasureTest {
     DoubleMeasure myMeasure = meter.doubleMeasureBuilder("MyMeasure").build();
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Unsupported negative values");
-    myMeasure.bind(meter.emptyLabelSet()).record(-5.0);
+    myMeasure.bind(meter.createLabelSet()).record(-5.0);
   }
 
   @Test
   public void doesNotThrow() {
     DoubleMeasure myMeasure = meter.doubleMeasureBuilder("MyMeasure").build();
-    myMeasure.bind(meter.emptyLabelSet()).record(5.0);
+    myMeasure.bind(meter.createLabelSet()).record(5.0);
   }
 }

--- a/api/src/test/java/io/opentelemetry/metrics/LongCounterTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/LongCounterTest.java
@@ -129,6 +129,6 @@ public class LongCounterTest {
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
-    longCounter.bind(meter.emptyLabelSet()).add(1);
+    longCounter.bind(meter.createLabelSet()).add(1);
   }
 }

--- a/api/src/test/java/io/opentelemetry/metrics/LongGaugeTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/LongGaugeTest.java
@@ -126,6 +126,6 @@ public class LongGaugeTest {
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
-    longGauge.bind(meter.emptyLabelSet()).set(5);
+    longGauge.bind(meter.createLabelSet()).set(5);
   }
 }

--- a/api/src/test/java/io/opentelemetry/metrics/LongMeasureTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/LongMeasureTest.java
@@ -90,12 +90,12 @@ public final class LongMeasureTest {
     LongMeasure myMeasure = meter.longMeasureBuilder("MyMeasure").build();
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Unsupported negative values");
-    myMeasure.bind(meter.emptyLabelSet()).record(-5);
+    myMeasure.bind(meter.createLabelSet()).record(-5);
   }
 
   @Test
   public void doesNotThrow() {
     LongMeasure myMeasure = meter.longMeasureBuilder("MyMeasure").build();
-    myMeasure.bind(meter.emptyLabelSet()).record(5);
+    myMeasure.bind(meter.createLabelSet()).record(5);
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
@@ -16,9 +16,6 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static java.util.Collections.singletonMap;
-
-import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.metrics.BatchRecorder;
 import io.opentelemetry.metrics.DoubleCounter;
 import io.opentelemetry.metrics.DoubleGauge;
@@ -82,7 +79,7 @@ public class MeterSdk implements Meter {
 
   @Override
   public LabelSet createLabelSet(String... keyValuePairs) {
-    throw new UnsupportedOperationException("to be implemented");
+    return SdkLabelSet.create(keyValuePairs);
   }
 
   @Override

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
@@ -81,24 +81,8 @@ public class MeterSdk implements Meter {
   }
 
   @Override
-  public LabelSet createLabelSet(String k1, String v1) {
-    return SdkLabelSet.create(singletonMap(k1, v1));
-  }
-
-  @Override
-  public LabelSet createLabelSet(String k1, String v1, String k2, String v2) {
-    return SdkLabelSet.create(ImmutableMap.of(k1, v1, k2, v2));
-  }
-
-  @Override
-  public LabelSet createLabelSet(String k1, String v1, String k2, String v2, String k3, String v3) {
-    return SdkLabelSet.create(ImmutableMap.of(k1, v1, k2, v2, k3, v3));
-  }
-
-  @Override
-  public LabelSet createLabelSet(
-      String k1, String v1, String k2, String v2, String k3, String v3, String k4, String v4) {
-    return SdkLabelSet.create(ImmutableMap.of(k1, v1, k2, v2, k3, v3, k4, v4));
+  public LabelSet createLabelSet(String... keyValuePairs) {
+    throw new UnsupportedOperationException("to be implemented");
   }
 
   @Override

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
@@ -86,9 +86,4 @@ public class MeterSdk implements Meter {
   public LabelSet createLabelSet(Map<String, String> labels) {
     return SdkLabelSet.create(labels);
   }
-
-  @Override
-  public LabelSet emptyLabelSet() {
-    return SdkLabelSet.empty();
-  }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/SdkLabelSet.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/SdkLabelSet.java
@@ -19,13 +19,16 @@ package io.opentelemetry.sdk.metrics;
 import static java.util.Collections.unmodifiableMap;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
 import io.opentelemetry.metrics.LabelSet;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 @AutoValue
 abstract class SdkLabelSet implements LabelSet {
 
-  private static final LabelSet EMPTY = create(null);
+  private static final LabelSet EMPTY = create();
 
   static LabelSet empty() {
     return EMPTY;
@@ -36,6 +39,21 @@ abstract class SdkLabelSet implements LabelSet {
       return EMPTY;
     }
     return new AutoValue_SdkLabelSet(unmodifiableMap(labels));
+  }
+
+  static LabelSet create(String... keyValuePairs) {
+    if (keyValuePairs.length == 0) {
+      return EMPTY;
+    }
+    Preconditions.checkArgument(
+        (keyValuePairs.length % 2) == 0,
+        "LabelSets must be created with the same number of keys as values.");
+    Map<String, String> data = new HashMap<>(keyValuePairs.length / 2);
+    for (int i = 0; i < keyValuePairs.length; i++) {
+      String key = keyValuePairs[i];
+      data.put(key, keyValuePairs[++i]);
+    }
+    return new AutoValue_SdkLabelSet(Collections.unmodifiableMap(data));
   }
 
   abstract Map<String, String> getLabels();

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.sdk.metrics;
 
 import static com.google.common.truth.Truth.assertThat;
-import static java.util.Collections.singletonMap;
 
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.metrics.LongCounter;
@@ -26,7 +25,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link MeterSdk}. */
+/**
+ * Unit tests for {@link MeterSdk}.
+ */
 @RunWith(JUnit4.class)
 public class MeterSdkTest {
 
@@ -54,19 +55,15 @@ public class MeterSdkTest {
     MeterSdk testSdk = new MeterSdk();
 
     assertThat(testSdk.emptyLabelSet()).isSameInstanceAs(testSdk.emptyLabelSet());
+    assertThat(testSdk.emptyLabelSet()).isSameInstanceAs(testSdk.createLabelSet());
     assertThat(testSdk.emptyLabelSet())
         .isSameInstanceAs(testSdk.createLabelSet(Collections.<String, String>emptyMap()));
-    assertThat(testSdk.createLabelSet("key", "value"))
-        .isEqualTo(testSdk.createLabelSet("key", "value"));
-    assertThat(testSdk.createLabelSet("k1", "v1", "k2", "v2"))
-        .isEqualTo(testSdk.createLabelSet("k1", "v1", "k2", "v2"));
-    assertThat(testSdk.createLabelSet("k1", "v1", "k2", "v2", "k3", "v3"))
-        .isEqualTo(testSdk.createLabelSet("k1", "v1", "k2", "v2", "k3", "v3"));
-    assertThat(testSdk.createLabelSet("k1", "v1", "k2", "v2", "k3", "v3", "k4", "v4"))
-        .isEqualTo(testSdk.createLabelSet("k1", "v1", "k2", "v2", "k3", "v3", "k4", "v4"));
 
     assertThat(testSdk.createLabelSet("key", "value"))
-        .isEqualTo(testSdk.createLabelSet(singletonMap("key", "value")));
+        .isEqualTo(testSdk.createLabelSet("key", "value"));
+
+    assertThat(testSdk.createLabelSet(Collections.singletonMap("key", "value")))
+        .isEqualTo(testSdk.createLabelSet("key", "value"));
 
     assertThat(testSdk.createLabelSet("key", "value"))
         .isNotEqualTo(testSdk.createLabelSet("value", "key"));

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
@@ -60,6 +60,9 @@ public class MeterSdkTest {
     assertThat(testSdk.createLabelSet("key", "value"))
         .isEqualTo(testSdk.createLabelSet("key", "value"));
 
+    assertThat(testSdk.createLabelSet("k1", "v1", "k2", "v2"))
+        .isEqualTo(testSdk.createLabelSet("k1", "v1", "k2", "v2"));
+
     assertThat(testSdk.createLabelSet(Collections.singletonMap("key", "value")))
         .isEqualTo(testSdk.createLabelSet("key", "value"));
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
@@ -52,9 +52,8 @@ public class MeterSdkTest {
   public void testLabelSets() {
     MeterSdk testSdk = new MeterSdk();
 
-    assertThat(testSdk.emptyLabelSet()).isSameInstanceAs(testSdk.emptyLabelSet());
-    assertThat(testSdk.emptyLabelSet()).isSameInstanceAs(testSdk.createLabelSet());
-    assertThat(testSdk.emptyLabelSet())
+    assertThat(testSdk.createLabelSet()).isSameInstanceAs(testSdk.createLabelSet());
+    assertThat(testSdk.createLabelSet())
         .isSameInstanceAs(testSdk.createLabelSet(Collections.<String, String>emptyMap()));
 
     assertThat(testSdk.createLabelSet("key", "value"))

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
@@ -25,9 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/**
- * Unit tests for {@link MeterSdk}.
- */
+/** Unit tests for {@link MeterSdk}. */
 @RunWith(JUnit4.class)
 public class MeterSdkTest {
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/SdkLongCounterTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/SdkLongCounterTest.java
@@ -49,7 +49,7 @@ public class SdkLongCounterTest {
             .setMonotonic(true)
             .build();
 
-    longCounter.add(45, testSdk.emptyLabelSet());
+    longCounter.add(45, testSdk.createLabelSet());
 
     BoundLongCounter boundLongCounter = longCounter.bind(labelSet);
     boundLongCounter.add(334);
@@ -68,7 +68,7 @@ public class SdkLongCounterTest {
         SdkLongCounter.SdkLongCounterBuilder.builder("testCounter").setMonotonic(true).build();
 
     thrown.expect(IllegalArgumentException.class);
-    longCounter.add(-45, testSdk.emptyLabelSet());
+    longCounter.add(-45, testSdk.createLabelSet());
   }
 
   @Test
@@ -79,6 +79,6 @@ public class SdkLongCounterTest {
         SdkLongCounter.SdkLongCounterBuilder.builder("testCounter").setMonotonic(true).build();
 
     thrown.expect(IllegalArgumentException.class);
-    longCounter.bind(testSdk.emptyLabelSet()).add(-9);
+    longCounter.bind(testSdk.createLabelSet()).add(-9);
   }
 }


### PR DESCRIPTION
For now, keeping the version that takes a Map, and the emptyLabelSet method, although they both technically could be removed if we go with this.

resolves #723 