### PR TITLE
Change MultiSpanExporter creation visibility

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/MultiSpanExporter.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/MultiSpanExporter.java
@@ -38,7 +38,13 @@ public final class MultiSpanExporter implements SpanExporter {
   private static final Logger logger = Logger.getLogger(MultiSpanExporter.class.getName());
   private final List<SpanExporter> spanExporters;
 
-  static SpanExporter create(List<SpanExporter> spanExporters) {
+  /**
+   * Constructs and returns an instance of this class.
+   *
+   * @param spanExporters the exporters spans should be sent to
+   * @return the aggregate span exporter
+   */
+  public static SpanExporter create(List<SpanExporter> spanExporters) {
     return new MultiSpanExporter(Collections.unmodifiableList(new ArrayList<>(spanExporters)));
   }
 


### PR DESCRIPTION
Changed static create to public so it can be used by Spring Boot autoconfiguration.
