### PR TITLE
Inline generation of XRay trace IDs to remove heavyweight SDK depende…

### DIFF
--- a/sdk_contrib/aws_v1_support/build.gradle
+++ b/sdk_contrib/aws_v1_support/build.gradle
@@ -12,8 +12,8 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    api project(':opentelemetry-api')
-    api project(':opentelemetry-sdk')
+    api project(':opentelemetry-api'),
+            project(':opentelemetry-sdk')
 
     implementation 'com.amazonaws:aws-java-sdk-core:1.11.701'
     implementation 'com.amazonaws:aws-java-sdk-ec2:1.11.701'

--- a/sdk_contrib/aws_v1_support/build.gradle
+++ b/sdk_contrib/aws_v1_support/build.gradle
@@ -12,12 +12,9 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    api project(':opentelemetry-api'),
-            project(':opentelemetry-sdk')
+    api project(':opentelemetry-api')
+    api project(':opentelemetry-sdk')
 
-    implementation libraries.guava
-
-    implementation 'com.amazonaws:aws-xray-recorder-sdk-core:2.4.0'
     implementation 'com.amazonaws:aws-java-sdk-core:1.11.701'
     implementation 'com.amazonaws:aws-java-sdk-ec2:1.11.701'
 

--- a/sdk_contrib/aws_v1_support/build.gradle
+++ b/sdk_contrib/aws_v1_support/build.gradle
@@ -15,8 +15,8 @@ dependencies {
     api project(':opentelemetry-api'),
             project(':opentelemetry-sdk')
 
-    implementation 'com.amazonaws:aws-java-sdk-core:1.11.701'
-    implementation 'com.amazonaws:aws-java-sdk-ec2:1.11.701'
+    implementation 'com.amazonaws:aws-java-sdk-core:1.11.701',
+            'com.amazonaws:aws-java-sdk-ec2:1.11.701'
 
     signature "org.codehaus.mojo.signature:java18:1.0@signature"
 }

--- a/sdk_contrib/aws_v1_support/src/main/java/io/opentelemetry/sdk/contrib/trace/aws/Ec2Resource.java
+++ b/sdk_contrib/aws_v1_support/src/main/java/io/opentelemetry/sdk/contrib/trace/aws/Ec2Resource.java
@@ -16,8 +16,6 @@
 
 package io.opentelemetry.sdk.contrib.trace.aws;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
-
 import com.amazonaws.util.EC2MetadataUtils;
 import com.amazonaws.util.EC2MetadataUtils.InstanceInfo;
 import io.opentelemetry.common.AttributeValue;
@@ -67,7 +65,7 @@ public class Ec2Resource {
       labels.put(
           ResourceConstants.HOST_IMAGE_ID, AttributeValue.stringAttributeValue(info.getImageId()));
     }
-    if (!isNullOrEmpty(hostname)) {
+    if (hostname != null && !hostname.isEmpty()) {
       labels.put(ResourceConstants.HOST_HOSTNAME, AttributeValue.stringAttributeValue(hostname));
     }
     return Resource.create(labels);

--- a/sdk_contrib/aws_v1_support/src/test/java/io/opentelemetry/sdk/contrib/trace/aws/AwsXRayIdsGeneratorTest.java
+++ b/sdk_contrib/aws_v1_support/src/test/java/io/opentelemetry/sdk/contrib/trace/aws/AwsXRayIdsGeneratorTest.java
@@ -38,22 +38,26 @@ public class AwsXRayIdsGeneratorTest {
   @Test
   public void shouldGenerateValidIds() {
     AwsXRayIdsGenerator generator = new AwsXRayIdsGenerator();
-    TraceId traceId = generator.generateTraceId();
-    assertThat(traceId.isValid()).isTrue();
-    SpanId spanId = generator.generateSpanId();
-    assertThat(spanId.isValid()).isTrue();
+    for (int i = 0; i < 1000; i++) {
+      TraceId traceId = generator.generateTraceId();
+      assertThat(traceId.isValid()).isTrue();
+      SpanId spanId = generator.generateSpanId();
+      assertThat(spanId.isValid()).isTrue();
+    }
   }
 
   @Test
   public void shouldGenerateTraceIdsWithTimestampsWithAllowedXrayTimeRange() {
     AwsXRayIdsGenerator generator = new AwsXRayIdsGenerator();
-    TraceId traceId = generator.generateTraceId();
-    Long unixSeconds = Long.valueOf(traceId.toLowerBase16().substring(0, 8), 16);
-    long ts = unixSeconds * 1000L;
-    long currentTs = System.currentTimeMillis();
-    assertThat(ts <= currentTs).isTrue();
-    long month = 86400000L * 30L;
-    assertThat(ts > currentTs - month).isTrue();
+    for (int i = 0; i < 1000; i++) {
+      TraceId traceId = generator.generateTraceId();
+      Long unixSeconds = Long.valueOf(traceId.toLowerBase16().substring(0, 8), 16);
+      long ts = unixSeconds * 1000L;
+      long currentTs = System.currentTimeMillis();
+      assertThat(ts).isAtMost(currentTs);
+      long month = 86400000L * 30L;
+      assertThat(ts).isGreaterThan(currentTs - month);
+    }
   }
 
   @Test
@@ -71,8 +75,8 @@ public class AwsXRayIdsGeneratorTest {
     }
     barrier.await();
     barrier.await();
-    assertThat(traceIds.size()).isEqualTo(threads * generations);
-    assertThat(spanIds.size()).isEqualTo(threads * generations);
+    assertThat(traceIds).hasSize(threads * generations);
+    assertThat(spanIds).hasSize(threads * generations);
   }
 
   static class GenerateRunner implements Runnable {


### PR DESCRIPTION
…ncy.

The X-Ray SDK is pretty heavyweight, meant for instrumenting, not something as simple as generating IDs. This implements ID generation without the dependency. Also removes Guava since it was only used once so not really worth it.

In a future PR I'll reimplement `EC2Resource` as well to remove the AWS SDK dependency too.