### PR TITLE
Correct minimum Android API level in SDK README.

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -3,7 +3,7 @@ OpenTelemetry SDK
 
 [![Javadocs][javadoc-image]][javadoc-url]
 
-* Java 7 and Android 14 compatible.
+* Java 7 and Android API Level 24 compatible.
 
 [javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-sdk.svg
 [javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk


### PR DESCRIPTION
This was forgotten in #823. Probably other READMEs are also affected.