### PR TITLE
moved jaeger_client dependency to trace_propagators

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -184,8 +184,7 @@ subprojects {
         testImplementation libraries.junit,
                 libraries.mockito,
                 libraries.truth,
-                libraries.guava_testlib,
-                libraries.jaeger_client
+                libraries.guava_testlib
 
         // The ErrorProne plugin defaults to the latest, which would break our
         // build if error prone releases a new version with a new check

--- a/contrib/trace_propagators/build.gradle
+++ b/contrib/trace_propagators/build.gradle
@@ -12,6 +12,8 @@ ext.moduleName = "io.opentelemetry.contrib.trace.propagation"
 dependencies {
     api project(':opentelemetry-api')
 
+    testImplementation libraries.jaeger_client
+
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
 }


### PR DESCRIPTION
As requested by @bogdandrutu (from comment in PR #1176), this PR fixes a dependency misconfiguration.

The ```jaeger_client``` test dependency was included in the dependencies in the root project, but it's only required in the ```contrib/trace_propagators``` project.