### PR TITLE
Fix incorrect renaming of files.

### DIFF
--- a/sdk_contrib/aws_v1_support/src/main/java/io/opentelemetry/sdk/contrib/trace/aws/resource/AwsResource.java
+++ b/sdk_contrib/aws_v1_support/src/main/java/io/opentelemetry/sdk/contrib/trace/aws/resource/AwsResource.java
@@ -30,7 +30,7 @@ public abstract class AwsResource {
    * environment, e.g., metadata for the instance if the app is running on EC2.
    */
   public static Resource create() {
-    return create(new Ec2ResourcePopulator());
+    return create(new Ec2Resource());
   }
 
   @VisibleForTesting

--- a/sdk_contrib/aws_v1_support/src/main/java/io/opentelemetry/sdk/contrib/trace/aws/resource/Ec2Resource.java
+++ b/sdk_contrib/aws_v1_support/src/main/java/io/opentelemetry/sdk/contrib/trace/aws/resource/Ec2Resource.java
@@ -39,9 +39,9 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-class Ec2ResourcePopulator extends AwsResource {
+class Ec2Resource extends AwsResource {
 
-  private static final Logger logger = Logger.getLogger(Ec2ResourcePopulator.class.getName());
+  private static final Logger logger = Logger.getLogger(Ec2Resource.class.getName());
 
   private static final int TIMEOUT_MILLIS = 2000;
 
@@ -53,14 +53,14 @@ class Ec2ResourcePopulator extends AwsResource {
   private final URL hostnameUrl;
   private final URL tokenUrl;
 
-  Ec2ResourcePopulator() {
+  Ec2Resource() {
     // This is only for testing e.g., with a mock IMDS server and never in production so we just
     // read from a system property. This is similar to the AWS SDK.
     this(System.getProperty("otel.aws.imds.endpointOverride", DEFAULT_IMDS_ENDPOINT));
   }
 
   @VisibleForTesting
-  Ec2ResourcePopulator(String endpoint) {
+  Ec2Resource(String endpoint) {
     String urlBase = "http://" + endpoint;
     try {
       this.identityDocumentUrl = new URL(urlBase + "/latest/dynamic/instance-identity/document");

--- a/sdk_contrib/aws_v1_support/src/test/java/io/opentelemetry/sdk/contrib/trace/aws/resource/Ec2ResourceTest.java
+++ b/sdk_contrib/aws_v1_support/src/test/java/io/opentelemetry/sdk/contrib/trace/aws/resource/Ec2ResourceTest.java
@@ -39,7 +39,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-public class Ec2Resource {
+public class Ec2ResourceTest {
 
   // From https://docs.amazonaws.cn/en_us/AWSEC2/latest/UserGuide/instance-identity-documents.html
   private static final String IDENTITY_DOCUMENT =
@@ -64,11 +64,11 @@ public class Ec2Resource {
   @ClassRule
   public static WireMockClassRule server = new WireMockClassRule(wireMockConfig().dynamicPort());
 
-  private Ec2ResourcePopulator populator;
+  private Ec2Resource populator;
 
   @Before
   public void setUp() {
-    populator = new Ec2ResourcePopulator("localhost:" + server.port());
+    populator = new Ec2Resource("localhost:" + server.port());
   }
 
   @Test


### PR DESCRIPTION
I realized in #1289 I accidentally renamed the test file to `Ec2Resource` when I meant to rename the logic to that and the test to `Ec2ResourceTest` (currently test file doesn't end with Test). Sorry about this ><