### PR TITLE
Correct spelling of key/file for the TraceProvider service lookup.

### DIFF
--- a/api/src/main/java/io/opentelemetry/metrics/spi/MetricsProvider.java
+++ b/api/src/main/java/io/opentelemetry/metrics/spi/MetricsProvider.java
@@ -20,8 +20,8 @@ import io.opentelemetry.metrics.MeterProvider;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * MetricsProvider is a service provider for {@link MeterProvider}. Fully qualified class name
- * of the implementation should be registered in {@code
+ * MetricsProvider is a service provider for {@link MeterProvider}. Fully qualified class name of
+ * the implementation should be registered in {@code
  * META-INF/services/io.opentelemetry.metrics.spi.MetricsProvider}. <br>
  * <br>
  * A specific implementation can be selected by a system property {@code

--- a/api/src/main/java/io/opentelemetry/metrics/spi/MetricsProvider.java
+++ b/api/src/main/java/io/opentelemetry/metrics/spi/MetricsProvider.java
@@ -20,12 +20,12 @@ import io.opentelemetry.metrics.MeterProvider;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * MeterRegistryProvider is a service provider for {@link MeterProvider}. Fully qualified class name
+ * MetricsProvider is a service provider for {@link MeterProvider}. Fully qualified class name
  * of the implementation should be registered in {@code
- * META-INF/services/io.opentelemetry.metrics.spi.MeterRegistryProvider}. <br>
+ * META-INF/services/io.opentelemetry.metrics.spi.MetricsProvider}. <br>
  * <br>
  * A specific implementation can be selected by a system property {@code
- * io.opentelemetry.metrics.spi.MeterRegistryProvider} with value of fully qualified class name.
+ * io.opentelemetry.metrics.spi.MetricsProvider} with value of fully qualified class name.
  *
  * @see io.opentelemetry.OpenTelemetry
  */

--- a/api/src/main/java/io/opentelemetry/trace/spi/TraceProvider.java
+++ b/api/src/main/java/io/opentelemetry/trace/spi/TraceProvider.java
@@ -22,10 +22,10 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * TracerProvider is a service provider for a {@link TracerProvider}. Fully qualified class name of
  * the implementation should be registered in {@code
- * META-INF/services/io.opentelemetry.trace.spi.TracerProvider}. <br>
+ * META-INF/services/io.opentelemetry.trace.spi.TraceProvider}. <br>
  * <br>
  * A specific implementation can be selected by a system property {@code
- * io.opentelemetry.trace.spi.TracerProvider} with value of fully qualified class name.
+ * io.opentelemetry.trace.spi.TraceProvider} with value of fully qualified class name.
  *
  * @see io.opentelemetry.OpenTelemetry
  */

--- a/api/src/main/java/io/opentelemetry/trace/spi/TraceProvider.java
+++ b/api/src/main/java/io/opentelemetry/trace/spi/TraceProvider.java
@@ -20,7 +20,7 @@ import io.opentelemetry.trace.TracerProvider;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * TracerProvider is a service provider for a {@link TracerProvider}. Fully qualified class name of
+ * TraceProvider is a service provider for a {@link TracerProvider}. Fully qualified class name of
  * the implementation should be registered in {@code
  * META-INF/services/io.opentelemetry.trace.spi.TraceProvider}. <br>
  * <br>


### PR DESCRIPTION
While testing an alternate TracerProvider implementation, I found that the docs for `TraceProvider` service lookup had an incorrect spelling of the class name.