### PR TITLE
Convert span kind values to lowercase for Jaeger exporter

### DIFF
--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/Adapter.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/Adapter.java
@@ -28,6 +28,7 @@ import io.opentelemetry.sdk.trace.data.SpanData.TimedEvent;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import javax.annotation.concurrent.ThreadSafe;
@@ -89,7 +90,10 @@ final class Adapter {
 
     if (span.getKind() != null) {
       target.addTags(
-          Model.KeyValue.newBuilder().setKey(KEY_SPAN_KIND).setVStr(span.getKind().name()).build());
+          Model.KeyValue.newBuilder()
+              .setKey(KEY_SPAN_KIND)
+              .setVStr(span.getKind().name().toLowerCase(Locale.ROOT))
+              .build());
     }
 
     target.addTags(

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
@@ -91,7 +91,7 @@ public class AdapterTest {
     assertEquals(4, jaegerSpan.getTagsCount());
     Model.KeyValue keyValue = getValue(jaegerSpan.getTagsList(), Adapter.KEY_SPAN_KIND);
     assertNotNull(keyValue);
-    assertEquals("SERVER", keyValue.getVStr());
+    assertEquals("server", keyValue.getVStr());
     keyValue = getValue(jaegerSpan.getTagsList(), Adapter.KEY_SPAN_STATUS_CODE);
     assertNotNull(keyValue);
     assertEquals(0, keyValue.getVInt64());


### PR DESCRIPTION
The OpenTelemetry Span.Kind enumerated type values are in uppercase, e.g. SERVER, CLIENT. These are incompatible with Jaeger which is based on the OpenTracing semantics where these are in lowercase.
The spans are collected as expected, but Jaeger is unable to display deep dependancy graphs as these are based on span kind values in lowercase, e.g. "server".