### PR TITLE
Make the MinMaxSumCount aggregations be true delta aggregations

### DIFF
--- a/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingMetricExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingMetricExporterTest.java
@@ -21,6 +21,7 @@ import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.TemporalQuality;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
 import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
@@ -52,7 +53,8 @@ public class LoggingMetricExporterTest {
                     "A summarized test measure",
                     "ms",
                     Type.SUMMARY,
-                    ImmutableMap.of("foo", "bar", "baz", "zoom")),
+                    ImmutableMap.of("foo", "bar", "baz", "zoom"),
+                    TemporalQuality.CUMULATIVE),
                 resource,
                 instrumentationLibraryInfo,
                 Collections.<Point>singletonList(
@@ -71,7 +73,8 @@ public class LoggingMetricExporterTest {
                     "A simple counter",
                     "one",
                     Type.MONOTONIC_LONG,
-                    ImmutableMap.of("alpha", "aleph", "beta", "bet")),
+                    ImmutableMap.of("alpha", "aleph", "beta", "bet"),
+                    TemporalQuality.CUMULATIVE),
                 resource,
                 instrumentationLibraryInfo,
                 Collections.<Point>singletonList(
@@ -86,7 +89,8 @@ public class LoggingMetricExporterTest {
                     "an observer gauge",
                     "kb",
                     Type.NON_MONOTONIC_DOUBLE,
-                    ImmutableMap.of("uno", "eins", "dos", "zwei")),
+                    ImmutableMap.of("uno", "eins", "dos", "zwei"),
+                    TemporalQuality.CUMULATIVE),
                 resource,
                 instrumentationLibraryInfo,
                 Collections.<Point>singletonList(

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/MetricAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/MetricAdapterTest.java
@@ -37,6 +37,7 @@ import io.opentelemetry.proto.metrics.v1.SummaryDataPoint.ValueAtPercentile;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.TemporalQuality;
 import io.opentelemetry.sdk.metrics.data.MetricData.Point;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
@@ -249,7 +250,8 @@ public class MetricAdapterTest {
                     "description",
                     "1",
                     Descriptor.Type.MONOTONIC_DOUBLE,
-                    Collections.singletonMap("k", "v"))))
+                    Collections.singletonMap("k", "v"),
+                    TemporalQuality.CUMULATIVE)))
         .isEqualTo(
             MetricDescriptor.newBuilder()
                 .setName("name")
@@ -267,7 +269,8 @@ public class MetricAdapterTest {
                     "description",
                     "1",
                     Descriptor.Type.MONOTONIC_DOUBLE,
-                    Collections.<String, String>emptyMap())))
+                    Collections.<String, String>emptyMap(),
+                    TemporalQuality.CUMULATIVE)))
         .isEqualTo(
             MetricDescriptor.newBuilder()
                 .setName("name")
@@ -287,7 +290,8 @@ public class MetricAdapterTest {
                         "description",
                         "1",
                         Descriptor.Type.MONOTONIC_LONG,
-                        Collections.singletonMap("k", "v")),
+                        Collections.singletonMap("k", "v"),
+                        TemporalQuality.CUMULATIVE),
                     Resource.getEmpty(),
                     InstrumentationLibraryInfo.getEmpty(),
                     Collections.<Point>singletonList(
@@ -324,7 +328,8 @@ public class MetricAdapterTest {
                         "description",
                         "1",
                         Descriptor.Type.MONOTONIC_DOUBLE,
-                        Collections.singletonMap("k", "v")),
+                        Collections.singletonMap("k", "v"),
+                        TemporalQuality.CUMULATIVE),
                     Resource.getEmpty(),
                     InstrumentationLibraryInfo.getEmpty(),
                     Collections.<Point>singletonList(
@@ -363,7 +368,8 @@ public class MetricAdapterTest {
             "description",
             "1",
             Descriptor.Type.MONOTONIC_DOUBLE,
-            Collections.singletonMap("k", "v"));
+            Collections.singletonMap("k", "v"),
+            TemporalQuality.CUMULATIVE);
     Resource resource =
         Resource.create(Collections.singletonMap("ka", AttributeValue.stringAttributeValue("va")));
     io.opentelemetry.proto.resource.v1.Resource resourceProto =

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcMetricExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcMetricExporterTest.java
@@ -30,6 +30,7 @@ import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.TemporalQuality;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.Point;
@@ -209,7 +210,8 @@ public class OtlpGrpcMetricExporterTest {
             "description",
             "1",
             Type.MONOTONIC_LONG,
-            Collections.<String, String>emptyMap()),
+            Collections.<String, String>emptyMap(),
+            TemporalQuality.CUMULATIVE),
         Resource.getEmpty(),
         InstrumentationLibraryInfo.getEmpty(),
         Collections.<Point>singletonList(

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
@@ -23,6 +23,7 @@ import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.TemporalQuality;
 import io.opentelemetry.sdk.metrics.view.Aggregation;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -182,6 +183,15 @@ abstract class AbstractInstrument implements Instrument {
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState meterSharedState,
       Aggregation defaultAggregation) {
+    if (defaultAggregation.getTemporalQuality() == TemporalQuality.DELTA) {
+      return Batchers.getDeltaAllLabels(
+          getDefaultMetricDescriptor(
+              descriptor, instrumentType, instrumentValueType, defaultAggregation),
+          meterProviderSharedState.getResource(),
+          meterSharedState.getInstrumentationLibraryInfo(),
+          defaultAggregation.getAggregatorFactory(instrumentValueType),
+          meterProviderSharedState.getClock());
+    }
     return Batchers.getCumulativeAllLabels(
         getDefaultMetricDescriptor(
             descriptor, instrumentType, instrumentValueType, defaultAggregation),

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
@@ -171,7 +171,8 @@ abstract class AbstractInstrument implements Instrument {
         descriptor.getDescription(),
         aggregation.getUnit(descriptor.getUnit()),
         aggregation.getDescriptorType(instrumentType, instrumentValueType),
-        descriptor.getConstantLabels());
+        descriptor.getConstantLabels(),
+        aggregation.getTemporalQuality());
   }
 
   static Batcher getDefaultBatcher(

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/Batchers.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/Batchers.java
@@ -44,13 +44,44 @@ final class Batchers {
       InstrumentationLibraryInfo instrumentationLibraryInfo,
       AggregatorFactory aggregatorFactory,
       Clock clock) {
-    return new AllLabels(
+    return getAllLabelsBatcher(
         descriptor,
         resource,
         instrumentationLibraryInfo,
         aggregatorFactory,
         clock,
         /* delta= */ false);
+  }
+
+  static Batcher getDeltaAllLabels(
+      Descriptor descriptor,
+      Resource resource,
+      InstrumentationLibraryInfo instrumentationLibraryInfo,
+      AggregatorFactory aggregatorFactory,
+      Clock clock) {
+    return getAllLabelsBatcher(
+        descriptor,
+        resource,
+        instrumentationLibraryInfo,
+        aggregatorFactory,
+        clock,
+        /* delta= */ true);
+  }
+
+  private static Batcher getAllLabelsBatcher(
+      Descriptor descriptor,
+      Resource resource,
+      InstrumentationLibraryInfo instrumentationLibraryInfo,
+      AggregatorFactory aggregatorFactory,
+      Clock clock,
+      boolean delta) {
+    return new AllLabels(
+        descriptor,
+        resource,
+        instrumentationLibraryInfo,
+        aggregatorFactory,
+        clock,
+        /* delta= */ delta);
   }
 
   private static final class Noop implements Batcher {

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCount.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCount.java
@@ -50,14 +50,7 @@ public final class LongMinMaxSumCount extends AbstractAggregator {
   @Override
   void doMergeAndReset(Aggregator target) {
     LongMinMaxSumCount other = (LongMinMaxSumCount) target;
-
-    thinger(other);
-  }
-
-  private void thinger(LongMinMaxSumCount other) {
     current.mergeAndReset(other.current);
-    //    LongSummary copy = current.copyAndReset();
-    //    other.current.update(copy);
   }
 
   @Nullable

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/data/MetricData.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/data/MetricData.java
@@ -32,6 +32,7 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 @AutoValue
 public abstract class MetricData {
+
   MetricData() {}
 
   /**
@@ -79,6 +80,7 @@ public abstract class MetricData {
 
   @Immutable
   public abstract static class Point {
+
     Point() {}
 
     /**
@@ -116,6 +118,7 @@ public abstract class MetricData {
   @Immutable
   @AutoValue
   public abstract static class LongPoint extends Point {
+
     LongPoint() {}
 
     /**
@@ -138,6 +141,7 @@ public abstract class MetricData {
   @Immutable
   @AutoValue
   public abstract static class DoublePoint extends Point {
+
     DoublePoint() {}
 
     /**
@@ -200,6 +204,7 @@ public abstract class MetricData {
   @Immutable
   @AutoValue
   public abstract static class ValueAtPercentile {
+
     ValueAtPercentile() {}
 
     /**
@@ -275,6 +280,20 @@ public abstract class MetricData {
       SUMMARY,
     }
 
+    public enum TemporalQuality {
+      /**
+       * The MetricData is relevant for a single moment in time. This is most common for metrics
+       * generated from Observer Instruments
+       */
+      INSTANTANEOUS,
+
+      /** The MetricData is aggregated over the lifetime of the instrument that created it. */
+      CUMULATIVE,
+
+      /** The MetricData is aggregated since the last collection cycle. */
+      DELTA
+    }
+
     /**
      * Returns the metric descriptor name.
      *
@@ -315,13 +334,17 @@ public abstract class MetricData {
      */
     public abstract Map<String, String> getConstantLabels();
 
+    public abstract TemporalQuality getTemporalQuality();
+
     public static Descriptor create(
         String name,
         String description,
         String unit,
         Type type,
-        Map<String, String> constantLabels) {
-      return new AutoValue_MetricData_Descriptor(name, description, unit, type, constantLabels);
+        Map<String, String> constantLabels,
+        TemporalQuality temporalQuality) {
+      return new AutoValue_MetricData_Descriptor(
+          name, description, unit, type, constantLabels, temporalQuality);
     }
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/data/MetricData.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/data/MetricData.java
@@ -273,6 +273,10 @@ public abstract class MetricData {
       SUMMARY,
     }
 
+    /**
+     * A description of the temporal nature of the aggregation that was performed to produce the
+     * MetricData.
+     */
     public enum TemporalQuality {
       /**
        * The MetricData is relevant for a single moment in time. This is most common for metrics

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/data/MetricData.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/data/MetricData.java
@@ -32,7 +32,6 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 @AutoValue
 public abstract class MetricData {
-
   MetricData() {}
 
   /**
@@ -80,7 +79,6 @@ public abstract class MetricData {
 
   @Immutable
   public abstract static class Point {
-
     Point() {}
 
     /**
@@ -118,7 +116,6 @@ public abstract class MetricData {
   @Immutable
   @AutoValue
   public abstract static class LongPoint extends Point {
-
     LongPoint() {}
 
     /**
@@ -141,7 +138,6 @@ public abstract class MetricData {
   @Immutable
   @AutoValue
   public abstract static class DoublePoint extends Point {
-
     DoublePoint() {}
 
     /**
@@ -164,7 +160,6 @@ public abstract class MetricData {
   @Immutable
   @AutoValue
   public abstract static class SummaryPoint extends Point {
-
     SummaryPoint() {}
 
     /**
@@ -204,7 +199,6 @@ public abstract class MetricData {
   @Immutable
   @AutoValue
   public abstract static class ValueAtPercentile {
-
     ValueAtPercentile() {}
 
     /**
@@ -234,7 +228,6 @@ public abstract class MetricData {
   @Immutable
   @AutoValue
   public abstract static class Descriptor {
-
     Descriptor() {}
 
     /**
@@ -334,6 +327,11 @@ public abstract class MetricData {
      */
     public abstract Map<String, String> getConstantLabels();
 
+    /**
+     * A description of the time period over which the data was aggregated.
+     *
+     * @return The {@link TemporalQuality} of this data.
+     */
     public abstract TemporalQuality getTemporalQuality();
 
     public static Descriptor create(

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/view/Aggregation.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/view/Aggregation.java
@@ -20,6 +20,7 @@ import io.opentelemetry.sdk.metrics.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.TemporalQuality;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -68,4 +69,6 @@ public interface Aggregation {
    *     InstrumentType}.
    */
   boolean availableForInstrument(InstrumentType instrumentType);
+
+  TemporalQuality getTemporalQuality();
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/view/Aggregations.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/view/Aggregations.java
@@ -26,6 +26,7 @@ import io.opentelemetry.sdk.metrics.aggregator.LongSumAggregator;
 import io.opentelemetry.sdk.metrics.aggregator.NoopAggregator;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.TemporalQuality;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
 import javax.annotation.concurrent.Immutable;
 
@@ -115,6 +116,11 @@ public class Aggregations {
       return instrumentType == InstrumentType.MEASURE_ABSOLUTE
           || instrumentType == InstrumentType.MEASURE_NON_ABSOLUTE;
     }
+
+    @Override
+    public TemporalQuality getTemporalQuality() {
+      return TemporalQuality.DELTA;
+    }
   }
 
   @Immutable
@@ -158,6 +164,11 @@ public class Aggregations {
       // Available for all instruments.
       return true;
     }
+
+    @Override
+    public TemporalQuality getTemporalQuality() {
+      return TemporalQuality.CUMULATIVE;
+    }
   }
 
   @Immutable
@@ -185,6 +196,11 @@ public class Aggregations {
     public boolean availableForInstrument(InstrumentType instrumentType) {
       // Available for all instruments.
       return true;
+    }
+
+    @Override
+    public TemporalQuality getTemporalQuality() {
+      return TemporalQuality.CUMULATIVE;
     }
   }
 
@@ -216,6 +232,12 @@ public class Aggregations {
     @Override
     public boolean availableForInstrument(InstrumentType instrumentType) {
       throw new UnsupportedOperationException("Implement this");
+    }
+
+    @Override
+    public TemporalQuality getTemporalQuality() {
+      // TODO: Implement as appropriate
+      return TemporalQuality.CUMULATIVE;
     }
   }
 
@@ -258,6 +280,11 @@ public class Aggregations {
       // Do not change this unless the limitations of the current LastValueAggregator are fixed.
       return instrumentType == InstrumentType.OBSERVER_MONOTONIC
           || instrumentType == InstrumentType.OBSERVER_NON_MONOTONIC;
+    }
+
+    @Override
+    public TemporalQuality getTemporalQuality() {
+      return TemporalQuality.INSTANTANEOUS;
     }
   }
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/BatchRecorderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/BatchRecorderSdkTest.java
@@ -23,6 +23,7 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.TemporalQuality;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
 import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
@@ -82,7 +83,8 @@ public class BatchRecorderSdkTest {
                     "",
                     "1",
                     Type.MONOTONIC_DOUBLE,
-                    Collections.<String, String>emptyMap()),
+                    Collections.<String, String>emptyMap(),
+                    TemporalQuality.CUMULATIVE),
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 Collections.<Point>singletonList(
@@ -96,7 +98,8 @@ public class BatchRecorderSdkTest {
                     "",
                     "1",
                     Type.MONOTONIC_LONG,
-                    Collections.<String, String>emptyMap()),
+                    Collections.<String, String>emptyMap(),
+                    TemporalQuality.CUMULATIVE),
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 Collections.<Point>singletonList(

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleCounterSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleCounterSdkTest.java
@@ -26,6 +26,7 @@ import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.metrics.StressTestRunner.OperationUpdater;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.TemporalQuality;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
 import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
 import io.opentelemetry.sdk.resources.Resource;
@@ -76,7 +77,8 @@ public class DoubleCounterSdkTest {
                 "My very own counter",
                 "ms",
                 Type.MONOTONIC_DOUBLE,
-                Collections.singletonMap("sk1", "sv1")));
+                Collections.singletonMap("sk1", "sv1"),
+                TemporalQuality.CUMULATIVE));
     assertThat(metricData.getResource()).isEqualTo(RESOURCE);
     assertThat(metricData.getInstrumentationLibraryInfo()).isEqualTo(INSTRUMENTATION_LIBRARY_INFO);
     assertThat(metricData.getPoints()).isEmpty();

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleMeasureSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleMeasureSdkTest.java
@@ -26,6 +26,7 @@ import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.metrics.StressTestRunner.OperationUpdater;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.TemporalQuality;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
 import io.opentelemetry.sdk.metrics.data.MetricData.Point;
 import io.opentelemetry.sdk.metrics.data.MetricData.SummaryPoint;
@@ -78,7 +79,8 @@ public class DoubleMeasureSdkTest {
                     "My very own measure",
                     "ms",
                     Type.SUMMARY,
-                    Collections.singletonMap("sk1", "sv1")),
+                    Collections.singletonMap("sk1", "sv1"),
+                    TemporalQuality.DELTA),
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 Collections.<Point>emptyList()));
@@ -94,7 +96,12 @@ public class DoubleMeasureSdkTest {
         .containsExactly(
             MetricData.create(
                 Descriptor.create(
-                    "testMeasure", "", "1", Type.SUMMARY, Collections.<String, String>emptyMap()),
+                    "testMeasure",
+                    "",
+                    "1",
+                    Type.SUMMARY,
+                    Collections.<String, String>emptyMap(),
+                    TemporalQuality.DELTA),
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 Collections.<Point>singletonList(

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleMeasureSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleMeasureSdkTest.java
@@ -152,7 +152,7 @@ public class DoubleMeasureSdkTest {
                   555.9d,
                   valueAtPercentiles(111.1d, 321.5d)));
 
-      // Repeat to prove we keep previous values.
+      // Repeat to prove we delta vs. the previous values.
       testClock.advanceNanos(SECOND_NANOS);
       boundMeasure.record(222d);
       doubleMeasure.record(11d);
@@ -164,19 +164,19 @@ public class DoubleMeasureSdkTest {
       assertThat(metricData.getPoints())
           .containsExactly(
               SummaryPoint.create(
-                  startTime,
+                  firstCollect,
                   secondCollect,
                   emptyLabelSet.getLabels(),
-                  3,
-                  44.5d,
-                  valueAtPercentiles(11d, 21.4d)),
+                  1,
+                  11d,
+                  valueAtPercentiles(11d, 11d)),
               SummaryPoint.create(
-                  startTime,
+                  firstCollect,
                   secondCollect,
                   labelSet.getLabels(),
-                  4,
-                  777.9d,
-                  valueAtPercentiles(111.1d, 321.5d)));
+                  1,
+                  222d,
+                  valueAtPercentiles(222d, 222d)));
     } finally {
       boundMeasure.unbind();
     }

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleObserverSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleObserverSdkTest.java
@@ -25,6 +25,7 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.TemporalQuality;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
 import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.Point;
@@ -92,7 +93,8 @@ public class DoubleObserverSdkTest {
                     "My very own measure",
                     "ms",
                     Type.NON_MONOTONIC_DOUBLE,
-                    Collections.singletonMap("sk1", "sv1")),
+                    Collections.singletonMap("sk1", "sv1"),
+                    TemporalQuality.INSTANTANEOUS),
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 Collections.<Point>emptyList()));
@@ -118,7 +120,8 @@ public class DoubleObserverSdkTest {
                     "",
                     "1",
                     Type.MONOTONIC_DOUBLE,
-                    Collections.<String, String>emptyMap()),
+                    Collections.<String, String>emptyMap(),
+                    TemporalQuality.INSTANTANEOUS),
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 Collections.<Point>singletonList(
@@ -136,7 +139,8 @@ public class DoubleObserverSdkTest {
                     "",
                     "1",
                     Type.MONOTONIC_DOUBLE,
-                    Collections.<String, String>emptyMap()),
+                    Collections.<String, String>emptyMap(),
+                    TemporalQuality.INSTANTANEOUS),
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 Collections.<Point>singletonList(

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongCounterSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongCounterSdkTest.java
@@ -26,6 +26,7 @@ import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.metrics.StressTestRunner.OperationUpdater;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.TemporalQuality;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
 import io.opentelemetry.sdk.resources.Resource;
@@ -76,7 +77,8 @@ public class LongCounterSdkTest {
                 "My very own counter",
                 "ms",
                 Type.MONOTONIC_LONG,
-                Collections.singletonMap("sk1", "sv1")));
+                Collections.singletonMap("sk1", "sv1"),
+                TemporalQuality.CUMULATIVE));
     assertThat(metricData.getResource()).isEqualTo(RESOURCE);
     assertThat(metricData.getInstrumentationLibraryInfo()).isEqualTo(INSTRUMENTATION_LIBRARY_INFO);
     assertThat(metricData.getPoints()).isEmpty();

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongMeasureSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongMeasureSdkTest.java
@@ -154,7 +154,7 @@ public class LongMeasureSdkTest {
                   555,
                   valueAtPercentiles(111, 321)));
 
-      // Repeat to prove we keep previous values.
+      // Repeat to prove we delta vs. the previous values.
       testClock.advanceNanos(SECOND_NANOS);
       boundMeasure.record(222);
       longMeasure.record(11);
@@ -167,19 +167,19 @@ public class LongMeasureSdkTest {
       assertThat(metricData.getPoints())
           .containsExactly(
               SummaryPoint.create(
-                  startTime,
+                  firstCollect,
                   secondCollect,
                   emptyLabelSet.getLabels(),
-                  3,
-                  44,
-                  valueAtPercentiles(11, 21)),
+                  1,
+                  11,
+                  valueAtPercentiles(11, 11)),
               SummaryPoint.create(
-                  startTime,
+                  firstCollect,
                   secondCollect,
                   labelSet.getLabels(),
-                  4,
-                  777,
-                  valueAtPercentiles(111, 321)));
+                  1,
+                  222,
+                  valueAtPercentiles(222, 222)));
     } finally {
       boundMeasure.unbind();
     }

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongMeasureSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongMeasureSdkTest.java
@@ -26,6 +26,7 @@ import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.metrics.StressTestRunner.OperationUpdater;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.TemporalQuality;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
 import io.opentelemetry.sdk.metrics.data.MetricData.Point;
 import io.opentelemetry.sdk.metrics.data.MetricData.SummaryPoint;
@@ -79,7 +80,8 @@ public class LongMeasureSdkTest {
                     "My very own counter",
                     "ms",
                     Type.SUMMARY,
-                    Collections.singletonMap("sk1", "sv1")),
+                    Collections.singletonMap("sk1", "sv1"),
+                    TemporalQuality.DELTA),
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 Collections.<Point>emptyList()));
@@ -95,7 +97,12 @@ public class LongMeasureSdkTest {
         .containsExactly(
             MetricData.create(
                 Descriptor.create(
-                    "testMeasure", "", "1", Type.SUMMARY, Collections.<String, String>emptyMap()),
+                    "testMeasure",
+                    "",
+                    "1",
+                    Type.SUMMARY,
+                    Collections.<String, String>emptyMap(),
+                    TemporalQuality.DELTA),
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 Collections.<Point>singletonList(

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongObserverSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongObserverSdkTest.java
@@ -25,6 +25,7 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.TemporalQuality;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.Point;
@@ -92,7 +93,8 @@ public class LongObserverSdkTest {
                     "My very own measure",
                     "ms",
                     Type.NON_MONOTONIC_LONG,
-                    Collections.singletonMap("sk1", "sv1")),
+                    Collections.singletonMap("sk1", "sv1"),
+                    TemporalQuality.INSTANTANEOUS),
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 Collections.<Point>emptyList()));
@@ -118,7 +120,8 @@ public class LongObserverSdkTest {
                     "",
                     "1",
                     Type.MONOTONIC_LONG,
-                    Collections.<String, String>emptyMap()),
+                    Collections.<String, String>emptyMap(),
+                    TemporalQuality.INSTANTANEOUS),
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 Collections.<Point>singletonList(
@@ -136,7 +139,8 @@ public class LongObserverSdkTest {
                     "",
                     "1",
                     Type.MONOTONIC_LONG,
-                    Collections.<String, String>emptyMap()),
+                    Collections.<String, String>emptyMap(),
+                    TemporalQuality.INSTANTANEOUS),
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 Collections.<Point>singletonList(

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkRegistryTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkRegistryTest.java
@@ -24,6 +24,7 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.TemporalQuality;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.Point;
@@ -110,7 +111,8 @@ public class MeterSdkRegistryTest {
                     "",
                     "1",
                     Type.MONOTONIC_LONG,
-                    Collections.<String, String>emptyMap()),
+                    Collections.<String, String>emptyMap(),
+                    TemporalQuality.CUMULATIVE),
                 Resource.getEmpty(),
                 meterSdk1.getInstrumentationLibraryInfo(),
                 Collections.<Point>singletonList(
@@ -125,7 +127,8 @@ public class MeterSdkRegistryTest {
                     "",
                     "1",
                     Type.MONOTONIC_LONG,
-                    Collections.<String, String>emptyMap()),
+                    Collections.<String, String>emptyMap(),
+                    TemporalQuality.CUMULATIVE),
                 Resource.getEmpty(),
                 meterSdk2.getInstrumentationLibraryInfo(),
                 Collections.<Point>singletonList(

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
@@ -25,6 +25,7 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.TemporalQuality;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
 import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
@@ -259,7 +260,8 @@ public class MeterSdkTest {
                     "",
                     "1",
                     Type.MONOTONIC_LONG,
-                    Collections.<String, String>emptyMap()),
+                    Collections.<String, String>emptyMap(),
+                    TemporalQuality.CUMULATIVE),
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 Collections.<Point>singletonList(
@@ -274,7 +276,8 @@ public class MeterSdkTest {
                     "",
                     "1",
                     Type.MONOTONIC_DOUBLE,
-                    Collections.<String, String>emptyMap()),
+                    Collections.<String, String>emptyMap(),
+                    TemporalQuality.CUMULATIVE),
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 Collections.<Point>singletonList(
@@ -289,7 +292,8 @@ public class MeterSdkTest {
                     "",
                     "1",
                     Type.SUMMARY,
-                    Collections.<String, String>emptyMap()),
+                    Collections.<String, String>emptyMap(),
+                    TemporalQuality.DELTA),
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 Collections.<Point>singletonList(
@@ -307,7 +311,8 @@ public class MeterSdkTest {
                     "",
                     "1",
                     Type.SUMMARY,
-                    Collections.<String, String>emptyMap()),
+                    Collections.<String, String>emptyMap(),
+                    TemporalQuality.DELTA),
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 Collections.<Point>singletonList(

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/data/MetricDataDescriptorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/data/MetricDataDescriptorTest.java
@@ -19,6 +19,7 @@ package io.opentelemetry.sdk.metrics.data;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.TemporalQuality;
 import java.util.Collections;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,46 +43,71 @@ public class MetricDataDescriptorTest {
   public void testGet() {
     Descriptor descriptor =
         Descriptor.create(
-            METRIC_NAME, DESCRIPTION, UNIT, TYPE, Collections.singletonMap(KEY, VALUE));
+            METRIC_NAME,
+            DESCRIPTION,
+            UNIT,
+            TYPE,
+            Collections.singletonMap(KEY, VALUE),
+            TemporalQuality.INSTANTANEOUS);
     assertThat(descriptor.getName()).isEqualTo(METRIC_NAME);
     assertThat(descriptor.getDescription()).isEqualTo(DESCRIPTION);
     assertThat(descriptor.getUnit()).isEqualTo(UNIT);
     assertThat(descriptor.getType()).isEqualTo(TYPE);
     assertThat(descriptor.getConstantLabels()).containsExactly(KEY, VALUE);
+    assertThat(descriptor.getTemporalQuality()).isEqualTo(TemporalQuality.INSTANTANEOUS);
   }
 
   @Test
   public void create_NullName() {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("name");
-    Descriptor.create(null, DESCRIPTION, UNIT, TYPE, Collections.singletonMap(KEY, VALUE));
+    Descriptor.create(
+        null,
+        DESCRIPTION,
+        UNIT,
+        TYPE,
+        Collections.singletonMap(KEY, VALUE),
+        TemporalQuality.INSTANTANEOUS);
   }
 
   @Test
   public void create_NullDescription() {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("description");
-    Descriptor.create(METRIC_NAME, null, UNIT, TYPE, Collections.singletonMap(KEY, VALUE));
+    Descriptor.create(
+        METRIC_NAME, null, UNIT, TYPE, Collections.singletonMap(KEY, VALUE), TemporalQuality.DELTA);
   }
 
   @Test
   public void create_NullUnit() {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("unit");
-    Descriptor.create(METRIC_NAME, DESCRIPTION, null, TYPE, Collections.singletonMap(KEY, VALUE));
+    Descriptor.create(
+        METRIC_NAME,
+        DESCRIPTION,
+        null,
+        TYPE,
+        Collections.singletonMap(KEY, VALUE),
+        TemporalQuality.DELTA);
   }
 
   @Test
   public void create_NullType() {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("type");
-    Descriptor.create(METRIC_NAME, DESCRIPTION, UNIT, null, Collections.singletonMap(KEY, VALUE));
+    Descriptor.create(
+        METRIC_NAME,
+        DESCRIPTION,
+        UNIT,
+        null,
+        Collections.singletonMap(KEY, VALUE),
+        TemporalQuality.DELTA);
   }
 
   @Test
   public void create_NullConstantLabels() {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("constantLabels");
-    Descriptor.create(METRIC_NAME, DESCRIPTION, UNIT, TYPE, null);
+    Descriptor.create(METRIC_NAME, DESCRIPTION, UNIT, TYPE, null, TemporalQuality.DELTA);
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/data/MetricDataTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/data/MetricDataTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.TemporalQuality;
 import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.Point;
@@ -47,14 +48,16 @@ public class MetricDataTest {
           "metric_description",
           "ms",
           Descriptor.Type.MONOTONIC_LONG,
-          Collections.singletonMap("key_const", "value_const"));
+          Collections.singletonMap("key_const", "value_const"),
+          TemporalQuality.CUMULATIVE);
   private static final Descriptor DOUBLE_METRIC_DESCRIPTOR =
       Descriptor.create(
           "metric_name",
           "metric_description",
           "ms",
           Descriptor.Type.NON_MONOTONIC_DOUBLE,
-          Collections.singletonMap("key_const", "value_const"));
+          Collections.singletonMap("key_const", "value_const"),
+          TemporalQuality.CUMULATIVE);
   private static final long START_EPOCH_NANOS = TimeUnit.MILLISECONDS.toNanos(1000);
   private static final long EPOCH_NANOS = TimeUnit.MILLISECONDS.toNanos(2000);
   private static final long LONG_VALUE = 10;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.TemporalQuality;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.Point;
@@ -45,7 +46,8 @@ public class IntervalMetricReaderTest {
           "my metric description",
           "us",
           Type.MONOTONIC_LONG,
-          Collections.<String, String>emptyMap());
+          Collections.<String, String>emptyMap(),
+          TemporalQuality.CUMULATIVE);
 
   private static final List<Point> LONG_POINT_LIST =
       Collections.<Point>singletonList(


### PR DESCRIPTION
This is a follow-on from #1032 to make the MinMaxSumCount aggregations actually create deltas properly, with the timestamps set appropriately.

It also demonstrates the beginnings of how we might make the aggregations be able to behave in a delta or a cumulative mode.