### PR TITLE
Prevent casting to TraceProviderSdk

### DIFF
--- a/api/src/main/java/io/opentelemetry/OpenTelemetry.java
+++ b/api/src/main/java/io/opentelemetry/OpenTelemetry.java
@@ -190,7 +190,12 @@ public final class OpenTelemetry {
     instance = null;
   }
 
-  /** @see Obfuscated */
+  /**
+   * A {@link TracerProvider} wrapper that forces users to access the SDK specific implementation
+   * via the SDK, instead of via the API and casting it to the SDK specific implementation.
+   *
+   * @see Obfuscated
+   */
   @ThreadSafe
   private static class ObfuscatedTracerProvider implements TracerProvider, Obfuscated {
 

--- a/api/src/main/java/io/opentelemetry/OpenTelemetry.java
+++ b/api/src/main/java/io/opentelemetry/OpenTelemetry.java
@@ -22,6 +22,7 @@ import io.opentelemetry.correlationcontext.CorrelationContextManager;
 import io.opentelemetry.correlationcontext.DefaultCorrelationContextManager;
 import io.opentelemetry.correlationcontext.DefaultCorrelationContextManagerProvider;
 import io.opentelemetry.correlationcontext.spi.CorrelationContextManagerProvider;
+import io.opentelemetry.internal.Obfuscated;
 import io.opentelemetry.internal.Utils;
 import io.opentelemetry.metrics.DefaultMeterProvider;
 import io.opentelemetry.metrics.DefaultMetricsProvider;
@@ -143,7 +144,7 @@ public final class OpenTelemetry {
     TraceProvider traceProvider = loadSpi(TraceProvider.class);
     this.tracerProvider =
         traceProvider != null
-            ? traceProvider.create()
+            ? new ObfuscatedTracerProvider(traceProvider.create())
             : DefaultTraceProvider.getInstance().create();
 
     MetricsProvider metricsProvider = loadSpi(MetricsProvider.class);
@@ -187,5 +188,31 @@ public final class OpenTelemetry {
   // for testing
   static void reset() {
     instance = null;
+  }
+
+  /** @see Obfuscated */
+  @ThreadSafe
+  private static class ObfuscatedTracerProvider implements TracerProvider, Obfuscated {
+
+    private final TracerProvider delegate;
+
+    private ObfuscatedTracerProvider(TracerProvider delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public Tracer get(String instrumentationName) {
+      return delegate.get(instrumentationName);
+    }
+
+    @Override
+    public Tracer get(String instrumentationName, String instrumentationVersion) {
+      return delegate.get(instrumentationName, instrumentationVersion);
+    }
+
+    @Override
+    public TracerProvider unobfuscate() {
+      return delegate;
+    }
   }
 }

--- a/api/src/main/java/io/opentelemetry/OpenTelemetry.java
+++ b/api/src/main/java/io/opentelemetry/OpenTelemetry.java
@@ -197,7 +197,8 @@ public final class OpenTelemetry {
    * @see Obfuscated
    */
   @ThreadSafe
-  private static class ObfuscatedTracerProvider implements TracerProvider, Obfuscated {
+  private static class ObfuscatedTracerProvider
+      implements TracerProvider, Obfuscated<TracerProvider> {
 
     private final TracerProvider delegate;
 

--- a/api/src/main/java/io/opentelemetry/internal/Obfuscated.java
+++ b/api/src/main/java/io/opentelemetry/internal/Obfuscated.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.internal;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * This interface allows the SDK to unobfuscate an obfuscated static global provider.
+ *
+ * <p>Static global providers are obfuscated when they are returned from the API to prevent users
+ * from casting them to their SDK specific implementation.
+ *
+ * <p>This is important for auto-instrumentation, because if users take the static global providers
+ * that are returned from the API, and cast them to their SDK specific implementations, then those
+ * casts will fail under auto-instrumentation, because auto-instrumentation takes over the static
+ * global providers returned by the API and points them to it's embedded SDK.
+ *
+ * @since 0.4.0
+ */
+@ThreadSafe
+public interface Obfuscated {
+
+  /**
+   * Returns the unobfuscated provider.
+   *
+   * @return the unobfuscated provider.
+   * @since 0.4.0
+   */
+  Object unobfuscate();
+}

--- a/api/src/main/java/io/opentelemetry/internal/Obfuscated.java
+++ b/api/src/main/java/io/opentelemetry/internal/Obfuscated.java
@@ -32,7 +32,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * @since 0.4.0
  */
 @ThreadSafe
-public interface Obfuscated {
+public interface Obfuscated<T> {
 
   /**
    * Returns the unobfuscated provider.
@@ -40,5 +40,5 @@ public interface Obfuscated {
    * @return the unobfuscated provider.
    * @since 0.4.0
    */
-  Object unobfuscate();
+  T unobfuscate();
 }

--- a/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
+++ b/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
@@ -95,8 +95,8 @@ public class OpenTelemetryTest {
         createService(TraceProvider.class, FirstTraceProvider.class, SecondTraceProvider.class);
     try {
       assertTrue(
-          (OpenTelemetry.getTracerProvider() instanceof FirstTraceProvider)
-              || (OpenTelemetry.getTracerProvider() instanceof SecondTraceProvider));
+          (OpenTelemetry.getTracerProvider().get("") instanceof FirstTraceProvider)
+              || (OpenTelemetry.getTracerProvider().get("") instanceof SecondTraceProvider));
     } finally {
       serviceFile.delete();
     }
@@ -108,7 +108,7 @@ public class OpenTelemetryTest {
         createService(TraceProvider.class, FirstTraceProvider.class, SecondTraceProvider.class);
     System.setProperty(TraceProvider.class.getName(), SecondTraceProvider.class.getName());
     try {
-      assertThat(OpenTelemetry.getTracerProvider()).isInstanceOf(SecondTraceProvider.class);
+      assertThat(OpenTelemetry.getTracerProvider().get("")).isInstanceOf(SecondTraceProvider.class);
     } finally {
       serviceFile.delete();
     }

--- a/sdk/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -17,6 +17,7 @@
 package io.opentelemetry.sdk;
 
 import io.opentelemetry.OpenTelemetry;
+import io.opentelemetry.internal.Obfuscated;
 import io.opentelemetry.sdk.correlationcontext.CorrelationContextManagerSdk;
 import io.opentelemetry.sdk.metrics.MeterSdkProvider;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
@@ -40,7 +41,7 @@ public final class OpenTelemetrySdk {
    * @since 0.1.0
    */
   public static TracerSdkProvider getTracerProvider() {
-    return (TracerSdkProvider) OpenTelemetry.getTracerProvider();
+    return (TracerSdkProvider) ((Obfuscated) OpenTelemetry.getTracerProvider()).unobfuscate();
   }
 
   /**

--- a/sdk/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -41,7 +41,7 @@ public final class OpenTelemetrySdk {
    * @since 0.1.0
    */
   public static TracerSdkProvider getTracerProvider() {
-    return (TracerSdkProvider) ((Obfuscated) OpenTelemetry.getTracerProvider()).unobfuscate();
+    return (TracerSdkProvider) ((Obfuscated<?>) OpenTelemetry.getTracerProvider()).unobfuscate();
   }
 
   /**

--- a/sdk/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -28,8 +28,8 @@ public class OpenTelemetrySdkTest {
 
   @Test
   public void testDefault() {
-    assertThat(OpenTelemetrySdk.getTracerProvider())
-        .isSameInstanceAs(OpenTelemetry.getTracerProvider());
+    assertThat(OpenTelemetrySdk.getTracerProvider().get(""))
+        .isSameInstanceAs(OpenTelemetry.getTracerProvider().get(""));
     assertThat(OpenTelemetrySdk.getCorrelationContextManager())
         .isSameInstanceAs(OpenTelemetry.getCorrelationContextManager());
     assertThat(OpenTelemetrySdk.getMeterProvider())

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/spi/TraceProviderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/spi/TraceProviderSdkTest.java
@@ -19,7 +19,7 @@ package io.opentelemetry.sdk.trace.spi;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.sdk.trace.TracerSdk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -30,6 +30,6 @@ public class TraceProviderSdkTest {
 
   @Test
   public void testDefault() {
-    assertThat(OpenTelemetry.getTracerProvider()).isInstanceOf(TracerSdkProvider.class);
+    assertThat(OpenTelemetry.getTracerProvider().get("")).isInstanceOf(TracerSdk.class);
   }
 }


### PR DESCRIPTION
**Problem statement:**

If users take the static global providers that are returned from the API, and cast them to their SDK specific implementations, then those casts will fail under auto-instrumentation, because auto-instrumentation takes over the static global providers returned by the API and points them to it's embedded SDK.

**Proposal:**

Prevent users from doing this to get SDK-specific implementation, so that auto-instrumentation does not cause them ClassCastException unexpectedly.

The preferably way to get the SDK-specific implementation is through `OpenTelemetrySdk` anyways.

**Implementation:**

Wrap (obfuscate) the static global providers that are returned from the API to prevent users from casting them to their SDK specific implementation.

Unfortunately, `OpenTelemetrySdk` needs to access the `TracerSdkProvider` _somehow_, and with this change it can no longer perform the cast either, so there's a semi-obscured `unobfuscate()` method that the SDK can use to get access to the underlying `TracerSdkProvider`. If anyone has other ideas for how to hide this from users, but allow it from the SDK let me know!

**Terminology choice:**

An alternative naming scheme could be:

* `ObfuscatedTracerProvider` --> `WrappedTracerProvider`
* `Obfuscated` --> `Wrapped`
* `unobfuscate()` --> `unwrap()`

But I wanted to it be really clear to end users that this is not something they should do, and casting to something called `Wrapped` and calling `unwrap()` sounds much more likely for someone to do compared to casting to something called `Obfuscated` and calling `unobfuscate()`.

**Note:**

This PR only covers `TracerProvider`, but if/when there's agreement on this, we can extend to `MeterProvider` and `CorrelationContextManager`.