### PR TITLE
Add a MeterSharedState class that includes the InstrumentationLibraryinfo

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/internal/ComponentRegistry.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/internal/ComponentRegistry.java
@@ -22,7 +22,7 @@ import java.util.concurrent.ConcurrentMap;
 import javax.annotation.Nullable;
 
 /**
- * Base class for all the registry classes (Tracer, Meter, etc.).
+ * Base class for all the provider classes (TracerProvider, MeterProvider, etc.).
  *
  * @param <V> the type of the registered value.
  */

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractCounter.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractCounter.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.metrics.Counter;
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
@@ -33,19 +32,19 @@ abstract class AbstractCounter<B extends AbstractBoundInstrument>
       InstrumentDescriptor descriptor,
       InstrumentValueType instrumentValueType,
       MeterProviderSharedState meterProviderSharedState,
-      InstrumentationLibraryInfo instrumentationLibraryInfo,
+      MeterSharedState meterSharedState,
       boolean monotonic) {
     super(
         descriptor,
         meterProviderSharedState,
-        instrumentationLibraryInfo,
+        meterSharedState,
         new ActiveBatcher(
             getDefaultBatcher(
                 descriptor,
                 getCounterInstrumentType(monotonic),
                 instrumentValueType,
                 meterProviderSharedState,
-                instrumentationLibraryInfo)));
+                meterSharedState)));
     this.monotonic = monotonic;
     this.instrumentValueType = instrumentValueType;
   }
@@ -86,8 +85,8 @@ abstract class AbstractCounter<B extends AbstractBoundInstrument>
     Builder(
         String name,
         MeterProviderSharedState meterProviderSharedState,
-        InstrumentationLibraryInfo instrumentationLibraryInfo) {
-      super(name, meterProviderSharedState, instrumentationLibraryInfo);
+        MeterSharedState meterSharedState) {
+      super(name, meterProviderSharedState, meterSharedState);
     }
 
     @Override
@@ -110,13 +109,13 @@ abstract class AbstractCounter<B extends AbstractBoundInstrument>
       InstrumentType instrumentType,
       InstrumentValueType instrumentValueType,
       MeterProviderSharedState meterProviderSharedState,
-      InstrumentationLibraryInfo instrumentationLibraryInfo) {
+      MeterSharedState meterSharedState) {
     Aggregation defaultAggregation = Aggregations.sum();
     return Batchers.getCumulativeAllLabels(
         getDefaultMetricDescriptor(
             descriptor, instrumentType, instrumentValueType, defaultAggregation),
         meterProviderSharedState.getResource(),
-        instrumentationLibraryInfo,
+        meterSharedState.getInstrumentationLibraryInfo(),
         defaultAggregation.getAggregatorFactory(instrumentValueType),
         meterProviderSharedState.getClock());
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
@@ -19,7 +19,6 @@ package io.opentelemetry.sdk.metrics;
 import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.internal.Utils;
 import io.opentelemetry.metrics.Instrument;
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,18 +30,18 @@ abstract class AbstractInstrument implements Instrument {
 
   private final InstrumentDescriptor descriptor;
   private final MeterProviderSharedState meterProviderSharedState;
-  private final InstrumentationLibraryInfo instrumentationLibraryInfo;
+  private final MeterSharedState meterSharedState;
   private final ActiveBatcher activeBatcher;
 
   // All arguments cannot be null because they are checked in the abstract builder classes.
   AbstractInstrument(
       InstrumentDescriptor descriptor,
       MeterProviderSharedState meterProviderSharedState,
-      InstrumentationLibraryInfo instrumentationLibraryInfo,
+      MeterSharedState meterSharedState,
       ActiveBatcher activeBatcher) {
     this.descriptor = descriptor;
     this.meterProviderSharedState = meterProviderSharedState;
-    this.instrumentationLibraryInfo = instrumentationLibraryInfo;
+    this.meterSharedState = meterSharedState;
     this.activeBatcher = activeBatcher;
   }
 
@@ -54,8 +53,8 @@ abstract class AbstractInstrument implements Instrument {
     return meterProviderSharedState;
   }
 
-  final InstrumentationLibraryInfo getInstrumentationLibraryInfo() {
-    return instrumentationLibraryInfo;
+  final MeterSharedState getMeterSharedState() {
+    return meterSharedState;
   }
 
   final ActiveBatcher getActiveBatcher() {
@@ -93,7 +92,7 @@ abstract class AbstractInstrument implements Instrument {
 
     private final String name;
     private final MeterProviderSharedState meterProviderSharedState;
-    private final InstrumentationLibraryInfo instrumentationLibraryInfo;
+    private final MeterSharedState meterSharedState;
     private String description = "";
     private String unit = "1";
     private List<String> labelKeys = Collections.emptyList();
@@ -102,14 +101,14 @@ abstract class AbstractInstrument implements Instrument {
     Builder(
         String name,
         MeterProviderSharedState meterProviderSharedState,
-        InstrumentationLibraryInfo instrumentationLibraryInfo) {
+        MeterSharedState meterSharedState) {
       Utils.checkNotNull(name, "name");
       Utils.checkArgument(
           StringUtils.isValidMetricName(name) && name.length() <= NAME_MAX_LENGTH,
           ERROR_MESSAGE_INVALID_NAME);
       this.name = name;
       this.meterProviderSharedState = meterProviderSharedState;
-      this.instrumentationLibraryInfo = instrumentationLibraryInfo;
+      this.meterSharedState = meterSharedState;
     }
 
     @Override
@@ -143,8 +142,8 @@ abstract class AbstractInstrument implements Instrument {
       return meterProviderSharedState;
     }
 
-    final InstrumentationLibraryInfo getInstrumentationLibraryInfo() {
-      return instrumentationLibraryInfo;
+    final MeterSharedState getMeterSharedState() {
+      return meterSharedState;
     }
 
     final InstrumentDescriptor getInstrumentDescriptor() {

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrumentWithBinding.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrumentWithBinding.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.metrics.LabelSet;
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.util.List;
 import java.util.Map;
@@ -32,9 +31,9 @@ abstract class AbstractInstrumentWithBinding<B extends AbstractBoundInstrument>
   AbstractInstrumentWithBinding(
       InstrumentDescriptor descriptor,
       MeterProviderSharedState meterProviderSharedState,
-      InstrumentationLibraryInfo instrumentationLibraryInfo,
+      MeterSharedState meterSharedState,
       ActiveBatcher activeBatcher) {
-    super(descriptor, meterProviderSharedState, instrumentationLibraryInfo, activeBatcher);
+    super(descriptor, meterProviderSharedState, meterSharedState, activeBatcher);
     boundLabels = new ConcurrentHashMap<>();
     collectLock = new ReentrantLock();
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractMeasure.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractMeasure.java
@@ -17,8 +17,6 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.metrics.Measure;
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 
 abstract class AbstractMeasure<B extends AbstractBoundInstrument>
@@ -30,12 +28,12 @@ abstract class AbstractMeasure<B extends AbstractBoundInstrument>
       InstrumentDescriptor descriptor,
       InstrumentValueType instrumentValueType,
       MeterProviderSharedState meterProviderSharedState,
-      InstrumentationLibraryInfo instrumentationLibraryInfo,
+      MeterSharedState meterSharedState,
       boolean absolute) {
     super(
         descriptor,
         meterProviderSharedState,
-        instrumentationLibraryInfo,
+        meterSharedState,
         new ActiveBatcher(Batchers.getNoop()));
     this.absolute = absolute;
     this.instrumentValueType = instrumentValueType;
@@ -77,8 +75,8 @@ abstract class AbstractMeasure<B extends AbstractBoundInstrument>
     Builder(
         String name,
         MeterProviderSharedState meterProviderSharedState,
-        InstrumentationLibraryInfo instrumentationLibraryInfo) {
-      super(name, meterProviderSharedState, instrumentationLibraryInfo);
+        MeterSharedState meterSharedState) {
+      super(name, meterProviderSharedState, meterSharedState);
     }
 
     @Override
@@ -90,9 +88,5 @@ abstract class AbstractMeasure<B extends AbstractBoundInstrument>
     final boolean isAbsolute() {
       return this.absolute;
     }
-  }
-
-  static InstrumentType getInstrumentType(boolean absolute) {
-    return absolute ? InstrumentType.MEASURE_ABSOLUTE : InstrumentType.MEASURE_NON_ABSOLUTE;
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractObserver.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractObserver.java
@@ -17,8 +17,6 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.metrics.Observer;
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.util.Collections;
@@ -32,12 +30,12 @@ class AbstractObserver extends AbstractInstrument {
       InstrumentDescriptor descriptor,
       InstrumentValueType instrumentValueType,
       MeterProviderSharedState meterProviderSharedState,
-      InstrumentationLibraryInfo instrumentationLibraryInfo,
+      MeterSharedState meterSharedState,
       boolean monotonic) {
     super(
         descriptor,
         meterProviderSharedState,
-        instrumentationLibraryInfo,
+        meterSharedState,
         new ActiveBatcher(Batchers.getNoop()));
     this.monotonic = monotonic;
     this.instrumentValueType = instrumentValueType;
@@ -85,8 +83,8 @@ class AbstractObserver extends AbstractInstrument {
     Builder(
         String name,
         MeterProviderSharedState meterProviderSharedState,
-        InstrumentationLibraryInfo instrumentationLibraryInfo) {
-      super(name, meterProviderSharedState, instrumentationLibraryInfo);
+        MeterSharedState meterSharedState) {
+      super(name, meterProviderSharedState, meterSharedState);
     }
 
     @Override
@@ -98,10 +96,5 @@ class AbstractObserver extends AbstractInstrument {
     final boolean isMonotonic() {
       return this.monotonic;
     }
-  }
-
-  // TODO: make this private
-  static InstrumentType getInstrumentType(boolean monotonic) {
-    return monotonic ? InstrumentType.OBSERVER_MONOTONIC : InstrumentType.OBSERVER_NON_MONOTONIC;
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleCounterSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleCounterSdk.java
@@ -18,7 +18,6 @@ package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.metrics.DoubleCounter;
 import io.opentelemetry.metrics.LabelSet;
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.DoubleCounterSdk.BoundInstrument;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 
@@ -28,12 +27,12 @@ final class DoubleCounterSdk extends AbstractCounter<BoundInstrument> implements
       InstrumentDescriptor descriptor,
       boolean monotonic,
       MeterProviderSharedState meterProviderSharedState,
-      InstrumentationLibraryInfo instrumentationLibraryInfo) {
+      MeterSharedState meterSharedState) {
     super(
         descriptor,
         InstrumentValueType.DOUBLE,
         meterProviderSharedState,
-        instrumentationLibraryInfo,
+        meterSharedState,
         monotonic);
   }
 
@@ -75,8 +74,8 @@ final class DoubleCounterSdk extends AbstractCounter<BoundInstrument> implements
   static DoubleCounter.Builder builder(
       String name,
       MeterProviderSharedState meterProviderSharedState,
-      InstrumentationLibraryInfo instrumentationLibraryInfo) {
-    return new Builder(name, meterProviderSharedState, instrumentationLibraryInfo);
+      MeterSharedState meterSharedState) {
+    return new Builder(name, meterProviderSharedState, meterSharedState);
   }
 
   private static final class Builder
@@ -86,8 +85,8 @@ final class DoubleCounterSdk extends AbstractCounter<BoundInstrument> implements
     private Builder(
         String name,
         MeterProviderSharedState meterProviderSharedState,
-        InstrumentationLibraryInfo instrumentationLibraryInfo) {
-      super(name, meterProviderSharedState, instrumentationLibraryInfo);
+        MeterSharedState meterSharedState) {
+      super(name, meterProviderSharedState, meterSharedState);
     }
 
     @Override
@@ -101,7 +100,7 @@ final class DoubleCounterSdk extends AbstractCounter<BoundInstrument> implements
           getInstrumentDescriptor(),
           isMonotonic(),
           getMeterProviderSharedState(),
-          getInstrumentationLibraryInfo());
+          getMeterSharedState());
     }
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleMeasureSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleMeasureSdk.java
@@ -18,7 +18,6 @@ package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.metrics.DoubleMeasure;
 import io.opentelemetry.metrics.LabelSet;
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.DoubleMeasureSdk.BoundInstrument;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 
@@ -27,13 +26,13 @@ final class DoubleMeasureSdk extends AbstractMeasure<BoundInstrument> implements
   private DoubleMeasureSdk(
       InstrumentDescriptor descriptor,
       MeterProviderSharedState meterProviderSharedState,
-      InstrumentationLibraryInfo instrumentationLibraryInfo,
+      MeterSharedState meterSharedState,
       boolean absolute) {
     super(
         descriptor,
         InstrumentValueType.DOUBLE,
         meterProviderSharedState,
-        instrumentationLibraryInfo,
+        meterSharedState,
         absolute);
   }
 
@@ -75,8 +74,8 @@ final class DoubleMeasureSdk extends AbstractMeasure<BoundInstrument> implements
   static DoubleMeasure.Builder builder(
       String name,
       MeterProviderSharedState meterProviderSharedState,
-      InstrumentationLibraryInfo instrumentationLibraryInfo) {
-    return new Builder(name, meterProviderSharedState, instrumentationLibraryInfo);
+      MeterSharedState meterSharedState) {
+    return new Builder(name, meterProviderSharedState, meterSharedState);
   }
 
   private static final class Builder
@@ -86,8 +85,8 @@ final class DoubleMeasureSdk extends AbstractMeasure<BoundInstrument> implements
     private Builder(
         String name,
         MeterProviderSharedState meterProviderSharedState,
-        InstrumentationLibraryInfo instrumentationLibraryInfo) {
-      super(name, meterProviderSharedState, instrumentationLibraryInfo);
+        MeterSharedState meterSharedState) {
+      super(name, meterProviderSharedState, meterSharedState);
     }
 
     @Override
@@ -100,7 +99,7 @@ final class DoubleMeasureSdk extends AbstractMeasure<BoundInstrument> implements
       return new DoubleMeasureSdk(
           getInstrumentDescriptor(),
           getMeterProviderSharedState(),
-          getInstrumentationLibraryInfo(),
+          getMeterSharedState(),
           isAbsolute());
     }
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleObserverSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleObserverSdk.java
@@ -17,20 +17,19 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.metrics.DoubleObserver;
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 
 final class DoubleObserverSdk extends AbstractObserver implements DoubleObserver {
   DoubleObserverSdk(
       InstrumentDescriptor descriptor,
       MeterProviderSharedState meterProviderSharedState,
-      InstrumentationLibraryInfo instrumentationLibraryInfo,
+      MeterSharedState meterSharedState,
       boolean monotonic) {
     super(
         descriptor,
         InstrumentValueType.LONG,
         meterProviderSharedState,
-        instrumentationLibraryInfo,
+        meterSharedState,
         monotonic);
   }
 
@@ -42,8 +41,8 @@ final class DoubleObserverSdk extends AbstractObserver implements DoubleObserver
   static DoubleObserver.Builder builder(
       String name,
       MeterProviderSharedState meterProviderSharedState,
-      InstrumentationLibraryInfo instrumentationLibraryInfo) {
-    return new Builder(name, meterProviderSharedState, instrumentationLibraryInfo);
+      MeterSharedState meterSharedState) {
+    return new Builder(name, meterProviderSharedState, meterSharedState);
   }
 
   private static final class Builder
@@ -53,8 +52,8 @@ final class DoubleObserverSdk extends AbstractObserver implements DoubleObserver
     private Builder(
         String name,
         MeterProviderSharedState meterProviderSharedState,
-        InstrumentationLibraryInfo instrumentationLibraryInfo) {
-      super(name, meterProviderSharedState, instrumentationLibraryInfo);
+        MeterSharedState meterSharedState) {
+      super(name, meterProviderSharedState, meterSharedState);
     }
 
     @Override
@@ -67,7 +66,7 @@ final class DoubleObserverSdk extends AbstractObserver implements DoubleObserver
       return new DoubleObserverSdk(
           getInstrumentDescriptor(),
           getMeterProviderSharedState(),
-          getInstrumentationLibraryInfo(),
+          getMeterSharedState(),
           isMonotonic());
     }
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongCounterSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongCounterSdk.java
@@ -18,7 +18,6 @@ package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.metrics.LabelSet;
 import io.opentelemetry.metrics.LongCounter;
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.LongCounterSdk.BoundInstrument;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 
@@ -27,13 +26,13 @@ final class LongCounterSdk extends AbstractCounter<BoundInstrument> implements L
   private LongCounterSdk(
       InstrumentDescriptor descriptor,
       MeterProviderSharedState meterProviderSharedState,
-      InstrumentationLibraryInfo instrumentationLibraryInfo,
+      MeterSharedState meterSharedState,
       boolean monotonic) {
     super(
         descriptor,
         InstrumentValueType.LONG,
         meterProviderSharedState,
-        instrumentationLibraryInfo,
+        meterSharedState,
         monotonic);
   }
 
@@ -75,8 +74,8 @@ final class LongCounterSdk extends AbstractCounter<BoundInstrument> implements L
   static LongCounter.Builder builder(
       String name,
       MeterProviderSharedState meterProviderSharedState,
-      InstrumentationLibraryInfo instrumentationLibraryInfo) {
-    return new Builder(name, meterProviderSharedState, instrumentationLibraryInfo);
+      MeterSharedState meterSharedState) {
+    return new Builder(name, meterProviderSharedState, meterSharedState);
   }
 
   private static final class Builder
@@ -86,8 +85,8 @@ final class LongCounterSdk extends AbstractCounter<BoundInstrument> implements L
     private Builder(
         String name,
         MeterProviderSharedState meterProviderSharedState,
-        InstrumentationLibraryInfo instrumentationLibraryInfo) {
-      super(name, meterProviderSharedState, instrumentationLibraryInfo);
+        MeterSharedState meterSharedState) {
+      super(name, meterProviderSharedState, meterSharedState);
     }
 
     @Override
@@ -100,7 +99,7 @@ final class LongCounterSdk extends AbstractCounter<BoundInstrument> implements L
       return new LongCounterSdk(
           getInstrumentDescriptor(),
           getMeterProviderSharedState(),
-          getInstrumentationLibraryInfo(),
+          getMeterSharedState(),
           isMonotonic());
     }
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongMeasureSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongMeasureSdk.java
@@ -18,7 +18,6 @@ package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.metrics.LabelSet;
 import io.opentelemetry.metrics.LongMeasure;
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.LongMeasureSdk.BoundInstrument;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 
@@ -27,14 +26,10 @@ final class LongMeasureSdk extends AbstractMeasure<BoundInstrument> implements L
   private LongMeasureSdk(
       InstrumentDescriptor descriptor,
       MeterProviderSharedState meterProviderSharedState,
-      InstrumentationLibraryInfo instrumentationLibraryInfo,
+      MeterSharedState meterSharedState,
       boolean absolute) {
     super(
-        descriptor,
-        InstrumentValueType.LONG,
-        meterProviderSharedState,
-        instrumentationLibraryInfo,
-        absolute);
+        descriptor, InstrumentValueType.LONG, meterProviderSharedState, meterSharedState, absolute);
   }
 
   @Override
@@ -76,8 +71,8 @@ final class LongMeasureSdk extends AbstractMeasure<BoundInstrument> implements L
   static LongMeasure.Builder builder(
       String name,
       MeterProviderSharedState meterProviderSharedState,
-      InstrumentationLibraryInfo instrumentationLibraryInfo) {
-    return new Builder(name, meterProviderSharedState, instrumentationLibraryInfo);
+      MeterSharedState meterSharedState) {
+    return new Builder(name, meterProviderSharedState, meterSharedState);
   }
 
   private static final class Builder
@@ -87,8 +82,8 @@ final class LongMeasureSdk extends AbstractMeasure<BoundInstrument> implements L
     private Builder(
         String name,
         MeterProviderSharedState meterProviderSharedState,
-        InstrumentationLibraryInfo instrumentationLibraryInfo) {
-      super(name, meterProviderSharedState, instrumentationLibraryInfo);
+        MeterSharedState meterSharedState) {
+      super(name, meterProviderSharedState, meterSharedState);
     }
 
     @Override
@@ -101,7 +96,7 @@ final class LongMeasureSdk extends AbstractMeasure<BoundInstrument> implements L
       return new LongMeasureSdk(
           getInstrumentDescriptor(),
           getMeterProviderSharedState(),
-          getInstrumentationLibraryInfo(),
+          getMeterSharedState(),
           isAbsolute());
     }
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongObserverSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongObserverSdk.java
@@ -17,20 +17,19 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.metrics.LongObserver;
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 
 final class LongObserverSdk extends AbstractObserver implements LongObserver {
   LongObserverSdk(
       InstrumentDescriptor descriptor,
       MeterProviderSharedState meterProviderSharedState,
-      InstrumentationLibraryInfo instrumentationLibraryInfo,
+      MeterSharedState meterSharedState,
       boolean monotonic) {
     super(
         descriptor,
         InstrumentValueType.LONG,
         meterProviderSharedState,
-        instrumentationLibraryInfo,
+        meterSharedState,
         monotonic);
   }
 
@@ -42,8 +41,8 @@ final class LongObserverSdk extends AbstractObserver implements LongObserver {
   static LongObserver.Builder builder(
       String name,
       MeterProviderSharedState meterProviderSharedState,
-      InstrumentationLibraryInfo instrumentationLibraryInfo) {
-    return new Builder(name, meterProviderSharedState, instrumentationLibraryInfo);
+      MeterSharedState meterSharedState) {
+    return new Builder(name, meterProviderSharedState, meterSharedState);
   }
 
   private static final class Builder
@@ -53,8 +52,8 @@ final class LongObserverSdk extends AbstractObserver implements LongObserver {
     private Builder(
         String name,
         MeterProviderSharedState meterProviderSharedState,
-        InstrumentationLibraryInfo instrumentationLibraryInfo) {
-      super(name, meterProviderSharedState, instrumentationLibraryInfo);
+        MeterSharedState meterSharedState) {
+      super(name, meterProviderSharedState, meterSharedState);
     }
 
     @Override
@@ -67,7 +66,7 @@ final class LongObserverSdk extends AbstractObserver implements LongObserver {
       return new LongObserverSdk(
           getInstrumentDescriptor(),
           getMeterProviderSharedState(),
-          getInstrumentationLibraryInfo(),
+          getMeterSharedState(),
           isMonotonic());
     }
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
@@ -31,47 +31,47 @@ import java.util.Map;
 /** {@link MeterSdk} is SDK implementation of {@link Meter}. */
 final class MeterSdk implements Meter {
   private final MeterProviderSharedState meterProviderSharedState;
-  private final InstrumentationLibraryInfo instrumentationLibraryInfo;
+  private final MeterSharedState meterSharedState;
 
   MeterSdk(
       MeterProviderSharedState meterProviderSharedState,
       InstrumentationLibraryInfo instrumentationLibraryInfo) {
     this.meterProviderSharedState = meterProviderSharedState;
-    this.instrumentationLibraryInfo = instrumentationLibraryInfo;
+    this.meterSharedState = MeterSharedState.create(instrumentationLibraryInfo);
   }
 
   InstrumentationLibraryInfo getInstrumentationLibraryInfo() {
-    return instrumentationLibraryInfo;
+    return meterSharedState.getInstrumentationLibraryInfo();
   }
 
   @Override
   public DoubleCounter.Builder doubleCounterBuilder(String name) {
-    return DoubleCounterSdk.builder(name, meterProviderSharedState, instrumentationLibraryInfo);
+    return DoubleCounterSdk.builder(name, meterProviderSharedState, meterSharedState);
   }
 
   @Override
   public LongCounter.Builder longCounterBuilder(String name) {
-    return LongCounterSdk.builder(name, meterProviderSharedState, instrumentationLibraryInfo);
+    return LongCounterSdk.builder(name, meterProviderSharedState, meterSharedState);
   }
 
   @Override
   public DoubleMeasure.Builder doubleMeasureBuilder(String name) {
-    return DoubleMeasureSdk.builder(name, meterProviderSharedState, instrumentationLibraryInfo);
+    return DoubleMeasureSdk.builder(name, meterProviderSharedState, meterSharedState);
   }
 
   @Override
   public LongMeasure.Builder longMeasureBuilder(String name) {
-    return LongMeasureSdk.builder(name, meterProviderSharedState, instrumentationLibraryInfo);
+    return LongMeasureSdk.builder(name, meterProviderSharedState, meterSharedState);
   }
 
   @Override
   public DoubleObserver.Builder doubleObserverBuilder(String name) {
-    return DoubleObserverSdk.builder(name, meterProviderSharedState, instrumentationLibraryInfo);
+    return DoubleObserverSdk.builder(name, meterProviderSharedState, meterSharedState);
   }
 
   @Override
   public LongObserver.Builder longObserverBuilder(String name) {
-    return LongObserverSdk.builder(name, meterProviderSharedState, instrumentationLibraryInfo);
+    return LongObserverSdk.builder(name, meterProviderSharedState, meterSharedState);
   }
 
   @Override

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSharedState.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSharedState.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.metrics;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import javax.annotation.concurrent.Immutable;
+
+@AutoValue
+@Immutable
+abstract class MeterSharedState {
+  static MeterSharedState create(InstrumentationLibraryInfo instrumentationLibraryInfo) {
+    return new AutoValue_MeterSharedState(instrumentationLibraryInfo);
+  }
+
+  abstract InstrumentationLibraryInfo getInstrumentationLibraryInfo();
+}

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractCounterBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractCounterBuilderTest.java
@@ -38,19 +38,19 @@ public class AbstractCounterBuilderTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   private static final String NAME = "name";
-  private static final MeterProviderSharedState METER_SHARED_STATE =
+  private static final MeterProviderSharedState METER_PROVIDER_SHARED_STATE =
       MeterProviderSharedState.create(TestClock.create(), Resource.getEmpty());
-  private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
-      InstrumentationLibraryInfo.getEmpty();
+  private static final MeterSharedState METER_SHARED_STATE =
+      MeterSharedState.create(InstrumentationLibraryInfo.getEmpty());
 
   @Test
   public void defaultValue() {
     TestInstrumentBuilder testInstrumentBuilder =
-        new TestInstrumentBuilder(NAME, METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO);
+        new TestInstrumentBuilder(NAME, METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE);
     assertThat(testInstrumentBuilder.isMonotonic()).isTrue();
-    assertThat(testInstrumentBuilder.getMeterProviderSharedState()).isEqualTo(METER_SHARED_STATE);
-    assertThat(testInstrumentBuilder.getInstrumentationLibraryInfo())
-        .isEqualTo(INSTRUMENTATION_LIBRARY_INFO);
+    assertThat(testInstrumentBuilder.getMeterProviderSharedState())
+        .isSameInstanceAs(METER_PROVIDER_SHARED_STATE);
+    assertThat(testInstrumentBuilder.getMeterSharedState()).isSameInstanceAs(METER_SHARED_STATE);
 
     TestInstrument testInstrument = testInstrumentBuilder.build();
     assertThat(testInstrument).isInstanceOf(TestInstrument.class);
@@ -64,7 +64,7 @@ public class AbstractCounterBuilderTest {
   @Test
   public void setAndGetValues() {
     TestInstrumentBuilder testInstrumentBuilder =
-        new TestInstrumentBuilder(NAME, METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO)
+        new TestInstrumentBuilder(NAME, METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE)
             .setMonotonic(false);
     assertThat(testInstrumentBuilder.isMonotonic()).isFalse();
     assertThat(testInstrumentBuilder.build()).isInstanceOf(TestInstrument.class);
@@ -74,9 +74,9 @@ public class AbstractCounterBuilderTest {
       extends AbstractCounter.Builder<TestInstrumentBuilder, TestInstrument> {
     TestInstrumentBuilder(
         String name,
-        MeterProviderSharedState sharedState,
-        InstrumentationLibraryInfo instrumentationLibraryInfo) {
-      super(name, sharedState, instrumentationLibraryInfo);
+        MeterProviderSharedState meterProviderSharedState,
+        MeterSharedState meterSharedState) {
+      super(name, meterProviderSharedState, meterSharedState);
     }
 
     @Override
@@ -89,7 +89,7 @@ public class AbstractCounterBuilderTest {
       return new TestInstrument(
           getInstrumentDescriptor(),
           getMeterProviderSharedState(),
-          getInstrumentationLibraryInfo(),
+          getMeterSharedState(),
           isMonotonic());
     }
   }
@@ -99,13 +99,13 @@ public class AbstractCounterBuilderTest {
     TestInstrument(
         InstrumentDescriptor descriptor,
         MeterProviderSharedState meterProviderSharedState,
-        InstrumentationLibraryInfo instrumentationLibraryInfo,
+        MeterSharedState meterSharedState,
         boolean monotonic) {
       super(
           descriptor,
           InstrumentValueType.LONG,
           meterProviderSharedState,
-          instrumentationLibraryInfo,
+          meterSharedState,
           monotonic);
     }
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractCounterTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractCounterTest.java
@@ -65,17 +65,17 @@ public class AbstractCounterTest {
             "1",
             Collections.singletonMap("key_2", "value_2"),
             Collections.singletonList("key"));
-    private static final MeterProviderSharedState METER_SHARED_STATE =
+    private static final MeterProviderSharedState METER_PROVIDER_SHARED_STATE =
         MeterProviderSharedState.create(TestClock.create(), Resource.getEmpty());
-    private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
-        InstrumentationLibraryInfo.create("test_abstract_instrument", "");
+    private static final MeterSharedState METER_SHARED_STATE =
+        MeterSharedState.create(InstrumentationLibraryInfo.getEmpty());
 
     TestCounterInstrument(InstrumentValueType instrumentValueType, boolean monotonic) {
       super(
           INSTRUMENT_DESCRIPTOR,
           instrumentValueType,
+          METER_PROVIDER_SHARED_STATE,
           METER_SHARED_STATE,
-          INSTRUMENTATION_LIBRARY_INFO,
           monotonic);
     }
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
@@ -43,41 +43,40 @@ public class AbstractInstrumentBuilderTest {
   private static final List<String> LABEL_KEY = Collections.singletonList("key");
   private static final Map<String, String> CONSTANT_LABELS =
       Collections.singletonMap("key_2", "value_2");
-  private static final MeterProviderSharedState METER_SHARED_STATE =
+  private static final MeterProviderSharedState METER_PROVIDER_SHARED_STATE =
       MeterProviderSharedState.create(TestClock.create(), Resource.getEmpty());
-  private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
-      InstrumentationLibraryInfo.getEmpty();
+  private static final MeterSharedState METER_SHARED_STATE =
+      MeterSharedState.create(InstrumentationLibraryInfo.getEmpty());
 
   @Test
   public void preventNull_Name() {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("name");
-    new TestInstrumentBuilder(null, METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO).build();
+    new TestInstrumentBuilder(null, METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE).build();
   }
 
   @Test
   public void preventEmpty_Name() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Name");
-    new TestInstrumentBuilder("", METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO);
+    new TestInstrumentBuilder("", METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE);
   }
 
   @Test
   public void checkCorrect_Name() {
-    new TestInstrumentBuilder("a", METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO);
-    new TestInstrumentBuilder("METRIC_name", METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO);
-    new TestInstrumentBuilder("metric.name_01", METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO);
-    new TestInstrumentBuilder("metric_name.01", METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO);
+    new TestInstrumentBuilder("a", METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE);
+    new TestInstrumentBuilder("METRIC_name", METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE);
+    new TestInstrumentBuilder("metric.name_01", METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE);
+    new TestInstrumentBuilder("metric_name.01", METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE);
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Name");
-    new TestInstrumentBuilder(
-        "01.metric_name_01", METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO);
+    new TestInstrumentBuilder("01.metric_name_01", METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE);
   }
 
   @Test
   public void preventNonPrintableName() {
     thrown.expect(IllegalArgumentException.class);
-    new TestInstrumentBuilder("\2", METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO).build();
+    new TestInstrumentBuilder("\2", METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE).build();
   }
 
   @Test
@@ -87,14 +86,14 @@ public class AbstractInstrumentBuilderTest {
     String longName = String.valueOf(chars);
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage(AbstractInstrument.Builder.ERROR_MESSAGE_INVALID_NAME);
-    new TestInstrumentBuilder(longName, METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO).build();
+    new TestInstrumentBuilder(longName, METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE).build();
   }
 
   @Test
   public void preventNull_Description() {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("description");
-    new TestInstrumentBuilder(NAME, METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO)
+    new TestInstrumentBuilder(NAME, METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE)
         .setDescription(null)
         .build();
   }
@@ -103,7 +102,7 @@ public class AbstractInstrumentBuilderTest {
   public void preventNull_Unit() {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("unit");
-    new TestInstrumentBuilder(NAME, METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO)
+    new TestInstrumentBuilder(NAME, METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE)
         .setUnit(null)
         .build();
   }
@@ -112,7 +111,7 @@ public class AbstractInstrumentBuilderTest {
   public void preventNull_LabelKeys() {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("labelKeys");
-    new TestInstrumentBuilder(NAME, METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO)
+    new TestInstrumentBuilder(NAME, METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE)
         .setLabelKeys(null)
         .build();
   }
@@ -121,7 +120,7 @@ public class AbstractInstrumentBuilderTest {
   public void preventNull_LabelKey() {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("labelKey");
-    new TestInstrumentBuilder(NAME, METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO)
+    new TestInstrumentBuilder(NAME, METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE)
         .setLabelKeys(Collections.<String>singletonList(null))
         .build();
   }
@@ -130,7 +129,7 @@ public class AbstractInstrumentBuilderTest {
   public void preventNull_ConstantLabels() {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("constantLabels");
-    new TestInstrumentBuilder(NAME, METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO)
+    new TestInstrumentBuilder(NAME, METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE)
         .setConstantLabels(null)
         .build();
   }
@@ -138,7 +137,7 @@ public class AbstractInstrumentBuilderTest {
   @Test
   public void defaultValue() {
     TestInstrumentBuilder testInstrumentBuilder =
-        new TestInstrumentBuilder(NAME, METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO);
+        new TestInstrumentBuilder(NAME, METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE);
     TestInstrument testInstrument = testInstrumentBuilder.build();
     assertThat(testInstrument).isInstanceOf(TestInstrument.class);
     assertThat(testInstrument.getDescriptor().getName()).isEqualTo(NAME);
@@ -151,14 +150,14 @@ public class AbstractInstrumentBuilderTest {
   @Test
   public void setAndGetValues() {
     TestInstrumentBuilder testInstrumentBuilder =
-        new TestInstrumentBuilder(NAME, METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO)
+        new TestInstrumentBuilder(NAME, METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE)
             .setDescription(DESCRIPTION)
             .setUnit(UNIT)
             .setLabelKeys(LABEL_KEY)
             .setConstantLabels(CONSTANT_LABELS);
-    assertThat(testInstrumentBuilder.getMeterProviderSharedState()).isEqualTo(METER_SHARED_STATE);
-    assertThat(testInstrumentBuilder.getInstrumentationLibraryInfo())
-        .isEqualTo(INSTRUMENTATION_LIBRARY_INFO);
+    assertThat(testInstrumentBuilder.getMeterProviderSharedState())
+        .isSameInstanceAs(METER_PROVIDER_SHARED_STATE);
+    assertThat(testInstrumentBuilder.getMeterSharedState()).isSameInstanceAs(METER_SHARED_STATE);
 
     TestInstrument testInstrument = testInstrumentBuilder.build();
     assertThat(testInstrument).isInstanceOf(TestInstrument.class);
@@ -172,10 +171,8 @@ public class AbstractInstrumentBuilderTest {
   private static final class TestInstrumentBuilder
       extends AbstractInstrument.Builder<TestInstrumentBuilder, TestInstrument> {
     TestInstrumentBuilder(
-        String name,
-        MeterProviderSharedState sharedState,
-        InstrumentationLibraryInfo instrumentationLibraryInfo) {
-      super(name, sharedState, instrumentationLibraryInfo);
+        String name, MeterProviderSharedState sharedState, MeterSharedState meterSharedState) {
+      super(name, sharedState, meterSharedState);
     }
 
     @Override
@@ -186,9 +183,7 @@ public class AbstractInstrumentBuilderTest {
     @Override
     public TestInstrument build() {
       return new TestInstrument(
-          getInstrumentDescriptor(),
-          getMeterProviderSharedState(),
-          getInstrumentationLibraryInfo());
+          getInstrumentDescriptor(), getMeterProviderSharedState(), getMeterSharedState());
     }
   }
 
@@ -196,8 +191,8 @@ public class AbstractInstrumentBuilderTest {
     TestInstrument(
         InstrumentDescriptor descriptor,
         MeterProviderSharedState meterProviderSharedState,
-        InstrumentationLibraryInfo instrumentationLibraryInfo) {
-      super(descriptor, meterProviderSharedState, instrumentationLibraryInfo, null);
+        MeterSharedState meterSharedState) {
+      super(descriptor, meterProviderSharedState, meterSharedState, null);
     }
 
     @Override

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentTest.java
@@ -38,34 +38,33 @@ public class AbstractInstrumentTest {
           "1",
           Collections.singletonMap("key_2", "value_2"),
           Collections.singletonList("key"));
-  private static final MeterProviderSharedState METER_SHARED_STATE =
+  private static final MeterProviderSharedState METER_PROVIDER_SHARED_STATE =
       MeterProviderSharedState.create(TestClock.create(), Resource.getEmpty());
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create("test_abstract_instrument", "");
+  private static final MeterSharedState METER_SHARED_STATE =
+      MeterSharedState.create(INSTRUMENTATION_LIBRARY_INFO);
   private static final ActiveBatcher ACTIVE_BATCHER = new ActiveBatcher(Batchers.getNoop());
 
   @Test
   public void getValues() {
     TestInstrument testInstrument =
         new TestInstrument(
-            INSTRUMENT_DESCRIPTOR,
-            METER_SHARED_STATE,
-            INSTRUMENTATION_LIBRARY_INFO,
-            ACTIVE_BATCHER);
+            INSTRUMENT_DESCRIPTOR, METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE, ACTIVE_BATCHER);
     assertThat(testInstrument.getDescriptor()).isSameInstanceAs(INSTRUMENT_DESCRIPTOR);
-    assertThat(testInstrument.getMeterProviderSharedState()).isSameInstanceAs(METER_SHARED_STATE);
-    assertThat(testInstrument.getInstrumentationLibraryInfo())
-        .isSameInstanceAs(INSTRUMENTATION_LIBRARY_INFO);
+    assertThat(testInstrument.getMeterProviderSharedState())
+        .isSameInstanceAs(METER_PROVIDER_SHARED_STATE);
+    assertThat(testInstrument.getMeterSharedState()).isSameInstanceAs(METER_SHARED_STATE);
     assertThat(testInstrument.getActiveBatcher()).isSameInstanceAs(ACTIVE_BATCHER);
   }
 
   private static final class TestInstrument extends AbstractInstrument {
     TestInstrument(
         InstrumentDescriptor descriptor,
-        MeterProviderSharedState meterSharedState,
-        InstrumentationLibraryInfo instrumentationLibraryInfo,
+        MeterProviderSharedState meterProviderSharedState,
+        MeterSharedState meterSharedState,
         ActiveBatcher activeBatcher) {
-      super(descriptor, meterSharedState, instrumentationLibraryInfo, activeBatcher);
+      super(descriptor, meterProviderSharedState, meterSharedState, activeBatcher);
     }
 
     @Override

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractMeasureBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractMeasureBuilderTest.java
@@ -38,19 +38,19 @@ public class AbstractMeasureBuilderTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   private static final String NAME = "name";
-  private static final MeterProviderSharedState METER_SHARED_STATE =
+  private static final MeterProviderSharedState METER_PROVIDER_SHARED_STATE =
       MeterProviderSharedState.create(TestClock.create(), Resource.getEmpty());
-  private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
-      InstrumentationLibraryInfo.getEmpty();
+  private static final MeterSharedState METER_SHARED_STATE =
+      MeterSharedState.create(InstrumentationLibraryInfo.getEmpty());
 
   @Test
   public void defaultValue() {
     TestInstrumentBuilder testInstrumentBuilder =
-        new TestInstrumentBuilder(NAME, METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO);
+        new TestInstrumentBuilder(NAME, METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE);
     assertThat(testInstrumentBuilder.isAbsolute()).isTrue();
-    assertThat(testInstrumentBuilder.getMeterProviderSharedState()).isEqualTo(METER_SHARED_STATE);
-    assertThat(testInstrumentBuilder.getInstrumentationLibraryInfo())
-        .isEqualTo(INSTRUMENTATION_LIBRARY_INFO);
+    assertThat(testInstrumentBuilder.getMeterProviderSharedState())
+        .isSameInstanceAs(METER_PROVIDER_SHARED_STATE);
+    assertThat(testInstrumentBuilder.getMeterSharedState()).isSameInstanceAs(METER_SHARED_STATE);
 
     TestInstrument testInstrument = testInstrumentBuilder.build();
     assertThat(testInstrument).isInstanceOf(TestInstrument.class);
@@ -64,7 +64,7 @@ public class AbstractMeasureBuilderTest {
   @Test
   public void setAndGetValues() {
     TestInstrumentBuilder testInstrumentBuilder =
-        new TestInstrumentBuilder(NAME, METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO)
+        new TestInstrumentBuilder(NAME, METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE)
             .setAbsolute(false);
     assertThat(testInstrumentBuilder.isAbsolute()).isFalse();
     assertThat(testInstrumentBuilder.build()).isInstanceOf(TestInstrument.class);
@@ -74,9 +74,9 @@ public class AbstractMeasureBuilderTest {
       extends AbstractMeasure.Builder<TestInstrumentBuilder, TestInstrument> {
     TestInstrumentBuilder(
         String name,
-        MeterProviderSharedState sharedState,
-        InstrumentationLibraryInfo instrumentationLibraryInfo) {
-      super(name, sharedState, instrumentationLibraryInfo);
+        MeterProviderSharedState meterProviderSharedState,
+        MeterSharedState meterSharedState) {
+      super(name, meterProviderSharedState, meterSharedState);
     }
 
     @Override
@@ -89,7 +89,7 @@ public class AbstractMeasureBuilderTest {
       return new TestInstrument(
           getInstrumentDescriptor(),
           getMeterProviderSharedState(),
-          getInstrumentationLibraryInfo(),
+          getMeterSharedState(),
           isAbsolute());
     }
   }
@@ -99,14 +99,14 @@ public class AbstractMeasureBuilderTest {
 
     TestInstrument(
         InstrumentDescriptor descriptor,
-        MeterProviderSharedState meterSharedState,
-        InstrumentationLibraryInfo instrumentationLibraryInfo,
+        MeterProviderSharedState meterProviderSharedState,
+        MeterSharedState meterSharedState,
         boolean absolute) {
       super(
           descriptor,
           InstrumentValueType.LONG,
+          meterProviderSharedState,
           meterSharedState,
-          instrumentationLibraryInfo,
           absolute);
     }
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractMeasureTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractMeasureTest.java
@@ -64,17 +64,17 @@ public class AbstractMeasureTest {
             "1",
             Collections.singletonMap("key_2", "value_2"),
             Collections.singletonList("key"));
-    private static final MeterProviderSharedState METER_SHARED_STATE =
+    private static final MeterProviderSharedState METER_PROVIDER_SHARED_STATE =
         MeterProviderSharedState.create(TestClock.create(), Resource.getEmpty());
-    private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
-        InstrumentationLibraryInfo.create("test_abstract_instrument", "");
+    private static final MeterSharedState METER_SHARED_STATE =
+        MeterSharedState.create(InstrumentationLibraryInfo.getEmpty());
 
     TestMeasureInstrument(InstrumentValueType instrumentValueType, boolean absolute) {
       super(
           INSTRUMENT_DESCRIPTOR,
           instrumentValueType,
+          METER_PROVIDER_SHARED_STATE,
           METER_SHARED_STATE,
-          INSTRUMENTATION_LIBRARY_INFO,
           absolute);
     }
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractObserverBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractObserverBuilderTest.java
@@ -35,19 +35,19 @@ public class AbstractObserverBuilderTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   private static final String NAME = "name";
-  private static final MeterProviderSharedState METER_SHARED_STATE =
+  private static final MeterProviderSharedState METER_PROVIDER_SHARED_STATE =
       MeterProviderSharedState.create(TestClock.create(), Resource.getEmpty());
-  private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
-      InstrumentationLibraryInfo.getEmpty();
+  private static final MeterSharedState METER_SHARED_STATE =
+      MeterSharedState.create(InstrumentationLibraryInfo.getEmpty());
 
   @Test
   public void defaultValue() {
     TestInstrumentBuilder testInstrumentBuilder =
-        new TestInstrumentBuilder(NAME, METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO);
+        new TestInstrumentBuilder(NAME, METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE);
     assertThat(testInstrumentBuilder.isMonotonic()).isFalse();
-    assertThat(testInstrumentBuilder.getMeterProviderSharedState()).isEqualTo(METER_SHARED_STATE);
-    assertThat(testInstrumentBuilder.getInstrumentationLibraryInfo())
-        .isEqualTo(INSTRUMENTATION_LIBRARY_INFO);
+    assertThat(testInstrumentBuilder.getMeterProviderSharedState())
+        .isSameInstanceAs(METER_PROVIDER_SHARED_STATE);
+    assertThat(testInstrumentBuilder.getMeterSharedState()).isSameInstanceAs(METER_SHARED_STATE);
 
     TestInstrument testInstrument = testInstrumentBuilder.build();
     assertThat(testInstrument).isInstanceOf(TestInstrument.class);
@@ -61,7 +61,7 @@ public class AbstractObserverBuilderTest {
   @Test
   public void setAndGetValues() {
     TestInstrumentBuilder testInstrumentBuilder =
-        new TestInstrumentBuilder(NAME, METER_SHARED_STATE, INSTRUMENTATION_LIBRARY_INFO)
+        new TestInstrumentBuilder(NAME, METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE)
             .setMonotonic(true);
     assertThat(testInstrumentBuilder.isMonotonic()).isTrue();
     assertThat(testInstrumentBuilder.build()).isInstanceOf(TestInstrument.class);
@@ -71,9 +71,9 @@ public class AbstractObserverBuilderTest {
       extends AbstractObserver.Builder<TestInstrumentBuilder, TestInstrument> {
     TestInstrumentBuilder(
         String name,
-        MeterProviderSharedState sharedState,
-        InstrumentationLibraryInfo instrumentationLibraryInfo) {
-      super(name, sharedState, instrumentationLibraryInfo);
+        MeterProviderSharedState meterProviderSharedState,
+        MeterSharedState meterSharedState) {
+      super(name, meterProviderSharedState, meterSharedState);
     }
 
     @Override
@@ -86,7 +86,7 @@ public class AbstractObserverBuilderTest {
       return new TestInstrument(
           getInstrumentDescriptor(),
           getMeterProviderSharedState(),
-          getInstrumentationLibraryInfo(),
+          getMeterSharedState(),
           isMonotonic());
     }
   }
@@ -96,14 +96,14 @@ public class AbstractObserverBuilderTest {
 
     TestInstrument(
         InstrumentDescriptor descriptor,
-        MeterProviderSharedState meterSharedState,
-        InstrumentationLibraryInfo instrumentationLibraryInfo,
+        MeterProviderSharedState meterProviderSharedState,
+        MeterSharedState meterSharedState,
         boolean monotonic) {
       super(
           descriptor,
           InstrumentValueType.LONG,
+          meterProviderSharedState,
           meterSharedState,
-          instrumentationLibraryInfo,
           monotonic);
     }
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractObserverTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractObserverTest.java
@@ -64,17 +64,17 @@ public class AbstractObserverTest {
             "1",
             Collections.singletonMap("key_2", "value_2"),
             Collections.singletonList("key"));
-    private static final MeterProviderSharedState METER_SHARED_STATE =
+    private static final MeterProviderSharedState METER_PROVIDER_SHARED_STATE =
         MeterProviderSharedState.create(TestClock.create(), Resource.getEmpty());
-    private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
-        InstrumentationLibraryInfo.create("test_abstract_instrument", "");
+    private static final MeterSharedState METER_SHARED_STATE =
+        MeterSharedState.create(InstrumentationLibraryInfo.getEmpty());
 
     TestObserverInstrument(InstrumentValueType instrumentValueType, boolean monotonic) {
       super(
           INSTRUMENT_DESCRIPTOR,
           instrumentValueType,
+          METER_PROVIDER_SHARED_STATE,
           METER_SHARED_STATE,
-          INSTRUMENTATION_LIBRARY_INFO,
           monotonic);
     }
   }

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkRegistryTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkRegistryTest.java
@@ -77,7 +77,7 @@ public class MeterSdkRegistryTest {
   }
 
   @Test
-  public void propagatesInstrumentationLibraryInfoToTracer() {
+  public void propagatesInstrumentationLibraryInfoToMeter() {
     InstrumentationLibraryInfo expected =
         InstrumentationLibraryInfo.create("theName", "theVersion");
     MeterSdk meter = meterRegistry.get(expected.getName(), expected.getVersion());


### PR DESCRIPTION
This change allows us to pass the entire Meter shared state to the instruments, next PR will add a registry for the Instruments that is passed to the Builders to register the created instruments when build is called.