### PR TITLE
Add public Samplers.emptyDecision(boolean) and decision(boolean, Map).

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -21,6 +21,7 @@ import static java.util.Collections.singletonMap;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.sdk.trace.Sampler.Decision;
 import io.opentelemetry.trace.Link;
@@ -33,6 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -75,16 +77,16 @@ public final class Samplers {
    *
    * @param isSampled The value to return from {@link Decision#isSampled()}.
    * @param attributes The attributes to return from {@link Decision#getAttributes()}. A different
-   *     object instance with the same elements may be returned. The map must not be modified after
-   *     being passed to this function. Use {@link Collections#emptyMap()} for an empty decision.
+   *     object instance with the same elements may be returned.
    * @return A {@link Decision} with the attributes equivalent to {@code attributes} and {@link
    *     Decision#isSampled()} returning {@code isSampled}.
    */
-  public static final Decision decision(boolean isSampled, Map<String, AttributeValue> attributes) {
+  public static final Decision decision(
+      boolean isSampled, @Nonnull Map<String, AttributeValue> attributes) {
     Objects.requireNonNull(attributes, "attributes");
     return attributes.isEmpty()
         ? emptyDecision(isSampled)
-        : DecisionImpl.create(isSampled, attributes);
+        : DecisionImpl.create(isSampled, ImmutableMap.copyOf(attributes));
   }
 
   /**

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -74,9 +74,9 @@ public final class Samplers {
    *     value of the parameter {@code isSampled}.
    */
   public static final Decision emptyDecision(boolean isSampled) {
-    return isSampled ? ALWAYS_ON_DECISION : ALWAYS_OFF_DECISION;
+    return isSampled ? EMPTY_SAMPLED_DECISION : EMPTY_NOT_SAMPLED_DECISION;
   }
-  
+
   /**
    * Returns a {@link Sampler} that always makes a "yes" decision on {@link Span} sampling.
    *

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -64,6 +64,20 @@ public final class Samplers {
   private Samplers() {}
 
   /**
+   * Returns a {@link Decision} with empty attributes and {@link Decision#isSampled()} returning the
+   * value of the parameter {@code isSampled}.
+   *
+   * <p>This is meant for use by custom {@link Sampler} implementations.
+   *
+   * @param isSampled The value to return from {@link Decision#isSampled()}.
+   * @return A {@link Decision} with empty attributes and {@link Decision#isSampled()} returning the
+   *     value of the parameter {@code isSampled}.
+   */
+  public static final Decision emptyDecision(boolean isSampled) {
+    return isSampled ? ALWAYS_ON_DECISION : ALWAYS_OFF_DECISION;
+  }
+  
+  /**
    * Returns a {@link Sampler} that always makes a "yes" decision on {@link Span} sampling.
    *
    * @return a {@code Sampler} that always makes a "yes" decision on {@code Span} sampling.

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -19,6 +19,7 @@ package io.opentelemetry.sdk.trace;
 import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.common.AttributeValue.doubleAttributeValue;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.truth.Truth;
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.sdk.trace.Sampler.Decision;
@@ -30,6 +31,7 @@ import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
@@ -59,10 +61,37 @@ public class SamplersTest {
 
   @Test
   public void emptySamplingDecision() {
+    Truth.assertThat(Samplers.emptyDecision(true)).isSameInstanceAs(Samplers.emptyDecision(true));
+    Truth.assertThat(Samplers.emptyDecision(false)).isSameInstanceAs(Samplers.emptyDecision(false));
+
     Truth.assertThat(Samplers.emptyDecision(true).isSampled()).isTrue();
     Truth.assertThat(Samplers.emptyDecision(true).getAttributes()).isEmpty();
     Truth.assertThat(Samplers.emptyDecision(false).isSampled()).isFalse();
     Truth.assertThat(Samplers.emptyDecision(false).getAttributes()).isEmpty();
+  }
+
+  @Test
+  public void samplingDecisionEmpty() {
+    Truth.assertThat(Samplers.decision(/*isSampled=*/ true, new HashMap<String, AttributeValue>()))
+        .isSameInstanceAs(Samplers.emptyDecision(true));
+    Truth.assertThat(
+            Samplers.decision(/*isSampled=*/ false, Collections.<String, AttributeValue>emptyMap()))
+        .isSameInstanceAs(Samplers.emptyDecision(false));
+  }
+
+  @Test
+  public void samplingDecisionAttrs() {
+    final ImmutableMap<String, AttributeValue> attrs =
+        ImmutableMap.of(
+            "foo", AttributeValue.longAttributeValue(42),
+            "bar", AttributeValue.stringAttributeValue("baz"));
+    final Decision sampledDecision = Samplers.decision(/*isSampled=*/ true, attrs);
+    Truth.assertThat(sampledDecision.isSampled()).isTrue();
+    Truth.assertThat(sampledDecision.getAttributes()).isEqualTo(attrs);
+
+    final Decision notSampledDecision = Samplers.decision(/*isSampled=*/ false, attrs);
+    Truth.assertThat(notSampledDecision.isSampled()).isFalse();
+    Truth.assertThat(notSampledDecision.getAttributes()).isEqualTo(attrs);
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -58,6 +58,14 @@ public class SamplersTest {
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   @Test
+  public void emptySamplingDecision() {
+    Truth.assertThat(Samplers.emptyDecision(true).isSampled()).isTrue();
+    Truth.assertThat(Samplers.emptyDecision(true).getAttributes()).isEmpty();
+    Truth.assertThat(Samplers.emptyDecision(false).isSampled()).isFalse();
+    Truth.assertThat(Samplers.emptyDecision(false).getAttributes()).isEmpty();
+  }
+
+  @Test
   public void alwaysOnSampler() {
     // Sampled parent.
     Truth.assertThat(


### PR DESCRIPTION
This is meant for use by custom Sampler implementations. As of now, you have to use an anonymous inner class or otherwise derive a new class because there is no publicly accessible implementation of Decision.