### PR TITLE
Limit RecordEventsReadableSpan attributes to configured max

### DIFF
--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/SpanAdapter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/SpanAdapter.java
@@ -135,7 +135,8 @@ final class SpanAdapter {
       builder.addAttributes(
           CommonAdapter.toProtoAttribute(resourceEntry.getKey(), resourceEntry.getValue()));
     }
-    builder.setDroppedAttributesCount(timedEvent.getDroppedAttributeCount());
+    builder.setDroppedAttributesCount(
+        timedEvent.getTotalAttributeCount() - timedEvent.getAttributes().size());
     return builder.build();
   }
 
@@ -148,7 +149,7 @@ final class SpanAdapter {
       builder.addAttributes(
           CommonAdapter.toProtoAttribute(resourceEntry.getKey(), resourceEntry.getValue()));
     }
-    builder.setDroppedAttributesCount(link.getDroppedAttributeCount());
+    builder.setDroppedAttributesCount(link.getTotalAttributeCount() - link.getAttributes().size());
     return builder.build();
   }
 

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/SpanAdapter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/SpanAdapter.java
@@ -96,7 +96,8 @@ final class SpanAdapter {
       builder.addAttributes(
           CommonAdapter.toProtoAttribute(resourceEntry.getKey(), resourceEntry.getValue()));
     }
-    builder.setDroppedAttributesCount(spanData.getDroppedAttributeCount());
+    builder.setDroppedAttributesCount(
+        spanData.getTotalAttributeCount() - spanData.getAttributes().size());
     for (TimedEvent timedEvent : spanData.getTimedEvents()) {
       builder.addEvents(toProtoSpanEvent(timedEvent));
     }

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
@@ -68,7 +68,7 @@ public class SpanAdapterTest {
                 .setEndEpochNanos(12349)
                 .setAttributes(
                     Collections.singletonMap("key", AttributeValue.booleanAttributeValue(true)))
-                .setDroppedAttributeCount(1)
+                .setTotalAttributeCount(2)
                 .setTimedEvents(
                     Collections.singletonList(
                         TimedEvent.create(

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
@@ -265,7 +265,7 @@ public class SpanAdapterTest {
                         .setStringValue("string")
                         .setType(ValueType.STRING)
                         .build())
-                .setDroppedAttributesCount(5)
+                .setDroppedAttributesCount(4)
                 .build());
   }
 
@@ -298,7 +298,7 @@ public class SpanAdapterTest {
                         .setStringValue("string")
                         .setType(ValueType.STRING)
                         .build())
-                .setDroppedAttributesCount(5)
+                .setDroppedAttributesCount(4)
                 .build());
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -392,8 +392,17 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
 
     Map<String, AttributeValue> temp = new HashMap<String, AttributeValue>();
     for (Map.Entry<String, AttributeValue> entry : attributes.entrySet()) {
-      temp.put(entry.getKey(), entry.getValue());
+      if (temp.size() < this.maxNumberOfAttributesPerEvent) {
+        temp.put(entry.getKey(), entry.getValue());
+      }
     }
+    logger.log(
+        Level.FINE,
+        "Link has reached the maximum number of attributes ("
+            + maxNumberOfAttributesPerEvent
+            + "). Dropping "
+            + (attributes.size() - temp.size())
+            + " attributes.");
     return temp;
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -63,10 +63,10 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   private final List<Link> links;
   // Number of links recorded.
   private final int totalRecordedLinks;
-  // Max number of attibutes per span
+  // Max number of attibutes per span.
   private int maxNumberOfAttributes = 0;
-  // Number of dropped attributes after reaching maxNumberOfAttributes
-  private int droppedAttributeCount = 0;
+  // Number of attributes recorded.
+  private int totalAttributeCount = 0;
 
   // Lock used to internally guard the mutable state of this instance
   private final Object lock = new Object();
@@ -176,7 +176,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
             .setHasRemoteParent(hasRemoteParent)
             .setResource(resource)
             .setStartEpochNanos(startEpochNanos)
-            .setDroppedAttributeCount(droppedAttributeCount);
+            .setTotalAttributeCount(totalAttributeCount);
 
     // Copy remainder within synchronized
     synchronized (lock) {
@@ -330,13 +330,13 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
         logger.log(Level.FINE, "Calling setAttribute() on an ended Span.");
         return;
       }
+      totalAttributeCount++;
       if (attributes.get(key) == null && attributes.size() >= maxNumberOfAttributes) {
         logger.log(
             Level.FINE,
             "Span has maximum number of attributes ("
                 + maxNumberOfAttributes
                 + "). Dropping new entries.");
-        droppedAttributeCount += 1;
         return;
       }
       attributes.putAttribute(key, value);

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -50,6 +50,10 @@ import javax.annotation.concurrent.ThreadSafe;
 final class RecordEventsReadableSpan implements ReadableSpan, Span {
 
   private static final Logger logger = Logger.getLogger(Tracer.class.getName());
+  private static final String MAX_SPAN_ATTRIBUTE_COUNT_LOG_MESSAGE =
+      "Span with name '%s' has reached the maximum number of attributes (%d). Dropping attribute with key '%s'";
+  private static final String MAX_LINK_ATTRIBUTE_COUNT_LOG_MESSAGE =
+      "Link has reached the maximum number of attributes (%d). Dropping %d attributes.";
 
   // Contains the identifiers associated with this Span.
   private final SpanContext context;
@@ -338,13 +342,8 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
       if (attributes.get(key) == null && attributes.size() >= maxNumberOfAttributes) {
         logger.log(
             Level.FINE,
-            "Span with name '"
-                + this.name
-                + "' has reached the maximum number of attributes ("
-                + maxNumberOfAttributes
-                + "). Dropping attribute with key '"
-                + key
-                + "'");
+            String.format(
+                MAX_SPAN_ATTRIBUTE_COUNT_LOG_MESSAGE, this.name, maxNumberOfAttributes, key));
         return;
       }
       attributes.putAttribute(key, value);
@@ -399,11 +398,10 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     }
     logger.log(
         Level.FINE,
-        "Link has reached the maximum number of attributes ("
-            + maxNumberOfAttributesPerEvent
-            + "). Dropping "
-            + (attributes.size() - temp.size())
-            + " attributes.");
+        String.format(
+            MAX_LINK_ATTRIBUTE_COUNT_LOG_MESSAGE,
+            maxNumberOfAttributesPerEvent,
+            attributes.size() - temp.size()));
     return temp;
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -50,8 +50,11 @@ import javax.annotation.concurrent.ThreadSafe;
 final class RecordEventsReadableSpan implements ReadableSpan, Span {
 
   private static final Logger logger = Logger.getLogger(Tracer.class.getName());
+
+  @SuppressWarnings("checkstyle:LineLength")
   private static final String MAX_SPAN_ATTRIBUTE_COUNT_LOG_MESSAGE =
       "Span with name '%s' has reached the maximum number of attributes (%d). Dropping attribute with key '%s'";
+
   private static final String MAX_LINK_ATTRIBUTE_COUNT_LOG_MESSAGE =
       "Link has reached the maximum number of attributes (%d). Dropping %d attributes.";
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -66,8 +66,6 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   private final int totalRecordedLinks;
   // Max number of attibutes per span.
   private final int maxNumberOfAttributes;
-  // Number of attributes recorded.
-  private int totalAttributeCount = 0;
   // Max number of attributes per event.
   private final int maxNumberOfAttributesPerEvent;
 
@@ -92,6 +90,9 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   // List of recorded events.
   @GuardedBy("lock")
   private final EvictingQueue<TimedEvent> events;
+  // Number of attributes recorded.
+  @GuardedBy("lock")
+  private int totalAttributeCount = 0;
   // Number of events recorded.
   @GuardedBy("lock")
   private int totalRecordedEvents = 0;
@@ -178,8 +179,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
             .setParentSpanId(parentSpanId)
             .setHasRemoteParent(hasRemoteParent)
             .setResource(resource)
-            .setStartEpochNanos(startEpochNanos)
-            .setTotalAttributeCount(totalAttributeCount);
+            .setStartEpochNanos(startEpochNanos);
 
     // Copy remainder within synchronized
     synchronized (lock) {
@@ -189,6 +189,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
           .setEndEpochNanos(getEndEpochNanos())
           .setStatus(getStatusWithDefault())
           .setTimedEvents(adaptTimedEvents())
+          .setTotalAttributeCount(totalAttributeCount)
           .setTotalRecordedEvents(totalRecordedEvents)
           // build() does the actual copying of the collections: it needs to be synchronized
           // because of the attributes and events collections.

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -64,7 +64,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   // Number of links recorded.
   private final int totalRecordedLinks;
   // Max number of attibutes per span.
-  private int maxNumberOfAttributes = 0;
+  private final int maxNumberOfAttributes = 0;
   // Number of attributes recorded.
   private int totalAttributeCount = 0;
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -337,9 +337,13 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
       if (attributes.get(key) == null && attributes.size() >= maxNumberOfAttributes) {
         logger.log(
             Level.FINE,
-            "Span has maximum number of attributes ("
+            "Span with name '"
+                + this.name
+                + "' has reached the maximum number of attributes ("
                 + maxNumberOfAttributes
-                + "). Dropping new entries.");
+                + "). Dropping attribute with key '"
+                + key
+                + "'");
         return;
       }
       attributes.putAttribute(key, value);

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TimedEvent.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TimedEvent.java
@@ -29,12 +29,15 @@ abstract class TimedEvent {
 
   private static final Map<String, AttributeValue> EMPTY_ATTRIBUTES =
       Collections.unmodifiableMap(Collections.<String, AttributeValue>emptyMap());
+  private static final int DEFAULT_TOTAL_ATTRIBUTE_COUNT = 0;
 
   abstract long getEpochNanos();
 
   abstract String getName();
 
   abstract Map<String, AttributeValue> getAttributes();
+
+  abstract int getTotalAttributeCount();
 
   TimedEvent() {}
 
@@ -58,7 +61,24 @@ abstract class TimedEvent {
    * @return an {@code TimedEvent}.
    */
   static TimedEvent create(long epochNanos, String name, Map<String, AttributeValue> attributes) {
-    return new AutoValue_TimedEvent_RawTimedEvent(epochNanos, name, attributes);
+    return new AutoValue_TimedEvent_RawTimedEvent(epochNanos, name, attributes, attributes.size());
+  }
+
+  /**
+   * Creates an {@link TimedEvent} with the given time, name and attributes.
+   *
+   * @param epochNanos epoch timestamp in nanos.
+   * @param name the name of this {@code TimedEvent}.
+   * @param attributes the attributes of this {@code TimedEvent}.
+   * @return an {@code TimedEvent}.
+   */
+  static TimedEvent create(
+      long epochNanos,
+      String name,
+      Map<String, AttributeValue> attributes,
+      int totalAttributeCount) {
+    return new AutoValue_TimedEvent_RawTimedEvent(
+        epochNanos, name, attributes, totalAttributeCount);
   }
 
   /**
@@ -69,7 +89,8 @@ abstract class TimedEvent {
    * @return an {@code TimedEvent}.
    */
   static TimedEvent create(long epochNanos, Event event) {
-    return new AutoValue_TimedEvent_RawTimedEventWithEvent(epochNanos, event);
+    return new AutoValue_TimedEvent_RawTimedEventWithEvent(
+        epochNanos, event, DEFAULT_TOTAL_ATTRIBUTE_COUNT);
   }
 
   @AutoValue
@@ -86,6 +107,9 @@ abstract class TimedEvent {
     Map<String, AttributeValue> getAttributes() {
       return getEvent().getAttributes();
     }
+
+    @Override
+    abstract int getTotalAttributeCount();
   }
 
   @AutoValue

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
@@ -206,7 +206,7 @@ public abstract class SpanData {
    * the number of attributes that are attached to this span, if the total number recorded was
    * greater than the configured maximum value. See: {@link TraceConfig#getMaxNumberOfAttributes()}
    *
-   * @return the number of dropped attributes.
+   * @return The total number of attributes on this span.
    */
   public abstract int getTotalAttributeCount();
 
@@ -219,7 +219,7 @@ public abstract class SpanData {
   @AutoValue
   public abstract static class Link implements io.opentelemetry.trace.Link {
 
-    private static final int ZERO_DROPPED_ATTRIBUTE_COUNT = 0;
+    private static final int DEFAULT_ATTRIBUTE_COUNT = 0;
 
     /**
      * Returns a new immutable {@code Link}.
@@ -230,9 +230,7 @@ public abstract class SpanData {
      */
     public static Link create(SpanContext spanContext) {
       return new AutoValue_SpanData_Link(
-          spanContext,
-          Collections.<String, AttributeValue>emptyMap(),
-          ZERO_DROPPED_ATTRIBUTE_COUNT);
+          spanContext, Collections.<String, AttributeValue>emptyMap(), DEFAULT_ATTRIBUTE_COUNT);
     }
 
     /**
@@ -247,7 +245,7 @@ public abstract class SpanData {
       return new AutoValue_SpanData_Link(
           spanContext,
           Collections.unmodifiableMap(new LinkedHashMap<>(attributes)),
-          ZERO_DROPPED_ATTRIBUTE_COUNT);
+          DEFAULT_ATTRIBUTE_COUNT);
     }
 
     /**
@@ -255,26 +253,27 @@ public abstract class SpanData {
      *
      * @param spanContext the {@code SpanContext} of this {@code Link}.
      * @param attributes the attributes of this {@code Link}.
-     * @param droppedAttributeCount number of dropped attributed for this {@code Link}.
+     * @param totalAttributeCount the total number of attributed for this {@code Link}.
      * @return a new immutable {@code TimedEvent<T>}
      * @since 0.1.0
      */
     public static Link create(
-        SpanContext spanContext,
-        Map<String, AttributeValue> attributes,
-        int droppedAttributeCount) {
+        SpanContext spanContext, Map<String, AttributeValue> attributes, int totalAttributeCount) {
       return new AutoValue_SpanData_Link(
           spanContext,
           Collections.unmodifiableMap(new LinkedHashMap<>(attributes)),
-          droppedAttributeCount);
+          totalAttributeCount);
     }
 
     /**
-     * Returns the number of dropped attributes.
+     * The total number of attributes that were recorded on this Link. This number may be larger
+     * than the number of attributes that are attached to this span, if the total number recorded
+     * was greater than the configured maximum value. See: {@link
+     * TraceConfig#getMaxNumberOfAttributesPerLink()}
      *
-     * @return the number of dropped attributes.
+     * @return The number of attributes on this link.
      */
-    public abstract int getDroppedAttributeCount();
+    public abstract int getTotalAttributeCount();
 
     Link() {}
   }
@@ -288,7 +287,7 @@ public abstract class SpanData {
   @AutoValue
   public abstract static class TimedEvent implements Event {
 
-    private static final int ZERO_DROPPED_ATTRIBUTE_COUNT = 0;
+    private static final int DEFAULT_ATTRIBUTE_COUNT = 0;
 
     /**
      * Returns a new immutable {@code TimedEvent}.
@@ -302,7 +301,7 @@ public abstract class SpanData {
     public static TimedEvent create(
         long epochNanos, String name, Map<String, AttributeValue> attributes) {
       return new AutoValue_SpanData_TimedEvent(
-          epochNanos, name, attributes, ZERO_DROPPED_ATTRIBUTE_COUNT);
+          epochNanos, name, attributes, DEFAULT_ATTRIBUTE_COUNT);
     }
 
     /**
@@ -311,6 +310,7 @@ public abstract class SpanData {
      * @param epochNanos epoch timestamp in nanos of the {@code Event}.
      * @param name the name of the {@code Event}.
      * @param attributes the attributes of the {@code Event}.
+     * @param totalAttributeCount the total number of attributes for this {@code} Event.
      * @return a new immutable {@code TimedEvent<T>}
      * @since 0.1.0
      */
@@ -318,8 +318,8 @@ public abstract class SpanData {
         long epochNanos,
         String name,
         Map<String, AttributeValue> attributes,
-        int droppedAttributeCount) {
-      return new AutoValue_SpanData_TimedEvent(epochNanos, name, attributes, droppedAttributeCount);
+        int totalAttributeCount) {
+      return new AutoValue_SpanData_TimedEvent(epochNanos, name, attributes, totalAttributeCount);
     }
 
     /**
@@ -337,11 +337,14 @@ public abstract class SpanData {
     public abstract Map<String, AttributeValue> getAttributes();
 
     /**
-     * Returns the number of dropped attributes.
+     * The total number of attributes that were recorded on this Event. This number may be larger
+     * than the number of attributes that are attached to this span, if the total number recorded
+     * was greater than the configured maximum value. See: {@link
+     * TraceConfig#getMaxNumberOfAttributesPerEvent()}
      *
-     * @return the number of dropped attributes.
+     * @return The total number of attributes on this event.
      */
-    public abstract int getDroppedAttributeCount();
+    public abstract int getTotalAttributeCount();
 
     TimedEvent() {}
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
@@ -219,6 +219,8 @@ public abstract class SpanData {
   @AutoValue
   public abstract static class Link implements io.opentelemetry.trace.Link {
 
+    private static final Map<String, AttributeValue> DEFAULT_ATTRIBUTE_COLLECTION =
+        Collections.<String, AttributeValue>emptyMap();
     private static final int DEFAULT_ATTRIBUTE_COUNT = 0;
 
     /**
@@ -230,7 +232,7 @@ public abstract class SpanData {
      */
     public static Link create(SpanContext spanContext) {
       return new AutoValue_SpanData_Link(
-          spanContext, Collections.<String, AttributeValue>emptyMap(), DEFAULT_ATTRIBUTE_COUNT);
+          spanContext, DEFAULT_ATTRIBUTE_COLLECTION, DEFAULT_ATTRIBUTE_COUNT);
     }
 
     /**
@@ -245,7 +247,7 @@ public abstract class SpanData {
       return new AutoValue_SpanData_Link(
           spanContext,
           Collections.unmodifiableMap(new LinkedHashMap<>(attributes)),
-          DEFAULT_ATTRIBUTE_COUNT);
+          attributes.size());
     }
 
     /**
@@ -287,8 +289,6 @@ public abstract class SpanData {
   @AutoValue
   public abstract static class TimedEvent implements Event {
 
-    private static final int DEFAULT_ATTRIBUTE_COUNT = 0;
-
     /**
      * Returns a new immutable {@code TimedEvent}.
      *
@@ -300,8 +300,7 @@ public abstract class SpanData {
      */
     public static TimedEvent create(
         long epochNanos, String name, Map<String, AttributeValue> attributes) {
-      return new AutoValue_SpanData_TimedEvent(
-          epochNanos, name, attributes, DEFAULT_ATTRIBUTE_COUNT);
+      return new AutoValue_SpanData_TimedEvent(epochNanos, name, attributes, attributes.size());
     }
 
     /**

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
@@ -202,11 +202,13 @@ public abstract class SpanData {
   public abstract int getTotalRecordedLinks();
 
   /**
-   * Returns the number of dropped attributes.
+   * The total number of attributes that were recorded on this span. This number may be larger than
+   * the number of attributes that are attached to this span, if the total number recorded was
+   * greater than the configured maximum value. See: {@link TraceConfig#getMaxNumberOfAttributes()}
    *
    * @return the number of dropped attributes.
    */
-  public abstract int getDroppedAttributeCount();
+  public abstract int getTotalAttributeCount();
 
   /**
    * An immutable implementation of {@link Link}.
@@ -363,7 +365,7 @@ public abstract class SpanData {
         .setTraceState(TraceState.getDefault())
         .setTraceFlags(TraceFlags.getDefault())
         .setHasRemoteParent(false)
-        .setDroppedAttributeCount(0);
+        .setTotalAttributeCount(0);
   }
 
   /**
@@ -570,11 +572,11 @@ public abstract class SpanData {
     public abstract Builder setTotalRecordedLinks(int totalRecordedLinks);
 
     /**
-     * Set the number of dropped attributes on this span.
+     * Set the total number of attributes recorded on this span.
      *
-     * @param droppedAttributeCount The number of dropped attributes.
+     * @param totalAttributeCount The total number of attributes recorded.
      * @return this
      */
-    public abstract Builder setDroppedAttributeCount(int droppedAttributeCount);
+    public abstract Builder setTotalAttributeCount(int totalAttributeCount);
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -341,13 +341,13 @@ public class RecordEventsReadableSpanTest {
       }
       SpanData spanData = span.toSpanData();
       assertThat(spanData.getAttributes().size()).isEqualTo(maxNumberOfAttributes);
-      assertThat(spanData.getDroppedAttributeCount()).isEqualTo(maxNumberOfAttributes);
+      assertThat(spanData.getTotalAttributeCount()).isEqualTo(2 * maxNumberOfAttributes);
     } finally {
       span.end();
     }
     SpanData spanData = span.toSpanData();
     assertThat(spanData.getAttributes().size()).isEqualTo(maxNumberOfAttributes);
-    assertThat(spanData.getDroppedAttributeCount()).isEqualTo(maxNumberOfAttributes);
+    assertThat(spanData.getTotalAttributeCount()).isEqualTo(2 * maxNumberOfAttributes);
   }
 
   @Test
@@ -365,7 +365,7 @@ public class RecordEventsReadableSpanTest {
       }
       SpanData spanData = span.toSpanData();
       assertThat(spanData.getAttributes().size()).isEqualTo(maxNumberOfAttributes);
-      assertThat(spanData.getDroppedAttributeCount()).isEqualTo(maxNumberOfAttributes);
+      assertThat(spanData.getTotalAttributeCount()).isEqualTo(2 * maxNumberOfAttributes);
 
       for (int i = 0; i < maxNumberOfAttributes / 2; i++) {
         int val = i + maxNumberOfAttributes * 3 / 2;

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -341,22 +341,13 @@ public class RecordEventsReadableSpanTest {
       }
       SpanData spanData = span.toSpanData();
       assertThat(spanData.getAttributes().size()).isEqualTo(maxNumberOfAttributes);
-      for (int i = 0; i < maxNumberOfAttributes; i++) {
-        AttributeValue expectedValue = AttributeValue.longAttributeValue(i + maxNumberOfAttributes);
-        assertThat(
-                spanData.getAttributes().get("MyStringAttributeKey" + (i + maxNumberOfAttributes)))
-            .isEqualTo(expectedValue);
-      }
+      assertThat(spanData.getDroppedAttributeCount()).isEqualTo(maxNumberOfAttributes);
     } finally {
       span.end();
     }
     SpanData spanData = span.toSpanData();
     assertThat(spanData.getAttributes().size()).isEqualTo(maxNumberOfAttributes);
-    for (int i = 0; i < maxNumberOfAttributes; i++) {
-      AttributeValue expectedValue = AttributeValue.longAttributeValue(i + maxNumberOfAttributes);
-      assertThat(spanData.getAttributes().get("MyStringAttributeKey" + (i + maxNumberOfAttributes)))
-          .isEqualTo(expectedValue);
-    }
+    assertThat(spanData.getDroppedAttributeCount()).isEqualTo(maxNumberOfAttributes);
   }
 
   @Test
@@ -374,15 +365,11 @@ public class RecordEventsReadableSpanTest {
       }
       SpanData spanData = span.toSpanData();
       assertThat(spanData.getAttributes().size()).isEqualTo(maxNumberOfAttributes);
-      for (int i = 0; i < maxNumberOfAttributes; i++) {
-        AttributeValue expectedValue = AttributeValue.longAttributeValue(i + maxNumberOfAttributes);
-        assertThat(
-                spanData.getAttributes().get("MyStringAttributeKey" + (i + maxNumberOfAttributes)))
-            .isEqualTo(expectedValue);
-      }
+      assertThat(spanData.getDroppedAttributeCount()).isEqualTo(maxNumberOfAttributes);
 
       for (int i = 0; i < maxNumberOfAttributes / 2; i++) {
-        span.setAttribute("MyStringAttributeKey" + i, AttributeValue.longAttributeValue(i));
+        int val = i + maxNumberOfAttributes * 3 / 2;
+        span.setAttribute("MyStringAttributeKey" + i, AttributeValue.longAttributeValue(val));
       }
       spanData = span.toSpanData();
       assertThat(spanData.getAttributes().size()).isEqualTo(maxNumberOfAttributes);
@@ -390,11 +377,11 @@ public class RecordEventsReadableSpanTest {
       for (int i = 0; i < maxNumberOfAttributes / 2; i++) {
         int val = i + maxNumberOfAttributes * 3 / 2;
         AttributeValue expectedValue = AttributeValue.longAttributeValue(val);
-        assertThat(spanData.getAttributes().get("MyStringAttributeKey" + val))
+        assertThat(spanData.getAttributes().get("MyStringAttributeKey" + i))
             .isEqualTo(expectedValue);
       }
       // Test that we have the newest re-added initial entries.
-      for (int i = 0; i < maxNumberOfAttributes / 2; i++) {
+      for (int i = maxNumberOfAttributes / 2; i < maxNumberOfAttributes; i++) {
         AttributeValue expectedValue = AttributeValue.longAttributeValue(i);
         assertThat(spanData.getAttributes().get("MyStringAttributeKey" + i))
             .isEqualTo(expectedValue);

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TimedEventTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TimedEventTest.java
@@ -63,6 +63,16 @@ public class TimedEventTest {
     assertThat(event.getEpochNanos()).isEqualTo(1234567890L);
     assertThat(event.getName()).isEqualTo(NAME);
     assertThat(event.getAttributes()).isEqualTo(ATTRIBUTES);
+    assertThat(event.getTotalAttributeCount()).isEqualTo(ATTRIBUTES.size());
+  }
+
+  @Test
+  public void rawTimedEventWithNameAndAttributesAndTotalAttributeCount() {
+    TimedEvent event = TimedEvent.create(1234567890L, NAME, ATTRIBUTES, ATTRIBUTES.size() + 2);
+    assertThat(event.getEpochNanos()).isEqualTo(1234567890L);
+    assertThat(event.getName()).isEqualTo(NAME);
+    assertThat(event.getAttributes()).isEqualTo(ATTRIBUTES);
+    assertThat(event.getTotalAttributeCount()).isEqualTo(ATTRIBUTES.size() + 2);
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/data/SpanDataTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/data/SpanDataTest.java
@@ -87,13 +87,13 @@ public class SpanDataTest {
   @Test
   public void defaultDroppedAttributeCountIsZero() {
     SpanData spanData = createSpanDataWithMutableCollections();
-    assertThat(spanData.getDroppedAttributeCount()).isEqualTo(0);
+    assertThat(spanData.getTotalAttributeCount()).isEqualTo(0);
   }
 
   @Test
   public void canSetDroppedAttributecountWithBuilder() {
-    SpanData spanData = createBasicSpanBuilder().setDroppedAttributeCount(123).build();
-    assertThat(spanData.getDroppedAttributeCount()).isEqualTo(123);
+    SpanData spanData = createBasicSpanBuilder().setTotalAttributeCount(123).build();
+    assertThat(spanData.getTotalAttributeCount()).isEqualTo(123);
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/data/SpanDataTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/data/SpanDataTest.java
@@ -103,7 +103,7 @@ public class SpanDataTest {
   }
 
   @Test
-  public void link_canSetTotalAttributeCountIsZero() {
+  public void link_canSetTotalAttributeCount() {
     SpanData.Link link = SpanData.Link.create(SpanContext.getInvalid());
     assertThat(link.getTotalAttributeCount()).isEqualTo(0);
   }
@@ -117,7 +117,7 @@ public class SpanDataTest {
   }
 
   @Test
-  public void timedEvent_canSetTotalAttributeCountIsZero() {
+  public void timedEvent_canSetTotalAttributeCount() {
     SpanData.TimedEvent event =
         SpanData.TimedEvent.create(
             START_EPOCH_NANOS, "foo", Collections.<String, AttributeValue>emptyMap(), 123);

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/data/SpanDataTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/data/SpanDataTest.java
@@ -85,43 +85,43 @@ public class SpanDataTest {
   }
 
   @Test
-  public void defaultDroppedAttributeCountIsZero() {
+  public void defaultTotalAttributeCountIsZero() {
     SpanData spanData = createSpanDataWithMutableCollections();
     assertThat(spanData.getTotalAttributeCount()).isEqualTo(0);
   }
 
   @Test
-  public void canSetDroppedAttributecountWithBuilder() {
+  public void canSetTotalAttributeCountWithBuilder() {
     SpanData spanData = createBasicSpanBuilder().setTotalAttributeCount(123).build();
     assertThat(spanData.getTotalAttributeCount()).isEqualTo(123);
   }
 
   @Test
-  public void link_defaultDroppedAttributeCountIsZero() {
+  public void link_defaultTotalAttributeCountIsZero() {
     SpanData.Link link = SpanData.Link.create(SpanContext.getInvalid());
-    assertThat(link.getDroppedAttributeCount()).isEqualTo(0);
+    assertThat(link.getTotalAttributeCount()).isEqualTo(0);
   }
 
   @Test
-  public void link_canSetDroppedAttributeCountIsZero() {
+  public void link_canSetTotalAttributeCountIsZero() {
     SpanData.Link link = SpanData.Link.create(SpanContext.getInvalid());
-    assertThat(link.getDroppedAttributeCount()).isEqualTo(0);
+    assertThat(link.getTotalAttributeCount()).isEqualTo(0);
   }
 
   @Test
-  public void timedEvent_defaultDroppedAttributeCountIsZero() {
+  public void timedEvent_defaultTotalAttributeCountIsZero() {
     SpanData.TimedEvent event =
         SpanData.TimedEvent.create(
             START_EPOCH_NANOS, "foo", Collections.<String, AttributeValue>emptyMap());
-    assertThat(event.getDroppedAttributeCount()).isEqualTo(0);
+    assertThat(event.getTotalAttributeCount()).isEqualTo(0);
   }
 
   @Test
-  public void timedEvent_canSetDroppedAttributeCountIsZero() {
+  public void timedEvent_canSetTotalAttributeCountIsZero() {
     SpanData.TimedEvent event =
         SpanData.TimedEvent.create(
             START_EPOCH_NANOS, "foo", Collections.<String, AttributeValue>emptyMap(), 123);
-    assertThat(event.getDroppedAttributeCount()).isEqualTo(123);
+    assertThat(event.getTotalAttributeCount()).isEqualTo(123);
   }
 
   private static SpanData createSpanDataWithMutableCollections() {


### PR DESCRIPTION
Another step towards #993 and extends #1004. Closes #1022.

This PR adds support for dropping span attributes once the max configured in the `TraceConfig` has been reached and also maintain a count for the number of dropped attributes.

This also fixes up some existing tests that were broken by this change.