### PR TITLE
Proposal: Add @thisthat as an approver

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
  # For anything not explicitly taken by someone else:
-*  @arminru @bogdandrutu @carlosalberto @jkwatson @pavolloffay @songy23 @tylerbenson
+*  @arminru @bogdandrutu @carlosalberto @jkwatson @pavolloffay @songy23 @thisthat @tylerbenson


### PR DESCRIPTION
During the past 2-3 months @thisthat contribute significant PRs to the Java repository (like the config refactoring) as well as participated in a bunch of code reviews and technical discussions.