### PR TITLE
Rename StringUtils.isNullOrBlank to isNullOrEmpty

### DIFF
--- a/api/src/main/java/io/opentelemetry/internal/StringUtils.java
+++ b/api/src/main/java/io/opentelemetry/internal/StringUtils.java
@@ -41,7 +41,7 @@ public final class StringUtils {
     return ch >= ' ' && ch <= '~';
   }
 
-  public static boolean isNullOrBlank(String value) {
+  public static boolean isNullOrEmpty(String value) {
     return value == null || value.length() == 0;
   }
 

--- a/api/src/test/java/io/opentelemetry/internal/StringUtilsTest.java
+++ b/api/src/test/java/io/opentelemetry/internal/StringUtilsTest.java
@@ -34,8 +34,9 @@ public final class StringUtilsTest {
 
   @Test
   public void isNullOrEmpty() throws Exception {
-    assertThat(StringUtils.isNullOrBlank("")).isTrue();
-    assertThat(StringUtils.isNullOrBlank(null)).isTrue();
-    assertThat(StringUtils.isNullOrBlank("hello")).isFalse();
+    assertThat(StringUtils.isNullOrEmpty("")).isTrue();
+    assertThat(StringUtils.isNullOrEmpty(null)).isTrue();
+    assertThat(StringUtils.isNullOrEmpty("hello")).isFalse();
+    assertThat(StringUtils.isNullOrEmpty(" ")).isFalse();
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -318,7 +318,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   public void setAttribute(String key, AttributeValue value) {
     Preconditions.checkNotNull(key, "key");
     Preconditions.checkNotNull(value, "value");
-    if (value.getType() == Type.STRING && StringUtils.isNullOrBlank(value.getStringValue())) {
+    if (value.getType() == Type.STRING && StringUtils.isNullOrEmpty(value.getStringValue())) {
       return;
     }
     synchronized (lock) {

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -169,7 +169,7 @@ final class SpanBuilderSdk implements Span.Builder {
   public Span.Builder setAttribute(String key, AttributeValue value) {
     Utils.checkNotNull(key, "key");
     Utils.checkNotNull(value, "value");
-    if (value.getType() == Type.STRING && StringUtils.isNullOrBlank(value.getStringValue())) {
+    if (value.getType() == Type.STRING && StringUtils.isNullOrEmpty(value.getStringValue())) {
       return this;
     }
     attributes.putAttribute(key, value);


### PR DESCRIPTION
`isNullOrBlank` usually means null, empty, or only consisting of whitespace (cf. Kotlin's 
[`isNullOrBlank`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/is-null-or-blank.html), for example) so I renamed it to what it actually does to avoid confusion