### PR TITLE
Update config / deps to allow building on Java 14.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,11 +38,17 @@ configure(opentelemetryProjects) {
     targetCompatibility = 1.7
 
     tasks.withType(JavaCompile) {
-        // We suppress the "try" warning because it disallows managing an auto-closeable with
-        // try-with-resources without referencing the auto-closeable within the try block.
-        // We suppress the "processing" warning as suggested in
-        // https://groups.google.com/forum/#!topic/bazel-discuss/_R3A9TJSoPM
-        it.options.compilerArgs += ["-Xlint:all", "-Xlint:-try", "-Xlint:-processing"]
+        it.options.compilerArgs += [
+                "-Xlint:all",
+                // We suppress the "try" warning because it disallows managing an auto-closeable with
+                // try-with-resources without referencing the auto-closeable within the try block.
+                "-Xlint:-try",
+                // We suppress the "processing" warning as suggested in
+                // https://groups.google.com/forum/#!topic/bazel-discuss/_R3A9TJSoPM
+                "-Xlint:-processing",
+                // We suppress the "options" warning because it prevents
+                "-Xlint:-options",
+        ]
         it.options.errorprone.disableWarningsInGeneratedCode = true
         it.options.errorprone.allDisabledChecksAsWarnings = true
 
@@ -66,17 +72,17 @@ configure(opentelemetryProjects) {
         it.options.errorprone.disable("AutoValueImmutableFields")
         // "-Xep:AutoValueImmutableFields:OFF"
 
+        // UnnecessaryAnonymousClass requires Java 8 but we target Java 7
+        it.options.errorprone.disable("UnnecessaryAnonymousClass")
+        // "-Xep:UnnecessaryAnonymousClass:OFF"
+
         it.options.encoding = "UTF-8"
 
         // Ignore warnings for protobuf and jmh generated files.
         it.options.errorprone.excludedPaths = ".*generated.*"
         // "-XepExcludedPaths:.*/build/generated/source/proto/.*"
 
-        // Enforce errorprone warnings to be errors.
-        if (!JavaVersion.current().isJava9() && !JavaVersion.current().isJava10() && !JavaVersion.current().isJava11()) {
-            // TODO: Enable -Werror for Java 9+
-            it.options.compilerArgs += ["-Werror"]
-        }
+        it.options.compilerArgs += ["-Werror"]
     }
 
     compileTestJava {
@@ -95,7 +101,7 @@ configure(opentelemetryProjects) {
 
     ext {
         autoValueVersion = '1.6.6'
-        errorProneVersion = '2.3.3'
+        errorProneVersion = '2.3.4'
         errorProneJavacVersion = '9+181-r4173-1'
         findBugsJsr305Version = '3.0.2'
         grpcVersion = '1.28.0'
@@ -144,7 +150,7 @@ configure(opentelemetryProjects) {
                 // Test dependencies.
                 guava_testlib           : "com.google.guava:guava-testlib",
                 junit                   : 'junit:junit:4.12',
-                mockito                 : 'org.mockito:mockito-core:2.28.2',
+                mockito                 : 'org.mockito:mockito-core:3.3.3',
                 truth                   : 'com.google.truth:truth:1.0.1',
                 system_rules            : 'com.github.stefanbirkner:system-rules:1.19.0', // env and system properties
                 slf4jsimple             : 'org.slf4j:slf4j-simple:1.7.25', // Compatibility layer
@@ -163,7 +169,7 @@ configure(opentelemetryProjects) {
         configProperties["rootDir"] = rootDir
     }
 
-    jacoco { toolVersion = "0.8.2" }
+    jacoco { toolVersion = "0.8.5" }
 
     googleJavaFormat {
         toolVersion = '1.7'
@@ -197,9 +203,11 @@ configure(opentelemetryProjects) {
         // The ErrorProne plugin defaults to the latest, which would break our
         // build if error prone releases a new version with a new check
         errorprone libraries.errorprone_core
-        errorproneJavac libraries.errorprone_javac
+        if (!JavaVersion.current().isJava9Compatible()) {
+            errorproneJavac libraries.errorprone_javac
+        }
 
-        if (JavaVersion.current().isJava9() || JavaVersion.current().isJava10() || JavaVersion.current().isJava11()) {
+        if (JavaVersion.current().isJava9Compatible()) {
             // Workaround for @javax.annotation.Generated
             // see: https://github.com/grpc/grpc-java/issues/3633
             compile("javax.annotation:javax.annotation-api:1.3.2")

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ configure(opentelemetryProjects) {
                 // We suppress the "processing" warning as suggested in
                 // https://groups.google.com/forum/#!topic/bazel-discuss/_R3A9TJSoPM
                 "-Xlint:-processing",
-                // We suppress the "options" warning because it prevents
+                // We suppress the "options" warning because it prevents compilation on modern JDKs
                 "-Xlint:-options",
         ]
         it.options.errorprone.disableWarningsInGeneratedCode = true

--- a/contrib/trace_utils/src/main/java/io/opentelemetry/contrib/trace/CurrentSpanUtils.java
+++ b/contrib/trace_utils/src/main/java/io/opentelemetry/contrib/trace/CurrentSpanUtils.java
@@ -75,7 +75,7 @@ public final class CurrentSpanUtils {
         } else if (t instanceof Error) {
           throw (Error) t;
         }
-        throw new RuntimeException("unexpected", t);
+        throw new IllegalStateException("unexpected", t);
       } finally {
         Context.current().detach(origContext);
         if (endSpan) {
@@ -109,7 +109,7 @@ public final class CurrentSpanUtils {
         if (t instanceof Error) {
           throw (Error) t;
         }
-        throw new RuntimeException("unexpected", t);
+        throw new IllegalStateException("unexpected", t);
       } finally {
         Context.current().detach(origContext);
         if (endSpan) {

--- a/contrib/trace_utils/src/test/java/io/opentelemetry/contrib/trace/CurrentSpanUtilsTest.java
+++ b/contrib/trace_utils/src/test/java/io/opentelemetry/contrib/trace/CurrentSpanUtilsTest.java
@@ -18,7 +18,7 @@ package io.opentelemetry.contrib.trace;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
@@ -78,7 +78,7 @@ public class CurrentSpanUtilsTest {
           }
         };
     CurrentSpanUtils.withSpan(span, false, runnable).run();
-    verifyZeroInteractions(span);
+    verifyNoInteractions(span);
     assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
   }
 
@@ -150,7 +150,7 @@ public class CurrentSpanUtilsTest {
           }
         };
     assertThat(CurrentSpanUtils.withSpan(span, false, callable).call()).isEqualTo(ret);
-    verifyZeroInteractions(span);
+    verifyNoInteractions(span);
     assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
   }
 

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporter.java
@@ -16,7 +16,6 @@
 
 package io.opentelemetry.exporters.zipkin;
 
-import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import io.opentelemetry.common.AttributeValue;
@@ -199,7 +198,7 @@ public final class ZipkinSpanExporter implements SpanExporter {
   }
 
   private static long toEpochMicros(long epochNanos) {
-    return MICROSECONDS.convert(epochNanos, NANOSECONDS);
+    return NANOSECONDS.toMicros(epochNanos);
   }
 
   private static String attributeValueToString(AttributeValue attributeValue) {

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/AttributesMap.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/AttributesMap.java
@@ -67,17 +67,17 @@ final class AttributesMap extends HashMap<String, AttributeValue> {
 
   @SuppressWarnings("MissingOverride")
   public AttributeValue putIfAbsent(String key, AttributeValue value) {
-    throw new RuntimeException("Do not call methods on the map");
+    throw new UnsupportedOperationException("Do not call methods on the map");
   }
 
   @SuppressWarnings("MissingOverride")
   public AttributeValue replace(String key, AttributeValue value) {
-    throw new RuntimeException("Do not call methods on the map");
+    throw new UnsupportedOperationException("Do not call methods on the map");
   }
 
   @SuppressWarnings("MissingOverride")
   public boolean replace(String key, AttributeValue oldValue, AttributeValue newValue) {
-    throw new RuntimeException("Do not call methods on the map");
+    throw new UnsupportedOperationException("Do not call methods on the map");
   }
 
   int getTotalAddedValues() {

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractBoundInstrumentTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractBoundInstrumentTest.java
@@ -95,7 +95,7 @@ public class AbstractBoundInstrumentTest {
   @Test
   public void recordDoubleValue() {
     TestBoundInstrument testBoundInstrument = new TestBoundInstrument(aggregator);
-    Mockito.verifyZeroInteractions(aggregator);
+    Mockito.verifyNoInteractions(aggregator);
     Mockito.doNothing().when(aggregator).recordDouble(Mockito.anyDouble());
     testBoundInstrument.recordDouble(1.2);
     Mockito.verify(aggregator, Mockito.times(1)).recordDouble(1.2);
@@ -104,7 +104,7 @@ public class AbstractBoundInstrumentTest {
   @Test
   public void recordLongValue() {
     TestBoundInstrument testBoundInstrument = new TestBoundInstrument(aggregator);
-    Mockito.verifyZeroInteractions(aggregator);
+    Mockito.verifyNoInteractions(aggregator);
     Mockito.doNothing().when(aggregator).recordLong(Mockito.anyLong());
     testBoundInstrument.recordLong(13);
     Mockito.verify(aggregator, Mockito.times(1)).recordLong(13);

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/MultiSpanProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/MultiSpanProcessorTest.java
@@ -21,7 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -89,10 +89,10 @@ public class MultiSpanProcessorTest {
     assertThat(multiSpanProcessor.isEndRequired()).isFalse();
 
     multiSpanProcessor.onStart(readableSpan);
-    verifyZeroInteractions(spanProcessor1);
+    verifyNoMoreInteractions(spanProcessor1);
 
     multiSpanProcessor.onEnd(readableSpan);
-    verifyZeroInteractions(spanProcessor1);
+    verifyNoMoreInteractions(spanProcessor1);
 
     multiSpanProcessor.forceFlush();
     verify(spanProcessor1).forceFlush();

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
@@ -19,7 +19,7 @@ package io.opentelemetry.sdk.trace.export;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.sdk.trace.ReadableSpan;
@@ -72,7 +72,7 @@ public class SimpleSpanProcessorTest {
   @Test
   public void onStartSync() {
     simpleSampledSpansProcessor.onStart(readableSpan);
-    verifyZeroInteractions(spanExporter);
+    verifyNoInteractions(spanExporter);
   }
 
   @Test
@@ -88,7 +88,7 @@ public class SimpleSpanProcessorTest {
   public void onEndSync_NotSampledSpan() {
     when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
     simpleSampledSpansProcessor.onEnd(readableSpan);
-    verifyZeroInteractions(spanExporter);
+    verifyNoInteractions(spanExporter);
   }
 
   @Test
@@ -99,7 +99,7 @@ public class SimpleSpanProcessorTest {
         .thenThrow(new RuntimeException());
     SimpleSpanProcessor simpleSpanProcessor = SimpleSpanProcessor.newBuilder(spanExporter).build();
     simpleSpanProcessor.onEnd(readableSpan);
-    verifyZeroInteractions(spanExporter);
+    verifyNoInteractions(spanExporter);
   }
 
   @Test
@@ -189,7 +189,7 @@ public class SimpleSpanProcessorTest {
 
     when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
     spanProcessor.onEnd(readableSpan);
-    verifyZeroInteractions(spanExporter);
+    verifyNoInteractions(spanExporter);
   }
 
   @Test
@@ -201,7 +201,7 @@ public class SimpleSpanProcessorTest {
 
     when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
     spanProcessor.onEnd(readableSpan);
-    verifyZeroInteractions(spanExporter);
+    verifyNoInteractions(spanExporter);
   }
 
   @Test

--- a/sdk_contrib/async_processor/src/main/java/io/opentelemetry/sdk/contrib/trace/export/DisruptorEventQueue.java
+++ b/sdk_contrib/async_processor/src/main/java/io/opentelemetry/sdk/contrib/trace/export/DisruptorEventQueue.java
@@ -63,8 +63,6 @@ final class DisruptorEventQueue {
         }
       };
 
-  // The event queue is built on this {@link Disruptor}.
-  private final Disruptor<DisruptorEvent> disruptor;
   private final RingBuffer<DisruptorEvent> ringBuffer;
   private final AtomicBoolean loggedShutdownMessage = new AtomicBoolean(false);
   private volatile boolean isShutdown = false;
@@ -89,7 +87,7 @@ final class DisruptorEventQueue {
     // Create new Disruptor for processing. Note that Disruptor creates a single thread per
     // consumer (see https://github.com/LMAX-Exchange/disruptor/issues/121 for details);
     // this ensures that the event handler can take unsynchronized actions whenever possible.
-    this.disruptor =
+    Disruptor<DisruptorEvent> disruptor =
         new Disruptor<>(
             EVENT_FACTORY,
             bufferSize,

--- a/sdk_contrib/aws_v1_support/src/test/java/io/opentelemetry/sdk/contrib/trace/aws/AwsXRayIdsGeneratorTest.java
+++ b/sdk_contrib/aws_v1_support/src/test/java/io/opentelemetry/sdk/contrib/trace/aws/AwsXRayIdsGeneratorTest.java
@@ -51,7 +51,7 @@ public class AwsXRayIdsGeneratorTest {
     AwsXRayIdsGenerator generator = new AwsXRayIdsGenerator();
     for (int i = 0; i < 1000; i++) {
       TraceId traceId = generator.generateTraceId();
-      Long unixSeconds = Long.valueOf(traceId.toLowerBase16().substring(0, 8), 16);
+      long unixSeconds = Long.valueOf(traceId.toLowerBase16().substring(0, 8), 16);
       long ts = unixSeconds * 1000L;
       long currentTs = System.currentTimeMillis();
       assertThat(ts).isAtMost(currentTs);

--- a/sdk_contrib/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/JaegerRemoteSampler.java
+++ b/sdk_contrib/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/contrib/trace/jaeger/sampler/JaegerRemoteSampler.java
@@ -53,7 +53,6 @@ public class JaegerRemoteSampler implements Sampler {
   private final String serviceName;
   private final SamplingManagerBlockingStub stub;
   private Sampler sampler;
-  private final ScheduledExecutorService scheduledExecutorService;
 
   @SuppressWarnings("FutureReturnValueIgnored")
   private JaegerRemoteSampler(
@@ -61,9 +60,9 @@ public class JaegerRemoteSampler implements Sampler {
     this.serviceName = serviceName;
     this.stub = SamplingManagerGrpc.newBlockingStub(channel);
     this.sampler = initialSampler;
-    this.scheduledExecutorService =
+    ScheduledExecutorService scheduledExecutorService =
         Executors.newScheduledThreadPool(1, new DaemonThreadFactory(WORKER_THREAD_NAME));
-    this.scheduledExecutorService.scheduleAtFixedRate(
+    scheduledExecutorService.scheduleAtFixedRate(
         updateSampleRunnable(), 0, pollingIntervalMs, TimeUnit.MILLISECONDS);
   }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
         id "com.jfrog.artifactory" version "4.13.0"
         id "io.morethan.jmhreport" version "0.9.0"
         id "me.champeau.gradle.jmh" version "0.5.0"
-        id "net.ltgt.errorprone" version "0.8.1"
+        id "net.ltgt.errorprone" version "1.2.0"
         id "ru.vyarus.animalsniffer" version "1.5.0"
     }
 


### PR DESCRIPTION
I normally use Java 14 and found my build failing due to deprecated source=7 option. I figured suppressing this option would be enough to get the build to work and ended up in a rabbit hole :)

- Suppress options warnings because we are a library, not executable, so warnings about compiler arguments aren't so useful
- Instead of updating check to disable Werror on Java 9+, enabled Werror on all Java. 
- Update error prone to fix buggy check that triggered false positive on Utils.checkNotNull
- Only set error prone javac for pre Java 9 (though I don't think anyone uses such a JDK to build this project)
- Improve javax.annotation-api branch to apply to Java 9+ forever
- Update jacoco and mockito to support Java 14
- Fix error prone warnings
- Fix mockito deprecations