### PR TITLE
fix for potential race condition in JaegerRemoteSamplerTest

### DIFF
--- a/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/JaegerRemoteSamplerTest.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/JaegerRemoteSamplerTest.java
@@ -129,6 +129,11 @@ public class JaegerRemoteSamplerTest {
             .getDescription()
             .matches(
                 "JaegerRemoteSampler\\{Probability\\{probability=0.001, idUpperBound=.*\\}\\}"));
+
+    // wait until the sampling strategy is retrieved before exiting test method
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .until(samplerIsType(sampler, RateLimitingSampler.class));
   }
 
   static Callable<Boolean> samplerIsType(


### PR DESCRIPTION
I've added some comment to #1275 

This PR will prevent the ```description``` test in ```JaegerRemoteSamplerTest``` from immediately calling the ```GrpcCleanupRule``` before the sampling strategy is retrieved by gRPC in a separate thread.