### PR TITLE
Remove the RETRYABLE failure mode from the exporter interfaces.

### DIFF
--- a/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporter.java
+++ b/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporter.java
@@ -88,7 +88,7 @@ public final class InMemorySpanExporter implements SpanExporter {
   public ResultCode export(Collection<SpanData> spans) {
     synchronized (this) {
       if (isStopped) {
-        return ResultCode.FAILED_NOT_RETRYABLE;
+        return ResultCode.FAILURE;
       }
       finishedSpanItems.addAll(spans);
     }

--- a/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
+++ b/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
@@ -92,11 +92,11 @@ public class InMemorySpanExporterTest {
     exporter.shutdown();
     // After shutdown no more export.
     assertThat(exporter.export(Collections.singletonList(makeBasicSpan())))
-        .isEqualTo(ResultCode.FAILED_NOT_RETRYABLE);
+        .isEqualTo(ResultCode.FAILURE);
     exporter.reset();
     // Reset does not do anything if already shutdown.
     assertThat(exporter.export(Collections.singletonList(makeBasicSpan())))
-        .isEqualTo(ResultCode.FAILED_NOT_RETRYABLE);
+        .isEqualTo(ResultCode.FAILURE);
   }
 
   static SpanData makeBasicSpan() {

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporter.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporter.java
@@ -18,7 +18,6 @@ package io.opentelemetry.exporters.jaeger;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.grpc.StatusRuntimeException;
 import io.opentelemetry.exporters.jaeger.proto.api_v2.Collector;
 import io.opentelemetry.exporters.jaeger.proto.api_v2.CollectorServiceGrpc;
 import io.opentelemetry.exporters.jaeger.proto.api_v2.Model;
@@ -128,16 +127,8 @@ public final class JaegerGrpcSpanExporter implements SpanExporter {
       //noinspection ResultOfMethodCallIgnored
       stub.postSpans(request);
       return ResultCode.SUCCESS;
-    } catch (StatusRuntimeException e) {
-      switch (e.getStatus().getCode()) {
-        case DEADLINE_EXCEEDED:
-        case UNAVAILABLE:
-          return ResultCode.FAILED_RETRYABLE;
-        default:
-          return ResultCode.FAILED_NOT_RETRYABLE;
-      }
-    } catch (Throwable t) {
-      return ResultCode.FAILED_NOT_RETRYABLE;
+    } catch (Throwable e) {
+      return ResultCode.FAILURE;
     }
   }
 

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcMetricExporter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcMetricExporter.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.exporters.otlp;
 
 import io.grpc.ManagedChannel;
-import io.grpc.StatusRuntimeException;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.proto.collector.metrics.v1.MetricsServiceGrpc;
 import io.opentelemetry.sdk.metrics.data.MetricData;
@@ -73,21 +72,8 @@ public final class OtlpGrpcMetricExporter implements MetricExporter {
       // noinspection ResultOfMethodCallIgnored
       stub.export(exportMetricsServiceRequest);
       return ResultCode.SUCCESS;
-    } catch (StatusRuntimeException e) {
-      // Retryable codes from https://github.com/open-telemetry/oteps/pull/65
-      switch (e.getStatus().getCode()) {
-        case CANCELLED:
-        case DEADLINE_EXCEEDED:
-        case RESOURCE_EXHAUSTED:
-        case OUT_OF_RANGE:
-        case UNAVAILABLE:
-        case DATA_LOSS:
-          return ResultCode.FAILED_RETRYABLE;
-        default:
-          return ResultCode.FAILED_NOT_RETRYABLE;
-      }
-    } catch (Throwable t) {
-      return ResultCode.FAILED_NOT_RETRYABLE;
+    } catch (Throwable e) {
+      return ResultCode.FAILURE;
     }
   }
 

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.exporters.otlp;
 
 import io.grpc.ManagedChannel;
-import io.grpc.StatusRuntimeException;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -73,21 +72,8 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
       // noinspection ResultOfMethodCallIgnored
       stub.export(exportTraceServiceRequest);
       return ResultCode.SUCCESS;
-    } catch (StatusRuntimeException e) {
-      // Retryable codes from https://github.com/open-telemetry/oteps/pull/65
-      switch (e.getStatus().getCode()) {
-        case CANCELLED:
-        case DEADLINE_EXCEEDED:
-        case RESOURCE_EXHAUSTED:
-        case OUT_OF_RANGE:
-        case UNAVAILABLE:
-        case DATA_LOSS:
-          return ResultCode.FAILED_RETRYABLE;
-        default:
-          return ResultCode.FAILED_NOT_RETRYABLE;
-      }
-    } catch (Throwable t) {
-      return ResultCode.FAILED_NOT_RETRYABLE;
+    } catch (Throwable e) {
+      return ResultCode.FAILURE;
     }
   }
 

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcMetricExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcMetricExporterTest.java
@@ -104,9 +104,7 @@ public class OtlpGrpcMetricExporterTest {
     OtlpGrpcMetricExporter exporter =
         OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
     exporter.shutdown();
-    // TODO: This probably should not be retryable because we never restart the channel.
-    assertThat(exporter.export(Collections.singletonList(span)))
-        .isEqualTo(ResultCode.FAILED_RETRYABLE);
+    assertThat(exporter.export(Collections.singletonList(span))).isEqualTo(ResultCode.FAILURE);
   }
 
   @Test
@@ -116,7 +114,7 @@ public class OtlpGrpcMetricExporterTest {
         OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeMetric())))
-          .isEqualTo(ResultCode.FAILED_RETRYABLE);
+          .isEqualTo(ResultCode.FAILURE);
     } finally {
       exporter.shutdown();
     }
@@ -129,7 +127,7 @@ public class OtlpGrpcMetricExporterTest {
         OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeMetric())))
-          .isEqualTo(ResultCode.FAILED_RETRYABLE);
+          .isEqualTo(ResultCode.FAILURE);
     } finally {
       exporter.shutdown();
     }
@@ -142,7 +140,7 @@ public class OtlpGrpcMetricExporterTest {
         OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeMetric())))
-          .isEqualTo(ResultCode.FAILED_RETRYABLE);
+          .isEqualTo(ResultCode.FAILURE);
     } finally {
       exporter.shutdown();
     }
@@ -155,7 +153,7 @@ public class OtlpGrpcMetricExporterTest {
         OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeMetric())))
-          .isEqualTo(ResultCode.FAILED_RETRYABLE);
+          .isEqualTo(ResultCode.FAILURE);
     } finally {
       exporter.shutdown();
     }
@@ -168,7 +166,7 @@ public class OtlpGrpcMetricExporterTest {
         OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeMetric())))
-          .isEqualTo(ResultCode.FAILED_RETRYABLE);
+          .isEqualTo(ResultCode.FAILURE);
     } finally {
       exporter.shutdown();
     }
@@ -181,7 +179,7 @@ public class OtlpGrpcMetricExporterTest {
         OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeMetric())))
-          .isEqualTo(ResultCode.FAILED_RETRYABLE);
+          .isEqualTo(ResultCode.FAILURE);
     } finally {
       exporter.shutdown();
     }
@@ -194,7 +192,7 @@ public class OtlpGrpcMetricExporterTest {
         OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeMetric())))
-          .isEqualTo(ResultCode.FAILED_NOT_RETRYABLE);
+          .isEqualTo(ResultCode.FAILURE);
     } finally {
       exporter.shutdown();
     }

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
@@ -106,8 +106,7 @@ public class OtlpGrpcSpanExporterTest {
         OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
     exporter.shutdown();
     // TODO: This probably should not be retryable because we never restart the channel.
-    assertThat(exporter.export(Collections.singletonList(span)))
-        .isEqualTo(ResultCode.FAILED_RETRYABLE);
+    assertThat(exporter.export(Collections.singletonList(span))).isEqualTo(ResultCode.FAILURE);
   }
 
   @Test
@@ -117,7 +116,7 @@ public class OtlpGrpcSpanExporterTest {
         OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeSpan())))
-          .isEqualTo(ResultCode.FAILED_RETRYABLE);
+          .isEqualTo(ResultCode.FAILURE);
     } finally {
       exporter.shutdown();
     }
@@ -130,7 +129,7 @@ public class OtlpGrpcSpanExporterTest {
         OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeSpan())))
-          .isEqualTo(ResultCode.FAILED_RETRYABLE);
+          .isEqualTo(ResultCode.FAILURE);
     } finally {
       exporter.shutdown();
     }
@@ -143,7 +142,7 @@ public class OtlpGrpcSpanExporterTest {
         OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeSpan())))
-          .isEqualTo(ResultCode.FAILED_RETRYABLE);
+          .isEqualTo(ResultCode.FAILURE);
     } finally {
       exporter.shutdown();
     }
@@ -156,7 +155,7 @@ public class OtlpGrpcSpanExporterTest {
         OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeSpan())))
-          .isEqualTo(ResultCode.FAILED_RETRYABLE);
+          .isEqualTo(ResultCode.FAILURE);
     } finally {
       exporter.shutdown();
     }
@@ -169,7 +168,7 @@ public class OtlpGrpcSpanExporterTest {
         OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeSpan())))
-          .isEqualTo(ResultCode.FAILED_RETRYABLE);
+          .isEqualTo(ResultCode.FAILURE);
     } finally {
       exporter.shutdown();
     }
@@ -182,7 +181,7 @@ public class OtlpGrpcSpanExporterTest {
         OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeSpan())))
-          .isEqualTo(ResultCode.FAILED_RETRYABLE);
+          .isEqualTo(ResultCode.FAILURE);
     } finally {
       exporter.shutdown();
     }
@@ -195,7 +194,7 @@ public class OtlpGrpcSpanExporterTest {
         OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeSpan())))
-          .isEqualTo(ResultCode.FAILED_NOT_RETRYABLE);
+          .isEqualTo(ResultCode.FAILURE);
     } finally {
       exporter.shutdown();
     }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/export/MetricExporter.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/export/MetricExporter.java
@@ -39,14 +39,8 @@ public interface MetricExporter {
     /** The export operation finished successfully. */
     SUCCESS,
 
-    /** The export operation finished with an error, but retrying may succeed. */
-    FAILED_RETRYABLE,
-
-    /**
-     * The export operation finished with an error, the caller should not try to export the same
-     * data again.
-     */
-    FAILED_NOT_RETRYABLE
+    /** The export operation finished with an error. */
+    FAILURE
   }
 
   /**

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/MultiSpanExporter.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/MultiSpanExporter.java
@@ -16,8 +16,7 @@
 
 package io.opentelemetry.sdk.trace.export;
 
-import static io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode.FAILED_NOT_RETRYABLE;
-import static io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode.FAILED_RETRYABLE;
+import static io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode.FAILURE;
 import static io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode.SUCCESS;
 
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -56,7 +55,7 @@ public final class MultiSpanExporter implements SpanExporter {
       } catch (Throwable t) {
         // If an exception was thrown by the exporter
         logger.log(Level.WARNING, "Exception thrown by the export.", t);
-        currentResultCode = FAILED_NOT_RETRYABLE;
+        currentResultCode = FAILURE;
       }
     }
     return currentResultCode;
@@ -77,14 +76,7 @@ public final class MultiSpanExporter implements SpanExporter {
       return SUCCESS;
     }
 
-    // If any of the codes is none retryable then return none_retryable;
-    if (currentResultCode == FAILED_NOT_RETRYABLE || newResultCode == FAILED_NOT_RETRYABLE) {
-      return FAILED_NOT_RETRYABLE;
-    }
-
-    // At this point at least one of the code is FAILED_RETRYABLE and none are
-    // FAILED_NOT_RETRYABLE, so return FAILED_RETRYABLE.
-    return FAILED_RETRYABLE;
+    return FAILURE;
   }
 
   private MultiSpanExporter(List<SpanExporter> spanExporters) {

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SpanExporter.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SpanExporter.java
@@ -34,14 +34,8 @@ public interface SpanExporter {
     /** The export operation finished successfully. */
     SUCCESS,
 
-    /** The export operation finished with an error, but retrying may succeed. */
-    FAILED_RETRYABLE,
-
-    /**
-     * The export operation finished with an error, the caller should not try to export the same
-     * data again.
-     */
-    FAILED_NOT_RETRYABLE
+    /** The export operation finished with an error. */
+    FAILURE
   }
 
   /**

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/MultiSpanExporterTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/MultiSpanExporterTest.java
@@ -85,23 +85,12 @@ public class MultiSpanExporterTest {
   }
 
   @Test
-  public void twoSpanExporter_OneReturnNoneRetryable() {
+  public void twoSpanExporter_OneReturnFailure() {
     SpanExporter multiSpanExporter =
         MultiSpanExporter.create(Arrays.asList(spanExporter1, spanExporter2));
     when(spanExporter1.export(same(SPAN_LIST))).thenReturn(ResultCode.SUCCESS);
-    when(spanExporter2.export(same(SPAN_LIST))).thenReturn(ResultCode.FAILED_NOT_RETRYABLE);
-    assertThat(multiSpanExporter.export(SPAN_LIST)).isEqualTo(ResultCode.FAILED_NOT_RETRYABLE);
-    verify(spanExporter1).export(same(SPAN_LIST));
-    verify(spanExporter2).export(same(SPAN_LIST));
-  }
-
-  @Test
-  public void twoSpanExporter_OneReturnRetryable() {
-    SpanExporter multiSpanExporter =
-        MultiSpanExporter.create(Arrays.asList(spanExporter1, spanExporter2));
-    when(spanExporter1.export(same(SPAN_LIST))).thenReturn(ResultCode.SUCCESS);
-    when(spanExporter2.export(same(SPAN_LIST))).thenReturn(ResultCode.FAILED_RETRYABLE);
-    assertThat(multiSpanExporter.export(SPAN_LIST)).isEqualTo(ResultCode.FAILED_RETRYABLE);
+    when(spanExporter2.export(same(SPAN_LIST))).thenReturn(ResultCode.FAILURE);
+    assertThat(multiSpanExporter.export(SPAN_LIST)).isEqualTo(ResultCode.FAILURE);
     verify(spanExporter1).export(same(SPAN_LIST));
     verify(spanExporter2).export(same(SPAN_LIST));
   }
@@ -113,7 +102,7 @@ public class MultiSpanExporterTest {
         .export(ArgumentMatchers.<SpanData>anyList());
     SpanExporter multiSpanExporter =
         MultiSpanExporter.create(Arrays.asList(spanExporter1, spanExporter2));
-    assertThat(multiSpanExporter.export(SPAN_LIST)).isEqualTo(ResultCode.FAILED_NOT_RETRYABLE);
+    assertThat(multiSpanExporter.export(SPAN_LIST)).isEqualTo(ResultCode.FAILURE);
     verify(spanExporter1).export(same(SPAN_LIST));
     verify(spanExporter2).export(same(SPAN_LIST));
   }


### PR DESCRIPTION
With the merging of https://github.com/open-telemetry/opentelemetry-specification/pull/511, this should get us into spec compliance.