### PR TITLE
Make TracerSdk non-public

### DIFF
--- a/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureSpanProcessorExample.java
+++ b/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureSpanProcessorExample.java
@@ -20,10 +20,10 @@ import io.opentelemetry.exporters.logging.LoggingSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.MultiSpanProcessor;
 import io.opentelemetry.sdk.trace.SpanProcessor;
-import io.opentelemetry.sdk.trace.TracerSdk;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpansProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
+import io.opentelemetry.trace.Tracer;
 import java.util.Arrays;
 
 /** This example shows how to instantiate different Span Processors. */
@@ -34,7 +34,7 @@ public class ConfigureSpanProcessorExample {
   // Get the Tracer Provider
   static TracerSdkProvider tracerProvider = OpenTelemetrySdk.getTracerProvider();
   // Acquire a tracer
-  static TracerSdk tracer = tracerProvider.get("ConfigureSpanProcessorExample");
+  static Tracer tracer = tracerProvider.get("ConfigureSpanProcessorExample");
 
   public static void main(String[] args) throws Exception {
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfo.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfo.java
@@ -17,14 +17,14 @@
 package io.opentelemetry.sdk.common;
 
 import com.google.auto.value.AutoValue;
-import io.opentelemetry.sdk.trace.TracerSdk;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.trace.Tracer;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
  * Holds information about the instrumentation library specified when creating an instance of {@link
- * TracerSdk} using {@link TracerSdkProvider}.
+ * Tracer} using {@link TracerSdkProvider}.
  */
 @AutoValue
 @Immutable

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
@@ -24,7 +24,7 @@ import io.opentelemetry.trace.Tracer;
 import io.opentelemetry.trace.TracingContextUtils;
 
 /** {@link TracerSdk} is SDK implementation of {@link Tracer}. */
-public final class TracerSdk implements Tracer {
+final class TracerSdk implements Tracer {
   private final TracerSharedState sharedState;
   private final InstrumentationLibraryInfo instrumentationLibraryInfo;
 


### PR DESCRIPTION
It doesn't seem necessary for it to be public, and this will help make sure nobody does:

```
TracerSdk tracer = (TracerSdk) OpenTelemetry.getTracerProvider().get("...");
```

which will break under auto-instrumentation's TracerProvider substitution.