### PR TITLE
Update to latest Resource semantic conventions.

### DIFF
--- a/sdk_contrib/aws_v1_support/src/main/java/io/opentelemetry/sdk/contrib/trace/aws/Ec2Resource.java
+++ b/sdk_contrib/aws_v1_support/src/main/java/io/opentelemetry/sdk/contrib/trace/aws/Ec2Resource.java
@@ -55,6 +55,7 @@ public class Ec2Resource {
       labels.put(ResourceConstants.HOST_ID, info.getInstanceId());
       labels.put(ResourceConstants.HOST_NAME, info.getPrivateIp());
       labels.put(ResourceConstants.HOST_TYPE, info.getInstanceType());
+      labels.put(ResourceConstants.HOST_IMAGE_ID, info.getImageId());
     }
     if (!isNullOrEmpty(hostname)) {
       labels.put(ResourceConstants.HOST_HOSTNAME, hostname);

--- a/sdk_contrib/aws_v1_support/src/test/java/io/opentelemetry/sdk/contrib/trace/aws/Ec2ResourceTest.java
+++ b/sdk_contrib/aws_v1_support/src/test/java/io/opentelemetry/sdk/contrib/trace/aws/Ec2ResourceTest.java
@@ -79,5 +79,6 @@ public class Ec2ResourceTest {
     assertThat(resource.getLabels().get(ResourceConstants.HOST_NAME)).isEqualTo(privateIp);
     assertThat(resource.getLabels().get(ResourceConstants.HOST_TYPE)).isEqualTo(instanceType);
     assertThat(resource.getLabels().get(ResourceConstants.HOST_HOSTNAME)).isEqualTo(hostname);
+    assertThat(resource.getLabels().get(ResourceConstants.HOST_IMAGE_ID)).isEqualTo(imageId);
   }
 }


### PR DESCRIPTION
Adds the value of the AWS AMI ID retrieved from the EC2 metadata endpoint to the resource labels.
