### PR TITLE
[Draft] Initial code for System Metrics support.

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -23,6 +23,7 @@ def subprojects = [
         project(':opentelemetry-sdk-contrib-async-processor'),
         project(':opentelemetry-sdk-contrib-auto-config'),
         project(':opentelemetry-sdk-contrib-otproto'),
+        project(':opentelemetry-sdk-contrib-system-metrics'),
         project(':opentelemetry-sdk-contrib-testbed'),
         project(':opentelemetry-sdk-contrib-jaeger-remote-sampler'),
 ]

--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,7 @@ configure(opentelemetryProjects) {
                 jmh_core                : "org.openjdk.jmh:jmh-core:${jmhVersion}",
                 jmh_bytecode            : "org.openjdk.jmh:jmh-generator-bytecode:${jmhVersion}",
                 jsr305                  : "com.google.code.findbugs:jsr305:${findBugsJsr305Version}",
+                oshi                    : "com.github.oshi:oshi-core:5.1.1",
                 prometheus_client       : "io.prometheus:simpleclient:${prometheusVersion}",
                 prometheus_client_common: "io.prometheus:simpleclient_common:${prometheusVersion}",
                 protobuf                : "com.google.protobuf:protobuf-java",

--- a/sdk_contrib/system_metrics/build.gradle
+++ b/sdk_contrib/system_metrics/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id "java"
+    id "maven-publish"
+
+    id "ru.vyarus.animalsniffer"
+}
+
+description = 'OpenTelemetry SDK System Metrics'
+ext.moduleName = "io.opentelemetry.sdk.contrib.metrics.system"
+
+dependencies {
+    api project(':opentelemetry-api'),
+            project(':opentelemetry-sdk')
+
+    implementation libraries.oshi
+
+    signature "org.codehaus.mojo.signature:java18:1.0@signature"
+}

--- a/sdk_contrib/system_metrics/src/main/java/io/opentelemetry/sdk/contrib/metrics/system/SystemMetrics.java
+++ b/sdk_contrib/system_metrics/src/main/java/io/opentelemetry/sdk/contrib/metrics/system/SystemMetrics.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.contrib.metrics.system;
+
+import io.opentelemetry.OpenTelemetry;
+import io.opentelemetry.internal.Utils;
+import io.opentelemetry.metrics.AsynchronousInstrument.Callback;
+import io.opentelemetry.metrics.AsynchronousInstrument.DoubleResult;
+import io.opentelemetry.metrics.AsynchronousInstrument.LongResult;
+import io.opentelemetry.metrics.Meter;
+import io.opentelemetry.sdk.metrics.export.IntervalMetricReader;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
+import oshi.SystemInfo;
+import oshi.hardware.CentralProcessor.TickType;
+import oshi.hardware.GlobalMemory;
+import oshi.hardware.HardwareAbstractionLayer;
+import oshi.hardware.NetworkIF;
+import oshi.software.os.OSProcess;
+import oshi.software.os.OperatingSystem;
+
+/** Add me. */
+public final class SystemMetrics {
+  private static final String TYPE_LABEL_KEY = "type";
+
+  private final IntervalMetricReader intervalReader;
+
+  private SystemMetrics(
+      Meter meter, MetricExporter exporter, Map<String, String> labels, int interval) {
+
+    registerObservers(meter, labels);
+    intervalReader =
+        IntervalMetricReader.builder()
+            .setExportIntervalMillis(interval)
+            .setMetricExporter(exporter)
+            .build();
+  }
+
+  public void shutdown() {
+    intervalReader.shutdown();
+  }
+
+  void registerObservers(Meter meter, Map<String, String> labels) {
+    SystemInfo systemInfo = new SystemInfo();
+    OperatingSystem osInfo = systemInfo.getOperatingSystem();
+
+    final HardwareAbstractionLayer hal = systemInfo.getHardware();
+    final OSProcess processInfo = osInfo.getProcess(osInfo.getProcessId());
+
+    meter
+        .longValueObserverBuilder("system.mem")
+        .setDescription("System memory")
+        .setUnit("bytes")
+        .setConstantLabels(labels)
+        .build()
+        .setCallback(
+            new Callback<LongResult>() {
+              @Override
+              public void update(LongResult r) {
+                GlobalMemory mem = hal.getMemory();
+                r.observe(mem.getTotal(), TYPE_LABEL_KEY, "total");
+                r.observe(mem.getAvailable(), TYPE_LABEL_KEY, "available");
+              }
+            });
+
+    meter
+        .doubleValueObserverBuilder("system.cpu")
+        .setDescription("System CPU")
+        .setUnit("seconds")
+        .setConstantLabels(labels)
+        .build()
+        .setCallback(
+            new Callback<DoubleResult>() {
+              @Override
+              public void update(DoubleResult r) {
+                long[] cpuTicks = hal.getProcessor().getSystemCpuLoadTicks();
+                r.observe(cpuTicks[TickType.SYSTEM.getIndex()] * 1000, TYPE_LABEL_KEY, "system");
+                r.observe(cpuTicks[TickType.USER.getIndex()] * 1000, TYPE_LABEL_KEY, "user");
+                r.observe(cpuTicks[TickType.IDLE.getIndex()] * 1000, TYPE_LABEL_KEY, "idle");
+              }
+            });
+
+    meter
+        .longValueObserverBuilder("sys.net.bytes")
+        .setDescription("System network bytes")
+        .setUnit("bytes")
+        .setConstantLabels(labels)
+        .build()
+        .setCallback(
+            new Callback<LongResult>() {
+              @Override
+              public void update(LongResult r) {
+                long recv = 0;
+                long sent = 0;
+
+                for (NetworkIF networkIf : hal.getNetworkIFs()) {
+                  recv += networkIf.getBytesRecv();
+                  sent += networkIf.getBytesSent();
+                }
+
+                r.observe(recv, TYPE_LABEL_KEY, "bytes_recv");
+                r.observe(sent, TYPE_LABEL_KEY, "bytes_sent");
+              }
+            });
+
+    meter
+        .longValueObserverBuilder("runtime.java.mem")
+        .setDescription("Runtime memory")
+        .setUnit("bytes")
+        .setConstantLabels(labels)
+        .build()
+        .setCallback(
+            new Callback<LongResult>() {
+              @Override
+              public void update(LongResult r) {
+                processInfo.updateAttributes();
+                r.observe(processInfo.getResidentSetSize(), TYPE_LABEL_KEY, "rss");
+                r.observe(processInfo.getVirtualSize(), TYPE_LABEL_KEY, "vms");
+              }
+            });
+
+    meter
+        .doubleValueObserverBuilder("runtime.java.cpu")
+        .setDescription("Runtime CPU")
+        .setUnit("seconds")
+        .setConstantLabels(labels)
+        .build()
+        .setCallback(
+            new Callback<DoubleResult>() {
+              @Override
+              public void update(DoubleResult r) {
+                processInfo.updateAttributes();
+                r.observe(processInfo.getUserTime() * 1000, TYPE_LABEL_KEY, "user");
+                r.observe(processInfo.getKernelTime() * 1000, TYPE_LABEL_KEY, "system");
+              }
+            });
+
+    meter
+        .longValueObserverBuilder("runtime.java.gc")
+        .setDescription("Runtime GC")
+        .setUnit("objects")
+        .setConstantLabels(labels)
+        .build()
+        .setCallback(
+            new Callback<LongResult>() {
+              @Override
+              public void update(LongResult r) {
+                long gcCount = 0;
+                for (final GarbageCollectorMXBean gcBean :
+                    ManagementFactory.getGarbageCollectorMXBeans()) {
+                  gcCount += gcBean.getCollectionCount();
+                }
+
+                r.observe(gcCount, TYPE_LABEL_KEY, "count");
+              }
+            });
+  }
+
+  /** Add me. */
+  public static final class Builder {
+    private Meter meter = OpenTelemetry.getMeterProvider().get(SystemMetrics.class.getName());
+    private MetricExporter exporter;
+    private Map<String, String> labels;
+    private int interval;
+
+    /** Add me. */
+    public Builder setMeter(Meter meter) {
+      this.meter = meter;
+      return this;
+    }
+
+    /** Add me. */
+    public Builder setExporter(MetricExporter exporter) {
+      this.exporter = exporter;
+      return this;
+    }
+
+    /** Add me. */
+    public Builder setConstantLabels(Map<String, String> labels) {
+      this.labels = Collections.unmodifiableMap(new TreeMap<>(labels));
+      return this;
+    }
+
+    /** Add me. */
+    public Builder setInterval(int interval) {
+      Utils.checkArgument(interval > 0, "Interval must be positive");
+      this.interval = interval;
+      return this;
+    }
+
+    /** Add me. */
+    public SystemMetrics build() {
+      return new SystemMetrics(meter, exporter, labels, interval);
+    }
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,6 +38,7 @@ include ":opentelemetry-all",
         ":opentelemetry-sdk-contrib-auto-config",
         ":opentelemetry-sdk-contrib-aws-v1-support",
         ":opentelemetry-sdk-contrib-otproto",
+        ":opentelemetry-sdk-contrib-system-metrics",
         ":opentelemetry-sdk-contrib-testbed",
         ":opentelemetry-sdk-contrib-jaeger-remote-sampler",
         ":opentelemetry-bom"


### PR DESCRIPTION
This is an initial draft PR for having an SDK-contrib library that automatically reports a few system metrics (initial implementations for other languages exist, such as [Python](https://github.com/open-telemetry/opentelemetry-python/tree/master/ext/opentelemetry-ext-system-metrics)) using observers.

The [Oshi](https://github.com/oshi/oshi) library is used to gather hardware information, and the reported metrics are (in either `bytes` or `seconds`, depending on the metric itself):

*  System memory (total and available).
* System CPU (system, user time and idle time)
* System Network Bytes (sent and received)
* Java Process memory (rss and vms)
* Java Process CPU (system and user time)
* Java GC (only GC count at this moment).

Internally the class is creating its own `IntervalMetricReader`. Also, these metric names will be updated when we have the related semantic conventions.

Tests, configuration support and code lifting code (such as maybe moving the small `Callback` code to their own file) is needed, but wanted to get initial feedback on this feature.
