### PR TITLE
Apply platforms to resolved classpaths instead of dependency containe…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,8 +185,14 @@ configure(opentelemetryProjects) {
     }
 
     dependencies {
-
-        implementation platform(boms.grpc)
+        configurations.all {
+            if (it.name.endsWith('Classpath')) {
+                add(it.name, enforcedPlatform(boms.grpc))
+                add(it.name, enforcedPlatform(boms.guava))
+                add(it.name, enforcedPlatform(boms.protobuf))
+                add(it.name, enforcedPlatform(boms.zipkin_reporter))
+            }
+        }
 
         compileOnly libraries.auto_value_annotation,
                 libraries.errorprone_annotation,
@@ -195,8 +201,7 @@ configure(opentelemetryProjects) {
         testImplementation libraries.junit,
                 libraries.mockito,
                 libraries.truth,
-                libraries.guava_testlib,
-                platform(boms.guava)
+                libraries.guava_testlib
 
         // The ErrorProne plugin defaults to the latest, which would break our
         // build if error prone releases a new version with a new check
@@ -322,8 +327,8 @@ configure(opentelemetryProjects) {
                     artifact javadocJar
 
                     versionMapping {
-                        usage('java-api') {
-                            fromResolutionOf('runtimeClasspath')
+                        allVariants {
+                            fromResolutionResult()
                         }
                     }
 

--- a/exporters/jaeger/build.gradle
+++ b/exporters/jaeger/build.gradle
@@ -14,7 +14,6 @@ dependencies {
 
     implementation project(':opentelemetry-sdk-contrib-otproto'),
             project(':opentelemetry-sdk'),
-            platform(boms.protobuf),
             libraries.grpc_api,
             libraries.grpc_protobuf,
             libraries.grpc_stub,

--- a/exporters/otlp/build.gradle
+++ b/exporters/otlp/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     api project(':opentelemetry-sdk')
 
     implementation project(':opentelemetry-sdk-contrib-otproto'),
-            platform(boms.protobuf),
             libraries.grpc_api,
             libraries.grpc_protobuf,
             libraries.grpc_stub,

--- a/exporters/prometheus/build.gradle
+++ b/exporters/prometheus/build.gradle
@@ -11,8 +11,7 @@ ext.moduleName = "io.opentelemetry.exporters.prometheus"
 dependencies {
     api project(':opentelemetry-sdk')
 
-    implementation libraries.guava,
-            libraries.prometheus_client
+    implementation libraries.prometheus_client
 
     testImplementation libraries.prometheus_client_common
 

--- a/exporters/prometheus/build.gradle
+++ b/exporters/prometheus/build.gradle
@@ -11,7 +11,8 @@ ext.moduleName = "io.opentelemetry.exporters.prometheus"
 dependencies {
     api project(':opentelemetry-sdk')
 
-    implementation libraries.prometheus_client
+    implementation libraries.guava,
+            libraries.prometheus_client
 
     testImplementation libraries.prometheus_client_common
 

--- a/exporters/zipkin/build.gradle
+++ b/exporters/zipkin/build.gradle
@@ -16,8 +16,7 @@ dependencies {
     annotationProcessor libraries.auto_value
 
     implementation libraries.zipkin_reporter,
-            libraries.zipkin_urlconnection,
-            platform(boms.zipkin_reporter)
+            libraries.zipkin_urlconnection
 
     testImplementation libraries.guava,
             libraries.zipkin_junit

--- a/proto/build.gradle
+++ b/proto/build.gradle
@@ -13,8 +13,7 @@ dependencies {
     api libraries.protobuf,
             libraries.grpc_api,
             libraries.grpc_protobuf,
-            libraries.grpc_stub,
-            platform(boms.protobuf)
+            libraries.grpc_stub
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -12,8 +12,7 @@ ext.moduleName = "io.opentelemetry.sdk"
 dependencies {
     api project(':opentelemetry-api')
 
-    implementation libraries.guava,
-            platform(boms.guava)
+    implementation libraries.guava
 
     annotationProcessor libraries.auto_value
 

--- a/sdk_contrib/async_processor/build.gradle
+++ b/sdk_contrib/async_processor/build.gradle
@@ -13,8 +13,7 @@ dependencies {
             project(':opentelemetry-sdk')
 
     implementation libraries.guava,
-            libraries.disruptor,
-            platform(boms.guava)
+            libraries.disruptor
 
     signature "org.codehaus.mojo.signature:java18:1.0@signature"
 }

--- a/sdk_contrib/jaeger_remote_sampler/build.gradle
+++ b/sdk_contrib/jaeger_remote_sampler/build.gradle
@@ -14,7 +14,6 @@ dependencies {
 
     implementation project(':opentelemetry-sdk-contrib-otproto'),
             project(':opentelemetry-sdk'),
-            platform(boms.protobuf),
             libraries.grpc_api,
             libraries.grpc_protobuf,
             libraries.grpc_stub,

--- a/sdk_contrib/otproto/build.gradle
+++ b/sdk_contrib/otproto/build.gradle
@@ -14,8 +14,7 @@ dependencies {
             project(':opentelemetry-sdk')
 
     implementation libraries.protobuf,
-            libraries.protobuf_util,
-            platform(boms.protobuf)
+            libraries.protobuf_util
 
     testImplementation "io.grpc:grpc-testing:${grpcVersion}"
     testRuntime "io.grpc:grpc-netty-shaded:${grpcVersion}"

--- a/sdk_contrib/testbed/build.gradle
+++ b/sdk_contrib/testbed/build.gradle
@@ -12,8 +12,7 @@ dependencies {
             project(':opentelemetry-sdk'),
             project(':opentelemetry-exporters-inmemory'),
             libraries.awaitility,
-            libraries.guava,
-            platform(boms.guava)
+            libraries.guava
 
     signature "org.codehaus.mojo.signature:java18:1.0@signature"
 }


### PR DESCRIPTION
…rs and have maven publication use resolution result for all variants.

This is an alternative to #1281. I think it's better since BOMs aren't in the published POMs at all - the platforms are used to manage versions for this project but aren't meant for users. It removes worries related to gRPC version, etc too for free.

API POM - no BOMs
```
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>io.opentelemetry</groupId>
  <artifactId>opentelemetry-api</artifactId>
  <version>0.5.0-SNAPSHOT</version>
  <name>OpenTelemetry Java</name>
  <description>OpenTelemetry API</description>
  <url>https://github.com/open-telemetry/opentelemetry-java</url>
  <licenses>
    <license>
      <name>The Apache License, Version 2.0</name>
      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
    </license>
  </licenses>
  <developers>
    <developer>
      <id>opentelemetry</id>
      <name>OpenTelemetry Gitter</name>
      <url>https://gitter.im/open-telemetry/community</url>
    </developer>
  </developers>
  <scm>
    <connection>scm:git:git@github.com:open-telemetry/opentelemetry-java.git</connection>
    <developerConnection>scm:git:git@github.com:open-telemetry/opentelemetry-java.git</developerConnection>
    <url>git@github.com:open-telemetry/opentelemetry-java.git</url>
  </scm>
  <dependencies>
    <dependency>
      <groupId>javax.annotation</groupId>
      <artifactId>javax.annotation-api</artifactId>
      <version>1.3.2</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>io.opentelemetry</groupId>
      <artifactId>opentelemetry-context-prop</artifactId>
      <version>0.5.0-SNAPSHOT</version>
      <scope>compile</scope>
    </dependency>
  </dependencies>
</project>
```

SDK POM - Guava version filled in
```
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>io.opentelemetry</groupId>
  <artifactId>opentelemetry-sdk</artifactId>
  <version>0.5.0-SNAPSHOT</version>
  <name>OpenTelemetry Java</name>
  <description>OpenTelemetry SDK</description>
  <url>https://github.com/open-telemetry/opentelemetry-java</url>
  <licenses>
    <license>
      <name>The Apache License, Version 2.0</name>
      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
    </license>
  </licenses>
  <developers>
    <developer>
      <id>opentelemetry</id>
      <name>OpenTelemetry Gitter</name>
      <url>https://gitter.im/open-telemetry/community</url>
    </developer>
  </developers>
  <scm>
    <connection>scm:git:git@github.com:open-telemetry/opentelemetry-java.git</connection>
    <developerConnection>scm:git:git@github.com:open-telemetry/opentelemetry-java.git</developerConnection>
    <url>git@github.com:open-telemetry/opentelemetry-java.git</url>
  </scm>
  <dependencies>
    <dependency>
      <groupId>javax.annotation</groupId>
      <artifactId>javax.annotation-api</artifactId>
      <version>1.3.2</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>io.opentelemetry</groupId>
      <artifactId>opentelemetry-api</artifactId>
      <version>0.5.0-SNAPSHOT</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.google.guava</groupId>
      <artifactId>guava</artifactId>
      <version>28.2-android</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
</project>
```