### PR TITLE
Implementing ForceFlush for SpanProcessor

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/MultiSpanProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/MultiSpanProcessor.java
@@ -62,6 +62,13 @@ public final class MultiSpanProcessor implements SpanProcessor {
     }
   }
 
+  @Override
+  public void forceFlush() {
+    for (SpanProcessor spanProcessor : spanProcessors) {
+      spanProcessor.forceFlush();
+    }
+  }
+
   private MultiSpanProcessor(List<SpanProcessor> spanProcessors) {
     this.spanProcessors = spanProcessors;
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/NoopSpanProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/NoopSpanProcessor.java
@@ -32,5 +32,8 @@ final class NoopSpanProcessor implements SpanProcessor {
   @Override
   public void shutdown() {}
 
+  @Override
+  public void forceFlush() {}
+
   private NoopSpanProcessor() {}
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
@@ -52,7 +52,8 @@ public interface SpanProcessor {
   /**
    * Exports all ended spans that have not yet been exported.
    *
-   * <p>This method is called synchronously on the execution thread, should not throw or block the
+   * <p>This method is called synchronously on the execution thread, and should not throw exceptions 
+             or block the execution thread.
    * execution thread.
    */
   void forceFlush();

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
@@ -52,8 +52,8 @@ public interface SpanProcessor {
   /**
    * Exports all ended spans that have not yet been exported.
    *
-   * <p>This method is called synchronously on the execution thread, and should not throw exceptions
-   * or block the execution thread. execution thread.
+   * <p>This method is called synchronously on the execution thread, and should not throw
+   * exceptions.
    */
   void forceFlush();
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
@@ -48,4 +48,12 @@ public interface SpanProcessor {
 
   /** Called when {@link TracerSdkRegistry#shutdown()} is called. */
   void shutdown();
+
+  /**
+   * Exports all ended spans that have not yet been exported.
+   *
+   * <p>This method is called synchronously on the execution thread, should not throw or block the
+   * execution thread.
+   */
+  void forceFlush();
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
@@ -52,9 +52,8 @@ public interface SpanProcessor {
   /**
    * Exports all ended spans that have not yet been exported.
    *
-   * <p>This method is called synchronously on the execution thread, and should not throw exceptions 
-             or block the execution thread.
-   * execution thread.
+   * <p>This method is called synchronously on the execution thread, and should not throw exceptions
+   * or block the execution thread. execution thread.
    */
   void forceFlush();
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessor.java
@@ -96,6 +96,11 @@ public final class BatchSpansProcessor implements SpanProcessor {
     worker.flush();
   }
 
+  @Override
+  public void forceFlush() {
+    worker.forceFlush();
+  }
+
   /**
    * Returns a new Builder for {@link BatchSpansProcessor}.
    *
@@ -315,6 +320,11 @@ public final class BatchSpansProcessor implements SpanProcessor {
     }
 
     private void flush() {
+      forceFlush();
+      executorService.shutdown();
+    }
+
+    private void forceFlush() {
       ArrayList<ReadableSpan> spansCopy;
       synchronized (monitor) {
         spansCopy = new ArrayList<>(spansList);
@@ -322,7 +332,6 @@ public final class BatchSpansProcessor implements SpanProcessor {
       }
       // Execute the batch export outside the synchronized to not block all producers.
       exportBatches(spansCopy);
-      executorService.shutdown();
     }
 
     private void exportBatches(ArrayList<ReadableSpan> spanList) {

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessor.java
@@ -93,7 +93,7 @@ public final class BatchSpansProcessor implements SpanProcessor {
   @Override
   public void shutdown() {
     workerThread.interrupt();
-    worker.flush();
+    worker.shutdown();
   }
 
   @Override
@@ -319,7 +319,7 @@ public final class BatchSpansProcessor implements SpanProcessor {
       }
     }
 
-    private void flush() {
+    private void shutdown() {
       forceFlush();
       executorService.shutdown();
     }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpansProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpansProcessor.java
@@ -64,6 +64,11 @@ public final class SimpleSpansProcessor implements SpanProcessor {
     spanExporter.shutdown();
   }
 
+  @Override
+  public void forceFlush() {
+    // Do nothing.
+  }
+
   /**
    * Returns a new Builder for {@link SimpleSpansProcessor}.
    *

--- a/sdk_contrib/async_processor/src/main/java/io/opentelemetry/sdk/contrib/trace/export/DisruptorAsyncSpanProcessor.java
+++ b/sdk_contrib/async_processor/src/main/java/io/opentelemetry/sdk/contrib/trace/export/DisruptorAsyncSpanProcessor.java
@@ -59,6 +59,11 @@ public final class DisruptorAsyncSpanProcessor implements SpanProcessor {
     disruptorEventQueue.shutdown();
   }
 
+  @Override
+  public void forceFlush() {
+    disruptorEventQueue.forceFlush();
+  }
+
   /**
    * Returns a new Builder for {@link DisruptorAsyncSpanProcessor}.
    *


### PR DESCRIPTION
With https://github.com/open-telemetry/opentelemetry-specification/pull/370, the `SpanProcessor` interface changed introducing a new `ForceFlush()` method. 

Should we also provide a `ForceFlush(int, TimeUnit)` interface to configure an upper-bound time limit?

This also addresses #794.