### PR TITLE
change the naming of the SPI provider classes to *Factory

### DIFF
--- a/api/src/main/java/io/opentelemetry/OpenTelemetry.java
+++ b/api/src/main/java/io/opentelemetry/OpenTelemetry.java
@@ -20,18 +20,18 @@ import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.DefaultContextPropagators;
 import io.opentelemetry.correlationcontext.CorrelationContextManager;
 import io.opentelemetry.correlationcontext.DefaultCorrelationContextManager;
-import io.opentelemetry.correlationcontext.spi.CorrelationContextManagerProvider;
+import io.opentelemetry.correlationcontext.spi.CorrelationContextManagerFactory;
 import io.opentelemetry.internal.Obfuscated;
 import io.opentelemetry.internal.Utils;
 import io.opentelemetry.metrics.DefaultMeterProvider;
 import io.opentelemetry.metrics.Meter;
 import io.opentelemetry.metrics.MeterProvider;
-import io.opentelemetry.metrics.spi.MetricsProvider;
+import io.opentelemetry.metrics.spi.MeterProviderFactory;
 import io.opentelemetry.trace.DefaultTracerProvider;
 import io.opentelemetry.trace.Tracer;
 import io.opentelemetry.trace.TracerProvider;
 import io.opentelemetry.trace.propagation.HttpTraceContext;
-import io.opentelemetry.trace.spi.TraceProvider;
+import io.opentelemetry.trace.spi.TracerProviderFactory;
 import java.util.ServiceLoader;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -43,8 +43,8 @@ import javax.annotation.concurrent.ThreadSafe;
  * <p>The telemetry objects are lazy-loaded singletons resolved via {@link ServiceLoader} mechanism.
  *
  * @see TracerProvider
- * @see MetricsProvider
- * @see CorrelationContextManagerProvider
+ * @see MeterProviderFactory
+ * @see CorrelationContextManagerFactory
  */
 @ThreadSafe
 public final class OpenTelemetry {
@@ -199,17 +199,19 @@ public final class OpenTelemetry {
   }
 
   private OpenTelemetry() {
-    TraceProvider traceProvider = loadSpi(TraceProvider.class);
+    TracerProviderFactory tracerProviderFactory = loadSpi(TracerProviderFactory.class);
     this.tracerProvider =
-        traceProvider != null
-            ? new ObfuscatedTracerProvider(traceProvider.create())
+        tracerProviderFactory != null
+            ? new ObfuscatedTracerProvider(tracerProviderFactory.create())
             : DefaultTracerProvider.getInstance();
 
-    MetricsProvider metricsProvider = loadSpi(MetricsProvider.class);
+    MeterProviderFactory meterProviderFactory = loadSpi(MeterProviderFactory.class);
     meterProvider =
-        metricsProvider != null ? metricsProvider.create() : DefaultMeterProvider.getInstance();
-    CorrelationContextManagerProvider contextManagerProvider =
-        loadSpi(CorrelationContextManagerProvider.class);
+        meterProviderFactory != null
+            ? meterProviderFactory.create()
+            : DefaultMeterProvider.getInstance();
+    CorrelationContextManagerFactory contextManagerProvider =
+        loadSpi(CorrelationContextManagerFactory.class);
     contextManager =
         contextManagerProvider != null
             ? contextManagerProvider.create()

--- a/api/src/main/java/io/opentelemetry/correlationcontext/spi/CorrelationContextManagerFactory.java
+++ b/api/src/main/java/io/opentelemetry/correlationcontext/spi/CorrelationContextManagerFactory.java
@@ -14,29 +14,30 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.trace.spi;
+package io.opentelemetry.correlationcontext.spi;
 
-import io.opentelemetry.trace.TracerProvider;
+import io.opentelemetry.correlationcontext.CorrelationContextManager;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * TraceProvider is a service provider for a {@link TracerProvider}. Fully qualified class name of
- * the implementation should be registered in {@code
- * META-INF/services/io.opentelemetry.trace.spi.TraceProvider}. <br>
+ * CorrelationContextManagerFactory is a service provider for {@link CorrelationContextManager}.
+ * Fully qualified class name of the implementation should be registered in {@code
+ * META-INF/services/io.opentelemetry.correlationcontext.spi.CorrelationContextManagerFactory}. <br>
  * <br>
  * A specific implementation can be selected by a system property {@code
- * io.opentelemetry.trace.spi.TraceProvider} with value of fully qualified class name.
+ * io.opentelemetry.correlationcontext.spi.CorrelationContextManagerFactory} with value of fully
+ * qualified class name.
  *
  * @see io.opentelemetry.OpenTelemetry
  */
 @ThreadSafe
-public interface TraceProvider {
+public interface CorrelationContextManagerFactory {
 
   /**
-   * Creates a new TracerProvider.
+   * Creates a new {@code CorrelationContextManager} instance.
    *
-   * @return a new TracerProvider.
+   * @return a {@code CorrelationContextManager} instance.
    * @since 0.1.0
    */
-  TracerProvider create();
+  CorrelationContextManager create();
 }

--- a/api/src/main/java/io/opentelemetry/metrics/spi/MeterProviderFactory.java
+++ b/api/src/main/java/io/opentelemetry/metrics/spi/MeterProviderFactory.java
@@ -14,31 +14,29 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.correlationcontext.spi;
+package io.opentelemetry.metrics.spi;
 
-import io.opentelemetry.correlationcontext.CorrelationContextManager;
+import io.opentelemetry.metrics.MeterProvider;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * CorrelationContextManagerProvider is a service provider for {@link CorrelationContextManager}.
- * Fully qualified class name of the implementation should be registered in {@code
- * META-INF/services/io.opentelemetry.correlationcontext.spi.CorrelationContextManagerProvider}.
- * <br>
+ * MeterProviderFactory is a service provider for {@link MeterProvider}. Fully qualified class name
+ * of the implementation should be registered in {@code
+ * META-INF/services/io.opentelemetry.metrics.spi.MeterProviderFactory}. <br>
  * <br>
  * A specific implementation can be selected by a system property {@code
- * io.opentelemetry.correlationcontext.spi.CorrelationContextManagerProvider} with value of fully
- * qualified class name.
+ * io.opentelemetry.metrics.spi.MeterProviderFactory} with value of fully qualified class name.
  *
  * @see io.opentelemetry.OpenTelemetry
  */
 @ThreadSafe
-public interface CorrelationContextManagerProvider {
+public interface MeterProviderFactory {
 
   /**
-   * Creates a new {@code CorrelationContextManager} instance.
+   * Creates a new meter registry instance.
    *
-   * @return a {@code CorrelationContextManager} instance.
+   * @return a meter factory instance.
    * @since 0.1.0
    */
-  CorrelationContextManager create();
+  MeterProvider create();
 }

--- a/api/src/main/java/io/opentelemetry/trace/TracerProvider.java
+++ b/api/src/main/java/io/opentelemetry/trace/TracerProvider.java
@@ -16,12 +16,12 @@
 
 package io.opentelemetry.trace;
 
+import io.opentelemetry.trace.spi.TracerProviderFactory;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A registry for creating named {@link Tracer}s. Although the class is provided at runtime via
- * {@link io.opentelemetry.trace.spi.TraceProvider}, the name <i>Provider</i> is for consistency
- * with other languages.
+ * {@link TracerProviderFactory}, the name <i>Provider</i> is for consistency with other languages.
  *
  * @see io.opentelemetry.OpenTelemetry
  * @see io.opentelemetry.trace.Tracer

--- a/api/src/main/java/io/opentelemetry/trace/spi/TracerProviderFactory.java
+++ b/api/src/main/java/io/opentelemetry/trace/spi/TracerProviderFactory.java
@@ -14,29 +14,29 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.metrics.spi;
+package io.opentelemetry.trace.spi;
 
-import io.opentelemetry.metrics.MeterProvider;
+import io.opentelemetry.trace.TracerProvider;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * MetricsProvider is a service provider for {@link MeterProvider}. Fully qualified class name of
- * the implementation should be registered in {@code
- * META-INF/services/io.opentelemetry.metrics.spi.MetricsProvider}. <br>
+ * TracerProviderFactory is a service provider for a {@link TracerProvider}. Fully qualified class
+ * name of the implementation should be registered in {@code
+ * META-INF/services/io.opentelemetry.trace.spi.TracerProviderFactory}. <br>
  * <br>
  * A specific implementation can be selected by a system property {@code
- * io.opentelemetry.metrics.spi.MetricsProvider} with value of fully qualified class name.
+ * io.opentelemetry.trace.spi.TracerProviderFactory} with value of fully qualified class name.
  *
  * @see io.opentelemetry.OpenTelemetry
  */
 @ThreadSafe
-public interface MetricsProvider {
+public interface TracerProviderFactory {
 
   /**
-   * Creates a new meter registry instance.
+   * Creates a new TracerProvider.
    *
-   * @return a meter factory instance.
+   * @return a new TracerProvider.
    * @since 0.1.0
    */
-  MeterProvider create();
+  TracerProvider create();
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/correlationcontext/spi/CorrelationContextManagerFactorySdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/correlationcontext/spi/CorrelationContextManagerFactorySdk.java
@@ -17,18 +17,17 @@
 package io.opentelemetry.sdk.correlationcontext.spi;
 
 import io.opentelemetry.correlationcontext.CorrelationContextManager;
-import io.opentelemetry.correlationcontext.spi.CorrelationContextManagerProvider;
+import io.opentelemetry.correlationcontext.spi.CorrelationContextManagerFactory;
 import io.opentelemetry.sdk.correlationcontext.CorrelationContextManagerSdk;
 
 /**
  * {@code CorrelationContextManager} provider implementation for {@link
- * io.opentelemetry.correlationcontext.spi.CorrelationContextManagerProvider}.
+ * CorrelationContextManagerFactory}.
  *
  * <p>This class is not intended to be used in application code and it is used only by {@link
  * io.opentelemetry.OpenTelemetry}.
  */
-public final class CorrelationContextManagerProviderSdk
-    implements CorrelationContextManagerProvider {
+public final class CorrelationContextManagerFactorySdk implements CorrelationContextManagerFactory {
 
   @Override
   public CorrelationContextManager create() {

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/spi/MeterProviderFactorySdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/spi/MeterProviderFactorySdk.java
@@ -14,16 +14,21 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.sdk.trace.spi;
+package io.opentelemetry.sdk.metrics.spi;
 
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
-import io.opentelemetry.trace.TracerProvider;
-import io.opentelemetry.trace.spi.TraceProvider;
+import io.opentelemetry.metrics.spi.MeterProviderFactory;
+import io.opentelemetry.sdk.metrics.MeterSdkProvider;
 
-/** SDK implementation of the TracerProviderFactory for SPI. */
-public final class TraceProviderSdk implements TraceProvider {
+/**
+ * {@code MeterProvider} provider implementation for {@link MeterProviderFactory}.
+ *
+ * <p>This class is not intended to be used in application code and it is used only by {@link
+ * io.opentelemetry.OpenTelemetry}.
+ */
+public final class MeterProviderFactorySdk implements MeterProviderFactory {
+
   @Override
-  public TracerProvider create() {
-    return TracerSdkProvider.builder().build();
+  public MeterSdkProvider create() {
+    return MeterSdkProvider.builder().build();
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/spi/TracerProviderFactorySdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/spi/TracerProviderFactorySdk.java
@@ -14,21 +14,16 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.sdk.metrics.spi;
+package io.opentelemetry.sdk.trace.spi;
 
-import io.opentelemetry.metrics.spi.MetricsProvider;
-import io.opentelemetry.sdk.metrics.MeterSdkProvider;
+import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.trace.TracerProvider;
+import io.opentelemetry.trace.spi.TracerProviderFactory;
 
-/**
- * {@code MeterProvider} provider implementation for {@link MetricsProvider}.
- *
- * <p>This class is not intended to be used in application code and it is used only by {@link
- * io.opentelemetry.OpenTelemetry}.
- */
-public final class MetricsProviderSdk implements MetricsProvider {
-
+/** SDK implementation of the TracerProviderFactory for SPI. */
+public final class TracerProviderFactorySdk implements TracerProviderFactory {
   @Override
-  public MeterSdkProvider create() {
-    return MeterSdkProvider.builder().build();
+  public TracerProvider create() {
+    return TracerSdkProvider.builder().build();
   }
 }

--- a/sdk/src/main/resources/META-INF/services/io.opentelemetry.correlationcontext.spi.CorrelationContextManagerFactory
+++ b/sdk/src/main/resources/META-INF/services/io.opentelemetry.correlationcontext.spi.CorrelationContextManagerFactory
@@ -1,0 +1,1 @@
+io.opentelemetry.sdk.correlationcontext.spi.CorrelationContextManagerFactorySdk

--- a/sdk/src/main/resources/META-INF/services/io.opentelemetry.correlationcontext.spi.CorrelationContextManagerProvider
+++ b/sdk/src/main/resources/META-INF/services/io.opentelemetry.correlationcontext.spi.CorrelationContextManagerProvider
@@ -1,1 +1,0 @@
-io.opentelemetry.sdk.correlationcontext.spi.CorrelationContextManagerProviderSdk

--- a/sdk/src/main/resources/META-INF/services/io.opentelemetry.metrics.spi.MeterProviderFactory
+++ b/sdk/src/main/resources/META-INF/services/io.opentelemetry.metrics.spi.MeterProviderFactory
@@ -1,0 +1,1 @@
+io.opentelemetry.sdk.metrics.spi.MeterProviderFactorySdk

--- a/sdk/src/main/resources/META-INF/services/io.opentelemetry.metrics.spi.MetricsProvider
+++ b/sdk/src/main/resources/META-INF/services/io.opentelemetry.metrics.spi.MetricsProvider
@@ -1,1 +1,0 @@
-io.opentelemetry.sdk.metrics.spi.MetricsProviderSdk

--- a/sdk/src/main/resources/META-INF/services/io.opentelemetry.trace.spi.TraceProvider
+++ b/sdk/src/main/resources/META-INF/services/io.opentelemetry.trace.spi.TraceProvider
@@ -1,1 +1,0 @@
-io.opentelemetry.sdk.trace.spi.TraceProviderSdk

--- a/sdk/src/main/resources/META-INF/services/io.opentelemetry.trace.spi.TracerProviderFactory
+++ b/sdk/src/main/resources/META-INF/services/io.opentelemetry.trace.spi.TracerProviderFactory
@@ -1,0 +1,1 @@
+io.opentelemetry.sdk.trace.spi.TracerProviderFactorySdk

--- a/sdk/src/test/java/io/opentelemetry/sdk/correlationcontext/spi/CorrelationContextManagerFactorySdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/correlationcontext/spi/CorrelationContextManagerFactorySdkTest.java
@@ -14,24 +14,22 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.sdk.trace.spi;
+package io.opentelemetry.sdk.correlationcontext.spi;
 
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
-import io.opentelemetry.trace.Tracer;
+import io.opentelemetry.sdk.correlationcontext.CorrelationContextManagerSdk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link TraceProviderSdk}. */
 @RunWith(JUnit4.class)
-public class TraceProviderSdkTest {
+public class CorrelationContextManagerFactorySdkTest {
 
   @Test
   public void testDefault() {
-    Tracer tracerSdk = TracerSdkProvider.builder().build().get("");
-    assertThat(OpenTelemetry.getTracerProvider().get("")).isInstanceOf(tracerSdk.getClass());
+    assertThat(OpenTelemetry.getCorrelationContextManager())
+        .isInstanceOf(CorrelationContextManagerSdk.class);
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/spi/MeterProviderFactorySdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/spi/MeterProviderFactorySdkTest.java
@@ -14,22 +14,21 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.sdk.correlationcontext.spi;
+package io.opentelemetry.sdk.metrics.spi;
 
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.sdk.correlationcontext.CorrelationContextManagerSdk;
+import io.opentelemetry.sdk.metrics.MeterSdkProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+/** Unit tests for {@link MeterProviderFactorySdk}. */
 @RunWith(JUnit4.class)
-public class CorrelationContextManagerProviderSdkTest {
-
+public class MeterProviderFactorySdkTest {
   @Test
   public void testDefault() {
-    assertThat(OpenTelemetry.getCorrelationContextManager())
-        .isInstanceOf(CorrelationContextManagerSdk.class);
+    assertThat(OpenTelemetry.getMeterProvider()).isInstanceOf(MeterSdkProvider.class);
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/spi/TracerProviderFactorySdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/spi/TracerProviderFactorySdkTest.java
@@ -14,21 +14,24 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.sdk.metrics.spi;
+package io.opentelemetry.sdk.trace.spi;
 
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.sdk.metrics.MeterSdkProvider;
+import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.trace.Tracer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link MetricsProviderSdk}. */
+/** Unit tests for {@link TracerProviderFactorySdk}. */
 @RunWith(JUnit4.class)
-public class MetricsProviderSdkTest {
+public class TracerProviderFactorySdkTest {
+
   @Test
   public void testDefault() {
-    assertThat(OpenTelemetry.getMeterProvider()).isInstanceOf(MeterSdkProvider.class);
+    Tracer tracerSdk = TracerSdkProvider.builder().build().get("");
+    assertThat(OpenTelemetry.getTracerProvider().get("")).isInstanceOf(tracerSdk.getClass());
   }
 }


### PR DESCRIPTION
Two benefits:
1) It makes the naming less confusing 
2) lines up with the naming of SPI interfaces in the auto-instrumentation project

Resolves #1213 