### PR TITLE
Use the component registry in metrics, add a shared state

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
@@ -27,10 +27,26 @@ import io.opentelemetry.metrics.LongGauge;
 import io.opentelemetry.metrics.LongMeasure;
 import io.opentelemetry.metrics.LongObserver;
 import io.opentelemetry.metrics.Meter;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import java.util.Map;
 
 /** {@link MeterSdk} is SDK implementation of {@link Meter}. */
-public class MeterSdk implements Meter {
+final class MeterSdk implements Meter {
+  private final MeterSharedState sharedState;
+  private final InstrumentationLibraryInfo instrumentationLibraryInfo;
+
+  MeterSdk(MeterSharedState sharedState, InstrumentationLibraryInfo instrumentationLibraryInfo) {
+    this.sharedState = sharedState;
+    this.instrumentationLibraryInfo = instrumentationLibraryInfo;
+  }
+
+  InstrumentationLibraryInfo getInstrumentationLibraryInfo() {
+    return instrumentationLibraryInfo;
+  }
+
+  MeterSharedState getSharedState() {
+    return sharedState;
+  }
 
   @Override
   public LongGauge.Builder longGaugeBuilder(String name) {

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdkRegistry.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdkRegistry.java
@@ -92,7 +92,7 @@ public class MeterSdkRegistry implements MeterRegistry {
      * @return this
      */
     public Builder setResource(@Nonnull Resource resource) {
-      Utils.checkNotNull(resource, "The Resource must be non-null");
+      Utils.checkNotNull(resource, "resource");
       this.resource = resource;
       return this;
     }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdkRegistry.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdkRegistry.java
@@ -16,11 +16,15 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import io.opentelemetry.metrics.Meter;
+import io.opentelemetry.internal.Utils;
 import io.opentelemetry.metrics.MeterRegistry;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import io.opentelemetry.sdk.common.Clock;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.internal.ComponentRegistry;
+import io.opentelemetry.sdk.internal.MillisClock;
+import io.opentelemetry.sdk.resources.EnvVarResource;
+import io.opentelemetry.sdk.resources.Resource;
+import javax.annotation.Nonnull;
 
 /**
  * {@code Meter} provider implementation for {@link MeterRegistry}.
@@ -29,24 +33,90 @@ import java.util.Map;
  * io.opentelemetry.OpenTelemetry}.
  */
 public class MeterSdkRegistry implements MeterRegistry {
-  private final Map<String, Meter> metersByKey =
-      Collections.synchronizedMap(new HashMap<String, Meter>());
+  private final MeterSharedState sharedState;
+  private final MeterSdkComponentRegistry registry;
 
-  @Override
-  public Meter get(String instrumentationName) {
-    return get(instrumentationName, null);
+  private MeterSdkRegistry(Clock clock, Resource resource) {
+    this.sharedState = new MeterSharedState(clock, resource);
+    this.registry = new MeterSdkComponentRegistry(sharedState);
   }
 
   @Override
-  public Meter get(String instrumentationName, String instrumentationVersion) {
-    String key = instrumentationName + "/" + instrumentationVersion;
-    Meter meter = metersByKey.get(key);
+  public MeterSdk get(String instrumentationName) {
+    return registry.get(instrumentationName);
+  }
 
-    if (meter == null) {
-      meter = new MeterSdk();
-      metersByKey.put(key, meter);
+  @Override
+  public MeterSdk get(String instrumentationName, String instrumentationVersion) {
+    return registry.get(instrumentationName, instrumentationVersion);
+  }
+
+  /**
+   * Returns a new {@link Builder} for {@link MeterSdkRegistry}.
+   *
+   * @return a new {@link Builder} for {@link MeterSdkRegistry}.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder class for the {@link MeterSdkRegistry}. Has fully functional default implementations of
+   * all three required interfaces.
+   *
+   * @since 0.4.0
+   */
+  public static final class Builder {
+
+    private Clock clock = MillisClock.getInstance();
+    private Resource resource = EnvVarResource.getResource();
+
+    private Builder() {}
+
+    /**
+     * Assign a {@link Clock}.
+     *
+     * @param clock The clock to use for all temporal needs.
+     * @return this
+     */
+    public Builder setClock(@Nonnull Clock clock) {
+      Utils.checkNotNull(clock, "clock");
+      this.clock = clock;
+      return this;
     }
 
-    return meter;
+    /**
+     * Assign a {@link Resource} to be attached to all Spans created by Tracers.
+     *
+     * @param resource A Resource implementation.
+     * @return this
+     */
+    public Builder setResource(@Nonnull Resource resource) {
+      Utils.checkNotNull(resource, "The Resource must be non-null");
+      this.resource = resource;
+      return this;
+    }
+
+    /**
+     * Create a new TracerSdkFactory instance.
+     *
+     * @return An initialized TracerSdkFactory.
+     */
+    public MeterSdkRegistry build() {
+      return new MeterSdkRegistry(clock, resource);
+    }
+  }
+
+  private static final class MeterSdkComponentRegistry extends ComponentRegistry<MeterSdk> {
+    private final MeterSharedState sharedState;
+
+    private MeterSdkComponentRegistry(MeterSharedState sharedState) {
+      this.sharedState = sharedState;
+    }
+
+    @Override
+    public MeterSdk newComponent(InstrumentationLibraryInfo instrumentationLibraryInfo) {
+      return new MeterSdk(sharedState, instrumentationLibraryInfo);
+    }
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSharedState.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSharedState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,23 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
+import io.opentelemetry.sdk.common.Clock;
+import io.opentelemetry.sdk.resources.Resource;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+final class MeterSharedState {
+  private final Clock clock;
+  private final Resource resource;
 
-@RunWith(JUnit4.class)
-public class MeterSdkProviderTest {
+  MeterSharedState(Clock clock, Resource resource) {
+    this.clock = clock;
+    this.resource = resource;
+  }
 
-  @Test
-  public void testDefault() {
-    assertThat(new SdkMetricsProvider().create()).isInstanceOf(MeterSdkRegistry.class);
+  Clock getClock() {
+    return clock;
+  }
+
+  Resource getResource() {
+    return resource;
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkRegistryTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkRegistryTest.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.sdk.metrics;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 import io.opentelemetry.sdk.common.Clock;
@@ -38,23 +37,25 @@ public class MeterSdkRegistryTest {
 
   @Test
   public void builder_HappyPath() {
-    MeterSdkRegistry registry =
-        MeterSdkRegistry.builder()
-            .setClock(mock(Clock.class))
-            .setResource(mock(Resource.class))
-            .build();
-    assertNotNull(registry);
+    assertThat(
+            MeterSdkRegistry.builder()
+                .setClock(mock(Clock.class))
+                .setResource(mock(Resource.class))
+                .build())
+        .isNotNull();
   }
 
   @Test
   public void builder_NullClock() {
     thrown.expect(NullPointerException.class);
+    thrown.expectMessage("clock");
     MeterSdkRegistry.builder().setClock(null);
   }
 
   @Test
   public void builder_NullResource() {
     thrown.expect(NullPointerException.class);
+    thrown.expectMessage("resource");
     MeterSdkRegistry.builder().setResource(null);
   }
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkRegistryTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkRegistryTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+import io.opentelemetry.sdk.common.Clock;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link MeterSdkRegistry}. */
+@RunWith(JUnit4.class)
+public class MeterSdkRegistryTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+  private final MeterSdkRegistry meterRegistry = MeterSdkRegistry.builder().build();
+
+  @Test
+  public void builder_HappyPath() {
+    MeterSdkRegistry registry =
+        MeterSdkRegistry.builder()
+            .setClock(mock(Clock.class))
+            .setResource(mock(Resource.class))
+            .build();
+    assertNotNull(registry);
+  }
+
+  @Test
+  public void builder_NullClock() {
+    thrown.expect(NullPointerException.class);
+    MeterSdkRegistry.builder().setClock(null);
+  }
+
+  @Test
+  public void builder_NullResource() {
+    thrown.expect(NullPointerException.class);
+    MeterSdkRegistry.builder().setResource(null);
+  }
+
+  @Test
+  public void defaultGet() {
+    assertThat(meterRegistry.get("test")).isInstanceOf(MeterSdk.class);
+  }
+
+  @Test
+  public void getSameInstanceForSameName_WithoutVersion() {
+    assertThat(meterRegistry.get("test")).isSameInstanceAs(meterRegistry.get("test"));
+    assertThat(meterRegistry.get("test")).isSameInstanceAs(meterRegistry.get("test", null));
+  }
+
+  @Test
+  public void getSameInstanceForSameName_WithVersion() {
+    assertThat(meterRegistry.get("test", "version"))
+        .isSameInstanceAs(meterRegistry.get("test", "version"));
+  }
+
+  @Test
+  public void propagatesInstrumentationLibraryInfoToTracer() {
+    InstrumentationLibraryInfo expected =
+        InstrumentationLibraryInfo.create("theName", "theVersion");
+    MeterSdk meter = meterRegistry.get(expected.getName(), expected.getVersion());
+    assertThat(meter.getInstrumentationLibraryInfo()).isEqualTo(expected);
+  }
+}

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
@@ -29,11 +29,11 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link MeterSdk}. */
 @RunWith(JUnit4.class)
 public class MeterSdkTest {
+  private final MeterSdk testSdk =
+      new SdkMetricsProvider().create().get("io.opentelemetry.sdk.metrics.MeterSdkTest");
 
   @Test
   public void testLongCounter() {
-    MeterSdk testSdk = new MeterSdk();
-
     LongCounter longCounter =
         testSdk
             .longCounterBuilder("testCounter")
@@ -51,8 +51,6 @@ public class MeterSdkTest {
 
   @Test
   public void testDoubleCounter() {
-    MeterSdk testSdk = new MeterSdk();
-
     DoubleCounter doubleCounter =
         testSdk
             .doubleCounterBuilder("testCounter")
@@ -70,8 +68,6 @@ public class MeterSdkTest {
 
   @Test
   public void testLabelSets() {
-    MeterSdk testSdk = new MeterSdk();
-
     assertThat(testSdk.createLabelSet()).isSameInstanceAs(testSdk.createLabelSet());
     assertThat(testSdk.createLabelSet())
         .isSameInstanceAs(testSdk.createLabelSet(Collections.<String, String>emptyMap()));

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleCounterTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleCounterTest.java
@@ -34,10 +34,11 @@ import org.junit.runners.JUnit4;
 public class SdkDoubleCounterTest {
 
   @Rule public ExpectedException thrown = ExpectedException.none();
+  private final MeterSdk testSdk =
+      new SdkMetricsProvider().create().get("io.opentelemetry.sdk.metrics.SdkDoubleCounterTest");
 
   @Test
   public void testDoubleCounter() {
-    MeterSdk testSdk = new MeterSdk();
     LabelSet labelSet = testSdk.createLabelSet("K", "v");
 
     DoubleCounter doubleCounter =
@@ -62,8 +63,6 @@ public class SdkDoubleCounterTest {
 
   @Test
   public void testDoubleCounter_monotonicity() {
-    MeterSdk testSdk = new MeterSdk();
-
     DoubleCounter doubleCounter =
         SdkDoubleCounter.Builder.builder("testCounter").setMonotonic(true).build();
 
@@ -73,8 +72,6 @@ public class SdkDoubleCounterTest {
 
   @Test
   public void testBoundDoubleCounter_monotonicity() {
-    MeterSdk testSdk = new MeterSdk();
-
     DoubleCounter doubleCounter =
         SdkDoubleCounter.Builder.builder("testCounter").setMonotonic(true).build();
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleMeasureTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleMeasureTest.java
@@ -34,10 +34,11 @@ import org.junit.runners.JUnit4;
 public class SdkDoubleMeasureTest {
 
   @Rule public ExpectedException thrown = ExpectedException.none();
+  private final MeterSdk testSdk =
+      new SdkMetricsProvider().create().get("io.opentelemetry.sdk.metrics.SdkDoubleMeasureTest");
 
   @Test
   public void testDoubleMeasure() {
-    MeterSdk testSdk = new MeterSdk();
     LabelSet labelSet = testSdk.createLabelSet("K", "v");
 
     DoubleMeasure doubleMeasure =
@@ -62,8 +63,6 @@ public class SdkDoubleMeasureTest {
 
   @Test
   public void testDoubleMeasure_absolute() {
-    MeterSdk testSdk = new MeterSdk();
-
     DoubleMeasure doubleMeasure =
         SdkDoubleMeasure.Builder.builder("testMeasure").setAbsolute(true).build();
 
@@ -73,8 +72,6 @@ public class SdkDoubleMeasureTest {
 
   @Test
   public void testBoundDoubleMeasure_absolute() {
-    MeterSdk testSdk = new MeterSdk();
-
     DoubleMeasure doubleMeasure =
         SdkDoubleMeasure.Builder.builder("testMeasure").setAbsolute(true).build();
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/SdkLongCounterTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/SdkLongCounterTest.java
@@ -34,10 +34,11 @@ import org.junit.runners.JUnit4;
 public class SdkLongCounterTest {
 
   @Rule public ExpectedException thrown = ExpectedException.none();
+  private final MeterSdk testSdk =
+      new SdkMetricsProvider().create().get("io.opentelemetry.sdk.metrics.SdkLongCounterTest");
 
   @Test
   public void testLongCounter() {
-    MeterSdk testSdk = new MeterSdk();
     LabelSet labelSet = testSdk.createLabelSet("K", "v");
 
     LongCounter longCounter =
@@ -62,8 +63,6 @@ public class SdkLongCounterTest {
 
   @Test
   public void testLongCounter_monotonicity() {
-    MeterSdk testSdk = new MeterSdk();
-
     LongCounter longCounter =
         SdkLongCounter.Builder.builder("testCounter").setMonotonic(true).build();
 
@@ -73,8 +72,6 @@ public class SdkLongCounterTest {
 
   @Test
   public void testBoundLongCounter_monotonicity() {
-    MeterSdk testSdk = new MeterSdk();
-
     LongCounter longCounter =
         SdkLongCounter.Builder.builder("testCounter").setMonotonic(true).build();
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/SdkLongMeasureTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/SdkLongMeasureTest.java
@@ -34,10 +34,11 @@ import org.junit.runners.JUnit4;
 public class SdkLongMeasureTest {
 
   @Rule public ExpectedException thrown = ExpectedException.none();
+  private final MeterSdk testSdk =
+      new SdkMetricsProvider().create().get("io.opentelemetry.sdk.metrics.SdkLongMeasureTest");
 
   @Test
   public void testLongMeasure() {
-    MeterSdk testSdk = new MeterSdk();
     LabelSet labelSet = testSdk.createLabelSet("K", "v");
 
     LongMeasure longMeasure =
@@ -62,8 +63,6 @@ public class SdkLongMeasureTest {
 
   @Test
   public void testLongMeasure_absolute() {
-    MeterSdk testSdk = new MeterSdk();
-
     LongMeasure longMeasure =
         SdkLongMeasure.Builder.builder("testMeasure").setAbsolute(true).build();
 
@@ -73,8 +72,6 @@ public class SdkLongMeasureTest {
 
   @Test
   public void testBoundLongMeasure_absolute() {
-    MeterSdk testSdk = new MeterSdk();
-
     LongMeasure longMeasure =
         SdkLongMeasure.Builder.builder("testMeasure").setAbsolute(true).build();
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/SdkMetricsProviderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/SdkMetricsProviderTest.java
@@ -16,18 +16,18 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import io.opentelemetry.metrics.spi.MetricsProvider;
+import static com.google.common.truth.Truth.assertThat;
 
-/**
- * {@code MeterRegistry} provider implementation for {@link MetricsProvider}.
- *
- * <p>This class is not intended to be used in application code and it is used only by {@link
- * io.opentelemetry.OpenTelemetry}.
- */
-public class SdkMetricsProvider implements MetricsProvider {
+import io.opentelemetry.OpenTelemetry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
-  @Override
-  public MeterSdkRegistry create() {
-    return MeterSdkRegistry.builder().build();
+/** Unit tests for {@link SdkMetricsProvider}. */
+@RunWith(JUnit4.class)
+public class SdkMetricsProviderTest {
+  @Test
+  public void testDefault() {
+    assertThat(OpenTelemetry.getMeterRegistry()).isInstanceOf(MeterSdkRegistry.class);
   }
 }


### PR DESCRIPTION
In this PR:
* Make use of the newly added ComponentRegistry in metrics;
* Add a Builder class for the MeterSdkRegistry;
* Add a Shared state class between MeterSdks, this class will start to be used soon;