### PR TITLE
Make the ZipkinSpanExporter public, so it can actually be used. (#1186)

### DIFF
--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporter.java
@@ -47,7 +47,7 @@ import zipkin2.reporter.Sender;
  * This class was based on the OpenCensus zipkin exporter code at
  * https://github.com/census-instrumentation/opencensus-java/tree/c960b19889de5e4a7b25f90919d28b066590d4f0/exporters/trace/zipkin
  */
-final class ZipkinSpanExporter implements SpanExporter {
+public final class ZipkinSpanExporter implements SpanExporter {
 
   private static final Logger logger = Logger.getLogger(ZipkinSpanExporter.class.getName());
 


### PR DESCRIPTION
(cherry picked from commit 414ddb05fa132289fcdac4c3e7b7a42f47b8cfa6)