### PR TITLE
Add Jaeger remote sampler

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -22,6 +22,7 @@ def subprojects = [
         project(':opentelemetry-sdk-contrib-auto-config'),
         project(':opentelemetry-sdk-contrib-otproto'),
         project(':opentelemetry-sdk-contrib-testbed'),
+        project(':opentelemetry-sdk-contrib-jaeger-remote-sampler'),
 ]
 
 for (subproject in rootProject.subprojects) {

--- a/sdk_contrib/jaeger_remote_sampler/README.md
+++ b/sdk_contrib/jaeger_remote_sampler/README.md
@@ -1,0 +1,18 @@
+# Jaeger Remote Sampler
+
+This module implements [Jaeger remote sampler](https://www.jaegertracing.io/docs/latest/sampling/#collector-sampling-configuration).
+The sampler configuration is received from collector's gRPC endpoint.
+
+### Example
+
+The following example shows initialization and installation of the sampler:
+
+```java
+Builder remoteSamplerBuilder = JaegerRemoteSampler.newBuilder()
+    .setChannel(grpcChannel)
+    .setServiceName("my-service");
+TraceConfig traceConfig = provider.getActiveTraceConfig()
+    .toBuilder().setSampler(remoteSamplerBuilder.build())
+    .build();
+provider.updateActiveTraceConfig(traceConfig);
+```

--- a/sdk_contrib/jaeger_remote_sampler/build.gradle
+++ b/sdk_contrib/jaeger_remote_sampler/build.gradle
@@ -22,8 +22,7 @@ dependencies {
 
     testImplementation "io.grpc:grpc-testing:${grpcVersion}",
             libraries.testcontainers,
-            libraries.awaitility,
-            libraries.rest_assured
+            libraries.awaitility
 
     testRuntime "io.grpc:grpc-netty-shaded:${grpcVersion}"
 

--- a/sdk_contrib/jaeger_remote_sampler/build.gradle
+++ b/sdk_contrib/jaeger_remote_sampler/build.gradle
@@ -1,0 +1,61 @@
+plugins {
+    id "java"
+    id "maven-publish"
+
+    id "com.google.protobuf"
+    id "ru.vyarus.animalsniffer"
+}
+
+description = 'OpenTelemetry - Jaeger Remote sampler'
+ext.moduleName = "io.opentelemetry.sdk.contrib.trace.jaeger"
+
+dependencies {
+    api project(':opentelemetry-sdk')
+
+    implementation project(':opentelemetry-sdk-contrib-otproto'),
+            project(':opentelemetry-sdk'),
+            libraries.grpc_api,
+            libraries.grpc_protobuf,
+            libraries.grpc_stub,
+            libraries.protobuf,
+            libraries.protobuf_util
+
+    testImplementation "io.grpc:grpc-testing:${grpcVersion}",
+            libraries.testcontainers,
+            libraries.awaitility,
+            libraries.rest_assured
+
+    testRuntime "io.grpc:grpc-netty-shaded:${grpcVersion}"
+
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+}
+
+animalsniffer {
+    // Don't check sourceSets.jmh and sourceSets.test
+    sourceSets = [
+            sourceSets.main
+    ]
+}
+
+protobuf {
+    protoc {
+        // The artifact spec for the Protobuf Compiler
+        artifact = "com.google.protobuf:protoc:${protocVersion}"
+    }
+    plugins {
+        grpc { artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}" }
+    }
+    generateProtoTasks {
+        all()*.plugins { grpc {} }
+    }
+}
+
+// IntelliJ complains that the generated classes are not found, ask IntelliJ to include the
+// generated Java directories as source folders.
+idea {
+    module {
+        sourceDirs += file("build/generated/source/proto/main/java")
+        // If you have additional sourceSets and/or codegen plugins, add all of them
+    }
+}

--- a/sdk_contrib/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/JaegerRemoteSampler.java
+++ b/sdk_contrib/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/JaegerRemoteSampler.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.contrib.trace.jaeger.sampler;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.grpc.ManagedChannel;
+import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.exporters.jaeger.proto.api_v2.Sampling.PerOperationSamplingStrategies;
+import io.opentelemetry.exporters.jaeger.proto.api_v2.Sampling.SamplingStrategyParameters;
+import io.opentelemetry.exporters.jaeger.proto.api_v2.Sampling.SamplingStrategyResponse;
+import io.opentelemetry.exporters.jaeger.proto.api_v2.SamplingManagerGrpc;
+import io.opentelemetry.exporters.jaeger.proto.api_v2.SamplingManagerGrpc.SamplingManagerBlockingStub;
+import io.opentelemetry.sdk.trace.Sampler;
+import io.opentelemetry.sdk.trace.Samplers;
+import io.opentelemetry.trace.Link;
+import io.opentelemetry.trace.Span.Kind;
+import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceId;
+import java.util.List;
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/** Remote sampler that gets sampling configuration from remote Jaeger server. */
+public class JaegerRemoteSampler implements Sampler {
+  private static final Logger logger = Logger.getLogger(JaegerRemoteSampler.class.getName());
+
+  private static final int DEFAULT_POLLING_INTERVAL_MS = 60000;
+  private static final Sampler INITIAL_SAMPLER = Samplers.probability(0.001);
+
+  private final String serviceName;
+  private final SamplingManagerBlockingStub stub;
+  private Sampler sampler;
+  private final Timer pollTimer;
+
+  private JaegerRemoteSampler(
+      String serviceName, ManagedChannel channel, int pollingIntervalMs, Sampler initialSampler) {
+    this.serviceName = serviceName;
+    this.stub = SamplingManagerGrpc.newBlockingStub(channel);
+    this.sampler = initialSampler;
+
+    pollTimer = new Timer(true); // true makes this a daemon thread
+    pollTimer.schedule(
+        new TimerTask() {
+          @Override
+          public void run() {
+            try {
+              updateSampler();
+            } catch (Exception e) { // keep the timer thread alive
+              logger.log(Level.WARNING, "Failed to update sampler", e);
+            }
+          }
+        },
+        0,
+        pollingIntervalMs);
+  }
+
+  @Override
+  public Decision shouldSample(
+      @Nullable SpanContext parentContext,
+      TraceId traceId,
+      SpanId spanId,
+      String name,
+      Kind spanKind,
+      Map<String, AttributeValue> attributes,
+      List<Link> parentLinks) {
+    return sampler.shouldSample(
+        parentContext, traceId, spanId, name, spanKind, attributes, parentLinks);
+  }
+
+  private void updateSampler() {
+    SamplingStrategyParameters params =
+        SamplingStrategyParameters.newBuilder().setServiceName(this.serviceName).build();
+    SamplingStrategyResponse response = stub.getSamplingStrategy(params);
+    this.sampler = getSampler(response);
+  }
+
+  @VisibleForTesting
+  Sampler getSampler() {
+    return this.sampler;
+  }
+
+  private static Sampler getSampler(SamplingStrategyResponse response) {
+
+    PerOperationSamplingStrategies operationSampling = response.getOperationSampling();
+    if (operationSampling != null && operationSampling.getPerOperationStrategiesList().size() > 0) {
+      Sampler defaultSampler =
+          Samplers.probability(operationSampling.getDefaultSamplingProbability());
+      return new PerOperationSampler(
+          defaultSampler, operationSampling.getPerOperationStrategiesList());
+    }
+    switch (response.getStrategyType()) {
+      case PROBABILISTIC:
+        return Samplers.probability(response.getProbabilisticSampling().getSamplingRate());
+      case RATE_LIMITING:
+        return new RateLimitingSampler(response.getRateLimitingSampling().getMaxTracesPerSecond());
+      case UNRECOGNIZED:
+        throw new AssertionError("unrecognized sampler type");
+    }
+    throw new AssertionError("unrecognized sampler type");
+  }
+
+  @Override
+  public String getDescription() {
+    return this.toString();
+  }
+
+  @Override
+  public String toString() {
+    return String.format("JaegerRemoteSampler{%s}", this.sampler);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private ManagedChannel channel;
+    private String serviceName;
+    private Sampler initialSampler = INITIAL_SAMPLER;
+    private int pollingIntervalMs = DEFAULT_POLLING_INTERVAL_MS;
+
+    /**
+     * Sets the service name to be used by this exporter. Required.
+     *
+     * @param serviceName the service name.
+     * @return this.
+     */
+    public Builder setServiceName(String serviceName) {
+      this.serviceName = serviceName;
+      return this;
+    }
+
+    /**
+     * Sets the managed chanel to use when communicating with the backend. Required.
+     *
+     * @param channel the channel to use.
+     * @return this.
+     */
+    public Builder setChannel(ManagedChannel channel) {
+      this.channel = channel;
+      return this;
+    }
+
+    /**
+     * Sets the polling interval. Optional.
+     *
+     * @param pollingIntervalMs the polling interval in Ms.
+     * @return this.
+     */
+    public Builder withPollingInterval(int pollingIntervalMs) {
+      this.pollingIntervalMs = pollingIntervalMs;
+      return this;
+    }
+
+    /**
+     * Sets the initial sampler that is used before sampling configuration is obtained from the
+     * server. By default probabilistic sampler with is used with probability 0.001. Optional.
+     *
+     * @param initialSampler the initial sampler to use.
+     * @return this.
+     */
+    public Builder withInitialSampler(Sampler initialSampler) {
+      this.initialSampler = initialSampler;
+      return this;
+    }
+
+    /**
+     * Builds the {@link JaegerRemoteSampler}.
+     *
+     * @return the remote sampler instance.
+     */
+    public JaegerRemoteSampler build() {
+      return new JaegerRemoteSampler(
+          this.serviceName, this.channel, this.pollingIntervalMs, this.initialSampler);
+    }
+
+    private Builder() {}
+  }
+}

--- a/sdk_contrib/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/PerOperationSampler.java
+++ b/sdk_contrib/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/PerOperationSampler.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.contrib.trace.jaeger.sampler;
+
+import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.exporters.jaeger.proto.api_v2.Sampling.OperationSamplingStrategy;
+import io.opentelemetry.sdk.trace.Sampler;
+import io.opentelemetry.sdk.trace.Samplers;
+import io.opentelemetry.trace.Link;
+import io.opentelemetry.trace.Span.Kind;
+import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceId;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/** {@link PerOperationSampler} samples spans per operation. */
+class PerOperationSampler implements Sampler {
+
+  private final Sampler defaultSampler;
+  private final Map<String, Sampler> perOperationSampler;
+
+  PerOperationSampler(
+      Sampler defaultSampler, List<OperationSamplingStrategy> perOperationSampling) {
+    this.defaultSampler = defaultSampler;
+    this.perOperationSampler = new LinkedHashMap<>(perOperationSampling.size());
+    for (OperationSamplingStrategy opSamplingStrategy : perOperationSampling) {
+      this.perOperationSampler.put(
+          opSamplingStrategy.getOperation(),
+          Samplers.probability(opSamplingStrategy.getProbabilisticSampling().getSamplingRate()));
+    }
+  }
+
+  @Override
+  public Decision shouldSample(
+      @Nullable SpanContext parentContext,
+      TraceId traceId,
+      SpanId spanId,
+      String name,
+      Kind spanKind,
+      Map<String, AttributeValue> attributes,
+      List<Link> parentLinks) {
+    Sampler sampler = this.perOperationSampler.get(name);
+    if (sampler == null) {
+      sampler = this.defaultSampler;
+    }
+    return sampler.shouldSample(
+        parentContext, traceId, spanId, name, spanKind, attributes, parentLinks);
+  }
+
+  @Override
+  public String getDescription() {
+    return toString();
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "PerOperationSampler{default=%s, perOperation=%s}",
+        this.defaultSampler, this.perOperationSampler);
+  }
+}

--- a/sdk_contrib/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/RateLimiter.java
+++ b/sdk_contrib/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/RateLimiter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.contrib.trace.jaeger.sampler;
+
+import io.opentelemetry.sdk.common.Clock;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * This class was taken from Jaeger java client.
+ * https://github.com/jaegertracing/jaeger-client-java/blob/master/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/RateLimitingSampler.java
+ */
+class RateLimiter {
+  private final Clock clock;
+  private final double creditsPerNanosecond;
+  private final long maxBalance; // max balance in nano ticks
+  private final AtomicLong debit; // last op nano time less remaining balance
+
+  RateLimiter(double creditsPerSecond, double maxBalance, Clock clock) {
+    this.clock = clock;
+    this.creditsPerNanosecond = creditsPerSecond / 1.0e9;
+    this.maxBalance = (long) (maxBalance / creditsPerNanosecond);
+    this.debit = new AtomicLong(clock.nanoTime() - this.maxBalance);
+  }
+
+  public boolean checkCredit(double itemCost) {
+    long cost = (long) (itemCost / creditsPerNanosecond);
+    long credit;
+    long currentDebit;
+    long balance;
+    do {
+      currentDebit = debit.get();
+      credit = clock.nanoTime();
+      balance = credit - currentDebit;
+      if (balance > maxBalance) {
+        balance = maxBalance;
+      }
+      balance -= cost;
+      if (balance < 0) {
+        return false;
+      }
+    } while (!debit.compareAndSet(currentDebit, credit - balance));
+    return true;
+  }
+}

--- a/sdk_contrib/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/RateLimitingSampler.java
+++ b/sdk_contrib/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/RateLimitingSampler.java
@@ -91,7 +91,7 @@ class RateLimitingSampler implements Sampler {
 
   @Override
   public String toString() {
-    return String.format("RateLimitingSampler{%f}", maxTracesPerSecond);
+    return String.format("RateLimitingSampler{%.2f}", maxTracesPerSecond);
   }
 
   @VisibleForTesting

--- a/sdk_contrib/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/RateLimitingSampler.java
+++ b/sdk_contrib/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/RateLimitingSampler.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.contrib.trace.jaeger.sampler;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.sdk.internal.MillisClock;
+import io.opentelemetry.sdk.trace.Sampler;
+import io.opentelemetry.sdk.trace.Samplers;
+import io.opentelemetry.trace.Link;
+import io.opentelemetry.trace.Span.Kind;
+import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceId;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * {@link RateLimitingSampler} sampler uses a leaky bucket rate limiter to ensure that traces are
+ * sampled with a certain constant rate.
+ */
+class RateLimitingSampler implements Sampler {
+  static final String TYPE = "ratelimiting";
+  static final String SAMPLER_TYPE = "sampler.type";
+  static final String SAMPLER_PARAM = "sampler.param";
+
+  private final double maxTracesPerSecond;
+  private final RateLimiter rateLimiter;
+  private final Map<String, AttributeValue> attributes;
+
+  /**
+   * Creates rate limiting sampler.
+   *
+   * @param maxTracesPerSecond the maximum number of sampled traces per second.
+   */
+  RateLimitingSampler(int maxTracesPerSecond) {
+    this.maxTracesPerSecond = maxTracesPerSecond;
+    double maxBalance = maxTracesPerSecond < 1.0 ? 1.0 : maxTracesPerSecond;
+    this.rateLimiter = new RateLimiter(maxTracesPerSecond, maxBalance, MillisClock.getInstance());
+    this.attributes = new LinkedHashMap<>();
+    attributes.put(SAMPLER_TYPE, AttributeValue.stringAttributeValue(TYPE));
+    attributes.put(SAMPLER_PARAM, AttributeValue.doubleAttributeValue(maxTracesPerSecond));
+  }
+
+  @Override
+  public Decision shouldSample(
+      @Nullable SpanContext parentContext,
+      TraceId traceId,
+      SpanId spanId,
+      String name,
+      Kind spanKind,
+      Map<String, AttributeValue> attributes,
+      List<Link> parentLinks) {
+    boolean sampled = this.rateLimiter.checkCredit(1.0);
+    if (parentContext != null && parentContext.getTraceFlags().isSampled()) {
+      return Samplers.alwaysOn()
+          .shouldSample(parentContext, traceId, spanId, name, spanKind, attributes, parentLinks);
+    }
+    if (parentLinks != null) {
+      for (Link parentLink : parentLinks) {
+        if (parentLink.getContext().getTraceFlags().isSampled()) {
+          return Samplers.alwaysOn()
+              .shouldSample(
+                  parentContext, traceId, spanId, name, spanKind, attributes, parentLinks);
+        }
+      }
+    }
+    return new SamplingDecision(sampled, this.attributes);
+  }
+
+  @Override
+  public String getDescription() {
+    return this.toString();
+  }
+
+  @Override
+  public String toString() {
+    return String.format("RateLimitingSampler{%f}", maxTracesPerSecond);
+  }
+
+  @VisibleForTesting
+  double getMaxTracesPerSecond() {
+    return maxTracesPerSecond;
+  }
+}

--- a/sdk_contrib/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/SamplingDecision.java
+++ b/sdk_contrib/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/SamplingDecision.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.contrib.trace.jaeger.sampler;
+
+import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.sdk.trace.Sampler.Decision;
+import java.util.Map;
+
+class SamplingDecision implements Decision {
+
+  private final boolean sampled;
+  private final Map<String, AttributeValue> attributes;
+
+  SamplingDecision(boolean sampled, Map<String, AttributeValue> attributes) {
+    this.sampled = sampled;
+    this.attributes = attributes;
+  }
+
+  @Override
+  public boolean isSampled() {
+    return sampled;
+  }
+
+  @Override
+  public Map<String, AttributeValue> attributes() {
+    return attributes;
+  }
+}

--- a/sdk_contrib/jaeger_remote_sampler/src/main/proto/jaeger/api_v2/sampling.proto
+++ b/sdk_contrib/jaeger_remote_sampler/src/main/proto/jaeger/api_v2/sampling.proto
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax="proto3";
+
+package jaeger.api_v2;
+
+import "google/api/annotations.proto";
+
+option java_package = "io.opentelemetry.exporters.jaeger.proto.api_v2";
+
+enum SamplingStrategyType {
+  PROBABILISTIC = 0;
+  RATE_LIMITING = 1;
+};
+
+message ProbabilisticSamplingStrategy {
+  double samplingRate = 1;
+}
+
+message RateLimitingSamplingStrategy {
+  int32 maxTracesPerSecond = 1;
+}
+
+message OperationSamplingStrategy {
+  string operation = 1;
+  ProbabilisticSamplingStrategy probabilisticSampling = 2;
+}
+
+message PerOperationSamplingStrategies {
+  double defaultSamplingProbability = 1;
+  double defaultLowerBoundTracesPerSecond = 2;
+  repeated OperationSamplingStrategy perOperationStrategies = 3;
+  double defaultUpperBoundTracesPerSecond = 4;
+}
+
+message SamplingStrategyResponse {
+  SamplingStrategyType strategyType = 1;
+  ProbabilisticSamplingStrategy probabilisticSampling = 2;
+  RateLimitingSamplingStrategy rateLimitingSampling = 3;
+  PerOperationSamplingStrategies operationSampling =4;
+}
+
+message SamplingStrategyParameters {
+  string serviceName = 1;
+}
+
+service SamplingManager {
+  rpc GetSamplingStrategy(SamplingStrategyParameters) returns (SamplingStrategyResponse) {
+    option (google.api.http) = {
+            post: "/api/v2/samplingStrategy"
+            body: "*"
+        };
+  }
+}

--- a/sdk_contrib/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/JaegerRemoteSamplerIntegrationTest.java
+++ b/sdk_contrib/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/JaegerRemoteSamplerIntegrationTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.contrib.trace.jaeger.sampler;
+
+import static io.opentelemetry.sdk.contrib.trace.jaeger.sampler.JaegerRemoteSamplerTest.samplerIsType;
+
+import io.grpc.ManagedChannelBuilder;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+
+@RunWith(JUnit4.class)
+public class JaegerRemoteSamplerIntegrationTest {
+
+  private static final int QUERY_PORT = 16686;
+  private static final int COLLECTOR_PORT = 14250;
+  private static final String JAEGER_VERSION = "1.17";
+  private static final String SERVICE_NAME = "E2E-test";
+  private static final String SERVICE_NAME_RATE_LIMITING = "bar";
+  private static final int RATE = 150;
+
+  @SuppressWarnings("rawtypes")
+  @ClassRule
+  public static GenericContainer jaeger =
+      new GenericContainer("jaegertracing/all-in-one:" + JAEGER_VERSION)
+          .withCommand("--sampling.strategies-file=/sampling.json")
+          .withExposedPorts(COLLECTOR_PORT, QUERY_PORT)
+          .waitingFor(new HttpWaitStrategy().forPath("/"))
+          .withClasspathResourceMapping("sampling.json", "/sampling.json", BindMode.READ_ONLY);
+
+  @Test
+  public void remoteSampling_perOperation() {
+    String jaegerHost = String.format("127.0.0.1:%d", jaeger.getMappedPort(COLLECTOR_PORT));
+    final JaegerRemoteSampler remoteSampler =
+        JaegerRemoteSampler.newBuilder()
+            .setChannel(ManagedChannelBuilder.forTarget(jaegerHost).usePlaintext().build())
+            .setServiceName(SERVICE_NAME)
+            .build();
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .until(samplerIsType(remoteSampler, PerOperationSampler.class));
+    Assert.assertTrue(remoteSampler.getSampler() instanceof PerOperationSampler);
+    Assert.assertTrue(remoteSampler.getDescription().contains("0.33"));
+    Assert.assertFalse(remoteSampler.getDescription().contains("150"));
+  }
+
+  @Test
+  public void remoteSampling_rateLimiting() {
+    String jaegerHost = String.format("127.0.0.1:%d", jaeger.getMappedPort(COLLECTOR_PORT));
+    final JaegerRemoteSampler remoteSampler =
+        JaegerRemoteSampler.newBuilder()
+            .setChannel(ManagedChannelBuilder.forTarget(jaegerHost).usePlaintext().build())
+            .setServiceName(SERVICE_NAME_RATE_LIMITING)
+            .build();
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .until(samplerIsType(remoteSampler, RateLimitingSampler.class));
+    Assert.assertTrue(remoteSampler.getSampler() instanceof RateLimitingSampler);
+    Assert.assertEquals(
+        RATE, ((RateLimitingSampler) remoteSampler.getSampler()).getMaxTracesPerSecond(), 0);
+  }
+}

--- a/sdk_contrib/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/JaegerRemoteSamplerTest.java
+++ b/sdk_contrib/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/JaegerRemoteSamplerTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.contrib.trace.jaeger.sampler;
+
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.grpc.ManagedChannel;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import io.opentelemetry.exporters.jaeger.proto.api_v2.Sampling;
+import io.opentelemetry.exporters.jaeger.proto.api_v2.Sampling.RateLimitingSamplingStrategy;
+import io.opentelemetry.exporters.jaeger.proto.api_v2.Sampling.SamplingStrategyParameters;
+import io.opentelemetry.exporters.jaeger.proto.api_v2.Sampling.SamplingStrategyResponse;
+import io.opentelemetry.exporters.jaeger.proto.api_v2.Sampling.SamplingStrategyType;
+import io.opentelemetry.exporters.jaeger.proto.api_v2.SamplingManagerGrpc;
+import io.opentelemetry.sdk.trace.Sampler;
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+
+@RunWith(JUnit4.class)
+public class JaegerRemoteSamplerTest {
+
+  private static final String SERVICE_NAME = "my-service";
+  private static final int RATE = 999;
+
+  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  private final SamplingManagerGrpc.SamplingManagerImplBase service =
+      mock(
+          SamplingManagerGrpc.SamplingManagerImplBase.class,
+          delegatesTo(new MockSamplingManagerService()));
+
+  static class MockSamplingManagerService extends SamplingManagerGrpc.SamplingManagerImplBase {
+
+    @Override
+    public void getSamplingStrategy(
+        io.opentelemetry.exporters.jaeger.proto.api_v2.Sampling.SamplingStrategyParameters request,
+        io.grpc.stub.StreamObserver<
+                io.opentelemetry.exporters.jaeger.proto.api_v2.Sampling.SamplingStrategyResponse>
+            responseObserver) {
+
+      SamplingStrategyResponse response =
+          SamplingStrategyResponse.newBuilder()
+              .setStrategyType(SamplingStrategyType.RATE_LIMITING)
+              .setRateLimitingSampling(
+                  RateLimitingSamplingStrategy.newBuilder().setMaxTracesPerSecond(RATE).build())
+              .build();
+
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    }
+  }
+
+  @Test
+  public void connectionWorks() throws IOException {
+    final String serverName = InProcessServerBuilder.generateName();
+    final ArgumentCaptor<SamplingStrategyParameters> requestCaptor =
+        ArgumentCaptor.forClass(Sampling.SamplingStrategyParameters.class);
+
+    grpcCleanup.register(
+        InProcessServerBuilder.forName(serverName)
+            .directExecutor()
+            .addService(service)
+            .build()
+            .start());
+
+    ManagedChannel channel =
+        grpcCleanup.register(InProcessChannelBuilder.forName(serverName).directExecutor().build());
+
+    final JaegerRemoteSampler remoteSampler =
+        JaegerRemoteSampler.newBuilder().setChannel(channel).setServiceName(SERVICE_NAME).build();
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .until(samplerIsType(remoteSampler, RateLimitingSampler.class));
+
+    // verify
+    verify(service)
+        .getSamplingStrategy(
+            requestCaptor.capture(),
+            ArgumentMatchers.<StreamObserver<SamplingStrategyResponse>>any());
+    Assert.assertEquals(SERVICE_NAME, requestCaptor.getValue().getServiceName());
+    Assert.assertTrue(remoteSampler.getSampler() instanceof RateLimitingSampler);
+    Assert.assertEquals(
+        RATE, ((RateLimitingSampler) remoteSampler.getSampler()).getMaxTracesPerSecond(), 0);
+  }
+
+  static Callable<Boolean> samplerIsType(
+      final JaegerRemoteSampler sampler, final Class<? extends Sampler> expected) {
+    return new Callable<Boolean>() {
+      @Override
+      public Boolean call() {
+        return sampler.getSampler().getClass().equals(expected);
+      }
+    };
+  }
+}

--- a/sdk_contrib/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/RateLimiterTest.java
+++ b/sdk_contrib/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/RateLimiterTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.contrib.trace.jaeger.sampler;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import io.opentelemetry.sdk.common.Clock;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * This class was taken from Jaeger java client.
+ * https://github.com/jaegertracing/jaeger-client-java/blob/master/jaeger-core/src/test/java/io/jaegertracing/internal/utils/RateLimiterTest.java
+ */
+@RunWith(JUnit4.class)
+public class RateLimiterTest {
+
+  private static class MockClock implements Clock {
+
+    long timeNanos;
+
+    @Override
+    public long now() {
+      return 0;
+    }
+
+    @Override
+    public long nanoTime() {
+      return timeNanos;
+    }
+  }
+
+  @Test
+  public void testRateLimiterWholeNumber() {
+    MockClock clock = new MockClock();
+    RateLimiter limiter = new RateLimiter(2.0, 2.0, clock);
+
+    long currentTime = TimeUnit.MICROSECONDS.toNanos(100);
+    clock.timeNanos = currentTime;
+    assertTrue(limiter.checkCredit(1.0));
+    assertTrue(limiter.checkCredit(1.0));
+    assertFalse(limiter.checkCredit(1.0));
+    // move time 250ms forward, not enough credits to pay for 1.0 item
+    currentTime += TimeUnit.MILLISECONDS.toNanos(250);
+    clock.timeNanos = currentTime;
+    assertFalse(limiter.checkCredit(1.0));
+
+    // move time 500ms forward, now enough credits to pay for 1.0 item
+    currentTime += TimeUnit.MILLISECONDS.toNanos(500);
+    clock.timeNanos = currentTime;
+
+    assertTrue(limiter.checkCredit(1.0));
+    assertFalse(limiter.checkCredit(1.0));
+
+    // move time 5s forward, enough to accumulate credits for 10 messages, but it should still be
+    // capped at 2
+    currentTime += TimeUnit.MILLISECONDS.toNanos(5000);
+    clock.timeNanos = currentTime;
+
+    assertTrue(limiter.checkCredit(1.0));
+    assertTrue(limiter.checkCredit(1.0));
+    assertFalse(limiter.checkCredit(1.0));
+    assertFalse(limiter.checkCredit(1.0));
+    assertFalse(limiter.checkCredit(1.0));
+  }
+
+  @Test
+  public void testRateLimiterLessThanOne() {
+    MockClock clock = new MockClock();
+    RateLimiter limiter = new RateLimiter(0.5, 0.5, clock);
+
+    long currentTime = TimeUnit.MICROSECONDS.toNanos(100);
+    clock.timeNanos = currentTime;
+    assertTrue(limiter.checkCredit(0.25));
+    assertTrue(limiter.checkCredit(0.25));
+    assertFalse(limiter.checkCredit(0.25));
+    // move time 250ms forward, not enough credits to pay for 1.0 item
+    currentTime += TimeUnit.MILLISECONDS.toNanos(250);
+    clock.timeNanos = currentTime;
+    assertFalse(limiter.checkCredit(0.25));
+
+    // move time 500ms forward, now enough credits to pay for 1.0 item
+    currentTime += TimeUnit.MILLISECONDS.toNanos(500);
+    clock.timeNanos = currentTime;
+
+    assertTrue(limiter.checkCredit(0.25));
+    assertFalse(limiter.checkCredit(0.25));
+
+    // move time 5s forward, enough to accumulate credits for 10 messages, but it should still be
+    // capped at 2
+    currentTime += TimeUnit.MILLISECONDS.toNanos(5000);
+    clock.timeNanos = currentTime;
+
+    assertTrue(limiter.checkCredit(0.25));
+    assertTrue(limiter.checkCredit(0.25));
+    assertFalse(limiter.checkCredit(0.25));
+    assertFalse(limiter.checkCredit(0.25));
+    assertFalse(limiter.checkCredit(0.25));
+  }
+
+  @Test
+  public void testRateLimiterMaxBalance() {
+    MockClock clock = new MockClock();
+    RateLimiter limiter = new RateLimiter(0.1, 1.0, clock);
+
+    long currentTime = TimeUnit.MICROSECONDS.toNanos(100);
+    clock.timeNanos = currentTime;
+    assertTrue(limiter.checkCredit(1.0));
+    assertFalse(limiter.checkCredit(1.0));
+
+    // move time 20s forward, enough to accumulate credits for 2 messages, but it should still be
+    // capped at 1
+    currentTime += TimeUnit.MILLISECONDS.toNanos(20000);
+    clock.timeNanos = currentTime;
+
+    assertTrue(limiter.checkCredit(1.0));
+    assertFalse(limiter.checkCredit(1.0));
+  }
+
+  /**
+   * Validates rate limiter behavior with {@link System#nanoTime()}-like (non-zero) initial nano
+   * ticks.
+   */
+  @Test
+  public void testRateLimiterInitial() {
+    MockClock clock = new MockClock();
+    clock.timeNanos = TimeUnit.MILLISECONDS.toNanos(-1_000_000);
+    RateLimiter limiter = new RateLimiter(1000, 100, clock);
+
+    assertTrue(limiter.checkCredit(100)); // consume initial (max) balance
+    assertFalse(limiter.checkCredit(1));
+
+    clock.timeNanos += TimeUnit.MILLISECONDS.toNanos(49); // add 49 credits
+    assertFalse(limiter.checkCredit(50));
+
+    clock.timeNanos += TimeUnit.MILLISECONDS.toNanos(1); // add one credit
+    assertTrue(limiter.checkCredit(50)); // consume accrued balance
+    assertFalse(limiter.checkCredit(1));
+
+    clock.timeNanos +=
+        TimeUnit.MILLISECONDS.toNanos(1_000_000); // add a lot of credits (max out balance)
+    assertTrue(limiter.checkCredit(1)); // take one credit
+
+    clock.timeNanos +=
+        TimeUnit.MILLISECONDS.toNanos(1_000_000); // add a lot of credits (max out balance)
+    assertFalse(limiter.checkCredit(101)); // can't consume more than max balance
+    assertTrue(limiter.checkCredit(100)); // consume max balance
+    assertFalse(limiter.checkCredit(1));
+  }
+
+  /** Validates concurrent credit check correctness. */
+  @Test
+  public void testRateLimiterConcurrency() throws InterruptedException, ExecutionException {
+    int numWorkers = 8;
+    ExecutorService executorService = Executors.newFixedThreadPool(numWorkers);
+    final int creditsPerWorker = 1000;
+    MockClock clock = new MockClock();
+    final RateLimiter limiter = new RateLimiter(1, numWorkers * creditsPerWorker, clock);
+    final AtomicInteger count = new AtomicInteger();
+    List<Future<?>> futures = new ArrayList<>(numWorkers);
+    for (int w = 0; w < numWorkers; ++w) {
+      Future<?> future =
+          executorService.submit(
+              new Runnable() {
+                @Override
+                public void run() {
+                  for (int i = 0; i < creditsPerWorker * 2; ++i) {
+                    if (limiter.checkCredit(1)) {
+                      count.getAndIncrement(); // count allowed operations
+                    }
+                  }
+                }
+              });
+      futures.add(future);
+    }
+    for (Future<?> future : futures) {
+      future.get();
+    }
+    executorService.shutdown();
+    executorService.awaitTermination(1, TimeUnit.SECONDS);
+    assertEquals(
+        "Exactly the allocated number of credits must be consumed",
+        numWorkers * creditsPerWorker,
+        count.get());
+    assertFalse(limiter.checkCredit(1));
+  }
+}

--- a/sdk_contrib/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/RateLimitingSamplerTest.java
+++ b/sdk_contrib/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/RateLimitingSamplerTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.contrib.trace.jaeger.sampler;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.sdk.trace.Sampler.Decision;
+import io.opentelemetry.trace.Link;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceFlags;
+import io.opentelemetry.trace.TraceId;
+import io.opentelemetry.trace.TraceState;
+import java.util.Collections;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class RateLimitingSamplerTest {
+  private static final String SPAN_NAME = "MySpanName";
+  private static final Span.Kind SPAN_KIND = Span.Kind.INTERNAL;
+  private final TraceId traceId = new TraceId(150, 150);
+  private final SpanId spanId = new SpanId(150);
+  private final SpanId parentSpanId = new SpanId(250);
+  private final TraceState traceState = TraceState.builder().build();
+  private final SpanContext sampledSpanContext =
+      SpanContext.create(
+          traceId, parentSpanId, TraceFlags.builder().setIsSampled(true).build(), traceState);
+  private final SpanContext notSampledSpanContext =
+      SpanContext.create(
+          traceId, parentSpanId, TraceFlags.builder().setIsSampled(false).build(), traceState);
+
+  @Test
+  public void alwaysSampleSampledContext() {
+    RateLimitingSampler sampler = new RateLimitingSampler(1);
+    assertTrue(
+        sampler
+            .shouldSample(
+                sampledSpanContext,
+                traceId,
+                spanId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Collections.<String, AttributeValue>emptyMap(),
+                Collections.<Link>emptyList())
+            .isSampled());
+    assertTrue(
+        sampler
+            .shouldSample(
+                sampledSpanContext,
+                traceId,
+                spanId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Collections.<String, AttributeValue>emptyMap(),
+                Collections.<Link>emptyList())
+            .isSampled());
+  }
+
+  @Test
+  public void sampleOneTrace() {
+    RateLimitingSampler sampler = new RateLimitingSampler(1);
+    Decision decision =
+        sampler.shouldSample(
+            notSampledSpanContext,
+            traceId,
+            spanId,
+            SPAN_NAME,
+            SPAN_KIND,
+            Collections.<String, AttributeValue>emptyMap(),
+            Collections.<Link>emptyList());
+    assertTrue(decision.isSampled());
+    assertFalse(
+        sampler
+            .shouldSample(
+                notSampledSpanContext,
+                traceId,
+                spanId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Collections.<String, AttributeValue>emptyMap(),
+                Collections.<Link>emptyList())
+            .isSampled());
+    assertEquals(2, decision.attributes().size());
+    assertEquals(
+        AttributeValue.doubleAttributeValue(1),
+        decision.attributes().get(RateLimitingSampler.SAMPLER_PARAM));
+    assertEquals(
+        AttributeValue.stringAttributeValue(RateLimitingSampler.TYPE),
+        decision.attributes().get(RateLimitingSampler.SAMPLER_TYPE));
+  }
+}

--- a/sdk_contrib/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/RateLimitingSamplerTest.java
+++ b/sdk_contrib/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/RateLimitingSamplerTest.java
@@ -108,4 +108,10 @@ public class RateLimitingSamplerTest {
         AttributeValue.stringAttributeValue(RateLimitingSampler.TYPE),
         decision.attributes().get(RateLimitingSampler.SAMPLER_TYPE));
   }
+
+  @Test
+  public void description() {
+    RateLimitingSampler sampler = new RateLimitingSampler(15);
+    assertEquals("RateLimitingSampler{15.00}", sampler.getDescription());
+  }
 }

--- a/sdk_contrib/jaeger_remote_sampler/src/test/resources/sampling.json
+++ b/sdk_contrib/jaeger_remote_sampler/src/test/resources/sampling.json
@@ -1,0 +1,30 @@
+{
+  "service_strategies": [
+    {
+      "service": "E2E-test",
+      "type": "probabilistic",
+      "param": 0.33,
+      "operation_strategies": [
+        {
+          "operation": "op1",
+          "type": "probabilistic",
+          "param": 0.2
+        },
+        {
+          "operation": "op2",
+          "type": "probabilistic",
+          "param": 0.4
+        }
+      ]
+    },
+    {
+      "service": "bar",
+      "type": "ratelimiting",
+      "param": 150
+    }
+  ],
+  "default_strategy": {
+    "type": "probabilistic",
+    "param": 0.8
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -36,7 +36,8 @@ include ":opentelemetry-all",
         ":opentelemetry-sdk-contrib-auto-config",
         ":opentelemetry-sdk-contrib-aws-v1-support",
         ":opentelemetry-sdk-contrib-otproto",
-        ":opentelemetry-sdk-contrib-testbed"
+        ":opentelemetry-sdk-contrib-testbed",
+        ":opentelemetry-sdk-contrib-jaeger-remote-sampler"
 
 rootProject.children.each {
     it.projectDir = "$rootDir/" + it.name


### PR DESCRIPTION
Resolves #796

This PR adds Jaeger remote sampler. The sampling configuration is retrieved via gRPC (as opposed to thrift in Jaeger clients).

Othe notable changes:
* Added proto for Jaeger sampling model with service
* The proto is generated to the same package as Jaeger gRPC exporter (`io.opentelemetry.exporters.jaeger.proto.api_v2`), this differs from the package defined in Jaeger proto (`io.jaegertracing.api_v2`)
* Added RateLimitingSampler implementation from Jaeger
* There is e2e test with Testcontainers and mock proto service test



Signed-off-by: Pavol Loffay <ploffay@redhat.com>