### PR TITLE
Remove generic usage in the metrics API

### DIFF
--- a/api/src/main/java/io/opentelemetry/metrics/Counter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Counter.java
@@ -17,6 +17,8 @@
 package io.opentelemetry.metrics;
 
 import io.opentelemetry.metrics.InstrumentWithBinding.BoundInstrument;
+import java.util.List;
+import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -29,7 +31,19 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface Counter<H extends BoundInstrument> extends InstrumentWithBinding<H> {
 
   /** Builder class for {@link Counter}. */
-  interface Builder<B extends Counter.Builder<B, V>, V> extends Instrument.Builder<B, V> {
+  interface Builder extends Instrument.Builder {
+    @Override
+    Builder setDescription(String description);
+
+    @Override
+    Builder setUnit(String unit);
+
+    @Override
+    Builder setLabelKeys(List<String> labelKeys);
+
+    @Override
+    Builder setConstantLabels(Map<String, String> constantLabels);
+
     /**
      * Sets the monotonicity property for this {@code Counter}. If {@code true} only non-negative
      * values are expected.
@@ -39,6 +53,9 @@ public interface Counter<H extends BoundInstrument> extends InstrumentWithBindin
      * @param monotonic {@code true} only positive values are expected.
      * @return this.
      */
-    B setMonotonic(boolean monotonic);
+    Builder setMonotonic(boolean monotonic);
+
+    @Override
+    Counter<?> build();
   }
 }

--- a/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
@@ -145,11 +145,11 @@ public final class DefaultMeter implements Meter {
       public void unbind() {}
     }
 
-    private static final class NoopBuilder
-        extends NoopAbstractCounterBuilder<Builder, DoubleCounter> implements Builder {
+    private static final class NoopBuilder extends NoopAbstractCounterBuilder<NoopBuilder>
+        implements Builder {
 
       @Override
-      protected Builder getThis() {
+      protected NoopBuilder getThis() {
         return this;
       }
 
@@ -188,11 +188,11 @@ public final class DefaultMeter implements Meter {
       public void unbind() {}
     }
 
-    private static final class NoopBuilder extends NoopAbstractCounterBuilder<Builder, LongCounter>
+    private static final class NoopBuilder extends NoopAbstractCounterBuilder<NoopBuilder>
         implements Builder {
 
       @Override
-      protected Builder getThis() {
+      protected NoopBuilder getThis() {
         return this;
       }
 
@@ -234,11 +234,11 @@ public final class DefaultMeter implements Meter {
       public void unbind() {}
     }
 
-    private static final class NoopBuilder
-        extends NoopAbstractInstrumentBuilder<Builder, DoubleMeasure> implements Builder {
+    private static final class NoopBuilder extends NoopAbstractInstrumentBuilder<NoopBuilder>
+        implements Builder {
 
       @Override
-      protected Builder getThis() {
+      protected NoopBuilder getThis() {
         return this;
       }
 
@@ -284,11 +284,11 @@ public final class DefaultMeter implements Meter {
       public void unbind() {}
     }
 
-    private static final class NoopBuilder
-        extends NoopAbstractInstrumentBuilder<Builder, LongMeasure> implements Builder {
+    private static final class NoopBuilder extends NoopAbstractInstrumentBuilder<NoopBuilder>
+        implements Builder {
 
       @Override
-      protected Builder getThis() {
+      protected NoopBuilder getThis() {
         return this;
       }
 
@@ -314,11 +314,11 @@ public final class DefaultMeter implements Meter {
       Utils.checkNotNull(metricUpdater, "metricUpdater");
     }
 
-    private static final class NoopBuilder
-        extends NoopAbstractObserverBuilder<Builder, DoubleObserver> implements Builder {
+    private static final class NoopBuilder extends NoopAbstractObserverBuilder<NoopBuilder>
+        implements Builder {
 
       @Override
-      protected Builder getThis() {
+      protected NoopBuilder getThis() {
         return this;
       }
 
@@ -339,11 +339,11 @@ public final class DefaultMeter implements Meter {
       Utils.checkNotNull(metricUpdater, "metricUpdater");
     }
 
-    private static final class NoopBuilder
-        extends NoopAbstractObserverBuilder<Builder, LongObserver> implements Builder {
+    private static final class NoopBuilder extends NoopAbstractObserverBuilder<NoopBuilder>
+        implements Builder {
 
       @Override
-      protected Builder getThis() {
+      protected NoopBuilder getThis() {
         return this;
       }
 
@@ -386,8 +386,8 @@ public final class DefaultMeter implements Meter {
     public void record() {}
   }
 
-  private abstract static class NoopAbstractCounterBuilder<B extends Counter.Builder<B, V>, V>
-      extends NoopAbstractInstrumentBuilder<B, V> implements Counter.Builder<B, V> {
+  private abstract static class NoopAbstractCounterBuilder<B extends NoopAbstractCounterBuilder<B>>
+      extends NoopAbstractInstrumentBuilder<B> implements Counter.Builder {
 
     @Override
     public B setMonotonic(boolean monotonic) {
@@ -395,8 +395,9 @@ public final class DefaultMeter implements Meter {
     }
   }
 
-  private abstract static class NoopAbstractObserverBuilder<B extends Observer.Builder<B, V>, V>
-      extends NoopAbstractInstrumentBuilder<B, V> implements Observer.Builder<B, V> {
+  private abstract static class NoopAbstractObserverBuilder<
+          B extends NoopAbstractObserverBuilder<B>>
+      extends NoopAbstractInstrumentBuilder<B> implements Observer.Builder {
 
     @Override
     public B setMonotonic(boolean monotonic) {
@@ -404,8 +405,9 @@ public final class DefaultMeter implements Meter {
     }
   }
 
-  private abstract static class NoopAbstractInstrumentBuilder<B extends Instrument.Builder<B, V>, V>
-      implements Instrument.Builder<B, V> {
+  private abstract static class NoopAbstractInstrumentBuilder<
+          B extends NoopAbstractInstrumentBuilder<B>>
+      implements Instrument.Builder {
 
     @Override
     public B setDescription(String description) {

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleCounter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleCounter.java
@@ -17,6 +17,8 @@
 package io.opentelemetry.metrics;
 
 import io.opentelemetry.metrics.DoubleCounter.BoundDoubleCounter;
+import java.util.List;
+import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -90,5 +92,23 @@ public interface DoubleCounter extends Counter<BoundDoubleCounter> {
   }
 
   /** Builder class for {@link DoubleCounter}. */
-  interface Builder extends Counter.Builder<Builder, DoubleCounter> {}
+  interface Builder extends Counter.Builder {
+    @Override
+    Builder setDescription(String description);
+
+    @Override
+    Builder setUnit(String unit);
+
+    @Override
+    Builder setLabelKeys(List<String> labelKeys);
+
+    @Override
+    Builder setConstantLabels(Map<String, String> constantLabels);
+
+    @Override
+    Builder setMonotonic(boolean monotonic);
+
+    @Override
+    DoubleCounter build();
+  }
 }

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleMeasure.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleMeasure.java
@@ -17,6 +17,8 @@
 package io.opentelemetry.metrics;
 
 import io.opentelemetry.metrics.DoubleMeasure.BoundDoubleMeasure;
+import java.util.List;
+import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -84,5 +86,23 @@ public interface DoubleMeasure extends Measure<BoundDoubleMeasure> {
   }
 
   /** Builder class for {@link DoubleMeasure}. */
-  interface Builder extends Measure.Builder<Builder, DoubleMeasure> {}
+  interface Builder extends Measure.Builder {
+    @Override
+    Builder setDescription(String description);
+
+    @Override
+    Builder setUnit(String unit);
+
+    @Override
+    Builder setLabelKeys(List<String> labelKeys);
+
+    @Override
+    Builder setConstantLabels(Map<String, String> constantLabels);
+
+    @Override
+    Builder setAbsolute(boolean absolute);
+
+    @Override
+    DoubleMeasure build();
+  }
 }

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleObserver.java
@@ -17,6 +17,8 @@
 package io.opentelemetry.metrics;
 
 import io.opentelemetry.metrics.DoubleObserver.ResultDoubleObserver;
+import java.util.List;
+import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -57,7 +59,25 @@ public interface DoubleObserver extends Observer<ResultDoubleObserver> {
   void setCallback(Callback<ResultDoubleObserver> metricUpdater);
 
   /** Builder class for {@link DoubleObserver}. */
-  interface Builder extends Observer.Builder<DoubleObserver.Builder, DoubleObserver> {}
+  interface Builder extends Observer.Builder {
+    @Override
+    Builder setDescription(String description);
+
+    @Override
+    Builder setUnit(String unit);
+
+    @Override
+    Builder setLabelKeys(List<String> labelKeys);
+
+    @Override
+    Builder setConstantLabels(Map<String, String> constantLabels);
+
+    @Override
+    Builder setMonotonic(boolean monotonic);
+
+    @Override
+    DoubleObserver build();
+  }
 
   /** The result for the {@link io.opentelemetry.metrics.Observer.Callback}. */
   interface ResultDoubleObserver {

--- a/api/src/main/java/io/opentelemetry/metrics/Instrument.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Instrument.java
@@ -29,13 +29,8 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 @SuppressWarnings("InterfaceWithOnlyStatics")
 public interface Instrument {
-  /**
-   * The {@code Builder} class for the {@code Instrument}.
-   *
-   * @param <B> the specific builder object.
-   * @param <V> the return value for {@code build()}.
-   */
-  interface Builder<B extends Builder<B, V>, V> {
+  /** The {@code Builder} class for the {@code Instrument}. */
+  interface Builder {
     /**
      * Sets the description of the {@code Instrument}.
      *
@@ -44,7 +39,7 @@ public interface Instrument {
      * @param description the description of the Instrument.
      * @return this.
      */
-    B setDescription(String description);
+    Builder setDescription(String description);
 
     /**
      * Sets the unit of the {@code Instrument}.
@@ -54,7 +49,7 @@ public interface Instrument {
      * @param unit the unit of the Instrument.
      * @return this.
      */
-    B setUnit(String unit);
+    Builder setUnit(String unit);
 
     /**
      * Sets the list of label keys for the Instrument.
@@ -64,7 +59,7 @@ public interface Instrument {
      * @param labelKeys the list of label keys for the Instrument.
      * @return this.
      */
-    B setLabelKeys(List<String> labelKeys);
+    Builder setLabelKeys(List<String> labelKeys);
 
     /**
      * Sets the map of constant labels (they will be added to all the Bound Instruments) for the
@@ -75,13 +70,13 @@ public interface Instrument {
      * @param constantLabels the map of constant labels for the Instrument.
      * @return this.
      */
-    B setConstantLabels(Map<String, String> constantLabels);
+    Builder setConstantLabels(Map<String, String> constantLabels);
 
     /**
      * Builds and returns a {@code Instrument} with the desired options.
      *
      * @return a {@code Instrument} with the desired options.
      */
-    V build();
+    Instrument build();
   }
 }

--- a/api/src/main/java/io/opentelemetry/metrics/LongCounter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongCounter.java
@@ -17,6 +17,8 @@
 package io.opentelemetry.metrics;
 
 import io.opentelemetry.metrics.LongCounter.BoundLongCounter;
+import java.util.List;
+import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -91,5 +93,23 @@ public interface LongCounter extends Counter<BoundLongCounter> {
   }
 
   /** Builder class for {@link LongCounter}. */
-  interface Builder extends Counter.Builder<Builder, LongCounter> {}
+  interface Builder extends Counter.Builder {
+    @Override
+    Builder setDescription(String description);
+
+    @Override
+    Builder setUnit(String unit);
+
+    @Override
+    Builder setLabelKeys(List<String> labelKeys);
+
+    @Override
+    Builder setConstantLabels(Map<String, String> constantLabels);
+
+    @Override
+    Builder setMonotonic(boolean monotonic);
+
+    @Override
+    LongCounter build();
+  }
 }

--- a/api/src/main/java/io/opentelemetry/metrics/LongMeasure.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongMeasure.java
@@ -17,6 +17,8 @@
 package io.opentelemetry.metrics;
 
 import io.opentelemetry.metrics.LongMeasure.BoundLongMeasure;
+import java.util.List;
+import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -84,5 +86,23 @@ public interface LongMeasure extends Measure<BoundLongMeasure> {
   }
 
   /** Builder class for {@link LongMeasure}. */
-  interface Builder extends Measure.Builder<Builder, LongMeasure> {}
+  interface Builder extends Measure.Builder {
+    @Override
+    Builder setDescription(String description);
+
+    @Override
+    Builder setUnit(String unit);
+
+    @Override
+    Builder setLabelKeys(List<String> labelKeys);
+
+    @Override
+    Builder setConstantLabels(Map<String, String> constantLabels);
+
+    @Override
+    Builder setAbsolute(boolean absolute);
+
+    @Override
+    LongMeasure build();
+  }
 }

--- a/api/src/main/java/io/opentelemetry/metrics/LongObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongObserver.java
@@ -17,6 +17,8 @@
 package io.opentelemetry.metrics;
 
 import io.opentelemetry.metrics.LongObserver.ResultLongObserver;
+import java.util.List;
+import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -57,7 +59,25 @@ public interface LongObserver extends Observer<ResultLongObserver> {
   void setCallback(Callback<ResultLongObserver> metricUpdater);
 
   /** Builder class for {@link LongObserver}. */
-  interface Builder extends Observer.Builder<LongObserver.Builder, LongObserver> {}
+  interface Builder extends Observer.Builder {
+    @Override
+    Builder setDescription(String description);
+
+    @Override
+    Builder setUnit(String unit);
+
+    @Override
+    Builder setLabelKeys(List<String> labelKeys);
+
+    @Override
+    Builder setConstantLabels(Map<String, String> constantLabels);
+
+    @Override
+    Builder setMonotonic(boolean monotonic);
+
+    @Override
+    LongObserver build();
+  }
 
   /** The result for the {@link io.opentelemetry.metrics.Observer.Callback}. */
   interface ResultLongObserver {

--- a/api/src/main/java/io/opentelemetry/metrics/Measure.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Measure.java
@@ -17,6 +17,8 @@
 package io.opentelemetry.metrics;
 
 import io.opentelemetry.metrics.InstrumentWithBinding.BoundInstrument;
+import java.util.List;
+import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -29,7 +31,19 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface Measure<H extends BoundInstrument> extends InstrumentWithBinding<H> {
 
   /** Builder class for {@link Measure}. */
-  interface Builder<B extends Measure.Builder<B, V>, V> extends Instrument.Builder<B, V> {
+  interface Builder extends Instrument.Builder {
+    @Override
+    Builder setDescription(String description);
+
+    @Override
+    Builder setUnit(String unit);
+
+    @Override
+    Builder setLabelKeys(List<String> labelKeys);
+
+    @Override
+    Builder setConstantLabels(Map<String, String> constantLabels);
+
     /**
      * Sets the absolute property for this {@code Builder}. If {@code true} only positive values are
      * expected.
@@ -39,6 +53,9 @@ public interface Measure<H extends BoundInstrument> extends InstrumentWithBindin
      * @param absolute {@code true} only positive values are expected.
      * @return this.
      */
-    B setAbsolute(boolean absolute);
+    Builder setAbsolute(boolean absolute);
+
+    @Override
+    Measure<?> build();
   }
 }

--- a/api/src/main/java/io/opentelemetry/metrics/Observer.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Observer.java
@@ -16,6 +16,8 @@
 
 package io.opentelemetry.metrics;
 
+import java.util.List;
+import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -47,7 +49,19 @@ public interface Observer<R> extends Instrument {
   void setCallback(Callback<R> metricUpdater);
 
   /** Builder class for {@link Observer}. */
-  interface Builder<B extends Instrument.Builder<B, V>, V> extends Instrument.Builder<B, V> {
+  interface Builder extends Instrument.Builder {
+    @Override
+    Builder setDescription(String description);
+
+    @Override
+    Builder setUnit(String unit);
+
+    @Override
+    Builder setLabelKeys(List<String> labelKeys);
+
+    @Override
+    Builder setConstantLabels(Map<String, String> constantLabels);
+
     /**
      * Sets the monotonicity property for this {@code Instrument}. If {@code true} successive values
      * are expected to rise monotonically.
@@ -57,6 +71,9 @@ public interface Observer<R> extends Instrument {
      * @param monotonic {@code true} successive values are expected to rise monotonically.
      * @return this.
      */
-    B setMonotonic(boolean monotonic);
+    Builder setMonotonic(boolean monotonic);
+
+    @Override
+    Observer<?> build();
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractCounter.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractCounter.java
@@ -77,8 +77,8 @@ abstract class AbstractCounter<B extends AbstractBoundInstrument>
     return result;
   }
 
-  abstract static class Builder<B extends Counter.Builder<B, V>, V>
-      extends AbstractInstrument.Builder<B, V> implements Counter.Builder<B, V> {
+  abstract static class Builder<B extends AbstractCounter.Builder<B>>
+      extends AbstractInstrument.Builder<B> implements Counter.Builder {
     private boolean monotonic = true;
 
     Builder(

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
@@ -86,8 +86,8 @@ abstract class AbstractInstrument implements Instrument {
     return descriptor.hashCode();
   }
 
-  abstract static class Builder<B extends Instrument.Builder<B, V>, V>
-      implements Instrument.Builder<B, V> {
+  abstract static class Builder<B extends AbstractInstrument.Builder<?>>
+      implements Instrument.Builder {
     /* VisibleForTesting */ static final int NAME_MAX_LENGTH = 255;
     /* VisibleForTesting */ static final String ERROR_MESSAGE_INVALID_NAME =
         "Name should be a ASCII string with a length no greater than "

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractMeasure.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractMeasure.java
@@ -77,8 +77,8 @@ abstract class AbstractMeasure<B extends AbstractBoundInstrument>
     return result;
   }
 
-  abstract static class Builder<B extends Measure.Builder<B, V>, V>
-      extends AbstractInstrument.Builder<B, V> implements Measure.Builder<B, V> {
+  abstract static class Builder<B extends AbstractMeasure.Builder<B>>
+      extends AbstractInstrument.Builder<B> implements Measure.Builder {
     private boolean absolute = true;
 
     Builder(

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractObserver.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractObserver.java
@@ -67,8 +67,8 @@ abstract class AbstractObserver extends AbstractInstrument {
     return result;
   }
 
-  abstract static class Builder<B extends Observer.Builder<B, V>, V>
-      extends AbstractInstrument.Builder<B, V> implements Observer.Builder<B, V> {
+  abstract static class Builder<B extends AbstractObserver.Builder<B>>
+      extends AbstractInstrument.Builder<B> implements Observer.Builder {
     private boolean monotonic = false;
 
     Builder(

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleCounterSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleCounterSdk.java
@@ -72,7 +72,7 @@ final class DoubleCounterSdk extends AbstractCounter<BoundInstrument> implements
     }
   }
 
-  static final class Builder extends AbstractCounter.Builder<DoubleCounter.Builder, DoubleCounter>
+  static final class Builder extends AbstractCounter.Builder<DoubleCounterSdk.Builder>
       implements DoubleCounter.Builder {
 
     Builder(

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleMeasureSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleMeasureSdk.java
@@ -72,7 +72,7 @@ final class DoubleMeasureSdk extends AbstractMeasure<BoundInstrument> implements
     }
   }
 
-  static final class Builder extends AbstractMeasure.Builder<DoubleMeasure.Builder, DoubleMeasure>
+  static final class Builder extends AbstractMeasure.Builder<DoubleMeasureSdk.Builder>
       implements DoubleMeasure.Builder {
 
     Builder(

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleObserverSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleObserverSdk.java
@@ -58,8 +58,7 @@ final class DoubleObserverSdk extends AbstractObserver implements DoubleObserver
     this.metricUpdater = Utils.checkNotNull(metricUpdater, "metricUpdater");
   }
 
-  static final class Builder
-      extends AbstractObserver.Builder<DoubleObserver.Builder, DoubleObserver>
+  static final class Builder extends AbstractObserver.Builder<DoubleObserverSdk.Builder>
       implements DoubleObserver.Builder {
 
     Builder(

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongCounterSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongCounterSdk.java
@@ -72,7 +72,7 @@ final class LongCounterSdk extends AbstractCounter<BoundInstrument> implements L
     }
   }
 
-  static final class Builder extends AbstractCounter.Builder<LongCounter.Builder, LongCounter>
+  static final class Builder extends AbstractCounter.Builder<LongCounterSdk.Builder>
       implements LongCounter.Builder {
 
     Builder(

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongMeasureSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongMeasureSdk.java
@@ -69,7 +69,7 @@ final class LongMeasureSdk extends AbstractMeasure<BoundInstrument> implements L
     }
   }
 
-  static final class Builder extends AbstractMeasure.Builder<LongMeasure.Builder, LongMeasure>
+  static final class Builder extends AbstractMeasure.Builder<LongMeasureSdk.Builder>
       implements LongMeasure.Builder {
 
     Builder(

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongObserverSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongObserverSdk.java
@@ -58,7 +58,7 @@ final class LongObserverSdk extends AbstractObserver implements LongObserver {
     this.metricUpdater = Utils.checkNotNull(metricUpdater, "metricUpdater");
   }
 
-  static final class Builder extends AbstractObserver.Builder<LongObserver.Builder, LongObserver>
+  static final class Builder extends AbstractObserver.Builder<LongObserverSdk.Builder>
       implements LongObserver.Builder {
 
     Builder(

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractCounterBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractCounterBuilderTest.java
@@ -71,7 +71,7 @@ public class AbstractCounterBuilderTest {
   }
 
   private static final class TestInstrumentBuilder
-      extends AbstractCounter.Builder<TestInstrumentBuilder, TestInstrument> {
+      extends AbstractCounter.Builder<TestInstrumentBuilder> {
     TestInstrumentBuilder(
         String name,
         MeterProviderSharedState meterProviderSharedState,

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
@@ -169,7 +169,7 @@ public class AbstractInstrumentBuilderTest {
   }
 
   private static final class TestInstrumentBuilder
-      extends AbstractInstrument.Builder<TestInstrumentBuilder, TestInstrument> {
+      extends AbstractInstrument.Builder<TestInstrumentBuilder> {
     TestInstrumentBuilder(
         String name, MeterProviderSharedState sharedState, MeterSharedState meterSharedState) {
       super(name, sharedState, meterSharedState);

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractMeasureBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractMeasureBuilderTest.java
@@ -71,7 +71,7 @@ public class AbstractMeasureBuilderTest {
   }
 
   private static final class TestInstrumentBuilder
-      extends AbstractMeasure.Builder<TestInstrumentBuilder, TestInstrument> {
+      extends AbstractMeasure.Builder<TestInstrumentBuilder> {
     TestInstrumentBuilder(
         String name,
         MeterProviderSharedState meterProviderSharedState,

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractObserverBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractObserverBuilderTest.java
@@ -71,7 +71,7 @@ public class AbstractObserverBuilderTest {
   }
 
   private static final class TestInstrumentBuilder
-      extends AbstractObserver.Builder<TestInstrumentBuilder, TestInstrument> {
+      extends AbstractObserver.Builder<TestInstrumentBuilder> {
     TestInstrumentBuilder(
         String name,
         MeterProviderSharedState meterProviderSharedState,

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleCounterSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleCounterSdkTest.java
@@ -57,7 +57,7 @@ public class DoubleCounterSdkTest {
 
   @Test
   public void collectMetrics_NoRecords() {
-    DoubleCounter doubleCounter =
+    DoubleCounterSdk doubleCounter =
         testSdk
             .doubleCounterBuilder("testCounter")
             .setConstantLabels(Collections.singletonMap("sk1", "sv1"))
@@ -66,8 +66,7 @@ public class DoubleCounterSdkTest {
             .setUnit("ms")
             .setMonotonic(true)
             .build();
-    assertThat(doubleCounter).isInstanceOf(DoubleCounterSdk.class);
-    List<MetricData> metricDataList = ((DoubleCounterSdk) doubleCounter).collectAll();
+    List<MetricData> metricDataList = doubleCounter.collectAll();
     assertThat(metricDataList).hasSize(1);
     MetricData metricData = metricDataList.get(0);
     assertThat(metricData.getDescriptor())
@@ -153,7 +152,7 @@ public class DoubleCounterSdkTest {
 
   @Test
   public void sameBound_ForSameLabelSet() {
-    DoubleCounter doubleCounter = testSdk.doubleCounterBuilder("testCounter").build();
+    DoubleCounterSdk doubleCounter = testSdk.doubleCounterBuilder("testCounter").build();
     BoundDoubleCounter boundCounter = doubleCounter.bind(testSdk.createLabelSet("K", "v"));
     BoundDoubleCounter duplicateBoundCounter = doubleCounter.bind(testSdk.createLabelSet("K", "v"));
     try {
@@ -184,7 +183,7 @@ public class DoubleCounterSdkTest {
 
   @Test
   public void doubleCounterAdd_Monotonicity() {
-    DoubleCounter doubleCounter =
+    DoubleCounterSdk doubleCounter =
         testSdk.doubleCounterBuilder("testCounter").setMonotonic(true).build();
 
     thrown.expect(IllegalArgumentException.class);
@@ -193,7 +192,7 @@ public class DoubleCounterSdkTest {
 
   @Test
   public void boundDoubleCounterAdd_Monotonicity() {
-    DoubleCounter doubleCounter =
+    DoubleCounterSdk doubleCounter =
         testSdk.doubleCounterBuilder("testCounter").setMonotonic(true).build();
 
     thrown.expect(IllegalArgumentException.class);

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleMeasureSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleMeasureSdkTest.java
@@ -177,7 +177,7 @@ public class DoubleMeasureSdkTest {
 
   @Test
   public void sameBound_ForSameLabelSet() {
-    DoubleMeasure doubleMeasure = testSdk.doubleMeasureBuilder("testMeasure").build();
+    DoubleMeasureSdk doubleMeasure = testSdk.doubleMeasureBuilder("testMeasure").build();
     BoundDoubleMeasure boundMeasure = doubleMeasure.bind(testSdk.createLabelSet("K", "v"));
     BoundDoubleMeasure duplicateBoundMeasure = doubleMeasure.bind(testSdk.createLabelSet("K", "v"));
     try {
@@ -208,7 +208,7 @@ public class DoubleMeasureSdkTest {
 
   @Test
   public void doubleMeasureRecord_Absolute() {
-    DoubleMeasure doubleMeasure =
+    DoubleMeasureSdk doubleMeasure =
         testSdk.doubleMeasureBuilder("testMeasure").setAbsolute(true).build();
 
     thrown.expect(IllegalArgumentException.class);
@@ -217,7 +217,7 @@ public class DoubleMeasureSdkTest {
 
   @Test
   public void boundDoubleMeasureRecord_Absolute() {
-    DoubleMeasure doubleMeasure =
+    DoubleMeasureSdk doubleMeasure =
         testSdk.doubleMeasureBuilder("testMeasure").setAbsolute(true).build();
 
     thrown.expect(IllegalArgumentException.class);

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleObserverSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleObserverSdkTest.java
@@ -49,8 +49,7 @@ public class DoubleObserverSdkTest {
   @Test
   public void observeMonotonic_NegativeValue() {
     DoubleObserverSdk doubleObserver =
-        (DoubleObserverSdk)
-            testSdk.doubleObserverBuilder("testObserver").setMonotonic(true).build();
+        testSdk.doubleObserverBuilder("testObserver").setMonotonic(true).build();
 
     doubleObserver.setCallback(
         new Callback<ResultDoubleObserver>() {

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongCounterSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongCounterSdkTest.java
@@ -57,7 +57,7 @@ public class LongCounterSdkTest {
 
   @Test
   public void collectMetrics_NoRecords() {
-    LongCounter longCounter =
+    LongCounterSdk longCounter =
         testSdk
             .longCounterBuilder("testCounter")
             .setConstantLabels(Collections.singletonMap("sk1", "sv1"))
@@ -66,8 +66,7 @@ public class LongCounterSdkTest {
             .setUnit("ms")
             .setMonotonic(true)
             .build();
-    assertThat(longCounter).isInstanceOf(LongCounterSdk.class);
-    List<MetricData> metricDataList = ((LongCounterSdk) longCounter).collectAll();
+    List<MetricData> metricDataList = longCounter.collectAll();
     assertThat(metricDataList).hasSize(1);
     MetricData metricData = metricDataList.get(0);
     assertThat(metricData.getDescriptor())
@@ -151,7 +150,7 @@ public class LongCounterSdkTest {
 
   @Test
   public void sameBound_ForSameLabelSet() {
-    LongCounter longCounter = testSdk.longCounterBuilder("testCounter").build();
+    LongCounterSdk longCounter = testSdk.longCounterBuilder("testCounter").build();
     BoundLongCounter boundCounter = longCounter.bind(testSdk.createLabelSet("K", "v"));
     BoundLongCounter duplicateBoundCounter = longCounter.bind(testSdk.createLabelSet("K", "v"));
     try {
@@ -181,7 +180,8 @@ public class LongCounterSdkTest {
 
   @Test
   public void longCounterAdd_MonotonicityCheck() {
-    LongCounter longCounter = testSdk.longCounterBuilder("testCounter").setMonotonic(true).build();
+    LongCounterSdk longCounter =
+        testSdk.longCounterBuilder("testCounter").setMonotonic(true).build();
 
     thrown.expect(IllegalArgumentException.class);
     longCounter.add(-45, testSdk.createLabelSet());
@@ -189,7 +189,8 @@ public class LongCounterSdkTest {
 
   @Test
   public void boundLongCounterAdd_MonotonicityCheck() {
-    LongCounter longCounter = testSdk.longCounterBuilder("testCounter").setMonotonic(true).build();
+    LongCounterSdk longCounter =
+        testSdk.longCounterBuilder("testCounter").setMonotonic(true).build();
 
     thrown.expect(IllegalArgumentException.class);
     longCounter.bind(testSdk.createLabelSet()).add(-9);

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongMeasureSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongMeasureSdkTest.java
@@ -180,7 +180,7 @@ public class LongMeasureSdkTest {
 
   @Test
   public void sameBound_ForSameLabelSet() {
-    LongMeasure longMeasure = testSdk.longMeasureBuilder("testMeasure").build();
+    LongMeasureSdk longMeasure = testSdk.longMeasureBuilder("testMeasure").build();
     BoundLongMeasure boundMeasure = longMeasure.bind(testSdk.createLabelSet("K", "v"));
     BoundLongMeasure duplicateBoundMeasure = longMeasure.bind(testSdk.createLabelSet("K", "v"));
     try {
@@ -210,7 +210,8 @@ public class LongMeasureSdkTest {
 
   @Test
   public void longMeasureRecord_Absolute() {
-    LongMeasure longMeasure = testSdk.longMeasureBuilder("testMeasure").setAbsolute(true).build();
+    LongMeasureSdk longMeasure =
+        testSdk.longMeasureBuilder("testMeasure").setAbsolute(true).build();
 
     thrown.expect(IllegalArgumentException.class);
     longMeasure.record(-45, testSdk.createLabelSet());
@@ -218,7 +219,8 @@ public class LongMeasureSdkTest {
 
   @Test
   public void boundLongMeasure_Absolute() {
-    LongMeasure longMeasure = testSdk.longMeasureBuilder("testMeasure").setAbsolute(true).build();
+    LongMeasureSdk longMeasure =
+        testSdk.longMeasureBuilder("testMeasure").setAbsolute(true).build();
 
     thrown.expect(IllegalArgumentException.class);
     longMeasure.bind(testSdk.createLabelSet()).record(-9);

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongObserverSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongObserverSdkTest.java
@@ -49,7 +49,7 @@ public class LongObserverSdkTest {
   @Test
   public void observeMonotonic_NegativeValue() {
     LongObserverSdk longObserver =
-        (LongObserverSdk) testSdk.longObserverBuilder("testObserver").setMonotonic(true).build();
+        testSdk.longObserverBuilder("testObserver").setMonotonic(true).build();
 
     longObserver.setCallback(
         new Callback<ResultLongObserver>() {

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkRegistryTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkRegistryTest.java
@@ -19,7 +19,6 @@ package io.opentelemetry.sdk.metrics;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 
-import io.opentelemetry.metrics.LongCounter;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
@@ -97,10 +96,10 @@ public class MeterSdkRegistryTest {
   @Test
   public void metricProducer_GetAllMetrics() {
     MeterSdk meterSdk1 = meterRegistry.get("io.opentelemetry.sdk.metrics.MeterSdkRegistryTest_1");
-    LongCounter longCounter1 = meterSdk1.longCounterBuilder("testLongCounter").build();
+    LongCounterSdk longCounter1 = meterSdk1.longCounterBuilder("testLongCounter").build();
     longCounter1.add(10, meterSdk1.createLabelSet());
     MeterSdk meterSdk2 = meterRegistry.get("io.opentelemetry.sdk.metrics.MeterSdkRegistryTest_2");
-    LongCounter longCounter2 = meterSdk2.longCounterBuilder("testLongCounter").build();
+    LongCounterSdk longCounter2 = meterSdk2.longCounterBuilder("testLongCounter").build();
     longCounter2.add(10, meterSdk2.createLabelSet());
 
     assertThat(meterRegistry.getMetricProducer().getAllMetrics())

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
@@ -20,12 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.metrics.BatchRecorder;
-import io.opentelemetry.metrics.DoubleCounter;
-import io.opentelemetry.metrics.DoubleMeasure;
-import io.opentelemetry.metrics.DoubleObserver;
-import io.opentelemetry.metrics.LongCounter;
-import io.opentelemetry.metrics.LongMeasure;
-import io.opentelemetry.metrics.LongObserver;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.metrics.data.MetricData;
@@ -65,7 +59,7 @@ public class MeterSdkTest {
 
   @Test
   public void testLongCounter() {
-    LongCounter longCounter =
+    LongCounterSdk longCounter =
         testSdk
             .longCounterBuilder("testLongCounter")
             .setConstantLabels(ImmutableMap.of("sk1", "sv1"))
@@ -75,7 +69,6 @@ public class MeterSdkTest {
             .setMonotonic(true)
             .build();
     assertThat(longCounter).isNotNull();
-    assertThat(longCounter).isInstanceOf(LongCounterSdk.class);
 
     assertThat(
             testSdk
@@ -95,7 +88,7 @@ public class MeterSdkTest {
 
   @Test
   public void testLongMeasure() {
-    LongMeasure longMeasure =
+    LongMeasureSdk longMeasure =
         testSdk
             .longMeasureBuilder("testLongMeasure")
             .setConstantLabels(ImmutableMap.of("sk1", "sv1"))
@@ -105,7 +98,6 @@ public class MeterSdkTest {
             .setAbsolute(true)
             .build();
     assertThat(longMeasure).isNotNull();
-    assertThat(longMeasure).isInstanceOf(LongMeasureSdk.class);
 
     assertThat(
             testSdk
@@ -125,7 +117,7 @@ public class MeterSdkTest {
 
   @Test
   public void testLongObserver() {
-    LongObserver longObserver =
+    LongObserverSdk longObserver =
         testSdk
             .longObserverBuilder("testLongObserver")
             .setConstantLabels(ImmutableMap.of("sk1", "sv1"))
@@ -135,7 +127,6 @@ public class MeterSdkTest {
             .setMonotonic(true)
             .build();
     assertThat(longObserver).isNotNull();
-    assertThat(longObserver).isInstanceOf(LongObserverSdk.class);
 
     assertThat(
             testSdk
@@ -155,7 +146,7 @@ public class MeterSdkTest {
 
   @Test
   public void testDoubleCounter() {
-    DoubleCounter doubleCounter =
+    DoubleCounterSdk doubleCounter =
         testSdk
             .doubleCounterBuilder("testDoubleCounter")
             .setConstantLabels(ImmutableMap.of("sk1", "sv1"))
@@ -165,7 +156,6 @@ public class MeterSdkTest {
             .setMonotonic(true)
             .build();
     assertThat(doubleCounter).isNotNull();
-    assertThat(doubleCounter).isInstanceOf(DoubleCounterSdk.class);
 
     assertThat(
             testSdk
@@ -185,7 +175,7 @@ public class MeterSdkTest {
 
   @Test
   public void testDoubleMeasure() {
-    DoubleMeasure doubleMeasure =
+    DoubleMeasureSdk doubleMeasure =
         testSdk
             .doubleMeasureBuilder("testDoubleMeasure")
             .setConstantLabels(ImmutableMap.of("sk1", "sv1"))
@@ -195,7 +185,6 @@ public class MeterSdkTest {
             .setAbsolute(true)
             .build();
     assertThat(doubleMeasure).isNotNull();
-    assertThat(doubleMeasure).isInstanceOf(DoubleMeasureSdk.class);
 
     assertThat(
             testSdk
@@ -215,7 +204,7 @@ public class MeterSdkTest {
 
   @Test
   public void testDoubleObserver() {
-    DoubleObserver doubleObserver =
+    DoubleObserverSdk doubleObserver =
         testSdk
             .doubleObserverBuilder("testDoubleObserver")
             .setConstantLabels(ImmutableMap.of("sk1", "sv1"))
@@ -225,7 +214,6 @@ public class MeterSdkTest {
             .setMonotonic(true)
             .build();
     assertThat(doubleObserver).isNotNull();
-    assertThat(doubleObserver).isInstanceOf(DoubleObserverSdk.class);
 
     assertThat(
             testSdk
@@ -252,14 +240,14 @@ public class MeterSdkTest {
 
   @Test
   public void collectAll() {
-    LongCounter longCounter = testSdk.longCounterBuilder("testLongCounter").build();
+    LongCounterSdk longCounter = testSdk.longCounterBuilder("testLongCounter").build();
     longCounter.add(10, testSdk.createLabelSet());
-    LongMeasure longMeasure = testSdk.longMeasureBuilder("testLongMeasure").build();
+    LongMeasureSdk longMeasure = testSdk.longMeasureBuilder("testLongMeasure").build();
     longMeasure.record(10, testSdk.createLabelSet());
     // LongObserver longObserver = testSdk.longObserverBuilder("testLongObserver").build();
-    DoubleCounter doubleCounter = testSdk.doubleCounterBuilder("testDoubleCounter").build();
+    DoubleCounterSdk doubleCounter = testSdk.doubleCounterBuilder("testDoubleCounter").build();
     doubleCounter.add(10.1, testSdk.createLabelSet());
-    DoubleMeasure doubleMeasure = testSdk.doubleMeasureBuilder("testDoubleMeasure").build();
+    DoubleMeasureSdk doubleMeasure = testSdk.doubleMeasureBuilder("testDoubleMeasure").build();
     doubleMeasure.record(10.1, testSdk.createLabelSet());
     // DoubleObserver doubleObserver = testSdk.doubleObserverBuilder("testDoubleObserver").build();
 


### PR DESCRIPTION
This change allows us in the SDK and default implementation to return the implementation types for builder's methods.

The main downside is that if we forget to override any of the builder methods in any API builder then we have a broken builder in the API.