### PR TITLE
Remove SpanID from sampling parameters

### DIFF
--- a/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureTraceExample.java
+++ b/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureTraceExample.java
@@ -115,7 +115,6 @@ class ConfigureTraceExample {
       public Decision shouldSample(
           SpanContext parentContext,
           TraceId traceId,
-          SpanId spanId,
           String name,
           Span.Kind spanKind,
           Map<String, AttributeValue> attributes,

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/Sampler.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/Sampler.java
@@ -20,7 +20,6 @@ import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.trace.Link;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
-import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceId;
 import java.util.List;
 import java.util.Map;
@@ -41,7 +40,6 @@ public interface Sampler {
    *     span.
    * @param traceId the {@link TraceId} for the new {@code Span}. This will be identical to that in
    *     the parentContext, unless this is a root span.
-   * @param spanId the {@link SpanId} for the new {@code Span}.
    * @param name the name of the new {@code Span}.
    * @param parentLinks the parentLinks associated with the new {@code Span}.
    * @param spanKind the {@link Span.Kind} of the {@code Span}.
@@ -52,7 +50,6 @@ public interface Sampler {
   Decision shouldSample(
       @Nullable SpanContext parentContext,
       TraceId traceId,
-      SpanId spanId,
       String name,
       Span.Kind spanKind,
       Map<String, AttributeValue> attributes,
@@ -70,7 +67,7 @@ public interface Sampler {
   String getDescription();
 
   /**
-   * Sampling decision returned by {@link Sampler#shouldSample(SpanContext, TraceId, SpanId, String,
+   * Sampling decision returned by {@link Sampler#shouldSample(SpanContext, TraceId, String,
    * Span.Kind, Map, List)}.
    *
    * @since 0.1.0

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -27,7 +27,6 @@ import io.opentelemetry.sdk.trace.Sampler.Decision;
 import io.opentelemetry.trace.Link;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
-import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.attributes.DoubleAttributeSetter;
 import java.util.Collections;
@@ -146,7 +145,6 @@ public final class Samplers {
     public Decision shouldSample(
         @Nullable SpanContext parentContext,
         TraceId traceId,
-        SpanId spanId,
         String name,
         Span.Kind spanKind,
         Map<String, AttributeValue> attributes,
@@ -169,7 +167,6 @@ public final class Samplers {
     public Decision shouldSample(
         @Nullable SpanContext parentContext,
         TraceId traceId,
-        SpanId spanId,
         String name,
         Span.Kind spanKind,
         Map<String, AttributeValue> attributes,
@@ -230,7 +227,6 @@ public final class Samplers {
     public final Decision shouldSample(
         @Nullable SpanContext parentContext,
         TraceId traceId,
-        SpanId spanId,
         String name,
         Span.Kind spanKind,
         Map<String, AttributeValue> attributes,

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -196,6 +196,7 @@ final class SpanBuilderSdk implements Span.Builder {
   public Span startSpan() {
     SpanContext parentContext = parent(parentType, parent, remoteParent);
     TraceId traceId;
+    SpanId spanId = idsGenerator.generateSpanId();
     TraceState traceState = TraceState.getDefault();
     if (parentContext == null || !parentContext.isValid()) {
       // New root span.
@@ -224,13 +225,12 @@ final class SpanBuilderSdk implements Span.Builder {
             .shouldSample(
                 parentContext, traceId, spanName, spanKind, immutableAttributes, immutableLinks);
 
-    SpanId spanId = SpanId.getInvalid();
-    TraceFlags traceFlags = TRACE_OPTIONS_NOT_SAMPLED;
-    if (samplingDecision.isSampled()) {
-      spanId = idsGenerator.generateSpanId();
-      traceFlags = TRACE_OPTIONS_SAMPLED;
-    }
-    SpanContext spanContext = SpanContext.create(traceId, spanId, traceFlags, traceState);
+    SpanContext spanContext =
+        SpanContext.create(
+            traceId,
+            spanId,
+            samplingDecision.isSampled() ? TRACE_OPTIONS_SAMPLED : TRACE_OPTIONS_NOT_SAMPLED,
+            traceState);
 
     if (!samplingDecision.isSampled()) {
       return DefaultSpan.create(spanContext);

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -223,13 +223,7 @@ final class SpanBuilderSdk implements Span.Builder {
         traceConfig
             .getSampler()
             .shouldSample(
-                parentContext,
-                traceId,
-                spanId,
-                spanName,
-                spanKind,
-                immutableAttributes,
-                immutableLinks);
+                parentContext, traceId, spanName, spanKind, immutableAttributes, immutableLinks);
 
     SpanContext spanContext =
         SpanContext.create(

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -47,7 +47,6 @@ public class SamplersTest {
   private static final int NUM_SAMPLE_TRIES = 1000;
   private final IdsGenerator idsGenerator = new RandomIdsGenerator();
   private final TraceId traceId = idsGenerator.generateTraceId();
-  private final SpanId spanId = idsGenerator.generateSpanId();
   private final SpanId parentSpanId = idsGenerator.generateSpanId();
   private final TraceState traceState = TraceState.builder().build();
   private final SpanContext sampledSpanContext =
@@ -102,7 +101,6 @@ public class SamplersTest {
                 .shouldSample(
                     sampledSpanContext,
                     traceId,
-                    spanId,
                     SPAN_NAME,
                     SPAN_KIND,
                     Collections.<String, AttributeValue>emptyMap(),
@@ -116,7 +114,6 @@ public class SamplersTest {
                 .shouldSample(
                     notSampledSpanContext,
                     traceId,
-                    spanId,
                     SPAN_NAME,
                     SPAN_KIND,
                     Collections.<String, AttributeValue>emptyMap(),
@@ -130,7 +127,6 @@ public class SamplersTest {
                 .shouldSample(
                     null,
                     traceId,
-                    spanId,
                     SPAN_NAME,
                     SPAN_KIND,
                     Collections.<String, AttributeValue>emptyMap(),
@@ -152,7 +148,6 @@ public class SamplersTest {
                 .shouldSample(
                     sampledSpanContext,
                     traceId,
-                    spanId,
                     SPAN_NAME,
                     SPAN_KIND,
                     Collections.<String, AttributeValue>emptyMap(),
@@ -166,7 +161,6 @@ public class SamplersTest {
                 .shouldSample(
                     notSampledSpanContext,
                     traceId,
-                    spanId,
                     SPAN_NAME,
                     SPAN_KIND,
                     Collections.<String, AttributeValue>emptyMap(),
@@ -180,7 +174,6 @@ public class SamplersTest {
                 .shouldSample(
                     null,
                     traceId,
-                    spanId,
                     SPAN_NAME,
                     SPAN_KIND,
                     Collections.<String, AttributeValue>emptyMap(),
@@ -224,7 +217,7 @@ public class SamplersTest {
         .isEqualTo(String.format("ProbabilitySampler{%.6f}", 0.5));
   }
 
-  // Applies the given sampler to NUM_SAMPLE_TRIES random traceId/spanId pairs.
+  // Applies the given sampler to NUM_SAMPLE_TRIES random traceId.
   private void assertSamplerSamplesWithProbability(
       Sampler sampler,
       SpanContext parent,
@@ -236,7 +229,6 @@ public class SamplersTest {
           .shouldSample(
               parent,
               idsGenerator.generateTraceId(),
-              idsGenerator.generateSpanId(),
               SPAN_NAME,
               SPAN_KIND,
               Collections.<String, AttributeValue>emptyMap(),
@@ -344,7 +336,6 @@ public class SamplersTest {
         defaultProbability.shouldSample(
             null,
             notSampledtraceId,
-            idsGenerator.generateSpanId(),
             SPAN_NAME,
             SPAN_KIND,
             Collections.<String, AttributeValue>emptyMap(),
@@ -379,7 +370,6 @@ public class SamplersTest {
         defaultProbability.shouldSample(
             null,
             sampledtraceId,
-            idsGenerator.generateSpanId(),
             SPAN_NAME,
             SPAN_KIND,
             Collections.<String, AttributeValue>emptyMap(),

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -518,7 +518,6 @@ public class SpanBuilderSdkTest {
                       public Decision shouldSample(
                           @Nullable SpanContext parentContext,
                           TraceId traceId,
-                          SpanId spanId,
                           String name,
                           Span.Kind spanKind,
                           Map<String, AttributeValue> attributes,

--- a/sdk_contrib/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/JaegerRemoteSampler.java
+++ b/sdk_contrib/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/JaegerRemoteSampler.java
@@ -30,7 +30,6 @@ import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.trace.Link;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanContext;
-import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceId;
 import java.util.List;
 import java.util.Map;
@@ -84,13 +83,11 @@ public class JaegerRemoteSampler implements Sampler {
   public Decision shouldSample(
       @Nullable SpanContext parentContext,
       TraceId traceId,
-      SpanId spanId,
       String name,
       Kind spanKind,
       Map<String, AttributeValue> attributes,
       List<Link> parentLinks) {
-    return sampler.shouldSample(
-        parentContext, traceId, spanId, name, spanKind, attributes, parentLinks);
+    return sampler.shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
   }
 
   private void getAndUpdateSampler() {

--- a/sdk_contrib/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/PerOperationSampler.java
+++ b/sdk_contrib/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/PerOperationSampler.java
@@ -23,7 +23,6 @@ import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.trace.Link;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanContext;
-import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceId;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -51,7 +50,6 @@ class PerOperationSampler implements Sampler {
   public Decision shouldSample(
       @Nullable SpanContext parentContext,
       TraceId traceId,
-      SpanId spanId,
       String name,
       Kind spanKind,
       Map<String, AttributeValue> attributes,
@@ -60,8 +58,7 @@ class PerOperationSampler implements Sampler {
     if (sampler == null) {
       sampler = this.defaultSampler;
     }
-    return sampler.shouldSample(
-        parentContext, traceId, spanId, name, spanKind, attributes, parentLinks);
+    return sampler.shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
   }
 
   @Override

--- a/sdk_contrib/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/RateLimitingSampler.java
+++ b/sdk_contrib/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/RateLimitingSampler.java
@@ -24,7 +24,6 @@ import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.trace.Link;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanContext;
-import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceId;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -62,7 +61,6 @@ class RateLimitingSampler implements Sampler {
   public Decision shouldSample(
       @Nullable SpanContext parentContext,
       TraceId traceId,
-      SpanId spanId,
       String name,
       Kind spanKind,
       Map<String, AttributeValue> attributes,
@@ -70,14 +68,13 @@ class RateLimitingSampler implements Sampler {
     boolean sampled = this.rateLimiter.checkCredit(1.0);
     if (parentContext != null && parentContext.getTraceFlags().isSampled()) {
       return Samplers.alwaysOn()
-          .shouldSample(parentContext, traceId, spanId, name, spanKind, attributes, parentLinks);
+          .shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
     }
     if (parentLinks != null) {
       for (Link parentLink : parentLinks) {
         if (parentLink.getContext().getTraceFlags().isSampled()) {
           return Samplers.alwaysOn()
-              .shouldSample(
-                  parentContext, traceId, spanId, name, spanKind, attributes, parentLinks);
+              .shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
         }
       }
     }

--- a/sdk_contrib/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/RateLimitingSamplerTest.java
+++ b/sdk_contrib/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/RateLimitingSamplerTest.java
@@ -39,7 +39,6 @@ public class RateLimitingSamplerTest {
   private static final String SPAN_NAME = "MySpanName";
   private static final Span.Kind SPAN_KIND = Span.Kind.INTERNAL;
   private final TraceId traceId = new TraceId(150, 150);
-  private final SpanId spanId = new SpanId(150);
   private final SpanId parentSpanId = new SpanId(250);
   private final TraceState traceState = TraceState.builder().build();
   private final SpanContext sampledSpanContext =
@@ -57,7 +56,6 @@ public class RateLimitingSamplerTest {
             .shouldSample(
                 sampledSpanContext,
                 traceId,
-                spanId,
                 SPAN_NAME,
                 SPAN_KIND,
                 Collections.<String, AttributeValue>emptyMap(),
@@ -68,7 +66,6 @@ public class RateLimitingSamplerTest {
             .shouldSample(
                 sampledSpanContext,
                 traceId,
-                spanId,
                 SPAN_NAME,
                 SPAN_KIND,
                 Collections.<String, AttributeValue>emptyMap(),
@@ -83,7 +80,6 @@ public class RateLimitingSamplerTest {
         sampler.shouldSample(
             notSampledSpanContext,
             traceId,
-            spanId,
             SPAN_NAME,
             SPAN_KIND,
             Collections.<String, AttributeValue>emptyMap(),
@@ -94,7 +90,6 @@ public class RateLimitingSamplerTest {
             .shouldSample(
                 notSampledSpanContext,
                 traceId,
-                spanId,
                 SPAN_NAME,
                 SPAN_KIND,
                 Collections.<String, AttributeValue>emptyMap(),


### PR DESCRIPTION
Update code per latest spec, see:
https://github.com/open-telemetry/opentelemetry-specification/pull/621

The goal is to avoid any SDK implementation from taking a dependency on it.