### PR TITLE
Don't uselessly rerun opentracing_shim tests.

### DIFF
--- a/opentracing_shim/build.gradle
+++ b/opentracing_shim/build.gradle
@@ -18,6 +18,5 @@ dependencies {
             libraries.awaitility
 }
 test {
-    dependsOn cleanTest
     testLogging.showStandardStreams = true
 }


### PR DESCRIPTION
Gradle should rerun automatically if any input/dependencies changed.

No other build.gradle uses cleanTest.

CC @carlosalberto 