### PR TITLE
Remove bound support from Observers

### DIFF
--- a/api/src/main/java/io/opentelemetry/metrics/Counter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Counter.java
@@ -22,7 +22,7 @@ package io.opentelemetry.metrics;
  * @param <H> the Bound Counter type.
  * @since 0.1.0
  */
-public interface Counter<H> extends InstrumentWithBound<H> {
+public interface Counter<H> extends InstrumentWithBinding<H> {
 
   /** Builder class for {@link Counter}. */
   interface Builder<B extends Counter.Builder<B, V>, V> extends Instrument.Builder<B, V> {

--- a/api/src/main/java/io/opentelemetry/metrics/Counter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Counter.java
@@ -22,7 +22,7 @@ package io.opentelemetry.metrics;
  * @param <H> the Bound Counter type.
  * @since 0.1.0
  */
-public interface Counter<H> extends Instrument<H> {
+public interface Counter<H> extends InstrumentWithBound<H> {
 
   /** Builder class for {@link Counter}. */
   interface Builder<B extends Counter.Builder<B, V>, V> extends Instrument.Builder<B, V> {

--- a/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
@@ -434,25 +434,8 @@ public final class DefaultMeter implements Meter {
     private NoopDoubleObserver() {}
 
     @Override
-    public NoopBoundDoubleObserver bind(LabelSet labelSet) {
-      Utils.checkNotNull(labelSet, "labelSet");
-      return NoopBoundDoubleObserver.INSTANCE;
-    }
-
-    @Override
-    public void unbind(BoundDoubleObserver boundInstrument) {
-      Utils.checkNotNull(boundInstrument, "boundDoubleObserver");
-    }
-
-    @Override
     public void setCallback(Callback<ResultDoubleObserver> metricUpdater) {
       Utils.checkNotNull(metricUpdater, "metricUpdater");
-    }
-
-    /** No-op implementations of BoundDoubleObserver class. */
-    @Immutable
-    private enum NoopBoundDoubleObserver implements BoundDoubleObserver {
-      INSTANCE
     }
 
     private static final class NoopBuilder
@@ -476,25 +459,8 @@ public final class DefaultMeter implements Meter {
     private NoopLongObserver() {}
 
     @Override
-    public NoopBoundLongObserver bind(LabelSet labelSet) {
-      Utils.checkNotNull(labelSet, "labelSet");
-      return NoopBoundLongObserver.INSTANCE;
-    }
-
-    @Override
-    public void unbind(BoundLongObserver boundInstrument) {
-      Utils.checkNotNull(boundInstrument, "boundLongObserver");
-    }
-
-    @Override
     public void setCallback(Callback<ResultLongObserver> metricUpdater) {
       Utils.checkNotNull(metricUpdater, "metricUpdater");
-    }
-
-    /** No-op implementation of BoundLongObserver interface. */
-    @Immutable
-    private enum NoopBoundLongObserver implements BoundLongObserver {
-      INSTANCE
     }
 
     private static final class NoopBuilder

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleObserver.java
@@ -60,6 +60,6 @@ public interface DoubleObserver extends Observer<ResultDoubleObserver> {
 
   /** The result for the {@link io.opentelemetry.metrics.Observer.Callback}. */
   interface ResultDoubleObserver {
-    void put(double value, LabelSet labelSet);
+    void observe(double value, LabelSet labelSet);
   }
 }

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleObserver.java
@@ -16,7 +16,6 @@
 
 package io.opentelemetry.metrics;
 
-import io.opentelemetry.metrics.DoubleObserver.BoundDoubleObserver;
 import io.opentelemetry.metrics.DoubleObserver.ResultDoubleObserver;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -52,29 +51,15 @@ import javax.annotation.concurrent.ThreadSafe;
  * @since 0.1.0
  */
 @ThreadSafe
-public interface DoubleObserver extends Observer<ResultDoubleObserver, BoundDoubleObserver> {
-  @Override
-  BoundDoubleObserver bind(LabelSet labelSet);
-
-  @Override
-  void unbind(BoundDoubleObserver boundInstrument);
-
+public interface DoubleObserver extends Observer<ResultDoubleObserver> {
   @Override
   void setCallback(Callback<ResultDoubleObserver> metricUpdater);
 
   /** Builder class for {@link DoubleObserver}. */
   interface Builder extends Observer.Builder<DoubleObserver.Builder, DoubleObserver> {}
 
-  /**
-   * A {@code BoundDoubleObserver} for a {@code Observer} for double values.
-   *
-   * @since 0.1.0
-   */
-  @ThreadSafe
-  interface BoundDoubleObserver {}
-
   /** The result for the {@link io.opentelemetry.metrics.Observer.Callback}. */
   interface ResultDoubleObserver {
-    void put(BoundDoubleObserver boundDoubleObserver, double value);
+    void put(double value, LabelSet labelSet);
   }
 }

--- a/api/src/main/java/io/opentelemetry/metrics/Gauge.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Gauge.java
@@ -22,7 +22,7 @@ package io.opentelemetry.metrics;
  * @param <H> the specific Bound Gauge type.
  * @since 0.1.0
  */
-public interface Gauge<H> extends Instrument<H> {
+public interface Gauge<H> extends InstrumentWithBound<H> {
   /** Builder class for {@link Gauge}. */
   interface Builder<B extends Gauge.Builder<B, V>, V> extends Instrument.Builder<B, V> {
     /**

--- a/api/src/main/java/io/opentelemetry/metrics/Gauge.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Gauge.java
@@ -22,7 +22,7 @@ package io.opentelemetry.metrics;
  * @param <H> the specific Bound Gauge type.
  * @since 0.1.0
  */
-public interface Gauge<H> extends InstrumentWithBound<H> {
+public interface Gauge<H> extends InstrumentWithBinding<H> {
   /** Builder class for {@link Gauge}. */
   interface Builder<B extends Gauge.Builder<B, V>, V> extends Instrument.Builder<B, V> {
     /**

--- a/api/src/main/java/io/opentelemetry/metrics/Instrument.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Instrument.java
@@ -24,34 +24,11 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * Base interface for all metrics defined in this package.
  *
- * @param <B> the specific type of Bound Instrument this instrument can provide.
  * @since 0.1.0
  */
 @ThreadSafe
-public interface Instrument<B> {
-  /**
-   * Returns a {@code Bound Instrument} associated with the specified {@code labelSet}. Multiples
-   * requests with the same {@code labelSet} may return the same {@code Bound Instrument} instance.
-   *
-   * <p>It is recommended that callers keep a reference to the Bound Instrument instead of always
-   * calling this method for every operation.
-   *
-   * @param labelSet the set of labels.
-   * @return a {@code Bound Instrument}
-   * @throws NullPointerException if {@code labelValues} is null.
-   * @since 0.1.0
-   */
-  B bind(LabelSet labelSet);
-
-  /**
-   * Removes the {@code Bound Instrument} from the Instrument. i.e. references to previous {@code
-   * Bound Instrument} are invalid (not being managed by the instrument).
-   *
-   * @param boundInstrument the {@code Bound Instrument} to be removed.
-   * @since 0.1.0
-   */
-  void unbind(B boundInstrument);
-
+@SuppressWarnings("InterfaceWithOnlyStatics")
+public interface Instrument {
   /**
    * The {@code Builder} class for the {@code Instrument}.
    *

--- a/api/src/main/java/io/opentelemetry/metrics/InstrumentWithBinding.java
+++ b/api/src/main/java/io/opentelemetry/metrics/InstrumentWithBinding.java
@@ -22,7 +22,7 @@ package io.opentelemetry.metrics;
  * @param <B> the specific type of Bound Instrument this instrument can provide.
  * @since 0.1.0
  */
-public interface InstrumentWithBound<B> extends Instrument {
+public interface InstrumentWithBinding<B> extends Instrument {
   /**
    * Returns a {@code Bound Instrument} associated with the specified {@code labelSet}. Multiples
    * requests with the same {@code labelSet} may return the same {@code Bound Instrument} instance.

--- a/api/src/main/java/io/opentelemetry/metrics/InstrumentWithBound.java
+++ b/api/src/main/java/io/opentelemetry/metrics/InstrumentWithBound.java
@@ -1,0 +1,32 @@
+package io.opentelemetry.metrics;
+
+/**
+ * Base interface for all metrics with bounds defined in this package.
+ *
+ * @param <B> the specific type of Bound Instrument this instrument can provide.
+ * @since 0.1.0
+ */
+public interface InstrumentWithBound<B> extends Instrument {
+  /**
+   * Returns a {@code Bound Instrument} associated with the specified {@code labelSet}. Multiples
+   * requests with the same {@code labelSet} may return the same {@code Bound Instrument} instance.
+   *
+   * <p>It is recommended that callers keep a reference to the Bound Instrument instead of always
+   * calling this method for every operation.
+   *
+   * @param labelSet the set of labels.
+   * @return a {@code Bound Instrument}
+   * @throws NullPointerException if {@code labelValues} is null.
+   * @since 0.1.0
+   */
+  B bind(LabelSet labelSet);
+
+  /**
+   * Removes the {@code Bound Instrument} from the Instrument. i.e. references to previous {@code
+   * Bound Instrument} are invalid (not being managed by the instrument).
+   *
+   * @param boundInstrument the {@code Bound Instrument} to be removed.
+   * @since 0.1.0
+   */
+  void unbind(B boundInstrument);
+}

--- a/api/src/main/java/io/opentelemetry/metrics/InstrumentWithBound.java
+++ b/api/src/main/java/io/opentelemetry/metrics/InstrumentWithBound.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.opentelemetry.metrics;
 
 /**

--- a/api/src/main/java/io/opentelemetry/metrics/LongCounter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongCounter.java
@@ -50,7 +50,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * @since 0.1.0
  */
 @ThreadSafe
-public interface LongCounter extends Instrument<BoundLongCounter> {
+public interface LongCounter extends Counter<BoundLongCounter> {
 
   /**
    * Adds the given {@code delta} to the current value. The values can be negative iff monotonic was

--- a/api/src/main/java/io/opentelemetry/metrics/LongObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongObserver.java
@@ -60,6 +60,6 @@ public interface LongObserver extends Observer<ResultLongObserver> {
 
   /** The result for the {@link io.opentelemetry.metrics.Observer.Callback}. */
   interface ResultLongObserver {
-    void put(long value, LabelSet labelSet);
+    void observe(long value, LabelSet labelSet);
   }
 }

--- a/api/src/main/java/io/opentelemetry/metrics/LongObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongObserver.java
@@ -16,7 +16,6 @@
 
 package io.opentelemetry.metrics;
 
-import io.opentelemetry.metrics.LongObserver.BoundLongObserver;
 import io.opentelemetry.metrics.LongObserver.ResultLongObserver;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -52,29 +51,15 @@ import javax.annotation.concurrent.ThreadSafe;
  * @since 0.1.0
  */
 @ThreadSafe
-public interface LongObserver extends Observer<ResultLongObserver, BoundLongObserver> {
-  @Override
-  BoundLongObserver bind(LabelSet labelSet);
-
-  @Override
-  void unbind(BoundLongObserver boundInstrument);
-
+public interface LongObserver extends Observer<ResultLongObserver> {
   @Override
   void setCallback(Callback<ResultLongObserver> metricUpdater);
 
   /** Builder class for {@link LongObserver}. */
   interface Builder extends Observer.Builder<LongObserver.Builder, LongObserver> {}
 
-  /**
-   * A {@code Bound} for a {@code Observer}.
-   *
-   * @since 0.1.0
-   */
-  @ThreadSafe
-  interface BoundLongObserver {}
-
   /** The result for the {@link io.opentelemetry.metrics.Observer.Callback}. */
   interface ResultLongObserver {
-    void put(BoundLongObserver bound, long value);
+    void put(long value, LabelSet labelSet);
   }
 }

--- a/api/src/main/java/io/opentelemetry/metrics/Measure.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Measure.java
@@ -22,7 +22,7 @@ package io.opentelemetry.metrics;
  * @param <H> the Bound Instrument type.
  * @since 0.1.0
  */
-public interface Measure<H> extends InstrumentWithBound<H> {
+public interface Measure<H> extends InstrumentWithBinding<H> {
 
   /** Builder class for {@link Measure}. */
   interface Builder<B extends Measure.Builder<B, V>, V> extends Instrument.Builder<B, V> {

--- a/api/src/main/java/io/opentelemetry/metrics/Measure.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Measure.java
@@ -22,7 +22,7 @@ package io.opentelemetry.metrics;
  * @param <H> the Bound Instrument type.
  * @since 0.1.0
  */
-public interface Measure<H> extends Instrument<H> {
+public interface Measure<H> extends InstrumentWithBound<H> {
 
   /** Builder class for {@link Measure}. */
   interface Builder<B extends Measure.Builder<B, V>, V> extends Instrument.Builder<B, V> {

--- a/api/src/main/java/io/opentelemetry/metrics/Observer.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Observer.java
@@ -19,11 +19,10 @@ package io.opentelemetry.metrics;
 /**
  * Base interface for all the Observer metrics.
  *
- * @param <B> the Bound Observer type.
  * @param <R> the callback Result type.
  * @since 0.1.0
  */
-public interface Observer<R, B> extends Instrument<B> {
+public interface Observer<R> extends Instrument {
   /**
    * A {@code Callback} for a {@code Observer}.
    *

--- a/api/src/test/java/io/opentelemetry/metrics/DoubleObserverTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/DoubleObserverTest.java
@@ -19,7 +19,6 @@ package io.opentelemetry.metrics;
 import io.opentelemetry.OpenTelemetry;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -30,11 +29,6 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class DoubleObserverTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
-
-  private static final String NAME = "name";
-  private static final String DESCRIPTION = "description";
-  private static final String UNIT = "1";
-  private static final List<String> LABEL_KEY = Collections.singletonList("key");
 
   private final Meter meter = OpenTelemetry.getMeterRegistry().get("observer_double_test");
 
@@ -90,33 +84,5 @@ public class DoubleObserverTest {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("constantLabels");
     meter.doubleObserverBuilder("metric").setConstantLabels(null).build();
-  }
-
-  @Test
-  public void noopBind_WithNullLabelSet() {
-    DoubleObserver doubleObserver =
-        meter
-            .doubleObserverBuilder(NAME)
-            .setDescription(DESCRIPTION)
-            .setLabelKeys(LABEL_KEY)
-            .setUnit(UNIT)
-            .build();
-    thrown.expect(NullPointerException.class);
-    thrown.expectMessage("labelSet");
-    doubleObserver.bind(null);
-  }
-
-  @Test
-  public void noopUnbind_WithNullBoundInstrument() {
-    DoubleObserver doubleObserver =
-        meter
-            .doubleObserverBuilder(NAME)
-            .setDescription(DESCRIPTION)
-            .setLabelKeys(LABEL_KEY)
-            .setUnit(UNIT)
-            .build();
-    thrown.expect(NullPointerException.class);
-    thrown.expectMessage("boundDoubleObserver");
-    doubleObserver.unbind(null);
   }
 }

--- a/api/src/test/java/io/opentelemetry/metrics/LongObserverTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/LongObserverTest.java
@@ -19,7 +19,6 @@ package io.opentelemetry.metrics;
 import io.opentelemetry.OpenTelemetry;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -30,11 +29,6 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class LongObserverTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
-
-  private static final String NAME = "name";
-  private static final String DESCRIPTION = "description";
-  private static final String UNIT = "1";
-  private static final List<String> LABEL_KEY = Collections.singletonList("key");
 
   private final Meter meter = OpenTelemetry.getMeterRegistry().get("observer_long_test");
 
@@ -90,33 +84,5 @@ public class LongObserverTest {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("constantLabels");
     meter.longObserverBuilder("metric").setConstantLabels(null).build();
-  }
-
-  @Test
-  public void noopBind_WithNullLabelSet() {
-    LongObserver longObserver =
-        meter
-            .longObserverBuilder(NAME)
-            .setDescription(DESCRIPTION)
-            .setLabelKeys(LABEL_KEY)
-            .setUnit(UNIT)
-            .build();
-    thrown.expect(NullPointerException.class);
-    thrown.expectMessage("labelSet");
-    longObserver.bind(null);
-  }
-
-  @Test
-  public void noopUnbind_WithNullInstrument() {
-    LongObserver longObserver =
-        meter
-            .longObserverBuilder(NAME)
-            .setDescription(DESCRIPTION)
-            .setLabelKeys(LABEL_KEY)
-            .setUnit(UNIT)
-            .build();
-    thrown.expect(NullPointerException.class);
-    thrown.expectMessage("boundLongObserver");
-    longObserver.unbind(null);
   }
 }

--- a/contrib/runtime_metrics/src/main/java/io/opentelemetry/contrib/metrics/runtime/GarbageCollector.java
+++ b/contrib/runtime_metrics/src/main/java/io/opentelemetry/contrib/metrics/runtime/GarbageCollector.java
@@ -75,7 +75,7 @@ public final class GarbageCollector {
           @Override
           public void update(ResultLongObserver resultLongObserver) {
             for (int i = 0; i < garbageCollectors.size(); i++) {
-              resultLongObserver.put(
+              resultLongObserver.observe(
                   garbageCollectors.get(i).getCollectionTime(), labelSets.get(i));
             }
           }

--- a/contrib/runtime_metrics/src/main/java/io/opentelemetry/contrib/metrics/runtime/MemoryPools.java
+++ b/contrib/runtime_metrics/src/main/java/io/opentelemetry/contrib/metrics/runtime/MemoryPools.java
@@ -95,12 +95,12 @@ public final class MemoryPools {
           public void update(ResultLongObserver resultLongObserver) {
             MemoryUsage heapUsage = memoryBean.getHeapMemoryUsage();
             MemoryUsage nonHeapUsage = memoryBean.getNonHeapMemoryUsage();
-            resultLongObserver.put(heapUsage.getUsed(), usedHeap);
-            resultLongObserver.put(nonHeapUsage.getUsed(), usedNonHeap);
-            resultLongObserver.put(heapUsage.getUsed(), committedHeap);
-            resultLongObserver.put(nonHeapUsage.getUsed(), committedNonHeap);
-            resultLongObserver.put(heapUsage.getUsed(), maxHeap);
-            resultLongObserver.put(nonHeapUsage.getUsed(), maxNonHeap);
+            resultLongObserver.observe(heapUsage.getUsed(), usedHeap);
+            resultLongObserver.observe(nonHeapUsage.getUsed(), usedNonHeap);
+            resultLongObserver.observe(heapUsage.getUsed(), committedHeap);
+            resultLongObserver.observe(nonHeapUsage.getUsed(), committedNonHeap);
+            resultLongObserver.observe(heapUsage.getUsed(), maxHeap);
+            resultLongObserver.observe(nonHeapUsage.getUsed(), maxNonHeap);
           }
         });
   }
@@ -131,11 +131,11 @@ public final class MemoryPools {
           public void update(ResultLongObserver resultLongObserver) {
             for (int i = 0; i < poolBeans.size(); i++) {
               MemoryUsage poolUsage = poolBeans.get(i).getUsage();
-              resultLongObserver.put(poolUsage.getUsed(), usedLabelSets.get(i));
-              resultLongObserver.put(poolUsage.getCommitted(), committedLabelSets.get(i));
+              resultLongObserver.observe(poolUsage.getUsed(), usedLabelSets.get(i));
+              resultLongObserver.observe(poolUsage.getCommitted(), committedLabelSets.get(i));
               // TODO: Decide if max is needed or not. May be derived with some approximation from
               //  max(used).
-              resultLongObserver.put(poolUsage.getMax(), maxLabelSets.get(i));
+              resultLongObserver.observe(poolUsage.getMax(), maxLabelSets.get(i));
             }
           }
         });

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/BaseInstrument.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/BaseInstrument.java
@@ -16,13 +16,13 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import io.opentelemetry.metrics.InstrumentWithBound;
+import io.opentelemetry.metrics.InstrumentWithBinding;
 import io.opentelemetry.metrics.LabelSet;
 import java.util.List;
 import java.util.Map;
 
 // TODO: add a BaseInstrument and a BaseInstrumentWithBounds.
-abstract class BaseInstrument<B> implements InstrumentWithBound<B> {
+abstract class BaseInstrument<B> implements InstrumentWithBinding<B> {
 
   private final String name;
   private final String description;

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/BaseInstrument.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/BaseInstrument.java
@@ -16,12 +16,13 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import io.opentelemetry.metrics.Instrument;
+import io.opentelemetry.metrics.InstrumentWithBound;
 import io.opentelemetry.metrics.LabelSet;
 import java.util.List;
 import java.util.Map;
 
-abstract class BaseInstrument<B> implements Instrument<B> {
+// TODO: add a BaseInstrument and a BaseInstrumentWithBounds.
+abstract class BaseInstrument<B> implements InstrumentWithBound<B> {
 
   private final String name;
   private final String description;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
@@ -19,7 +19,6 @@ package io.opentelemetry.sdk.metrics;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.metrics.Instrument;
-import io.opentelemetry.metrics.LabelSet;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -149,17 +148,5 @@ public class AbstractInstrumentBuilderTest {
     }
   }
 
-  private static final class TestInstrument implements Instrument<TestBound> {
-    private static final TestBound HANDLE = new TestBound();
-
-    @Override
-    public TestBound bind(LabelSet labelSet) {
-      return HANDLE;
-    }
-
-    @Override
-    public void unbind(TestBound boundInstrument) {}
-  }
-
-  private static final class TestBound {}
+  private static final class TestInstrument implements Instrument {}
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractObserverBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractObserverBuilderTest.java
@@ -18,9 +18,7 @@ package io.opentelemetry.sdk.metrics;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import io.opentelemetry.metrics.LabelSet;
 import io.opentelemetry.metrics.Observer;
-import javax.annotation.Nullable;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -76,22 +74,10 @@ public class AbstractObserverBuilderTest {
     }
   }
 
-  private static final class TestInstrument implements Observer<TestResult, TestBound> {
-
-    @Nullable
-    @Override
-    public TestBound bind(LabelSet labelSet) {
-      return null;
-    }
-
-    @Override
-    public void unbind(TestBound boundInstrument) {}
-
+  private static final class TestInstrument implements Observer<TestResult> {
     @Override
     public void setCallback(Callback<TestResult> metricUpdater) {}
   }
-
-  private static final class TestBound {}
 
   private static final class TestResult {}
 }


### PR DESCRIPTION
For more details see https://github.com/open-telemetry/oteps/blob/master/text/0072-metric-observer.md

Also rename the result method from `put` to `observe`.