### PR TITLE
Add javadoc link to all readmes

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -10,28 +10,16 @@ def subprojects = [
         project(':opentelemetry-context-prop'),
         project(':opentelemetry-contrib-runtime-metrics'),
         project(':opentelemetry-contrib-trace-utils'),
+        project(':opentelemetry-exporters-logging'),
         project(':opentelemetry-exporters-inmemory'),
         project(':opentelemetry-exporters-jaeger'),
+        project(':opentelemetry-exporters-otprotocol'),
         project(':opentelemetry-opentracing-shim'),
         project(':opentelemetry-sdk'),
         project(':opentelemetry-sdk-contrib-async-processor'),
-        project(':opentelemetry-sdk-contrib-testbed'),
         project(':opentelemetry-sdk-contrib-auto-config'),
-]
-
-// A subset of subprojects for which we want to publish javadoc.
-def subprojects_javadoc = [
-        project(':opentelemetry-api'),
-        project(':opentelemetry-context-prop'),
-        project(':opentelemetry-contrib-runtime-metrics'),
-        project(':opentelemetry-contrib-trace-utils'),
-        project(':opentelemetry-exporters-inmemory'),
-        project(':opentelemetry-exporters-jaeger'),
-        project(':opentelemetry-opentracing-shim'),
-        project(':opentelemetry-sdk'),
-        project(':opentelemetry-sdk-contrib-async-processor'),
+        project(':opentelemetry-sdk-contrib-otproto'),
         project(':opentelemetry-sdk-contrib-testbed'),
-        project(':opentelemetry-sdk-contrib-auto-config'),
 ]
 
 for (subproject in rootProject.subprojects) {
@@ -43,19 +31,6 @@ for (subproject in rootProject.subprojects) {
 
 dependencies {
     compile subprojects
-}
-
-javadoc {
-    classpath = files(subprojects_javadoc.collect { subproject ->
-        subproject.javadoc.classpath
-    })
-    for (subproject in subprojects_javadoc) {
-        if (subproject == project) {
-            continue
-        }
-        source subproject.javadoc.source
-        options.links subproject.javadoc.options.links.toArray(new String[0])
-    }
 }
 
 task jacocoMerge(type: JacocoMerge) {

--- a/api/README.md
+++ b/api/README.md
@@ -1,6 +1,10 @@
-OpenTelemetry API
-======================================================
+# OpenTelemetry API
+
+[![Javadocs][javadoc-image]][javadoc-url]
 
 * Java 7 and Android 14 compatible.
 * The abstract classes in this directory can be subclassed to create alternative
   implementations of the OpenTelemetry library.
+
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-api.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-api

--- a/context_prop/README.md
+++ b/context_prop/README.md
@@ -1,0 +1,8 @@
+# OpenTelemetry Context Propagation
+
+[![Javadocs][javadoc-image]][javadoc-url]
+
+* Java 7 compatible.
+
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-context-prop.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-context-prop

--- a/contrib/runtime_metrics/README.md
+++ b/contrib/runtime_metrics/README.md
@@ -1,4 +1,9 @@
 OpenTelemetry Contrib Runtime Metrics
 ======================================================
 
+[![Javadocs][javadoc-image]][javadoc-url]
+
 * Java 7 compatible.
+
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-contrib-runtime-metrics.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-contrib-runtime-metrics

--- a/contrib/trace_utils/README.md
+++ b/contrib/trace_utils/README.md
@@ -1,4 +1,9 @@
 OpenTelemetry Contrib Trace Utils
 ======================================================
 
+[![Javadocs][javadoc-image]][javadoc-url]
+
 * Java 7 compatible.
+
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-contrib-trace-utils.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-contrib-trace-utils

--- a/exporters/inmemory/README.md
+++ b/exporters/inmemory/README.md
@@ -1,0 +1,8 @@
+# OpenTelemetry - In-Memory Exporter
+
+[![Javadocs][javadoc-image]][javadoc-url]
+
+* Java 7 compatible.
+
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporters-inmemory.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporters-inmemory

--- a/exporters/jaeger/README.md
+++ b/exporters/jaeger/README.md
@@ -1,5 +1,7 @@
 # OpenTelemetry - Jaeger Exporter - gRPC
 
+[![Javadocs][javadoc-image]][javadoc-url]
+
 This is the OpenTelemetry exporter, sending span data to Jaeger via gRPC. 
 
 ## Proto files
@@ -8,3 +10,5 @@ The proto files in this repository were copied over from the [Jaeger main reposi
 
 [proto-origin]: https://github.com/jaegertracing/jaeger/tree/5b8c1f40f932897b9322bf3f110d830536ae4c71/model/proto
 [proto-discussion]: https://github.com/open-telemetry/opentelemetry-java/issues/235
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporters-jaeger.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporters-jaeger

--- a/exporters/logging/README.md
+++ b/exporters/logging/README.md
@@ -1,0 +1,8 @@
+# OpenTelemetry - Logging Exporter
+
+[![Javadocs][javadoc-image]][javadoc-url]
+
+* Java 7 compatible.
+
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporters-logging.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporters-logging

--- a/exporters/otprotocol/README.md
+++ b/exporters/otprotocol/README.md
@@ -1,4 +1,8 @@
-# OpenTelemetry Protocol Exporter - gRPC
+# OpenTelemetry - OTLP Exporter - gRPC
 
-This is the OpenTelemetry exporter, sending span data to OpenTelemetry collector
-via gRPC. 
+[![Javadocs][javadoc-image]][javadoc-url]
+
+This is the OpenTelemetry exporter, sending span data to OpenTelemetry collector via gRPC.
+
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporters-otprotocol.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporters-otprotocol

--- a/opentracing_shim/README.md
+++ b/opentracing_shim/README.md
@@ -1,0 +1,6 @@
+# OpenTelemetry - OpenTracing Shim
+
+[![Javadocs][javadoc-image]][javadoc-url]
+
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-opentracing-shim.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-opentracing-shim

--- a/proto/README.md
+++ b/proto/README.md
@@ -1,0 +1,6 @@
+# OpenTelemetry - Protobuf messages
+
+[![Javadocs][javadoc-image]][javadoc-url]
+
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-proto.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-proto

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,4 +1,9 @@
 OpenTelemetry SDK
 ======================================================
 
+[![Javadocs][javadoc-image]][javadoc-url]
+
 * Java 7 and Android 14 compatible.
+
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-sdk.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk

--- a/sdk_contrib/async_processor/README.md
+++ b/sdk_contrib/async_processor/README.md
@@ -1,7 +1,12 @@
 # OpenTelemetry SDK Contrib Async Processor
 
+[![Javadocs][javadoc-image]][javadoc-url]
+
 An implementation of the trace `SpanProcessors` that uses
 [Disruptor](https://github.com/LMAX-Exchange/disruptor) to make all the `SpanProcessors` hooks run
 async.
 
 * Java 8 compatible.
+
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-sdk-contrib-async-processor.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-contrib-async-processor

--- a/sdk_contrib/auto_config/README.md
+++ b/sdk_contrib/auto_config/README.md
@@ -1,5 +1,10 @@
 # OpenTelemetry SDK Contrib - Auto Instrumentation Configuration Utilities
 
+[![Javadocs][javadoc-image]][javadoc-url]
+
 This module contains code to assist with configuring the SDK for the auto-instrumentation
 project. It is temporarily a separate module from the SDK in order to stabilize
 the APIs, then it will be moved into the SDK project proper.
+
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-sdk-contrib-auto-config.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-contrib-auto-config

--- a/sdk_contrib/aws_v1_support/README.md
+++ b/sdk_contrib/aws_v1_support/README.md
@@ -1,0 +1,6 @@
+# OpenTelemetry AWS Utils
+
+[![Javadocs][javadoc-image]][javadoc-url]
+
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-sdk-aws-v1-support.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-aws-v1-support

--- a/sdk_contrib/otproto/README.md
+++ b/sdk_contrib/otproto/README.md
@@ -1,4 +1,9 @@
 # OpenTelemetry Proto Utils
 
+[![Javadocs][javadoc-image]][javadoc-url]
+
 This module contains code to helps with conversions from OpenTelemetry proto objects to API or SDK
 objects (e.g. SpanId, TraceId, TraceConfig etc.).
+
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-sdk-contrib-otproto.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-contrib-otproto


### PR DESCRIPTION
All was genereting all javadoc as well because was copied form OpenCensus. We don't need to do that now, also all is not exported to maven.

Add links to javadoc hosted by `javadoc.io` for all exported packages.