### PR TITLE
Add explicit setup method to API.

### DIFF
--- a/api/src/main/java/io/opentelemetry/OpenTelemetry.java
+++ b/api/src/main/java/io/opentelemetry/OpenTelemetry.java
@@ -204,7 +204,7 @@ public final class OpenTelemetry {
    * <p>This method must not be called after attempting to access an API implementation object via
    * this class (i.e., after calling methods such as {@link #getTracerProvider()}). Basically this
    * means that the one who is in control of the main method is the only one who may call this
-   * method. Consequently, If another method calls this, this requirement applies to that method
+   * method. Consequently, if another method calls this, this requirement applies to that method
    * too, recursively.
    *
    * <p>This method must only be called once, even if you use any {@code null} arguments. Any null

--- a/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
+++ b/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
@@ -115,6 +115,39 @@ public class OpenTelemetryTest {
   }
 
   @Test
+  public void testSetupExplicit() {
+    final SecondTraceProvider tracerProvider = new SecondTraceProvider();
+    final SecondMetricsProvider meterProvider = new SecondMetricsProvider();
+    final SecondCorrelationContextManager contextManager = new SecondCorrelationContextManager();
+    OpenTelemetry.setupExplicitImplementations(tracerProvider, meterProvider, contextManager);
+    assertThat(OpenTelemetry.getTracerProvider()).isSameInstanceAs(tracerProvider);
+    assertThat(OpenTelemetry.getMeterProvider()).isSameInstanceAs(meterProvider);
+    assertThat(OpenTelemetry.getCorrelationContextManager()).isSameInstanceAs(contextManager);
+  }
+
+  @Test
+  public void testSetupDefault() {
+    OpenTelemetry.setupExplicitImplementations(null, null, null);
+    testDefault();
+  }
+
+  @Test
+  public void testSetupTwice() {
+    OpenTelemetry.setupExplicitImplementations(null, null, null);
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("already initialized");
+    OpenTelemetry.setupExplicitImplementations(null, null, null);
+  }
+
+  @Test
+  public void testSetupTooLate() {
+    OpenTelemetry.getTracerProvider(); // Triggers init
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("already initialized");
+    OpenTelemetry.setupExplicitImplementations(null, null, null);
+  }
+
+  @Test
   public void testTracerNotFound() {
     System.setProperty(TraceProvider.class.getName(), "io.does.not.exists");
     thrown.expect(IllegalStateException.class);


### PR DESCRIPTION
This allows programmatically setting up the API, which is useful if you
need to access runtime configuration during initialization that is
cumbersome to get when you are in a class newly constructed by the SPI
loader mechanism.

EDIT: Addresses #552, #747