### PR TITLE
Rename the Context methods returning Scope to currentContextWith()

### DIFF
--- a/api/src/main/java/io/opentelemetry/correlationcontext/CorrelationsContextUtils.java
+++ b/api/src/main/java/io/opentelemetry/correlationcontext/CorrelationsContextUtils.java
@@ -90,7 +90,7 @@ public final class CorrelationsContextUtils {
    * @return the {@link Scope} for the updated {@code Context}.
    * @since 0.1.0
    */
-  public static Scope withScopedCorrelationContext(CorrelationContext corrContext) {
+  public static Scope currentContextWith(CorrelationContext corrContext) {
     Context context = withCorrelationContext(corrContext, Context.current());
     return ContextUtils.withScopedContext(context);
   }

--- a/api/src/main/java/io/opentelemetry/correlationcontext/DefaultCorrelationContextManager.java
+++ b/api/src/main/java/io/opentelemetry/correlationcontext/DefaultCorrelationContextManager.java
@@ -59,7 +59,7 @@ public final class DefaultCorrelationContextManager implements CorrelationContex
 
   @Override
   public Scope withContext(CorrelationContext distContext) {
-    return CorrelationsContextUtils.withScopedCorrelationContext(distContext);
+    return CorrelationsContextUtils.currentContextWith(distContext);
   }
 
   @Override

--- a/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
@@ -50,7 +50,7 @@ public final class DefaultTracer implements Tracer {
 
   @Override
   public Scope withSpan(Span span) {
-    return TracingContextUtils.withScopedSpan(span);
+    return TracingContextUtils.currentContextWith(span);
   }
 
   @Override

--- a/api/src/main/java/io/opentelemetry/trace/TracingContextUtils.java
+++ b/api/src/main/java/io/opentelemetry/trace/TracingContextUtils.java
@@ -89,7 +89,7 @@ public final class TracingContextUtils {
    * @return the {@link Scope} for the updated {@code Context}.
    * @since 0.1.0
    */
-  public static Scope withScopedSpan(Span span) {
+  public static Scope currentContextWith(Span span) {
     return ContextUtils.withScopedContext(withSpan(span, Context.current()));
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/correlationcontext/CorrelationContextManagerSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/correlationcontext/CorrelationContextManagerSdk.java
@@ -40,7 +40,7 @@ public class CorrelationContextManagerSdk implements CorrelationContextManager {
 
   @Override
   public Scope withContext(CorrelationContext distContext) {
-    return CorrelationsContextUtils.withScopedCorrelationContext(distContext);
+    return CorrelationsContextUtils.currentContextWith(distContext);
   }
 
   @Override

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
@@ -44,7 +44,7 @@ public final class TracerSdk implements Tracer {
 
   @Override
   public Scope withSpan(Span span) {
-    return TracingContextUtils.withScopedSpan(span);
+    return TracingContextUtils.currentContextWith(span);
   }
 
   @Override


### PR DESCRIPTION
Small follow up to #904 