### PR TITLE
Give more meaningful names to the instruments in the jvm runtime metrics

### DIFF
--- a/contrib/runtime_metrics/src/main/java/io/opentelemetry/contrib/metrics/runtime/GarbageCollector.java
+++ b/contrib/runtime_metrics/src/main/java/io/opentelemetry/contrib/metrics/runtime/GarbageCollector.java
@@ -58,7 +58,7 @@ public final class GarbageCollector {
   public void exportAll() {
     final LongObserver gcMetric =
         meter
-            .longObserverBuilder("collection")
+            .longObserverBuilder("jvm.gc.collection")
             .setDescription("Time spent in a given JVM garbage collector in milliseconds.")
             .setUnit("ms")
             .setLabelKeys(Collections.singletonList(GC_LABEL_KEY))

--- a/contrib/runtime_metrics/src/main/java/io/opentelemetry/contrib/metrics/runtime/MemoryPools.java
+++ b/contrib/runtime_metrics/src/main/java/io/opentelemetry/contrib/metrics/runtime/MemoryPools.java
@@ -72,7 +72,7 @@ public final class MemoryPools {
     // TODO: Set this as non-monotonic.
     final LongObserver areaMetric =
         this.meter
-            .longObserverBuilder("area")
+            .longObserverBuilder("jvm.memory.area")
             .setDescription("Bytes of a given JVM memory area.")
             .setUnit("By")
             .setLabelKeys(Arrays.asList(TYPE_LABEL_KEY, AREA_LABEL_KEY))
@@ -107,7 +107,7 @@ public final class MemoryPools {
     // TODO: Set this as non-monotonic.
     final LongObserver poolMetric =
         this.meter
-            .longObserverBuilder("pool")
+            .longObserverBuilder("jvm.memory.pool")
             .setDescription("Bytes of a given JVM memory pool.")
             .setUnit("By")
             .setLabelKeys(Arrays.asList(TYPE_LABEL_KEY, POOL_LABEL_KEY))


### PR DESCRIPTION
I'm wondering if we should have semantic conventions for this kind of metric/instrument naming.