### PR TITLE
Add forceFlush on TracerSdkProvider.

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdkProvider.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdkProvider.java
@@ -120,6 +120,15 @@ public class TracerSdkProvider implements TracerProvider {
   }
 
   /**
+   * Requests the active span processor to process all span events that have not yet been processed.
+   *
+   * @see SpanProcessor#forceFlush()
+   */
+  public void forceFlush() {
+    sharedState.getActiveSpanProcessor().forceFlush();
+  }
+
+  /**
    * Builder class for the TracerSdkFactory. Has fully functional default implementations of all
    * three required interfaces.
    *

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkProviderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkProviderTest.java
@@ -121,6 +121,12 @@ public class TracerSdkProviderTest {
   }
 
   @Test
+  public void forceFlush() {
+    tracerFactory.forceFlush();
+    Mockito.verify(spanProcessor, Mockito.times(1)).forceFlush();
+  }
+
+  @Test
   public void shutdownTwice_OnlyFlushSpanProcessorOnce() {
     tracerFactory.shutdown();
     Mockito.verify(spanProcessor, Mockito.times(1)).shutdown();


### PR DESCRIPTION
Since there is no method to get the SpanProcessor(s),
there is no way to actually use the forceFlush API otherwise.