### PR TITLE
Avoid mockito magic for span processors test, test with empty configmap

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -321,11 +321,11 @@ public final class BatchSpanProcessor implements SpanProcessor {
     private static final String KEY_EXPORT_TIMEOUT_MILLIS = "otel.bsp.export.timeout";
     private static final String KEY_SAMPLED = "otel.bsp.export.sampled";
 
-    private static final long DEFAULT_SCHEDULE_DELAY_MILLIS = 5000;
-    private static final int DEFAULT_MAX_QUEUE_SIZE = 2048;
-    private static final int DEFAULT_MAX_EXPORT_BATCH_SIZE = 512;
-    private static final int DEFAULT_EXPORT_TIMEOUT_MILLIS = 30_000;
-    private static final boolean DEFAULT_EXPORT_ONLY_SAMPLED = true;
+    @VisibleForTesting static final long DEFAULT_SCHEDULE_DELAY_MILLIS = 5000;
+    @VisibleForTesting static final int DEFAULT_MAX_QUEUE_SIZE = 2048;
+    @VisibleForTesting static final int DEFAULT_MAX_EXPORT_BATCH_SIZE = 512;
+    @VisibleForTesting static final int DEFAULT_EXPORT_TIMEOUT_MILLIS = 30_000;
+    @VisibleForTesting static final boolean DEFAULT_EXPORT_ONLY_SAMPLED = true;
 
     private final SpanExporter spanExporter;
     private long scheduleDelayMillis = DEFAULT_SCHEDULE_DELAY_MILLIS;
@@ -344,7 +344,6 @@ public final class BatchSpanProcessor implements SpanProcessor {
      * @param configMap {@link Map} holding the configuration values.
      * @return this.
      */
-    @VisibleForTesting
     @Override
     protected Builder fromConfigMap(
         Map<String, String> configMap, Builder.NamingConvention namingConvention) {
@@ -379,13 +378,18 @@ public final class BatchSpanProcessor implements SpanProcessor {
      *
      * <p>Default value is {@code true}.
      *
-     * @param sampled report only sampled spans.
+     * @param exportOnlySampled if {@code true} report only sampled spans.
      * @return this.
      * @see BatchSpanProcessor.Builder#DEFAULT_EXPORT_ONLY_SAMPLED
      */
-    public Builder setExportOnlySampled(boolean sampled) {
-      this.exportOnlySampled = sampled;
+    public Builder setExportOnlySampled(boolean exportOnlySampled) {
+      this.exportOnlySampled = exportOnlySampled;
       return this;
+    }
+
+    @VisibleForTesting
+    boolean getExportOnlySampled() {
+      return exportOnlySampled;
     }
 
     /**
@@ -403,6 +407,11 @@ public final class BatchSpanProcessor implements SpanProcessor {
       return this;
     }
 
+    @VisibleForTesting
+    long getScheduleDelayMillis() {
+      return scheduleDelayMillis;
+    }
+
     /**
      * Sets the maximum time an exporter will be allowed to run before being cancelled.
      *
@@ -415,6 +424,11 @@ public final class BatchSpanProcessor implements SpanProcessor {
     public Builder setExporterTimeoutMillis(int exporterTimeoutMillis) {
       this.exporterTimeoutMillis = exporterTimeoutMillis;
       return this;
+    }
+
+    @VisibleForTesting
+    int getExporterTimeoutMillis() {
+      return exporterTimeoutMillis;
     }
 
     /**
@@ -435,6 +449,11 @@ public final class BatchSpanProcessor implements SpanProcessor {
       return this;
     }
 
+    @VisibleForTesting
+    int getMaxQueueSize() {
+      return maxQueueSize;
+    }
+
     /**
      * Sets the maximum batch size for every export. This must be smaller or equal to {@code
      * maxQueuedSpans}.
@@ -449,6 +468,11 @@ public final class BatchSpanProcessor implements SpanProcessor {
       Utils.checkArgument(maxExportBatchSize > 0, "maxExportBatchSize must be positive.");
       this.maxExportBatchSize = maxExportBatchSize;
       return this;
+    }
+
+    @VisibleForTesting
+    int getMaxExportBatchSize() {
+      return maxExportBatchSize;
     }
 
     /**

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
@@ -114,9 +114,9 @@ public final class SimpleSpanProcessor implements SpanProcessor {
 
     private static final String KEY_SAMPLED = "otel.ssp.export.sampled";
 
-    private static final boolean DEFAULT_EXPORT_ONLY_SAMPLED = true;
+    @VisibleForTesting static final boolean DEFAULT_EXPORT_ONLY_SAMPLED = true;
     private final SpanExporter spanExporter;
-    private boolean sampled = DEFAULT_EXPORT_ONLY_SAMPLED;
+    private boolean exportOnlySampled = DEFAULT_EXPORT_ONLY_SAMPLED;
 
     private Builder(SpanExporter spanExporter) {
       this.spanExporter = Objects.requireNonNull(spanExporter, "spanExporter");
@@ -133,7 +133,6 @@ public final class SimpleSpanProcessor implements SpanProcessor {
      * @param configMap {@link Map} holding the configuration values.
      * @return this.
      */
-    @VisibleForTesting
     @Override
     protected Builder fromConfigMap(
         Map<String, String> configMap, NamingConvention namingConvention) {
@@ -150,13 +149,17 @@ public final class SimpleSpanProcessor implements SpanProcessor {
      *
      * <p>Default value is {@code true}.
      *
-     * @see SimpleSpanProcessor.Builder#DEFAULT_EXPORT_ONLY_SAMPLED
-     * @param sampled report only sampled spans.
+     * @param exportOnlySampled if {@code true} report only sampled spans.
      * @return this.
      */
-    public Builder setExportOnlySampled(boolean sampled) {
-      this.sampled = sampled;
+    public Builder setExportOnlySampled(boolean exportOnlySampled) {
+      this.exportOnlySampled = exportOnlySampled;
       return this;
+    }
+
+    @VisibleForTesting
+    boolean getExportOnlySampled() {
+      return exportOnlySampled;
     }
 
     // TODO: Add metrics for total exported spans.
@@ -170,7 +173,7 @@ public final class SimpleSpanProcessor implements SpanProcessor {
      * @throws NullPointerException if the {@code spanExporter} is {@code null}.
      */
     public SimpleSpanProcessor build() {
-      return new SimpleSpanProcessor(spanExporter, sampled);
+      return new SimpleSpanProcessor(spanExporter, exportOnlySampled);
     }
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
@@ -45,7 +45,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 /** Unit tests for {@link SimpleSpanProcessor}. */
@@ -77,15 +76,19 @@ public class SimpleSpanProcessorTest {
   public void configTest() {
     Map<String, String> options = new HashMap<>();
     options.put("otel.ssp.export.sampled", "false");
-    SimpleSpanProcessor.Builder config = SimpleSpanProcessor.newBuilder(spanExporter);
-    /*
-    We are trying to spy a final class. To allow this, we need to create a resource file
-    ./mockito-extensions/org.mockito.plugins.MockMaker with content "mock-maker-inline".
-    https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/plugins/MockMaker.html
-    */
-    SimpleSpanProcessor.Builder spy = Mockito.spy(config);
-    spy.fromConfigMap(options, ConfigTester.getNamingDot());
-    Mockito.verify(spy).setExportOnlySampled(false);
+    SimpleSpanProcessor.Builder config =
+        SimpleSpanProcessor.newBuilder(spanExporter)
+            .fromConfigMap(options, ConfigTester.getNamingDot());
+    assertThat(config.getExportOnlySampled()).isEqualTo(false);
+  }
+
+  @Test
+  public void configTest_EmptyOptions() {
+    SimpleSpanProcessor.Builder config =
+        SimpleSpanProcessor.newBuilder(spanExporter)
+            .fromConfigMap(Collections.<String, String>emptyMap(), ConfigTester.getNamingDot());
+    assertThat(config.getExportOnlySampled())
+        .isEqualTo(SimpleSpanProcessor.Builder.DEFAULT_EXPORT_ONLY_SAMPLED);
   }
 
   @Test


### PR DESCRIPTION
Main motivation is to add tests for empty config map, so need to get access to the "default" values and getters, then no need to use mockito for the case where the map is not empty.