### PR TITLE
Support env vars for TraceConfig initialization

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/common/export/ConfigBuilder.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/common/export/ConfigBuilder.java
@@ -151,4 +151,21 @@ public abstract class ConfigBuilder<T> {
   protected static String getStringProperty(String name, Map<String, String> map) {
     return map.get(name);
   }
+
+  /**
+   * Get a double property from the map, {@code null} if it cannot be found or it has a wrong type.
+   *
+   * @param name The property name
+   * @param map The map where to look for the property
+   * @return the {@link Double} value of the property, {@code null} in case of error or if the
+   *     property cannot be found.
+   */
+  @Nullable
+  protected static Double getDoubleProperty(String name, Map<String, String> map) {
+    try {
+      return Double.parseDouble(map.get(name));
+    } catch (NumberFormatException | NullPointerException ex) {
+      return null;
+    }
+  }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
@@ -32,7 +32,7 @@ import javax.annotation.concurrent.Immutable;
  * Class that holds global trace parameters.
  *
  * <p>Note: To update the TraceConfig associated with a {@link
- * io.opentelemetry.sdk.trace.TracerSdkProvider}, you should use the {@link #newBuilder()} method on
+ * io.opentelemetry.sdk.trace.TracerSdkProvider}, you should use the {@link #toBuilder()} method on
  * the TraceConfig currently assigned to the provider, make the changes desired to the {@link
  * Builder} instance, then use the {@link
  * io.opentelemetry.sdk.trace.TracerSdkProvider#updateActiveTraceConfig(TraceConfig)} with the

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
@@ -91,16 +91,16 @@ public abstract class TraceConfig {
   private static final int DEFAULT_SPAN_MAX_NUM_ATTRIBUTES_PER_LINK = 32;
 
   /**
-   * Returns a new {@link TraceConfig} reading the configuration values from the environment and
-   * from system properties. System properties override values defined in the environment. If a
-   * configuration value is missing, it uses the default value.
+   * Returns the default {@code TraceConfig}.
    *
    * @return the default {@code TraceConfig}.
    * @since 0.1.0
    */
   public static TraceConfig getDefault() {
-    return newBuilder().readEnvironmentVariables().readSystemProperties().build();
+    return DEFAULT;
   }
+
+  private static final TraceConfig DEFAULT = TraceConfig.newBuilder().build();
 
   /**
    * Returns the global default {@code Sampler} which is used when constructing a new {@code Span}.

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
@@ -47,7 +47,8 @@ import javax.annotation.concurrent.Immutable;
  * for the following names:
  *
  * <ul>
- *   <li>{@code otel.config.sampler.probability}: to set the global default sampler for traces.
+ *   <li>{@code otel.config.sampler.probability}: to set the global default sampler which is used
+ *       when constructing a new {@code Span}.
  *   <li>{@code otel.config.max.attrs}: to set the global default max number of attributes per
  *       {@link Span}.
  *   <li>{@code otel.config.max.events}: to set the global default max number of {@link Event}s per
@@ -63,7 +64,8 @@ import javax.annotation.concurrent.Immutable;
  * <p>For environment variables, {@link TraceConfig} will look for the following names:
  *
  * <ul>
- *   <li>{@code OTEL_CONFIG_SAMPLER_PROBABILITY}: to set the global default sampler for traces.
+ *   <li>{@code OTEL_CONFIG_SAMPLER_PROBABILITY}: to set the global default sampler which is used
+ *       when constructing a new {@code Span}.
  *   <li>{@code OTEL_CONFIG_MAX_ATTRS}: to set the global default max number of attributes per
  *       {@link Span}.
  *   <li>{@code OTEL_CONFIG_MAX_EVENTS}: to set the global default max number of {@link Event}s per
@@ -259,7 +261,8 @@ public abstract class TraceConfig {
      * Sets the global default {@code Sampler}. It must be not {@code null} otherwise {@link
      * #build()} will throw an exception.
      *
-     * @param samplerProbability the global default {@code Sampler}.
+     * @param samplerProbability the global default probability used to make decisions on {@link
+     *     Span} sampling.
      * @return this.
      */
     public Builder setSamplerProbability(double samplerProbability) {
@@ -328,11 +331,10 @@ public abstract class TraceConfig {
      * Builds and returns a {@code TraceConfig} with the desired values.
      *
      * @return a {@code TraceConfig} with the desired values.
-     * @throws IllegalArgumentException if any of the max numbers are not positive
+     * @throws IllegalArgumentException if any of the max numbers are not positive.
      */
     public TraceConfig build() {
       TraceConfig traceConfig = autoBuild();
-      Preconditions.checkArgument(traceConfig.getSampler() != null, "sampler");
       Preconditions.checkArgument(
           traceConfig.getMaxNumberOfAttributes() > 0, "maxNumberOfAttributes");
       Preconditions.checkArgument(traceConfig.getMaxNumberOfEvents() > 0, "maxNumberOfEvents");

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
@@ -79,13 +79,14 @@ import javax.annotation.concurrent.Immutable;
 @AutoValue
 @Immutable
 public abstract class TraceConfig {
-
+  // These values are the default values for all the global parameters.
+  // TODO: decide which default sampler to use
+  private static final Sampler DEFAULT_SAMPLER = Samplers.alwaysOn();
   private static final int DEFAULT_SPAN_MAX_NUM_ATTRIBUTES = 32;
   private static final int DEFAULT_SPAN_MAX_NUM_EVENTS = 128;
   private static final int DEFAULT_SPAN_MAX_NUM_LINKS = 32;
   private static final int DEFAULT_SPAN_MAX_NUM_ATTRIBUTES_PER_EVENT = 32;
   private static final int DEFAULT_SPAN_MAX_NUM_ATTRIBUTES_PER_LINK = 32;
-  private static final Sampler DEFAULT_SAMPLER = Samplers.alwaysOn();
 
   /**
    * Returns a new {@link TraceConfig} reading the configuration values from the environment and

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
@@ -16,36 +16,38 @@
 
 package io.opentelemetry.sdk.trace.config;
 
-import com.google.auto.value.AutoValue;
-import com.google.common.base.Preconditions;
+import com.google.common.annotations.VisibleForTesting;
+import io.opentelemetry.internal.Utils;
+import io.opentelemetry.sdk.common.export.ConfigBuilder;
 import io.opentelemetry.sdk.trace.Sampler;
 import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.trace.Event;
 import io.opentelemetry.trace.Link;
 import io.opentelemetry.trace.Span;
+import java.util.Map;
+import java.util.Properties;
 import javax.annotation.concurrent.Immutable;
 
 /**
  * Class that holds global trace parameters.
  *
  * <p>Note: To update the TraceConfig associated with a {@link
- * io.opentelemetry.sdk.trace.TracerSdkProvider}, you should use the {@link #toBuilder()} method on
+ * io.opentelemetry.sdk.trace.TracerSdkProvider}, you should use the {@link #newBuilder()} method on
  * the TraceConfig currently assigned to the provider, make the changes desired to the {@link
  * Builder} instance, then use the {@link
  * io.opentelemetry.sdk.trace.TracerSdkProvider#updateActiveTraceConfig(TraceConfig)} with the
  * resulting TraceConfig instance.
  */
-@AutoValue
 @Immutable
-public abstract class TraceConfig {
+public class TraceConfig {
   // These values are the default values for all the global parameters.
   // TODO: decide which default sampler to use
-  private static final Sampler DEFAULT_SAMPLER = Samplers.alwaysOn();
-  private static final int DEFAULT_SPAN_MAX_NUM_ATTRIBUTES = 32;
-  private static final int DEFAULT_SPAN_MAX_NUM_EVENTS = 128;
-  private static final int DEFAULT_SPAN_MAX_NUM_LINKS = 32;
-  private static final int DEFAULT_SPAN_MAX_NUM_ATTRIBUTES_PER_EVENT = 32;
-  private static final int DEFAULT_SPAN_MAX_NUM_ATTRIBUTES_PER_LINK = 32;
+  private final Sampler sampler;
+  private final int maxNumberOfAttributes;
+  private final int maxNumberOfEvents;
+  private final int maxNumberOfLinks;
+  private final int maxNumberOfAttributesPerEvent;
+  private final int maxNumberOfAttributesPerLink;
 
   /**
    * Returns the default {@code TraceConfig}.
@@ -58,64 +60,84 @@ public abstract class TraceConfig {
   }
 
   private static final TraceConfig DEFAULT =
-      TraceConfig.newBuilder()
-          .setSampler(DEFAULT_SAMPLER)
-          .setMaxNumberOfAttributes(DEFAULT_SPAN_MAX_NUM_ATTRIBUTES)
-          .setMaxNumberOfEvents(DEFAULT_SPAN_MAX_NUM_EVENTS)
-          .setMaxNumberOfLinks(DEFAULT_SPAN_MAX_NUM_LINKS)
-          .setMaxNumberOfAttributesPerEvent(DEFAULT_SPAN_MAX_NUM_ATTRIBUTES_PER_EVENT)
-          .setMaxNumberOfAttributesPerLink(DEFAULT_SPAN_MAX_NUM_ATTRIBUTES_PER_LINK)
-          .build();
+      TraceConfig.newBuilder().readEnvironmentVariables().readSystemProperties().build();
+
+  private TraceConfig(
+      Sampler sampler,
+      int maxNumberOfAttributes,
+      int maxNumberOfEvents,
+      int maxNumberOfLinks,
+      int maxNumberOfAttributesPerEvent,
+      int maxNumberOfAttributesPerLink) {
+    this.sampler = sampler;
+    this.maxNumberOfAttributes = maxNumberOfAttributes;
+    this.maxNumberOfEvents = maxNumberOfEvents;
+    this.maxNumberOfLinks = maxNumberOfLinks;
+    this.maxNumberOfAttributesPerEvent = maxNumberOfAttributesPerEvent;
+    this.maxNumberOfAttributesPerLink = maxNumberOfAttributesPerLink;
+  }
 
   /**
    * Returns the global default {@code Sampler} which is used when constructing a new {@code Span}.
    *
    * @return the global default {@code Sampler}.
    */
-  public abstract Sampler getSampler();
+  public Sampler getSampler() {
+    return sampler;
+  }
 
   /**
    * Returns the global default max number of attributes per {@link Span}.
    *
    * @return the global default max number of attributes per {@link Span}.
    */
-  public abstract int getMaxNumberOfAttributes();
+  public int getMaxNumberOfAttributes() {
+    return maxNumberOfAttributes;
+  }
 
   /**
    * Returns the global default max number of {@link Event}s per {@link Span}.
    *
    * @return the global default max number of {@code Event}s per {@code Span}.
    */
-  public abstract int getMaxNumberOfEvents();
+  public int getMaxNumberOfEvents() {
+    return maxNumberOfEvents;
+  }
 
   /**
    * Returns the global default max number of {@link Link} entries per {@link Span}.
    *
    * @return the global default max number of {@code Link} entries per {@code Span}.
    */
-  public abstract int getMaxNumberOfLinks();
+  public int getMaxNumberOfLinks() {
+    return maxNumberOfLinks;
+  }
 
   /**
    * Returns the global default max number of attributes per {@link Event}.
    *
    * @return the global default max number of attributes per {@link Event}.
    */
-  public abstract int getMaxNumberOfAttributesPerEvent();
+  public int getMaxNumberOfAttributesPerEvent() {
+    return maxNumberOfAttributesPerEvent;
+  }
 
   /**
    * Returns the global default max number of attributes per {@link Link}.
    *
    * @return the global default max number of attributes per {@link Link}.
    */
-  public abstract int getMaxNumberOfAttributesPerLink();
+  public int getMaxNumberOfAttributesPerLink() {
+    return maxNumberOfAttributesPerLink;
+  }
 
   /**
    * Returns a new {@link Builder}.
    *
    * @return a new {@link Builder}.
    */
-  private static Builder newBuilder() {
-    return new AutoValue_TraceConfig.Builder();
+  public static Builder newBuilder() {
+    return new Builder();
   }
 
   /**
@@ -123,11 +145,170 @@ public abstract class TraceConfig {
    *
    * @return a {@link Builder} initialized to the same property values as the current instance.
    */
-  public abstract Builder toBuilder();
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
 
-  /** A {@code Builder} class for {@link TraceConfig}. */
-  @AutoValue.Builder
-  public abstract static class Builder {
+  public static final class Builder extends ConfigBuilder<Builder> {
+    private static final String KEY_SAMPLER_PROBABILITY = "otel.config.sampler.probability";
+    private static final String KEY_SPAN_MAX_NUM_ATTRIBUTES = "otel.config.max.attrs";
+    private static final String KEY_SPAN_MAX_NUM_EVENTS = "otel.config.max.events";
+    private static final String KEY_SPAN_MAX_NUM_LINKS = "otel.config.max.links";
+    private static final String KEY_SPAN_MAX_NUM_ATTRIBUTES_PER_EVENT =
+        "otel.config.max.event.attrs";
+    private static final String KEY_SPAN_MAX_NUM_ATTRIBUTES_PER_LINK = "otel.config.max.link.attrs";
+
+    private static final int DEFAULT_SPAN_MAX_NUM_ATTRIBUTES = 32;
+    private static final int DEFAULT_SPAN_MAX_NUM_EVENTS = 128;
+    private static final int DEFAULT_SPAN_MAX_NUM_LINKS = 32;
+    private static final int DEFAULT_SPAN_MAX_NUM_ATTRIBUTES_PER_EVENT = 32;
+    private static final int DEFAULT_SPAN_MAX_NUM_ATTRIBUTES_PER_LINK = 32;
+
+    private Sampler sampler = Samplers.alwaysOn();
+    private int maxNumberOfAttributes = DEFAULT_SPAN_MAX_NUM_ATTRIBUTES;
+    private int maxNumberOfEvents = DEFAULT_SPAN_MAX_NUM_EVENTS;
+    private int maxNumberOfLinks = DEFAULT_SPAN_MAX_NUM_LINKS;
+    private int maxNumberOfAttributesPerEvent = DEFAULT_SPAN_MAX_NUM_ATTRIBUTES_PER_EVENT;
+    private int maxNumberOfAttributesPerLink = DEFAULT_SPAN_MAX_NUM_ATTRIBUTES_PER_LINK;
+
+    private Builder(TraceConfig traceConfig) {
+      this.sampler = traceConfig.sampler;
+      this.maxNumberOfEvents = traceConfig.maxNumberOfEvents;
+      this.maxNumberOfLinks = traceConfig.maxNumberOfLinks;
+      this.maxNumberOfAttributesPerLink = traceConfig.maxNumberOfAttributesPerLink;
+      this.maxNumberOfAttributesPerEvent = traceConfig.maxNumberOfAttributesPerEvent;
+    }
+
+    private Builder() {}
+
+    /**
+     * Sets the configuration values from the given configuration map for only the available keys.
+     * This method looks for the following keys:
+     *
+     * <ul>
+     *   <li>{@code otel.config.sampler.probability}: to set the global default sampler for traces.
+     *   <li>{@code otel.config.max.attrs}: to set the global default max number of attributes per
+     *       {@link Span}.
+     *   <li>{@code otel.config.max.events}: to set the global default max number of {@link Event}s
+     *       per {@link Span}.
+     *   <li>{@code otel.config.max.links}: to set the global default max number of {@link Link}
+     *       entries per {@link Span}.
+     *   <li>{@code otel.config.max.event.attrs}: to set the global default max number of attributes
+     *       per {@link Event}.
+     *   <li>{@code otel.config.max.link.attrs}: to set the global default max number of attributes
+     *       per {@link Link}.
+     * </ul>
+     *
+     * @param configMap {@link Map} holding the configuration values.
+     * @return this.
+     */
+    @VisibleForTesting
+    @Override
+    protected Builder fromConfigMap(
+        Map<String, String> configMap, Builder.NamingConvention namingConvention) {
+      configMap = namingConvention.normalize(configMap);
+      Double doubleValue = getDoubleProperty(KEY_SAMPLER_PROBABILITY, configMap);
+      if (doubleValue != null) {
+        this.setSamplerProbability(doubleValue);
+      }
+      Integer intValue = getIntProperty(KEY_SPAN_MAX_NUM_ATTRIBUTES, configMap);
+      if (intValue != null) {
+        this.setMaxNumberOfAttributes(intValue);
+      }
+      intValue = getIntProperty(KEY_SPAN_MAX_NUM_EVENTS, configMap);
+      if (intValue != null) {
+        this.setMaxNumberOfEvents(intValue);
+      }
+      intValue = getIntProperty(KEY_SPAN_MAX_NUM_LINKS, configMap);
+      if (intValue != null) {
+        this.setMaxNumberOfLinks(intValue);
+      }
+      intValue = getIntProperty(KEY_SPAN_MAX_NUM_ATTRIBUTES_PER_EVENT, configMap);
+      if (intValue != null) {
+        this.setMaxNumberOfAttributesPerEvent(intValue);
+      }
+      intValue = getIntProperty(KEY_SPAN_MAX_NUM_ATTRIBUTES_PER_LINK, configMap);
+      if (intValue != null) {
+        this.setMaxNumberOfAttributesPerLink(intValue);
+      }
+      return this;
+    }
+
+    /**
+     * Sets the configuration values from the given properties object for only the available keys.
+     * This method looks for the following keys:
+     *
+     * <ul>
+     *   <li>{@code otel.config.sampler.probability}: to set the global default sampler for traces.
+     *   <li>{@code otel.config.max.attrs}: to set the global default max number of attributes per
+     *       {@link Span}.
+     *   <li>{@code otel.config.max.events}: to set the global default max number of {@link Event}s
+     *       per {@link Span}.
+     *   <li>{@code otel.config.max.links}: to set the global default max number of {@link Link}
+     *       entries per {@link Span}.
+     *   <li>{@code otel.config.max.event.attrs}: to set the global default max number of attributes
+     *       per {@link Event}.
+     *   <li>{@code otel.config.max.link.attrs}: to set the global default max number of attributes
+     *       per {@link Link}.
+     * </ul>
+     *
+     * @param properties {@link Properties} holding the configuration values.
+     * @return this.
+     */
+    @Override
+    public Builder readProperties(Properties properties) {
+      return super.readProperties(properties);
+    }
+
+    /**
+     * Sets the configuration values from environment variables for only the available keys. This
+     * method looks for the following keys:
+     *
+     * <ul>
+     *   <li>{@code OTEL_CONFIG_SAMPLER_PROBABILITY}: to set the global default sampler for traces.
+     *   <li>{@code OTEL_CONFIG_MAX_ATTRS}: to set the global default max number of attributes per
+     *       {@link Span}.
+     *   <li>{@code OTEL_CONFIG_MAX_EVENTS}: to set the global default max number of {@link Event}s
+     *       per {@link Span}.
+     *   <li>{@code OTEL_CONFIG_MAX_LINKS}: to set the global default max number of {@link Link}
+     *       entries per {@link Span}.
+     *   <li>{@code OTEL_CONFIG_MAX_EVENT_ATTRS}: to set the global default max number of attributes
+     *       per {@link Event}.
+     *   <li>{@code OTEL_CONFIG_MAX_LINK_ATTRS}: to set the global default max number of attributes
+     *       per {@link Link}.
+     * </ul>
+     *
+     * @return this.
+     */
+    @Override
+    public Builder readEnvironmentVariables() {
+      return super.readEnvironmentVariables();
+    }
+
+    /**
+     * Sets the configuration values from system properties for only the available keys. This method
+     * looks for the following keys:
+     *
+     * <ul>
+     *   <li>{@code otel.config.sampler.probability}: to set the global default sampler for traces.
+     *   <li>{@code otel.config.max.attrs}: to set the global default max number of attributes per
+     *       {@link Span}.
+     *   <li>{@code otel.config.max.events}: to set the global default max number of {@link Event}s
+     *       per {@link Span}.
+     *   <li>{@code otel.config.max.links}: to set the global default max number of {@link Link}
+     *       entries per {@link Span}.
+     *   <li>{@code otel.config.max.event.attrs}: to set the global default max number of attributes
+     *       per {@link Event}.
+     *   <li>{@code otel.config.max.link.attrs}: to set the global default max number of attributes
+     *       per {@link Link}.
+     * </ul>
+     *
+     * @return this.
+     */
+    @Override
+    public Builder readSystemProperties() {
+      return super.readSystemProperties();
+    }
 
     /**
      * Sets the global default {@code Sampler}. It must be not {@code null} otherwise {@link
@@ -136,7 +317,33 @@ public abstract class TraceConfig {
      * @param sampler the global default {@code Sampler}.
      * @return this.
      */
-    public abstract Builder setSampler(Sampler sampler);
+    public Builder setSampler(Sampler sampler) {
+      Utils.checkArgument(sampler != null, "sampler should not be null");
+      this.sampler = sampler;
+      return this;
+    }
+
+    /**
+     * Sets the global default {@code Sampler}. It must be not {@code null} otherwise {@link
+     * #build()} will throw an exception.
+     *
+     * @param samplerProbability the global default {@code Sampler}.
+     * @return this.
+     */
+    public Builder setSamplerProbability(double samplerProbability) {
+      Utils.checkArgument(
+          samplerProbability >= 0, "samplerProbability must be greater than or equal to 0.");
+      Utils.checkArgument(
+          samplerProbability <= 1, "samplerProbability must be lesser than or equal to 1.");
+      if (samplerProbability == 1) {
+        sampler = Samplers.alwaysOn();
+      } else if (samplerProbability == 0) {
+        sampler = Samplers.alwaysOff();
+      } else {
+        sampler = Samplers.probability(samplerProbability);
+      }
+      return this;
+    }
 
     /**
      * Sets the global default max number of attributes per {@link Span}.
@@ -145,7 +352,11 @@ public abstract class TraceConfig {
      *     must be positive otherwise {@link #build()} will throw an exception.
      * @return this.
      */
-    public abstract Builder setMaxNumberOfAttributes(int maxNumberOfAttributes);
+    public Builder setMaxNumberOfAttributes(int maxNumberOfAttributes) {
+      Utils.checkArgument(maxNumberOfAttributes > 0, "maxNumberOfAttributes must be positive.");
+      this.maxNumberOfAttributes = maxNumberOfAttributes;
+      return this;
+    }
 
     /**
      * Sets the global default max number of {@link Event}s per {@link Span}.
@@ -154,7 +365,11 @@ public abstract class TraceConfig {
      *     must be positive otherwise {@link #build()} will throw an exception.
      * @return this.
      */
-    public abstract Builder setMaxNumberOfEvents(int maxNumberOfEvents);
+    public Builder setMaxNumberOfEvents(int maxNumberOfEvents) {
+      Utils.checkArgument(maxNumberOfEvents > 0, "maxNumberOfEvents must be positive.");
+      this.maxNumberOfEvents = maxNumberOfEvents;
+      return this;
+    }
 
     /**
      * Sets the global default max number of {@link Link} entries per {@link Span}.
@@ -163,7 +378,11 @@ public abstract class TraceConfig {
      *     Span}. It must be positive otherwise {@link #build()} will throw an exception.
      * @return this.
      */
-    public abstract Builder setMaxNumberOfLinks(int maxNumberOfLinks);
+    public Builder setMaxNumberOfLinks(int maxNumberOfLinks) {
+      Utils.checkArgument(maxNumberOfLinks > 0, "maxNumberOfLinks must be positive.");
+      this.maxNumberOfLinks = maxNumberOfLinks;
+      return this;
+    }
 
     /**
      * Sets the global default max number of attributes per {@link Event}.
@@ -172,7 +391,12 @@ public abstract class TraceConfig {
      *     Event}. It must be positive otherwise {@link #build()} will throw an exception.
      * @return this.
      */
-    public abstract Builder setMaxNumberOfAttributesPerEvent(int maxNumberOfAttributesPerEvent);
+    public Builder setMaxNumberOfAttributesPerEvent(int maxNumberOfAttributesPerEvent) {
+      Utils.checkArgument(
+          maxNumberOfAttributesPerEvent > 0, "maxNumberOfAttributesPerEvent must be positive.");
+      this.maxNumberOfAttributesPerEvent = maxNumberOfAttributesPerEvent;
+      return this;
+    }
 
     /**
      * Sets the global default max number of attributes per {@link Link}.
@@ -181,9 +405,12 @@ public abstract class TraceConfig {
      *     Link}. It must be positive otherwise {@link #build()} will throw an exception.
      * @return this.
      */
-    public abstract Builder setMaxNumberOfAttributesPerLink(int maxNumberOfAttributesPerLink);
-
-    abstract TraceConfig autoBuild();
+    public Builder setMaxNumberOfAttributesPerLink(int maxNumberOfAttributesPerLink) {
+      Utils.checkArgument(
+          maxNumberOfAttributesPerLink > 0, "maxNumberOfAttributesPerLink must be positive.");
+      this.maxNumberOfAttributesPerLink = maxNumberOfAttributesPerLink;
+      return this;
+    }
 
     /**
      * Builds and returns a {@code TraceConfig} with the desired values.
@@ -192,16 +419,13 @@ public abstract class TraceConfig {
      * @throws IllegalArgumentException if any of the max numbers are not positive.
      */
     public TraceConfig build() {
-      TraceConfig traceConfig = autoBuild();
-      Preconditions.checkArgument(
-          traceConfig.getMaxNumberOfAttributes() > 0, "maxNumberOfAttributes");
-      Preconditions.checkArgument(traceConfig.getMaxNumberOfEvents() > 0, "maxNumberOfEvents");
-      Preconditions.checkArgument(traceConfig.getMaxNumberOfLinks() > 0, "maxNumberOfLinks");
-      Preconditions.checkArgument(
-          traceConfig.getMaxNumberOfAttributesPerEvent() > 0, "maxNumberOfAttributesPerEvent");
-      Preconditions.checkArgument(
-          traceConfig.getMaxNumberOfAttributesPerLink() > 0, "maxNumberOfAttributesPerLink");
-      return traceConfig;
+      return new TraceConfig(
+          sampler,
+          maxNumberOfAttributes,
+          maxNumberOfEvents,
+          maxNumberOfLinks,
+          maxNumberOfAttributesPerEvent,
+          maxNumberOfAttributesPerLink);
     }
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/config/package-info.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/config/package-info.java
@@ -41,7 +41,8 @@
  * io.opentelemetry.sdk.trace.config.TraceConfig} will look for the following names:
  *
  * <ul>
- *   <li>{@code otel.config.sampler.probability}: to set the global default sampler for traces.
+ *   <li>{@code otel.config.sampler.probability}: to set the global default sampler which is used
+ *       when constructing a new {@code Span}.
  *   <li>{@code otel.config.max.attrs}: to set the global default max number of attributes per
  *       {@link io.opentelemetry.trace.Span}.
  *   <li>{@code otel.config.max.events}: to set the global default max number of {@link
@@ -58,7 +59,8 @@
  * the following names:
  *
  * <ul>
- *   <li>{@code OTEL_CONFIG_SAMPLER_PROBABILITY}: to set the global default sampler for traces.
+ *   <li>{@code OTEL_CONFIG_SAMPLER_PROBABILITY}: to set the global default sampler which is used
+ *       when constructing a new {@code Span}.
  *   <li>{@code OTEL_CONFIG_MAX_ATTRS}: to set the global default max number of attributes per
  *       {@link io.opentelemetry.trace.Span}.
  *   <li>{@code OTEL_CONFIG_MAX_EVENTS}: to set the global default max number of {@link

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/config/package-info.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/config/package-info.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes that holds global trace parameters
+ *
+ * <h2>Contents</h2>
+ *
+ * <ul>
+ *   <li>{@link io.opentelemetry.sdk.trace.config.TraceConfig}
+ * </ul>
+ *
+ * <h2>Default values for {@link io.opentelemetry.sdk.trace.config.TraceConfig}</h2>
+ *
+ * <ul>
+ *   <li>{@code SAMPLER: Samplers.alwaysOn()}
+ *   <li>{@code SPAN_MAX_NUM_ATTRIBUTES: 32}
+ *   <li>{@code SPAN_MAX_NUM_EVENTS: 128}
+ *   <li>{@code SPAN_MAX_NUM_LINKS: 32}
+ *   <li>{@code SPAN_MAX_NUM_ATTRIBUTES_PER_EVENT: 32}
+ *   <li>{@code SPAN_MAX_NUM_ATTRIBUTES_PER_LINK: 32}
+ * </ul>
+ *
+ * <p>Values for {@link io.opentelemetry.sdk.trace.config.TraceConfig} can be read from system
+ * properties, environment variables, or {@link java.util.Properties} objects.
+ *
+ * <p>For System Properties and {@link java.util.Properties} objects, {@link
+ * io.opentelemetry.sdk.trace.config.TraceConfig} will look for the following names:
+ *
+ * <ul>
+ *   <li>{@code otel.config.sampler.probability}: to set the global default sampler for traces.
+ *   <li>{@code otel.config.max.attrs}: to set the global default max number of attributes per
+ *       {@link io.opentelemetry.trace.Span}.
+ *   <li>{@code otel.config.max.events}: to set the global default max number of {@link
+ *       io.opentelemetry.trace.Event}s per {@link io.opentelemetry.trace.Span}.
+ *   <li>{@code otel.config.max.links}: to set the global default max number of {@link
+ *       io.opentelemetry.trace.Link} entries per {@link io.opentelemetry.trace.Span}.
+ *   <li>{@code otel.config.max.event.attrs}: to set the global default max number of attributes per
+ *       {@link io.opentelemetry.trace.Event}.
+ *   <li>{@code otel.config.max.link.attrs}: to set the global default max number of attributes per
+ *       {@link io.opentelemetry.trace.Link}.
+ * </ul>
+ *
+ * <p>For Environment Variable, {@link io.opentelemetry.sdk.trace.config.TraceConfig} will look for
+ * the following names:
+ *
+ * <ul>
+ *   <li>{@code OTEL_CONFIG_SAMPLER_PROBABILITY}: to set the global default sampler for traces.
+ *   <li>{@code OTEL_CONFIG_MAX_ATTRS}: to set the global default max number of attributes per
+ *       {@link io.opentelemetry.trace.Span}.
+ *   <li>{@code OTEL_CONFIG_MAX_EVENTS}: to set the global default max number of {@link
+ *       io.opentelemetry.trace.Event}s per {@link io.opentelemetry.trace.Span}.
+ *   <li>{@code OTEL_CONFIG_MAX_LINKS}: to set the global default max number of {@link
+ *       io.opentelemetry.trace.Link} entries per {@link io.opentelemetry.trace.Span}.
+ *   <li>{@code OTEL_CONFIG_MAX_EVENT_ATTRS}: to set the global default max number of attributes per
+ *       {@link io.opentelemetry.trace.Event}.
+ *   <li>{@code OTEL_CONFIG_MAX_LINK_ATTRS}: to set the global default max number of attributes per
+ *       {@link io.opentelemetry.trace.Link}.
+ * </ul>
+ */
+package io.opentelemetry.sdk.trace.config;

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/config/package-info.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/config/package-info.java
@@ -34,8 +34,8 @@
  *   <li>{@code SPAN_MAX_NUM_ATTRIBUTES_PER_LINK: 32}
  * </ul>
  *
- * <p>Configuration options for {@link io.opentelemetry.sdk.trace.config.TraceConfig} can be read from system
- * properties, environment variables, or {@link java.util.Properties} objects.
+ * <p>Configuration options for {@link io.opentelemetry.sdk.trace.config.TraceConfig} can be read
+ * from system properties, environment variables, or {@link java.util.Properties} objects.
  *
  * <p>For system Properties and {@link java.util.Properties} objects, {@link
  * io.opentelemetry.sdk.trace.config.TraceConfig} will look for the following names:

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/config/package-info.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/config/package-info.java
@@ -34,10 +34,10 @@
  *   <li>{@code SPAN_MAX_NUM_ATTRIBUTES_PER_LINK: 32}
  * </ul>
  *
- * <p>Values for {@link io.opentelemetry.sdk.trace.config.TraceConfig} can be read from system
+ * <p>Configuration options for {@link io.opentelemetry.sdk.trace.config.TraceConfig} can be read from system
  * properties, environment variables, or {@link java.util.Properties} objects.
  *
- * <p>For System Properties and {@link java.util.Properties} objects, {@link
+ * <p>For system Properties and {@link java.util.Properties} objects, {@link
  * io.opentelemetry.sdk.trace.config.TraceConfig} will look for the following names:
  *
  * <ul>
@@ -54,7 +54,7 @@
  *       {@link io.opentelemetry.trace.Link}.
  * </ul>
  *
- * <p>For Environment Variable, {@link io.opentelemetry.sdk.trace.config.TraceConfig} will look for
+ * <p>For environment variable, {@link io.opentelemetry.sdk.trace.config.TraceConfig} will look for
  * the following names:
  *
  * <ul>

--- a/sdk/src/test/java/io/opentelemetry/sdk/common/export/ConfigBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/common/export/ConfigBuilderTest.java
@@ -18,7 +18,9 @@ package io.opentelemetry.sdk.common.export;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import io.opentelemetry.sdk.common.export.ConfigBuilder.NamingConvention;
 import java.util.Collections;
+import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,6 +28,17 @@ import org.junit.runners.JUnit4;
 /** Tests for {@link io.opentelemetry.sdk.common.export.ConfigBuilder}. */
 @RunWith(JUnit4.class)
 public class ConfigBuilderTest {
+
+  @Test
+  public void normalize() {
+    Map<String, String> dotValues =
+        NamingConvention.DOT.normalize(Collections.singletonMap("Test.Config.Key", "value"));
+    assertThat(dotValues).containsEntry("test.config.key", "value");
+
+    Map<String, String> envValue =
+        NamingConvention.ENV_VAR.normalize(Collections.singletonMap("TEST_CONFIG_KEY", "value"));
+    assertThat(envValue).containsEntry("test.config.key", "value");
+  }
 
   @Test
   public void booleanProperty() {

--- a/sdk/src/test/java/io/opentelemetry/sdk/common/export/ConfigBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/common/export/ConfigBuilderTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.common.export;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Collections;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link io.opentelemetry.sdk.common.export.ConfigBuilder}. */
+@RunWith(JUnit4.class)
+public class ConfigBuilderTest {
+
+  @Test
+  public void booleanProperty() {
+    Boolean booleanProperty =
+        ConfigBuilder.getBooleanProperty("boolean", Collections.singletonMap("boolean", "true"));
+    assertThat(booleanProperty).isTrue();
+  }
+
+  @Test
+  public void longProperty() {
+    Long longProperty =
+        ConfigBuilder.getLongProperty("long", Collections.singletonMap("long", "42343"));
+    assertThat(longProperty).isEqualTo(42343);
+  }
+
+  @Test
+  public void intProperty() {
+    Integer intProperty =
+        ConfigBuilder.getIntProperty("int", Collections.singletonMap("int", "43543"));
+    assertThat(intProperty).isEqualTo(43543);
+  }
+
+  @Test
+  public void doubleProperty() {
+    Double doubleProperty =
+        ConfigBuilder.getDoubleProperty("double", Collections.singletonMap("double", "5.6"));
+    assertThat(doubleProperty).isEqualTo(5.6);
+  }
+
+  @Test
+  public void invalidBooleanProperty() {
+    Boolean booleanProperty =
+        ConfigBuilder.getBooleanProperty("boolean", Collections.singletonMap("boolean", "23435"));
+    assertThat(booleanProperty).isFalse();
+  }
+
+  @Test
+  public void invalidLongProperty() {
+    Long longProperty =
+        ConfigBuilder.getLongProperty("long", Collections.singletonMap("long", "45.6"));
+    assertThat(longProperty).isNull();
+  }
+
+  @Test
+  public void invalidIntProperty() {
+    Integer intProperty =
+        ConfigBuilder.getIntProperty("int", Collections.singletonMap("int", "false"));
+    assertThat(intProperty).isNull();
+  }
+
+  @Test
+  public void invalidDoubleProperty() {
+    Double doubleProperty =
+        ConfigBuilder.getDoubleProperty("double", Collections.singletonMap("double", "something"));
+    assertThat(doubleProperty).isNull();
+  }
+
+  @Test
+  public void nullValue_BooleanProperty() {
+    Boolean booleanProperty =
+        ConfigBuilder.getBooleanProperty("boolean", Collections.<String, String>emptyMap());
+    assertThat(booleanProperty).isNull();
+  }
+
+  @Test
+  public void nullValue_LongProperty() {
+    Long longProperty =
+        ConfigBuilder.getLongProperty("long", Collections.<String, String>emptyMap());
+    assertThat(longProperty).isNull();
+  }
+
+  @Test
+  public void nullValue_IntProperty() {
+    Integer intProperty =
+        ConfigBuilder.getIntProperty("int", Collections.<String, String>emptyMap());
+    assertThat(intProperty).isNull();
+  }
+
+  @Test
+  public void nullValue_DoubleProperty() {
+    Double doubleProperty =
+        ConfigBuilder.getDoubleProperty("double", Collections.<String, String>emptyMap());
+    assertThat(doubleProperty).isNull();
+  }
+}

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.sdk.trace.Samplers;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -125,16 +124,6 @@ public class TraceConfigTest {
   public static class SystemPropertiesTest {
     @Rule public final ExpectedException thrown = ExpectedException.none();
 
-    @Before
-    public void setUp() {
-      System.setProperty("otel.config.sampler.probability", "0.3");
-      System.setProperty("otel.config.max.attrs", "5");
-      System.setProperty("otel.config.max.events", "6");
-      System.setProperty("otel.config.max.links", "9");
-      System.setProperty("otel.config.max.event.attrs", "7");
-      System.setProperty("otel.config.max.link.attrs", "10");
-    }
-
     @After
     public void tearDown() {
       System.clearProperty("otel.config.sampler.probability");
@@ -147,7 +136,18 @@ public class TraceConfigTest {
 
     @Test
     public void updateTraceConfig_SystemProperties() {
-      TraceConfig traceConfig = TraceConfig.getDefault().toBuilder().readSystemProperties().build();
+      System.setProperty("otel.config.sampler.probability", "0.3");
+      System.setProperty("otel.config.max.attrs", "5");
+      System.setProperty("otel.config.max.events", "6");
+      System.setProperty("otel.config.max.links", "9");
+      System.setProperty("otel.config.max.event.attrs", "7");
+      System.setProperty("otel.config.max.link.attrs", "10");
+      TraceConfig traceConfig =
+          TraceConfig.getDefault()
+              .toBuilder()
+              .readEnvironmentVariables()
+              .readSystemProperties()
+              .build();
       assertThat(traceConfig.getSampler()).isEqualTo(Samplers.probability(0.3));
       assertThat(traceConfig.getMaxNumberOfAttributes()).isEqualTo(5);
       assertThat(traceConfig.getMaxNumberOfEvents()).isEqualTo(6);

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
@@ -19,6 +19,8 @@ package io.opentelemetry.sdk.trace.config;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.sdk.trace.Samplers;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -42,7 +44,7 @@ public class TraceConfigTest {
 
   @Test
   public void updateTraceConfig_NullSampler() {
-    thrown.expect(IllegalArgumentException.class);
+    thrown.expect(NullPointerException.class);
     TraceConfig.getDefault().toBuilder().setSampler(null).build();
   }
 
@@ -77,6 +79,30 @@ public class TraceConfigTest {
   }
 
   @Test
+  public void updateTraceConfig_InvalidSamplerProbability() {
+    thrown.expect(IllegalArgumentException.class);
+    TraceConfig.getDefault().toBuilder().setSamplerProbability(2).build();
+  }
+
+  @Test
+  public void updateTraceConfig_NegativeSamplerProbability() {
+    thrown.expect(IllegalArgumentException.class);
+    TraceConfig.getDefault().toBuilder().setSamplerProbability(-1).build();
+  }
+
+  @Test
+  public void updateTraceConfig_OffSamplerProbability() {
+    TraceConfig traceConfig = TraceConfig.getDefault().toBuilder().setSamplerProbability(0).build();
+    assertThat(traceConfig.getSampler()).isEqualTo(Samplers.alwaysOff());
+  }
+
+  @Test
+  public void updateTraceConfig_OnSamplerProbability() {
+    TraceConfig traceConfig = TraceConfig.getDefault().toBuilder().setSamplerProbability(1).build();
+    assertThat(traceConfig.getSampler()).isEqualTo(Samplers.alwaysOn());
+  }
+
+  @Test
   public void updateTraceConfig_All() {
     TraceConfig traceConfig =
         TraceConfig.getDefault()
@@ -94,5 +120,82 @@ public class TraceConfigTest {
     assertThat(traceConfig.getMaxNumberOfLinks()).isEqualTo(11);
     assertThat(traceConfig.getMaxNumberOfAttributesPerEvent()).isEqualTo(1);
     assertThat(traceConfig.getMaxNumberOfAttributesPerLink()).isEqualTo(2);
+  }
+
+  public static class SystemPropertiesTest {
+    @Rule public final ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setUp() {
+      System.setProperty("otel.config.sampler.probability", "0.3");
+      System.setProperty("otel.config.max.attrs", "5");
+      System.setProperty("otel.config.max.events", "6");
+      System.setProperty("otel.config.max.links", "9");
+      System.setProperty("otel.config.max.event.attrs", "7");
+      System.setProperty("otel.config.max.link.attrs", "10");
+    }
+
+    @After
+    public void tearDown() {
+      System.clearProperty("otel.config.sampler.probability");
+      System.clearProperty("otel.config.max.attrs");
+      System.clearProperty("otel.config.max.events");
+      System.clearProperty("otel.config.max.links");
+      System.clearProperty("otel.config.max.event.attrs");
+      System.clearProperty("otel.config.max.link.attrs");
+    }
+
+    @Test
+    public void updateTraceConfig_SystemProperties() {
+      TraceConfig traceConfig = TraceConfig.getDefault();
+      assertThat(traceConfig.getSampler()).isEqualTo(Samplers.probability(0.3));
+      assertThat(traceConfig.getMaxNumberOfAttributes()).isEqualTo(5);
+      assertThat(traceConfig.getMaxNumberOfEvents()).isEqualTo(6);
+      assertThat(traceConfig.getMaxNumberOfLinks()).isEqualTo(9);
+      assertThat(traceConfig.getMaxNumberOfAttributesPerEvent()).isEqualTo(7);
+      assertThat(traceConfig.getMaxNumberOfAttributesPerLink()).isEqualTo(10);
+    }
+
+    @Test
+    public void updateTraceConfig_InvalidSamplerProbability() {
+      System.setProperty("otel.config.sampler.probability", "-1");
+      thrown.expect(IllegalArgumentException.class);
+      TraceConfig.getDefault();
+    }
+
+    @Test
+    public void updateTraceConfig_NonPositiveMaxNumberOfAttributes() {
+      System.setProperty("otel.config.max.attrs", "-5");
+      thrown.expect(IllegalArgumentException.class);
+      TraceConfig.getDefault();
+    }
+
+    @Test
+    public void updateTraceConfig_NonPositiveMaxNumberOfEvents() {
+      System.setProperty("otel.config.max.events", "-6");
+      thrown.expect(IllegalArgumentException.class);
+      TraceConfig.getDefault();
+    }
+
+    @Test
+    public void updateTraceConfig_NonPositiveMaxNumberOfLinks() {
+      System.setProperty("otel.config.max.links", "-9");
+      thrown.expect(IllegalArgumentException.class);
+      TraceConfig.getDefault();
+    }
+
+    @Test
+    public void updateTraceConfig_NonPositiveMaxNumberOfAttributesPerEvent() {
+      System.setProperty("otel.config.max.event.attrs", "-7");
+      thrown.expect(IllegalArgumentException.class);
+      TraceConfig.getDefault();
+    }
+
+    @Test
+    public void updateTraceConfig_NonPositiveMaxNumberOfAttributesPerLink() {
+      System.setProperty("otel.config.max.link.attrs", "-10");
+      thrown.expect(IllegalArgumentException.class);
+      TraceConfig.getDefault();
+    }
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
@@ -147,7 +147,7 @@ public class TraceConfigTest {
 
     @Test
     public void updateTraceConfig_SystemProperties() {
-      TraceConfig traceConfig = TraceConfig.getDefault();
+      TraceConfig traceConfig = TraceConfig.getDefault().toBuilder().readSystemProperties().build();
       assertThat(traceConfig.getSampler()).isEqualTo(Samplers.probability(0.3));
       assertThat(traceConfig.getMaxNumberOfAttributes()).isEqualTo(5);
       assertThat(traceConfig.getMaxNumberOfEvents()).isEqualTo(6);
@@ -160,42 +160,42 @@ public class TraceConfigTest {
     public void updateTraceConfig_InvalidSamplerProbability() {
       System.setProperty("otel.config.sampler.probability", "-1");
       thrown.expect(IllegalArgumentException.class);
-      TraceConfig.getDefault();
+      TraceConfig.getDefault().toBuilder().readSystemProperties().build();
     }
 
     @Test
     public void updateTraceConfig_NonPositiveMaxNumberOfAttributes() {
       System.setProperty("otel.config.max.attrs", "-5");
       thrown.expect(IllegalArgumentException.class);
-      TraceConfig.getDefault();
+      TraceConfig.getDefault().toBuilder().readSystemProperties().build();
     }
 
     @Test
     public void updateTraceConfig_NonPositiveMaxNumberOfEvents() {
       System.setProperty("otel.config.max.events", "-6");
       thrown.expect(IllegalArgumentException.class);
-      TraceConfig.getDefault();
+      TraceConfig.getDefault().toBuilder().readSystemProperties().build();
     }
 
     @Test
     public void updateTraceConfig_NonPositiveMaxNumberOfLinks() {
       System.setProperty("otel.config.max.links", "-9");
       thrown.expect(IllegalArgumentException.class);
-      TraceConfig.getDefault();
+      TraceConfig.getDefault().toBuilder().readSystemProperties().build();
     }
 
     @Test
     public void updateTraceConfig_NonPositiveMaxNumberOfAttributesPerEvent() {
       System.setProperty("otel.config.max.event.attrs", "-7");
       thrown.expect(IllegalArgumentException.class);
-      TraceConfig.getDefault();
+      TraceConfig.getDefault().toBuilder().readSystemProperties().build();
     }
 
     @Test
     public void updateTraceConfig_NonPositiveMaxNumberOfAttributesPerLink() {
       System.setProperty("otel.config.max.link.attrs", "-10");
       thrown.expect(IllegalArgumentException.class);
-      TraceConfig.getDefault();
+      TraceConfig.getDefault().toBuilder().readSystemProperties().build();
     }
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
@@ -141,7 +141,7 @@ public class TraceConfigTest {
       System.setProperty("otel.config.max.events", "6");
       System.setProperty("otel.config.max.links", "9");
       System.setProperty("otel.config.max.event.attrs", "7");
-      System.setProperty("otel.config.max.link.attrs", "10");
+      System.setProperty("otel.config.max.link.attrs", "11");
       TraceConfig traceConfig =
           TraceConfig.getDefault()
               .toBuilder()
@@ -153,7 +153,7 @@ public class TraceConfigTest {
       assertThat(traceConfig.getMaxNumberOfEvents()).isEqualTo(6);
       assertThat(traceConfig.getMaxNumberOfLinks()).isEqualTo(9);
       assertThat(traceConfig.getMaxNumberOfAttributesPerEvent()).isEqualTo(7);
-      assertThat(traceConfig.getMaxNumberOfAttributesPerLink()).isEqualTo(10);
+      assertThat(traceConfig.getMaxNumberOfAttributesPerLink()).isEqualTo(11);
     }
 
     @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
@@ -42,7 +42,7 @@ public class TraceConfigTest {
 
   @Test
   public void updateTraceConfig_NullSampler() {
-    thrown.expect(NullPointerException.class);
+    thrown.expect(IllegalArgumentException.class);
     TraceConfig.getDefault().toBuilder().setSampler(null).build();
   }
 


### PR DESCRIPTION
1. Extended ConfigBuilder for building TraceConfig class to support config from env vars
2. Added getDoubleProperty to ConfigBuilder class

Fixes #1239 