### PR TITLE
Add error tag to spans for Jaeger exporter

### DIFF
--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/Adapter.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/Adapter.java
@@ -37,6 +37,7 @@ import javax.annotation.concurrent.ThreadSafe;
 /** Adapts OpenTelemetry objects to Jaeger objects. */
 @ThreadSafe
 final class Adapter {
+  static final String KEY_ERROR = "error";
   static final String KEY_LOG_MESSAGE = "message";
   static final String KEY_SPAN_KIND = "span.kind";
   static final String KEY_SPAN_STATUS_MESSAGE = "span.status.message";
@@ -110,6 +111,10 @@ final class Adapter {
             .setVInt64(span.getStatus().getCanonicalCode().value())
             .setVType(Model.ValueType.INT64)
             .build());
+
+    if (!span.getStatus().isOk() && !span.getAttributes().containsKey(KEY_ERROR)) {
+      target.addTags(toKeyValue(KEY_ERROR, AttributeValue.booleanAttributeValue(true)));
+    }
 
     return target.build();
   }

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/Adapter.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/Adapter.java
@@ -112,7 +112,7 @@ final class Adapter {
             .setVType(Model.ValueType.INT64)
             .build());
 
-    if (!span.getStatus().isOk() && !span.getAttributes().containsKey(KEY_ERROR)) {
+    if (!span.getStatus().isOk()) {
       target.addTags(toKeyValue(KEY_ERROR, AttributeValue.booleanAttributeValue(true)));
     }
 


### PR DESCRIPTION
The auto-instrumentation libraries add errors to the spans when they occur. The `error` tag is not added to the spans by the Jaeger exporter if the span status code is not `OK`.
When sending these spans to the OpenTelemetry Collector it will automatically add the `error` tag when it translates them, based on the status code, and sends them to the Jaeger collector.
This process does not take place when sending spans directly to a Jaeger collector (not using the OTel collector) and so the Jaeger UI does not display visual indicators for spans with errors.
By adding the `error` tag in the Adapter class if the span.status.code is not `OK`, if this tag hasn't already been added, means that it will be present when using either the OTel collector
or the Jaeger collector directly. The Otel collector will remove this tag automatically when it receives the span and sets the status code so this will not be sent as a duplicate.

Fixes #1139