### PR TITLE
Change the usage of MMSC aggregations to always be deltas.

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdk.java
@@ -35,7 +35,7 @@ final class DoubleValueRecorderSdk extends AbstractSynchronousInstrument<BoundIn
         meterProviderSharedState,
         meterSharedState,
         new ActiveBatcher(
-            Batchers.getCumulativeAllLabels(
+            Batchers.getDeltaAllLabels(
                 descriptor,
                 meterProviderSharedState,
                 meterSharedState,

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdk.java
@@ -35,7 +35,7 @@ final class LongValueRecorderSdk extends AbstractSynchronousInstrument<BoundInst
         meterProviderSharedState,
         meterSharedState,
         new ActiveBatcher(
-            Batchers.getCumulativeAllLabels(
+            Batchers.getDeltaAllLabels(
                 descriptor,
                 meterProviderSharedState,
                 meterSharedState,

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdkTest.java
@@ -185,7 +185,7 @@ public class DoubleValueRecorderSdkTest {
                   323.3d,
                   valueAtPercentiles(-121.5d, 321.5d)));
 
-      // Repeat to prove we keep previous values.
+      // Repeat to prove we don't keep previous values.
       testClock.advanceNanos(SECOND_NANOS);
       boundMeasure.record(222d);
       doubleMeasure.record(17d, Labels.empty());
@@ -197,19 +197,19 @@ public class DoubleValueRecorderSdkTest {
       assertThat(metricData.getPoints())
           .containsExactly(
               SummaryPoint.create(
-                  startTime,
+                  startTime + SECOND_NANOS,
                   secondCollect,
                   Labels.empty(),
-                  3,
-                  16.0d,
-                  valueAtPercentiles(-13.1d, 17d)),
+                  1,
+                  17.0d,
+                  valueAtPercentiles(17d, 17d)),
               SummaryPoint.create(
-                  startTime,
+                  startTime + SECOND_NANOS,
                   secondCollect,
                   Labels.of("K", "V"),
-                  4,
-                  545.3d,
-                  valueAtPercentiles(-121.5, 321.5d)));
+                  1,
+                  222.0d,
+                  valueAtPercentiles(222.0, 222.0d)));
     } finally {
       boundMeasure.unbind();
     }

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdkTest.java
@@ -180,7 +180,7 @@ public class LongValueRecorderSdkTest {
                   323,
                   valueAtPercentiles(-121, 321)));
 
-      // Repeat to prove we keep previous values.
+      // Repeat to prove we don't keep previous values.
       testClock.advanceNanos(SECOND_NANOS);
       boundMeasure.record(222);
       longMeasure.record(17, Labels.empty());
@@ -193,14 +193,19 @@ public class LongValueRecorderSdkTest {
       assertThat(metricData.getPoints())
           .containsExactly(
               SummaryPoint.create(
-                  startTime, secondCollect, Labels.empty(), 3, 15, valueAtPercentiles(-14, 17)),
+                  startTime + SECOND_NANOS,
+                  secondCollect,
+                  Labels.empty(),
+                  1,
+                  17,
+                  valueAtPercentiles(17, 17)),
               SummaryPoint.create(
-                  startTime,
+                  startTime + SECOND_NANOS,
                   secondCollect,
                   Labels.of("K", "V"),
-                  4,
-                  545,
-                  valueAtPercentiles(-121, 321)));
+                  1,
+                  222,
+                  valueAtPercentiles(222, 222)));
     } finally {
       boundMeasure.unbind();
     }


### PR DESCRIPTION
I started looking at the data coming out of our aggregators for ValueRecorders, and realized that the current approach of having our MMSC aggregations be cumulative probably isn't very useful. In particular, the min & max are only useful when considered over a reporting interval, rather than over the lifetime of the process.

So, I propose in this PR to change to having the ValueRecorders use a delta-aggregation for MMSC, so as to make all 4 values produced be useful.