### PR TITLE
Expose RandomIdsGenerator so it can be delegated to.

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
@@ -16,7 +16,8 @@
 
 package io.opentelemetry.sdk.trace;
 
-import io.opentelemetry.internal.Utils;
+import static java.util.Objects.requireNonNull;
+
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceId;
 import java.util.Random;
@@ -57,7 +58,7 @@ public final class RandomIdsGenerator implements IdsGenerator {
    * IDs.
    */
   public RandomIdsGenerator(RandomSupplier randomSupplier) {
-    this.randomSupplier = Utils.checkNotNull(randomSupplier, "randomSupplier");
+    this.randomSupplier = requireNonNull(randomSupplier, "randomSupplier");
   }
 
   private final RandomSupplier randomSupplier;

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
@@ -21,8 +21,8 @@ import io.opentelemetry.trace.TraceId;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * The default {@link IdsGenerator} which generates IDs as random numbers using
- * {@link ThreadLocalRandom}.
+ * The default {@link IdsGenerator} which generates IDs as random numbers using {@link
+ * ThreadLocalRandom}.
  */
 public final class RandomIdsGenerator implements IdsGenerator {
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
@@ -16,57 +16,22 @@
 
 package io.opentelemetry.sdk.trace;
 
-import static java.util.Objects.requireNonNull;
-
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceId;
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
-/** The default {@link IdsGenerator} which generates IDs as random numbers. */
+/**
+ * The default {@link IdsGenerator} which generates IDs as random numbers using
+ * {@link ThreadLocalRandom}.
+ */
 public final class RandomIdsGenerator implements IdsGenerator {
 
   private static final long INVALID_ID = 0;
 
-  /**
-   * A supplier of the {@link Random} that will be used to generate random IDs. This is a functional
-   * interface and can be safely initialized as a lambda.
-   */
-  public interface RandomSupplier {
-    /** Returns the {@link Random} to use for generating IDs. */
-    Random get();
-  }
-
-  /** Creates a {@link RandomIdsGenerator} which uses {@link ThreadLocalRandom} to generate IDs. */
-  public RandomIdsGenerator() {
-    this(
-        new RandomSupplier() {
-          @Override
-          public Random get() {
-            return ThreadLocalRandom.current();
-          }
-
-          @Override
-          public String toString() {
-            return "ThreadLocalRandom";
-          }
-        });
-  }
-
-  /**
-   * Creates a {@link RandomIdsGenerator} which uses the provided {@link RandomSupplier} to generate
-   * IDs.
-   */
-  public RandomIdsGenerator(RandomSupplier randomSupplier) {
-    this.randomSupplier = requireNonNull(randomSupplier, "randomSupplier");
-  }
-
-  private final RandomSupplier randomSupplier;
-
   @Override
   public SpanId generateSpanId() {
     long id;
-    Random random = randomSupplier.get();
+    ThreadLocalRandom random = ThreadLocalRandom.current();
     do {
       id = random.nextLong();
     } while (id == INVALID_ID);
@@ -77,7 +42,7 @@ public final class RandomIdsGenerator implements IdsGenerator {
   public TraceId generateTraceId() {
     long idHi;
     long idLo;
-    Random random = randomSupplier.get();
+    ThreadLocalRandom random = ThreadLocalRandom.current();
     do {
       idHi = random.nextLong();
       idLo = random.nextLong();

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
@@ -21,9 +21,7 @@ import io.opentelemetry.trace.TraceId;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
-/**
- * The default {@link IdsGenerator} which generates IDs as random numbers.
- */
+/** The default {@link IdsGenerator} which generates IDs as random numbers. */
 public final class RandomIdsGenerator implements IdsGenerator {
 
   private static final long INVALID_ID = 0;
@@ -33,22 +31,24 @@ public final class RandomIdsGenerator implements IdsGenerator {
    * interface and can be safely initialized as a lambda.
    */
   public interface RandomSupplier {
-    /**
-     * Returns the {@link Random} to use for generating IDs.
-     */
+    /** Returns the {@link Random} to use for generating IDs. */
     Random get();
   }
 
-  /**
-   * Creates a {@link RandomIdsGenerator} which uses {@link ThreadLocalRandom} to generate IDs.
-   */
+  /** Creates a {@link RandomIdsGenerator} which uses {@link ThreadLocalRandom} to generate IDs. */
   public RandomIdsGenerator() {
-    this(new RandomSupplier() {
-      @Override
-      public Random get() {
-        return ThreadLocalRandom.current();
-      }
-    });
+    this(
+        new RandomSupplier() {
+          @Override
+          public Random get() {
+            return ThreadLocalRandom.current();
+          }
+
+          @Override
+          public String toString() {
+            return "ThreadLocalRandom";
+          }
+        });
   }
 
   /**

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.sdk.trace;
 
+import io.opentelemetry.internal.Utils;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceId;
 import java.util.Random;
@@ -56,7 +57,7 @@ public final class RandomIdsGenerator implements IdsGenerator {
    * IDs.
    */
   public RandomIdsGenerator(RandomSupplier randomSupplier) {
-    this.randomSupplier = randomSupplier;
+    this.randomSupplier = Utils.checkNotNull(randomSupplier, "randomSupplier");
   }
 
   private final RandomSupplier randomSupplier;

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.opentelemetry.sdk.trace;
 
 import static com.google.common.truth.Truth.assertThat;

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
@@ -1,0 +1,80 @@
+package io.opentelemetry.sdk.trace;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Random;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import io.opentelemetry.sdk.trace.RandomIdsGenerator.RandomSupplier;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceId;
+
+@RunWith(JUnit4.class)
+public class RandomIdsGeneratorTest {
+
+  @Mock private Random random;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void defaults() {
+    RandomIdsGenerator generator = new RandomIdsGenerator();
+
+    // Can't assert values but can assert they're valid.
+    TraceId traceId = generator.generateTraceId();
+    assertThat(traceId).isNotEqualTo(TraceId.getInvalid());
+
+    SpanId spanId = generator.generateSpanId();
+    assertThat(spanId).isNotEqualTo(SpanId.getInvalid());
+  }
+
+  @Test
+  public void customRandom() {
+    RandomIdsGenerator generator =
+        new RandomIdsGenerator(
+            new RandomSupplier() {
+              @Override
+              public Random get() {
+                return random;
+              }
+            });
+
+    when(random.nextLong()).thenReturn(1L).thenReturn(2L);
+    TraceId traceId = generator.generateTraceId();
+    assertThat(traceId.toLowerBase16()).isEqualTo("00000000000000010000000000000002");
+
+    when(random.nextLong()).thenReturn(3L);
+    SpanId spanId = generator.generateSpanId();
+    assertThat(spanId.toLowerBase16()).isEqualTo("0000000000000003");
+  }
+
+  @Test
+  public void ignoresInvalid() {
+    RandomIdsGenerator generator =
+        new RandomIdsGenerator(
+            new RandomSupplier() {
+              @Override
+              public Random get() {
+                return random;
+              }
+            });
+
+    // First two zeros skipped
+    when(random.nextLong()).thenReturn(0L).thenReturn(0L).thenReturn(3L).thenReturn(4L);
+    TraceId traceId = generator.generateTraceId();
+    assertThat(traceId.toLowerBase16()).isEqualTo("00000000000000030000000000000004");
+
+    when(random.nextLong()).thenReturn(0L).thenReturn(5L);
+    SpanId spanId = generator.generateSpanId();
+    assertThat(spanId.toLowerBase16()).isEqualTo("0000000000000005");
+  }
+}

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
@@ -17,28 +17,15 @@
 package io.opentelemetry.sdk.trace;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Mockito.when;
 
-import io.opentelemetry.sdk.trace.RandomIdsGenerator.RandomSupplier;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceId;
-import java.util.Random;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class RandomIdsGeneratorTest {
-
-  @Mock private Random random;
-
-  @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
-  }
 
   @Test
   public void defaults() {
@@ -50,46 +37,5 @@ public class RandomIdsGeneratorTest {
 
     SpanId spanId = generator.generateSpanId();
     assertThat(spanId).isNotEqualTo(SpanId.getInvalid());
-  }
-
-  @Test
-  public void customRandom() {
-    RandomIdsGenerator generator =
-        new RandomIdsGenerator(
-            new RandomSupplier() {
-              @Override
-              public Random get() {
-                return random;
-              }
-            });
-
-    when(random.nextLong()).thenReturn(1L).thenReturn(2L);
-    TraceId traceId = generator.generateTraceId();
-    assertThat(traceId.toLowerBase16()).isEqualTo("00000000000000010000000000000002");
-
-    when(random.nextLong()).thenReturn(3L);
-    SpanId spanId = generator.generateSpanId();
-    assertThat(spanId.toLowerBase16()).isEqualTo("0000000000000003");
-  }
-
-  @Test
-  public void ignoresInvalid() {
-    RandomIdsGenerator generator =
-        new RandomIdsGenerator(
-            new RandomSupplier() {
-              @Override
-              public Random get() {
-                return random;
-              }
-            });
-
-    // First two zeros skipped
-    when(random.nextLong()).thenReturn(0L).thenReturn(0L).thenReturn(0L).thenReturn(4L);
-    TraceId traceId = generator.generateTraceId();
-    assertThat(traceId.toLowerBase16()).isEqualTo("00000000000000000000000000000004");
-
-    when(random.nextLong()).thenReturn(0L).thenReturn(5L);
-    SpanId spanId = generator.generateSpanId();
-    assertThat(spanId.toLowerBase16()).isEqualTo("0000000000000005");
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
@@ -3,17 +3,16 @@ package io.opentelemetry.sdk.trace;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.when;
 
+import io.opentelemetry.sdk.trace.RandomIdsGenerator.RandomSupplier;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceId;
 import java.util.Random;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import io.opentelemetry.sdk.trace.RandomIdsGenerator.RandomSupplier;
-import io.opentelemetry.trace.SpanId;
-import io.opentelemetry.trace.TraceId;
 
 @RunWith(JUnit4.class)
 public class RandomIdsGeneratorTest {

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
@@ -69,9 +69,9 @@ public class RandomIdsGeneratorTest {
             });
 
     // First two zeros skipped
-    when(random.nextLong()).thenReturn(0L).thenReturn(0L).thenReturn(3L).thenReturn(4L);
+    when(random.nextLong()).thenReturn(0L).thenReturn(0L).thenReturn(0L).thenReturn(4L);
     TraceId traceId = generator.generateTraceId();
-    assertThat(traceId.toLowerBase16()).isEqualTo("00000000000000030000000000000004");
+    assertThat(traceId.toLowerBase16()).isEqualTo("00000000000000000000000000000004");
 
     when(random.nextLong()).thenReturn(0L).thenReturn(5L);
     SpanId spanId = generator.generateSpanId();

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
@@ -31,11 +31,13 @@ public class RandomIdsGeneratorTest {
   public void defaults() {
     RandomIdsGenerator generator = new RandomIdsGenerator();
 
-    // Can't assert values but can assert they're valid.
-    TraceId traceId = generator.generateTraceId();
-    assertThat(traceId).isNotEqualTo(TraceId.getInvalid());
+    // Can't assert values but can assert they're valid, try a lot as a sort of fuzz check.
+    for (int i = 0; i < 1000; i++) {
+      TraceId traceId = generator.generateTraceId();
+      assertThat(traceId).isNotEqualTo(TraceId.getInvalid());
 
-    SpanId spanId = generator.generateSpanId();
-    assertThat(spanId).isNotEqualTo(SpanId.getInvalid());
+      SpanId spanId = generator.generateSpanId();
+      assertThat(spanId).isNotEqualTo(SpanId.getInvalid());
+    }
   }
 }


### PR DESCRIPTION
When creating a custom `IdsGenerator`, I think it is common to want to delegate to the default random one, e.g., only customize trace ID and use the same code for span ID. I noticed this when writing https://github.com/aws-samples/aws-xray-sdk-with-opentelemetry-sample/blob/both-otel-and-xray/awsagentprovider/src/main/java/com/softwareaws/xray/opentelemetry/exporters/AwsXrayIdsGenerator.java#L29

The `AwsXrayIdsGenerator` in this repo has a huge dependency on the xray SDK which I want to remove (then I don't need to fork there :) ), and this would help when doing that.

~Also made `RandomIdsGenerator` a singleton while here.~

Realized it's more useful to be able to customize Random than make singleton.