### PR TITLE
Add a Builder in the SynchronousInstrument

### DIFF
--- a/api/src/main/java/io/opentelemetry/metrics/AsynchronousInstrument.java
+++ b/api/src/main/java/io/opentelemetry/metrics/AsynchronousInstrument.java
@@ -16,7 +16,6 @@
 
 package io.opentelemetry.metrics;
 
-import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -55,15 +54,6 @@ public interface AsynchronousInstrument<R> extends Instrument {
 
   /** Builder class for {@link AsynchronousInstrument}. */
   interface Builder extends Instrument.Builder {
-    @Override
-    Builder setDescription(String description);
-
-    @Override
-    Builder setUnit(String unit);
-
-    @Override
-    Builder setConstantLabels(Map<String, String> constantLabels);
-
     /**
      * Sets the monotonicity property for this {@code Instrument}. If {@code true} successive values
      * are expected to rise monotonically.

--- a/api/src/main/java/io/opentelemetry/metrics/SynchronousInstrument.java
+++ b/api/src/main/java/io/opentelemetry/metrics/SynchronousInstrument.java
@@ -56,4 +56,10 @@ public interface SynchronousInstrument<B extends BoundInstrument> extends Instru
      */
     void unbind();
   }
+
+  /** Builder class for {@link SynchronousInstrument}. */
+  interface Builder extends Instrument.Builder {
+    @Override
+    SynchronousInstrument<?> build();
+  }
 }


### PR DESCRIPTION
All the sync instruments inherited their builders from SynchronousInstrument.Builder which by default referred to Instrument.Builder.

The idea behind this is that if we add a new property to the SynchronousInstrument.Builder all sync instrument builders will inherit that property.