### PR TITLE
Ignore parent span id when invalid in OTLP exporter

### DIFF
--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/SpanAdapter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/SpanAdapter.java
@@ -88,7 +88,9 @@ final class SpanAdapter {
     builder.setTraceId(TraceProtoUtils.toProtoTraceId(spanData.getTraceId()));
     builder.setSpanId(TraceProtoUtils.toProtoSpanId(spanData.getSpanId()));
     // TODO: Set TraceState;
-    builder.setParentSpanId(TraceProtoUtils.toProtoSpanId(spanData.getParentSpanId()));
+    if (spanData.getParentSpanId().isValid()) {
+      builder.setParentSpanId(TraceProtoUtils.toProtoSpanId(spanData.getParentSpanId()));
+    }
     builder.setName(spanData.getName());
     builder.setKind(toProtoSpanKind(spanData.getKind()));
     builder.setStartTimeUnixNano(spanData.getStartEpochNanos());

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
@@ -81,7 +81,7 @@ public class SpanAdapterTest {
 
     assertThat(span.getTraceId().toByteArray()).isEqualTo(TRACE_ID_BYTES);
     assertThat(span.getSpanId().toByteArray()).isEqualTo(SPAN_ID_BYTES);
-    assertThat(span.getParentSpanId().toByteArray()).isEqualTo(new byte[] {0, 0, 0, 0, 0, 0, 0, 0});
+    assertThat(span.getParentSpanId().toByteArray()).isEqualTo(new byte[] {});
     assertThat(span.getName()).isEqualTo("GET /api/endpoint");
     assertThat(span.getKind()).isEqualTo(SpanKind.SERVER);
     assertThat(span.getStartTimeUnixNano()).isEqualTo(12345);


### PR DESCRIPTION
Setting the parent span id on a span if it is invalid causes errors in the OpenTelemetry Collector.
The parent span should not be set on a span when it is exported if the span id is invalid.

Fixes #1164