### PR TITLE
Contrib packages should not use "internal" API package

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -33,6 +33,7 @@ for (subproject in rootProject.subprojects) {
 
 dependencies {
     compile subprojects
+    testCompile libraries.archunit
 }
 
 task jacocoMerge(type: JacocoMerge) {

--- a/all/src/test/java/io/opentelemetry/InternalApiProtectionTest.java
+++ b/all/src/test/java/io/opentelemetry/InternalApiProtectionTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.syntax.elements.ClassesShouldConjunction;
+import org.junit.Test;
+
+public class InternalApiProtectionTest {
+
+  private static final String OTEL_BASE_PACKAGE = "io.opentelemetry";
+  private static final JavaClasses ALL_OTEL_CLASSES =
+      new ClassFileImporter().importPackages(OTEL_BASE_PACKAGE);
+
+  @Test
+  public void contrib_should_not_use_internal_api() {
+    ClassesShouldConjunction contribRule =
+        noClasses()
+            .that()
+            .resideInAPackage("..contrib..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage(OTEL_BASE_PACKAGE + ".internal");
+
+    contribRule.check(ALL_OTEL_CLASSES);
+  }
+}

--- a/api/src/main/java/io/opentelemetry/internal/StringUtils.java
+++ b/api/src/main/java/io/opentelemetry/internal/StringUtils.java
@@ -43,10 +43,6 @@ public final class StringUtils {
     return ch >= ' ' && ch <= '~';
   }
 
-  public static boolean isNullOrEmpty(String value) {
-    return value == null || value.length() == 0;
-  }
-
   /**
    * Determines whether the metric name contains a valid metric name.
    *
@@ -59,24 +55,6 @@ public final class StringUtils {
     }
     String pattern = "[aA-zZ][aA-zZ0-9_\\-.]*";
     return metricName.matches(pattern);
-  }
-
-  /**
-   * Pads a given string on the left with leading 0's up the length.
-   *
-   * @param value the string to pad
-   * @param length the number if characters to pad up to
-   * @return the padded string
-   */
-  public static String padLeft(String value, int length) {
-    if (value == null || length <= 0) {
-      throw new IllegalArgumentException();
-    }
-
-    if (value.length() >= length) {
-      return value;
-    }
-    return String.format("%1$" + length + "s", value).replace(' ', '0');
   }
 
   private StringUtils() {}

--- a/api/src/test/java/io/opentelemetry/internal/StringUtilsTest.java
+++ b/api/src/test/java/io/opentelemetry/internal/StringUtilsTest.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.internal;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,50 +30,5 @@ public final class StringUtilsTest {
   public void isPrintableString() {
     assertThat(StringUtils.isPrintableString("abcd")).isTrue();
     assertThat(StringUtils.isPrintableString("\2ab\3cd")).isFalse();
-  }
-
-  @Test
-  public void isNullOrEmpty() throws Exception {
-    assertThat(StringUtils.isNullOrEmpty("")).isTrue();
-    assertThat(StringUtils.isNullOrEmpty(null)).isTrue();
-    assertThat(StringUtils.isNullOrEmpty("hello")).isFalse();
-    assertThat(StringUtils.isNullOrEmpty(" ")).isFalse();
-  }
-
-  @Test
-  public void padLeft() {
-    assertEquals(StringUtils.padLeft("value", 10), "00000value");
-  }
-
-  @Test
-  public void padLeft_throws_for_null_value() {
-    try {
-      StringUtils.padLeft(null, 10);
-    } catch (Throwable e) {
-      assertThat(e).isInstanceOf(IllegalArgumentException.class);
-    }
-  }
-
-  @Test
-  public void padLeft_throws_for_negative_length() {
-    try {
-      StringUtils.padLeft("value", -10);
-    } catch (Throwable e) {
-      assertThat(e).isInstanceOf(IllegalArgumentException.class);
-    }
-  }
-
-  @Test
-  public void padLeft_throws_for_zero_length() {
-    try {
-      StringUtils.padLeft("value", 0);
-    } catch (Throwable e) {
-      assertThat(e).isInstanceOf(IllegalArgumentException.class);
-    }
-  }
-
-  @Test
-  public void padLeft_length_does_not_exceed_length() {
-    assertEquals(StringUtils.padLeft("value", 3), "value");
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -130,7 +130,8 @@ subprojects {
                 awaitility           : 'org.awaitility:awaitility:3.0.0', // Compatibility layer
                 testcontainers       : 'org.testcontainers:testcontainers:1.13.0',
                 rest_assured         : 'io.rest-assured:rest-assured:4.2.0',
-                jaeger_client        : 'io.jaegertracing:jaeger-client:1.2.0' // Jaeger Client
+                jaeger_client        : 'io.jaegertracing:jaeger-client:1.2.0', // Jaeger Client
+                archunit             : 'com.tngtech.archunit:archunit-junit4:0.13.1' //Architectural constraints
         ]
     }
 

--- a/contrib/trace_propagators/build.gradle
+++ b/contrib/trace_propagators/build.gradle
@@ -12,6 +12,8 @@ ext.moduleName = "io.opentelemetry.contrib.trace.propagation"
 dependencies {
     api project(':opentelemetry-api')
 
+    implementation libraries.guava
+
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
 }

--- a/contrib/trace_propagators/src/main/java/io/opentelemetry/contrib/trace/propagation/B3Propagator.java
+++ b/contrib/trace_propagators/src/main/java/io/opentelemetry/contrib/trace/propagation/B3Propagator.java
@@ -16,11 +16,11 @@
 
 package io.opentelemetry.contrib.trace.propagation;
 
-import static io.opentelemetry.internal.Utils.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
+import com.google.common.base.Strings;
 import io.grpc.Context;
 import io.opentelemetry.context.propagation.HttpTextFormat;
-import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
@@ -84,8 +84,8 @@ public class B3Propagator implements HttpTextFormat {
 
   @Override
   public <C> void inject(Context context, C carrier, Setter<C> setter) {
-    checkNotNull(context, "context");
-    checkNotNull(setter, "setter");
+    requireNonNull(context, "context");
+    requireNonNull(setter, "setter");
 
     Span span = TracingContextUtils.getSpanWithoutDefault(context);
     if (span == null) {
@@ -113,8 +113,8 @@ public class B3Propagator implements HttpTextFormat {
 
   @Override
   public <C> Context extract(Context context, C carrier, Getter<C> getter) {
-    checkNotNull(carrier, "carrier");
-    checkNotNull(getter, "getter");
+    requireNonNull(carrier, "carrier");
+    requireNonNull(getter, "getter");
 
     SpanContext spanContext = null;
 
@@ -130,7 +130,7 @@ public class B3Propagator implements HttpTextFormat {
   @SuppressWarnings("StringSplitter")
   private static <C> SpanContext getSpanContextFromSingleHeader(C carrier, Getter<C> getter) {
     String value = getter.get(carrier, COMBINED_HEADER);
-    if (StringUtils.isNullOrEmpty(value)) {
+    if (Strings.isNullOrEmpty(value)) {
       logger.info(
           "Missing or empty combined header: "
               + COMBINED_HEADER
@@ -196,7 +196,7 @@ public class B3Propagator implements HttpTextFormat {
               : NOT_SAMPLED_FLAGS;
 
       return SpanContext.createFromRemoteParent(
-          TraceId.fromLowerBase16(StringUtils.padLeft(traceId, MAX_TRACE_ID_LENGTH), 0),
+          TraceId.fromLowerBase16(Strings.padStart(traceId, MAX_TRACE_ID_LENGTH, '0'), 0),
           SpanId.fromLowerBase16(spanId, 0),
           traceFlags,
           TraceState.getDefault());
@@ -207,10 +207,10 @@ public class B3Propagator implements HttpTextFormat {
   }
 
   private static boolean isTraceIdValid(String value) {
-    return !(StringUtils.isNullOrEmpty(value) || value.length() > MAX_TRACE_ID_LENGTH);
+    return !(Strings.isNullOrEmpty(value) || value.length() > MAX_TRACE_ID_LENGTH);
   }
 
   private static boolean isSpanIdValid(String value) {
-    return !(StringUtils.isNullOrEmpty(value) || value.length() > MAX_SPAN_ID_LENGTH);
+    return !(Strings.isNullOrEmpty(value) || value.length() > MAX_SPAN_ID_LENGTH);
   }
 }

--- a/contrib/trace_propagators/src/main/java/io/opentelemetry/contrib/trace/propagation/JaegerPropagator.java
+++ b/contrib/trace_propagators/src/main/java/io/opentelemetry/contrib/trace/propagation/JaegerPropagator.java
@@ -16,11 +16,11 @@
 
 package io.opentelemetry.contrib.trace.propagation;
 
-import static io.opentelemetry.internal.Utils.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
+import com.google.common.base.Strings;
 import io.grpc.Context;
 import io.opentelemetry.context.propagation.HttpTextFormat;
-import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
@@ -71,8 +71,8 @@ public class JaegerPropagator implements HttpTextFormat {
 
   @Override
   public <C> void inject(Context context, C carrier, Setter<C> setter) {
-    checkNotNull(context, "context");
-    checkNotNull(setter, "setter");
+    requireNonNull(context, "context");
+    requireNonNull(setter, "setter");
 
     Span span = TracingContextUtils.getSpanWithoutDefault(context);
     if (span == null) {
@@ -96,8 +96,8 @@ public class JaegerPropagator implements HttpTextFormat {
 
   @Override
   public <C> Context extract(Context context, C carrier, Getter<C> getter) {
-    checkNotNull(carrier, "carrier");
-    checkNotNull(getter, "getter");
+    requireNonNull(carrier, "carrier");
+    requireNonNull(getter, "getter");
 
     SpanContext spanContext = getSpanContextFromHeader(carrier, getter);
 
@@ -107,7 +107,7 @@ public class JaegerPropagator implements HttpTextFormat {
   @SuppressWarnings("StringSplitter")
   private static <C> SpanContext getSpanContextFromHeader(C carrier, Getter<C> getter) {
     String value = getter.get(carrier, TRACE_ID_HEADER);
-    if (StringUtils.isNullOrEmpty(value)) {
+    if (Strings.isNullOrEmpty(value)) {
       return SpanContext.getInvalid();
     }
 
@@ -174,8 +174,8 @@ public class JaegerPropagator implements HttpTextFormat {
       TraceFlags traceFlags = ((flagsInt & 1) == 1) ? SAMPLED_FLAGS : NOT_SAMPLED_FLAGS;
 
       return SpanContext.createFromRemoteParent(
-          TraceId.fromLowerBase16(StringUtils.padLeft(traceId, MAX_TRACE_ID_LENGTH), 0),
-          SpanId.fromLowerBase16(StringUtils.padLeft(spanId, MAX_SPAN_ID_LENGTH), 0),
+          TraceId.fromLowerBase16(Strings.padStart(traceId, MAX_TRACE_ID_LENGTH, '0'), 0),
+          SpanId.fromLowerBase16(Strings.padStart(spanId, MAX_SPAN_ID_LENGTH, '0'), 0),
           traceFlags,
           TraceState.getDefault());
     } catch (Exception e) {
@@ -188,14 +188,14 @@ public class JaegerPropagator implements HttpTextFormat {
   }
 
   private static boolean isTraceIdValid(String value) {
-    return !(StringUtils.isNullOrEmpty(value) || value.length() > MAX_TRACE_ID_LENGTH);
+    return !(Strings.isNullOrEmpty(value) || value.length() > MAX_TRACE_ID_LENGTH);
   }
 
   private static boolean isSpanIdValid(String value) {
-    return !(StringUtils.isNullOrEmpty(value) || value.length() > MAX_SPAN_ID_LENGTH);
+    return !(Strings.isNullOrEmpty(value) || value.length() > MAX_SPAN_ID_LENGTH);
   }
 
   private static boolean isFlagsValid(String value) {
-    return !(StringUtils.isNullOrEmpty(value) || value.length() > MAX_FLAGS_LENGTH);
+    return !(Strings.isNullOrEmpty(value) || value.length() > MAX_FLAGS_LENGTH);
   }
 }

--- a/contrib/trace_propagators/src/test/java/io/opentelemetry/contrib/trace/propagation/B3PropagatorTest.java
+++ b/contrib/trace_propagators/src/test/java/io/opentelemetry/contrib/trace/propagation/B3PropagatorTest.java
@@ -18,10 +18,10 @@ package io.opentelemetry.contrib.trace.propagation;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.base.Strings;
 import io.grpc.Context;
 import io.opentelemetry.context.propagation.HttpTextFormat.Getter;
 import io.opentelemetry.context.propagation.HttpTextFormat.Setter;
-import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
@@ -48,7 +48,7 @@ public class B3PropagatorTest {
   private static final TraceId TRACE_ID = TraceId.fromLowerBase16(TRACE_ID_BASE16, 0);
   private static final String SHORT_TRACE_ID_BASE16 = "ff00000000000000";
   private static final TraceId SHORT_TRACE_ID =
-      TraceId.fromLowerBase16(StringUtils.padLeft(SHORT_TRACE_ID_BASE16, 32), 0);
+      TraceId.fromLowerBase16(Strings.padStart(SHORT_TRACE_ID_BASE16, 32, '0'), 0);
   private static final String SPAN_ID_BASE16 = "ff00000000000041";
   private static final SpanId SPAN_ID = SpanId.fromLowerBase16(SPAN_ID_BASE16, 0);
   private static final byte SAMPLED_TRACE_OPTIONS_BYTES = 1;


### PR DESCRIPTION
Fixes #1125.

This PR adds `InternalApiProtectionTest` which uses [ArchUnit](https://www.archunit.org) to enforce architectural constraints.
The test only verifies that classes in `contrib` packages do not use classes in `internal` package of API module.

Test was added into `opentelemetry-all` module because the latter depends on all other submodules
and therefore sees all classes in the project.

All found violations were fixed