### PR TITLE
Convert the exportable Event to an interface

### DIFF
--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
@@ -27,6 +27,7 @@ import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.exporters.jaeger.proto.api_v2.Model;
 import io.opentelemetry.sdk.contrib.otproto.TraceProtoUtils;
 import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.EventImpl;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
@@ -131,7 +132,7 @@ public class AdapterTest {
   @Test
   public void testJaegerLog() {
     // prepare
-    Event event = getTimedEvent();
+    EventImpl event = getTimedEvent();
 
     // test
     Model.Log log = Adapter.toJaegerLog(event);
@@ -291,11 +292,11 @@ public class AdapterTest {
     assertTrue(error.getVBool());
   }
 
-  private static Event getTimedEvent() {
+  private static EventImpl getTimedEvent() {
     long epochNanos = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
     AttributeValue valueS = AttributeValue.stringAttributeValue("bar");
     ImmutableMap<String, AttributeValue> attributes = ImmutableMap.of("foo", valueS);
-    return Event.create(epochNanos, "the log message", attributes);
+    return EventImpl.create(epochNanos, "the log message", attributes);
   }
 
   private static SpanData getSpanData(long startMs, long endMs) {
@@ -313,7 +314,7 @@ public class AdapterTest {
         .setStartEpochNanos(TimeUnit.MILLISECONDS.toNanos(startMs))
         .setEndEpochNanos(TimeUnit.MILLISECONDS.toNanos(endMs))
         .setAttributes(attributes)
-        .setEvents(Collections.singletonList(getTimedEvent()))
+        .setEvents(Collections.<Event>singletonList(getTimedEvent()))
         .setTotalRecordedEvents(1)
         .setLinks(Collections.singletonList(link))
         .setTotalRecordedLinks(1)

--- a/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingSpanExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingSpanExporterTest.java
@@ -22,6 +22,7 @@ import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 
 import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.sdk.trace.data.EventImpl;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.data.SpanDataImpl;
@@ -30,6 +31,7 @@ import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.TraceId;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
@@ -68,8 +70,8 @@ public class LoggingSpanExporterTest {
             .setName("testSpan")
             .setKind(Kind.INTERNAL)
             .setEvents(
-                singletonList(
-                    Event.create(
+                Collections.<Event>singletonList(
+                    EventImpl.create(
                         epochNanos + 500,
                         "somethingHappenedHere",
                         singletonMap("important", AttributeValue.booleanAttributeValue(true)))))

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
@@ -26,6 +26,7 @@ import io.opentelemetry.proto.trace.v1.Span;
 import io.opentelemetry.proto.trace.v1.Span.SpanKind;
 import io.opentelemetry.proto.trace.v1.Status;
 import io.opentelemetry.proto.trace.v1.Status.StatusCode;
+import io.opentelemetry.sdk.trace.data.EventImpl;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
 import io.opentelemetry.sdk.trace.data.SpanDataImpl;
@@ -70,8 +71,8 @@ public class SpanAdapterTest {
                     Collections.singletonMap("key", AttributeValue.booleanAttributeValue(true)))
                 .setTotalAttributeCount(2)
                 .setEvents(
-                    Collections.singletonList(
-                        Event.create(
+                    Collections.<Event>singletonList(
+                        EventImpl.create(
                             12347, "my_event", Collections.<String, AttributeValue>emptyMap())))
                 .setTotalRecordedEvents(3)
                 .setLinks(Collections.singletonList(Link.create(SPAN_CONTEXT)))
@@ -234,7 +235,7 @@ public class SpanAdapterTest {
   public void toProtoSpanEvent_WithoutAttributes() {
     assertThat(
             SpanAdapter.toProtoSpanEvent(
-                Event.create(
+                EventImpl.create(
                     12345,
                     "test_without_attributes",
                     Collections.<String, AttributeValue>emptyMap())))
@@ -249,7 +250,7 @@ public class SpanAdapterTest {
   public void toProtoSpanEvent_WithAttributes() {
     assertThat(
             SpanAdapter.toProtoSpanEvent(
-                Event.create(
+                EventImpl.create(
                     12345,
                     "test_with_attributes",
                     Collections.singletonMap(

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.sdk.trace.data.EventImpl;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
@@ -61,10 +62,10 @@ public class ZipkinSpanExporterEndToEndHttpTest {
   private static final long SENT_TIMESTAMP_NANOS = 1505855799_459486280L;
   private static final Map<String, AttributeValue> attributes = Collections.emptyMap();
   private static final List<Event> annotations =
-      ImmutableList.of(
-          Event.create(
+      ImmutableList.<Event>of(
+          EventImpl.create(
               RECEIVED_TIMESTAMP_NANOS, "RECEIVED", Collections.<String, AttributeValue>emptyMap()),
-          Event.create(
+          EventImpl.create(
               SENT_TIMESTAMP_NANOS, "SENT", Collections.<String, AttributeValue>emptyMap()));
 
   private static final String ENDPOINT_V1_SPANS = "/api/v1/spans";

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.resources.ResourceConstants;
+import io.opentelemetry.sdk.trace.data.EventImpl;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
@@ -67,10 +68,10 @@ public class ZipkinSpanExporterTest {
   private static final String PARENT_SPAN_ID = "8b03ab423da481c5";
   private static final Map<String, AttributeValue> attributes = Collections.emptyMap();
   private static final List<Event> annotations =
-      ImmutableList.of(
-          Event.create(
+      ImmutableList.<Event>of(
+          EventImpl.create(
               1505855799_433901068L, "RECEIVED", Collections.<String, AttributeValue>emptyMap()),
-          Event.create(
+          EventImpl.create(
               1505855799_459486280L, "SENT", Collections.<String, AttributeValue>emptyMap()));
 
   @Test

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -25,6 +25,7 @@ import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
+import io.opentelemetry.sdk.trace.data.EventImpl;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
@@ -508,7 +509,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     List<Event> result = new ArrayList<>(events.size());
     for (io.opentelemetry.sdk.trace.TimedEvent sourceEvent : events) {
       result.add(
-          Event.create(
+          EventImpl.create(
               sourceEvent.getEpochNanos(), sourceEvent.getName(), sourceEvent.getAttributes()));
     }
     return Collections.unmodifiableList(result);

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -25,7 +25,6 @@ import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
-import io.opentelemetry.sdk.trace.data.EventImpl;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
@@ -506,13 +505,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     if (events.isEmpty()) {
       return Collections.emptyList();
     }
-    List<Event> result = new ArrayList<>(events.size());
-    for (io.opentelemetry.sdk.trace.TimedEvent sourceEvent : events) {
-      result.add(
-          EventImpl.create(
-              sourceEvent.getEpochNanos(), sourceEvent.getName(), sourceEvent.getAttributes()));
-    }
-    return Collections.unmodifiableList(result);
+    return Collections.unmodifiableList(new ArrayList<Event>(events));
   }
 
   @GuardedBy("lock")

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -24,6 +24,7 @@ import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.TimedEvent.RawTimedEventWithEvent;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
@@ -505,7 +506,23 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     if (events.isEmpty()) {
       return Collections.emptyList();
     }
-    return Collections.unmodifiableList(new ArrayList<Event>(events));
+
+    List<Event> results = new ArrayList<>(events.size());
+    for (TimedEvent event : events) {
+      if (event instanceof RawTimedEventWithEvent) {
+        // make sure to copy the data if the event is wrapping another one,
+        // so we don't hold on the caller's memory
+        results.add(
+            TimedEvent.create(
+                event.getEpochNanos(),
+                event.getName(),
+                event.getAttributes(),
+                event.getTotalAttributeCount()));
+      } else {
+        results.add(event);
+      }
+    }
+    return Collections.unmodifiableList(results);
   }
 
   @GuardedBy("lock")

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TimedEvent.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TimedEvent.java
@@ -19,50 +19,16 @@ package io.opentelemetry.sdk.trace;
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.trace.Event;
-import java.util.Collections;
 import java.util.Map;
 import javax.annotation.concurrent.Immutable;
 
 /** Timed event. */
 @Immutable
-abstract class TimedEvent {
+abstract class TimedEvent implements io.opentelemetry.sdk.trace.data.SpanData.Event {
 
-  private static final Map<String, AttributeValue> EMPTY_ATTRIBUTES =
-      Collections.unmodifiableMap(Collections.<String, AttributeValue>emptyMap());
   private static final int DEFAULT_TOTAL_ATTRIBUTE_COUNT = 0;
 
-  abstract long getEpochNanos();
-
-  abstract String getName();
-
-  abstract Map<String, AttributeValue> getAttributes();
-
-  abstract int getTotalAttributeCount();
-
   TimedEvent() {}
-
-  /**
-   * Creates an {@link TimedEvent} with the given time, name and empty attributes.
-   *
-   * @param epochNanos epoch timestamp in nanos.
-   * @param name the name of this {@code TimedEvent}.
-   * @return an {@code TimedEvent}.
-   */
-  static TimedEvent create(long epochNanos, String name) {
-    return create(epochNanos, name, EMPTY_ATTRIBUTES);
-  }
-
-  /**
-   * Creates an {@link TimedEvent} with the given time, name and attributes.
-   *
-   * @param epochNanos epoch timestamp in nanos.
-   * @param name the name of this {@code TimedEvent}.
-   * @param attributes the attributes of this {@code TimedEvent}.
-   * @return an {@code TimedEvent}.
-   */
-  static TimedEvent create(long epochNanos, String name, Map<String, AttributeValue> attributes) {
-    return new AutoValue_TimedEvent_RawTimedEvent(epochNanos, name, attributes, attributes.size());
-  }
 
   /**
    * Creates an {@link TimedEvent} with the given time, name and attributes.
@@ -78,7 +44,7 @@ abstract class TimedEvent {
       Map<String, AttributeValue> attributes,
       int totalAttributeCount) {
     return new AutoValue_TimedEvent_RawTimedEvent(
-        epochNanos, name, attributes, totalAttributeCount);
+        name, attributes, epochNanos, totalAttributeCount);
   }
 
   /**
@@ -99,17 +65,17 @@ abstract class TimedEvent {
     abstract Event getEvent();
 
     @Override
-    String getName() {
+    public String getName() {
       return getEvent().getName();
     }
 
     @Override
-    Map<String, AttributeValue> getAttributes() {
+    public Map<String, AttributeValue> getAttributes() {
       return getEvent().getAttributes();
     }
 
     @Override
-    abstract int getTotalAttributeCount();
+    public abstract int getTotalAttributeCount();
   }
 
   @AutoValue

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/data/EventImpl.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/data/EventImpl.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.trace.data;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.common.AttributeValue;
+import java.util.Map;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * An immutable timed event representation. Enhances the core {@link io.opentelemetry.trace.Event}
+ * by adding the time at which the event occurred.
+ *
+ * @since 0.1.0
+ */
+@Immutable
+@AutoValue
+public abstract class EventImpl implements SpanData.Event {
+
+  /**
+   * Returns a new immutable {@code Event}.
+   *
+   * @param epochNanos epoch timestamp in nanos of the {@code Event}.
+   * @param name the name of the {@code Event}.
+   * @param attributes the attributes of the {@code Event}.
+   * @return a new immutable {@code Event<T>}
+   * @since 0.1.0
+   */
+  public static EventImpl create(
+      long epochNanos, String name, Map<String, AttributeValue> attributes) {
+    return new AutoValue_EventImpl(name, attributes, epochNanos, attributes.size());
+  }
+
+  /**
+   * Returns a new immutable {@code Event}.
+   *
+   * @param epochNanos epoch timestamp in nanos of the {@code Event}.
+   * @param name the name of the {@code Event}.
+   * @param attributes the attributes of the {@code Event}.
+   * @param totalAttributeCount the total number of attributes for this {@code} Event.
+   * @return a new immutable {@code Event<T>}
+   * @since 0.1.0
+   */
+  public static EventImpl create(
+      long epochNanos,
+      String name,
+      Map<String, AttributeValue> attributes,
+      int totalAttributeCount) {
+    return new AutoValue_EventImpl(name, attributes, epochNanos, totalAttributeCount);
+  }
+
+  EventImpl() {}
+}

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
@@ -274,55 +274,14 @@ public interface SpanData {
     Link() {}
   }
 
-  /**
-   * An immutable timed event representation. Enhances the core {@link io.opentelemetry.trace.Event}
-   * by adding the time at which the event occurred.
-   *
-   * @since 0.1.0
-   */
-  @Immutable
-  @AutoValue
-  abstract class Event implements io.opentelemetry.trace.Event {
-
-    /**
-     * Returns a new immutable {@code Event}.
-     *
-     * @param epochNanos epoch timestamp in nanos of the {@code Event}.
-     * @param name the name of the {@code Event}.
-     * @param attributes the attributes of the {@code Event}.
-     * @return a new immutable {@code Event<T>}
-     * @since 0.1.0
-     */
-    public static Event create(
-        long epochNanos, String name, Map<String, AttributeValue> attributes) {
-      return new AutoValue_SpanData_Event(name, attributes, epochNanos, attributes.size());
-    }
-
-    /**
-     * Returns a new immutable {@code Event}.
-     *
-     * @param epochNanos epoch timestamp in nanos of the {@code Event}.
-     * @param name the name of the {@code Event}.
-     * @param attributes the attributes of the {@code Event}.
-     * @param totalAttributeCount the total number of attributes for this {@code} Event.
-     * @return a new immutable {@code Event<T>}
-     * @since 0.1.0
-     */
-    public static Event create(
-        long epochNanos,
-        String name,
-        Map<String, AttributeValue> attributes,
-        int totalAttributeCount) {
-      return new AutoValue_SpanData_Event(name, attributes, epochNanos, totalAttributeCount);
-    }
-
+  interface Event extends io.opentelemetry.trace.Event {
     /**
      * Returns the epoch time in nanos of this event.
      *
      * @return the epoch time in nanos of this event.
      * @since 0.1.0
      */
-    public abstract long getEpochNanos();
+    long getEpochNanos();
 
     /**
      * The total number of attributes that were recorded on this Event. This number may be larger
@@ -332,8 +291,6 @@ public interface SpanData {
      *
      * @return The total number of attributes on this event.
      */
-    public abstract int getTotalAttributeCount();
-
-    Event() {}
+    int getTotalAttributeCount();
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -23,6 +23,7 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
+import io.opentelemetry.sdk.trace.data.EventImpl;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
@@ -161,7 +162,7 @@ public class RecordEventsReadableSpanTest {
       spanDoWork(span, null);
       SpanData spanData = span.toSpanData();
       Event event =
-          Event.create(
+          EventImpl.create(
               startEpochNanos + NANOS_PER_SECOND,
               "event2",
               Collections.<String, AttributeValue>emptyMap());
@@ -193,7 +194,7 @@ public class RecordEventsReadableSpanTest {
     Mockito.verify(spanProcessor, Mockito.times(1)).onEnd(span);
     SpanData spanData = span.toSpanData();
     Event event =
-        Event.create(
+        EventImpl.create(
             startEpochNanos + NANOS_PER_SECOND,
             "event2",
             Collections.<String, AttributeValue>emptyMap());
@@ -226,7 +227,7 @@ public class RecordEventsReadableSpanTest {
     thrown.expect(UnsupportedOperationException.class);
     spanData
         .getEvents()
-        .add(Event.create(1000, "test", Collections.<String, AttributeValue>emptyMap()));
+        .add(EventImpl.create(1000, "test", Collections.<String, AttributeValue>emptyMap()));
   }
 
   @Test
@@ -479,7 +480,7 @@ public class RecordEventsReadableSpanTest {
     try {
       assertThat(span.toSpanData().getEvents())
           .containsExactly(
-              Event.create(
+              EventImpl.create(
                   testClock.now(),
                   "name",
                   Collections.singletonMap("key0", AttributeValue.stringAttributeValue("str")),
@@ -487,7 +488,7 @@ public class RecordEventsReadableSpanTest {
       attributes.remove("key0");
       assertThat(span.toSpanData().getEvents())
           .containsExactly(
-              Event.create(
+              EventImpl.create(
                   testClock.now(),
                   "name",
                   Collections.singletonMap("key0", AttributeValue.stringAttributeValue("str")),
@@ -506,7 +507,7 @@ public class RecordEventsReadableSpanTest {
     try {
       assertThat(span.toSpanData().getEvents())
           .containsExactly(
-              Event.create(
+              EventImpl.create(
                   100,
                   "name",
                   Collections.singletonMap("key0", AttributeValue.stringAttributeValue("str")),
@@ -514,7 +515,7 @@ public class RecordEventsReadableSpanTest {
       attributes.remove("key0");
       assertThat(span.toSpanData().getEvents())
           .containsExactly(
-              Event.create(
+              EventImpl.create(
                   100,
                   "name",
                   Collections.singletonMap("key0", AttributeValue.stringAttributeValue("str")),
@@ -605,7 +606,7 @@ public class RecordEventsReadableSpanTest {
       assertThat(spanData.getEvents().size()).isEqualTo(maxNumberOfEvents);
       for (int i = 0; i < maxNumberOfEvents; i++) {
         Event expectedEvent =
-            Event.create(
+            EventImpl.create(
                 startEpochNanos + (maxNumberOfEvents + i) * NANOS_PER_SECOND,
                 "event2",
                 Collections.<String, AttributeValue>emptyMap());
@@ -619,7 +620,7 @@ public class RecordEventsReadableSpanTest {
     assertThat(spanData.getEvents().size()).isEqualTo(maxNumberOfEvents);
     for (int i = 0; i < maxNumberOfEvents; i++) {
       Event expectedEvent =
-          Event.create(
+          EventImpl.create(
               startEpochNanos + (maxNumberOfEvents + i) * NANOS_PER_SECOND,
               "event2",
               Collections.<String, AttributeValue>emptyMap());
@@ -774,9 +775,9 @@ public class RecordEventsReadableSpanTest {
     long endEpochNanos = clock.now();
 
     List<Event> events =
-        Arrays.asList(
-            Event.create(firstEventEpochNanos, "event1", event1Attributes),
-            Event.create(secondEventTimeNanos, "event2", event2Attributes));
+        Arrays.<Event>asList(
+            EventImpl.create(firstEventEpochNanos, "event1", event1Attributes),
+            EventImpl.create(secondEventTimeNanos, "event2", event2Attributes));
 
     SpanData result = readableSpan.toSpanData();
     verifySpanData(

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -162,10 +162,11 @@ public class RecordEventsReadableSpanTest {
       spanDoWork(span, null);
       SpanData spanData = span.toSpanData();
       Event event =
-          EventImpl.create(
+          TimedEvent.create(
               startEpochNanos + NANOS_PER_SECOND,
               "event2",
-              Collections.<String, AttributeValue>emptyMap());
+              Collections.<String, AttributeValue>emptyMap(),
+              0);
       verifySpanData(
           spanData,
           expectedAttributes,
@@ -194,10 +195,11 @@ public class RecordEventsReadableSpanTest {
     Mockito.verify(spanProcessor, Mockito.times(1)).onEnd(span);
     SpanData spanData = span.toSpanData();
     Event event =
-        EventImpl.create(
+        TimedEvent.create(
             startEpochNanos + NANOS_PER_SECOND,
             "event2",
-            Collections.<String, AttributeValue>emptyMap());
+            Collections.<String, AttributeValue>emptyMap(),
+            0);
     verifySpanData(
         spanData,
         expectedAttributes,
@@ -480,7 +482,7 @@ public class RecordEventsReadableSpanTest {
     try {
       assertThat(span.toSpanData().getEvents())
           .containsExactly(
-              EventImpl.create(
+              TimedEvent.create(
                   testClock.now(),
                   "name",
                   Collections.singletonMap("key0", AttributeValue.stringAttributeValue("str")),
@@ -488,7 +490,7 @@ public class RecordEventsReadableSpanTest {
       attributes.remove("key0");
       assertThat(span.toSpanData().getEvents())
           .containsExactly(
-              EventImpl.create(
+              TimedEvent.create(
                   testClock.now(),
                   "name",
                   Collections.singletonMap("key0", AttributeValue.stringAttributeValue("str")),
@@ -507,7 +509,7 @@ public class RecordEventsReadableSpanTest {
     try {
       assertThat(span.toSpanData().getEvents())
           .containsExactly(
-              EventImpl.create(
+              TimedEvent.create(
                   100,
                   "name",
                   Collections.singletonMap("key0", AttributeValue.stringAttributeValue("str")),
@@ -515,7 +517,7 @@ public class RecordEventsReadableSpanTest {
       attributes.remove("key0");
       assertThat(span.toSpanData().getEvents())
           .containsExactly(
-              EventImpl.create(
+              TimedEvent.create(
                   100,
                   "name",
                   Collections.singletonMap("key0", AttributeValue.stringAttributeValue("str")),
@@ -606,10 +608,11 @@ public class RecordEventsReadableSpanTest {
       assertThat(spanData.getEvents().size()).isEqualTo(maxNumberOfEvents);
       for (int i = 0; i < maxNumberOfEvents; i++) {
         Event expectedEvent =
-            EventImpl.create(
+            TimedEvent.create(
                 startEpochNanos + (maxNumberOfEvents + i) * NANOS_PER_SECOND,
                 "event2",
-                Collections.<String, AttributeValue>emptyMap());
+                Collections.<String, AttributeValue>emptyMap(),
+                0);
         assertThat(spanData.getEvents().get(i)).isEqualTo(expectedEvent);
         assertThat(spanData.getTotalRecordedEvents()).isEqualTo(2 * maxNumberOfEvents);
       }
@@ -620,10 +623,11 @@ public class RecordEventsReadableSpanTest {
     assertThat(spanData.getEvents().size()).isEqualTo(maxNumberOfEvents);
     for (int i = 0; i < maxNumberOfEvents; i++) {
       Event expectedEvent =
-          EventImpl.create(
+          TimedEvent.create(
               startEpochNanos + (maxNumberOfEvents + i) * NANOS_PER_SECOND,
               "event2",
-              Collections.<String, AttributeValue>emptyMap());
+              Collections.<String, AttributeValue>emptyMap(),
+              0);
       assertThat(spanData.getEvents().get(i)).isEqualTo(expectedEvent);
     }
   }
@@ -776,8 +780,10 @@ public class RecordEventsReadableSpanTest {
 
     List<Event> events =
         Arrays.<Event>asList(
-            EventImpl.create(firstEventEpochNanos, "event1", event1Attributes),
-            EventImpl.create(secondEventTimeNanos, "event2", event2Attributes));
+            TimedEvent.create(
+                firstEventEpochNanos, "event1", event1Attributes, event1Attributes.size()),
+            TimedEvent.create(
+                secondEventTimeNanos, "event2", event2Attributes, event2Attributes.size()));
 
     SpanData result = readableSpan.toSpanData();
     verifySpanData(

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TimedEventTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TimedEventTest.java
@@ -50,23 +50,6 @@ public class TimedEventTest {
       };
 
   @Test
-  public void rawTimedEventWithName() {
-    TimedEvent event = TimedEvent.create(9876543210L, NAME);
-    assertThat(event.getEpochNanos()).isEqualTo(9876543210L);
-    assertThat(event.getName()).isEqualTo(NAME);
-    assertThat(event.getAttributes()).isEmpty();
-  }
-
-  @Test
-  public void rawTimedEventWithNameAndAttributes() {
-    TimedEvent event = TimedEvent.create(1234567890L, NAME, ATTRIBUTES);
-    assertThat(event.getEpochNanos()).isEqualTo(1234567890L);
-    assertThat(event.getName()).isEqualTo(NAME);
-    assertThat(event.getAttributes()).isEqualTo(ATTRIBUTES);
-    assertThat(event.getTotalAttributeCount()).isEqualTo(ATTRIBUTES.size());
-  }
-
-  @Test
   public void rawTimedEventWithNameAndAttributesAndTotalAttributeCount() {
     TimedEvent event = TimedEvent.create(1234567890L, NAME, ATTRIBUTES, ATTRIBUTES.size() + 2);
     assertThat(event.getEpochNanos()).isEqualTo(1234567890L);

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/data/SpanDataImplTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/data/SpanDataImplTest.java
@@ -21,7 +21,6 @@ import static java.util.Collections.emptyList;
 
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanContext;
@@ -82,7 +81,7 @@ public class SpanDataImplTest {
     thrown.expect(UnsupportedOperationException.class);
     spanData
         .getEvents()
-        .add(Event.create(1234, "foo", Collections.<String, AttributeValue>emptyMap()));
+        .add(EventImpl.create(1234, "foo", Collections.<String, AttributeValue>emptyMap()));
   }
 
   @Test
@@ -111,22 +110,23 @@ public class SpanDataImplTest {
 
   @Test
   public void timedEvent_defaultTotalAttributeCountIsZero() {
-    Event event =
-        Event.create(START_EPOCH_NANOS, "foo", Collections.<String, AttributeValue>emptyMap());
+    EventImpl event =
+        EventImpl.create(START_EPOCH_NANOS, "foo", Collections.<String, AttributeValue>emptyMap());
     assertThat(event.getTotalAttributeCount()).isEqualTo(0);
   }
 
   @Test
   public void timedEvent_canSetTotalAttributeCount() {
-    Event event =
-        Event.create(START_EPOCH_NANOS, "foo", Collections.<String, AttributeValue>emptyMap(), 123);
+    EventImpl event =
+        EventImpl.create(
+            START_EPOCH_NANOS, "foo", Collections.<String, AttributeValue>emptyMap(), 123);
     assertThat(event.getTotalAttributeCount()).isEqualTo(123);
   }
 
   private static SpanData createSpanDataWithMutableCollections() {
     return createBasicSpanBuilder()
         .setLinks(new ArrayList<Link>())
-        .setEvents(new ArrayList<Event>())
+        .setEvents(new ArrayList<SpanData.Event>())
         .setAttributes(new HashMap<String, AttributeValue>())
         .build();
   }


### PR DESCRIPTION
And, make the internal TimedEvent implement that interface, so we don't need to copy the data in the Span pipeline.

This is continuing work towards #1191 

Benchmark results before this change:
```
SpanPipelineBenchmark.runThePipeline_05Threads                                   thrpt    5  4004.539 ± 255.354  ops/ms
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.alloc.rate                    thrpt    5  7670.084 ± 495.608  MB/sec
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.alloc.rate.norm               thrpt    5  3016.001 ±   0.001    B/op
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.churn.PS_Eden_Space           thrpt    5  7677.574 ± 530.403  MB/sec
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.churn.PS_Eden_Space.norm      thrpt    5  3019.633 ± 288.382    B/op
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.churn.PS_Survivor_Space       thrpt    5     0.203 ±   0.296  MB/sec
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.churn.PS_Survivor_Space.norm  thrpt    5     0.080 ±   0.119    B/op
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.count                         thrpt    5    74.000            counts
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.time                          thrpt    5    48.000                ms
```

Benchmark results after this change:
```
SpanPipelineBenchmark.runThePipeline_05Threads                                   thrpt    5  3972.373 ±  112.536  ops/ms
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.alloc.rate                    thrpt    5  7441.701 ±  250.148  MB/sec
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.alloc.rate.norm               thrpt    5  2952.001 ±    0.001    B/op
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.churn.PS_Eden_Space           thrpt    5  7470.590 ± 1733.367  MB/sec
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.churn.PS_Eden_Space.norm      thrpt    5  2962.492 ±  599.333    B/op
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.churn.PS_Survivor_Space       thrpt    5     0.245 ±    0.380  MB/sec
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.churn.PS_Survivor_Space.norm  thrpt    5     0.097 ±    0.148    B/op
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.count                         thrpt    5    76.000             counts
SpanPipelineBenchmark.runThePipeline_05Threads:·gc.time                          thrpt    5    47.000                 ms```

