### PR TITLE
fix: force maven publish to include version for api conf

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -315,6 +315,12 @@ configure(opentelemetryProjects) {
                     artifact sourcesJar
                     artifact javadocJar
 
+                    versionMapping {
+                        usage('java-api') {
+                            fromResolutionOf('runtimeClasspath')
+                        }
+                    }
+
                     pom {
                         name = 'OpenTelemetry Java'
                         packaging = 'jar'


### PR DESCRIPTION
resolves #1246 
result:
```
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <!-- This module was also published with a richer model, Gradle metadata,  -->
  <!-- which should be used instead. Do not delete the following line which  -->
  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
  <!-- that they should prefer consuming it instead. -->
  <!-- do_not_remove: published-with-gradle-metadata -->
  <modelVersion>4.0.0</modelVersion>
  <groupId>io.opentelemetry</groupId>
  <artifactId>opentelemetry-context-prop</artifactId>
  <version>0.5.0-SNAPSHOT</version>
  <name>OpenTelemetry Java</name>
  <description>OpenTelemetry Context Propagation</description>
  <url>https://github.com/open-telemetry/opentelemetry-java</url>
  <licenses>
    <license>
      <name>The Apache License, Version 2.0</name>
      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
    </license>
  </licenses>
  <developers>
    <developer>
      <id>opentelemetry</id>
      <name>OpenTelemetry Gitter</name>
      <url>https://gitter.im/open-telemetry/community</url>
    </developer>
  </developers>
  <scm>
    <connection>scm:git:git@github.com:open-telemetry/opentelemetry-java.git</connection>
    <developerConnection>scm:git:git@github.com:open-telemetry/opentelemetry-java.git</developerConnection>
    <url>git@github.com:open-telemetry/opentelemetry-java.git</url>
  </scm>
  <dependencyManagement>
    <dependencies>
      <dependency>
        <groupId>io.grpc</groupId>
        <artifactId>grpc-bom</artifactId>
        <version>1.28.0</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
      <dependency>
        <groupId>com.google.guava</groupId>
        <artifactId>guava-bom</artifactId>
        <version>28.2-android</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
      <dependency>
        <groupId>com.google.protobuf</groupId>
        <artifactId>protobuf-bom</artifactId>
        <version>3.11.4</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
      <dependency>
        <groupId>io.zipkin.reporter2</groupId>
        <artifactId>zipkin-reporter-bom</artifactId>
        <version>2.12.2</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
    </dependencies>
  </dependencyManagement>
  <dependencies>
    <dependency>
      <groupId>io.grpc</groupId>
      <artifactId>grpc-context</artifactId>
      <version>1.28.0</version>
      <scope>compile</scope>
    </dependency>
  </dependencies>
</project>
```
dependencies section now include version from gradle api configuration, i think that should solve problem with missing version for clients
