### PR TITLE
Improve propagator performance

### DIFF
--- a/contrib/trace_propagators/src/jmh/java/io/opentelemetry/contrib/trace/propagation/PropagatorContextExtractBenchmark.java
+++ b/contrib/trace_propagators/src/jmh/java/io/opentelemetry/contrib/trace/propagation/PropagatorContextExtractBenchmark.java
@@ -88,20 +88,63 @@ public class PropagatorContextExtractBenchmark {
     private static final List<Map<String, String>> traceHeaders =
         Arrays.asList(
             Collections.singletonMap(
-                JaegerPropagator.TRACE_ID_HEADER,
+                JaegerPropagator.PROPAGATION_HEADER,
                 "905734c59b913b4a905734c59b913b4a:9909983295041501:0:1"),
             Collections.singletonMap(
-                JaegerPropagator.TRACE_ID_HEADER,
+                JaegerPropagator.PROPAGATION_HEADER,
                 "21196a77f299580e21196a77f299580e:993a97ee3691eb26:0:0"),
             Collections.singletonMap(
-                JaegerPropagator.TRACE_ID_HEADER,
+                JaegerPropagator.PROPAGATION_HEADER,
                 "2e7d0ad2390617702e7d0ad239061770:d49582a2de984b86:0:1"),
             Collections.singletonMap(
-                JaegerPropagator.TRACE_ID_HEADER,
+                JaegerPropagator.PROPAGATION_HEADER,
                 "905734c59b913b4a905734c59b913b4a:776ff807b787538a:0:0"),
             Collections.singletonMap(
-                JaegerPropagator.TRACE_ID_HEADER,
+                JaegerPropagator.PROPAGATION_HEADER,
                 "68ec932c33b3f2ee68ec932c33b3f2ee:68ec932c33b3f2ee:0:0"));
+
+    private final JaegerPropagator.Getter<Map<String, String>> getter =
+        new JaegerPropagator.Getter<Map<String, String>>() {
+          @Override
+          public String get(Map<String, String> carrier, String key) {
+            return carrier.get(key);
+          }
+        };
+
+    private final JaegerPropagator jaegerPropagator = new JaegerPropagator();
+
+    @Override
+    protected Context doExtract() {
+      return jaegerPropagator.extract(Context.current(), getCarrier(), getter);
+    }
+
+    @Override
+    protected List<Map<String, String>> getHeaders() {
+      return traceHeaders;
+    }
+  }
+
+  /** Benchmark for extracting context from Jaeger headers which are url encoded. */
+  public static class JaegerUrlEncodedContextExtractBenchmark
+      extends AbstractContextExtractBenchmark {
+
+    private static final List<Map<String, String>> traceHeaders =
+        Arrays.asList(
+            Collections.singletonMap(
+                JaegerPropagator.PROPAGATION_HEADER,
+                "905734c59b913b4a905734c59b913b4a%3A9909983295041501%3A0%3A1"),
+            Collections.singletonMap(
+                JaegerPropagator.PROPAGATION_HEADER,
+                "21196a77f299580e21196a77f299580e%3A993a97ee3691eb26%3A0%3A0"),
+            Collections.singletonMap(
+                JaegerPropagator.PROPAGATION_HEADER,
+                "2e7d0ad2390617702e7d0ad239061770%3Ad49582a2de984b86%3A0%3A1"),
+            Collections.singletonMap(
+                JaegerPropagator.PROPAGATION_HEADER,
+                "905734c59b913b4a905734c59b913b4a%3A776ff807b787538a%3A0%3A0"),
+            Collections.singletonMap(
+                JaegerPropagator.PROPAGATION_HEADER,
+                "68ec932c33b3f2ee68ec932c33b3f2ee%3A68ec932c33b3f2ee%3A0%3A0"));
 
     private final JaegerPropagator.Getter<Map<String, String>> getter =
         new JaegerPropagator.Getter<Map<String, String>>() {

--- a/contrib/trace_propagators/src/main/java/io/opentelemetry/contrib/trace/propagation/B3Propagator.java
+++ b/contrib/trace_propagators/src/main/java/io/opentelemetry/contrib/trace/propagation/B3Propagator.java
@@ -58,6 +58,20 @@ public class B3Propagator implements HttpTextFormat {
   private static final TraceFlags NOT_SAMPLED_FLAGS =
       TraceFlags.builder().setIsSampled(false).build();
 
+  private static final char COMBINED_HEADER_DELIMITER_CHAR = '-';
+  private static final char IS_SAMPLED = '1';
+  private static final char NOT_SAMPLED = '0';
+
+  private static final int TRACE_ID_HEX_SIZE = 2 * TraceId.getSize();
+  private static final int SPAN_ID_HEX_SIZE = 2 * SpanId.getSize();
+  private static final int SAMPLED_FLAG_SIZE = 1;
+  private static final int COMBINED_HEADER_DELIMITER_SIZE = 1;
+
+  private static final int SPAN_ID_OFFSET = TRACE_ID_HEX_SIZE + COMBINED_HEADER_DELIMITER_SIZE;
+  private static final int SAMPLED_FLAG_OFFSET =
+      SPAN_ID_OFFSET + SPAN_ID_HEX_SIZE + COMBINED_HEADER_DELIMITER_SIZE;
+  private static final int COMBINED_HEADER_SIZE = SAMPLED_FLAG_OFFSET + SAMPLED_FLAG_SIZE;
+
   private static final List<String> FIELDS =
       Collections.unmodifiableList(Arrays.asList(TRACE_ID_HEADER, SPAN_ID_HEADER, SAMPLED_HEADER));
 
@@ -81,20 +95,6 @@ public class B3Propagator implements HttpTextFormat {
   public List<String> fields() {
     return FIELDS;
   }
-
-  private static final char COMBINED_HEADER_DELIMITER_CHAR = '-';
-  private static final char IS_SAMPLED = '1';
-  private static final char NOT_SAMPLED = '0';
-
-  private static final int TRACE_ID_HEX_SIZE = 2 * TraceId.getSize();
-  private static final int SPAN_ID_HEX_SIZE = 2 * SpanId.getSize();
-  private static final int SAMPLED_FLAG_SIZE = 1;
-  private static final int COMBINED_HEADER_DELIMITER_SIZE = 1;
-
-  private static final int SPAN_ID_OFFSET = TRACE_ID_HEX_SIZE + COMBINED_HEADER_DELIMITER_SIZE;
-  private static final int SAMPLED_FLAG_OFFSET =
-      SPAN_ID_OFFSET + SPAN_ID_HEX_SIZE + COMBINED_HEADER_DELIMITER_SIZE;
-  private static final int COMBINED_HEADER_SIZE = SAMPLED_FLAG_OFFSET + SAMPLED_FLAG_SIZE;
 
   @Override
   public <C> void inject(Context context, C carrier, Setter<C> setter) {

--- a/contrib/trace_propagators/src/main/java/io/opentelemetry/contrib/trace/propagation/JaegerPropagator.java
+++ b/contrib/trace_propagators/src/main/java/io/opentelemetry/contrib/trace/propagation/JaegerPropagator.java
@@ -47,22 +47,36 @@ public class JaegerPropagator implements HttpTextFormat {
 
   private static final Logger logger = Logger.getLogger(JaegerPropagator.class.getName());
 
-  static final String TRACE_ID_HEADER = "uber-trace-id";
+  static final String PROPAGATION_HEADER = "uber-trace-id";
   // Parent span has been deprecated but Jaeger propagation protocol requires it
-  static final String DEPRECATED_PARENT_SPAN = "0";
-  static final String SEPARATOR = ":";
-
-  private static final String IS_SAMPLED = "1";
-  private static final String NOT_SAMPLED = "0";
+  static final char DEPRECATED_PARENT_SPAN = '0';
+  static final char PROPAGATION_HEADER_DELIMITER = ':';
 
   private static final int MAX_TRACE_ID_LENGTH = 2 * TraceId.getSize();
   private static final int MAX_SPAN_ID_LENGTH = 2 * SpanId.getSize();
   private static final int MAX_FLAGS_LENGTH = 2;
+
+  private static final char IS_SAMPLED = '1';
+  private static final char NOT_SAMPLED = '0';
+  private static final int PROPAGATION_HEADER_DELIMITER_SIZE = 1;
+
+  private static final int TRACE_ID_HEX_SIZE = 2 * TraceId.getSize();
+  private static final int SPAN_ID_HEX_SIZE = 2 * SpanId.getSize();
+  private static final int PARENT_SPAN_ID_SIZE = 1;
+  private static final int SAMPLED_FLAG_SIZE = 1;
+
+  private static final int SPAN_ID_OFFSET = TRACE_ID_HEX_SIZE + PROPAGATION_HEADER_DELIMITER_SIZE;
+  private static final int PARENT_SPAN_ID_OFFSET =
+      SPAN_ID_OFFSET + SPAN_ID_HEX_SIZE + PROPAGATION_HEADER_DELIMITER_SIZE;
+  private static final int SAMPLED_FLAG_OFFSET =
+      PARENT_SPAN_ID_OFFSET + PARENT_SPAN_ID_SIZE + PROPAGATION_HEADER_DELIMITER_SIZE;
+  private static final int PROPAGATION_HEADER_SIZE = SAMPLED_FLAG_OFFSET + SAMPLED_FLAG_SIZE;
+
   private static final TraceFlags SAMPLED_FLAGS = TraceFlags.builder().setIsSampled(true).build();
   private static final TraceFlags NOT_SAMPLED_FLAGS =
       TraceFlags.builder().setIsSampled(false).build();
 
-  private static final List<String> FIELDS = Collections.singletonList(TRACE_ID_HEADER);
+  private static final List<String> FIELDS = Collections.singletonList(PROPAGATION_HEADER);
 
   @Override
   public List<String> fields() {
@@ -80,18 +94,16 @@ public class JaegerPropagator implements HttpTextFormat {
     }
 
     SpanContext spanContext = span.getContext();
-    String sampled = spanContext.getTraceFlags().isSampled() ? IS_SAMPLED : NOT_SAMPLED;
 
-    setter.set(
-        carrier,
-        TRACE_ID_HEADER,
-        spanContext.getTraceId().toLowerBase16()
-            + SEPARATOR
-            + spanContext.getSpanId().toLowerBase16()
-            + SEPARATOR
-            + DEPRECATED_PARENT_SPAN
-            + SEPARATOR
-            + sampled);
+    char[] chars = new char[PROPAGATION_HEADER_SIZE];
+    spanContext.getTraceId().copyLowerBase16To(chars, 0);
+    chars[SPAN_ID_OFFSET - 1] = PROPAGATION_HEADER_DELIMITER;
+    spanContext.getSpanId().copyLowerBase16To(chars, SPAN_ID_OFFSET);
+    chars[PARENT_SPAN_ID_OFFSET - 1] = PROPAGATION_HEADER_DELIMITER;
+    chars[PARENT_SPAN_ID_OFFSET] = DEPRECATED_PARENT_SPAN;
+    chars[SAMPLED_FLAG_OFFSET - 1] = PROPAGATION_HEADER_DELIMITER;
+    chars[SAMPLED_FLAG_OFFSET] = spanContext.getTraceFlags().isSampled() ? IS_SAMPLED : NOT_SAMPLED;
+    setter.set(carrier, PROPAGATION_HEADER, new String(chars));
   }
 
   @Override
@@ -106,30 +118,33 @@ public class JaegerPropagator implements HttpTextFormat {
 
   @SuppressWarnings("StringSplitter")
   private static <C> SpanContext getSpanContextFromHeader(C carrier, Getter<C> getter) {
-    String value = getter.get(carrier, TRACE_ID_HEADER);
+    String value = getter.get(carrier, PROPAGATION_HEADER);
     if (StringUtils.isNullOrEmpty(value)) {
       return SpanContext.getInvalid();
     }
 
-    try {
-      // the propagation value may contain UTF-8 encoded SEPARATOR's (:), so we need to decode it
-      // before attempting to split it.
-      value = URLDecoder.decode(value, "UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      logger.info(
-          "Error decoding '"
-              + TRACE_ID_HEADER
-              + "' with value "
-              + value
-              + ". Returning INVALID span context.");
-      return SpanContext.getInvalid();
+    // if the delimiter (:) cannot be found then the propagation value could be UTF-8
+    // encoded, so we need to decode it before attempting to split it.
+    if (value.lastIndexOf(PROPAGATION_HEADER_DELIMITER) == -1) {
+      try {
+        // the propagation value
+        value = URLDecoder.decode(value, "UTF-8");
+      } catch (UnsupportedEncodingException e) {
+        logger.info(
+            "Error decoding '"
+                + PROPAGATION_HEADER
+                + "' with value "
+                + value
+                + ". Returning INVALID span context.");
+        return SpanContext.getInvalid();
+      }
     }
 
-    String[] parts = value.split(SEPARATOR);
+    String[] parts = value.split(String.valueOf(PROPAGATION_HEADER_DELIMITER));
     if (parts.length != 4) {
       logger.info(
           "Invalid header '"
-              + TRACE_ID_HEADER
+              + PROPAGATION_HEADER
               + "' with value "
               + value
               + ". Returning INVALID span context.");
@@ -140,7 +155,7 @@ public class JaegerPropagator implements HttpTextFormat {
     if (!isTraceIdValid(traceId)) {
       logger.info(
           "Invalid TraceId in Jaeger header: '"
-              + TRACE_ID_HEADER
+              + PROPAGATION_HEADER
               + "' with traceId "
               + traceId
               + ". Returning INVALID span context.");
@@ -151,7 +166,7 @@ public class JaegerPropagator implements HttpTextFormat {
     if (!isSpanIdValid(spanId)) {
       logger.info(
           "Invalid SpanId in Jaeger header: '"
-              + TRACE_ID_HEADER
+              + PROPAGATION_HEADER
               + "'. Returning INVALID span context.");
       return SpanContext.getInvalid();
     }
@@ -160,7 +175,7 @@ public class JaegerPropagator implements HttpTextFormat {
     if (!isFlagsValid(flags)) {
       logger.info(
           "Invalid Flags in Jaeger header: '"
-              + TRACE_ID_HEADER
+              + PROPAGATION_HEADER
               + "'. Returning INVALID span context.");
       return SpanContext.getInvalid();
     }
@@ -181,7 +196,7 @@ public class JaegerPropagator implements HttpTextFormat {
     } catch (Exception e) {
       logger.log(
           Level.INFO,
-          "Error parsing '" + TRACE_ID_HEADER + "' header. Returning INVALID span context.",
+          "Error parsing '" + PROPAGATION_HEADER + "' header. Returning INVALID span context.",
           e);
       return SpanContext.getInvalid();
     }

--- a/contrib/trace_propagators/src/main/java/io/opentelemetry/contrib/trace/propagation/JaegerPropagator.java
+++ b/contrib/trace_propagators/src/main/java/io/opentelemetry/contrib/trace/propagation/JaegerPropagator.java
@@ -123,7 +123,7 @@ public class JaegerPropagator implements HttpTextFormat {
       return SpanContext.getInvalid();
     }
 
-    // if the delimiter (:) cannot be found then the propagation value could be UTF-8
+    // if the delimiter (:) cannot be found then the propagation value could be URL
     // encoded, so we need to decode it before attempting to split it.
     if (value.lastIndexOf(PROPAGATION_HEADER_DELIMITER) == -1) {
       try {


### PR DESCRIPTION
Now we've got benchmarks for the propagators, there looks like there's a few quick wins to optimise these.

B3 propagator: single header - when injecting context, values are written directly to char[] instead of string concatenation (similar to ```HttpTraceContext.inject```)

Jaeger propagator - when injecting context, values are written directly to char[] (as above)

Jaeger propagator - when extracting context, only do URL decoding if the delimiter cannot be found in the value.

I've also added extra benchmark to measure this, and a unit test, with some minor refactoring.

(compare these with screenshots in #1122)
Extract benchmarks:
![Screenshot from 2020-04-21 10-51-02](https://user-images.githubusercontent.com/23311805/79853943-9a113580-83c0-11ea-9abf-eff4a8331c2a.png)

Inject benchmarks:
![Screenshot from 2020-04-21 10-53-58](https://user-images.githubusercontent.com/23311805/79854009-b1502300-83c0-11ea-9a8c-0caeaec8c242.png)
