### PR TITLE
quickstart: update link to "Obtaining a Tracer"

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -380,5 +380,5 @@ tracerProvider.addSpanProcessor(BatchSpansProcessor.newBuilder(
 [OpenTelemetry Collector]: https://github.com/open-telemetry/opentelemetry-collector
 [OpenTelemetry Registry]: https://opentelemetry.io/registry/?s=exporter
 [OpenTelemetry Website]: https://opentelemetry.io/
-[Obtaining a Tracer]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/api-tracing.md#obtaining-a-tracer
+[Obtaining a Tracer]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#obtaining-a-tracer
 [Semantic Conventions]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md


### PR DESCRIPTION
the current link is a 404