### PR TITLE
Move otproto utils from exporter to a contrib sdk package

### DIFF
--- a/exporters/jaeger/build.gradle
+++ b/exporters/jaeger/build.gradle
@@ -12,7 +12,7 @@ ext.moduleName = "io.opentelemetry.exporters.jaeger"
 dependencies {
     api project(':opentelemetry-sdk')
 
-    implementation project(':opentelemetry-exporters-otprotocol'),
+    implementation project(':opentelemetry-sdk-contrib-otproto'),
             libraries.grpc_api,
             project(':opentelemetry-sdk'),
             libraries.grpc_protobuf,

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/Adapter.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/Adapter.java
@@ -20,7 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
 import io.opentelemetry.exporters.jaeger.proto.api_v2.Model;
-import io.opentelemetry.exporters.otprotocol.TraceProtoUtils;
+import io.opentelemetry.sdk.contrib.otproto.TraceProtoUtils;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.TimedEvent;
 import io.opentelemetry.trace.AttributeValue;

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
@@ -24,7 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.util.Durations;
 import com.google.protobuf.util.Timestamps;
 import io.opentelemetry.exporters.jaeger.proto.api_v2.Model;
-import io.opentelemetry.exporters.otprotocol.TraceProtoUtils;
+import io.opentelemetry.sdk.contrib.otproto.TraceProtoUtils;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.TimedEvent;

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporterTest.java
@@ -16,7 +16,6 @@
 
 package io.opentelemetry.exporters.jaeger;
 
-import static io.opentelemetry.exporters.otprotocol.TraceProtoUtils.toProtoTraceId;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.AdditionalAnswers.delegatesTo;
@@ -32,7 +31,7 @@ import io.opentelemetry.exporters.jaeger.proto.api_v2.Collector;
 import io.opentelemetry.exporters.jaeger.proto.api_v2.Collector.PostSpansRequest;
 import io.opentelemetry.exporters.jaeger.proto.api_v2.CollectorServiceGrpc;
 import io.opentelemetry.exporters.jaeger.proto.api_v2.Model;
-import io.opentelemetry.exporters.otprotocol.TraceProtoUtils;
+import io.opentelemetry.sdk.contrib.otproto.TraceProtoUtils;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.Link;
 import io.opentelemetry.trace.Span.Kind;
@@ -108,7 +107,8 @@ public class JaegerGrpcSpanExporterTest {
     assertEquals(1, batch.getSpansCount());
     assertEquals("GET /api/endpoint", batch.getSpans(0).getOperationName());
     assertEquals(
-        toProtoTraceId(TraceId.fromLowerBase16(TRACE_ID, 0)), batch.getSpans(0).getTraceId());
+        TraceProtoUtils.toProtoTraceId(TraceId.fromLowerBase16(TRACE_ID, 0)),
+        batch.getSpans(0).getTraceId());
     assertEquals(
         TraceProtoUtils.toProtoSpanId(SpanId.fromLowerBase16(SPAN_ID, 0)),
         batch.getSpans(0).getSpanId());

--- a/sdk_contrib/otproto/README.md
+++ b/sdk_contrib/otproto/README.md
@@ -1,0 +1,4 @@
+# OpenTelemetry Proto Utils
+
+This module contains code to helps with conversions from OpenTelemetry proto objects to API or SDK
+objects (e.g. SpanId, TraceId, TraceConfig etc.).

--- a/sdk_contrib/otproto/build.gradle
+++ b/sdk_contrib/otproto/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id "java"
+    id "maven-publish"
+
+    id "ru.vyarus.animalsniffer"
+}
+
+description = 'OpenTelemetry Protocol Exporter'
+ext.moduleName = "io.opentelemetry.exporters.otprotocol"
+
+dependencies {
+    api project(':opentelemetry-api'),
+            project(':opentelemetry-proto'),
+            project(':opentelemetry-sdk')
+
+    implementation libraries.protobuf,
+            libraries.protobuf_util
+
+    testImplementation "io.grpc:grpc-testing:${grpcVersion}"
+    testRuntime "io.grpc:grpc-netty-shaded:${grpcVersion}"
+
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+}

--- a/sdk_contrib/otproto/src/main/java/io/opentelemetry/sdk/contrib/otproto/TraceProtoUtils.java
+++ b/sdk_contrib/otproto/src/main/java/io/opentelemetry/sdk/contrib/otproto/TraceProtoUtils.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.exporters.otprotocol;
+package io.opentelemetry.sdk.contrib.otproto;
 
 import com.google.protobuf.ByteString;
 import io.opentelemetry.proto.trace.v1.ConstantSampler;
@@ -25,7 +25,7 @@ import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceId;
 
 /** Utilities for converting various objects to protobuf representations. */
-public class TraceProtoUtils {
+public final class TraceProtoUtils {
   private TraceProtoUtils() {}
 
   /**
@@ -88,7 +88,8 @@ public class TraceProtoUtils {
       }
     }
     if (traceConfigProto.hasProbabilitySampler()) {
-      // TODO: add support for Probability Sampler
+      return Samplers.probability(
+          traceConfigProto.getProbabilitySampler().getSamplingProbability());
     }
     if (traceConfigProto.hasRateLimitingSampler()) {
       // TODO: add support for RateLimiting Sampler

--- a/sdk_contrib/otproto/src/test/java/io/opentelemetry/sdk/contrib/otproto/TraceProtoUtilsTest.java
+++ b/sdk_contrib/otproto/src/test/java/io/opentelemetry/sdk/contrib/otproto/TraceProtoUtilsTest.java
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.exporters.otprotocol;
+package io.opentelemetry.sdk.contrib.otproto;
 
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.protobuf.ByteString;
 import io.opentelemetry.proto.trace.v1.ConstantSampler;
 import io.opentelemetry.proto.trace.v1.ConstantSampler.ConstantDecision;
+import io.opentelemetry.proto.trace.v1.ProbabilitySampler;
 import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.trace.SpanId;
@@ -29,13 +30,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link io.opentelemetry.exporters.otprotocol.TraceProtoUtils}. */
+/** Unit tests for {@link TraceProtoUtils}. */
 @RunWith(JUnit4.class)
 public class TraceProtoUtilsTest {
   private static final io.opentelemetry.proto.trace.v1.TraceConfig TRACE_CONFIG_PROTO =
       io.opentelemetry.proto.trace.v1.TraceConfig.newBuilder()
           .setConstantSampler(
-              ConstantSampler.newBuilder().setDecision(ConstantDecision.ALWAYS_OFF).build())
+              ConstantSampler.newBuilder().setDecision(ConstantDecision.ALWAYS_ON).build())
           .setMaxNumberOfAttributes(10)
           .setMaxNumberOfTimedEvents(9)
           .setMaxNumberOfLinks(8)
@@ -64,11 +65,43 @@ public class TraceProtoUtilsTest {
   @Test
   public void traceConfigFromProto() {
     TraceConfig traceConfig = TraceProtoUtils.traceConfigFromProto(TRACE_CONFIG_PROTO);
-    assertThat(traceConfig.getSampler()).isEqualTo(Samplers.alwaysOff());
+    assertThat(traceConfig.getSampler()).isEqualTo(Samplers.alwaysOn());
     assertThat(traceConfig.getMaxNumberOfAttributes()).isEqualTo(10);
     assertThat(traceConfig.getMaxNumberOfEvents()).isEqualTo(9);
     assertThat(traceConfig.getMaxNumberOfLinks()).isEqualTo(8);
     assertThat(traceConfig.getMaxNumberOfAttributesPerEvent()).isEqualTo(2);
     assertThat(traceConfig.getMaxNumberOfAttributesPerLink()).isEqualTo(1);
+  }
+
+  @Test
+  public void traceConfigFromProto_AlwaysOffSampler() {
+    TraceConfig traceConfig =
+        TraceProtoUtils.traceConfigFromProto(
+            io.opentelemetry.proto.trace.v1.TraceConfig.newBuilder()
+                .setConstantSampler(
+                    ConstantSampler.newBuilder().setDecision(ConstantDecision.ALWAYS_OFF).build())
+                .setMaxNumberOfAttributes(10)
+                .setMaxNumberOfTimedEvents(9)
+                .setMaxNumberOfLinks(8)
+                .setMaxNumberOfAttributesPerTimedEvent(2)
+                .setMaxNumberOfAttributesPerLink(1)
+                .build());
+    assertThat(traceConfig.getSampler()).isEqualTo(Samplers.alwaysOff());
+  }
+
+  @Test
+  public void traceConfigFromProto_ProbabilitySampler() {
+    TraceConfig traceConfig =
+        TraceProtoUtils.traceConfigFromProto(
+            io.opentelemetry.proto.trace.v1.TraceConfig.newBuilder()
+                .setProbabilitySampler(
+                    ProbabilitySampler.newBuilder().setSamplingProbability(0.1).build())
+                .setMaxNumberOfAttributes(10)
+                .setMaxNumberOfTimedEvents(9)
+                .setMaxNumberOfLinks(8)
+                .setMaxNumberOfAttributesPerTimedEvent(2)
+                .setMaxNumberOfAttributesPerLink(1)
+                .build());
+    assertThat(traceConfig.getSampler()).isEqualTo(Samplers.probability(0.1));
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,9 +31,10 @@ include ":opentelemetry-all",
         ":opentelemetry-proto",
         ":opentelemetry-sdk",
         ":opentelemetry-sdk-contrib-async-processor",
+        ":opentelemetry-sdk-contrib-auto-config",
         ":opentelemetry-sdk-contrib-aws-v1-support",
-        ":opentelemetry-sdk-contrib-testbed",
-        ":opentelemetry-sdk-contrib-auto-config"
+        ":opentelemetry-sdk-contrib-otproto",
+        ":opentelemetry-sdk-contrib-testbed"
 
 project(':opentelemetry-all').projectDir = "$rootDir/all" as File
 project(':opentelemetry-api').projectDir = "$rootDir/api" as File
@@ -56,9 +57,11 @@ project(':opentelemetry-proto').projectDir = "$rootDir/proto" as File
 project(':opentelemetry-sdk').projectDir = "$rootDir/sdk" as File
 project(':opentelemetry-sdk-contrib-async-processor').projectDir =
         "$rootDir/sdk_contrib/async_processor" as File
-project(':opentelemetry-sdk-contrib-aws-v1-support').projectDir =
-        "$rootDir/sdk_contrib/aws_v1_support" as File
-project(':opentelemetry-sdk-contrib-testbed').projectDir =
-        "$rootDir/sdk_contrib/testbed" as File
 project(':opentelemetry-sdk-contrib-auto-config').projectDir =
         "$rootDir/sdk_contrib/auto_config" as File
+project(':opentelemetry-sdk-contrib-aws-v1-support').projectDir =
+        "$rootDir/sdk_contrib/aws_v1_support" as File
+project(':opentelemetry-sdk-contrib-otproto').projectDir =
+        "$rootDir/sdk_contrib/otproto" as File
+project(':opentelemetry-sdk-contrib-testbed').projectDir =
+        "$rootDir/sdk_contrib/testbed" as File


### PR DESCRIPTION
We don't want the Jaeger exporter which shares these utils to depend on the otelprotocol