### PR TITLE
Mark all threads/pools as daemon.

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/common/DaemonThreadFactory.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/common/DaemonThreadFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.common;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * A {@link ThreadFactory} that delegates to {@code MoreExecutors.platformThreadFactory()} and marks
+ * all threads as daemon.
+ */
+public class DaemonThreadFactory implements ThreadFactory {
+  @Override
+  public Thread newThread(Runnable runnable) {
+    Thread t = MoreExecutors.platformThreadFactory().newThread(runnable);
+    try {
+      t.setDaemon(true);
+    } catch (SecurityException e) {
+      // Well, we tried.
+    }
+    return t;
+  }
+}

--- a/sdk/src/main/java/io/opentelemetry/sdk/common/DaemonThreadFactory.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/common/DaemonThreadFactory.java
@@ -18,17 +18,26 @@ package io.opentelemetry.sdk.common;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * A {@link ThreadFactory} that delegates to {@code MoreExecutors.platformThreadFactory()} and marks
  * all threads as daemon.
  */
 public class DaemonThreadFactory implements ThreadFactory {
+  private final String namePrefix;
+  private final AtomicInteger counter = new AtomicInteger();
+
+  public DaemonThreadFactory(String namePrefix) {
+    this.namePrefix = namePrefix;
+  }
+
   @Override
   public Thread newThread(Runnable runnable) {
     Thread t = MoreExecutors.platformThreadFactory().newThread(runnable);
     try {
       t.setDaemon(true);
+      t.setName(namePrefix + "_" + counter.incrementAndGet());
     } catch (SecurityException e) {
       // Well, we tried.
     }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
@@ -122,6 +122,7 @@ public final class IntervalMetricReader {
      * Builds a new {@link IntervalMetricReader} with current settings.
      *
      * @return a {@code IntervalMetricReader}.
+     * @throws java.lang.SecurityException if permission to set Threads as daemon is revoked
      * @since 0.3.0
      */
     public IntervalMetricReader build() {

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
@@ -135,7 +135,8 @@ public final class IntervalMetricReader {
   @SuppressWarnings("FutureReturnValueIgnored")
   private IntervalMetricReader(InternalState internalState) {
     this.exporter = new Exporter(internalState);
-    this.scheduler = Executors.newScheduledThreadPool(1, new DaemonThreadFactory());
+    this.scheduler =
+        Executors.newScheduledThreadPool(1, new DaemonThreadFactory("IntervalMetricReader"));
     this.scheduler.scheduleAtFixedRate(
         exporter,
         internalState.getExportIntervalMillis(),

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
@@ -18,6 +18,7 @@ package io.opentelemetry.sdk.metrics.export;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.opentelemetry.internal.Utils;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.util.ArrayList;
@@ -135,7 +136,13 @@ public final class IntervalMetricReader {
   @SuppressWarnings("FutureReturnValueIgnored")
   private IntervalMetricReader(InternalState internalState) {
     this.exporter = new Exporter(internalState);
-    this.scheduler = Executors.newScheduledThreadPool(1, MoreExecutors.platformThreadFactory());
+    this.scheduler =
+        Executors.newScheduledThreadPool(
+            1,
+            new ThreadFactoryBuilder()
+                .setDaemon(true)
+                .setThreadFactory(MoreExecutors.platformThreadFactory())
+                .build());
     this.scheduler.scheduleAtFixedRate(
         exporter,
         internalState.getExportIntervalMillis(),

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
@@ -17,9 +17,8 @@
 package io.opentelemetry.sdk.metrics.export;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.opentelemetry.internal.Utils;
+import io.opentelemetry.sdk.common.DaemonThreadFactory;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -122,7 +121,6 @@ public final class IntervalMetricReader {
      * Builds a new {@link IntervalMetricReader} with current settings.
      *
      * @return a {@code IntervalMetricReader}.
-     * @throws java.lang.SecurityException if permission to set Threads as daemon is revoked
      * @since 0.3.0
      */
     public IntervalMetricReader build() {
@@ -137,13 +135,7 @@ public final class IntervalMetricReader {
   @SuppressWarnings("FutureReturnValueIgnored")
   private IntervalMetricReader(InternalState internalState) {
     this.exporter = new Exporter(internalState);
-    this.scheduler =
-        Executors.newScheduledThreadPool(
-            1,
-            new ThreadFactoryBuilder()
-                .setDaemon(true)
-                .setThreadFactory(MoreExecutors.platformThreadFactory())
-                .build());
+    this.scheduler = Executors.newScheduledThreadPool(1, new DaemonThreadFactory());
     this.scheduler.scheduleAtFixedRate(
         exporter,
         internalState.getExportIntervalMillis(),

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessor.java
@@ -16,12 +16,12 @@
 
 package io.opentelemetry.sdk.trace.export;
 
-import com.google.common.util.concurrent.MoreExecutors;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.internal.Utils;
 import io.opentelemetry.metrics.LongCounter;
 import io.opentelemetry.metrics.LongCounter.BoundLongCounter;
 import io.opentelemetry.metrics.Meter;
+import io.opentelemetry.sdk.common.DaemonThreadFactory;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -236,10 +236,9 @@ public final class BatchSpansProcessor implements SpanProcessor {
   }
 
   private static Thread newThread(Runnable runnable) {
-    Thread thread = MoreExecutors.platformThreadFactory().newThread(runnable);
+    Thread thread = new DaemonThreadFactory().newThread(runnable);
     try {
       thread.setName(WORKER_THREAD_NAME);
-      thread.setDaemon(true);
     } catch (SecurityException e) {
       // OK if we can't set the name in this environment.
     }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessor.java
@@ -237,9 +237,9 @@ public final class BatchSpansProcessor implements SpanProcessor {
 
   private static Thread newThread(Runnable runnable) {
     Thread thread = MoreExecutors.platformThreadFactory().newThread(runnable);
-    thread.setDaemon(true);
     try {
       thread.setName(WORKER_THREAD_NAME);
+      thread.setDaemon(true);
     } catch (SecurityException e) {
       // OK if we can't set the name in this environment.
     }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessor.java
@@ -237,6 +237,7 @@ public final class BatchSpansProcessor implements SpanProcessor {
 
   private static Thread newThread(Runnable runnable) {
     Thread thread = MoreExecutors.platformThreadFactory().newThread(runnable);
+    thread.setDaemon(true);
     try {
       thread.setName(WORKER_THREAD_NAME);
     } catch (SecurityException e) {

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpansProcessor.java
@@ -32,7 +32,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
@@ -78,7 +77,7 @@ public final class BatchSpansProcessor implements SpanProcessor {
             maxQueueSize,
             maxExportBatchSize,
             exporterTimeoutMillis);
-    this.workerThread = newThread(worker);
+    this.workerThread = new DaemonThreadFactory(WORKER_THREAD_NAME).newThread(worker);
     this.workerThread.start();
     this.sampled = sampled;
   }
@@ -235,16 +234,6 @@ public final class BatchSpansProcessor implements SpanProcessor {
     }
   }
 
-  private static Thread newThread(Runnable runnable) {
-    Thread thread = new DaemonThreadFactory().newThread(runnable);
-    try {
-      thread.setName(WORKER_THREAD_NAME);
-    } catch (SecurityException e) {
-      // OK if we can't set the name in this environment.
-    }
-    return thread;
-  }
-
   // Worker is a thread that batches multiple spans and calls the registered SpanExporter to export
   // the data.
   //
@@ -269,13 +258,7 @@ public final class BatchSpansProcessor implements SpanProcessor {
     private static final BoundLongCounter droppedSpans;
 
     private final ExecutorService executorService =
-        Executors.newSingleThreadExecutor(
-            new ThreadFactory() {
-              @Override
-              public Thread newThread(Runnable r) {
-                return new Thread(r, EXPORTER_THREAD_NAME);
-              }
-            });
+        Executors.newSingleThreadExecutor(new DaemonThreadFactory(EXPORTER_THREAD_NAME));
 
     private static final Logger logger = Logger.getLogger(Worker.class.getName());
     private final SpanExporter spanExporter;

--- a/sdk_contrib/async_processor/src/main/java/io/opentelemetry/sdk/contrib/trace/export/DisruptorEventQueue.java
+++ b/sdk_contrib/async_processor/src/main/java/io/opentelemetry/sdk/contrib/trace/export/DisruptorEventQueue.java
@@ -249,6 +249,7 @@ final class DisruptorEventQueue {
     @Override
     public Thread newThread(Runnable runnable) {
       Thread thread = MoreExecutors.platformThreadFactory().newThread(runnable);
+      thread.setDaemon(true);
       try {
         thread.setName(threadName);
       } catch (SecurityException e) {

--- a/sdk_contrib/async_processor/src/main/java/io/opentelemetry/sdk/contrib/trace/export/DisruptorEventQueue.java
+++ b/sdk_contrib/async_processor/src/main/java/io/opentelemetry/sdk/contrib/trace/export/DisruptorEventQueue.java
@@ -27,7 +27,6 @@ import io.opentelemetry.sdk.common.DaemonThreadFactory;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
@@ -94,7 +93,7 @@ final class DisruptorEventQueue {
         new Disruptor<>(
             EVENT_FACTORY,
             bufferSize,
-            new ThreadFactoryWithName(WORKER_THREAD_NAME),
+            new DaemonThreadFactory(WORKER_THREAD_NAME),
             ProducerType.MULTI,
             waitStrategy);
     disruptor.handleEventsWith(new DisruptorEventHandler(spanProcessor));
@@ -236,25 +235,6 @@ final class DisruptorEventQueue {
         // Remove the reference to the previous entry to allow the memory to be gc'ed.
         event.setEntry(null, null, null);
       }
-    }
-  }
-
-  private static final class ThreadFactoryWithName implements ThreadFactory {
-    private final String threadName;
-
-    private ThreadFactoryWithName(String threadName) {
-      this.threadName = threadName;
-    }
-
-    @Override
-    public Thread newThread(Runnable runnable) {
-      Thread thread = new DaemonThreadFactory().newThread(runnable);
-      try {
-        thread.setName(threadName);
-      } catch (SecurityException e) {
-        // OK if we can't set the name in this environment.
-      }
-      return thread;
     }
   }
 }

--- a/sdk_contrib/async_processor/src/main/java/io/opentelemetry/sdk/contrib/trace/export/DisruptorEventQueue.java
+++ b/sdk_contrib/async_processor/src/main/java/io/opentelemetry/sdk/contrib/trace/export/DisruptorEventQueue.java
@@ -249,9 +249,9 @@ final class DisruptorEventQueue {
     @Override
     public Thread newThread(Runnable runnable) {
       Thread thread = MoreExecutors.platformThreadFactory().newThread(runnable);
-      thread.setDaemon(true);
       try {
         thread.setName(threadName);
+        thread.setDaemon(true);
       } catch (SecurityException e) {
         // OK if we can't set the name in this environment.
       }

--- a/sdk_contrib/async_processor/src/main/java/io/opentelemetry/sdk/contrib/trace/export/DisruptorEventQueue.java
+++ b/sdk_contrib/async_processor/src/main/java/io/opentelemetry/sdk/contrib/trace/export/DisruptorEventQueue.java
@@ -16,7 +16,6 @@
 
 package io.opentelemetry.sdk.contrib.trace.export;
 
-import com.google.common.util.concurrent.MoreExecutors;
 import com.lmax.disruptor.EventFactory;
 import com.lmax.disruptor.EventHandler;
 import com.lmax.disruptor.EventTranslatorThreeArg;
@@ -24,6 +23,7 @@ import com.lmax.disruptor.RingBuffer;
 import com.lmax.disruptor.WaitStrategy;
 import com.lmax.disruptor.dsl.Disruptor;
 import com.lmax.disruptor.dsl.ProducerType;
+import io.opentelemetry.sdk.common.DaemonThreadFactory;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import java.util.concurrent.CountDownLatch;
@@ -248,10 +248,9 @@ final class DisruptorEventQueue {
 
     @Override
     public Thread newThread(Runnable runnable) {
-      Thread thread = MoreExecutors.platformThreadFactory().newThread(runnable);
+      Thread thread = new DaemonThreadFactory().newThread(runnable);
       try {
         thread.setName(threadName);
-        thread.setDaemon(true);
       } catch (SecurityException e) {
         // OK if we can't set the name in this environment.
       }


### PR DESCRIPTION
Our SDK shouldn't prevent apps/cli tools/etc. from exiting.  Mark all threads/pools as daemon.
Closes #1093