### PR TITLE
use java 8 for tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,12 @@ $ git commit -m "Update javadoc for API."
   possible, for any new value classes. Remember to add package-private
   constructors to all AutoValue classes to prevent classes in other packages
   from extending them.
+  
+  
+### Unit Tests
+
+* Unit tests target Java 8, so language features such as lambda and streams can be used in tests.
+
 
 ## Building opentelemetry-java
 

--- a/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
@@ -33,7 +33,6 @@ import io.opentelemetry.trace.TracingContextUtils;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import javax.annotation.Nullable;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -58,21 +57,8 @@ public class HttpTraceContextTest {
       "00-" + TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-01";
   private static final String TRACEPARENT_HEADER_NOT_SAMPLED =
       "00-" + TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-00";
-  private static final Setter<Map<String, String>> setter =
-      new Setter<Map<String, String>>() {
-        @Override
-        public void set(Map<String, String> carrier, String key, String value) {
-          carrier.put(key, value);
-        }
-      };
-  private static final Getter<Map<String, String>> getter =
-      new Getter<Map<String, String>>() {
-        @Nullable
-        @Override
-        public String get(Map<String, String> carrier, String key) {
-          return carrier.get(key);
-        }
-      };
+  private static final Setter<Map<String, String>> setter = Map::put;
+  private static final Getter<Map<String, String>> getter = (carrier, key) -> carrier.get(key);
   // Encoding preserves the order which is the reverse order of adding.
   private static final String TRACESTATE_NOT_DEFAULT_ENCODING = "bar=baz,foo=bar";
   private static final String TRACESTATE_NOT_DEFAULT_ENCODING_WITH_SPACES =
@@ -105,12 +91,7 @@ public class HttpTraceContextTest {
     httpTraceContext.inject(
         context,
         null,
-        new Setter<Map<String, String>>() {
-          @Override
-          public void set(Map<String, String> ignored, String key, String value) {
-            carrier.put(key, value);
-          }
-        });
+        (Setter<Map<String, String>>) (ignored, key, value) -> carrier.put(key, value));
     assertThat(carrier).containsExactly(TRACE_PARENT, TRACEPARENT_HEADER_SAMPLED);
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,13 @@ configure(opentelemetryProjects) {
     compileTestJava {
         // serialVersionUID is basically guaranteed to be useless in tests
         options.compilerArgs += ["-Xlint:-serial"]
+        sourceCompatibility = 1.8
+        targetCompatibility = 1.8
+
+        // Disable Java7 checks in test sources
+        options.errorprone.disable("Java7ApiChecker")
+        // Disable AndroidJdkLibs checks in test sources
+        options.errorprone.disable("AndroidJdkLibsChecker")
     }
 
     jar.manifest {


### PR DESCRIPTION
resolves #1187 

Tests now use Java 8.
I modified the ```HttpTraceContextTest``` to demonstrate that Java 8 is used,  I removed some boilerplate, which is now using lambdas.
I also disabled the ```Java7ApiChecker``` and ```AndroidJdkLibsChecker``` errorprone checks when compiling tests as these will warn if you use e.g. streams in your test.
