### PR TITLE
Add support to use SemanticAttributes with Span.Builder.

### DIFF
--- a/api/src/main/java/io/opentelemetry/common/Acceptor.java
+++ b/api/src/main/java/io/opentelemetry/common/Acceptor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.common;
+
+/**
+ * A function to be executed with a single argument, having a side effect.
+ *
+ * <p>Adapted from Java 8's {@code java.util.function.Consumer}.
+ *
+ * @param <T> Type of the input argument.
+ */
+public interface Acceptor<T> {
+
+  /**
+   * Performs this operation on the given argument.
+   *
+   * @param arg the input argument
+   */
+  void exec(T arg);
+}

--- a/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.trace;
 
+import io.opentelemetry.common.Acceptor;
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.internal.Utils;
@@ -154,6 +155,12 @@ public final class DefaultTracer implements Tracer {
     @Override
     public NoopSpanBuilder setStartTimestamp(long startTimestamp) {
       Utils.checkArgument(startTimestamp >= 0, "Negative startTimestamp");
+      return this;
+    }
+
+    @Override
+    public Span.Builder apply(Acceptor<Span.Builder> acceptor) {
+      acceptor.exec(this);
       return this;
     }
 

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -548,7 +548,7 @@ public interface Span {
     /**
      * Applies the given consumer to this {@link Builder}.
      *
-     * <p>This is indented to be used with {@link
+     * <p>This is intended to be used with {@link
      * io.opentelemetry.trace.attributes.StringAttributeSetter#set(String)}, etc.
      *
      * @param acceptor The {@link Acceptor} to apply to this

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.trace;
 
+import io.opentelemetry.common.Acceptor;
 import io.opentelemetry.common.AttributeValue;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -543,6 +544,17 @@ public interface Span {
      * @since 0.1.0
      */
     Builder setStartTimestamp(long startTimestamp);
+
+    /**
+     * Applies the given consumer to this {@link Builder}.
+     *
+     * <p>This is indented to be used with {@link
+     * io.opentelemetry.trace.attributes.StringAttributeSetter#set(String)}, etc.
+     *
+     * @param acceptor The {@link Acceptor} to apply to this
+     * @return this.
+     */
+    Builder apply(Acceptor<Builder> acceptor);
 
     /**
      * Starts a new {@link Span}.

--- a/api/src/main/java/io/opentelemetry/trace/attributes/BooleanAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/BooleanAttributeSetter.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.trace.attributes;
 
+import io.opentelemetry.common.Acceptor;
 import io.opentelemetry.trace.Span;
 import javax.annotation.concurrent.Immutable;
 
@@ -59,5 +60,22 @@ public final class BooleanAttributeSetter {
    */
   public void set(Span span, boolean value) {
     span.setAttribute(key(), value);
+  }
+
+  /**
+   * Returns a {@link Acceptor} for use set {@link Span.Builder#apply(Acceptor)} that sets the
+   * attribute to {@code value}.
+   *
+   * @param value the value for this attribute
+   * @return A {@link Acceptor} for use set {@link Span.Builder#apply(Acceptor)}.
+   */
+  @SuppressWarnings("InconsistentOverloads")
+  public Acceptor<Span.Builder> set(final boolean value) {
+    return new Acceptor<Span.Builder>() {
+      @Override
+      public void exec(Span.Builder arg) {
+        arg.setAttribute(key(), value);
+      }
+    };
   }
 }

--- a/api/src/main/java/io/opentelemetry/trace/attributes/BooleanAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/BooleanAttributeSetter.java
@@ -63,7 +63,7 @@ public final class BooleanAttributeSetter {
   }
 
   /**
-   * Returns a {@link Acceptor} for use set {@link Span.Builder#apply(Acceptor)} that sets the
+   * Returns an {@link Acceptor} for use with {@link Span.Builder#apply(Acceptor)} that sets the
    * attribute to {@code value}.
    *
    * @param value the value for this attribute

--- a/api/src/main/java/io/opentelemetry/trace/attributes/DoubleAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/DoubleAttributeSetter.java
@@ -63,7 +63,7 @@ public final class DoubleAttributeSetter {
   }
 
   /**
-   * Returns a {@link Acceptor} for use set {@link Span.Builder#apply(Acceptor)} that sets the
+   * Returns an {@link Acceptor} for use with {@link Span.Builder#apply(Acceptor)} that sets the
    * attribute to {@code value}.
    *
    * @param value the value for this attribute

--- a/api/src/main/java/io/opentelemetry/trace/attributes/DoubleAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/DoubleAttributeSetter.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.trace.attributes;
 
+import io.opentelemetry.common.Acceptor;
 import io.opentelemetry.trace.Span;
 import javax.annotation.concurrent.Immutable;
 
@@ -59,5 +60,22 @@ public final class DoubleAttributeSetter {
    */
   public void set(Span span, double value) {
     span.setAttribute(key(), value);
+  }
+
+  /**
+   * Returns a {@link Acceptor} for use set {@link Span.Builder#apply(Acceptor)} that sets the
+   * attribute to {@code value}.
+   *
+   * @param value the value for this attribute
+   * @return A {@link Acceptor} for use set {@link Span.Builder#apply(Acceptor)}.
+   */
+  @SuppressWarnings("InconsistentOverloads")
+  public Acceptor<Span.Builder> set(final double value) {
+    return new Acceptor<Span.Builder>() {
+      @Override
+      public void exec(Span.Builder arg) {
+        arg.setAttribute(key(), value);
+      }
+    };
   }
 }

--- a/api/src/main/java/io/opentelemetry/trace/attributes/LongAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/LongAttributeSetter.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.trace.attributes;
 
+import io.opentelemetry.common.Acceptor;
 import io.opentelemetry.trace.Span;
 import javax.annotation.concurrent.Immutable;
 
@@ -59,5 +60,22 @@ public final class LongAttributeSetter {
    */
   public void set(Span span, long value) {
     span.setAttribute(key(), value);
+  }
+
+  /**
+   * Returns a {@link Acceptor} for use set {@link Span.Builder#apply(Acceptor)} that sets the
+   * attribute to {@code value}.
+   *
+   * @param value the value for this attribute
+   * @return A {@link Acceptor} for use set {@link Span.Builder#apply(Acceptor)}.
+   */
+  @SuppressWarnings("InconsistentOverloads")
+  public Acceptor<Span.Builder> set(final long value) {
+    return new Acceptor<Span.Builder>() {
+      @Override
+      public void exec(Span.Builder arg) {
+        arg.setAttribute(key(), value);
+      }
+    };
   }
 }

--- a/api/src/main/java/io/opentelemetry/trace/attributes/LongAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/LongAttributeSetter.java
@@ -63,7 +63,7 @@ public final class LongAttributeSetter {
   }
 
   /**
-   * Returns a {@link Acceptor} for use set {@link Span.Builder#apply(Acceptor)} that sets the
+   * Returns an {@link Acceptor} for use with {@link Span.Builder#apply(Acceptor)} that sets the
    * attribute to {@code value}.
    *
    * @param value the value for this attribute

--- a/api/src/main/java/io/opentelemetry/trace/attributes/StringAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/StringAttributeSetter.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.trace.attributes;
 
+import io.opentelemetry.common.Acceptor;
 import io.opentelemetry.trace.Span;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -60,5 +61,22 @@ public final class StringAttributeSetter {
    */
   public void set(Span span, @Nullable String value) {
     span.setAttribute(key(), value);
+  }
+
+  /**
+   * Returns a {@link Acceptor} for use set {@link Span.Builder#apply(Acceptor)} that sets the
+   * attribute to {@code value}.
+   *
+   * @param value the value for this attribute
+   * @return A {@link Acceptor} for use set {@link Span.Builder#apply(Acceptor)}.
+   */
+  @SuppressWarnings("InconsistentOverloads")
+  public Acceptor<Span.Builder> set(@Nullable final String value) {
+    return new Acceptor<Span.Builder>() {
+      @Override
+      public void exec(Span.Builder arg) {
+        arg.setAttribute(key(), value);
+      }
+    };
   }
 }

--- a/api/src/main/java/io/opentelemetry/trace/attributes/StringAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/StringAttributeSetter.java
@@ -64,7 +64,7 @@ public final class StringAttributeSetter {
   }
 
   /**
-   * Returns a {@link Acceptor} for use set {@link Span.Builder#apply(Acceptor)} that sets the
+   * Returns an {@link Acceptor} for use with {@link Span.Builder#apply(Acceptor)} that sets the
    * attribute to {@code value}.
    *
    * @param value the value for this attribute

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -17,6 +17,7 @@
 package io.opentelemetry.sdk.trace;
 
 import io.grpc.Context;
+import io.opentelemetry.common.Acceptor;
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.internal.Utils;
 import io.opentelemetry.sdk.common.Clock;
@@ -195,6 +196,12 @@ final class SpanBuilderSdk implements Span.Builder {
   public Span.Builder setStartTimestamp(long startTimestamp) {
     Utils.checkArgument(startTimestamp >= 0, "Negative startTimestamp");
     startEpochNanos = startTimestamp;
+    return this;
+  }
+
+  @Override
+  public Span.Builder apply(Acceptor<Span.Builder> acceptor) {
+    acceptor.exec(this);
     return this;
   }
 


### PR DESCRIPTION
Suggestion on how to resolve #1075.

This design ensures that the API would not depend on a hypothetical contrib-semantic-attributes package. If we don't care about that, we could add overloads taking *AttributeSetter directly to the Span.Builder interface, without needing the Acceptor<T> indirection.

This was designed with chainability in mind, i.e. you can do things like `spanBuilder.setAttribute(foo, bar).apply(ATTR1.set(23)).apply(ATTR2.set(43)).startSpan()`.