### PR TITLE
Move the MultiSpanProcessor into the export package, with its friends.

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSharedState.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSharedState.java
@@ -19,6 +19,7 @@ package io.opentelemetry.sdk.trace;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
+import io.opentelemetry.sdk.trace.export.MultiSpanProcessor;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.concurrent.GuardedBy;

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/MultiSpanProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/MultiSpanProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.sdk.trace;
+package io.opentelemetry.sdk.trace.export;
 
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SpanProcessor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/MultiSpanProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/MultiSpanProcessorTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
+import io.opentelemetry.sdk.trace.export.MultiSpanProcessor;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Before;

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/MultiSpanProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/MultiSpanProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.sdk.trace;
+package io.opentelemetry.sdk.trace.export;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -24,7 +24,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-import io.opentelemetry.sdk.trace.export.MultiSpanProcessor;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SpanProcessor;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Before;

--- a/sdk_contrib/async_processor/src/test/java/io/opentelemetry/sdk/contrib/trace/export/DisruptorAsyncSpanProcessorTest.java
+++ b/sdk_contrib/async_processor/src/test/java/io/opentelemetry/sdk/contrib/trace/export/DisruptorAsyncSpanProcessorTest.java
@@ -18,9 +18,9 @@ package io.opentelemetry.sdk.contrib.trace.export;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import io.opentelemetry.sdk.trace.MultiSpanProcessor;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.sdk.trace.export.MultiSpanProcessor;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Before;


### PR DESCRIPTION
Not sure how it ended up a level higher; it was even referenced in the export package-info file.