### PR TITLE
Refactor the tracer registry logic in a shared class

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfo.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfo.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.sdk.common;
 
 import com.google.auto.value.AutoValue;
-import io.opentelemetry.internal.Utils;
 import io.opentelemetry.sdk.trace.TracerSdk;
 import io.opentelemetry.sdk.trace.TracerSdkRegistry;
 import javax.annotation.Nullable;
@@ -41,14 +40,13 @@ public abstract class InstrumentationLibraryInfo {
    * @return the new instance
    */
   public static InstrumentationLibraryInfo create(String name, @Nullable String version) {
-    Utils.checkNotNull(name, "name");
     return new AutoValue_InstrumentationLibraryInfo(name, version);
   }
 
-  public abstract String name();
+  public abstract String getName();
 
   @Nullable
-  public abstract String version();
+  public abstract String getVersion();
 
   // Package protected ctor to avoid others to extend this class.
   InstrumentationLibraryInfo() {}

--- a/sdk/src/main/java/io/opentelemetry/sdk/internal/ComponentRegistry.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/internal/ComponentRegistry.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.internal;
+
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
+
+/**
+ * Base class for all the registry classes (Tracer, Meter, etc.).
+ *
+ * @param <V> the type of the registered value.
+ */
+public abstract class ComponentRegistry<V> {
+  private final Object lock = new Object();
+  private final Map<InstrumentationLibraryInfo, V> registry = new ConcurrentHashMap<>();
+
+  /**
+   * Returns the registered value associated with this name and {@code null} version if any,
+   * otherwise creates a new instance and associates it with the given name and {@code null}
+   * version.
+   *
+   * @param instrumentationName the name of the instrumentation library.
+   * @return the registered value associated with this name and {@code null} version.
+   */
+  public V get(String instrumentationName) {
+    return get(instrumentationName, null);
+  }
+
+  /**
+   * Returns the registered value associated with this name and version if any, otherwise creates a
+   * new instance and associates it with the given name and version.
+   *
+   * @param instrumentationName the name of the instrumentation library.
+   * @param instrumentationVersion the version of the instrumentation library.
+   * @return the registered value associated with this name and version.
+   */
+  public V get(String instrumentationName, @Nullable String instrumentationVersion) {
+    InstrumentationLibraryInfo instrumentationLibraryInfo =
+        InstrumentationLibraryInfo.create(instrumentationName, instrumentationVersion);
+    V tracer = registry.get(instrumentationLibraryInfo);
+    if (tracer == null) {
+      synchronized (lock) {
+        // Re-check if the value was added since the previous check, this can happen if multiple
+        // threads try to access the same named tracer during the same time. This way we ensure that
+        // we create only one TracerSdk per name.
+        tracer = registry.get(instrumentationLibraryInfo);
+        if (tracer != null) {
+          // A different thread already added the named Tracer, just reuse.
+          return tracer;
+        }
+        tracer = newComponent(instrumentationLibraryInfo);
+        registry.put(instrumentationLibraryInfo, tracer);
+      }
+    }
+    return tracer;
+  }
+
+  public abstract V newComponent(InstrumentationLibraryInfo instrumentationLibraryInfo);
+}

--- a/sdk/src/test/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfoTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfoTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.common;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link InstrumentationLibraryInfo}. */
+@RunWith(JUnit4.class)
+public class InstrumentationLibraryInfoTest {
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void emptyLibraryInfo() {
+    assertThat(InstrumentationLibraryInfo.EMPTY.getName()).isEmpty();
+    assertThat(InstrumentationLibraryInfo.EMPTY.getVersion()).isNull();
+  }
+
+  @Test
+  public void nullName() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("name");
+    InstrumentationLibraryInfo.create(null, "semver:1.0.0");
+  }
+}

--- a/sdk/src/test/java/io/opentelemetry/sdk/internal/ComponentRegistryTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/internal/ComponentRegistryTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link InstrumentationLibraryInfo}. */
+@RunWith(JUnit4.class)
+public class ComponentRegistryTest {
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  private static final String INSTRUMENTATION_NAME = "test_name";
+  private static final String INSTRUMENTATION_VERSION = "version";
+  private final ComponentRegistry<TestComponent> registry =
+      new ComponentRegistry<TestComponent>() {
+        @Override
+        public TestComponent newComponent(InstrumentationLibraryInfo instrumentationLibraryInfo) {
+          return new TestComponent(instrumentationLibraryInfo);
+        }
+      };
+
+  @Test
+  public void libraryName_MustNotBeNull() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("name");
+    registry.get(null, "version");
+  }
+
+  @Test
+  public void libraryVersion_AllowsNull() {
+    TestComponent testComponent = registry.get(INSTRUMENTATION_NAME, null);
+    assertThat(testComponent).isNotNull();
+    assertThat(testComponent.instrumentationLibraryInfo.getName()).isEqualTo(INSTRUMENTATION_NAME);
+    assertThat(testComponent.instrumentationLibraryInfo.getVersion()).isNull();
+  }
+
+  @Test
+  public void getSameInstanceForSameName_WithoutVersion() {
+    assertThat(registry.get(INSTRUMENTATION_NAME))
+        .isSameInstanceAs(registry.get(INSTRUMENTATION_NAME));
+    assertThat(registry.get(INSTRUMENTATION_NAME))
+        .isSameInstanceAs(registry.get(INSTRUMENTATION_NAME, null));
+  }
+
+  @Test
+  public void getSameInstanceForSameName_WithVersion() {
+    assertThat(registry.get(INSTRUMENTATION_NAME, INSTRUMENTATION_VERSION))
+        .isSameInstanceAs(registry.get(INSTRUMENTATION_NAME, INSTRUMENTATION_VERSION));
+  }
+
+  @Test
+  public void getDifferentInstancesForDifferentNames() {
+    assertThat(registry.get(INSTRUMENTATION_NAME, INSTRUMENTATION_VERSION))
+        .isNotSameInstanceAs(registry.get(INSTRUMENTATION_NAME + "_2", INSTRUMENTATION_VERSION));
+  }
+
+  @Test
+  public void getDifferentInstancesForDifferentVersions() {
+    assertThat(registry.get(INSTRUMENTATION_NAME, INSTRUMENTATION_VERSION))
+        .isNotSameInstanceAs(registry.get(INSTRUMENTATION_NAME, INSTRUMENTATION_VERSION + "_1"));
+  }
+
+  private static final class TestComponent {
+    private final InstrumentationLibraryInfo instrumentationLibraryInfo;
+
+    private TestComponent(InstrumentationLibraryInfo instrumentationLibraryInfo) {
+      this.instrumentationLibraryInfo = instrumentationLibraryInfo;
+    }
+  }
+}

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkRegistryTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkRegistryTest.java
@@ -47,16 +47,6 @@ public class TracerSdkRegistryTest {
     assertThat(tracerFactory.get("test")).isInstanceOf(TracerSdk.class);
   }
 
-  @Test(expected = NullPointerException.class)
-  public void libraryName_MustNotBeNull() {
-    tracerFactory.get(null);
-  }
-
-  @Test
-  public void libraryVersion_AllowsNull() {
-    assertThat(tracerFactory.get("name", null)).isNotNull();
-  }
-
   @Test
   public void getSameInstanceForSameName_WithoutVersion() {
     assertThat(tracerFactory.get("test")).isSameInstanceAs(tracerFactory.get("test"));
@@ -70,22 +60,10 @@ public class TracerSdkRegistryTest {
   }
 
   @Test
-  public void getDifferentInstancesForDifferentNames() {
-    assertThat(tracerFactory.get("test1", null))
-        .isNotSameInstanceAs(tracerFactory.get("test2", null));
-  }
-
-  @Test
-  public void getDifferentInstancesForDifferentVersions() {
-    assertThat(tracerFactory.get("test", "version1"))
-        .isNotSameInstanceAs(tracerFactory.get("test", "version2"));
-  }
-
-  @Test
   public void propagatesInstrumentationLibraryInfoToTracer() {
     InstrumentationLibraryInfo expected =
         InstrumentationLibraryInfo.create("theName", "theVersion");
-    TracerSdk tracer = tracerFactory.get(expected.name(), expected.version());
+    TracerSdk tracer = tracerFactory.get(expected.getName(), expected.getVersion());
     assertThat(tracer.getInstrumentationLibraryInfo()).isEqualTo(expected);
   }
 


### PR DESCRIPTION
The main idea is to use the ComponentRegistry for MeterSdk as well.