### PR TITLE
add the missing enclosing interface

### DIFF
--- a/api/src/main/java/io/opentelemetry/metrics/DoubleCounter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleCounter.java
@@ -73,7 +73,7 @@ public interface DoubleCounter extends Counter<BoundDoubleCounter> {
    * @since 0.1.0
    */
   @ThreadSafe
-  interface BoundDoubleCounter extends BoundInstrument {
+  interface BoundDoubleCounter extends InstrumentWithBinding.BoundInstrument {
     /**
      * Adds the given {@code delta} to the current value. The values can be negative iff monotonic
      * was set to {@code false}.

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleMeasure.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleMeasure.java
@@ -69,7 +69,7 @@ public interface DoubleMeasure extends Measure<BoundDoubleMeasure> {
    * @since 0.1.0
    */
   @ThreadSafe
-  interface BoundDoubleMeasure extends BoundInstrument {
+  interface BoundDoubleMeasure extends InstrumentWithBinding.BoundInstrument {
     /**
      * Records the given measurement, associated with the current {@code Context}.
      *

--- a/api/src/main/java/io/opentelemetry/metrics/LongCounter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongCounter.java
@@ -73,7 +73,7 @@ public interface LongCounter extends Counter<BoundLongCounter> {
    * @since 0.1.0
    */
   @ThreadSafe
-  interface BoundLongCounter extends BoundInstrument {
+  interface BoundLongCounter extends InstrumentWithBinding.BoundInstrument {
 
     /**
      * Adds the given {@code delta} to the current value. The values can be negative iff monotonic

--- a/api/src/main/java/io/opentelemetry/metrics/LongMeasure.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongMeasure.java
@@ -69,7 +69,7 @@ public interface LongMeasure extends Measure<BoundLongMeasure> {
    * @since 0.1.0
    */
   @ThreadSafe
-  interface BoundLongMeasure extends BoundInstrument {
+  interface BoundLongMeasure extends InstrumentWithBinding.BoundInstrument {
     /**
      * Records the given measurement, associated with the current {@code Context}.
      *


### PR DESCRIPTION
This causes warnings, and with some compilers, errors. Adding the enclosing interface reference quiets that down.