### PR TITLE
Fix OTLP exporter

### DIFF
--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/ResourceAdapter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/ResourceAdapter.java
@@ -23,7 +23,7 @@ import java.util.Map;
 final class ResourceAdapter {
   static Resource toProtoResource(io.opentelemetry.sdk.resources.Resource resource) {
     Resource.Builder builder = Resource.newBuilder();
-    for (Map.Entry<String, AttributeValue> resourceEntry : resource.getLabels().entrySet()) {
+    for (Map.Entry<String, AttributeValue> resourceEntry : resource.getAttributes().entrySet()) {
       builder.addAttributes(
           CommonAdapter.toProtoAttribute(resourceEntry.getKey(), resourceEntry.getValue()));
     }


### PR DESCRIPTION
#984 added a call to `Resource.getLabels` which was renamed in #970 but both were merged without updating the other PR first. This fixes the broken build.