### PR TITLE
Add instrumentation to the BatchSpansProcessor to count the number of dropped spans

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessor.java
@@ -238,7 +238,7 @@ public final class BatchSpansProcessor implements SpanProcessor {
   private static final class Worker implements Runnable {
 
     static {
-      Meter meter = OpenTelemetry.getMeterRegistry().get("opentelemetry");
+      Meter meter = OpenTelemetry.getMeterRegistry().get("io.opentelemetry.sdk.trace");
       LongCounter droppedSpansCounter =
           meter
               .longCounterBuilder("droppedSpans")


### PR DESCRIPTION
related to #766 

Is this the pattern that we think makes sense to use for instrumenting the SDK? Does this style of usage introduce a race condition in the creation of the SDKs? Does it mandate that the MeterSdk is created and installed before the TracerSdk is installed? Is there a better pattern to use?