### PR TITLE
Remove incorrect `@throws NullPointerException` in AttributeValue

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/AttributeValue.java
+++ b/api/src/main/java/io/opentelemetry/trace/AttributeValue.java
@@ -47,7 +47,6 @@ public abstract class AttributeValue {
    *
    * @param stringValue The new value.
    * @return an {@code AttributeValue} with a string value.
-   * @throws NullPointerException if {@code stringValue} is {@code null}.
    * @since 0.1.0
    */
   public static AttributeValue stringAttributeValue(String stringValue) {


### PR DESCRIPTION
Is actually doesn't throw (`RecordEventsReadableSpanTest.setAttribute`).

https://github.com/open-telemetry/opentelemetry-java/blob/8b4c1488e936f42783396ebb9c44092364f7a339/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java#L284-L289

Regarding error handling, the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/error-handling.md) defines:
> API methods MUST NOT throw unhandled exceptions when used incorrectly by end users. The API and SDK SHOULD provide safe defaults for missing or invalid arguments. For instance, a name like `empty` may be used if the user passes in `null` as the span name argument during `Span` construction.
