### PR TITLE
Avoid calling the AWS specific methods in unit-tests.

### DIFF
--- a/sdk_contrib/aws_v1_support/src/test/java/io/opentelemetry/sdk/contrib/trace/aws/Ec2ResourceTest.java
+++ b/sdk_contrib/aws_v1_support/src/test/java/io/opentelemetry/sdk/contrib/trace/aws/Ec2ResourceTest.java
@@ -31,7 +31,7 @@ public class Ec2ResourceTest {
 
   @Test
   public void shouldReturnResourceWithOnlyCloudProviderLabelIfNotRunningOnEc2() {
-    Resource resource = Ec2Resource.getResource();
+    Resource resource = Ec2Resource.getResourceFromInfoAndHost(null, null);
     assertThat(resource.getLabels().get(ResourceConstants.CLOUD_PROVIDER))
         .isEqualTo(Ec2Resource.CLOUD_PROVIDER_AWS);
   }


### PR DESCRIPTION
This avoids log errors and long waiting for retries to call into the AWS metadata, also unit-tests are deterministic and independent of the environment.