### PR TITLE
Let the carrier be null on the inject methods, to support possible lambda usages

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/propagation/B3Propagator.java
+++ b/api/src/main/java/io/opentelemetry/trace/propagation/B3Propagator.java
@@ -86,7 +86,6 @@ public class B3Propagator implements HttpTextFormat {
   public <C> void inject(Context context, C carrier, Setter<C> setter) {
     checkNotNull(context, "context");
     checkNotNull(setter, "setter");
-    checkNotNull(carrier, "carrier");
 
     Span span = TracingContextUtils.getSpanWithoutDefault(context);
     if (span == null) {

--- a/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
@@ -79,7 +79,6 @@ public class HttpTraceContext implements HttpTextFormat {
   public <C> void inject(Context context, C carrier, Setter<C> setter) {
     checkNotNull(context, "context");
     checkNotNull(setter, "setter");
-    checkNotNull(carrier, "carrier");
 
     Span span = TracingContextUtils.getSpanWithoutDefault(context);
     if (span == null) {

--- a/api/src/main/java/io/opentelemetry/trace/propagation/JaegerPropagator.java
+++ b/api/src/main/java/io/opentelemetry/trace/propagation/JaegerPropagator.java
@@ -73,7 +73,6 @@ public class JaegerPropagator implements HttpTextFormat {
   public <C> void inject(Context context, C carrier, Setter<C> setter) {
     checkNotNull(context, "context");
     checkNotNull(setter, "setter");
-    checkNotNull(carrier, "carrier");
 
     Span span = TracingContextUtils.getSpanWithoutDefault(context);
     if (span == null) {

--- a/api/src/test/java/io/opentelemetry/trace/propagation/B3PropagatorTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/propagation/B3PropagatorTest.java
@@ -96,6 +96,25 @@ public class B3PropagatorTest {
   }
 
   @Test
+  public void inject_SampledContext_nullCarrierUsage() {
+    final Map<String, String> carrier = new LinkedHashMap<>();
+    b3Propagator.inject(
+        withSpanContext(
+            SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
+            Context.current()),
+        null,
+        new Setter<Map<String, String>>() {
+          @Override
+          public void set(Map<String, String> ignored, String key, String value) {
+            carrier.put(key, value);
+          }
+        });
+    assertThat(carrier).containsEntry(B3Propagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
+    assertThat(carrier).containsEntry(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    assertThat(carrier).containsEntry(B3Propagator.SAMPLED_HEADER, "1");
+  }
+
+  @Test
   public void inject_NotSampledContext() {
     Map<String, String> carrier = new LinkedHashMap<>();
     b3Propagator.inject(

--- a/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
@@ -90,9 +90,28 @@ public class HttpTraceContextTest {
 
   @Test
   public void inject_Nothing() {
-    Map<String, String> carrier = new LinkedHashMap<String, String>();
+    Map<String, String> carrier = new LinkedHashMap<>();
     httpTraceContext.inject(Context.current(), carrier, setter);
     assertThat(carrier).hasSize(0);
+  }
+
+  @Test
+  public void inject_NullCarrierUsage() {
+    final Map<String, String> carrier = new LinkedHashMap<>();
+    Context context =
+        withSpanContext(
+            SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
+            Context.current());
+    httpTraceContext.inject(
+        context,
+        null,
+        new Setter<Map<String, String>>() {
+          @Override
+          public void set(Map<String, String> ignored, String key, String value) {
+            carrier.put(key, value);
+          }
+        });
+    assertThat(carrier).containsExactly(TRACE_PARENT, TRACEPARENT_HEADER_SAMPLED);
   }
 
   @Test

--- a/context_prop/src/main/java/io/opentelemetry/context/propagation/HttpTextFormat.java
+++ b/context_prop/src/main/java/io/opentelemetry/context/propagation/HttpTextFormat.java
@@ -69,7 +69,7 @@ public interface HttpTextFormat {
   List<String> fields();
 
   /**
-   * Injects the value downstream. For example, as http headers. The carrier may be null to
+   * Injects the value downstream, for example as HTTP headers. The carrier may be null to
    * facilitate calling this method with a java lambda for the {@link Setter}, in which case that
    * null will be passed to your {@link Setter} implementation.
    *

--- a/context_prop/src/main/java/io/opentelemetry/context/propagation/HttpTextFormat.java
+++ b/context_prop/src/main/java/io/opentelemetry/context/propagation/HttpTextFormat.java
@@ -70,7 +70,7 @@ public interface HttpTextFormat {
 
   /**
    * Injects the value downstream, for example as HTTP headers. The carrier may be null to
-   * facilitate calling this method with a java lambda for the {@link Setter}, in which case that
+   * facilitate calling this method with a lambda for the {@link Setter}, in which case that
    * null will be passed to your {@link Setter} implementation.
    *
    * @param context the {@code Context} containing the value to be injected.

--- a/context_prop/src/main/java/io/opentelemetry/context/propagation/HttpTextFormat.java
+++ b/context_prop/src/main/java/io/opentelemetry/context/propagation/HttpTextFormat.java
@@ -71,7 +71,7 @@ public interface HttpTextFormat {
   /**
    * Injects the value downstream, for example as HTTP headers. The carrier may be null to
    * facilitate calling this method with a lambda for the {@link Setter}, in which case that
-   * null will be passed to your {@link Setter} implementation.
+   * null will be passed to the {@link Setter} implementation.
    *
    * @param context the {@code Context} containing the value to be injected.
    * @param carrier holds propagation fields. For example, an outgoing message or http request.

--- a/context_prop/src/main/java/io/opentelemetry/context/propagation/HttpTextFormat.java
+++ b/context_prop/src/main/java/io/opentelemetry/context/propagation/HttpTextFormat.java
@@ -69,7 +69,9 @@ public interface HttpTextFormat {
   List<String> fields();
 
   /**
-   * Injects the value downstream. For example, as http headers.
+   * Injects the value downstream. For example, as http headers. The carrier may be null to
+   * facilitate calling this method with a java lambda for the {@link Setter}, in which case that
+   * null will be passed to your {@link Setter} implementation.
    *
    * @param context the {@code Context} containing the value to be injected.
    * @param carrier holds propagation fields. For example, an outgoing message or http request.
@@ -77,7 +79,7 @@ public interface HttpTextFormat {
    * @param <C> carrier of propagation fields, such as an http request
    * @since 0.1.0
    */
-  <C> void inject(Context context, C carrier, Setter<C> setter);
+  <C> void inject(Context context, @Nullable C carrier, Setter<C> setter);
 
   /**
    * Class that allows a {@code HttpTextFormat} to set propagated fields into a carrier.
@@ -96,12 +98,13 @@ public interface HttpTextFormat {
      * <p>For example, a setter for an {@link java.net.HttpURLConnection} would be the method
      * reference {@link java.net.HttpURLConnection#addRequestProperty(String, String)}
      *
-     * @param carrier holds propagation fields. For example, an outgoing message or http request.
+     * @param carrier holds propagation fields. For example, an outgoing message or http request. To
+     *     facilitate implementations as java lambdas, this parameter may be null.
      * @param key the key of the field.
      * @param value the value of the field.
      * @since 0.1.0
      */
-    void set(C carrier, String key, String value);
+    void set(@Nullable C carrier, String key, String value);
   }
 
   /**

--- a/context_prop/src/main/java/io/opentelemetry/context/propagation/HttpTextFormat.java
+++ b/context_prop/src/main/java/io/opentelemetry/context/propagation/HttpTextFormat.java
@@ -70,8 +70,8 @@ public interface HttpTextFormat {
 
   /**
    * Injects the value downstream, for example as HTTP headers. The carrier may be null to
-   * facilitate calling this method with a lambda for the {@link Setter}, in which case that
-   * null will be passed to the {@link Setter} implementation.
+   * facilitate calling this method with a lambda for the {@link Setter}, in which case that null
+   * will be passed to the {@link Setter} implementation.
    *
    * @param context the {@code Context} containing the value to be injected.
    * @param carrier holds propagation fields. For example, an outgoing message or http request.


### PR DESCRIPTION
I think this should resolve #916 , but if we want to have no-op implementations if the other two parameters are null, I can amend this PR with that.