### PR TITLE
Prototype of making applying semantic attributes a little more type-safe

### DIFF
--- a/api/src/main/java/io/opentelemetry/common/BooleanValuedKey.java
+++ b/api/src/main/java/io/opentelemetry/common/BooleanValuedKey.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.common;
+
+public interface BooleanValuedKey {
+  String key();
+}

--- a/api/src/main/java/io/opentelemetry/common/DoubleValuedKey.java
+++ b/api/src/main/java/io/opentelemetry/common/DoubleValuedKey.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.common;
+
+public interface DoubleValuedKey {
+  String key();
+}

--- a/api/src/main/java/io/opentelemetry/common/LongValuedKey.java
+++ b/api/src/main/java/io/opentelemetry/common/LongValuedKey.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.common;
+
+public interface LongValuedKey {
+  String key();
+}

--- a/api/src/main/java/io/opentelemetry/common/StringValuedKey.java
+++ b/api/src/main/java/io/opentelemetry/common/StringValuedKey.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.common;
+
+public interface StringValuedKey {
+  String key();
+}

--- a/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
@@ -17,6 +17,10 @@
 package io.opentelemetry.trace;
 
 import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.common.BooleanValuedKey;
+import io.opentelemetry.common.DoubleValuedKey;
+import io.opentelemetry.common.LongValuedKey;
+import io.opentelemetry.common.StringValuedKey;
 import io.opentelemetry.internal.Utils;
 import java.util.Map;
 import java.util.Random;
@@ -96,6 +100,26 @@ public final class DefaultSpan implements Span {
   public void setAttribute(String key, AttributeValue value) {
     Utils.checkNotNull(key, "key");
     Utils.checkNotNull(value, "value");
+  }
+
+  @Override
+  public void setAttribute(StringValuedKey key, String value) {
+    Utils.checkNotNull(key, "key");
+  }
+
+  @Override
+  public void setAttribute(DoubleValuedKey key, double value) {
+    Utils.checkNotNull(key, "key");
+  }
+
+  @Override
+  public void setAttribute(BooleanValuedKey key, boolean value) {
+    Utils.checkNotNull(key, "key");
+  }
+
+  @Override
+  public void setAttribute(LongValuedKey key, long value) {
+    Utils.checkNotNull(key, "key");
   }
 
   @Override

--- a/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
@@ -17,6 +17,10 @@
 package io.opentelemetry.trace;
 
 import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.common.BooleanValuedKey;
+import io.opentelemetry.common.DoubleValuedKey;
+import io.opentelemetry.common.LongValuedKey;
+import io.opentelemetry.common.StringValuedKey;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.internal.Utils;
 import java.util.Map;
@@ -143,6 +147,30 @@ public final class DefaultTracer implements Tracer {
     public NoopSpanBuilder setAttribute(String key, AttributeValue value) {
       Utils.checkNotNull(key, "key");
       Utils.checkNotNull(value, "value");
+      return this;
+    }
+
+    @Override
+    public NoopSpanBuilder setAttribute(StringValuedKey key, String value) {
+      Utils.checkNotNull(key, "key");
+      return this;
+    }
+
+    @Override
+    public NoopSpanBuilder setAttribute(DoubleValuedKey key, double value) {
+      Utils.checkNotNull(key, "key");
+      return this;
+    }
+
+    @Override
+    public NoopSpanBuilder setAttribute(BooleanValuedKey key, boolean value) {
+      Utils.checkNotNull(key, "key");
+      return this;
+    }
+
+    @Override
+    public NoopSpanBuilder setAttribute(LongValuedKey key, long value) {
+      Utils.checkNotNull(key, "key");
       return this;
     }
 

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -17,6 +17,10 @@
 package io.opentelemetry.trace;
 
 import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.common.BooleanValuedKey;
+import io.opentelemetry.common.DoubleValuedKey;
+import io.opentelemetry.common.LongValuedKey;
+import io.opentelemetry.common.StringValuedKey;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -132,6 +136,14 @@ public interface Span {
    * @since 0.1.0
    */
   void setAttribute(String key, AttributeValue value);
+
+  void setAttribute(StringValuedKey key, String value);
+
+  void setAttribute(DoubleValuedKey key, double value);
+
+  void setAttribute(BooleanValuedKey key, boolean value);
+
+  void setAttribute(LongValuedKey key, long value);
 
   /**
    * Adds an event to the {@code Span}.
@@ -518,6 +530,14 @@ public interface Span {
      * @since 0.3.0
      */
     Builder setAttribute(String key, AttributeValue value);
+
+    Builder setAttribute(StringValuedKey key, String value);
+
+    Builder setAttribute(DoubleValuedKey key, double value);
+
+    Builder setAttribute(BooleanValuedKey key, boolean value);
+
+    Builder setAttribute(LongValuedKey key, long value);
 
     /**
      * Sets the {@link Span.Kind} for the newly created {@code Span}. If not called, the

--- a/api/src/main/java/io/opentelemetry/trace/attributes/BooleanAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/BooleanAttributeSetter.java
@@ -16,12 +16,13 @@
 
 package io.opentelemetry.trace.attributes;
 
+import io.opentelemetry.common.BooleanValuedKey;
 import io.opentelemetry.trace.Span;
 import javax.annotation.concurrent.Immutable;
 
 /** Defines the behavior for a span attribute with boolean values. */
 @Immutable
-public final class BooleanAttributeSetter {
+public final class BooleanAttributeSetter implements BooleanValuedKey {
 
   /**
    * Returns a new attribute setter.
@@ -47,6 +48,7 @@ public final class BooleanAttributeSetter {
    *
    * @return the attribute map key
    */
+  @Override
   public String key() {
     return attributeKey;
   }

--- a/api/src/main/java/io/opentelemetry/trace/attributes/DoubleAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/DoubleAttributeSetter.java
@@ -16,12 +16,13 @@
 
 package io.opentelemetry.trace.attributes;
 
+import io.opentelemetry.common.DoubleValuedKey;
 import io.opentelemetry.trace.Span;
 import javax.annotation.concurrent.Immutable;
 
 /** Defines the behavior for a span attribute with double values. */
 @Immutable
-public final class DoubleAttributeSetter {
+public final class DoubleAttributeSetter implements DoubleValuedKey {
 
   /**
    * Returns a new attribute setter.
@@ -47,6 +48,7 @@ public final class DoubleAttributeSetter {
    *
    * @return the attribute map key
    */
+  @Override
   public String key() {
     return attributeKey;
   }

--- a/api/src/main/java/io/opentelemetry/trace/attributes/LongAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/LongAttributeSetter.java
@@ -16,12 +16,13 @@
 
 package io.opentelemetry.trace.attributes;
 
+import io.opentelemetry.common.LongValuedKey;
 import io.opentelemetry.trace.Span;
 import javax.annotation.concurrent.Immutable;
 
 /** Defines the behavior for a span attribute with long values. */
 @Immutable
-public final class LongAttributeSetter {
+public final class LongAttributeSetter implements LongValuedKey {
 
   /**
    * Returns a new attribute setter.
@@ -47,6 +48,7 @@ public final class LongAttributeSetter {
    *
    * @return the attribute map key
    */
+  @Override
   public String key() {
     return attributeKey;
   }

--- a/api/src/main/java/io/opentelemetry/trace/attributes/StringAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/StringAttributeSetter.java
@@ -16,13 +16,14 @@
 
 package io.opentelemetry.trace.attributes;
 
+import io.opentelemetry.common.StringValuedKey;
 import io.opentelemetry.trace.Span;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /** Defines the behavior for a span attribute with string values. */
 @Immutable
-public final class StringAttributeSetter {
+public final class StringAttributeSetter implements StringValuedKey {
 
   /**
    * Returns a new attribute setter.
@@ -48,6 +49,7 @@ public final class StringAttributeSetter {
    *
    * @return the attribute map key
    */
+  @Override
   public String key() {
     return attributeKey;
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -20,6 +20,10 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.EvictingQueue;
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.AttributeValue.Type;
+import io.opentelemetry.common.BooleanValuedKey;
+import io.opentelemetry.common.DoubleValuedKey;
+import io.opentelemetry.common.LongValuedKey;
+import io.opentelemetry.common.StringValuedKey;
 import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -351,6 +355,26 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
       }
       attributes.putAttribute(key, value);
     }
+  }
+
+  @Override
+  public void setAttribute(StringValuedKey key, String value) {
+    setAttribute(key.key(), value);
+  }
+
+  @Override
+  public void setAttribute(DoubleValuedKey key, double value) {
+    setAttribute(key.key(), value);
+  }
+
+  @Override
+  public void setAttribute(BooleanValuedKey key, boolean value) {
+    setAttribute(key.key(), value);
+  }
+
+  @Override
+  public void setAttribute(LongValuedKey key, long value) {
+    setAttribute(key.key(), value);
   }
 
   @Override

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -18,6 +18,10 @@ package io.opentelemetry.sdk.trace;
 
 import io.grpc.Context;
 import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.common.BooleanValuedKey;
+import io.opentelemetry.common.DoubleValuedKey;
+import io.opentelemetry.common.LongValuedKey;
+import io.opentelemetry.common.StringValuedKey;
 import io.opentelemetry.internal.Utils;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -163,6 +167,26 @@ final class SpanBuilderSdk implements Span.Builder {
   @Override
   public Span.Builder setAttribute(String key, boolean value) {
     return setAttribute(key, AttributeValue.booleanAttributeValue(value));
+  }
+
+  @Override
+  public Span.Builder setAttribute(StringValuedKey key, String value) {
+    return setAttribute(key.key(), value);
+  }
+
+  @Override
+  public Span.Builder setAttribute(DoubleValuedKey key, double value) {
+    return setAttribute(key.key(), value);
+  }
+
+  @Override
+  public Span.Builder setAttribute(BooleanValuedKey key, boolean value) {
+    return setAttribute(key.key(), value);
+  }
+
+  @Override
+  public Span.Builder setAttribute(LongValuedKey key, long value) {
+    return setAttribute(key.key(), value);
   }
 
   @Override


### PR DESCRIPTION
This would be a pretty significant increase in the API surface around spans. Can we quantify the gains to be had by adding these convenience methods? 

Also, I really wish we could have primitive generics, because then we could squash this down to a single method that was parameterized over the type being set.

Prototype suggestion for #1076 , #1075 

(Also, I didn't add any javadoc for this stuff...that would be required if we wanted to go forward)