### PR TITLE
Revise null values for AttributeValue

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -167,24 +167,20 @@ final class SpanBuilderSdk implements Span.Builder {
   @Override
   public Span.Builder setAttribute(String key, AttributeValue value) {
     Utils.checkNotNull(key, "key");
-    Object contentValue = null;
+    boolean remove = true;
     if (value != null) {
       switch (value.getType()) {
-        case BOOLEAN:
-          contentValue = value.getBooleanValue();
-          break;
-        case LONG:
-          contentValue = value.getLongValue();
-          break;
-        case DOUBLE:
-          contentValue = value.getDoubleValue();
-          break;
         case STRING:
-          contentValue = value.getStringValue();
+          remove = value.getStringValue() == null;
+          break;
+        case BOOLEAN:
+        case LONG:
+        case DOUBLE:
+          remove = false;
           break;
       }
     }
-    if (contentValue == null) {
+    if (remove) {
       attributes.remove(key);
     } else {
       attributes.putAttribute(key, value);

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -167,7 +167,7 @@ final class SpanBuilderSdk implements Span.Builder {
   @Override
   public Span.Builder setAttribute(String key, AttributeValue value) {
     Utils.checkNotNull(key, "key");
-    if (isToRemove(value)) {
+    if (isRemovedValue(value)) {
       attributes.remove(key);
     } else {
       attributes.putAttribute(key, value);
@@ -175,7 +175,7 @@ final class SpanBuilderSdk implements Span.Builder {
     return this;
   }
 
-  private static boolean isToRemove(AttributeValue value) {
+  private static boolean isRemovedValue(AttributeValue value) {
     boolean remove = true;
     if (value != null) {
       switch (value.getType()) {

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -167,6 +167,15 @@ final class SpanBuilderSdk implements Span.Builder {
   @Override
   public Span.Builder setAttribute(String key, AttributeValue value) {
     Utils.checkNotNull(key, "key");
+    if (isToRemove(value)) {
+      attributes.remove(key);
+    } else {
+      attributes.putAttribute(key, value);
+    }
+    return this;
+  }
+
+  private static boolean isToRemove(AttributeValue value) {
     boolean remove = true;
     if (value != null) {
       switch (value.getType()) {
@@ -180,12 +189,7 @@ final class SpanBuilderSdk implements Span.Builder {
           break;
       }
     }
-    if (remove) {
-      attributes.remove(key);
-    } else {
-      attributes.putAttribute(key, value);
-    }
-    return this;
+    return remove;
   }
 
   @Override

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -17,8 +17,6 @@
 package io.opentelemetry.sdk.trace;
 
 import io.opentelemetry.common.AttributeValue;
-import io.opentelemetry.common.AttributeValue.Type;
-import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.internal.Utils;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -169,11 +167,28 @@ final class SpanBuilderSdk implements Span.Builder {
   @Override
   public Span.Builder setAttribute(String key, AttributeValue value) {
     Utils.checkNotNull(key, "key");
-    Utils.checkNotNull(value, "value");
-    if (value.getType() == Type.STRING && StringUtils.isNullOrEmpty(value.getStringValue())) {
-      return this;
+    Object contentValue = null;
+    if (value != null) {
+      switch (value.getType()) {
+        case BOOLEAN:
+          contentValue = value.getBooleanValue();
+          break;
+        case LONG:
+          contentValue = value.getLongValue();
+          break;
+        case DOUBLE:
+          contentValue = value.getDoubleValue();
+          break;
+        case STRING:
+          contentValue = value.getStringValue();
+          break;
+      }
     }
-    attributes.putAttribute(key, value);
+    if (contentValue == null) {
+      attributes.remove(key);
+    } else {
+      attributes.putAttribute(key, value);
+    }
     return this;
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -176,20 +176,18 @@ final class SpanBuilderSdk implements Span.Builder {
   }
 
   private static boolean isRemovedValue(AttributeValue value) {
-    boolean remove = true;
-    if (value != null) {
-      switch (value.getType()) {
-        case STRING:
-          remove = value.getStringValue() == null;
-          break;
-        case BOOLEAN:
-        case LONG:
-        case DOUBLE:
-          remove = false;
-          break;
-      }
+    if (value == null) {
+      return true;
     }
-    return remove;
+    switch (value.getType()) {
+      case STRING:
+        return value.getStringValue() == null;
+      case BOOLEAN:
+      case LONG:
+      case DOUBLE:
+        return false;
+    }
+    return false;
   }
 
   @Override

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -180,6 +180,29 @@ public class SpanBuilderSdkTest {
     spanBuilder.setAttribute("nullStringAttributeValue", AttributeValue.stringAttributeValue(null));
     spanBuilder.setAttribute("emptyStringAttributeValue", AttributeValue.stringAttributeValue(""));
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    assertThat(span.toSpanData().getAttributes().size()).isEqualTo(2);
+    spanBuilder.setAttribute("emptyString", (String) null);
+    spanBuilder.setAttribute("emptyStringAttributeValue", (String) null);
+    assertThat(span.toSpanData().getAttributes()).isEmpty();
+  }
+
+  @Test
+  public void setAttribute_nullAttributeValue() throws Exception {
+    Span.Builder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
+    spanBuilder.setAttribute("emptyString", "");
+    spanBuilder.setAttribute("nullString", (AttributeValue) null);
+    spanBuilder.setAttribute("nullStringAttributeValue", AttributeValue.stringAttributeValue(null));
+    spanBuilder.setAttribute("emptyStringAttributeValue", AttributeValue.stringAttributeValue(""));
+    spanBuilder.setAttribute("longAttribute", 0L);
+    spanBuilder.setAttribute("boolAttribute", false);
+    spanBuilder.setAttribute("doubleAttribute", 0.12345f);
+    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    assertThat(span.toSpanData().getAttributes().size()).isEqualTo(5);
+    spanBuilder.setAttribute("emptyString", (AttributeValue) null);
+    spanBuilder.setAttribute("emptyStringAttributeValue", (AttributeValue) null);
+    spanBuilder.setAttribute("longAttribute", (AttributeValue) null);
+    spanBuilder.setAttribute("boolAttribute", (AttributeValue) null);
+    spanBuilder.setAttribute("doubleAttribute", (AttributeValue) null);
     assertThat(span.toSpanData().getAttributes()).isEmpty();
   }
 


### PR DESCRIPTION
This partially resolves #948 addressing:
 - empty strings are now a valid `AttributeValue` 
 - null values remove existing `AttributeValue`s and their relative key is dropped.

Note, Array will be handled in a follow up PR or as part of #807, depending on the merge order.