### PR TITLE
Clean up the external interface for the RecordEventsReadableSpan

### DIFF
--- a/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
+++ b/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
@@ -109,6 +109,9 @@ public class InMemorySpanExporterTest {
         .setStartEpochNanos(100_000_000_100L)
         .setStatus(io.opentelemetry.trace.Status.OK)
         .setEndEpochNanos(200_000_000_200L)
+        .setTotalRecordedLinks(0)
+        .setTotalRecordedEvents(0)
+        .setNumberOfChildren(0)
         .build();
   }
 }

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
@@ -226,6 +226,9 @@ public class AdapterTest {
             .setEndEpochNanos(TimeUnit.MILLISECONDS.toNanos(endMs))
             .setKind(Span.Kind.SERVER)
             .setStatus(Status.CANCELLED)
+            .setTotalRecordedEvents(0)
+            .setTotalRecordedLinks(0)
+            .setNumberOfChildren(0)
             .build();
 
     assertNotNull(Adapter.toJaeger(span));
@@ -254,10 +257,13 @@ public class AdapterTest {
         .setEndEpochNanos(TimeUnit.MILLISECONDS.toNanos(endMs))
         .setAttributes(attributes)
         .setTimedEvents(Collections.singletonList(getTimedEvent()))
+        .setTotalRecordedEvents(1)
         .setLinks(Collections.singletonList(link))
+        .setTotalRecordedLinks(1)
         .setKind(Span.Kind.SERVER)
         .setResource(Resource.create(Collections.<String, String>emptyMap()))
         .setStatus(Status.OK)
+        .setNumberOfChildren(0)
         .build();
   }
 

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporterTest.java
@@ -88,6 +88,9 @@ public class JaegerGrpcSpanExporterTest {
             .setStatus(Status.OK)
             .setKind(Kind.CONSUMER)
             .setLinks(Collections.<Link>emptyList())
+            .setTotalRecordedLinks(0)
+            .setTotalRecordedEvents(0)
+            .setNumberOfChildren(0)
             .build();
 
     // test

--- a/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingExporterTest.java
@@ -51,6 +51,9 @@ public class LoggingExporterTest {
                         epochNanos + 500,
                         "somethingHappenedHere",
                         singletonMap("important", AttributeValue.booleanAttributeValue(true)))))
+            .setTotalRecordedEvents(1)
+            .setTotalRecordedLinks(0)
+            .setNumberOfChildren(0)
             .build();
     ResultCode resultCode = exporter.export(singletonList(spanData));
     assertEquals(ResultCode.SUCCESS, resultCode);

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -16,7 +16,6 @@
 
 package io.opentelemetry.sdk.trace;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.EvictingQueue;
 import io.opentelemetry.sdk.common.Clock;
@@ -59,8 +58,6 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   // The displayed name of the span.
   // List of recorded links to parent and child spans.
   private final List<Link> links;
-  // Number of links recorded.
-  private final int totalRecordedLinks;
 
   // Lock used to internally guard the mutable state of this instance
   private final Object lock = new Object();
@@ -83,12 +80,6 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   // List of recorded events.
   @GuardedBy("lock")
   private final EvictingQueue<TimedEvent> events;
-  // Number of events recorded.
-  @GuardedBy("lock")
-  private int totalRecordedEvents = 0;
-  // The number of children.
-  @GuardedBy("lock")
-  private int numberOfChildren;
   // The status of the span.
   @GuardedBy("lock")
   @Nullable
@@ -115,10 +106,8 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
    * @param resource the resource associated with this span.
    * @param attributes the attributes set during span creation.
    * @param links the links set during span creation, may be truncated.
-   * @param totalRecordedLinks the total number of links set (including dropped links).
    * @return a new and started span.
    */
-  @VisibleForTesting
   static RecordEventsReadableSpan startSpan(
       SpanContext context,
       String name,
@@ -132,7 +121,6 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
       Resource resource,
       AttributesWithCapacity attributes,
       List<Link> links,
-      int totalRecordedLinks,
       long startEpochNanos) {
     RecordEventsReadableSpan span =
         new RecordEventsReadableSpan(
@@ -148,7 +136,6 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
             resource,
             attributes,
             links,
-            totalRecordedLinks,
             startEpochNanos == 0 ? clock.now() : startEpochNanos);
     // Call onStart here instead of calling in the constructor to make sure the span is completely
     // initialized.
@@ -158,7 +145,6 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
 
   @Override
   public SpanData toSpanData() {
-
     // Copy immutable fields outside synchronized block.
     SpanContext spanContext = getSpanContext();
     SpanData.Builder builder =
@@ -272,17 +258,6 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   }
 
   /**
-   * Returns an unmodifiable view of the attributes associated with this span.
-   *
-   * @return An unmodifiable view of the attributes associated wit this span
-   */
-  @VisibleForTesting
-  @GuardedBy("lock")
-  Map<String, AttributeValue> getAttributes() {
-    return Collections.unmodifiableMap(attributes);
-  }
-
-  /**
    * Returns the latency of the {@code Span} in nanos. If still active then returns now() - start
    * time.
    *
@@ -305,22 +280,11 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   }
 
   /**
-   * Returns the span id of this span's parent span.
-   *
-   * @return The span id of the parent span.
-   */
-  @VisibleForTesting
-  public SpanId getParentSpanId() {
-    return parentSpanId;
-  }
-
-  /**
    * Returns the {@code Clock} used by this {@code Span}.
    *
    * @return the {@code Clock} used by this {@code Span}.
    */
-  @VisibleForTesting
-  public Clock getClock() {
+  Clock getClock() {
     return clock;
   }
 
@@ -394,7 +358,6 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
         return;
       }
       events.add(timedEvent);
-      totalRecordedEvents++;
     }
   }
 
@@ -459,9 +422,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     synchronized (lock) {
       if (hasEnded) {
         logger.log(Level.FINE, "Calling end() on an ended Span.");
-        return;
       }
-      numberOfChildren++;
     }
   }
 
@@ -485,20 +446,17 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
       Resource resource,
       AttributesWithCapacity attributes,
       List<Link> links,
-      int totalRecordedLinks,
       long startEpochNanos) {
     this.context = context;
     this.instrumentationLibraryInfo = instrumentationLibraryInfo;
     this.parentSpanId = parentSpanId;
     this.hasRemoteParent = hasRemoteParent;
     this.links = links;
-    this.totalRecordedLinks = totalRecordedLinks;
     this.name = name;
     this.kind = kind;
     this.spanProcessor = spanProcessor;
     this.resource = resource;
     this.hasEnded = false;
-    this.numberOfChildren = 0;
     this.clock = clock;
     this.startEpochNanos = startEpochNanos;
     this.attributes = attributes;
@@ -515,15 +473,4 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     }
     super.finalize();
   }
-
-  /**
-   * The count of links that have been dropped.
-   *
-   * @return The number of links that have been dropped.
-   */
-  @VisibleForTesting
-  int getDroppedLinksCount() {
-    return totalRecordedLinks - links.size();
-  }
-
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -250,24 +250,11 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   }
 
   /**
-   * Returns the status of the {@code Span}. If not set defaults to {@link Status#OK}.
-   *
-   * @return the status of the {@code Span}.
-   */
-  @VisibleForTesting
-  Status getStatus() {
-    synchronized (lock) {
-      return getStatusWithDefault();
-    }
-  }
-
-  /**
    * Returns a copy of the links for this span.
    *
    * @return A copy of the Links for this span.
    */
-  @VisibleForTesting
-  List<Link> getLinks() {
+  private List<Link> getLinks() {
     if (links == null) {
       return Collections.emptyList();
     }
@@ -539,17 +526,4 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     return totalRecordedLinks - links.size();
   }
 
-  @VisibleForTesting
-  int getNumberOfChildren() {
-    synchronized (lock) {
-      return numberOfChildren;
-    }
-  }
-
-  @VisibleForTesting
-  int getTotalRecordedEvents() {
-    synchronized (lock) {
-      return totalRecordedEvents;
-    }
-  }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -215,6 +215,7 @@ class SpanBuilderSdk implements Span.Builder {
         resource,
         attributes,
         truncatedLinks(),
+        links.size(),
         startEpochNanos);
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -208,14 +208,13 @@ class SpanBuilderSdk implements Span.Builder {
         instrumentationLibraryInfo,
         spanKind,
         parentContext != null ? parentContext.getSpanId() : null,
-        parentContext != null ? parentContext.isRemote() : false,
+        parentContext != null && parentContext.isRemote(),
         traceConfig,
         spanProcessor,
         getClock(parentSpan(parentType, parent), clock),
         resource,
         attributes,
         truncatedLinks(),
-        links.size(),
         startEpochNanos);
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanData.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanData.java
@@ -19,6 +19,7 @@ package io.opentelemetry.sdk.trace;
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.trace.AttributeValue;
 import io.opentelemetry.trace.Event;
 import io.opentelemetry.trace.Span.Kind;
@@ -181,6 +182,33 @@ public abstract class SpanData {
   public abstract boolean getHasEnded();
 
   /**
+   * The total number of {@link SpanData.TimedEvent} events that were recorded on this span. This
+   * number may be larger than the number of events that are attached to this span, if the total
+   * number recorded was greater than the configured maximum value. See: {@link
+   * TraceConfig#getMaxNumberOfEvents()}
+   *
+   * @return The total number of events recorded on this span.
+   */
+  public abstract int getTotalRecordedEvents();
+
+  /**
+   * The total number of child spans that were created for this span.
+   *
+   * @return The total number of child spans created from this span.
+   */
+  public abstract int getNumberOfChildren();
+
+  /**
+   * The total number of {@link SpanData.Link} links that were recorded on this span. This number
+   * may be larger than the number of links that are attached to this span, if the total number
+   * recorded was greater than the configured maximum value. See: {@link
+   * TraceConfig#getMaxNumberOfLinks()}
+   *
+   * @return The total number of links recorded on this span.
+   */
+  public abstract int getTotalRecordedLinks();
+
+  /**
    * An immutable implementation of {@link Link}.
    *
    * @since 0.1.0
@@ -188,6 +216,7 @@ public abstract class SpanData {
   @Immutable
   @AutoValue
   public abstract static class Link implements io.opentelemetry.trace.Link {
+
     /**
      * Returns a new immutable {@code Link}.
      *
@@ -222,6 +251,7 @@ public abstract class SpanData {
   @Immutable
   @AutoValue
   public abstract static class TimedEvent implements Event {
+
     /**
      * Returns a new immutable {@code TimedEvent}.
      *
@@ -459,5 +489,32 @@ public abstract class SpanData {
      * @since 0.4.0
      */
     public abstract Builder setHasEnded(boolean hasEnded);
+
+    /**
+     * Set the total number of events recorded on this span.
+     *
+     * @param totalRecordedEvents The total number of events recorded.
+     * @return this
+     * @since 0.4.0
+     */
+    public abstract Builder setTotalRecordedEvents(int totalRecordedEvents);
+
+    /**
+     * Set the total number of links recorded on this span.
+     *
+     * @param totalRecordedLinks The total number of links recorded.
+     * @return this
+     * @since 0.4.0
+     */
+    public abstract Builder setTotalRecordedLinks(int totalRecordedLinks);
+
+    /**
+     * Set the total number of child spans on this span.
+     *
+     * @param numberOfChildren The total number of children.
+     * @return this
+     * @since 0.4.0
+     */
+    public abstract Builder setNumberOfChildren(int numberOfChildren);
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -204,13 +204,13 @@ public class RecordEventsReadableSpanTest {
     RecordEventsReadableSpan span = createTestSpan(Kind.CONSUMER);
     try {
       testClock.advanceMillis(MILLIS_PER_SECOND);
-      assertThat(span.getStatus()).isEqualTo(Status.OK);
+      assertThat(span.toSpanData().getStatus()).isEqualTo(Status.OK);
       span.setStatus(Status.CANCELLED);
-      assertThat(span.getStatus()).isEqualTo(Status.CANCELLED);
+      assertThat(span.toSpanData().getStatus()).isEqualTo(Status.CANCELLED);
     } finally {
       span.end();
     }
-    assertThat(span.getStatus()).isEqualTo(Status.CANCELLED);
+    assertThat(span.toSpanData().getStatus()).isEqualTo(Status.CANCELLED);
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -485,7 +485,6 @@ public class RecordEventsReadableSpanTest {
             resource,
             attributesWithCapacity,
             Collections.singletonList(link),
-            1,
             0);
     Mockito.verify(spanProcessor, Mockito.times(1)).onStart(span);
     return span;
@@ -572,7 +571,6 @@ public class RecordEventsReadableSpanTest {
             resource,
             attributesWithCapacity,
             links,
-            1,
             0);
     long startEpochNanos = clock.now();
     clock.advanceMillis(4);

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -420,6 +420,7 @@ public class RecordEventsReadableSpanTest {
                 "event2",
                 Collections.<String, AttributeValue>emptyMap());
         assertThat(spanData.getTimedEvents().get(i)).isEqualTo(expectedEvent);
+        assertThat(spanData.getTotalRecordedEvents()).isEqualTo(2 * maxNumberOfEvents);
       }
     } finally {
       span.end();
@@ -485,6 +486,7 @@ public class RecordEventsReadableSpanTest {
             resource,
             attributesWithCapacity,
             Collections.singletonList(link),
+            1,
             0);
     Mockito.verify(spanProcessor, Mockito.times(1)).onStart(span);
     return span;
@@ -571,6 +573,7 @@ public class RecordEventsReadableSpanTest {
             resource,
             attributesWithCapacity,
             links,
+            1,
             0);
     long startEpochNanos = clock.now();
     clock.advanceMillis(4);
@@ -597,13 +600,16 @@ public class RecordEventsReadableSpanTest {
                 Arrays.asList(
                     SpanData.TimedEvent.create(firstEventEpochNanos, "event1", event1Attributes),
                     SpanData.TimedEvent.create(secondEventTimeNanos, "event2", event2Attributes)))
+            .setTotalRecordedEvents(2)
             .setResource(resource)
             .setParentSpanId(parentSpanId)
             .setLinks(links)
+            .setTotalRecordedLinks(links.size())
             .setTraceId(traceId)
             .setSpanId(spanId)
             .setAttributes(attributes)
             .setHasRemoteParent(false)
+            .setNumberOfChildren(0)
             .build();
 
     SpanData result = readableSpan.toSpanData();

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -110,7 +110,6 @@ public class SpanBuilderSdkTest {
     }
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     try {
-      assertThat(span.getDroppedLinksCount()).isEqualTo(maxNumberOfLinks);
       List<Link> links = span.toSpanData().getLinks();
       assertThat(links.size()).isEqualTo(maxNumberOfLinks);
       for (int i = 0; i < maxNumberOfLinks; i++) {
@@ -157,7 +156,7 @@ public class SpanBuilderSdkTest {
 
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     try {
-      Map<String, AttributeValue> attrs = span.getAttributes();
+      Map<String, AttributeValue> attrs = span.toSpanData().getAttributes();
       assertThat(attrs).hasSize(5);
       assertThat(attrs.get("string")).isEqualTo(AttributeValue.stringAttributeValue("value"));
       assertThat(attrs.get("long")).isEqualTo(AttributeValue.longAttributeValue(12345L));
@@ -186,7 +185,7 @@ public class SpanBuilderSdkTest {
     }
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     try {
-      Map<String, AttributeValue> attrs = span.getAttributes();
+      Map<String, AttributeValue> attrs = span.toSpanData().getAttributes();
       assertThat(attrs.size()).isEqualTo(maxNumberOfAttrs);
       for (int i = 0; i < maxNumberOfAttrs; i++) {
         assertThat(attrs.get("key" + (i + maxNumberOfAttrs)))
@@ -286,7 +285,7 @@ public class SpanBuilderSdkTest {
                 .startSpan();
     try {
       assertThat(span.getContext().getTraceFlags().isSampled()).isTrue();
-      assertThat(span.getAttributes()).containsKey(samplerAttributeName);
+      assertThat(span.toSpanData().getAttributes()).containsKey(samplerAttributeName);
     } finally {
       span.end();
     }
@@ -348,7 +347,7 @@ public class SpanBuilderSdkTest {
               tracerSdk.spanBuilder(SPAN_NAME).setNoParent().setParent(parent).startSpan();
       try {
         assertThat(span.getContext().getTraceId()).isEqualTo(parent.getContext().getTraceId());
-        assertThat(span.getParentSpanId()).isEqualTo(parent.getContext().getSpanId());
+        assertThat(span.toSpanData().getParentSpanId()).isEqualTo(parent.getContext().getSpanId());
 
         RecordEventsReadableSpan span2 =
             (RecordEventsReadableSpan)
@@ -384,7 +383,7 @@ public class SpanBuilderSdkTest {
                   .startSpan();
       try {
         assertThat(span.getContext().getTraceId()).isEqualTo(parent.getContext().getTraceId());
-        assertThat(span.getParentSpanId()).isEqualTo(parent.getContext().getSpanId());
+        assertThat(span.toSpanData().getParentSpanId()).isEqualTo(parent.getContext().getSpanId());
       } finally {
         span.end();
       }
@@ -402,7 +401,7 @@ public class SpanBuilderSdkTest {
           (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).startSpan();
       try {
         assertThat(span.getContext().getTraceId()).isEqualTo(parent.getContext().getTraceId());
-        assertThat(span.getParentSpanId()).isEqualTo(parent.getContext().getSpanId());
+        assertThat(span.toSpanData().getParentSpanId()).isEqualTo(parent.getContext().getSpanId());
       } finally {
         span.end();
       }
@@ -421,37 +420,9 @@ public class SpanBuilderSdkTest {
             tracerSdk.spanBuilder(SPAN_NAME).setParent(parent.getContext()).startSpan();
     try {
       assertThat(span.getContext().getTraceId()).isNotEqualTo(parent.getContext().getTraceId());
-      assertFalse(span.getParentSpanId().isValid());
+      assertFalse(span.toSpanData().getParentSpanId().isValid());
     } finally {
       span.end();
-    }
-  }
-
-  @Test
-  public void parent_timestampConverter() {
-    Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
-    try {
-      RecordEventsReadableSpan span =
-          (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).setParent(parent).startSpan();
-
-      assertThat(span.getClock()).isEqualTo(((RecordEventsReadableSpan) parent).getClock());
-    } finally {
-      parent.end();
-    }
-  }
-
-  @Test
-  public void parentCurrentSpan_timestampConverter() {
-    Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
-    Scope scope = tracerSdk.withSpan(parent);
-    try {
-      RecordEventsReadableSpan span =
-          (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).startSpan();
-
-      assertThat(span.getClock()).isEqualTo(((RecordEventsReadableSpan) parent).getClock());
-    } finally {
-      scope.close();
-      parent.end();
     }
   }
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -87,7 +87,7 @@ public class SpanBuilderSdkTest {
 
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     try {
-      assertThat(span.getLinks()).hasSize(3);
+      assertThat(span.toSpanData().getLinks()).hasSize(3);
     } finally {
       span.end();
     }
@@ -111,9 +111,10 @@ public class SpanBuilderSdkTest {
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     try {
       assertThat(span.getDroppedLinksCount()).isEqualTo(maxNumberOfLinks);
-      assertThat(span.getLinks().size()).isEqualTo(maxNumberOfLinks);
+      List<Link> links = span.toSpanData().getLinks();
+      assertThat(links.size()).isEqualTo(maxNumberOfLinks);
       for (int i = 0; i < maxNumberOfLinks; i++) {
-        assertThat(span.getLinks().get(i)).isEqualTo(SpanData.Link.create(sampledSpanContext));
+        assertThat(links.get(i)).isEqualTo(SpanData.Link.create(sampledSpanContext));
       }
     } finally {
       span.end();

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -432,4 +432,30 @@ public class SpanBuilderSdkTest {
     thrown.expectMessage("Negative startTimestamp");
     tracerSdk.spanBuilder(SPAN_NAME).setStartTimestamp(-1);
   }
+
+  @Test
+  public void parent_clockIsSame() {
+    Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
+    try {
+      RecordEventsReadableSpan span =
+          (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).setParent(parent).startSpan();
+
+      assertThat(span.getClock()).isSameInstanceAs(((RecordEventsReadableSpan) parent).getClock());
+    } finally {
+      parent.end();
+    }
+  }
+
+  @Test
+  public void parentCurrentSpan_clockIsSame() {
+    Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
+    try (Scope scope = tracerSdk.withSpan(parent)) {
+      RecordEventsReadableSpan span =
+          (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).startSpan();
+
+      assertThat(span.getClock()).isSameInstanceAs(((RecordEventsReadableSpan) parent).getClock());
+    } finally {
+      parent.end();
+    }
+  }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanDataTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanDataTest.java
@@ -40,16 +40,13 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/**
- * Unit tests for {@link SpanData}.
- */
+/** Unit tests for {@link SpanData}. */
 @RunWith(JUnit4.class)
 public class SpanDataTest {
 
   private static final long START_EPOCH_NANOS = TimeUnit.SECONDS.toNanos(3000) + 200;
   private static final long END_EPOCH_NANOS = TimeUnit.SECONDS.toNanos(3001) + 255;
-  @Rule
-  public final ExpectedException thrown = ExpectedException.none();
+  @Rule public final ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void defaultValues() {

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanDataTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanDataTest.java
@@ -16,9 +16,8 @@
 
 package io.opentelemetry.sdk.trace;
 
+import static com.google.common.truth.Truth.assertThat;
 import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.trace.SpanData.TimedEvent;
@@ -41,23 +40,28 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link SpanData}. */
+/**
+ * Unit tests for {@link SpanData}.
+ */
 @RunWith(JUnit4.class)
 public class SpanDataTest {
+
   private static final long START_EPOCH_NANOS = TimeUnit.SECONDS.toNanos(3000) + 200;
   private static final long END_EPOCH_NANOS = TimeUnit.SECONDS.toNanos(3001) + 255;
-  @Rule public final ExpectedException thrown = ExpectedException.none();
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void defaultValues() {
     SpanData spanData = createBasicSpanBuilder().build();
 
-    assertFalse(spanData.getParentSpanId().isValid());
-    assertEquals(Collections.<String, AttributeValue>emptyMap(), spanData.getAttributes());
-    assertEquals(emptyList(), spanData.getTimedEvents());
-    assertEquals(emptyList(), spanData.getLinks());
-    assertEquals(InstrumentationLibraryInfo.EMPTY, spanData.getInstrumentationLibraryInfo());
-    assertEquals(false, spanData.getHasRemoteParent());
+    assertThat(spanData.getParentSpanId().isValid()).isFalse();
+    assertThat(spanData.getAttributes()).isEqualTo(Collections.<String, AttributeValue>emptyMap());
+    assertThat(spanData.getTimedEvents()).isEqualTo(emptyList());
+    assertThat(spanData.getLinks()).isEqualTo(emptyList());
+    assertThat(spanData.getInstrumentationLibraryInfo())
+        .isSameInstanceAs(InstrumentationLibraryInfo.EMPTY);
+    assertThat(spanData.getHasRemoteParent()).isFalse();
   }
 
   @Test
@@ -113,6 +117,9 @@ public class SpanDataTest {
         .setEndEpochNanos(END_EPOCH_NANOS)
         .setKind(Kind.SERVER)
         .setStatus(Status.OK)
-        .setHasRemoteParent(false);
+        .setHasRemoteParent(false)
+        .setTotalRecordedEvents(0)
+        .setTotalRecordedLinks(0)
+        .setNumberOfChildren(0);
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
@@ -63,6 +63,9 @@ public final class TestUtils {
         .setStartEpochNanos(TimeUnit.SECONDS.toNanos(100) + 100)
         .setStatus(Status.OK)
         .setEndEpochNanos(TimeUnit.SECONDS.toNanos(200) + 200)
+        .setNumberOfChildren(0)
+        .setTotalRecordedLinks(0)
+        .setTotalRecordedEvents(0)
         .build();
   }
 


### PR DESCRIPTION
This is intended to resolve #719 .

Note: there were a few used-only-in-testing attributes on the RERS. I removed them, since they were never used anywhere in the system aside from tests. If we end up needing them in the future, we can add them back.