### PR TITLE
Prototype of removing bare span attribute keys

### DIFF
--- a/api/src/main/java/io/opentelemetry/common/BooleanValuedKey.java
+++ b/api/src/main/java/io/opentelemetry/common/BooleanValuedKey.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.common;
+
+public interface BooleanValuedKey {
+  String key();
+}

--- a/api/src/main/java/io/opentelemetry/common/DoubleValuedKey.java
+++ b/api/src/main/java/io/opentelemetry/common/DoubleValuedKey.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.common;
+
+public interface DoubleValuedKey {
+  String key();
+}

--- a/api/src/main/java/io/opentelemetry/common/LongValuedKey.java
+++ b/api/src/main/java/io/opentelemetry/common/LongValuedKey.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.common;
+
+public interface LongValuedKey {
+  String key();
+}

--- a/api/src/main/java/io/opentelemetry/common/StringValuedKey.java
+++ b/api/src/main/java/io/opentelemetry/common/StringValuedKey.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.common;
+
+public interface StringValuedKey {
+  String key();
+}

--- a/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
@@ -77,26 +77,6 @@ public final class DefaultSpan implements Span {
   }
 
   @Override
-  public void setAttribute(String key, String value) {
-    Utils.checkNotNull(key, "key");
-  }
-
-  @Override
-  public void setAttribute(String key, long value) {
-    Utils.checkNotNull(key, "key");
-  }
-
-  @Override
-  public void setAttribute(String key, double value) {
-    Utils.checkNotNull(key, "key");
-  }
-
-  @Override
-  public void setAttribute(String key, boolean value) {
-    Utils.checkNotNull(key, "key");
-  }
-
-  @Override
   public void setAttribute(String key, AttributeValue value) {
     Utils.checkNotNull(key, "key");
     Utils.checkNotNull(value, "value");

--- a/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
@@ -17,6 +17,10 @@
 package io.opentelemetry.trace;
 
 import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.common.BooleanValuedKey;
+import io.opentelemetry.common.DoubleValuedKey;
+import io.opentelemetry.common.LongValuedKey;
+import io.opentelemetry.common.StringValuedKey;
 import io.opentelemetry.internal.Utils;
 import java.util.Map;
 import java.util.Random;
@@ -96,6 +100,26 @@ public final class DefaultSpan implements Span {
   public void setAttribute(String key, AttributeValue value) {
     Utils.checkNotNull(key, "key");
     Utils.checkNotNull(value, "value");
+  }
+
+  @Override
+  public void setAttribute(StringValuedKey key, String value) {
+    Utils.checkNotNull(key, "key");
+  }
+
+  @Override
+  public void setAttribute(DoubleValuedKey key, double value) {
+    Utils.checkNotNull(key, "key");
+  }
+
+  @Override
+  public void setAttribute(BooleanValuedKey key, boolean value) {
+    Utils.checkNotNull(key, "key");
+  }
+
+  @Override
+  public void setAttribute(LongValuedKey key, long value) {
+    Utils.checkNotNull(key, "key");
   }
 
   @Override

--- a/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
@@ -17,6 +17,10 @@
 package io.opentelemetry.trace;
 
 import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.common.BooleanValuedKey;
+import io.opentelemetry.common.DoubleValuedKey;
+import io.opentelemetry.common.LongValuedKey;
+import io.opentelemetry.common.StringValuedKey;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.internal.Utils;
 import java.util.Map;
@@ -143,6 +147,30 @@ public final class DefaultTracer implements Tracer {
     public NoopSpanBuilder setAttribute(String key, AttributeValue value) {
       Utils.checkNotNull(key, "key");
       Utils.checkNotNull(value, "value");
+      return this;
+    }
+
+    @Override
+    public NoopSpanBuilder setAttribute(StringValuedKey key, String value) {
+      Utils.checkNotNull(key, "key");
+      return this;
+    }
+
+    @Override
+    public NoopSpanBuilder setAttribute(DoubleValuedKey key, double value) {
+      Utils.checkNotNull(key, "key");
+      return this;
+    }
+
+    @Override
+    public NoopSpanBuilder setAttribute(BooleanValuedKey key, boolean value) {
+      Utils.checkNotNull(key, "key");
+      return this;
+    }
+
+    @Override
+    public NoopSpanBuilder setAttribute(LongValuedKey key, long value) {
+      Utils.checkNotNull(key, "key");
       return this;
     }
 

--- a/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
@@ -120,30 +120,6 @@ public final class DefaultTracer implements Tracer {
     }
 
     @Override
-    public NoopSpanBuilder setAttribute(String key, String value) {
-      Utils.checkNotNull(key, "key");
-      return this;
-    }
-
-    @Override
-    public NoopSpanBuilder setAttribute(String key, long value) {
-      Utils.checkNotNull(key, "key");
-      return this;
-    }
-
-    @Override
-    public NoopSpanBuilder setAttribute(String key, double value) {
-      Utils.checkNotNull(key, "key");
-      return this;
-    }
-
-    @Override
-    public NoopSpanBuilder setAttribute(String key, boolean value) {
-      Utils.checkNotNull(key, "key");
-      return this;
-    }
-
-    @Override
     public NoopSpanBuilder setAttribute(String key, AttributeValue value) {
       Utils.checkNotNull(key, "key");
       Utils.checkNotNull(value, "value");

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -267,7 +267,7 @@ public interface Span {
 
   /**
    * Returns {@code true} if this {@code Span} records tracing events (e.g. {@link
-   * #addEvent(String)}, {@link #setAttribute(StringValuedKey, long)}).
+   * #addEvent(String)}, {@link #setAttribute(LongValuedKey, long)}).
    *
    * @return {@code true} if this {@code Span} records tracing events.
    * @since 0.1.0

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -88,6 +88,16 @@ public interface Span {
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
    * the key, the old value is replaced by the specified value.
    *
+   * @param key the key for this attribute.
+   * @param value the value for this attribute.
+   * @since 0.1.0
+   */
+  void setAttribute(String key, AttributeValue value);
+
+  /**
+   * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
+   * the key, the old value is replaced by the specified value.
+   *
    * <p>If a null or empty String {@code value} is passed in, the attribute will be silently
    * dropped. Note: this behavior could change in the future.
    *
@@ -95,7 +105,7 @@ public interface Span {
    * @param value the value for this attribute.
    * @since 0.1.0
    */
-  void setAttribute(String key, @Nullable String value);
+  void setAttribute(StringValuedKey key, @Nullable String value);
 
   /**
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
@@ -105,44 +115,26 @@ public interface Span {
    * @param value the value for this attribute.
    * @since 0.1.0
    */
-  void setAttribute(String key, long value);
-
-  /**
-   * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
-   * the key, the old value is replaced by the specified value.
-   *
-   * @param key the key for this attribute.
-   * @param value the value for this attribute.
-   * @since 0.1.0
-   */
-  void setAttribute(String key, double value);
-
-  /**
-   * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
-   * the key, the old value is replaced by the specified value.
-   *
-   * @param key the key for this attribute.
-   * @param value the value for this attribute.
-   * @since 0.1.0
-   */
-  void setAttribute(String key, boolean value);
-
-  /**
-   * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
-   * the key, the old value is replaced by the specified value.
-   *
-   * @param key the key for this attribute.
-   * @param value the value for this attribute.
-   * @since 0.1.0
-   */
-  void setAttribute(String key, AttributeValue value);
-
-  void setAttribute(StringValuedKey key, String value);
-
   void setAttribute(DoubleValuedKey key, double value);
 
+  /**
+   * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
+   * the key, the old value is replaced by the specified value.
+   *
+   * @param key the key for this attribute.
+   * @param value the value for this attribute.
+   * @since 0.1.0
+   */
   void setAttribute(BooleanValuedKey key, boolean value);
 
+  /**
+   * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
+   * the key, the old value is replaced by the specified value.
+   *
+   * @param key the key for this attribute.
+   * @param value the value for this attribute.
+   * @since 0.1.0
+   */
   void setAttribute(LongValuedKey key, long value);
 
   /**
@@ -275,7 +267,7 @@ public interface Span {
 
   /**
    * Returns {@code true} if this {@code Span} records tracing events (e.g. {@link
-   * #addEvent(String)}, {@link #setAttribute(String, long)}).
+   * #addEvent(String)}, {@link #setAttribute(StringValuedKey, long)}).
    *
    * @return {@code true} if this {@code Span} records tracing events.
    * @since 0.1.0
@@ -471,57 +463,6 @@ public interface Span {
      * Sets an attribute to the newly created {@code Span}. If {@code Span.Builder} previously
      * contained a mapping for the key, the old value is replaced by the specified value.
      *
-     * <p>If a null or empty String {@code value} is passed in, the attribute will be silently
-     * dropped. Note: this behavior could change in the future.
-     *
-     * @param key the key for this attribute.
-     * @param value the value for this attribute.
-     * @return this.
-     * @throws NullPointerException if {@code key} is {@code null}.
-     * @since 0.3.0
-     */
-    Builder setAttribute(String key, @Nullable String value);
-
-    /**
-     * Sets an attribute to the newly created {@code Span}. If {@code Span.Builder} previously
-     * contained a mapping for the key, the old value is replaced by the specified value.
-     *
-     * @param key the key for this attribute.
-     * @param value the value for this attribute.
-     * @return this.
-     * @throws NullPointerException if {@code key} is {@code null}.
-     * @since 0.3.0
-     */
-    Builder setAttribute(String key, long value);
-
-    /**
-     * Sets an attribute to the newly created {@code Span}. If {@code Span.Builder} previously
-     * contained a mapping for the key, the old value is replaced by the specified value.
-     *
-     * @param key the key for this attribute.
-     * @param value the value for this attribute.
-     * @return this.
-     * @throws NullPointerException if {@code key} is {@code null}.
-     * @since 0.3.0
-     */
-    Builder setAttribute(String key, double value);
-
-    /**
-     * Sets an attribute to the newly created {@code Span}. If {@code Span.Builder} previously
-     * contained a mapping for the key, the old value is replaced by the specified value.
-     *
-     * @param key the key for this attribute.
-     * @param value the value for this attribute.
-     * @return this.
-     * @throws NullPointerException if {@code key} is {@code null}.
-     * @since 0.3.0
-     */
-    Builder setAttribute(String key, boolean value);
-
-    /**
-     * Sets an attribute to the newly created {@code Span}. If {@code Span.Builder} previously
-     * contained a mapping for the key, the old value is replaced by the specified value.
-     *
      * @param key the key for this attribute.
      * @param value the value for this attribute.
      * @return this.
@@ -531,12 +472,55 @@ public interface Span {
      */
     Builder setAttribute(String key, AttributeValue value);
 
-    Builder setAttribute(StringValuedKey key, String value);
+    /**
+     * Sets an attribute to the newly created {@code Span}. If {@code Span.Builder} previously
+     * contained a mapping for the key, the old value is replaced by the specified value.
+     *
+     * <p>If a null or empty String {@code value} is passed in, the attribute will be silently
+     * dropped. Note: this behavior could change in the future.
+     *
+     * @param key the key for this attribute.
+     * @param value the value for this attribute.
+     * @return this.
+     * @throws NullPointerException if {@code key} is {@code null}.
+     * @since 0.3.0
+     */
+    Builder setAttribute(StringValuedKey key, @Nullable String value);
 
+    /**
+     * Sets an attribute to the newly created {@code Span}. If {@code Span.Builder} previously
+     * contained a mapping for the key, the old value is replaced by the specified value.
+     *
+     * @param key the key for this attribute.
+     * @param value the value for this attribute.
+     * @return this.
+     * @throws NullPointerException if {@code key} is {@code null}.
+     * @since 0.3.0
+     */
     Builder setAttribute(DoubleValuedKey key, double value);
 
+    /**
+     * Sets an attribute to the newly created {@code Span}. If {@code Span.Builder} previously
+     * contained a mapping for the key, the old value is replaced by the specified value.
+     *
+     * @param key the key for this attribute.
+     * @param value the value for this attribute.
+     * @return this.
+     * @throws NullPointerException if {@code key} is {@code null}.
+     * @since 0.3.0
+     */
     Builder setAttribute(BooleanValuedKey key, boolean value);
 
+    /**
+     * Sets an attribute to the newly created {@code Span}. If {@code Span.Builder} previously
+     * contained a mapping for the key, the old value is replaced by the specified value.
+     *
+     * @param key the key for this attribute.
+     * @param value the value for this attribute.
+     * @return this.
+     * @throws NullPointerException if {@code key} is {@code null}.
+     * @since 0.3.0
+     */
     Builder setAttribute(LongValuedKey key, long value);
 
     /**

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -17,6 +17,10 @@
 package io.opentelemetry.trace;
 
 import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.common.BooleanValuedKey;
+import io.opentelemetry.common.DoubleValuedKey;
+import io.opentelemetry.common.LongValuedKey;
+import io.opentelemetry.common.StringValuedKey;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -132,6 +136,14 @@ public interface Span {
    * @since 0.1.0
    */
   void setAttribute(String key, AttributeValue value);
+
+  void setAttribute(StringValuedKey key, String value);
+
+  void setAttribute(DoubleValuedKey key, double value);
+
+  void setAttribute(BooleanValuedKey key, boolean value);
+
+  void setAttribute(LongValuedKey key, long value);
 
   /**
    * Adds an event to the {@code Span}.
@@ -518,6 +530,14 @@ public interface Span {
      * @since 0.3.0
      */
     Builder setAttribute(String key, AttributeValue value);
+
+    Builder setAttribute(StringValuedKey key, String value);
+
+    Builder setAttribute(DoubleValuedKey key, double value);
+
+    Builder setAttribute(BooleanValuedKey key, boolean value);
+
+    Builder setAttribute(LongValuedKey key, long value);
 
     /**
      * Sets the {@link Span.Kind} for the newly created {@code Span}. If not called, the

--- a/api/src/main/java/io/opentelemetry/trace/attributes/BooleanAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/BooleanAttributeSetter.java
@@ -16,12 +16,13 @@
 
 package io.opentelemetry.trace.attributes;
 
+import io.opentelemetry.common.BooleanValuedKey;
 import io.opentelemetry.trace.Span;
 import javax.annotation.concurrent.Immutable;
 
 /** Defines the behavior for a span attribute with boolean values. */
 @Immutable
-public final class BooleanAttributeSetter {
+public final class BooleanAttributeSetter implements BooleanValuedKey {
 
   /**
    * Returns a new attribute setter.
@@ -47,6 +48,7 @@ public final class BooleanAttributeSetter {
    *
    * @return the attribute map key
    */
+  @Override
   public String key() {
     return attributeKey;
   }

--- a/api/src/main/java/io/opentelemetry/trace/attributes/BooleanAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/BooleanAttributeSetter.java
@@ -30,7 +30,7 @@ public final class BooleanAttributeSetter implements BooleanValuedKey {
    * @param attributeKey the attribute name
    * @return the setter object
    */
-  public static BooleanAttributeSetter create(String attributeKey) {
+  public static BooleanAttributeSetter booleanKey(String attributeKey) {
     return new BooleanAttributeSetter(attributeKey);
   }
 
@@ -60,6 +60,6 @@ public final class BooleanAttributeSetter implements BooleanValuedKey {
    * @param value the value for this attribute
    */
   public void set(Span span, boolean value) {
-    span.setAttribute(key(), value);
+    span.setAttribute(booleanKey(attributeKey), value);
   }
 }

--- a/api/src/main/java/io/opentelemetry/trace/attributes/DoubleAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/DoubleAttributeSetter.java
@@ -16,12 +16,13 @@
 
 package io.opentelemetry.trace.attributes;
 
+import io.opentelemetry.common.DoubleValuedKey;
 import io.opentelemetry.trace.Span;
 import javax.annotation.concurrent.Immutable;
 
 /** Defines the behavior for a span attribute with double values. */
 @Immutable
-public final class DoubleAttributeSetter {
+public final class DoubleAttributeSetter implements DoubleValuedKey {
 
   /**
    * Returns a new attribute setter.
@@ -47,6 +48,7 @@ public final class DoubleAttributeSetter {
    *
    * @return the attribute map key
    */
+  @Override
   public String key() {
     return attributeKey;
   }

--- a/api/src/main/java/io/opentelemetry/trace/attributes/DoubleAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/DoubleAttributeSetter.java
@@ -30,7 +30,7 @@ public final class DoubleAttributeSetter implements DoubleValuedKey {
    * @param attributeKey the attribute name
    * @return the setter object
    */
-  public static DoubleAttributeSetter create(String attributeKey) {
+  public static DoubleAttributeSetter doubleKey(String attributeKey) {
     return new DoubleAttributeSetter(attributeKey);
   }
 
@@ -60,6 +60,6 @@ public final class DoubleAttributeSetter implements DoubleValuedKey {
    * @param value the value for this attribute
    */
   public void set(Span span, double value) {
-    span.setAttribute(key(), value);
+    span.setAttribute(doubleKey(attributeKey), value);
   }
 }

--- a/api/src/main/java/io/opentelemetry/trace/attributes/LongAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/LongAttributeSetter.java
@@ -16,12 +16,13 @@
 
 package io.opentelemetry.trace.attributes;
 
+import io.opentelemetry.common.LongValuedKey;
 import io.opentelemetry.trace.Span;
 import javax.annotation.concurrent.Immutable;
 
 /** Defines the behavior for a span attribute with long values. */
 @Immutable
-public final class LongAttributeSetter {
+public final class LongAttributeSetter implements LongValuedKey {
 
   /**
    * Returns a new attribute setter.
@@ -47,6 +48,7 @@ public final class LongAttributeSetter {
    *
    * @return the attribute map key
    */
+  @Override
   public String key() {
     return attributeKey;
   }

--- a/api/src/main/java/io/opentelemetry/trace/attributes/LongAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/LongAttributeSetter.java
@@ -30,7 +30,7 @@ public final class LongAttributeSetter implements LongValuedKey {
    * @param attributeKey the attribute name
    * @return the setter object
    */
-  public static LongAttributeSetter create(String attributeKey) {
+  public static LongAttributeSetter longKey(String attributeKey) {
     return new LongAttributeSetter(attributeKey);
   }
 
@@ -60,6 +60,6 @@ public final class LongAttributeSetter implements LongValuedKey {
    * @param value the value for this attribute
    */
   public void set(Span span, long value) {
-    span.setAttribute(key(), value);
+    span.setAttribute(longKey(attributeKey), value);
   }
 }

--- a/api/src/main/java/io/opentelemetry/trace/attributes/SemanticAttributes.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/SemanticAttributes.java
@@ -16,6 +16,9 @@
 
 package io.opentelemetry.trace.attributes;
 
+import static io.opentelemetry.trace.attributes.LongAttributeSetter.longKey;
+import static io.opentelemetry.trace.attributes.StringAttributeSetter.stringKey;
+
 /**
  * Defines constants for all attribute names defined in the OpenTelemetry Semantic Conventions
  * specifications.
@@ -27,106 +30,81 @@ package io.opentelemetry.trace.attributes;
 public final class SemanticAttributes {
 
   /** Transport protocol used. */
-  public static final StringAttributeSetter NET_TRANSPORT =
-      StringAttributeSetter.stringKey("net.transport");
+  public static final StringAttributeSetter NET_TRANSPORT = stringKey("net.transport");
   /** Remote address of the peer (dotted decimal for IPv4 or RFC5952 for IPv6). */
-  public static final StringAttributeSetter NET_PEER_IP =
-      StringAttributeSetter.stringKey("net.peer.ip");
+  public static final StringAttributeSetter NET_PEER_IP = stringKey("net.peer.ip");
   /** Remote port number as an integer. E.g., 80. */
-  public static final LongAttributeSetter NET_PEER_PORT =
-      LongAttributeSetter.longKey("net.peer.port");
+  public static final LongAttributeSetter NET_PEER_PORT = longKey("net.peer.port");
   /** Remote hostname or similar. */
-  public static final StringAttributeSetter NET_PEER_NAME =
-      StringAttributeSetter.stringKey("net.peer.name");
+  public static final StringAttributeSetter NET_PEER_NAME = stringKey("net.peer.name");
   /** Like net.peer.ip but for the host IP. Useful in case of a multi-IP host. */
-  public static final StringAttributeSetter NET_HOST_IP =
-      StringAttributeSetter.stringKey("net.host.ip");
+  public static final StringAttributeSetter NET_HOST_IP = stringKey("net.host.ip");
   /** Like net.peer.port but for the host port. */
-  public static final LongAttributeSetter NET_HOST_PORT =
-      LongAttributeSetter.longKey("net.host.port");
+  public static final LongAttributeSetter NET_HOST_PORT = longKey("net.host.port");
   /** Local hostname or similar. */
-  public static final StringAttributeSetter NET_HOST_NAME =
-      StringAttributeSetter.stringKey("net.host.name");
+  public static final StringAttributeSetter NET_HOST_NAME = stringKey("net.host.name");
   /**
    * Username or client_id extracted from the access token or Authorization header in the inbound
    * request from outside the system.
    */
-  public static final StringAttributeSetter ENDUSER_ID =
-      StringAttributeSetter.stringKey("enduser.id");
+  public static final StringAttributeSetter ENDUSER_ID = stringKey("enduser.id");
   /**
    * Actual/assumed role the client is making the request under extracted from token or application
    * security context.
    */
-  public static final StringAttributeSetter ENDUSER_ROLE =
-      StringAttributeSetter.stringKey("enduser.role");
+  public static final StringAttributeSetter ENDUSER_ROLE = stringKey("enduser.role");
   /**
    * Scopes or granted authorities the client currently possesses extracted from token or
    * application security context. The value would come from the scope associated with an OAuth 2.0
    * Access Token or an attribute value in a SAML 2.0 Assertion.
    */
-  public static final StringAttributeSetter ENDUSER_SCOPE =
-      StringAttributeSetter.stringKey("enduser.scope");
+  public static final StringAttributeSetter ENDUSER_SCOPE = stringKey("enduser.scope");
   /** HTTP request method. E.g. "GET". */
-  public static final StringAttributeSetter HTTP_METHOD =
-      StringAttributeSetter.stringKey("http.method");
+  public static final StringAttributeSetter HTTP_METHOD = stringKey("http.method");
   /** Full HTTP request URL in the form scheme://host[:port]/path?query[#fragment]. */
-  public static final StringAttributeSetter HTTP_URL = StringAttributeSetter.stringKey("http.url");
+  public static final StringAttributeSetter HTTP_URL = stringKey("http.url");
   /** The full request target as passed in a HTTP request line or equivalent. */
-  public static final StringAttributeSetter HTTP_TARGET =
-      StringAttributeSetter.stringKey("http.target");
+  public static final StringAttributeSetter HTTP_TARGET = stringKey("http.target");
   /** The value of the HTTP host header. */
-  public static final StringAttributeSetter HTTP_HOST =
-      StringAttributeSetter.stringKey("http.host");
+  public static final StringAttributeSetter HTTP_HOST = stringKey("http.host");
   /** The URI scheme identifying the used protocol: "http" or "https". */
-  public static final StringAttributeSetter HTTP_SCHEME =
-      StringAttributeSetter.stringKey("http.scheme");
+  public static final StringAttributeSetter HTTP_SCHEME = stringKey("http.scheme");
   /** HTTP response status code. E.g. 200 (integer) If and only if one was received/sent. */
-  public static final LongAttributeSetter HTTP_STATUS_CODE =
-      LongAttributeSetter.longKey("http.status_code");
+  public static final LongAttributeSetter HTTP_STATUS_CODE = longKey("http.status_code");
   /** HTTP reason phrase. E.g. "OK" */
-  public static final StringAttributeSetter HTTP_STATUS_TEXT =
-      StringAttributeSetter.stringKey("http.status_text");
+  public static final StringAttributeSetter HTTP_STATUS_TEXT = stringKey("http.status_text");
   /** Kind of HTTP protocol used: "1.0", "1.1", "2", "SPDY" or "QUIC". */
-  public static final StringAttributeSetter HTTP_FLAVOR =
-      StringAttributeSetter.stringKey("http.flavor");
+  public static final StringAttributeSetter HTTP_FLAVOR = stringKey("http.flavor");
   /** Value of the HTTP "User-Agent" header sent by the client. */
-  public static final StringAttributeSetter HTTP_USER_AGENT =
-      StringAttributeSetter.stringKey("http.user_agent");
+  public static final StringAttributeSetter HTTP_USER_AGENT = stringKey("http.user_agent");
   /** The primary server name of the matched virtual host. Usually obtained via configuration. */
-  public static final StringAttributeSetter HTTP_SERVER_NAME =
-      StringAttributeSetter.stringKey("http.server_name");
+  public static final StringAttributeSetter HTTP_SERVER_NAME = stringKey("http.server_name");
   /** The matched route (path template). */
-  public static final StringAttributeSetter HTTP_ROUTE =
-      StringAttributeSetter.stringKey("http.route");
+  public static final StringAttributeSetter HTTP_ROUTE = stringKey("http.route");
   /** The IP address of the original client behind all proxies, if known. */
-  public static final StringAttributeSetter HTTP_CLIENT_IP =
-      StringAttributeSetter.stringKey("http.client_ip");
+  public static final StringAttributeSetter HTTP_CLIENT_IP = stringKey("http.client_ip");
   /** The service name, must be equal to the $service part in the span name. */
-  public static final StringAttributeSetter RPC_SERVICE =
-      StringAttributeSetter.stringKey("rpc.service");
+  public static final StringAttributeSetter RPC_SERVICE = stringKey("rpc.service");
   /** RPC span event attribute with value "SENT" or "RECEIVED". */
-  public static final StringAttributeSetter MESSAGE_TYPE =
-      StringAttributeSetter.stringKey("message.type");
+  public static final StringAttributeSetter MESSAGE_TYPE = stringKey("message.type");
   /** RPC span event attribute starting from 1 for each of sent messages and received messages. */
-  public static final LongAttributeSetter MESSAGE_ID = LongAttributeSetter.longKey("message.id");
+  public static final LongAttributeSetter MESSAGE_ID = longKey("message.id");
   /** RPC span event attribute for compressed size. */
   public static final LongAttributeSetter MESSAGE_COMPRESSED_SIZE =
-      LongAttributeSetter.longKey("message.compressed_size");
+      longKey("message.compressed_size");
   /** RPC span event attribute for uncompressed size. */
   public static final LongAttributeSetter MESSAGE_UNCOMPRESSED_SIZE =
-      LongAttributeSetter.longKey("message.uncompressed_size");
+      longKey("message.uncompressed_size");
   /** Database type. For any SQL database, "sql". For others, the lower-case database category. */
-  public static final StringAttributeSetter DB_TYPE = StringAttributeSetter.stringKey("db.type");
+  public static final StringAttributeSetter DB_TYPE = stringKey("db.type");
   /** Database instance name. */
-  public static final StringAttributeSetter DB_INSTANCE =
-      StringAttributeSetter.stringKey("db.instance");
+  public static final StringAttributeSetter DB_INSTANCE = stringKey("db.instance");
   /** Database statement for the given database type. */
-  public static final StringAttributeSetter DB_STATEMENT =
-      StringAttributeSetter.stringKey("db.statement");
+  public static final StringAttributeSetter DB_STATEMENT = stringKey("db.statement");
   /** Username for accessing database. */
-  public static final StringAttributeSetter DB_USER = StringAttributeSetter.stringKey("db.user");
+  public static final StringAttributeSetter DB_USER = stringKey("db.user");
   /** JDBC substring like "mysql://db.example.com:3306" */
-  public static final StringAttributeSetter DB_URL = StringAttributeSetter.stringKey("db.url");
+  public static final StringAttributeSetter DB_URL = stringKey("db.url");
 
   private SemanticAttributes() {}
 }

--- a/api/src/main/java/io/opentelemetry/trace/attributes/SemanticAttributes.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/SemanticAttributes.java
@@ -28,102 +28,105 @@ public final class SemanticAttributes {
 
   /** Transport protocol used. */
   public static final StringAttributeSetter NET_TRANSPORT =
-      StringAttributeSetter.create("net.transport");
+      StringAttributeSetter.stringKey("net.transport");
   /** Remote address of the peer (dotted decimal for IPv4 or RFC5952 for IPv6). */
   public static final StringAttributeSetter NET_PEER_IP =
-      StringAttributeSetter.create("net.peer.ip");
+      StringAttributeSetter.stringKey("net.peer.ip");
   /** Remote port number as an integer. E.g., 80. */
   public static final LongAttributeSetter NET_PEER_PORT =
-      LongAttributeSetter.create("net.peer.port");
+      LongAttributeSetter.longKey("net.peer.port");
   /** Remote hostname or similar. */
   public static final StringAttributeSetter NET_PEER_NAME =
-      StringAttributeSetter.create("net.peer.name");
+      StringAttributeSetter.stringKey("net.peer.name");
   /** Like net.peer.ip but for the host IP. Useful in case of a multi-IP host. */
   public static final StringAttributeSetter NET_HOST_IP =
-      StringAttributeSetter.create("net.host.ip");
+      StringAttributeSetter.stringKey("net.host.ip");
   /** Like net.peer.port but for the host port. */
   public static final LongAttributeSetter NET_HOST_PORT =
-      LongAttributeSetter.create("net.host.port");
+      LongAttributeSetter.longKey("net.host.port");
   /** Local hostname or similar. */
   public static final StringAttributeSetter NET_HOST_NAME =
-      StringAttributeSetter.create("net.host.name");
+      StringAttributeSetter.stringKey("net.host.name");
   /**
    * Username or client_id extracted from the access token or Authorization header in the inbound
    * request from outside the system.
    */
-  public static final StringAttributeSetter ENDUSER_ID = StringAttributeSetter.create("enduser.id");
+  public static final StringAttributeSetter ENDUSER_ID =
+      StringAttributeSetter.stringKey("enduser.id");
   /**
    * Actual/assumed role the client is making the request under extracted from token or application
    * security context.
    */
   public static final StringAttributeSetter ENDUSER_ROLE =
-      StringAttributeSetter.create("enduser.role");
+      StringAttributeSetter.stringKey("enduser.role");
   /**
    * Scopes or granted authorities the client currently possesses extracted from token or
    * application security context. The value would come from the scope associated with an OAuth 2.0
    * Access Token or an attribute value in a SAML 2.0 Assertion.
    */
   public static final StringAttributeSetter ENDUSER_SCOPE =
-      StringAttributeSetter.create("enduser.scope");
+      StringAttributeSetter.stringKey("enduser.scope");
   /** HTTP request method. E.g. "GET". */
   public static final StringAttributeSetter HTTP_METHOD =
-      StringAttributeSetter.create("http.method");
+      StringAttributeSetter.stringKey("http.method");
   /** Full HTTP request URL in the form scheme://host[:port]/path?query[#fragment]. */
-  public static final StringAttributeSetter HTTP_URL = StringAttributeSetter.create("http.url");
+  public static final StringAttributeSetter HTTP_URL = StringAttributeSetter.stringKey("http.url");
   /** The full request target as passed in a HTTP request line or equivalent. */
   public static final StringAttributeSetter HTTP_TARGET =
-      StringAttributeSetter.create("http.target");
+      StringAttributeSetter.stringKey("http.target");
   /** The value of the HTTP host header. */
-  public static final StringAttributeSetter HTTP_HOST = StringAttributeSetter.create("http.host");
+  public static final StringAttributeSetter HTTP_HOST =
+      StringAttributeSetter.stringKey("http.host");
   /** The URI scheme identifying the used protocol: "http" or "https". */
   public static final StringAttributeSetter HTTP_SCHEME =
-      StringAttributeSetter.create("http.scheme");
+      StringAttributeSetter.stringKey("http.scheme");
   /** HTTP response status code. E.g. 200 (integer) If and only if one was received/sent. */
   public static final LongAttributeSetter HTTP_STATUS_CODE =
-      LongAttributeSetter.create("http.status_code");
+      LongAttributeSetter.longKey("http.status_code");
   /** HTTP reason phrase. E.g. "OK" */
   public static final StringAttributeSetter HTTP_STATUS_TEXT =
-      StringAttributeSetter.create("http.status_text");
+      StringAttributeSetter.stringKey("http.status_text");
   /** Kind of HTTP protocol used: "1.0", "1.1", "2", "SPDY" or "QUIC". */
   public static final StringAttributeSetter HTTP_FLAVOR =
-      StringAttributeSetter.create("http.flavor");
+      StringAttributeSetter.stringKey("http.flavor");
   /** Value of the HTTP "User-Agent" header sent by the client. */
   public static final StringAttributeSetter HTTP_USER_AGENT =
-      StringAttributeSetter.create("http.user_agent");
+      StringAttributeSetter.stringKey("http.user_agent");
   /** The primary server name of the matched virtual host. Usually obtained via configuration. */
   public static final StringAttributeSetter HTTP_SERVER_NAME =
-      StringAttributeSetter.create("http.server_name");
+      StringAttributeSetter.stringKey("http.server_name");
   /** The matched route (path template). */
-  public static final StringAttributeSetter HTTP_ROUTE = StringAttributeSetter.create("http.route");
+  public static final StringAttributeSetter HTTP_ROUTE =
+      StringAttributeSetter.stringKey("http.route");
   /** The IP address of the original client behind all proxies, if known. */
   public static final StringAttributeSetter HTTP_CLIENT_IP =
-      StringAttributeSetter.create("http.client_ip");
+      StringAttributeSetter.stringKey("http.client_ip");
   /** The service name, must be equal to the $service part in the span name. */
   public static final StringAttributeSetter RPC_SERVICE =
-      StringAttributeSetter.create("rpc.service");
+      StringAttributeSetter.stringKey("rpc.service");
   /** RPC span event attribute with value "SENT" or "RECEIVED". */
   public static final StringAttributeSetter MESSAGE_TYPE =
-      StringAttributeSetter.create("message.type");
+      StringAttributeSetter.stringKey("message.type");
   /** RPC span event attribute starting from 1 for each of sent messages and received messages. */
-  public static final LongAttributeSetter MESSAGE_ID = LongAttributeSetter.create("message.id");
+  public static final LongAttributeSetter MESSAGE_ID = LongAttributeSetter.longKey("message.id");
   /** RPC span event attribute for compressed size. */
   public static final LongAttributeSetter MESSAGE_COMPRESSED_SIZE =
-      LongAttributeSetter.create("message.compressed_size");
+      LongAttributeSetter.longKey("message.compressed_size");
   /** RPC span event attribute for uncompressed size. */
   public static final LongAttributeSetter MESSAGE_UNCOMPRESSED_SIZE =
-      LongAttributeSetter.create("message.uncompressed_size");
+      LongAttributeSetter.longKey("message.uncompressed_size");
   /** Database type. For any SQL database, "sql". For others, the lower-case database category. */
-  public static final StringAttributeSetter DB_TYPE = StringAttributeSetter.create("db.type");
+  public static final StringAttributeSetter DB_TYPE = StringAttributeSetter.stringKey("db.type");
   /** Database instance name. */
   public static final StringAttributeSetter DB_INSTANCE =
-      StringAttributeSetter.create("db.instance");
+      StringAttributeSetter.stringKey("db.instance");
   /** Database statement for the given database type. */
   public static final StringAttributeSetter DB_STATEMENT =
-      StringAttributeSetter.create("db.statement");
+      StringAttributeSetter.stringKey("db.statement");
   /** Username for accessing database. */
-  public static final StringAttributeSetter DB_USER = StringAttributeSetter.create("db.user");
+  public static final StringAttributeSetter DB_USER = StringAttributeSetter.stringKey("db.user");
   /** JDBC substring like "mysql://db.example.com:3306" */
-  public static final StringAttributeSetter DB_URL = StringAttributeSetter.create("db.url");
+  public static final StringAttributeSetter DB_URL = StringAttributeSetter.stringKey("db.url");
 
   private SemanticAttributes() {}
 }

--- a/api/src/main/java/io/opentelemetry/trace/attributes/StringAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/StringAttributeSetter.java
@@ -16,13 +16,14 @@
 
 package io.opentelemetry.trace.attributes;
 
+import io.opentelemetry.common.StringValuedKey;
 import io.opentelemetry.trace.Span;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /** Defines the behavior for a span attribute with string values. */
 @Immutable
-public final class StringAttributeSetter {
+public final class StringAttributeSetter implements StringValuedKey {
 
   /**
    * Returns a new attribute setter.
@@ -48,6 +49,7 @@ public final class StringAttributeSetter {
    *
    * @return the attribute map key
    */
+  @Override
   public String key() {
     return attributeKey;
   }

--- a/api/src/main/java/io/opentelemetry/trace/attributes/StringAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/StringAttributeSetter.java
@@ -31,7 +31,7 @@ public final class StringAttributeSetter implements StringValuedKey {
    * @param attributeKey the attribute name
    * @return the setter object
    */
-  public static StringAttributeSetter create(String attributeKey) {
+  public static StringAttributeSetter stringKey(String attributeKey) {
     return new StringAttributeSetter(attributeKey);
   }
 
@@ -61,6 +61,6 @@ public final class StringAttributeSetter implements StringValuedKey {
    * @param value the value for this attribute
    */
   public void set(Span span, @Nullable String value) {
-    span.setAttribute(key(), value);
+    span.setAttribute(stringKey(attributeKey), value);
   }
 }

--- a/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
@@ -17,6 +17,7 @@
 package io.opentelemetry.trace;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.opentelemetry.trace.attributes.StringAttributeSetter.stringKey;
 
 import io.opentelemetry.common.AttributeValue;
 import java.util.Collections;
@@ -54,8 +55,8 @@ public class DefaultSpanTest {
         "MyStringAttributeKey", AttributeValue.stringAttributeValue("MyStringAttributeValue"));
     span.setAttribute("MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true));
     span.setAttribute("MyLongAttributeKey", AttributeValue.longAttributeValue(123));
-    span.setAttribute("NullString", (String) null);
-    span.setAttribute("EmptyString", "");
+    span.setAttribute(stringKey("NullString"), null);
+    span.setAttribute(stringKey("EmptyString"), "");
     span.addEvent("event");
     span.addEvent("event", 0);
     span.addEvent(

--- a/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
@@ -17,6 +17,10 @@
 package io.opentelemetry.trace;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.opentelemetry.trace.attributes.BooleanAttributeSetter.booleanKey;
+import static io.opentelemetry.trace.attributes.DoubleAttributeSetter.doubleKey;
+import static io.opentelemetry.trace.attributes.LongAttributeSetter.longKey;
+import static io.opentelemetry.trace.attributes.StringAttributeSetter.stringKey;
 
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.trace.Span.Kind;
@@ -57,10 +61,10 @@ public class SpanBuilderTest {
             return Collections.emptyMap();
           }
         });
-    spanBuilder.setAttribute("key", "value");
-    spanBuilder.setAttribute("key", 12345L);
-    spanBuilder.setAttribute("key", .12345);
-    spanBuilder.setAttribute("key", true);
+    spanBuilder.setAttribute(stringKey("key"), "value");
+    spanBuilder.setAttribute(longKey("key"), 12345L);
+    spanBuilder.setAttribute(doubleKey("key"), .12345);
+    spanBuilder.setAttribute(booleanKey("key"), true);
     spanBuilder.setAttribute("key", AttributeValue.stringAttributeValue("value"));
     spanBuilder.setStartTimestamp(12345L);
     assertThat(spanBuilder.startSpan()).isInstanceOf(DefaultSpan.class);

--- a/api/src/test/java/io/opentelemetry/trace/attributes/SemanticAttributesTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/attributes/SemanticAttributesTest.java
@@ -67,10 +67,12 @@ public class SemanticAttributesTest {
 
   @Test
   public void shouldCreateAllSetterTypes() {
-    assertThat(BooleanAttributeSetter.create("attr.one"))
+    assertThat(BooleanAttributeSetter.booleanKey("attr.one"))
         .isInstanceOf(BooleanAttributeSetter.class);
-    assertThat(DoubleAttributeSetter.create("attr.two")).isInstanceOf(DoubleAttributeSetter.class);
-    assertThat(LongAttributeSetter.create("attr.three")).isInstanceOf(LongAttributeSetter.class);
-    assertThat(StringAttributeSetter.create("attr.four")).isInstanceOf(StringAttributeSetter.class);
+    assertThat(DoubleAttributeSetter.doubleKey("attr.two"))
+        .isInstanceOf(DoubleAttributeSetter.class);
+    assertThat(LongAttributeSetter.longKey("attr.three")).isInstanceOf(LongAttributeSetter.class);
+    assertThat(StringAttributeSetter.stringKey("attr.four"))
+        .isInstanceOf(StringAttributeSetter.class);
   }
 }

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanShim.java
@@ -16,6 +16,11 @@
 
 package io.opentelemetry.opentracingshim;
 
+import static io.opentelemetry.trace.attributes.BooleanAttributeSetter.booleanKey;
+import static io.opentelemetry.trace.attributes.DoubleAttributeSetter.doubleKey;
+import static io.opentelemetry.trace.attributes.LongAttributeSetter.longKey;
+import static io.opentelemetry.trace.attributes.StringAttributeSetter.stringKey;
+
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.trace.Status;
 import io.opentracing.Span;
@@ -75,7 +80,7 @@ final class SpanShim extends BaseShimObject implements Span {
       Status status = Boolean.parseBoolean(value) ? Status.UNKNOWN : Status.OK;
       span.setStatus(status);
     } else {
-      span.setAttribute(key, value);
+      span.setAttribute(stringKey(key), value);
     }
 
     return this;
@@ -87,7 +92,7 @@ final class SpanShim extends BaseShimObject implements Span {
       Status status = value ? Status.UNKNOWN : Status.OK;
       span.setStatus(status);
     } else {
-      span.setAttribute(key, value);
+      span.setAttribute(booleanKey(key), value);
     }
 
     return this;
@@ -100,9 +105,9 @@ final class SpanShim extends BaseShimObject implements Span {
         || value instanceof Long
         || value instanceof Short
         || value instanceof Byte) {
-      span.setAttribute(key, value.longValue());
+      span.setAttribute(longKey(key), value.longValue());
     } else if (value instanceof Float || value instanceof Double) {
-      span.setAttribute(key, value.doubleValue());
+      span.setAttribute(doubleKey(key), value.doubleValue());
     } else {
       throw new IllegalArgumentException("Number type not supported");
     }

--- a/sdk/src/jmh/java/io/opentelemetry/sdk/trace/SpanBenchmark.java
+++ b/sdk/src/jmh/java/io/opentelemetry/sdk/trace/SpanBenchmark.java
@@ -16,6 +16,9 @@
 
 package io.opentelemetry.sdk.trace;
 
+import static io.opentelemetry.trace.attributes.LongAttributeSetter.longKey;
+import static io.opentelemetry.trace.attributes.StringAttributeSetter.stringKey;
+
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.Status;
@@ -44,7 +47,7 @@ public class SpanBenchmark {
             tracerSdk
                 .spanBuilder("benchmarkSpan")
                 .setSpanKind(Kind.CLIENT)
-                .setAttribute("key", "value");
+                .setAttribute(stringKey("key"), "value");
     span = (RecordEventsReadableSpan) spanBuilderSdk.startSpan();
   }
 
@@ -89,8 +92,8 @@ public class SpanBenchmark {
   }
 
   private static void doSpanWork(RecordEventsReadableSpan span) {
-    span.setAttribute("longAttribute", 33L);
-    span.setAttribute("stringAttribute", "test_value");
+    span.setAttribute(longKey("longAttribute"), 33L);
+    span.setAttribute(stringKey("stringAttribute"), "test_value");
     span.setStatus(Status.OK);
 
     span.addEvent("testEvent");

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -20,6 +20,10 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.EvictingQueue;
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.AttributeValue.Type;
+import io.opentelemetry.common.BooleanValuedKey;
+import io.opentelemetry.common.DoubleValuedKey;
+import io.opentelemetry.common.LongValuedKey;
+import io.opentelemetry.common.StringValuedKey;
 import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -351,6 +355,26 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
       }
       attributes.putAttribute(key, value);
     }
+  }
+
+  @Override
+  public void setAttribute(StringValuedKey key, String value) {
+    setAttribute(key.key(), value);
+  }
+
+  @Override
+  public void setAttribute(DoubleValuedKey key, double value) {
+    setAttribute(key.key(), value);
+  }
+
+  @Override
+  public void setAttribute(BooleanValuedKey key, boolean value) {
+    setAttribute(key.key(), value);
+  }
+
+  @Override
+  public void setAttribute(LongValuedKey key, long value) {
+    setAttribute(key.key(), value);
   }
 
   @Override

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -314,26 +314,6 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   }
 
   @Override
-  public void setAttribute(String key, String value) {
-    setAttribute(key, AttributeValue.stringAttributeValue(value));
-  }
-
-  @Override
-  public void setAttribute(String key, long value) {
-    setAttribute(key, AttributeValue.longAttributeValue(value));
-  }
-
-  @Override
-  public void setAttribute(String key, double value) {
-    setAttribute(key, AttributeValue.doubleAttributeValue(value));
-  }
-
-  @Override
-  public void setAttribute(String key, boolean value) {
-    setAttribute(key, AttributeValue.booleanAttributeValue(value));
-  }
-
-  @Override
   public void setAttribute(String key, AttributeValue value) {
     Preconditions.checkNotNull(key, "key");
     Preconditions.checkNotNull(value, "value");
@@ -359,22 +339,22 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
 
   @Override
   public void setAttribute(StringValuedKey key, String value) {
-    setAttribute(key.key(), value);
+    setAttribute(key.key(), AttributeValue.stringAttributeValue(value));
   }
 
   @Override
   public void setAttribute(DoubleValuedKey key, double value) {
-    setAttribute(key.key(), value);
+    setAttribute(key.key(), AttributeValue.doubleAttributeValue(value));
   }
 
   @Override
   public void setAttribute(BooleanValuedKey key, boolean value) {
-    setAttribute(key.key(), value);
+    setAttribute(key.key(), AttributeValue.booleanAttributeValue(value));
   }
 
   @Override
   public void setAttribute(LongValuedKey key, long value) {
-    setAttribute(key.key(), value);
+    setAttribute(key.key(), AttributeValue.longAttributeValue(value));
   }
 
   @Override

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -150,43 +150,23 @@ final class SpanBuilderSdk implements Span.Builder {
   }
 
   @Override
-  public Span.Builder setAttribute(String key, String value) {
-    return setAttribute(key, AttributeValue.stringAttributeValue(value));
-  }
-
-  @Override
-  public Span.Builder setAttribute(String key, long value) {
-    return setAttribute(key, AttributeValue.longAttributeValue(value));
-  }
-
-  @Override
-  public Span.Builder setAttribute(String key, double value) {
-    return setAttribute(key, AttributeValue.doubleAttributeValue(value));
-  }
-
-  @Override
-  public Span.Builder setAttribute(String key, boolean value) {
-    return setAttribute(key, AttributeValue.booleanAttributeValue(value));
-  }
-
-  @Override
   public Span.Builder setAttribute(StringValuedKey key, String value) {
-    return setAttribute(key.key(), value);
+    return setAttribute(key.key(), AttributeValue.stringAttributeValue(value));
   }
 
   @Override
   public Span.Builder setAttribute(DoubleValuedKey key, double value) {
-    return setAttribute(key.key(), value);
+    return setAttribute(key.key(), AttributeValue.doubleAttributeValue(value));
   }
 
   @Override
   public Span.Builder setAttribute(BooleanValuedKey key, boolean value) {
-    return setAttribute(key.key(), value);
+    return setAttribute(key.key(), AttributeValue.booleanAttributeValue(value));
   }
 
   @Override
   public Span.Builder setAttribute(LongValuedKey key, long value) {
-    return setAttribute(key.key(), value);
+    return setAttribute(key.key(), AttributeValue.longAttributeValue(value));
   }
 
   @Override

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -18,6 +18,10 @@ package io.opentelemetry.sdk.trace;
 
 import io.grpc.Context;
 import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.common.BooleanValuedKey;
+import io.opentelemetry.common.DoubleValuedKey;
+import io.opentelemetry.common.LongValuedKey;
+import io.opentelemetry.common.StringValuedKey;
 import io.opentelemetry.internal.Utils;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -163,6 +167,26 @@ final class SpanBuilderSdk implements Span.Builder {
   @Override
   public Span.Builder setAttribute(String key, boolean value) {
     return setAttribute(key, AttributeValue.booleanAttributeValue(value));
+  }
+
+  @Override
+  public Span.Builder setAttribute(StringValuedKey key, String value) {
+    return setAttribute(key.key(), value);
+  }
+
+  @Override
+  public Span.Builder setAttribute(DoubleValuedKey key, double value) {
+    return setAttribute(key.key(), value);
+  }
+
+  @Override
+  public Span.Builder setAttribute(BooleanValuedKey key, boolean value) {
+    return setAttribute(key.key(), value);
+  }
+
+  @Override
+  public Span.Builder setAttribute(LongValuedKey key, long value) {
+    return setAttribute(key.key(), value);
   }
 
   @Override

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -17,6 +17,10 @@
 package io.opentelemetry.sdk.trace;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.opentelemetry.trace.attributes.BooleanAttributeSetter.booleanKey;
+import static io.opentelemetry.trace.attributes.DoubleAttributeSetter.doubleKey;
+import static io.opentelemetry.trace.attributes.LongAttributeSetter.longKey;
+import static io.opentelemetry.trace.attributes.StringAttributeSetter.stringKey;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -286,14 +290,14 @@ public class RecordEventsReadableSpanTest {
   public void setAttribute() {
     RecordEventsReadableSpan span = createTestRootSpan();
     try {
-      span.setAttribute("StringKey", "StringVal");
-      span.setAttribute("NullStringKey", (String) null);
-      span.setAttribute("EmptyStringKey", "");
+      span.setAttribute(stringKey("StringKey"), "StringVal");
+      span.setAttribute(stringKey("NullStringKey"), (String) null);
+      span.setAttribute(stringKey("EmptyStringKey"), "");
       span.setAttribute("NullStringAttributeValue", AttributeValue.stringAttributeValue(null));
       span.setAttribute("EmptyStringAttributeValue", AttributeValue.stringAttributeValue(""));
-      span.setAttribute("LongKey", 1000L);
-      span.setAttribute("DoubleKey", 10.0);
-      span.setAttribute("BooleanKey", false);
+      span.setAttribute(longKey("LongKey"), 1000L);
+      span.setAttribute(doubleKey("DoubleKey"), 10.0);
+      span.setAttribute(booleanKey("BooleanKey"), false);
     } finally {
       span.end();
     }
@@ -615,7 +619,7 @@ public class RecordEventsReadableSpanTest {
               @Override
               public void run() {
                 for (int i = 0; i < 5096 * 5; ++i) {
-                  span.setAttribute("hey" + i, "");
+                  span.setAttribute(stringKey("hey" + i), "");
                 }
               }
             });

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -17,6 +17,10 @@
 package io.opentelemetry.sdk.trace;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.opentelemetry.trace.attributes.BooleanAttributeSetter.booleanKey;
+import static io.opentelemetry.trace.attributes.DoubleAttributeSetter.doubleKey;
+import static io.opentelemetry.trace.attributes.LongAttributeSetter.longKey;
+import static io.opentelemetry.trace.attributes.StringAttributeSetter.stringKey;
 import static org.junit.Assert.assertFalse;
 
 import io.opentelemetry.common.AttributeValue;
@@ -151,10 +155,10 @@ public class SpanBuilderSdkTest {
   @Test
   public void setAttribute() {
     Span.Builder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
-    spanBuilder.setAttribute("string", "value");
-    spanBuilder.setAttribute("long", 12345L);
-    spanBuilder.setAttribute("double", .12345);
-    spanBuilder.setAttribute("boolean", true);
+    spanBuilder.setAttribute(stringKey("string"), "value");
+    spanBuilder.setAttribute(longKey("long"), 12345L);
+    spanBuilder.setAttribute(doubleKey("double"), .12345);
+    spanBuilder.setAttribute(booleanKey("boolean"), true);
     spanBuilder.setAttribute("stringAttribute", AttributeValue.stringAttributeValue("attrvalue"));
 
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
@@ -175,34 +179,34 @@ public class SpanBuilderSdkTest {
   @Test
   public void setAttribute_nullStringValue() throws Exception {
     Span.Builder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
-    spanBuilder.setAttribute("emptyString", "");
-    spanBuilder.setAttribute("nullString", (String) null);
+    spanBuilder.setAttribute(stringKey("emptyString"), "");
+    spanBuilder.setAttribute(stringKey("nullString"), null);
     spanBuilder.setAttribute("nullStringAttributeValue", AttributeValue.stringAttributeValue(null));
     spanBuilder.setAttribute("emptyStringAttributeValue", AttributeValue.stringAttributeValue(""));
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(2);
-    spanBuilder.setAttribute("emptyString", (String) null);
-    spanBuilder.setAttribute("emptyStringAttributeValue", (String) null);
+    spanBuilder.setAttribute(stringKey("emptyString"), null);
+    spanBuilder.setAttribute(stringKey("emptyStringAttributeValue"), null);
     assertThat(span.toSpanData().getAttributes()).isEmpty();
   }
 
   @Test
   public void setAttribute_nullAttributeValue() throws Exception {
     Span.Builder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
-    spanBuilder.setAttribute("emptyString", "");
-    spanBuilder.setAttribute("nullString", (AttributeValue) null);
+    spanBuilder.setAttribute(stringKey("emptyString"), "");
+    spanBuilder.setAttribute("nullString", null);
     spanBuilder.setAttribute("nullStringAttributeValue", AttributeValue.stringAttributeValue(null));
     spanBuilder.setAttribute("emptyStringAttributeValue", AttributeValue.stringAttributeValue(""));
-    spanBuilder.setAttribute("longAttribute", 0L);
-    spanBuilder.setAttribute("boolAttribute", false);
-    spanBuilder.setAttribute("doubleAttribute", 0.12345f);
+    spanBuilder.setAttribute(longKey("longAttribute"), 0L);
+    spanBuilder.setAttribute(booleanKey("boolAttribute"), false);
+    spanBuilder.setAttribute(doubleKey("doubleAttribute"), 0.12345f);
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(5);
-    spanBuilder.setAttribute("emptyString", (AttributeValue) null);
-    spanBuilder.setAttribute("emptyStringAttributeValue", (AttributeValue) null);
-    spanBuilder.setAttribute("longAttribute", (AttributeValue) null);
-    spanBuilder.setAttribute("boolAttribute", (AttributeValue) null);
-    spanBuilder.setAttribute("doubleAttribute", (AttributeValue) null);
+    spanBuilder.setAttribute("emptyString", null);
+    spanBuilder.setAttribute("emptyStringAttributeValue", null);
+    spanBuilder.setAttribute("longAttribute", null);
+    spanBuilder.setAttribute("boolAttribute", null);
+    spanBuilder.setAttribute("doubleAttribute", null);
     assertThat(span.toSpanData().getAttributes()).isEmpty();
   }
 
@@ -218,7 +222,7 @@ public class SpanBuilderSdkTest {
     tracerSdkFactory.updateActiveTraceConfig(traceConfig);
     Span.Builder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
     for (int i = 0; i < 2 * maxNumberOfAttrs; i++) {
-      spanBuilder.setAttribute("key" + i, i);
+      spanBuilder.setAttribute(longKey("key" + i), i);
     }
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     try {
@@ -319,7 +323,7 @@ public class SpanBuilderSdkTest {
                         return "test sampler";
                       }
                     },
-                    Collections.<String, AttributeValue>singletonMap(
+                    Collections.singletonMap(
                         samplerAttributeName, AttributeValue.stringAttributeValue("none")))
                 .startSpan();
     try {

--- a/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/actorpropagation/ActorPropagationTest.java
+++ b/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/actorpropagation/ActorPropagationTest.java
@@ -17,6 +17,7 @@
 package io.opentelemetry.sdk.contrib.trace.testbed.actorpropagation;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.opentelemetry.trace.attributes.StringAttributeSetter.stringKey;
 
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
@@ -59,7 +60,7 @@ public class ActorPropagationTest {
     try (Actor actor = new Actor(tracer, phaser)) {
       phaser.register();
       Span parent = tracer.spanBuilder("actorTell").setSpanKind(Kind.PRODUCER).startSpan();
-      parent.setAttribute("component", "example-actor");
+      parent.setAttribute(stringKey("component"), "example-actor");
       try (Scope ignored = tracer.withSpan(parent)) {
         actor.tell("my message 1");
         actor.tell("my message 2");
@@ -95,7 +96,7 @@ public class ActorPropagationTest {
       Future<String> future1;
       Future<String> future2;
       Span span = tracer.spanBuilder("actorAsk").setSpanKind(Kind.PRODUCER).startSpan();
-      span.setAttribute("component", "example-actor");
+      span.setAttribute(stringKey("component"), "example-actor");
 
       try (Scope ignored = tracer.withSpan(span)) {
         future1 = actor.ask("my message 1");

--- a/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/clientserver/Client.java
+++ b/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/clientserver/Client.java
@@ -16,6 +16,8 @@
 
 package io.opentelemetry.sdk.contrib.trace.testbed.clientserver;
 
+import static io.opentelemetry.trace.attributes.StringAttributeSetter.stringKey;
+
 import io.grpc.Context;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.Scope;
@@ -39,7 +41,7 @@ final class Client {
     Message message = new Message();
 
     Span span = tracer.spanBuilder("send").setSpanKind(Kind.CLIENT).startSpan();
-    span.setAttribute("component", "example-client");
+    span.setAttribute(stringKey("component"), "example-client");
 
     try (Scope ignored = tracer.withSpan(span)) {
       OpenTelemetry.getPropagators()

--- a/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/clientserver/Server.java
+++ b/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/clientserver/Server.java
@@ -16,6 +16,8 @@
 
 package io.opentelemetry.sdk.contrib.trace.testbed.clientserver;
 
+import static io.opentelemetry.trace.attributes.StringAttributeSetter.stringKey;
+
 import io.grpc.Context;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.Scope;
@@ -55,7 +57,7 @@ final class Server extends Thread {
     SpanContext spanContext = TracingContextUtils.getSpan(context).getContext();
     Span span =
         tracer.spanBuilder("receive").setSpanKind(Kind.SERVER).setParent(spanContext).startSpan();
-    span.setAttribute("component", "example-server");
+    span.setAttribute(stringKey("component"), "example-server");
 
     try (Scope ignored = tracer.withSpan(span)) {
       // Simulate work.

--- a/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/nestedcallbacks/NestedCallbacksTest.java
+++ b/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/nestedcallbacks/NestedCallbacksTest.java
@@ -17,6 +17,7 @@
 package io.opentelemetry.sdk.contrib.trace.testbed.nestedcallbacks;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.opentelemetry.trace.attributes.StringAttributeSetter.stringKey;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -75,21 +76,21 @@ public final class NestedCallbacksTest {
           @Override
           public void run() {
             try (Scope ignored = tracer.withSpan(span)) {
-              span.setAttribute("key1", "1");
+              span.setAttribute(stringKey("key1"), "1");
 
               executor.submit(
                   new Runnable() {
                     @Override
                     public void run() {
                       try (Scope ignored = tracer.withSpan(span)) {
-                        span.setAttribute("key2", "2");
+                        span.setAttribute(stringKey("key2"), "2");
 
                         executor.submit(
                             new Runnable() {
                               @Override
                               public void run() {
                                 try (Scope ignored = tracer.withSpan(span)) {
-                                  span.setAttribute("key3", "3");
+                                  span.setAttribute(stringKey("key3"), "3");
                                 } finally {
                                   span.end();
                                 }

--- a/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/promisepropagation/Promise.java
+++ b/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/promisepropagation/Promise.java
@@ -16,6 +16,8 @@
 
 package io.opentelemetry.sdk.contrib.trace.testbed.promisepropagation;
 
+import static io.opentelemetry.trace.attributes.StringAttributeSetter.stringKey;
+
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -54,7 +56,7 @@ final class Promise<T> {
             @Override
             public void run() {
               Span childSpan = tracer.spanBuilder("success").setParent(parentSpan).startSpan();
-              childSpan.setAttribute("component", "success");
+              childSpan.setAttribute(stringKey("component"), "success");
               try (Scope ignored = tracer.withSpan(childSpan)) {
                 callback.accept(result);
               } finally {
@@ -74,7 +76,7 @@ final class Promise<T> {
             @Override
             public void run() {
               Span childSpan = tracer.spanBuilder("error").setParent(parentSpan).startSpan();
-              childSpan.setAttribute("component", "error");
+              childSpan.setAttribute(stringKey("component"), "error");
               try (Scope ignored = tracer.withSpan(childSpan)) {
                 callback.accept(error);
               } finally {

--- a/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/promisepropagation/PromisePropagationTest.java
+++ b/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/promisepropagation/PromisePropagationTest.java
@@ -17,6 +17,7 @@
 package io.opentelemetry.sdk.contrib.trace.testbed.promisepropagation;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.opentelemetry.trace.attributes.StringAttributeSetter.stringKey;
 
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
@@ -60,7 +61,7 @@ public class PromisePropagationTest {
 
     try (PromiseContext context = new PromiseContext(phaser, 3)) {
       Span parentSpan = tracer.spanBuilder("promises").startSpan();
-      parentSpan.setAttribute("component", "example-promises");
+      parentSpan.setAttribute(stringKey("component"), "example-promises");
 
       try (Scope ignored = tracer.withSpan(parentSpan)) {
         Promise<String> successPromise = new Promise<>(context, tracer);

--- a/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/suspendresumepropagation/SuspendResume.java
+++ b/sdk_contrib/testbed/src/test/java/io/opentelemetry/sdk/contrib/trace/testbed/suspendresumepropagation/SuspendResume.java
@@ -16,6 +16,8 @@
 
 package io.opentelemetry.sdk.contrib.trace.testbed.suspendresumepropagation;
 
+import static io.opentelemetry.trace.attributes.StringAttributeSetter.stringKey;
+
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -29,7 +31,7 @@ final class SuspendResume {
     this.tracer = tracer;
 
     Span span = tracer.spanBuilder("job " + id).startSpan();
-    span.setAttribute("component", "suspend-resume");
+    span.setAttribute(stringKey("component"), "suspend-resume");
     try (Scope scope = tracer.withSpan(span)) {
       this.span = span;
     }


### PR DESCRIPTION
As discussed extensively in #1076 , there is a desire to make the semantic attributes easier to apply in the context of a SpanBuilder. This suggestion replaces the bare `String` keys on the Span attribute setters, replacing them with interface-based methods that enforce the type of the value. 

This is a follow-on from the prototype in #1096, where the interfaces were introduced. 

Prototype suggestion for #1076 , #1075