### PR TITLE
Do not inject invalid SpanContext instances.

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
@@ -81,7 +81,7 @@ public class HttpTraceContext implements HttpTextFormat {
     checkNotNull(setter, "setter");
 
     Span span = TracingContextUtils.getSpanWithoutDefault(context);
-    if (span == null) {
+    if (span == null || !span.getContext().isValid()) {
       return;
     }
 

--- a/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
@@ -115,6 +115,22 @@ public class HttpTraceContextTest {
   }
 
   @Test
+  public void inject_invalidContext() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    httpTraceContext.inject(
+        withSpanContext(
+            SpanContext.create(
+                TraceId.getInvalid(),
+                SpanId.getInvalid(),
+                SAMPLED_TRACE_OPTIONS,
+                TraceState.builder().set("foo", "bar").build()),
+            Context.current()),
+        carrier,
+        setter);
+    assertThat(carrier).hasSize(0);
+  }
+
+  @Test
   public void inject_SampledContext() {
     Map<String, String> carrier = new LinkedHashMap<>();
     Context context =

--- a/contrib/trace_propagators/src/main/java/io/opentelemetry/contrib/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
+++ b/contrib/trace_propagators/src/main/java/io/opentelemetry/contrib/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
@@ -32,7 +32,7 @@ final class B3PropagatorInjectorMultipleHeaders implements B3PropagatorInjector 
     Objects.requireNonNull(setter, "setter");
 
     Span span = TracingContextUtils.getSpanWithoutDefault(context);
-    if (span == null) {
+    if (span == null || !span.getContext().isValid()) {
       return;
     }
 

--- a/contrib/trace_propagators/src/main/java/io/opentelemetry/contrib/trace/propagation/B3PropagatorInjectorSingleHeader.java
+++ b/contrib/trace_propagators/src/main/java/io/opentelemetry/contrib/trace/propagation/B3PropagatorInjectorSingleHeader.java
@@ -43,7 +43,7 @@ final class B3PropagatorInjectorSingleHeader implements B3PropagatorInjector {
     Objects.requireNonNull(setter, "setter");
 
     Span span = TracingContextUtils.getSpanWithoutDefault(context);
-    if (span == null) {
+    if (span == null || !span.getContext().isValid()) {
       return;
     }
 

--- a/contrib/trace_propagators/src/main/java/io/opentelemetry/contrib/trace/propagation/JaegerPropagator.java
+++ b/contrib/trace_propagators/src/main/java/io/opentelemetry/contrib/trace/propagation/JaegerPropagator.java
@@ -89,7 +89,7 @@ public class JaegerPropagator implements HttpTextFormat {
     checkNotNull(setter, "setter");
 
     Span span = TracingContextUtils.getSpanWithoutDefault(context);
-    if (span == null) {
+    if (span == null || !span.getContext().isValid()) {
       return;
     }
 

--- a/contrib/trace_propagators/src/test/java/io/opentelemetry/contrib/trace/propagation/B3PropagatorTest.java
+++ b/contrib/trace_propagators/src/test/java/io/opentelemetry/contrib/trace/propagation/B3PropagatorTest.java
@@ -82,6 +82,22 @@ public class B3PropagatorTest {
   }
 
   @Test
+  public void inject_invalidContext() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    b3Propagator.inject(
+        withSpanContext(
+            SpanContext.create(
+                TraceId.getInvalid(),
+                SpanId.getInvalid(),
+                SAMPLED_TRACE_OPTIONS,
+                TraceState.builder().set("foo", "bar").build()),
+            Context.current()),
+        carrier,
+        setter);
+    assertThat(carrier).hasSize(0);
+  }
+
+  @Test
   public void inject_SampledContext() {
     Map<String, String> carrier = new LinkedHashMap<>();
     b3Propagator.inject(
@@ -244,6 +260,22 @@ public class B3PropagatorTest {
     invalidHeaders.put(B3Propagator.SAMPLED_HEADER, B3Propagator.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameInstanceAs(SpanContext.getInvalid());
+  }
+
+  @Test
+  public void inject_invalidContext_SingleHeader() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    b3PropagatorSingleHeader.inject(
+        withSpanContext(
+            SpanContext.create(
+                TraceId.getInvalid(),
+                SpanId.getInvalid(),
+                SAMPLED_TRACE_OPTIONS,
+                TraceState.builder().set("foo", "bar").build()),
+            Context.current()),
+        carrier,
+        setter);
+    assertThat(carrier).hasSize(0);
   }
 
   @Test

--- a/contrib/trace_propagators/src/test/java/io/opentelemetry/contrib/trace/propagation/JaegerPropagatorTest.java
+++ b/contrib/trace_propagators/src/test/java/io/opentelemetry/contrib/trace/propagation/JaegerPropagatorTest.java
@@ -92,6 +92,22 @@ public class JaegerPropagatorTest {
   }
 
   @Test
+  public void inject_invalidContext() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    jaegerPropagator.inject(
+        withSpanContext(
+            SpanContext.create(
+                TraceId.getInvalid(),
+                SpanId.getInvalid(),
+                SAMPLED_TRACE_OPTIONS,
+                TraceState.builder().set("foo", "bar").build()),
+            Context.current()),
+        carrier,
+        setter);
+    assertThat(carrier).hasSize(0);
+  }
+
+  @Test
   public void inject_SampledContext() {
     Map<String, String> carrier = new LinkedHashMap<>();
     jaegerPropagator.inject(


### PR DESCRIPTION
Fixes #1272 

I don't imagine we propagating invalid `SpanContext` instances with non-default TraceFlags/TraceState, hence the `isValid()` check, as opposed to compare against `SpanContext.getInvalid()` ;) 