### PR TITLE
Fix Observer API examples in Javadoc 

### DIFF
--- a/api/src/main/java/io/opentelemetry/metrics/DoubleObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleObserver.java
@@ -34,14 +34,15 @@ import javax.annotation.concurrent.ThreadSafe;
  *           .setDescription("gRPC Latency")
  *           .setUnit("ms")
  *           .build();
+ *   private static final LabelSet labelSet = meter.createLabelSet("my_label");
  *
  *   void init() {
  *     observer.setCallback(
- *         new DoubleObserver.Callback<DoubleObserver.Result>() {
+ *         new DoubleObserver.Callback<DoubleObserver.ResultDoubleObserver>() {
  *           final AtomicInteger count = new AtomicInteger(0);
  *          {@literal @}Override
  *           public void update(Result result) {
- *             result.put(observer.bind(labelSet), 0.8 * count.addAndGet(1));
+ *             result.observe(0.8 * count.addAndGet(1), labelSet);
  *           }
  *         });
  *   }

--- a/api/src/main/java/io/opentelemetry/metrics/LongObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongObserver.java
@@ -34,14 +34,15 @@ import javax.annotation.concurrent.ThreadSafe;
  *           .setDescription("gRPC Latency")
  *           .setUnit("ms")
  *           .build();
+ *   private static final LabelSet labelSet = meter.createLabelSet("my_label");
  *
  *   void init() {
  *     observer.setCallback(
- *         new LongObserver.Callback<LongObserver.Result>() {
+ *         new LongObserver.Callback<LongObserver.ResultLongObserver>() {
  *           final AtomicInteger count = new AtomicInteger(0);
  *          {@literal @}Override
  *           public void update(ResultLongObserver result) {
- *             result.put(observer.bind(labelset), count.addAndGet(1));
+ *             result.observe(count.addAndGet(1), labelSet);
  *           }
  *         });
  *   }


### PR DESCRIPTION
This PR closes #824 aligning the examples in the API documentation with the implementation of the Observer meter. 