### PR TITLE
Fix exporterTimesOut test being flaky.

### DIFF
--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessorTest.java
@@ -230,7 +230,7 @@ public class BatchSpansProcessorTest {
     assertThat(exported).containsExactly(span2.toSpanData());
   }
 
-  @Test
+  @Test(timeout = 5000)
   public void exporterTimesOut() throws Exception {
     final CountDownLatch interruptMarker = new CountDownLatch(1);
     WaitingSpanExporter waitingSpanExporter =
@@ -262,7 +262,7 @@ public class BatchSpansProcessorTest {
 
     // since the interrupt happens outside the execution of the test method, we'll block to make
     // sure that the thread was actually interrupted due to the timeout.
-    assertThat(interruptMarker.await(exporterTimeoutMillis * 2, TimeUnit.MILLISECONDS)).isTrue();
+    interruptMarker.await();
   }
 
   @Test


### PR DESCRIPTION
This test fails if run on a machine that is slow or overloaded because <100 ms could be too little to get the interrupt both triggered and processed (200 ms timeout - at least 100 ms sleep time, then the thread has to wake up and trigger the interrupt, then the exporter thread has to wake up and process the interrupt).