### PR TITLE
Renamed SpanDataImpl to TestSpanData and moved to subdir test (#1291)

### DIFF
--- a/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
+++ b/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
@@ -20,7 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.sdk.trace.data.SpanDataImpl;
+import io.opentelemetry.sdk.trace.data.test.TestSpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode;
 import io.opentelemetry.trace.Tracer;
@@ -101,7 +101,7 @@ public class InMemorySpanExporterTest {
   }
 
   static SpanData makeBasicSpan() {
-    return SpanDataImpl.newBuilder()
+    return TestSpanData.newBuilder()
         .setHasEnded(true)
         .setTraceId(io.opentelemetry.trace.TraceId.getInvalid())
         .setSpanId(io.opentelemetry.trace.SpanId.getInvalid())

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
@@ -31,7 +31,7 @@ import io.opentelemetry.sdk.trace.data.EventImpl;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
-import io.opentelemetry.sdk.trace.data.SpanDataImpl;
+import io.opentelemetry.sdk.trace.data.test.TestSpanData;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
@@ -242,7 +242,7 @@ public class AdapterTest {
     long startMs = System.currentTimeMillis();
     long endMs = startMs + 900;
     SpanData span =
-        SpanDataImpl.newBuilder()
+        TestSpanData.newBuilder()
             .setHasEnded(true)
             .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
             .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
@@ -269,7 +269,7 @@ public class AdapterTest {
     long startMs = System.currentTimeMillis();
     long endMs = startMs + 900;
     SpanData span =
-        SpanDataImpl.newBuilder()
+        TestSpanData.newBuilder()
             .setHasEnded(true)
             .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
             .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
@@ -305,7 +305,7 @@ public class AdapterTest {
 
     Link link = Link.create(createSpanContext(LINK_TRACE_ID, LINK_SPAN_ID), attributes);
 
-    return SpanDataImpl.newBuilder()
+    return TestSpanData.newBuilder()
         .setHasEnded(true)
         .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
         .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporterTest.java
@@ -34,7 +34,7 @@ import io.opentelemetry.exporters.jaeger.proto.api_v2.Model;
 import io.opentelemetry.sdk.contrib.otproto.TraceProtoUtils;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
-import io.opentelemetry.sdk.trace.data.SpanDataImpl;
+import io.opentelemetry.sdk.trace.data.test.TestSpanData;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
@@ -82,7 +82,7 @@ public class JaegerGrpcSpanExporterTest {
     long startMs = System.currentTimeMillis();
     long endMs = startMs + duration;
     SpanData span =
-        SpanDataImpl.newBuilder()
+        TestSpanData.newBuilder()
             .setHasEnded(true)
             .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
             .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))

--- a/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingSpanExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingSpanExporterTest.java
@@ -25,7 +25,7 @@ import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.sdk.trace.data.EventImpl;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
-import io.opentelemetry.sdk.trace.data.SpanDataImpl;
+import io.opentelemetry.sdk.trace.data.test.TestSpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanId;
@@ -60,7 +60,7 @@ public class LoggingSpanExporterTest {
   public void returnCode() {
     long epochNanos = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
     SpanData spanData =
-        SpanDataImpl.newBuilder()
+        TestSpanData.newBuilder()
             .setHasEnded(true)
             .setTraceId(new TraceId(1234L, 6789L))
             .setSpanId(new SpanId(9876L))

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
@@ -29,7 +29,7 @@ import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
-import io.opentelemetry.sdk.trace.data.SpanDataImpl;
+import io.opentelemetry.sdk.trace.data.test.TestSpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanId;
@@ -206,7 +206,7 @@ public class OtlpGrpcSpanExporterTest {
     long duration = TimeUnit.MILLISECONDS.toNanos(900);
     long startNs = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
     long endNs = startNs + duration;
-    return SpanDataImpl.newBuilder()
+    return TestSpanData.newBuilder()
         .setHasEnded(true)
         .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
         .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
@@ -29,7 +29,7 @@ import io.opentelemetry.proto.trace.v1.Status.StatusCode;
 import io.opentelemetry.sdk.trace.data.EventImpl;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
-import io.opentelemetry.sdk.trace.data.SpanDataImpl;
+import io.opentelemetry.sdk.trace.data.test.TestSpanData;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
@@ -58,7 +58,7 @@ public class SpanAdapterTest {
   public void toProtoSpan() {
     Span span =
         SpanAdapter.toProtoSpan(
-            SpanDataImpl.newBuilder()
+            TestSpanData.newBuilder()
                 .setHasEnded(true)
                 .setTraceId(TRACE_ID)
                 .setSpanId(SPAN_ID)

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
@@ -24,7 +24,7 @@ import io.opentelemetry.sdk.trace.data.EventImpl;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
-import io.opentelemetry.sdk.trace.data.SpanDataImpl;
+import io.opentelemetry.sdk.trace.data.test.TestSpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanId;
@@ -156,8 +156,8 @@ public class ZipkinSpanExporterEndToEndHttpTest {
     assertThat(zipkinSpans.get(0)).isEqualTo(buildZipkinSpan());
   }
 
-  private static SpanDataImpl.Builder buildStandardSpan() {
-    return SpanDataImpl.newBuilder()
+  private static TestSpanData.Builder buildStandardSpan() {
+    return TestSpanData.newBuilder()
         .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
         .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
         .setParentSpanId(SpanId.fromLowerBase16(PARENT_SPAN_ID, 0))

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterTest.java
@@ -31,7 +31,7 @@ import io.opentelemetry.sdk.trace.data.EventImpl;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
-import io.opentelemetry.sdk.trace.data.SpanDataImpl;
+import io.opentelemetry.sdk.trace.data.test.TestSpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanId;
@@ -269,8 +269,8 @@ public class ZipkinSpanExporterTest {
     verify(mockSender).close();
   }
 
-  private static SpanDataImpl.Builder buildStandardSpan() {
-    return SpanDataImpl.newBuilder()
+  private static TestSpanData.Builder buildStandardSpan() {
+    return TestSpanData.newBuilder()
         .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
         .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
         .setParentSpanId(SpanId.fromLowerBase16(PARENT_SPAN_ID, 0))

--- a/sdk/src/jmh/java/io/opentelemetry/sdk/trace/export/MultiSpanExporterBenchmark.java
+++ b/sdk/src/jmh/java/io/opentelemetry/sdk/trace/export/MultiSpanExporterBenchmark.java
@@ -17,7 +17,7 @@
 package io.opentelemetry.sdk.trace.export;
 
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.sdk.trace.data.SpanDataImpl;
+import io.opentelemetry.sdk.trace.data.test.TestSpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanId;
@@ -73,10 +73,10 @@ public class MultiSpanExporterBenchmark {
     Arrays.fill(exporter, new NoopSpanExporter());
     this.exporter = MultiSpanExporter.create(Arrays.asList(exporter));
 
-    SpanDataImpl[] spans = new SpanDataImpl[spanCount];
+    TestSpanData[] spans = new TestSpanData[spanCount];
     for (int i = 0; i < spans.length; i++) {
       spans[i] =
-          SpanDataImpl.newBuilder()
+          TestSpanData.newBuilder()
               .setTraceId(new TraceId(1, 1))
               .setSpanId(new SpanId(1))
               .setName("noop")

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/data/test/TestSpanData.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/data/test/TestSpanData.java
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.sdk.trace.data;
+package io.opentelemetry.sdk.trace.data.test;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
@@ -40,7 +41,7 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 @AutoValue
-public abstract class SpanDataImpl implements SpanData {
+public abstract class TestSpanData implements SpanData {
 
   /**
    * Creates a new Builder for creating an SpanData instance.
@@ -49,7 +50,7 @@ public abstract class SpanDataImpl implements SpanData {
    * @since 0.1.0
    */
   public static Builder newBuilder() {
-    return new AutoValue_SpanDataImpl.Builder()
+    return new AutoValue_TestSpanData.Builder()
         .setParentSpanId(SpanId.getInvalid())
         .setInstrumentationLibraryInfo(InstrumentationLibraryInfo.getEmpty())
         .setLinks(Collections.<Link>emptyList())
@@ -65,14 +66,14 @@ public abstract class SpanDataImpl implements SpanData {
   }
 
   /**
-   * A {@code Builder} class for {@link SpanDataImpl}.
+   * A {@code Builder} class for {@link TestSpanData}.
    *
    * @since 0.1.0
    */
   @AutoValue.Builder
   public abstract static class Builder {
 
-    abstract SpanDataImpl autoBuild();
+    abstract TestSpanData autoBuild();
 
     abstract Map<String, AttributeValue> getAttributes();
 
@@ -86,7 +87,7 @@ public abstract class SpanDataImpl implements SpanData {
      * @return a new SpanData instance
      * @since 0.1.0
      */
-    public SpanDataImpl build() {
+    public TestSpanData build() {
       // make unmodifiable copies of any collections
       setAttributes(Collections.unmodifiableMap(new HashMap<>(getAttributes())));
       setEvents(Collections.unmodifiableList(new ArrayList<>(getEvents())));

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
@@ -19,7 +19,7 @@ package io.opentelemetry.sdk.trace;
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.sdk.trace.data.SpanDataImpl;
+import io.opentelemetry.sdk.trace.data.test.TestSpanData;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanId;
@@ -56,7 +56,7 @@ public final class TestUtils {
    * @return A SpanData instance.
    */
   public static SpanData makeBasicSpan() {
-    return SpanDataImpl.newBuilder()
+    return TestSpanData.newBuilder()
         .setHasEnded(true)
         .setTraceId(TraceId.getInvalid())
         .setSpanId(SpanId.getInvalid())

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/data/SpanDataImplTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/data/SpanDataImplTest.java
@@ -22,6 +22,7 @@ import static java.util.Collections.emptyList;
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
+import io.opentelemetry.sdk.trace.data.test.TestSpanData;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
@@ -135,8 +136,8 @@ public class SpanDataImplTest {
     return Link.create(SpanContext.getInvalid());
   }
 
-  private static SpanDataImpl.Builder createBasicSpanBuilder() {
-    return SpanDataImpl.newBuilder()
+  private static TestSpanData.Builder createBasicSpanBuilder() {
+    return TestSpanData.newBuilder()
         .setHasEnded(true)
         .setSpanId(SpanId.getInvalid())
         .setTraceId(TraceId.getInvalid())


### PR DESCRIPTION
Addressing issue #1291. SpanDataImpl is only used by tests now so has been renamed to TestSpanData.