### PR TITLE
Move the span operations inside the scope in the http server example

### DIFF
--- a/examples/http/src/main/java/io/opentelemetry/example/http/HttpServer.java
+++ b/examples/http/src/main/java/io/opentelemetry/example/http/HttpServer.java
@@ -47,14 +47,14 @@ public class HttpServer {
       // Name convention for the Span is not yet defined.
       // See: https://github.com/open-telemetry/opentelemetry-specification/issues/270
       Span.Builder spanBuilder = tracer.spanBuilder("/").setSpanKind(Span.Kind.SERVER);
-      Span span = null;
 
       // Extract the context from the HTTP request
       Context ctx =
           OpenTelemetry.getPropagators().getHttpTextFormat().extract(Context.current(), exchange, getter);
+
+      Span span = spanBuilder.startSpan();
       try (Scope scope = ContextUtils.withScopedContext(ctx)) {
         // Build a span automatically using the received context
-        span = spanBuilder.startSpan();
 
         // Set the Semantic Convention
         span.setAttribute("component", "http");

--- a/examples/http/src/main/java/io/opentelemetry/example/http/HttpServer.java
+++ b/examples/http/src/main/java/io/opentelemetry/example/http/HttpServer.java
@@ -40,7 +40,7 @@ import java.util.Map;
 
 public class HttpServer {
 
-  private class HelloHandler implements HttpHandler {
+  private static class HelloHandler implements HttpHandler {
 
     @Override
     public void handle(HttpExchange he) throws IOException {
@@ -55,25 +55,26 @@ public class HttpServer {
       try (Scope scope = ContextUtils.withScopedContext(ctx)) {
         // Build a span automatically using the received context
         span = spanBuilder.startSpan();
-      }
 
-      // Set the Semantic Convention
-      span.setAttribute("component", "http");
-      span.setAttribute("http.method", "GET");
-      /*
-      One of the following is required:
-      - http.scheme, http.host, http.target
-      - http.scheme, http.server_name, net.host.port, http.target
-      - http.scheme, net.host.name, net.host.port, http.target
-      - http.url
-      */
-      span.setAttribute("http.scheme", "http");
-      span.setAttribute("http.host", "localhost:" + HttpServer.port);
-      span.setAttribute("http.target", "/");
-      // Process the request
-      answer(he, span);
-      // Close the span
-      span.end();
+        // Set the Semantic Convention
+        span.setAttribute("component", "http");
+        span.setAttribute("http.method", "GET");
+        /*
+         One of the following is required:
+         - http.scheme, http.host, http.target
+         - http.scheme, http.server_name, net.host.port, http.target
+         - http.scheme, net.host.name, net.host.port, http.target
+         - http.url
+        */
+        span.setAttribute("http.scheme", "http");
+        span.setAttribute("http.host", "localhost:" + HttpServer.port);
+        span.setAttribute("http.target", "/");
+        // Process the request
+        answer(he, span);
+      } finally {
+        // Close the span
+        span.end();
+      }
     }
 
     private void answer(HttpExchange he, Span span) throws IOException {

--- a/examples/http/src/main/java/io/opentelemetry/example/http/HttpServer.java
+++ b/examples/http/src/main/java/io/opentelemetry/example/http/HttpServer.java
@@ -43,7 +43,7 @@ public class HttpServer {
   private static class HelloHandler implements HttpHandler {
 
     @Override
-    public void handle(HttpExchange he) throws IOException {
+    public void handle(HttpExchange exchange) throws IOException {
       // Name convention for the Span is not yet defined.
       // See: https://github.com/open-telemetry/opentelemetry-specification/issues/270
       Span.Builder spanBuilder = tracer.spanBuilder("/").setSpanKind(Span.Kind.SERVER);
@@ -51,7 +51,7 @@ public class HttpServer {
 
       // Extract the context from the HTTP request
       Context ctx =
-          OpenTelemetry.getPropagators().getHttpTextFormat().extract(Context.current(), he, getter);
+          OpenTelemetry.getPropagators().getHttpTextFormat().extract(Context.current(), exchange, getter);
       try (Scope scope = ContextUtils.withScopedContext(ctx)) {
         // Build a span automatically using the received context
         span = spanBuilder.startSpan();
@@ -70,7 +70,7 @@ public class HttpServer {
         span.setAttribute("http.host", "localhost:" + HttpServer.port);
         span.setAttribute("http.target", "/");
         // Process the request
-        answer(he, span);
+        answer(exchange, span);
       } finally {
         // Close the span
         span.end();


### PR DESCRIPTION
This shows better idiomatic usage of the API.