### PR TITLE
More progress on MetricData definition

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MetricData.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MetricData.java
@@ -17,8 +17,11 @@
 package io.opentelemetry.sdk.metrics;
 
 import com.google.auto.value.AutoValue;
+import io.opentelemetry.internal.Utils;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -34,33 +37,120 @@ public abstract class MetricData {
   /**
    * Returns the {@link Descriptor} of this metric.
    *
-   * @return the {@code MetricDescriptor} of this metric.
+   * @return the {@code Descriptor} of this metric.
    * @since 0.1.0
    */
   public abstract Descriptor getDescriptor();
 
   /**
-   * Returns the start epoch timestamp in nanos of this {@code Instrument}, usually the time when
-   * the metric was created or an aggregation was enabled.
+   * Returns the data {@link Int64Point}s for this metric, or {@code null} if the {@link
+   * Descriptor.Type} of the metric does not generate this type of points.
    *
-   * @return the start epoch timestamp in nanos.
-   * @since 0.1.0
+   * <p>Only one type of points are available at any moment for a {@link MetricData}.
+   *
+   * @return the data {@link Point}s for this metric, or {@code null} if this type of points are not
+   *     accepted.
+   * @since 0.3.0
    */
-  public abstract long getStartEpochNanos();
+  @Nullable
+  public abstract Collection<Int64Point> getInt64Points();
 
   /**
-   * Returns the the epoch timestamp in nanos when data were collected, usually it represents the
-   * moment when {@code Instrument.getData()} was called.
+   * Returns the data {@link DoublePoint}s for this metric, or {@code null} if the {@link
+   * Descriptor.Type} of the metric does not generate this type of points.
    *
-   * @return the epoch timestamp in nanos.
-   * @since 0.1.0
+   * <p>Only one type of points are available at any moment for a {@link MetricData}.
+   *
+   * @return the data {@link Point}s for this metric, or {@code null} if this type of points are not
+   *     accepted.
+   * @since 0.3.0
    */
-  public abstract long getEpochNanos();
+  @Nullable
+  public abstract Collection<DoublePoint> getDoublePoints();
 
-  // TODO: Add TimeSeries/Point
+  static MetricData createWithInt64Points(
+      Descriptor descriptor, Collection<Int64Point> int64Points) {
+    Descriptor.Type type = Utils.checkNotNull(descriptor, "descriptor").getType();
+    Utils.checkState(
+        type == Descriptor.Type.NON_MONOTONIC_INT64 || type == Descriptor.Type.MONOTONIC_INT64,
+        "Incompatible points type with metric type.");
+    return new AutoValue_MetricData(
+        descriptor, Utils.checkNotNull(int64Points, "longPoints"), null);
+  }
 
-  static MetricData createInternal(Descriptor descriptor, long startEpochNanos, long epochNanos) {
-    return new AutoValue_MetricData(descriptor, startEpochNanos, epochNanos);
+  static MetricData createWithDoublePoints(
+      Descriptor descriptor, Collection<DoublePoint> doublePoints) {
+    Descriptor.Type type = Utils.checkNotNull(descriptor, "descriptor").getType();
+    Utils.checkState(
+        type == Descriptor.Type.NON_MONOTONIC_DOUBLE || type == Descriptor.Type.MONOTONIC_DOUBLE,
+        "Incompatible points type with metric type.");
+    return new AutoValue_MetricData(
+        descriptor, null, Utils.checkNotNull(doublePoints, "doublePoints"));
+  }
+
+  @Immutable
+  abstract static class Point {
+    Point() {}
+
+    /**
+     * Returns the start epoch timestamp in nanos of this {@code Instrument}, usually the time when
+     * the metric was created or an aggregation was enabled.
+     *
+     * @return the start epoch timestamp in nanos.
+     * @since 0.3.0
+     */
+    public abstract long getStartEpochNanos();
+
+    /**
+     * Returns the the epoch timestamp in nanos when data were collected, usually it represents the
+     * moment when {@code Instrument.getData()} was called.
+     *
+     * @return the epoch timestamp in nanos.
+     * @since 0.3.0
+     */
+    public abstract long getEpochNanos();
+  }
+
+  /**
+   * Int64Point is a single data point in a timeseries that describes the time-varying values of a
+   * int64 metric.
+   */
+  @Immutable
+  @AutoValue
+  public abstract static class Int64Point extends Point {
+    Int64Point() {}
+
+    /**
+     * Returns the value of the data point.
+     *
+     * @return the value of the data point.
+     */
+    public abstract long getValue();
+
+    static Int64Point createInternal(long startEpochNanos, long epochNanos, long value) {
+      return new AutoValue_MetricData_Int64Point(startEpochNanos, epochNanos, value);
+    }
+  }
+
+  /**
+   * DoublePoint is a single data point in a timeseries that describes the time-varying value of a
+   * double metric.
+   */
+  @Immutable
+  @AutoValue
+  public abstract static class DoublePoint extends Point {
+    DoublePoint() {}
+
+    /**
+     * Returns the value of the data point.
+     *
+     * @return the value of the data point.
+     */
+    public abstract double getValue();
+
+    static DoublePoint createInternal(long startEpochNanos, long epochNanos, double value) {
+      return new AutoValue_MetricData_DoublePoint(startEpochNanos, epochNanos, value);
+    }
   }
 
   /**

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/MetricDataTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/MetricDataTest.java
@@ -19,6 +19,8 @@ package io.opentelemetry.sdk.metrics;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.sdk.metrics.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.MetricData.DoublePoint;
+import io.opentelemetry.sdk.metrics.MetricData.Int64Point;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import org.junit.Rule;
@@ -32,7 +34,7 @@ import org.junit.runners.JUnit4;
 public class MetricDataTest {
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
-  private static final Descriptor METRIC_DESCRIPTOR =
+  private static final Descriptor INT64_METRIC_DESCRIPTOR =
       Descriptor.createInternal(
           "metric_name",
           "metric_description",
@@ -40,22 +42,84 @@ public class MetricDataTest {
           Descriptor.Type.MONOTONIC_INT64,
           Collections.singletonList("key"),
           Collections.singletonMap("key_const", "value_const"));
+  private static final Descriptor DOUBLE_METRIC_DESCRIPTOR =
+      Descriptor.createInternal(
+          "metric_name",
+          "metric_description",
+          "ms",
+          Descriptor.Type.NON_MONOTONIC_DOUBLE,
+          Collections.singletonList("key"),
+          Collections.singletonMap("key_const", "value_const"));
   private static final long START_EPOCH_NANOS = TimeUnit.MILLISECONDS.toNanos(1000);
   private static final long EPOCH_NANOS = TimeUnit.MILLISECONDS.toNanos(2000);
+  private static final long LONG_VALUE = 10;
+  private static final double DOUBLE_VALUE = 1.234;
+  private static final Int64Point LONG_POINT =
+      Int64Point.createInternal(START_EPOCH_NANOS, EPOCH_NANOS, LONG_VALUE);
+  private static final DoublePoint DOUBLE_POINT =
+      DoublePoint.createInternal(START_EPOCH_NANOS, EPOCH_NANOS, DOUBLE_VALUE);
 
   @Test
-  public void testGet() {
+  public void metricData_Int64Points() {
     MetricData metricData =
-        MetricData.createInternal(METRIC_DESCRIPTOR, START_EPOCH_NANOS, EPOCH_NANOS);
-    assertThat(metricData.getDescriptor()).isEqualTo(METRIC_DESCRIPTOR);
-    assertThat(metricData.getStartEpochNanos()).isEqualTo(START_EPOCH_NANOS);
-    assertThat(metricData.getEpochNanos()).isEqualTo(EPOCH_NANOS);
+        MetricData.createWithInt64Points(
+            INT64_METRIC_DESCRIPTOR, Collections.singletonList(LONG_POINT));
+    assertThat(metricData.getDescriptor()).isEqualTo(INT64_METRIC_DESCRIPTOR);
+    assertThat(metricData.getInt64Points()).containsExactly(LONG_POINT);
+    assertThat(metricData.getDoublePoints()).isNull();
   }
 
   @Test
-  public void create_NullDescriptor() {
+  public void metricData_Int64Points_NullDescriptor() {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("descriptor");
-    MetricData.createInternal(null, START_EPOCH_NANOS, EPOCH_NANOS);
+    MetricData.createWithInt64Points(null, Collections.singletonList(LONG_POINT));
+  }
+
+  @Test
+  public void metricData_Int64Points_NullPoints() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("longPoints");
+    MetricData.createWithInt64Points(INT64_METRIC_DESCRIPTOR, null);
+  }
+
+  @Test
+  public void metricData_Int64Points_IncompatibleTypes() {
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("Incompatible points type with metric type.");
+    MetricData.createWithInt64Points(
+        DOUBLE_METRIC_DESCRIPTOR, Collections.singletonList(LONG_POINT));
+  }
+
+  @Test
+  public void metricData_DoublePoints() {
+    MetricData metricData =
+        MetricData.createWithDoublePoints(
+            DOUBLE_METRIC_DESCRIPTOR, Collections.singletonList(DOUBLE_POINT));
+    assertThat(metricData.getDescriptor()).isEqualTo(DOUBLE_METRIC_DESCRIPTOR);
+    assertThat(metricData.getInt64Points()).isNull();
+    assertThat(metricData.getDoublePoints()).containsExactly(DOUBLE_POINT);
+  }
+
+  @Test
+  public void metricData_DoublePoints_NullDescriptor() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("descriptor");
+    MetricData.createWithDoublePoints(null, Collections.singletonList(DOUBLE_POINT));
+  }
+
+  @Test
+  public void metricData_DoublePoints_NullPoints() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("doublePoints");
+    MetricData.createWithDoublePoints(DOUBLE_METRIC_DESCRIPTOR, null);
+  }
+
+  @Test
+  public void metricData_DoublePoints_IncompatibleTypes() {
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("Incompatible points type with metric type.");
+    MetricData.createWithDoublePoints(
+        INT64_METRIC_DESCRIPTOR, Collections.singletonList(DOUBLE_POINT));
   }
 }


### PR DESCRIPTION
This PR:
* Adds the notion of a Point as in the data model.
* Moves timestamps to the newly created Point as in the data model.

Still work left:
* Add label values to the base point.
* Add support for all types defined here https://github.com/open-telemetry/opentelemetry-proto/blob/master/opentelemetry/proto/metrics/v1/metrics.proto
