### PR TITLE
simple benchmarks for the default tracer APIs

### DIFF
--- a/api/src/jmh/java/io/opentelemetry/trace/DefaultTracerBenchmarks.java
+++ b/api/src/jmh/java/io/opentelemetry/trace/DefaultTracerBenchmarks.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.trace;
+
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Thread)
+public class DefaultTracerBenchmarks {
+
+  private final Tracer tracer = DefaultTracer.getInstance();
+  @Nullable private Span span = null;
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @Fork(1)
+  @Measurement(iterations = 15, time = 1)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  @Warmup(iterations = 5, time = 1)
+  public void measureFullSpanLifecycle() {
+    span = tracer.spanBuilder("span").startSpan();
+    try (io.opentelemetry.context.Scope ignored = tracer.withSpan(span)) {
+      //no-op
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @Fork(1)
+  @Measurement(iterations = 15, time = 1)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  @Warmup(iterations = 5, time = 1)
+  public void measureSpanBuilding() {
+    span = tracer.spanBuilder("span").startSpan();
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @Fork(1)
+  @Measurement(iterations = 15, time = 1)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  @Warmup(iterations = 5, time = 1)
+  public void measureScopeLifecycle() {
+    try (io.opentelemetry.context.Scope ignored = tracer.withSpan(span)) {
+      //no-op
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @Fork(1)
+  @Measurement(iterations = 15, time = 1)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  @Warmup(iterations = 5, time = 1)
+  public void measureGetCurrentSpan() {
+    tracer.getCurrentSpan();
+  }
+
+  @TearDown(Level.Iteration)
+  public void tearDown() {
+    if (span != null) {
+      span.end();
+    }
+  }
+
+
+
+}

--- a/api/src/jmh/java/io/opentelemetry/trace/DefaultTracerBenchmarks.java
+++ b/api/src/jmh/java/io/opentelemetry/trace/DefaultTracerBenchmarks.java
@@ -36,6 +36,7 @@ public class DefaultTracerBenchmarks {
   private final Tracer tracer = DefaultTracer.getInstance();
   @Nullable private Span span = null;
 
+  /** Benchmark the full span lifecycle. */
   @Benchmark
   @BenchmarkMode({Mode.AverageTime})
   @Fork(1)
@@ -44,8 +45,12 @@ public class DefaultTracerBenchmarks {
   @Warmup(iterations = 5, time = 1)
   public void measureFullSpanLifecycle() {
     span = tracer.spanBuilder("span").startSpan();
-    try (io.opentelemetry.context.Scope ignored = tracer.withSpan(span)) {
-      //no-op
+    io.opentelemetry.context.Scope ignored = tracer.withSpan(span);
+    try {
+      // no-op
+    } finally {
+      ignored.close();
+      span.end();
     }
   }
 
@@ -59,6 +64,7 @@ public class DefaultTracerBenchmarks {
     span = tracer.spanBuilder("span").startSpan();
   }
 
+  /** Benchmark just the scope lifecycle. */
   @Benchmark
   @BenchmarkMode({Mode.AverageTime})
   @Fork(1)
@@ -66,8 +72,11 @@ public class DefaultTracerBenchmarks {
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   @Warmup(iterations = 5, time = 1)
   public void measureScopeLifecycle() {
-    try (io.opentelemetry.context.Scope ignored = tracer.withSpan(span)) {
-      //no-op
+    io.opentelemetry.context.Scope ignored = tracer.withSpan(span);
+    try {
+      // no-op
+    } finally {
+      ignored.close();
     }
   }
 
@@ -87,7 +96,4 @@ public class DefaultTracerBenchmarks {
       span.end();
     }
   }
-
-
-
 }


### PR DESCRIPTION
resolves #788 

Benchmark results on my laptop:

![image](https://user-images.githubusercontent.com/858731/78801879-0bd59200-7972-11ea-9d39-89fe7efcb67a.png)
