### PR TITLE
Fix getTracerLower behavior

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/TraceId.java
+++ b/api/src/main/java/io/opentelemetry/trace/TraceId.java
@@ -210,8 +210,8 @@ public final class TraceId implements Comparable<TraceId> {
    *
    * @return the lower 8 bytes of the trace-id as a long value, assuming little-endian order.
    */
-  public long getLowerLong() {
-    return (idHi < 0) ? -idHi : idHi;
+  public long getTraceRandomPart() {
+    return (idLo < 0) ? -idLo : idLo;
   }
 
   @Override

--- a/api/src/main/java/io/opentelemetry/trace/TraceId.java
+++ b/api/src/main/java/io/opentelemetry/trace/TraceId.java
@@ -203,15 +203,15 @@ public final class TraceId implements Comparable<TraceId> {
   }
 
   /**
-   * Returns the lower 8 bytes of the trace-id as a long value, assuming little-endian order. This
-   * is used in ProbabilitySampler.
+   * Returns the rightmost 8 bytes of the trace-id as a long value. This is used in
+   * ProbabilitySampler.
    *
    * <p>This method is marked as internal and subject to change.
    *
-   * @return the lower 8 bytes of the trace-id as a long value, assuming little-endian order.
+   * @return the rightmost 8 bytes of the trace-id as a long value.
    */
   public long getTraceRandomPart() {
-    return (idLo < 0) ? -idLo : idLo;
+    return idLo;
   }
 
   @Override

--- a/api/src/test/java/io/opentelemetry/trace/TraceIdTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TraceIdTest.java
@@ -39,7 +39,7 @@ public class TraceIdTest {
 
   @Test
   public void invalidTraceId() {
-    assertThat(TraceId.getInvalid().getLowerLong()).isEqualTo(0);
+    assertThat(TraceId.getInvalid().getTraceRandomPart()).isEqualTo(0);
   }
 
   @Test
@@ -50,9 +50,13 @@ public class TraceIdTest {
   }
 
   @Test
-  public void getLowerLong() {
-    assertThat(first.getLowerLong()).isEqualTo(0);
-    assertThat(second.getLowerLong()).isEqualTo(-0xFF00000000000000L);
+  public void testCorrectGetRandomTracePart() {
+    byte[] id = {
+      0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8,
+      0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF, 0x0
+    };
+    TraceId traceid = TraceId.fromBytes(id, 0);
+    assertThat(traceid.getTraceRandomPart()).isEqualTo(0x90A0B0C0D0E0F00L);
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/trace/TraceIdTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TraceIdTest.java
@@ -50,13 +50,36 @@ public class TraceIdTest {
   }
 
   @Test
-  public void testCorrectGetRandomTracePart() {
+  public void testGetRandomTracePart() {
     byte[] id = {
-      0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8,
-      0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF, 0x0
+      0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x00
     };
     TraceId traceid = TraceId.fromBytes(id, 0);
-    assertThat(traceid.getTraceRandomPart()).isEqualTo(0x90A0B0C0D0E0F00L);
+    assertThat(traceid.getTraceRandomPart()).isEqualTo(0x090A0B0C0D0E0F00L);
+  }
+
+  @Test
+  public void testGetRandomTracePart_NegativeLongRepresentation() {
+    byte[] id = {
+      0x01,
+      0x02,
+      0x03,
+      0x04,
+      0x05,
+      0x06,
+      0x07,
+      0x08,
+      (byte) 0xFF, // force a negative value
+      0x0A,
+      0x0B,
+      0x0C,
+      0x0D,
+      0x0E,
+      0x0F,
+      0x00
+    };
+    TraceId traceid = TraceId.fromBytes(id, 0);
+    assertThat(traceid.getTraceRandomPart()).isEqualTo(0xFF0A0B0C0D0E0F00L);
   }
 
   @Test

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -210,7 +210,7 @@ public final class Samplers {
       // while allowing for a (very) small chance of *not* sampling if the id == Long.MAX_VALUE.
       // This is considered a reasonable tradeoff for the simplicity/performance requirements (this
       // code is executed in-line for every Span creation).
-      return Math.abs(traceId.getLowerLong()) < getIdUpperBound()
+      return Math.abs(traceId.getTraceRandomPart()) < getIdUpperBound()
           ? getPositiveDecision()
           : getNegativeDecision();
     }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -235,11 +235,19 @@ public class SamplersTest {
   @Test
   public void probabilitySampler_SampleBasedOnTraceId() {
     final Sampler defaultProbability = Samplers.Probability.create(0.0001);
-    // This traceId will not be sampled by the Probability Sampler because the first 8 bytes as long
+    // This traceId will not be sampled by the Probability Sampler because the last 8 bytes as long
     // is not less than probability * Long.MAX_VALUE;
     TraceId notSampledtraceId =
         TraceId.fromBytes(
             new byte[] {
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
               (byte) 0x8F,
               (byte) 0xFF,
               (byte) 0xFF,
@@ -247,15 +255,7 @@ public class SamplersTest {
               (byte) 0xFF,
               (byte) 0xFF,
               (byte) 0xFF,
-              (byte) 0xFF,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0
+              (byte) 0xFF
             },
             0);
     Decision decision1 =
@@ -270,7 +270,7 @@ public class SamplersTest {
     assertThat(decision1.isSampled()).isFalse();
     assertThat(decision1.getAttributes())
         .containsExactly(Samplers.SAMPLING_PROBABILITY.key(), doubleAttributeValue(0.0001));
-    // This traceId will be sampled by the Probability Sampler because the first 8 bytes as long
+    // This traceId will be sampled by the Probability Sampler because the last 8 bytes as long
     // is less than probability * Long.MAX_VALUE;
     TraceId sampledtraceId =
         TraceId.fromBytes(


### PR DESCRIPTION
This resolves #1190 
Since the method is marked as internal, I also followed the suggestion proposed in the last SIG call and rename it to `getTraceRandomPart()`