### PR TITLE
Handle Tracer.close() in the OT shim.

### DIFF
--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/NoopSpanBuilderShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/NoopSpanBuilderShim.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.opentracingshim;
+
+import io.opentelemetry.trace.DefaultTracer;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer.SpanBuilder;
+import io.opentracing.tag.Tag;
+
+final class NoopSpanBuilderShim extends BaseShimObject implements SpanBuilder {
+  private final String spanName;
+
+  public NoopSpanBuilderShim(TelemetryInfo telemetryInfo, String spanName) {
+    super(telemetryInfo);
+    this.spanName = spanName == null ? "" : spanName; // OT is more permissive than OTel.
+  }
+
+  @Override
+  public SpanBuilder asChildOf(Span parent) {
+    return this;
+  }
+
+  @Override
+  public SpanBuilder asChildOf(SpanContext parent) {
+    return this;
+  }
+
+  @Override
+  public SpanBuilder addReference(String referenceType, SpanContext referencedContext) {
+    return this;
+  }
+
+  @Override
+  public SpanBuilder ignoreActiveSpan() {
+    return this;
+  }
+
+  @Override
+  public SpanBuilder withTag(String key, String value) {
+    return this;
+  }
+
+  @Override
+  public SpanBuilder withTag(String key, boolean value) {
+    return this;
+  }
+
+  @Override
+  public SpanBuilder withTag(String key, Number number) {
+    return this;
+  }
+
+  @Override
+  public <T> SpanBuilder withTag(Tag<T> tag, T value) {
+    return this;
+  }
+
+  @Override
+  public SpanBuilder withStartTimestamp(long microseconds) {
+    return this;
+  }
+
+  @Override
+  public Span start() {
+    return new SpanShim(
+        telemetryInfo, DefaultTracer.getInstance().spanBuilder(spanName).startSpan());
+  }
+}

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/TracerShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/TracerShim.java
@@ -32,6 +32,7 @@ final class TracerShim extends BaseShimObject implements Tracer {
 
   private final ScopeManager scopeManagerShim;
   private final Propagation propagation;
+  private volatile boolean isClosed;
 
   TracerShim(TelemetryInfo telemetryInfo) {
     super(telemetryInfo);
@@ -56,6 +57,10 @@ final class TracerShim extends BaseShimObject implements Tracer {
 
   @Override
   public SpanBuilder buildSpan(String operationName) {
+    if (isClosed) {
+      return new NoopSpanBuilderShim(telemetryInfo(), operationName);
+    }
+
     return new SpanBuilderShim(telemetryInfo, operationName);
   }
 
@@ -97,7 +102,7 @@ final class TracerShim extends BaseShimObject implements Tracer {
 
   @Override
   public void close() {
-    // TODO
+    isClosed = true;
   }
 
   static SpanContextShim getContextShim(SpanContext context) {

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/TracerShimTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/TracerShimTest.java
@@ -19,8 +19,10 @@ package io.opentelemetry.opentracingshim;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import io.opentelemetry.OpenTelemetry;
+import io.opentelemetry.trace.DefaultSpan;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
@@ -84,5 +86,13 @@ public class TracerShimTest {
     Map<String, String> map = new HashMap<String, String>();
     tracerShim.inject(null, Format.Builtin.TEXT_MAP, new TextMapAdapter(map));
     assertEquals(0, map.size());
+  }
+
+  @Test
+  public void close() {
+    tracerShim.close();
+    Span otSpan = tracerShim.buildSpan(null).start();
+    io.opentelemetry.trace.Span span = ((SpanShim) otSpan).getSpan();
+    assertTrue(span instanceof DefaultSpan);
   }
 }


### PR DESCRIPTION
This was an old TODO that I had totally forgotten about ;)

PS - We 'sadly' cannot call any shutdown routine as those methods live (for now, at least) only in the SDK portion (which we don't want to depend on).