### PR TITLE
Add automatic release support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
   release_job:
     environment:
       # Configure the JVM and Gradle to avoid OOM errors
-      _JAVA_OPTIONS: "-Xmx3g"
+      _JAVA_OPTIONS: "-Xmx1g"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
     docker:
       - image: circleci/openjdk:8-jdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ verify_task: &verify_task
 publish_snapshots_task: &publish_snapshots_task
   name: Publish Snapshot Artifacts
   command: make publish-snapshots
+publish_release_task: &publish_release_task
+  name: Publish Release Artifacts
+  command: make publish-release-artifacts
 
 jobs:
   build:
@@ -76,6 +79,31 @@ jobs:
           paths:
             - ~/.gradle
           key: java11-gradle-{{ checksum "build.gradle" }}
+# Publish the released artifacts using the `build` job env.
+  release_job:
+    environment:
+      # Configure the JVM and Gradle to avoid OOM errors
+      _JAVA_OPTIONS: "-Xmx3g"
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
+    docker:
+      - image: circleci/openjdk:8-jdk
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - gradle-{{ checksum "build.gradle" }}
+      - run:
+          <<: *init_task
+      - run:
+          <<: *verify_task
+      - run:
+          <<: *build_task
+      - run:
+          <<: *publish_release_task
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: gradle-{{ checksum "build.gradle" }}
 
 workflows:
   version: 2
@@ -83,3 +111,11 @@ workflows:
     jobs:
       - build
       - java11
+  build_and_release:
+    jobs:
+      - release_job:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,7 @@ publish-snapshots:
 ifeq ($(CIRCLE_BRANCH),master)
 	./gradlew artifactoryPublish
 endif
+
+.PHONY: publish-release-artifacts
+publish-release-artifacts:
+	./gradlew bintrayUpload

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,28 +2,27 @@
 
 This repository uses semantic versioning. Please keep this in mind when choosing version numbers.
 
-1. **Alert others you are releasing**
+1. **Crease a version branch to release from.**
 
-   There should be no commits made to master while the release is in progress (about 10 minutes). Before you start
-   a release, alert others on [gitter](https://gitter.im/open-telemetry/opentelemetry-java) so that they don't accidentally
-   merge anything. If they do, and the build fails because of that, you'll have to recreate the release tag described below.
+   A version branch must be used to do the release in order to prevent commit race conditions.
 
-1. **Update CHANGELOG**
+1. **Update CHANGELOG.**
 
    Update CHANGELOG.md with a list changes since the last release. Each entry must include the release number,
-   date and a bulleted list of changes where each change is summarized in a single sentence.
+   date and a bulleted list of changes where each change is summarized in a single sentence, e.g.
+   "- Updated the Jaeger exporter to use the last gRPC version".
 
-1. **Update the version**
+1. **Update the version.**
 
    Update the version to the desired value in `build.gradle`, e.g. `version = "1.2.3"`. Make sure no `SNAPSHOT`
    sufix is appended (that is **only** used during development and when deploying snapshots, as the word implies).
-   Commit, merge to `master`, and update your local `master` branch with this update.
 
-1. **Push a git tag**
+1. **Push a git tag.**
 
-   The tag should be of the format `vN.M.L`, e.g. `git tag v1.2.3; git push origin v1.2.3`.
+   The tag should be of the format `vN.M.L`, e.g. `git tag v1.2.3; git push origin v1.2.3`. It is recommended
+   to have this tag marked in Github along with the CHANGELOG for this version.
 
-1. **Wait for Circle CI**
+1. **Wait for Circle CI.**
 
    This part is controlled by the Bintray plugin. It publishes the artifacts and syncs to Maven Central.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -37,7 +37,7 @@ is`v1.2.3-RC$`, where `$` denotes a release candidate version, e.g. `v1.2.3-RC1`
 The following credentials are required for publishing (and automatically set in Circle CI):
 
 * `BINTRAY_USER` and `BINTRAY_KEY`: Bintray username and API Key.
-  See [this](https://www.jfrog.com/confluence/display/BT/Bintray+Security#BintraySecurity-APIKeys)
+  See [this](https://www.jfrog.com/confluence/display/BT/Bintray+Security#BintraySecurity-APIKeys).
 
 * `SONATYPE_USER` and `SONATYPE_KEY`: Sonatype username and password.
 
@@ -46,7 +46,7 @@ The following credentials are required for publishing (and automatically set in 
 Releasing from the local setup can be done providing the previously mentioned four credential values, i.e.
 `BINTRAY_KEY`, `BINTRAY_USER`, `SONATYPE_USER` and `SONATYPE_KEY`:
 
-```
+```sh
 export BINTRAY_USER=my_bintray_user
 export BINTRAY_KEY=my_user_api_key
 export SONATYPE_USER=my_maven_user

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,55 @@
+# OpenTelemetry Release Process
+
+This repository uses semantic versioning. Please keep this in mind when choosing version numbers.
+
+1. **Alert others you are releasing**
+
+   There should be no commits made to master while the release is in progress (about 10 minutes). Before you start
+   a release, alert others on [gitter](https://gitter.im/open-telemetry/opentelemetry-java) so that they don't accidentally
+   merge anything. If they do, and the build fails because of that, you'll have to recreate the release tag described below.
+
+1. **Update CHANGELOG**
+
+   Update CHANGELOG.md with a list changes since the last release. Each entry must include the release number,
+   date and a bulleted list of changes where each change is summarized in a single sentence.
+
+1. **Update the version**
+
+   Update the version to the desired value in `build.gradle`, e.g. `version = "1.2.3"`. Make sure no `SNAPSHOT`
+   sufix is appended (that is **only** used during development and when deploying snapshots, as the word implies).
+   Commit, merge to `master`, and update your local `master` branch with this update.
+
+1. **Push a git tag**
+
+   The tag should be of the format `vN.M.L`, e.g. `git tag v1.2.3; git push origin v1.2.3`.
+
+1. **Wait for Circle CI**
+
+   This part is controlled by the Bintray plugin. It publishes the artifacts and syncs to Maven Central.
+
+## Release candidates
+
+Release candidate artifacts are released using the same process described above. The version schema for release candidates
+is`v1.2.3-RC$`, where `$` denotes a release candidate version, e.g. `v1.2.3-RC1`.
+
+## Credentials
+
+The following credentials are required for publishing (and automatically set in Circle CI):
+
+* `BINTRAY_USER` and `BINTRAY_KEY`: Bintray username and API Key.
+  See [this](https://www.jfrog.com/confluence/display/BT/Bintray+Security#BintraySecurity-APIKeys)
+
+* `SONATYPE_USER` and `SONATYPE_KEY`: Sonatype username and password.
+
+## Releasing from the local setup
+
+Releasing from the local setup can be done providing the previously mentioned four credential values, i.e.
+`BINTRAY_KEY`, `BINTRAY_USER`, `SONATYPE_USER` and `SONATYPE_KEY`:
+
+```
+export BINTRAY_USER=my_bintray_user
+export BINTRAY_KEY=my_user_api_key
+export SONATYPE_USER=my_maven_user
+export SONATYPE_KEY=my_maven_password
+make publish-release-artifacts
+```

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "com.github.sherter.google-java-format" apply false
     id "com.jfrog.artifactory" apply false
+    id "com.jfrog.bintray" version "1.8.4" apply false // Need *specific* version.
     id "net.ltgt.errorprone" apply false
     id "ru.vyarus.animalsniffer" apply false
     id "io.morethan.jmhreport" apply false
@@ -262,8 +263,9 @@ subprojects {
     }
 
     plugins.withId("maven-publish") {
-        // Always include the artifactory plugin to do the deployment.
+        // Always include the artifactory/bintray plugins to do the deployment.
         pluginManager.apply "com.jfrog.artifactory"
+        pluginManager.apply "com.jfrog.bintray"
 
         publishing {
             publications {
@@ -327,6 +329,38 @@ subprojects {
             }
             resolve {
                 repoKey = 'libs-release'
+            }
+        }
+
+        // Release artifacts publishing.
+        bintray {
+            user = System.getenv("BINTRAY_USER")
+            key = System.getenv("BINTRAY_KEY")
+            publications = ['mavenPublication']
+
+            publish = true
+
+            pkg {
+                repo = 'maven'
+                name = 'opentelemetry-java'
+                licenses = ['Apache-2.0']
+                vcsUrl = 'https://github.com/open-telemetry/opentelemetry-java.git'
+                userOrg = 'open-telemetry'
+
+                githubRepo = 'open-telemetry/opentelemetry-java'
+
+                version {
+                    name = project.version
+
+                    gpg {
+                        sign = true
+                    }
+
+                    mavenCentralSync {
+                        user = System.getenv("SONATYPE_USER")
+                        password = System.getenv("SONATYPE_KEY")
+                    }
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ subprojects {
     apply plugin: 'net.ltgt.errorprone'
 
     group = "io.opentelemetry"
-    version = "0.3.0-SNAPSHOT" // CURRENT_VERSION
+    version = "0.2.4" // CURRENT_VERSION
 
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ subprojects {
     apply plugin: 'net.ltgt.errorprone'
 
     group = "io.opentelemetry"
-    version = "0.2.4" // CURRENT_VERSION
+    version = "0.3.0-SNAPSHOT" // CURRENT_VERSION
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
Fixes #971 

We still need to manually update the `version` field in `build.gradle`,  but once that is done, creating a branch starting with `v.` triggers a deployment to Bintray/Maven Central.

See https://github.com/open-telemetry/opentelemetry-java/releases/tag/v0.2.4 as an example (I used this one to verify all works great).

In a future we can play with plugins that automatically update the version and create a tag (such as the Maven Release plugin does).

PS - I'd like to stop repeating all the steps in the different tasks *if possible* (now we have very similar `build`, `java11` and `release` tasks). But we need somebody who is a Circle wizard or one who digs enough into this. Anyway, something to do in the future.