### PR TITLE
Fix examples to use [Batch|Simple]SpanProcessor

### DIFF
--- a/examples/grpc/src/main/java/io/opentelemetry/example/HelloWorldClient.java
+++ b/examples/grpc/src/main/java/io/opentelemetry/example/HelloWorldClient.java
@@ -34,7 +34,7 @@ import io.opentelemetry.context.propagation.HttpTextFormat;
 import io.opentelemetry.exporters.logging.LoggingSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
-import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.Tracer;
@@ -85,7 +85,7 @@ public class HelloWorldClient {
     // Use the OpenTelemetry SDK
     TracerSdkProvider tracerProvider = OpenTelemetrySdk.getTracerProvider();
     // Set to process the spans by the log exporter
-    tracerProvider.addSpanProcessor(SimpleSpansProcessor.newBuilder(exporter).build());
+    tracerProvider.addSpanProcessor(SimpleSpanProcessor.newBuilder(exporter).build());
   }
 
   public void shutdown() throws InterruptedException {

--- a/examples/grpc/src/main/java/io/opentelemetry/example/HelloWorldClientStream.java
+++ b/examples/grpc/src/main/java/io/opentelemetry/example/HelloWorldClientStream.java
@@ -35,7 +35,7 @@ import io.opentelemetry.context.propagation.HttpTextFormat;
 import io.opentelemetry.exporters.logging.LoggingSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
-import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.Tracer;
@@ -88,7 +88,7 @@ public class HelloWorldClientStream {
     // Use the OpenTelemetry SDK
     TracerSdkProvider tracerProvider = OpenTelemetrySdk.getTracerProvider();
     // Set to process the spans by the log exporter
-    tracerProvider.addSpanProcessor(SimpleSpansProcessor.newBuilder(exporter).build());
+    tracerProvider.addSpanProcessor(SimpleSpanProcessor.newBuilder(exporter).build());
   }
 
   public void shutdown() throws InterruptedException {

--- a/examples/grpc/src/main/java/io/opentelemetry/example/HelloWorldServer.java
+++ b/examples/grpc/src/main/java/io/opentelemetry/example/HelloWorldServer.java
@@ -33,7 +33,7 @@ import io.opentelemetry.context.propagation.HttpTextFormat;
 import io.opentelemetry.exporters.logging.LoggingSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
-import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.Tracer;
@@ -109,7 +109,7 @@ public class HelloWorldServer {
     // Get the tracer
     TracerSdkProvider tracerProvider = OpenTelemetrySdk.getTracerProvider();
     // Set to process the the spans by the LogExporter
-    tracerProvider.addSpanProcessor(SimpleSpansProcessor.newBuilder(exporter).build());
+    tracerProvider.addSpanProcessor(SimpleSpanProcessor.newBuilder(exporter).build());
   }
 
   /** Await termination on the main thread since the grpc library uses daemon threads. */

--- a/examples/http/src/main/java/io/opentelemetry/example/http/HttpClient.java
+++ b/examples/http/src/main/java/io/opentelemetry/example/http/HttpClient.java
@@ -23,7 +23,7 @@ import io.opentelemetry.context.propagation.HttpTextFormat;
 import io.opentelemetry.exporters.logging.LoggingSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
-import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.Tracer;
@@ -55,7 +55,7 @@ public class HttpClient {
     // Show that multiple exporters can be used
 
     // Set to export the traces also to a log file
-    tracerProvider.addSpanProcessor(SimpleSpansProcessor.newBuilder(loggingExporter).build());
+    tracerProvider.addSpanProcessor(SimpleSpanProcessor.newBuilder(loggingExporter).build());
   }
 
   private HttpClient() throws Exception {

--- a/examples/http/src/main/java/io/opentelemetry/example/http/HttpServer.java
+++ b/examples/http/src/main/java/io/opentelemetry/example/http/HttpServer.java
@@ -26,7 +26,7 @@ import io.opentelemetry.context.propagation.HttpTextFormat;
 import io.opentelemetry.exporters.logging.LoggingSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
-import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.Tracer;
@@ -143,7 +143,7 @@ public class HttpServer {
     // Show that multiple exporters can be used
 
     // Set to export the traces also to a log file
-    tracerProvider.addSpanProcessor(SimpleSpansProcessor.newBuilder(loggingExporter).build());
+    tracerProvider.addSpanProcessor(SimpleSpanProcessor.newBuilder(loggingExporter).build());
   }
 
   private void stop() {

--- a/examples/jaeger/src/main/java/io/opentelemetry/example/JaegerExample.java
+++ b/examples/jaeger/src/main/java/io/opentelemetry/example/JaegerExample.java
@@ -5,7 +5,7 @@ import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.exporters.jaeger.JaegerGrpcSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
 
@@ -38,7 +38,7 @@ public class JaegerExample {
 
     // Set to process the spans by the Jaeger Exporter
     OpenTelemetrySdk.getTracerProvider()
-        .addSpanProcessor(SimpleSpansProcessor.newBuilder(this.jaegerExporter).build());
+        .addSpanProcessor(SimpleSpanProcessor.newBuilder(this.jaegerExporter).build());
   }
 
   private void myWonderfulUseCase() {

--- a/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureSpanProcessorExample.java
+++ b/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureSpanProcessorExample.java
@@ -21,8 +21,8 @@ import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.MultiSpanProcessor;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
-import io.opentelemetry.sdk.trace.export.BatchSpansProcessor;
-import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.trace.Tracer;
 import java.util.Arrays;
 
@@ -41,11 +41,11 @@ public class ConfigureSpanProcessorExample {
     // Example how to configure the default SpanProcessors.
     defaultSpanProcessors();
     // After this method, the following SpanProcessors are registered:
-    // - SimpleSpansProcessor
-    // - BatchSpansProcessor
+    // - SimpleSpanProcessor
+    // - BatchSpanProcessor
     // - MultiSpanProcessor <- this is a container for other SpanProcessors
-    // |-- SimpleSpansProcessor
-    // |-- BatchSpansProcessor
+    // |-- SimpleSpanProcessor
+    // |-- BatchSpanProcessor
 
     // We generate a single Span so we can see some output on the console.
     // Since there are 4 different SpanProcessor registered, this Span is exported 4 times.
@@ -67,12 +67,12 @@ public class ConfigureSpanProcessorExample {
 
     // Configure the simple spans processor. This span processor exports span immediately after they
     // are ended.
-    SimpleSpansProcessor simpleSpansProcessor = SimpleSpansProcessor.newBuilder(exporter).build();
+    SimpleSpanProcessor simpleSpansProcessor = SimpleSpanProcessor.newBuilder(exporter).build();
     tracerProvider.addSpanProcessor(simpleSpansProcessor);
 
     // Configure the batch spans processor. This span processor exports span in batches.
-    BatchSpansProcessor batchSpansProcessor =
-        BatchSpansProcessor.newBuilder(exporter)
+    BatchSpanProcessor batchSpansProcessor =
+        BatchSpanProcessor.newBuilder(exporter)
             .setExportOnlySampled(true) // send to the exporter only spans that have been sampled
             .setMaxExportBatchSize(512) // set the maximum batch size to use
             .setMaxQueueSize(2048) // set the queue size. This must be >= the export batch size

--- a/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureTraceExample.java
+++ b/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureTraceExample.java
@@ -23,7 +23,7 @@ import io.opentelemetry.sdk.trace.Sampler;
 import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
-import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.trace.Link;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
@@ -42,7 +42,7 @@ class ConfigureTraceExample {
 
   static {
     tracerProvider.addSpanProcessor(
-        SimpleSpansProcessor.newBuilder(new LoggingSpanExporter()).build());
+        SimpleSpanProcessor.newBuilder(new LoggingSpanExporter()).build());
   }
 
   public static void main(String[] args) {


### PR DESCRIPTION
PR #1241  changed the names of
[Batch|Simple]SpansProcessor to [Batch|Simple]SpanProcessor but did not change the examples to
match. 

This fixes the examples so that they now build correctly.