### PR TITLE
Extension packages should not use "internal" API package

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -37,6 +37,7 @@ for (subproject in rootProject.subprojects) {
 
 dependencies {
     compile subprojects
+    testCompile libraries.archunit
 }
 
 task jacocoMerge(type: JacocoMerge) {

--- a/all/src/test/java/io/opentelemetry/InternalApiProtectionTest.java
+++ b/all/src/test/java/io/opentelemetry/InternalApiProtectionTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.syntax.elements.ClassesShouldConjunction;
+import org.junit.Test;
+
+public class InternalApiProtectionTest {
+
+  private static final String OTEL_BASE_PACKAGE = "io.opentelemetry";
+  private static final JavaClasses ALL_OTEL_CLASSES =
+      new ClassFileImporter().importPackages(OTEL_BASE_PACKAGE);
+
+  @Test
+  public void contrib_should_not_use_internal_api() {
+    ClassesShouldConjunction contribRule =
+        noClasses()
+            .that()
+            .resideInAPackage("..extensions..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage(OTEL_BASE_PACKAGE + ".internal");
+
+    contribRule.check(ALL_OTEL_CLASSES);
+  }
+}

--- a/api/src/main/java/io/opentelemetry/internal/StringUtils.java
+++ b/api/src/main/java/io/opentelemetry/internal/StringUtils.java
@@ -43,10 +43,6 @@ public final class StringUtils {
     return ch >= ' ' && ch <= '~';
   }
 
-  public static boolean isNullOrEmpty(String value) {
-    return value == null || value.length() == 0;
-  }
-
   /**
    * Determines whether the metric name contains a valid metric name.
    *
@@ -59,24 +55,6 @@ public final class StringUtils {
     }
     String pattern = "[aA-zZ][aA-zZ0-9_\\-.]*";
     return metricName.matches(pattern);
-  }
-
-  /**
-   * Pads a given string on the left with leading 0's up the length.
-   *
-   * @param value the string to pad
-   * @param length the number if characters to pad up to
-   * @return the padded string
-   */
-  public static String padLeft(String value, int length) {
-    if (value == null || length <= 0) {
-      throw new IllegalArgumentException();
-    }
-
-    if (value.length() >= length) {
-      return value;
-    }
-    return String.format("%1$" + length + "s", value).replace(' ', '0');
   }
 
   private StringUtils() {}

--- a/api/src/test/java/io/opentelemetry/internal/StringUtilsTest.java
+++ b/api/src/test/java/io/opentelemetry/internal/StringUtilsTest.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.internal;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,50 +30,5 @@ public final class StringUtilsTest {
   public void isPrintableString() {
     assertThat(StringUtils.isPrintableString("abcd")).isTrue();
     assertThat(StringUtils.isPrintableString("\2ab\3cd")).isFalse();
-  }
-
-  @Test
-  public void isNullOrEmpty() {
-    assertThat(StringUtils.isNullOrEmpty("")).isTrue();
-    assertThat(StringUtils.isNullOrEmpty(null)).isTrue();
-    assertThat(StringUtils.isNullOrEmpty("hello")).isFalse();
-    assertThat(StringUtils.isNullOrEmpty(" ")).isFalse();
-  }
-
-  @Test
-  public void padLeft() {
-    assertEquals(StringUtils.padLeft("value", 10), "00000value");
-  }
-
-  @Test
-  public void padLeft_throws_for_null_value() {
-    try {
-      StringUtils.padLeft(null, 10);
-    } catch (Throwable e) {
-      assertThat(e).isInstanceOf(IllegalArgumentException.class);
-    }
-  }
-
-  @Test
-  public void padLeft_throws_for_negative_length() {
-    try {
-      StringUtils.padLeft("value", -10);
-    } catch (Throwable e) {
-      assertThat(e).isInstanceOf(IllegalArgumentException.class);
-    }
-  }
-
-  @Test
-  public void padLeft_throws_for_zero_length() {
-    try {
-      StringUtils.padLeft("value", 0);
-    } catch (Throwable e) {
-      assertThat(e).isInstanceOf(IllegalArgumentException.class);
-    }
-  }
-
-  @Test
-  public void padLeft_length_does_not_exceed_length() {
-    assertEquals(StringUtils.padLeft("value", 3), "value");
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -63,11 +63,9 @@ configure(opentelemetryProjects) {
         // (https://github.com/google/error-prone/issues/1253).
         it.options.errorprone.disable("NullableDereference") // "-Xep:NullableDereference:OFF"
 
-        // ExpectedExceptionRefactoring, TestExceptionRefactoring and TryFailRefactoring suggest using
-        // assertThrows, but assertThrows only works well with lambdas.
+        // We prefer ExpectedException to assertThrows
         it.options.errorprone.disable("ExpectedExceptionRefactoring")
         // "-Xep:ExpectedExceptionRefactoring:OFF"
-        it.options.errorprone.disable("TryFailRefactoring") // "-Xep:TryFailRefactoring:OFF"
 
         // AutoValueImmutableFields suggests returning Guava types from API methods
         it.options.errorprone.disable("AutoValueImmutableFields")

--- a/build.gradle
+++ b/build.gradle
@@ -63,10 +63,11 @@ configure(opentelemetryProjects) {
         // (https://github.com/google/error-prone/issues/1253).
         it.options.errorprone.disable("NullableDereference") // "-Xep:NullableDereference:OFF"
 
-        // ExpectedExceptionRefactoring and TestExceptionRefactoring suggest using
+        // ExpectedExceptionRefactoring, TestExceptionRefactoring and TryFailRefactoring suggest using
         // assertThrows, but assertThrows only works well with lambdas.
         it.options.errorprone.disable("ExpectedExceptionRefactoring")
         // "-Xep:ExpectedExceptionRefactoring:OFF"
+        it.options.errorprone.disable("TryFailRefactoring") // "-Xep:TryFailRefactoring:OFF"
 
         // AutoValueImmutableFields suggests returning Guava types from API methods
         it.options.errorprone.disable("AutoValueImmutableFields")
@@ -158,7 +159,8 @@ configure(opentelemetryProjects) {
                 testcontainers          : 'org.testcontainers:testcontainers:1.13.0',
                 rest_assured            : 'io.rest-assured:rest-assured:4.2.0',
                 jaeger_client           : 'io.jaegertracing:jaeger-client:1.2.0', // Jaeger Client
-                zipkin_junit            : "io.zipkin.zipkin2:zipkin-junit:${zipkinVersion}"  // Zipkin JUnit rule
+                zipkin_junit            : "io.zipkin.zipkin2:zipkin-junit:${zipkinVersion}",  // Zipkin JUnit rule
+                archunit                : 'com.tngtech.archunit:archunit-junit4:0.13.1' //Architectural constraints
         ]
     }
 

--- a/buildscripts/checkstyle.license
+++ b/buildscripts/checkstyle.license
@@ -1,5 +1,5 @@
 ^/\*$
-^ \* Copyright \d\d\d\d(-\d\d)?, OpenTelemetry Authors$
+^ \* Copyright \d\d\d\d(-\d\d)?, (OpenTelemetry|Guava) Authors$
 ^ \*$
 ^ \* Licensed under the Apache License, Version 2.0 \(the "License"\);$
 ^ \* you may not use this file except in compliance with the License\.$

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractor.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractor.java
@@ -22,7 +22,6 @@ import static io.opentelemetry.extensions.trace.propagation.B3Propagator.TRUE_IN
 
 import io.grpc.Context;
 import io.opentelemetry.context.propagation.HttpTextFormat;
-import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorSingleHeader.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorSingleHeader.java
@@ -21,7 +21,6 @@ import static io.opentelemetry.extensions.trace.propagation.B3Propagator.COMBINE
 
 import io.grpc.Context;
 import io.opentelemetry.context.propagation.HttpTextFormat;
-import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.TracingContextUtils;

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
@@ -16,11 +16,8 @@
 
 package io.opentelemetry.extensions.trace.propagation;
 
-import static io.opentelemetry.internal.Utils.checkNotNull;
-
 import io.grpc.Context;
 import io.opentelemetry.context.propagation.HttpTextFormat;
-import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
@@ -33,6 +30,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.concurrent.Immutable;
@@ -85,8 +83,8 @@ public class JaegerPropagator implements HttpTextFormat {
 
   @Override
   public <C> void inject(Context context, C carrier, Setter<C> setter) {
-    checkNotNull(context, "context");
-    checkNotNull(setter, "setter");
+    Objects.requireNonNull(context, "context");
+    Objects.requireNonNull(setter, "setter");
 
     Span span = TracingContextUtils.getSpanWithoutDefault(context);
     if (span == null || !span.getContext().isValid()) {
@@ -108,8 +106,8 @@ public class JaegerPropagator implements HttpTextFormat {
 
   @Override
   public <C> Context extract(Context context, C carrier, Getter<C> getter) {
-    checkNotNull(carrier, "carrier");
-    checkNotNull(getter, "getter");
+    Objects.requireNonNull(carrier, "carrier");
+    Objects.requireNonNull(getter, "getter");
 
     SpanContext spanContext = getSpanContextFromHeader(carrier, getter);
 

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/StringUtils.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/StringUtils.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2010, Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.extensions.trace.propagation;
+
+import java.util.Objects;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public final class StringUtils {
+
+  /**
+   * Returns a string, of length at least {@code minLength}, consisting of {@code string} prepended
+   * with as many copies of {@code padChar} as are necessary to reach that length. For example,
+   *
+   * <ul>
+   *   <li>{@code padStart("7", 3, '0')} returns {@code "007"}
+   *   <li>{@code padStart("2010", 3, '0')} returns {@code "2010"}
+   * </ul>
+   *
+   * <p>See {@link java.util.Formatter} for a richer set of formatting capabilities.
+   *
+   * <p>This method was copied almost verbatim from Guava library method
+   * com.google.common.base.Strings#padStart(java.lang.String, int, char).
+   *
+   * @param string the string which should appear at the end of the result
+   * @param minLength the minimum length the resulting string must have. Can be zero or negative, in
+   *     which case the input string is always returned.
+   * @param padChar the character to insert at the beginning of the result until the minimum length
+   *     is reached
+   * @return the padded string
+   */
+  public static String padStart(String string, int minLength, char padChar) {
+    Objects.requireNonNull(string);
+    if (string.length() >= minLength) {
+      return string;
+    }
+    StringBuilder sb = new StringBuilder(minLength);
+    for (int i = string.length(); i < minLength; i++) {
+      sb.append(padChar);
+    }
+    sb.append(string);
+    return sb.toString();
+  }
+
+  /**
+   * Returns {@code true} if the given string is null or is the empty string.
+   *
+   * <p>This method was copied verbatim from Guava library method
+   * com.google.common.base.Strings#isNullOrEmpty(java.lang.String).
+   *
+   * @param string a string reference to check
+   * @return {@code true} if the string is null or is the empty string
+   */
+  public static boolean isNullOrEmpty(String string) {
+    return string == null || string.isEmpty();
+  }
+
+  /**
+   * Pads a given string on the left with leading 0's up the length.
+   *
+   * @param value the string to pad
+   * @param minLength the minimum length the resulting padded string must have. Can be zero or
+   *     negative, in which case the input string is always returned.
+   * @return the padded string
+   */
+  public static String padLeft(String value, int minLength) {
+    return padStart(value, minLength, '0');
+  }
+
+  private StringUtils() {}
+}

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
@@ -21,7 +21,6 @@ import static com.google.common.truth.Truth.assertThat;
 import io.grpc.Context;
 import io.opentelemetry.context.propagation.HttpTextFormat.Getter;
 import io.opentelemetry.context.propagation.HttpTextFormat.Setter;
-import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/StringUtilsTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/StringUtilsTest.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.extensions.trace.propagation;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,7 +35,7 @@ public class StringUtilsTest {
 
   @Test
   public void padLeft() {
-    assertEquals(StringUtils.padLeft("value", 10), "00000value");
+    assertThat(StringUtils.padLeft("value", 10)).isEqualTo("00000value");
   }
 
   @Test

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/StringUtilsTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/StringUtilsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.extensions.trace.propagation;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+public class StringUtilsTest {
+
+  @Test
+  public void isNullOrEmpty() {
+    assertThat(StringUtils.isNullOrEmpty("")).isTrue();
+    assertThat(StringUtils.isNullOrEmpty(null)).isTrue();
+    assertThat(StringUtils.isNullOrEmpty("hello")).isFalse();
+    assertThat(StringUtils.isNullOrEmpty(" ")).isFalse();
+  }
+
+  @Test
+  public void padLeft() {
+    assertEquals(StringUtils.padLeft("value", 10), "00000value");
+  }
+
+  @Test
+  public void padLeft_throws_for_null_value() {
+    try {
+      StringUtils.padLeft(null, 10);
+      fail("Expected exception not");
+    } catch (NullPointerException expected) {
+    }
+  }
+
+  @Test
+  public void padLeft_length_does_not_exceed_length() {
+    assertEquals(StringUtils.padLeft("value", 3), "value");
+    assertEquals(StringUtils.padLeft("value", -10), "value");
+    assertEquals(StringUtils.padLeft("value", 0), "value");
+  }
+}

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/StringUtilsTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/StringUtilsTest.java
@@ -18,11 +18,13 @@ package io.opentelemetry.extensions.trace.propagation;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class StringUtilsTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void isNullOrEmpty() {
@@ -39,17 +41,14 @@ public class StringUtilsTest {
 
   @Test
   public void padLeft_throws_for_null_value() {
-    try {
-      StringUtils.padLeft(null, 10);
-      fail("Expected exception not");
-    } catch (NullPointerException expected) {
-    }
+    thrown.expect(NullPointerException.class);
+    StringUtils.padLeft(null, 10);
   }
 
   @Test
   public void padLeft_length_does_not_exceed_length() {
-    assertEquals(StringUtils.padLeft("value", 3), "value");
-    assertEquals(StringUtils.padLeft("value", -10), "value");
-    assertEquals(StringUtils.padLeft("value", 0), "value");
+    assertThat(StringUtils.padLeft("value", 3)).isEqualTo("value");
+    assertThat(StringUtils.padLeft("value", -10)).isEqualTo("value");
+    assertThat(StringUtils.padLeft("value", 0)).isEqualTo("value");
   }
 }


### PR DESCRIPTION
Fixes #1125, second attempt.

This PR adds InternalApiProtectionTest which uses ArchUnit to enforce architectural constraints. It only verifies that classes in contrib packages do not use classes in internal package of API module.

Test was added into opentelemetry-all module because the latter depends on all other submodules and therefore sees all classes in the project.

All found violations were fixed.

StringUtils was copied from Guava, so its original copyright notice was preserved with slight formatting changes. Even then I had to change our checkstyle configuration to make it pass.