### PR TITLE
Return SDK builders in the MeterSdk to avoid casting in tests

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleCounterSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleCounterSdk.java
@@ -72,18 +72,10 @@ final class DoubleCounterSdk extends AbstractCounter<BoundInstrument> implements
     }
   }
 
-  static DoubleCounter.Builder builder(
-      String name,
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState) {
-    return new Builder(name, meterProviderSharedState, meterSharedState);
-  }
-
-  private static final class Builder
-      extends AbstractCounter.Builder<DoubleCounter.Builder, DoubleCounter>
+  static final class Builder extends AbstractCounter.Builder<DoubleCounter.Builder, DoubleCounter>
       implements DoubleCounter.Builder {
 
-    private Builder(
+    Builder(
         String name,
         MeterProviderSharedState meterProviderSharedState,
         MeterSharedState meterSharedState) {
@@ -96,7 +88,7 @@ final class DoubleCounterSdk extends AbstractCounter<BoundInstrument> implements
     }
 
     @Override
-    public DoubleCounter build() {
+    public DoubleCounterSdk build() {
       return new DoubleCounterSdk(
           getInstrumentDescriptor(),
           isMonotonic(),

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleMeasureSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleMeasureSdk.java
@@ -72,18 +72,10 @@ final class DoubleMeasureSdk extends AbstractMeasure<BoundInstrument> implements
     }
   }
 
-  static DoubleMeasure.Builder builder(
-      String name,
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState) {
-    return new Builder(name, meterProviderSharedState, meterSharedState);
-  }
-
-  private static final class Builder
-      extends AbstractMeasure.Builder<DoubleMeasure.Builder, DoubleMeasure>
+  static final class Builder extends AbstractMeasure.Builder<DoubleMeasure.Builder, DoubleMeasure>
       implements DoubleMeasure.Builder {
 
-    private Builder(
+    Builder(
         String name,
         MeterProviderSharedState meterProviderSharedState,
         MeterSharedState meterSharedState) {
@@ -96,7 +88,7 @@ final class DoubleMeasureSdk extends AbstractMeasure<BoundInstrument> implements
     }
 
     @Override
-    public DoubleMeasure build() {
+    public DoubleMeasureSdk build() {
       return new DoubleMeasureSdk(
           getInstrumentDescriptor(),
           getMeterProviderSharedState(),

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleObserverSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleObserverSdk.java
@@ -38,18 +38,11 @@ final class DoubleObserverSdk extends AbstractObserver implements DoubleObserver
     throw new UnsupportedOperationException("to be implemented");
   }
 
-  static DoubleObserver.Builder builder(
-      String name,
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState) {
-    return new Builder(name, meterProviderSharedState, meterSharedState);
-  }
-
-  private static final class Builder
+  static final class Builder
       extends AbstractObserver.Builder<DoubleObserver.Builder, DoubleObserver>
       implements DoubleObserver.Builder {
 
-    private Builder(
+    Builder(
         String name,
         MeterProviderSharedState meterProviderSharedState,
         MeterSharedState meterSharedState) {
@@ -62,7 +55,7 @@ final class DoubleObserverSdk extends AbstractObserver implements DoubleObserver
     }
 
     @Override
-    public DoubleObserver build() {
+    public DoubleObserverSdk build() {
       return new DoubleObserverSdk(
           getInstrumentDescriptor(),
           getMeterProviderSharedState(),

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongCounterSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongCounterSdk.java
@@ -72,18 +72,10 @@ final class LongCounterSdk extends AbstractCounter<BoundInstrument> implements L
     }
   }
 
-  static LongCounter.Builder builder(
-      String name,
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState) {
-    return new Builder(name, meterProviderSharedState, meterSharedState);
-  }
-
-  private static final class Builder
-      extends AbstractCounter.Builder<LongCounter.Builder, LongCounter>
+  static final class Builder extends AbstractCounter.Builder<LongCounter.Builder, LongCounter>
       implements LongCounter.Builder {
 
-    private Builder(
+    Builder(
         String name,
         MeterProviderSharedState meterProviderSharedState,
         MeterSharedState meterSharedState) {
@@ -96,7 +88,7 @@ final class LongCounterSdk extends AbstractCounter<BoundInstrument> implements L
     }
 
     @Override
-    public LongCounter build() {
+    public LongCounterSdk build() {
       return new LongCounterSdk(
           getInstrumentDescriptor(),
           getMeterProviderSharedState(),

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongMeasureSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongMeasureSdk.java
@@ -69,18 +69,10 @@ final class LongMeasureSdk extends AbstractMeasure<BoundInstrument> implements L
     }
   }
 
-  static LongMeasure.Builder builder(
-      String name,
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState) {
-    return new Builder(name, meterProviderSharedState, meterSharedState);
-  }
-
-  private static final class Builder
-      extends AbstractMeasure.Builder<LongMeasure.Builder, LongMeasure>
+  static final class Builder extends AbstractMeasure.Builder<LongMeasure.Builder, LongMeasure>
       implements LongMeasure.Builder {
 
-    private Builder(
+    Builder(
         String name,
         MeterProviderSharedState meterProviderSharedState,
         MeterSharedState meterSharedState) {
@@ -93,7 +85,7 @@ final class LongMeasureSdk extends AbstractMeasure<BoundInstrument> implements L
     }
 
     @Override
-    public LongMeasure build() {
+    public LongMeasureSdk build() {
       return new LongMeasureSdk(
           getInstrumentDescriptor(),
           getMeterProviderSharedState(),

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongObserverSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongObserverSdk.java
@@ -38,18 +38,10 @@ final class LongObserverSdk extends AbstractObserver implements LongObserver {
     throw new UnsupportedOperationException("to be implemented");
   }
 
-  static LongObserver.Builder builder(
-      String name,
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState) {
-    return new Builder(name, meterProviderSharedState, meterSharedState);
-  }
-
-  private static final class Builder
-      extends AbstractObserver.Builder<LongObserver.Builder, LongObserver>
+  static final class Builder extends AbstractObserver.Builder<LongObserver.Builder, LongObserver>
       implements LongObserver.Builder {
 
-    private Builder(
+    Builder(
         String name,
         MeterProviderSharedState meterProviderSharedState,
         MeterSharedState meterSharedState) {
@@ -62,7 +54,7 @@ final class LongObserverSdk extends AbstractObserver implements LongObserver {
     }
 
     @Override
-    public LongObserver build() {
+    public LongObserverSdk build() {
       return new LongObserverSdk(
           getInstrumentDescriptor(),
           getMeterProviderSharedState(),

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
@@ -17,13 +17,7 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.metrics.BatchRecorder;
-import io.opentelemetry.metrics.DoubleCounter;
-import io.opentelemetry.metrics.DoubleMeasure;
-import io.opentelemetry.metrics.DoubleObserver;
 import io.opentelemetry.metrics.LabelSet;
-import io.opentelemetry.metrics.LongCounter;
-import io.opentelemetry.metrics.LongMeasure;
-import io.opentelemetry.metrics.LongObserver;
 import io.opentelemetry.metrics.Meter;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import java.util.Map;
@@ -45,33 +39,33 @@ final class MeterSdk implements Meter {
   }
 
   @Override
-  public DoubleCounter.Builder doubleCounterBuilder(String name) {
-    return DoubleCounterSdk.builder(name, meterProviderSharedState, meterSharedState);
+  public DoubleCounterSdk.Builder doubleCounterBuilder(String name) {
+    return new DoubleCounterSdk.Builder(name, meterProviderSharedState, meterSharedState);
   }
 
   @Override
-  public LongCounter.Builder longCounterBuilder(String name) {
-    return LongCounterSdk.builder(name, meterProviderSharedState, meterSharedState);
+  public LongCounterSdk.Builder longCounterBuilder(String name) {
+    return new LongCounterSdk.Builder(name, meterProviderSharedState, meterSharedState);
   }
 
   @Override
-  public DoubleMeasure.Builder doubleMeasureBuilder(String name) {
-    return DoubleMeasureSdk.builder(name, meterProviderSharedState, meterSharedState);
+  public DoubleMeasureSdk.Builder doubleMeasureBuilder(String name) {
+    return new DoubleMeasureSdk.Builder(name, meterProviderSharedState, meterSharedState);
   }
 
   @Override
-  public LongMeasure.Builder longMeasureBuilder(String name) {
-    return LongMeasureSdk.builder(name, meterProviderSharedState, meterSharedState);
+  public LongMeasureSdk.Builder longMeasureBuilder(String name) {
+    return new LongMeasureSdk.Builder(name, meterProviderSharedState, meterSharedState);
   }
 
   @Override
-  public DoubleObserver.Builder doubleObserverBuilder(String name) {
-    return DoubleObserverSdk.builder(name, meterProviderSharedState, meterSharedState);
+  public DoubleObserverSdk.Builder doubleObserverBuilder(String name) {
+    return new DoubleObserverSdk.Builder(name, meterProviderSharedState, meterSharedState);
   }
 
   @Override
-  public LongObserver.Builder longObserverBuilder(String name) {
-    return LongObserverSdk.builder(name, meterProviderSharedState, meterSharedState);
+  public LongObserverSdk.Builder longObserverBuilder(String name) {
+    return new LongObserverSdk.Builder(name, meterProviderSharedState, meterSharedState);
   }
 
   @Override

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleMeasureSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleMeasureSdkTest.java
@@ -63,8 +63,7 @@ public class DoubleMeasureSdkTest {
 
   @Test
   public void sameBound_ForSameLabelSet_InDifferentCollectionCycles() {
-    DoubleMeasureSdk doubleMeasure =
-        (DoubleMeasureSdk) testSdk.doubleMeasureBuilder("testMeasure").build();
+    DoubleMeasureSdk doubleMeasure = testSdk.doubleMeasureBuilder("testMeasure").build();
     BoundDoubleMeasure boundMeasure = doubleMeasure.bind(testSdk.createLabelSet("K", "v"));
     try {
       doubleMeasure.collect();

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongMeasureSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongMeasureSdkTest.java
@@ -63,7 +63,7 @@ public class LongMeasureSdkTest {
 
   @Test
   public void sameBound_ForSameLabelSet_InDifferentCollectionCycles() {
-    LongMeasureSdk longMeasure = (LongMeasureSdk) testSdk.longMeasureBuilder("testMeasure").build();
+    LongMeasureSdk longMeasure = testSdk.longMeasureBuilder("testMeasure").build();
     BoundLongMeasure boundMeasure = longMeasure.bind(testSdk.createLabelSet("K", "v"));
     try {
       longMeasure.collect();


### PR DESCRIPTION
TODO: need to work more on the case where any setter is used because that returns the non-sdk version so it still needs casting, will do that in a separate PR.

With this change I was able to remove a lot of the casts.