### PR TITLE
Add template for bug reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: Bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Steps to reproduce**
+If possible, provide a recipe for reproducing the error.
+
+**What did you expect to see?**
+A clear and concise description of what you expected to see.
+
+**What did you see instead?**
+A clear and concise description of what you saw instead.
+
+**What version and what artifacts are you using?**
+Version: (e.g., `v0.4.0`, `1eb551b`, etc)
+Artifacts: (e.g., `api`, `sdk`, etc)
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
I know that I did create a branch on this repo, but the github UI helped me created this template and I did not have other option. Thanks for understanding.

Updates https://github.com/open-telemetry/opentelemetry-java/issues/493