### PR TITLE
Return a wrapped span for SpanData so only the mutable data is copied.

### DIFF
--- a/sdk/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
+++ b/sdk/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
@@ -57,7 +57,7 @@ public class SpanPipelineBenchmark {
   @Threads(value = 5)
   @Fork(1)
   @Warmup(iterations = 5, time = 1)
-  @Measurement(iterations = 10, time = 1)
+  @Measurement(iterations = 5, time = 1)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public void runThePipeline_05Threads() {
     doWork();
@@ -73,6 +73,8 @@ public class SpanPipelineBenchmark {
             .startSpan();
     span.setAttribute("longAttribute", 33L);
     span.setAttribute("stringAttribute", "test_value");
+    span.setAttribute("doubleAttribute", 4844.44d);
+    span.setAttribute("booleanAttribute", false);
     span.setStatus(Status.OK);
 
     span.addEvent("testEvent");

--- a/sdk/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
+++ b/sdk/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.trace;
+
+import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.trace.Link;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.Span.Kind;
+import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.Status;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Benchmark)
+public class SpanPipelineBenchmark {
+
+  private final TracerSdk tracerSdk = OpenTelemetrySdk.getTracerProvider().get("benchmarkTracer");
+
+  @Setup(Level.Trial)
+  public final void setup() {
+    SpanExporter exporter = new NoOpSpanExporter();
+    OpenTelemetrySdk.getTracerProvider()
+        .addSpanProcessor(SimpleSpanProcessor.newBuilder(exporter).build());
+  }
+
+  @Benchmark
+  @Threads(value = 5)
+  @Fork(1)
+  @Warmup(iterations = 5, time = 1)
+  @Measurement(iterations = 10, time = 1)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void runThePipeline_05Threads() {
+    doWork();
+  }
+
+  private void doWork() {
+    Span span =
+        tracerSdk
+            .spanBuilder("benchmarkSpan")
+            .setSpanKind(Kind.CLIENT)
+            .setAttribute("key", "value")
+            .addLink(new TestLink())
+            .startSpan();
+    span.setAttribute("longAttribute", 33L);
+    span.setAttribute("stringAttribute", "test_value");
+    span.setStatus(Status.OK);
+
+    span.addEvent("testEvent");
+    span.end();
+  }
+
+  private static class NoOpSpanExporter implements SpanExporter {
+    @Override
+    public ResultCode export(Collection<SpanData> spans) {
+      return ResultCode.SUCCESS;
+    }
+
+    @Override
+    public ResultCode flush() {
+      return ResultCode.SUCCESS;
+    }
+
+    @Override
+    public void shutdown() {
+      // no-op
+    }
+  }
+
+  private static class TestLink implements Link {
+    @Override
+    public SpanContext getContext() {
+      return SpanContext.getInvalid();
+    }
+
+    @Override
+    public Map<String, AttributeValue> getAttributes() {
+      return Collections.singletonMap("linkAttr", AttributeValue.stringAttributeValue("linkValue"));
+    }
+  }
+}

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
@@ -27,7 +27,7 @@ import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.concurrent.Immutable;
@@ -59,9 +59,9 @@ abstract class SpanWrapper implements SpanData {
       Status status) {
     return new AutoValue_SpanWrapper(
         delegate,
-        links,
-        events,
-        new HashMap<>(attributes),
+        Collections.unmodifiableList(links),
+        Collections.unmodifiableList(events),
+        Collections.unmodifiableMap(attributes),
         totalAttributeCount,
         totalRecordedEvents,
         status);

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.trace;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.trace.Span.Kind;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.Status;
+import io.opentelemetry.trace.TraceFlags;
+import io.opentelemetry.trace.TraceId;
+import io.opentelemetry.trace.TraceState;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@AutoValue
+abstract class SpanWrapper implements SpanData {
+  abstract RecordEventsReadableSpan delegate();
+
+  abstract List<Link> resolvedLinks();
+
+  abstract List<Event> resolvedEvents();
+
+  abstract Map<String, AttributeValue> attributes();
+
+  abstract int totalAttributeCount();
+
+  abstract int totalRecordedEvents();
+
+  abstract Status status();
+
+  static SpanWrapper create(
+      RecordEventsReadableSpan delegate,
+      List<Link> links,
+      List<Event> events,
+      Map<String, AttributeValue> attributes,
+      int totalAttributeCount,
+      int totalRecordedEvents,
+      Status status) {
+    return new AutoValue_SpanWrapper(
+        delegate,
+        links,
+        events,
+        new HashMap<>(attributes),
+        totalAttributeCount,
+        totalRecordedEvents,
+        status);
+  }
+
+  @Override
+  public TraceId getTraceId() {
+    return delegate().getContext().getTraceId();
+  }
+
+  @Override
+  public SpanId getSpanId() {
+    return delegate().getContext().getSpanId();
+  }
+
+  @Override
+  public TraceFlags getTraceFlags() {
+    return delegate().getSpanContext().getTraceFlags();
+  }
+
+  @Override
+  public TraceState getTraceState() {
+    return delegate().getSpanContext().getTraceState();
+  }
+
+  @Override
+  public SpanId getParentSpanId() {
+    return delegate().getParentSpanId();
+  }
+
+  @Override
+  public Resource getResource() {
+    return delegate().getResource();
+  }
+
+  @Override
+  public InstrumentationLibraryInfo getInstrumentationLibraryInfo() {
+    return delegate().getInstrumentationLibraryInfo();
+  }
+
+  @Override
+  public String getName() {
+    return delegate().getName();
+  }
+
+  @Override
+  public Kind getKind() {
+    return delegate().getKind();
+  }
+
+  @Override
+  public long getStartEpochNanos() {
+    return delegate().getStartEpochNanos();
+  }
+
+  @Override
+  public Map<String, AttributeValue> getAttributes() {
+    return attributes();
+  }
+
+  @Override
+  public List<Event> getEvents() {
+    return resolvedEvents();
+  }
+
+  @Override
+  public List<Link> getLinks() {
+    return resolvedLinks();
+  }
+
+  @Override
+  public Status getStatus() {
+    return status();
+  }
+
+  @Override
+  public long getEndEpochNanos() {
+    return delegate().getEndEpochNanos();
+  }
+
+  @Override
+  public boolean getHasRemoteParent() {
+    return delegate().hasRemoteParent();
+  }
+
+  @Override
+  public boolean getHasEnded() {
+    return delegate().hasEnded();
+  }
+
+  @Override
+  public int getTotalRecordedEvents() {
+    return totalRecordedEvents();
+  }
+
+  @Override
+  public int getTotalRecordedLinks() {
+    return delegate().getTotalRecordedLinks();
+  }
+
+  @Override
+  public int getTotalAttributeCount() {
+    return totalAttributeCount();
+  }
+}

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -18,8 +18,6 @@ package io.opentelemetry.sdk.trace;
 
 import static com.google.common.truth.Truth.assertThat;
 import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -233,7 +231,7 @@ public class RecordEventsReadableSpanTest {
       span.end();
     }
     SpanData spanData = span.toSpanData();
-    assertFalse(spanData.getParentSpanId().isValid());
+    assertThat(spanData.getParentSpanId().isValid()).isFalse();
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -29,7 +29,6 @@ import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
-import io.opentelemetry.sdk.trace.data.SpanDataImpl;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
@@ -656,15 +655,13 @@ public class RecordEventsReadableSpanTest {
   public void testAsSpanData() {
     String name = "GreatSpan";
     Kind kind = Kind.SERVER;
-    TraceId traceId = idsGenerator.generateTraceId();
-    SpanId spanId = idsGenerator.generateSpanId();
-    SpanId parentSpanId = idsGenerator.generateSpanId();
+    TraceId traceId = this.traceId;
+    SpanId spanId = this.spanId;
+    SpanId parentSpanId = this.parentSpanId;
     TraceConfig traceConfig = TraceConfig.getDefault();
     SpanProcessor spanProcessor = NoopSpanProcessor.getInstance();
     TestClock clock = TestClock.create();
-    Map<String, AttributeValue> attribute = new HashMap<>();
-    attribute.put("foo", AttributeValue.stringAttributeValue("bar"));
-    Resource resource = Resource.create(attribute);
+    Resource resource = this.resource;
     Map<String, AttributeValue> attributes = TestUtils.generateRandomAttributes();
     AttributesMap attributesWithCapacity = new AttributesMap(32);
     attributesWithCapacity.putAll(attributes);
@@ -681,7 +678,7 @@ public class RecordEventsReadableSpanTest {
             instrumentationLibraryInfo,
             kind,
             parentSpanId,
-            /* hasRemoteParent= */ false,
+            /* hasRemoteParent= */ expectedHasRemoteParent,
             traceConfig,
             spanProcessor,
             clock,
@@ -702,33 +699,22 @@ public class RecordEventsReadableSpanTest {
     readableSpan.end();
     long endEpochNanos = clock.now();
 
-    SpanData expected =
-        SpanDataImpl.newBuilder()
-            .setHasEnded(true)
-            .setName(name)
-            .setInstrumentationLibraryInfo(instrumentationLibraryInfo)
-            .setKind(kind)
-            .setStatus(Status.OK)
-            .setStartEpochNanos(startEpochNanos)
-            .setEndEpochNanos(endEpochNanos)
-            .setEvents(
-                Arrays.asList(
-                    Event.create(firstEventEpochNanos, "event1", event1Attributes),
-                    Event.create(secondEventTimeNanos, "event2", event2Attributes)))
-            .setTotalRecordedEvents(2)
-            .setResource(resource)
-            .setParentSpanId(parentSpanId)
-            .setLinks(Collections.singletonList(link1))
-            .setTotalRecordedLinks(1)
-            .setTraceId(traceId)
-            .setSpanId(spanId)
-            .setAttributes(attributes)
-            .setTotalAttributeCount(1)
-            .setHasRemoteParent(false)
-            .build();
+    List<Event> events =
+        Arrays.asList(
+            Event.create(firstEventEpochNanos, "event1", event1Attributes),
+            Event.create(secondEventTimeNanos, "event2", event2Attributes));
 
     SpanData result = readableSpan.toSpanData();
-    assertEquals(expected, result);
+    verifySpanData(
+        result,
+        attributes,
+        events,
+        Collections.<io.opentelemetry.trace.Link>singletonList(link1),
+        name,
+        startEpochNanos,
+        endEpochNanos,
+        Status.OK,
+        /* hasEnded= */ true);
   }
 
   @Test


### PR DESCRIPTION
This is a optimization of the creation of the SpanData implementation. 

master benchmark:
```
SpanPipelineBenchmark.runThePipeline_05Threads                                   thrpt    5  3352.511 ±  53.533  ops/ms
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.alloc.rate                    thrpt    5  7233.932 ± 138.314  MB/sec
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.alloc.rate.norm               thrpt    5  3400.001 ±   0.001    B/op
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.churn.PS_Eden_Space           thrpt    5  7310.190 ± 695.826  MB/sec
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.churn.PS_Eden_Space.norm      thrpt    5  3435.823 ± 315.746    B/op
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.churn.PS_Survivor_Space       thrpt    5     0.232 ±   0.327  MB/sec
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.churn.PS_Survivor_Space.norm  thrpt    5     0.109 ±   0.156    B/op
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.count                         thrpt    5    79.000            counts
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.time                          thrpt    5    50.000                ms
```

this branch benchmark:
```
SpanPipelineBenchmark.runThePipeline_05Threads                                   thrpt    5  3980.803 ± 253.972  ops/ms
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.alloc.rate                    thrpt    5  6935.797 ± 455.120  MB/sec
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.alloc.rate.norm               thrpt    5  2744.001 ±   0.001    B/op
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.churn.PS_Eden_Space           thrpt    5  6984.225 ± 279.329  MB/sec
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.churn.PS_Eden_Space.norm      thrpt    5  2763.550 ± 139.847    B/op
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.churn.PS_Survivor_Space       thrpt    5     0.245 ±   0.330  MB/sec
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.churn.PS_Survivor_Space.norm  thrpt    5     0.097 ±   0.135    B/op
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.count                         thrpt    5    71.000            counts
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.time                          thrpt    5    46.000                ms
```

Or graphically (from a different run): 

Here are the benchmark results from master:  

![image](https://user-images.githubusercontent.com/858731/82482474-c1c0ef80-9a8b-11ea-897a-5fea04a5a085.png)

And on this branch:

![image](https://user-images.githubusercontent.com/858731/82482495-cdacb180-9a8b-11ea-9b38-0c17af8d62c7.png)
