### PR TITLE
Add instrument type and value type to InstrumentDescriptor

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractCounter.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractCounter.java
@@ -18,17 +18,14 @@ package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.metrics.Counter;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
-import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.view.Aggregations;
 
 abstract class AbstractCounter<B extends AbstractBoundInstrument>
     extends AbstractInstrumentWithBinding<B> {
   private final boolean monotonic;
-  private final InstrumentValueType instrumentValueType;
 
   AbstractCounter(
       InstrumentDescriptor descriptor,
-      InstrumentValueType instrumentValueType,
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState meterSharedState,
       boolean monotonic) {
@@ -38,43 +35,12 @@ abstract class AbstractCounter<B extends AbstractBoundInstrument>
         meterSharedState,
         new ActiveBatcher(
             getDefaultBatcher(
-                descriptor,
-                getInstrumentType(monotonic),
-                instrumentValueType,
-                meterProviderSharedState,
-                meterSharedState,
-                Aggregations.sum())));
+                descriptor, meterProviderSharedState, meterSharedState, Aggregations.sum())));
     this.monotonic = monotonic;
-    this.instrumentValueType = instrumentValueType;
   }
 
   final boolean isMonotonic() {
     return monotonic;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof AbstractCounter<?>)) {
-      return false;
-    }
-    if (!super.equals(o)) {
-      return false;
-    }
-
-    AbstractCounter<?> that = (AbstractCounter<?>) o;
-
-    return monotonic == that.monotonic && instrumentValueType == that.instrumentValueType;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = super.hashCode();
-    result = 31 * result + (monotonic ? 1 : 0);
-    result = 31 * result + instrumentValueType.hashCode();
-    return result;
   }
 
   abstract static class Builder<B extends AbstractCounter.Builder<B>>
@@ -99,7 +65,7 @@ abstract class AbstractCounter<B extends AbstractBoundInstrument>
     }
   }
 
-  private static InstrumentType getInstrumentType(boolean monotonic) {
+  static InstrumentType getInstrumentType(boolean monotonic) {
     return monotonic ? InstrumentType.COUNTER_MONOTONIC : InstrumentType.COUNTER_NON_MONOTONIC;
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
@@ -142,8 +142,9 @@ abstract class AbstractInstrument implements Instrument {
       return meterSharedState;
     }
 
-    final InstrumentDescriptor getInstrumentDescriptor() {
-      return InstrumentDescriptor.create(name, description, unit, constantLabels);
+    final InstrumentDescriptor getInstrumentDescriptor(
+        InstrumentType type, InstrumentValueType valueType) {
+      return InstrumentDescriptor.create(name, description, unit, constantLabels, type, valueType);
     }
 
     abstract B getThis();
@@ -154,31 +155,25 @@ abstract class AbstractInstrument implements Instrument {
   }
 
   static Descriptor getDefaultMetricDescriptor(
-      InstrumentDescriptor descriptor,
-      InstrumentType instrumentType,
-      InstrumentValueType instrumentValueType,
-      Aggregation aggregation) {
+      InstrumentDescriptor descriptor, Aggregation aggregation) {
     return Descriptor.create(
         descriptor.getName(),
         descriptor.getDescription(),
         aggregation.getUnit(descriptor.getUnit()),
-        aggregation.getDescriptorType(instrumentType, instrumentValueType),
+        aggregation.getDescriptorType(descriptor.getType(), descriptor.getValueType()),
         descriptor.getConstantLabels());
   }
 
   static Batcher getDefaultBatcher(
       InstrumentDescriptor descriptor,
-      InstrumentType instrumentType,
-      InstrumentValueType instrumentValueType,
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState meterSharedState,
       Aggregation defaultAggregation) {
     return Batchers.getCumulativeAllLabels(
-        getDefaultMetricDescriptor(
-            descriptor, instrumentType, instrumentValueType, defaultAggregation),
+        getDefaultMetricDescriptor(descriptor, defaultAggregation),
         meterProviderSharedState.getResource(),
         meterSharedState.getInstrumentationLibraryInfo(),
-        defaultAggregation.getAggregatorFactory(instrumentValueType),
+        defaultAggregation.getAggregatorFactory(descriptor.getValueType()),
         meterProviderSharedState.getClock());
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractMeasure.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractMeasure.java
@@ -18,17 +18,14 @@ package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.metrics.Measure;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
-import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.view.Aggregations;
 
 abstract class AbstractMeasure<B extends AbstractBoundInstrument>
     extends AbstractInstrumentWithBinding<B> {
   private final boolean absolute;
-  private final InstrumentValueType instrumentValueType;
 
   AbstractMeasure(
       InstrumentDescriptor descriptor,
-      InstrumentValueType instrumentValueType,
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState meterSharedState,
       boolean absolute) {
@@ -39,42 +36,14 @@ abstract class AbstractMeasure<B extends AbstractBoundInstrument>
         new ActiveBatcher(
             getDefaultBatcher(
                 descriptor,
-                getInstrumentType(absolute),
-                instrumentValueType,
                 meterProviderSharedState,
                 meterSharedState,
                 Aggregations.minMaxSumCount())));
     this.absolute = absolute;
-    this.instrumentValueType = instrumentValueType;
   }
 
   final boolean isAbsolute() {
     return absolute;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof AbstractMeasure)) {
-      return false;
-    }
-    if (!super.equals(o)) {
-      return false;
-    }
-
-    AbstractMeasure<?> that = (AbstractMeasure<?>) o;
-
-    return absolute == that.absolute && instrumentValueType == that.instrumentValueType;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = super.hashCode();
-    result = 31 * result + (absolute ? 1 : 0);
-    result = 31 * result + instrumentValueType.hashCode();
-    return result;
   }
 
   abstract static class Builder<B extends AbstractMeasure.Builder<B>>
@@ -99,7 +68,7 @@ abstract class AbstractMeasure<B extends AbstractBoundInstrument>
     }
   }
 
-  private static InstrumentType getInstrumentType(boolean absolute) {
+  static InstrumentType getInstrumentType(boolean absolute) {
     return absolute ? InstrumentType.MEASURE_ABSOLUTE : InstrumentType.MEASURE_NON_ABSOLUTE;
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractObserver.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractObserver.java
@@ -18,16 +18,13 @@ package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.metrics.Observer;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
-import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.view.Aggregations;
 
 abstract class AbstractObserver extends AbstractInstrument {
   private final boolean monotonic;
-  private final InstrumentValueType instrumentValueType;
 
   AbstractObserver(
       InstrumentDescriptor descriptor,
-      InstrumentValueType instrumentValueType,
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState meterSharedState,
       boolean monotonic) {
@@ -39,42 +36,14 @@ abstract class AbstractObserver extends AbstractInstrument {
             new ActiveBatcher(
                 getDefaultBatcher(
                     descriptor,
-                    getInstrumentType(monotonic),
-                    instrumentValueType,
                     meterProviderSharedState,
                     meterSharedState,
                     Aggregations.lastValue()))));
     this.monotonic = monotonic;
-    this.instrumentValueType = instrumentValueType;
   }
 
   final boolean isMonotonic() {
     return monotonic;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof AbstractObserver)) {
-      return false;
-    }
-    if (!super.equals(o)) {
-      return false;
-    }
-
-    AbstractObserver that = (AbstractObserver) o;
-
-    return monotonic == that.monotonic && instrumentValueType == that.instrumentValueType;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = super.hashCode();
-    result = 31 * result + (monotonic ? 1 : 0);
-    result = 31 * result + instrumentValueType.hashCode();
-    return result;
   }
 
   abstract static class Builder<B extends AbstractObserver.Builder<B>>
@@ -99,7 +68,7 @@ abstract class AbstractObserver extends AbstractInstrument {
     }
   }
 
-  private static InstrumentType getInstrumentType(boolean monotonic) {
+  static InstrumentType getInstrumentType(boolean monotonic) {
     return monotonic ? InstrumentType.OBSERVER_MONOTONIC : InstrumentType.OBSERVER_NON_MONOTONIC;
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleCounterSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleCounterSdk.java
@@ -27,12 +27,7 @@ final class DoubleCounterSdk extends AbstractCounter<BoundInstrument> implements
       boolean monotonic,
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState meterSharedState) {
-    super(
-        descriptor,
-        InstrumentValueType.DOUBLE,
-        meterProviderSharedState,
-        meterSharedState,
-        monotonic);
+    super(descriptor, meterProviderSharedState, meterSharedState, monotonic);
   }
 
   @Override
@@ -94,7 +89,8 @@ final class DoubleCounterSdk extends AbstractCounter<BoundInstrument> implements
     public DoubleCounterSdk build() {
       return register(
           new DoubleCounterSdk(
-              getInstrumentDescriptor(),
+              getInstrumentDescriptor(
+                  AbstractCounter.getInstrumentType(isMonotonic()), InstrumentValueType.DOUBLE),
               isMonotonic(),
               getMeterProviderSharedState(),
               getMeterSharedState()));

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleMeasureSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleMeasureSdk.java
@@ -27,12 +27,7 @@ final class DoubleMeasureSdk extends AbstractMeasure<BoundInstrument> implements
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState meterSharedState,
       boolean absolute) {
-    super(
-        descriptor,
-        InstrumentValueType.DOUBLE,
-        meterProviderSharedState,
-        meterSharedState,
-        absolute);
+    super(descriptor, meterProviderSharedState, meterSharedState, absolute);
   }
 
   @Override
@@ -94,7 +89,8 @@ final class DoubleMeasureSdk extends AbstractMeasure<BoundInstrument> implements
     public DoubleMeasureSdk build() {
       return register(
           new DoubleMeasureSdk(
-              getInstrumentDescriptor(),
+              getInstrumentDescriptor(
+                  AbstractMeasure.getInstrumentType(isAbsolute()), InstrumentValueType.DOUBLE),
               getMeterProviderSharedState(),
               getMeterSharedState(),
               isAbsolute()));

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleObserverSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleObserverSdk.java
@@ -35,12 +35,7 @@ final class DoubleObserverSdk extends AbstractObserver implements DoubleObserver
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState meterSharedState,
       boolean monotonic) {
-    super(
-        descriptor,
-        InstrumentValueType.DOUBLE,
-        meterProviderSharedState,
-        meterSharedState,
-        monotonic);
+    super(descriptor, meterProviderSharedState, meterSharedState, monotonic);
   }
 
   @Override
@@ -83,7 +78,8 @@ final class DoubleObserverSdk extends AbstractObserver implements DoubleObserver
     public DoubleObserverSdk build() {
       return register(
           new DoubleObserverSdk(
-              getInstrumentDescriptor(),
+              getInstrumentDescriptor(
+                  AbstractObserver.getInstrumentType(isMonotonic()), InstrumentValueType.DOUBLE),
               getMeterProviderSharedState(),
               getMeterSharedState(),
               isMonotonic()));

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/InstrumentDescriptor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/InstrumentDescriptor.java
@@ -17,6 +17,9 @@
 package io.opentelemetry.sdk.metrics;
 
 import com.google.auto.value.AutoValue;
+import com.google.auto.value.extension.memoized.Memoized;
+import io.opentelemetry.sdk.metrics.common.InstrumentType;
+import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import java.util.Map;
 import javax.annotation.concurrent.Immutable;
 
@@ -24,8 +27,14 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 abstract class InstrumentDescriptor {
   static InstrumentDescriptor create(
-      String name, String description, String unit, Map<String, String> constantLabels) {
-    return new AutoValue_InstrumentDescriptor(name, description, unit, constantLabels);
+      String name,
+      String description,
+      String unit,
+      Map<String, String> constantLabels,
+      InstrumentType type,
+      InstrumentValueType valueType) {
+    return new AutoValue_InstrumentDescriptor(
+        name, description, unit, constantLabels, type, valueType);
   }
 
   abstract String getName();
@@ -35,4 +44,12 @@ abstract class InstrumentDescriptor {
   abstract String getUnit();
 
   abstract Map<String, String> getConstantLabels();
+
+  abstract InstrumentType getType();
+
+  abstract InstrumentValueType getValueType();
+
+  @Memoized
+  @Override
+  public abstract int hashCode();
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongCounterSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongCounterSdk.java
@@ -27,12 +27,7 @@ final class LongCounterSdk extends AbstractCounter<BoundInstrument> implements L
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState meterSharedState,
       boolean monotonic) {
-    super(
-        descriptor,
-        InstrumentValueType.LONG,
-        meterProviderSharedState,
-        meterSharedState,
-        monotonic);
+    super(descriptor, meterProviderSharedState, meterSharedState, monotonic);
   }
 
   @Override
@@ -94,7 +89,8 @@ final class LongCounterSdk extends AbstractCounter<BoundInstrument> implements L
     public LongCounterSdk build() {
       return register(
           new LongCounterSdk(
-              getInstrumentDescriptor(),
+              getInstrumentDescriptor(
+                  AbstractCounter.getInstrumentType(isMonotonic()), InstrumentValueType.LONG),
               getMeterProviderSharedState(),
               getMeterSharedState(),
               isMonotonic()));

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongMeasureSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongMeasureSdk.java
@@ -27,8 +27,7 @@ final class LongMeasureSdk extends AbstractMeasure<BoundInstrument> implements L
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState meterSharedState,
       boolean absolute) {
-    super(
-        descriptor, InstrumentValueType.LONG, meterProviderSharedState, meterSharedState, absolute);
+    super(descriptor, meterProviderSharedState, meterSharedState, absolute);
   }
 
   @Override
@@ -90,7 +89,8 @@ final class LongMeasureSdk extends AbstractMeasure<BoundInstrument> implements L
     public LongMeasureSdk build() {
       return register(
           new LongMeasureSdk(
-              getInstrumentDescriptor(),
+              getInstrumentDescriptor(
+                  AbstractMeasure.getInstrumentType(isAbsolute()), InstrumentValueType.LONG),
               getMeterProviderSharedState(),
               getMeterSharedState(),
               isAbsolute()));

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongObserverSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongObserverSdk.java
@@ -35,12 +35,7 @@ final class LongObserverSdk extends AbstractObserver implements LongObserver {
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState meterSharedState,
       boolean monotonic) {
-    super(
-        descriptor,
-        InstrumentValueType.LONG,
-        meterProviderSharedState,
-        meterSharedState,
-        monotonic);
+    super(descriptor, meterProviderSharedState, meterSharedState, monotonic);
   }
 
   @Override
@@ -83,7 +78,8 @@ final class LongObserverSdk extends AbstractObserver implements LongObserver {
     public LongObserverSdk build() {
       return register(
           new LongObserverSdk(
-              getInstrumentDescriptor(),
+              getInstrumentDescriptor(
+                  AbstractObserver.getInstrumentType(isMonotonic()), InstrumentValueType.LONG),
               getMeterProviderSharedState(),
               getMeterSharedState(),
               isMonotonic()));

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractCounterBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractCounterBuilderTest.java
@@ -23,6 +23,7 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.aggregator.NoopAggregator;
+import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.resources.Resource;
 import org.junit.Rule;
@@ -85,7 +86,7 @@ public class AbstractCounterBuilderTest {
     @Override
     public TestInstrument build() {
       return new TestInstrument(
-          getInstrumentDescriptor(),
+          getInstrumentDescriptor(InstrumentType.COUNTER_NON_MONOTONIC, InstrumentValueType.DOUBLE),
           getMeterProviderSharedState(),
           getMeterSharedState(),
           isMonotonic());
@@ -99,12 +100,7 @@ public class AbstractCounterBuilderTest {
         MeterProviderSharedState meterProviderSharedState,
         MeterSharedState meterSharedState,
         boolean monotonic) {
-      super(
-          descriptor,
-          InstrumentValueType.LONG,
-          meterProviderSharedState,
-          meterSharedState,
-          monotonic);
+      super(descriptor, meterProviderSharedState, meterSharedState, monotonic);
     }
 
     @Override

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractCounterTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractCounterTest.java
@@ -58,9 +58,6 @@ public class AbstractCounterTest {
   }
 
   private static final class TestCounterInstrument extends AbstractCounter<TestBoundCounter> {
-    private static final InstrumentDescriptor INSTRUMENT_DESCRIPTOR =
-        InstrumentDescriptor.create(
-            "name", "description", "1", Collections.singletonMap("key_2", "value_2"));
     private static final MeterProviderSharedState METER_PROVIDER_SHARED_STATE =
         MeterProviderSharedState.create(TestClock.create(), Resource.getEmpty());
     private static final MeterSharedState METER_SHARED_STATE =
@@ -68,8 +65,13 @@ public class AbstractCounterTest {
 
     TestCounterInstrument(InstrumentValueType instrumentValueType, boolean monotonic) {
       super(
-          INSTRUMENT_DESCRIPTOR,
-          instrumentValueType,
+          InstrumentDescriptor.create(
+              "name",
+              "description",
+              "1",
+              Collections.singletonMap("key_2", "value_2"),
+              AbstractCounter.getInstrumentType(monotonic),
+              instrumentValueType),
           METER_PROVIDER_SHARED_STATE,
           METER_SHARED_STATE,
           monotonic);

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
@@ -20,6 +20,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
+import io.opentelemetry.sdk.metrics.common.InstrumentType;
+import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Arrays;
@@ -144,6 +146,9 @@ public class AbstractInstrumentBuilderTest {
     assertThat(testInstrument.getDescriptor().getDescription()).isEqualTo(DESCRIPTION);
     assertThat(testInstrument.getDescriptor().getUnit()).isEqualTo(UNIT);
     assertThat(testInstrument.getDescriptor().getConstantLabels()).isEqualTo(CONSTANT_LABELS);
+    assertThat(testInstrument.getDescriptor().getType())
+        .isEqualTo(InstrumentType.COUNTER_NON_MONOTONIC);
+    assertThat(testInstrument.getDescriptor().getValueType()).isEqualTo(InstrumentValueType.LONG);
   }
 
   private static final class TestInstrumentBuilder
@@ -161,7 +166,9 @@ public class AbstractInstrumentBuilderTest {
     @Override
     public TestInstrument build() {
       return new TestInstrument(
-          getInstrumentDescriptor(), getMeterProviderSharedState(), getMeterSharedState());
+          getInstrumentDescriptor(InstrumentType.COUNTER_NON_MONOTONIC, InstrumentValueType.LONG),
+          getMeterProviderSharedState(),
+          getMeterSharedState());
     }
   }
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentTest.java
@@ -20,6 +20,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
+import io.opentelemetry.sdk.metrics.common.InstrumentType;
+import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
@@ -33,7 +35,12 @@ import org.junit.runners.JUnit4;
 public class AbstractInstrumentTest {
   private static final InstrumentDescriptor INSTRUMENT_DESCRIPTOR =
       InstrumentDescriptor.create(
-          "name", "description", "1", Collections.singletonMap("key_2", "value_2"));
+          "name",
+          "description",
+          "1",
+          Collections.singletonMap("key_2", "value_2"),
+          InstrumentType.COUNTER_MONOTONIC,
+          InstrumentValueType.LONG);
   private static final MeterProviderSharedState METER_PROVIDER_SHARED_STATE =
       MeterProviderSharedState.create(TestClock.create(), Resource.getEmpty());
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractMeasureBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractMeasureBuilderTest.java
@@ -23,6 +23,7 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.aggregator.NoopAggregator;
+import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.resources.Resource;
 import org.junit.Rule;
@@ -85,7 +86,7 @@ public class AbstractMeasureBuilderTest {
     @Override
     public TestInstrument build() {
       return new TestInstrument(
-          getInstrumentDescriptor(),
+          getInstrumentDescriptor(InstrumentType.MEASURE_ABSOLUTE, InstrumentValueType.DOUBLE),
           getMeterProviderSharedState(),
           getMeterSharedState(),
           isAbsolute());
@@ -100,12 +101,7 @@ public class AbstractMeasureBuilderTest {
         MeterProviderSharedState meterProviderSharedState,
         MeterSharedState meterSharedState,
         boolean absolute) {
-      super(
-          descriptor,
-          InstrumentValueType.LONG,
-          meterProviderSharedState,
-          meterSharedState,
-          absolute);
+      super(descriptor, meterProviderSharedState, meterSharedState, absolute);
     }
 
     @Override

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractMeasureTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractMeasureTest.java
@@ -57,9 +57,6 @@ public class AbstractMeasureTest {
   }
 
   private static final class TestMeasureInstrument extends AbstractMeasure<TestBoundMeasure> {
-    private static final InstrumentDescriptor INSTRUMENT_DESCRIPTOR =
-        InstrumentDescriptor.create(
-            "name", "description", "1", Collections.singletonMap("key_2", "value_2"));
     private static final MeterProviderSharedState METER_PROVIDER_SHARED_STATE =
         MeterProviderSharedState.create(TestClock.create(), Resource.getEmpty());
     private static final MeterSharedState METER_SHARED_STATE =
@@ -67,8 +64,13 @@ public class AbstractMeasureTest {
 
     TestMeasureInstrument(InstrumentValueType instrumentValueType, boolean absolute) {
       super(
-          INSTRUMENT_DESCRIPTOR,
-          instrumentValueType,
+          InstrumentDescriptor.create(
+              "name",
+              "description",
+              "1",
+              Collections.singletonMap("key_2", "value_2"),
+              AbstractMeasure.getInstrumentType(absolute),
+              instrumentValueType),
           METER_PROVIDER_SHARED_STATE,
           METER_SHARED_STATE,
           absolute);

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractObserverBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractObserverBuilderTest.java
@@ -21,6 +21,7 @@ import static com.google.common.truth.Truth.assertThat;
 import io.opentelemetry.metrics.Observer;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
+import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.resources.Resource;
@@ -86,7 +87,7 @@ public class AbstractObserverBuilderTest {
     @Override
     public TestInstrument build() {
       return new TestInstrument(
-          getInstrumentDescriptor(),
+          getInstrumentDescriptor(InstrumentType.OBSERVER_MONOTONIC, InstrumentValueType.DOUBLE),
           getMeterProviderSharedState(),
           getMeterSharedState(),
           isMonotonic());
@@ -101,12 +102,7 @@ public class AbstractObserverBuilderTest {
         MeterProviderSharedState meterProviderSharedState,
         MeterSharedState meterSharedState,
         boolean monotonic) {
-      super(
-          descriptor,
-          InstrumentValueType.LONG,
-          meterProviderSharedState,
-          meterSharedState,
-          monotonic);
+      super(descriptor, meterProviderSharedState, meterSharedState, monotonic);
     }
 
     @Override

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractObserverTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractObserverTest.java
@@ -59,9 +59,6 @@ public class AbstractObserverTest {
   }
 
   private static final class TestObserverInstrument extends AbstractObserver {
-    private static final InstrumentDescriptor INSTRUMENT_DESCRIPTOR =
-        InstrumentDescriptor.create(
-            "name", "description", "1", Collections.singletonMap("key_2", "value_2"));
     private static final MeterProviderSharedState METER_PROVIDER_SHARED_STATE =
         MeterProviderSharedState.create(TestClock.create(), Resource.getEmpty());
     private static final MeterSharedState METER_SHARED_STATE =
@@ -69,8 +66,13 @@ public class AbstractObserverTest {
 
     TestObserverInstrument(InstrumentValueType instrumentValueType, boolean monotonic) {
       super(
-          INSTRUMENT_DESCRIPTOR,
-          instrumentValueType,
+          InstrumentDescriptor.create(
+              "name",
+              "description",
+              "1",
+              Collections.singletonMap("key_2", "value_2"),
+              AbstractObserver.getInstrumentType(monotonic),
+              instrumentValueType),
           METER_PROVIDER_SHARED_STATE,
           METER_SHARED_STATE,
           monotonic);

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/InstrumentRegistryTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/InstrumentRegistryTest.java
@@ -20,6 +20,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
+import io.opentelemetry.sdk.metrics.common.InstrumentType;
+import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
@@ -35,10 +37,20 @@ import org.junit.runners.JUnit4;
 public class InstrumentRegistryTest {
   private static final InstrumentDescriptor INSTRUMENT_DESCRIPTOR =
       InstrumentDescriptor.create(
-          "name", "description", "1", Collections.singletonMap("key_2", "value_2"));
+          "name",
+          "description",
+          "1",
+          Collections.singletonMap("key_2", "value_2"),
+          InstrumentType.COUNTER_MONOTONIC,
+          InstrumentValueType.LONG);
   private static final InstrumentDescriptor OTHER_INSTRUMENT_DESCRIPTOR =
       InstrumentDescriptor.create(
-          "name", "other_description", "1", Collections.singletonMap("key_2", "value_2"));
+          "name",
+          "other_description",
+          "1",
+          Collections.singletonMap("key_2", "value_2"),
+          InstrumentType.COUNTER_MONOTONIC,
+          InstrumentValueType.LONG);
   private static final MeterProviderSharedState METER_PROVIDER_SHARED_STATE =
       MeterProviderSharedState.create(TestClock.create(), Resource.getEmpty());
   private static final ActiveBatcher ACTIVE_BATCHER = new ActiveBatcher(Batchers.getNoop());


### PR DESCRIPTION
This way we embed all informations in the InstrumentDescriptor, so no need to override equal and hashCode in the Abstract[Counter, Measure, Observer].

This is extracted from https://github.com/open-telemetry/opentelemetry-java/pull/1201  where I am adding the new instruments, and I found that after adding UpDownCounter the only reason to have AbstractCounter or AbstractUpDownCounter was to include these 2 fields in equals and hashCode.