### PR TITLE
Cache docker images in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ publish_release_task: &publish_release_task
   command: make publish-release-artifacts
 
 #for test containers https://www.testcontainers.org/supported_docker_environment/continuous_integration/circle_ci/
-executorType: machine
 
 jobs:
   build:
@@ -28,12 +27,11 @@ jobs:
       # Configure the JVM and Gradle to avoid OOM errors
       _JAVA_OPTIONS: "-Xmx1g"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
-    docker:
-      - image: circleci/openjdk:8-jdk
+    machine:
+        image: circleci/openjdk:8-jdk
+        docker_layer_caching: true
     steps:
       - checkout
-      - setup_remote_docker:
-            docker_layer_caching: true
       - restore_cache:
           keys:
             - gradle-{{ checksum "build.gradle" }}
@@ -63,12 +61,11 @@ jobs:
       # Configure the JVM and Gradle to avoid OOM errors
       _JAVA_OPTIONS: "-Xmx3g"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
-    docker:
-      - image: circleci/openjdk:11.0.6-jdk-buster
+    machine:
+        image: circleci/openjdk:11.0.6-jdk-buster
+        docker_layer_caching: true
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
       - restore_cache:
           keys:
             - java11-gradle-{{ checksum "build.gradle" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       _JAVA_OPTIONS: "-Xmx1g"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
     machine:
-        image: circleci/openjdk:8-jdk
+        image: ubuntu-1604:202004-01
         docker_layer_caching: true
     steps:
       - checkout
@@ -62,7 +62,7 @@ jobs:
       _JAVA_OPTIONS: "-Xmx3g"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
     machine:
-        image: circleci/openjdk:11.0.6-jdk-buster
+        image: ubuntu-1604:202004-01
         docker_layer_caching: true
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,8 @@ jobs:
       - image: circleci/openjdk:8-jdk
     steps:
       - checkout
+      - setup_remote_docker:
+            docker_layer_caching: true
       - restore_cache:
           keys:
             - gradle-{{ checksum "build.gradle" }}
@@ -65,6 +67,8 @@ jobs:
       - image: circleci/openjdk:11.0.6-jdk-buster
     steps:
       - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
       - restore_cache:
           keys:
             - java11-gradle-{{ checksum "build.gradle" }}


### PR DESCRIPTION
According to the [CircleCI doc](https://circleci.com/docs/2.0/docker-layer-caching/), it is possible to cache docker images. This (hopefully) should avoid problems such as [build failure](https://circleci.com/gh/open-telemetry/opentelemetry-java/4073) due to outages of [docker registries](https://status.quay.io/) and improve the overall build speed. 