### PR TITLE
Avoid calling processors that do not require an event.

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/NoopSpanProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/NoopSpanProcessor.java
@@ -27,7 +27,17 @@ final class NoopSpanProcessor implements SpanProcessor {
   public void onStart(ReadableSpan span) {}
 
   @Override
+  public boolean isStartRequired() {
+    return false;
+  }
+
+  @Override
   public void onEnd(ReadableSpan span) {}
+
+  @Override
+  public boolean isEndRequired() {
+    return false;
+  }
 
   @Override
   public void shutdown() {}

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
@@ -35,6 +35,13 @@ public interface SpanProcessor {
   void onStart(ReadableSpan span);
 
   /**
+   * Returns {@code true} if this {@link SpanProcessor} requires start events.
+   *
+   * @return {@code true} if this {@link SpanProcessor} requires start events.
+   */
+  boolean isStartRequired();
+
+  /**
    * Called when a {@link io.opentelemetry.trace.Span} is ended, if the {@link Span#isRecording()}
    * returns true.
    *
@@ -43,14 +50,24 @@ public interface SpanProcessor {
    *
    * @param span the {@code ReadableSpan} that just ended.
    */
-  // TODO: Consider checking whether the given span is processed with onStart().
   void onEnd(ReadableSpan span);
 
-  /** Called when {@link TracerSdkProvider#shutdown()} is called. */
+  /**
+   * Returns {@code true} if this {@link SpanProcessor} requires end events.
+   *
+   * @return {@code true} if this {@link SpanProcessor} requires end events.
+   */
+  boolean isEndRequired();
+
+  /**
+   * Called when {@link TracerSdkProvider#shutdown()} is called.
+   *
+   * <p>Implementations must ensure that all span events are processed before returning.
+   */
   void shutdown();
 
   /**
-   * Exports all ended spans that have not yet been exported.
+   * Processes all span events that have not yet been processed.
    *
    * <p>This method is called synchronously on the execution thread, and should not throw
    * exceptions.

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessor.java
@@ -87,11 +87,21 @@ public final class BatchSpansProcessor implements SpanProcessor {
   public void onStart(ReadableSpan span) {}
 
   @Override
+  public boolean isStartRequired() {
+    return false;
+  }
+
+  @Override
   public void onEnd(ReadableSpan span) {
     if (sampled && !span.getSpanContext().getTraceFlags().isSampled()) {
       return;
     }
     worker.addSpan(span);
+  }
+
+  @Override
+  public boolean isEndRequired() {
+    return true;
   }
 
   @Override

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpansProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpansProcessor.java
@@ -47,6 +47,11 @@ public final class SimpleSpansProcessor implements SpanProcessor {
   }
 
   @Override
+  public boolean isStartRequired() {
+    return false;
+  }
+
+  @Override
   public void onEnd(ReadableSpan span) {
     if (sampled && !span.getSpanContext().getTraceFlags().isSampled()) {
       return;
@@ -57,6 +62,11 @@ public final class SimpleSpansProcessor implements SpanProcessor {
     } catch (Throwable e) {
       logger.log(Level.WARNING, "Exception thrown by the export.", e);
     }
+  }
+
+  @Override
+  public boolean isEndRequired() {
+    return true;
   }
 
   @Override

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/NoopSpanProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/NoopSpanProcessorTest.java
@@ -16,6 +16,8 @@
 
 package io.opentelemetry.sdk.trace;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,7 +39,10 @@ public class NoopSpanProcessorTest {
   public void noCrash() {
     SpanProcessor noopSpanProcessor = NoopSpanProcessor.getInstance();
     noopSpanProcessor.onStart(readableSpan);
+    assertThat(noopSpanProcessor.isStartRequired()).isFalse();
     noopSpanProcessor.onEnd(readableSpan);
+    assertThat(noopSpanProcessor.isEndRequired()).isFalse();
+    noopSpanProcessor.forceFlush();
     noopSpanProcessor.shutdown();
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessorTest.java
@@ -88,6 +88,14 @@ public class BatchSpansProcessorTest {
   }
 
   @Test
+  public void startEndRequirements() {
+    BatchSpansProcessor spansProcessor =
+        BatchSpansProcessor.newBuilder(new WaitingSpanExporter(0)).build();
+    assertThat(spansProcessor.isStartRequired()).isFalse();
+    assertThat(spansProcessor.isEndRequired()).isTrue();
+  }
+
+  @Test
   public void exportDifferentSampledSpans() {
     WaitingSpanExporter waitingSpanExporter = new WaitingSpanExporter(2);
     tracerSdkFactory.addSpanProcessor(


### PR DESCRIPTION
* MultiSpanProcessor dispatches start/end events only to SpanProcessors that require that.
* DisruptorSpanProcessor does not enqueue events if the next SpanProcessor does not require that event.