### PR TITLE
enhance OTLP Exporter configuration

### DIFF
--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
@@ -290,7 +290,6 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
       if (metadataValue != null) {
         for (String keyValueString : Splitter.on(';').split(metadataValue)) {
           final List<String> keyValue = Splitter.on('=').splitToList(keyValueString);
-          ;
           if (keyValue.size() == 2) {
             addHeader(keyValue.get(0), keyValue.get(1));
           }

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -227,7 +226,7 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
      * @param value header value
      * @return this builder's instance
      */
-    public Builder addHeader(@Nonnull String key, @Nonnull String value) {
+    public Builder addHeader(String key, String value) {
       if (metadata == null) {
         metadata = new Metadata();
       }

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -226,7 +227,7 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
      * @param value header value
      * @return this builder's instance
      */
-    public Builder addHeader(String key, String value) {
+    public Builder addHeader(@Nonnull String key, @Nonnull String value) {
       if (metadata == null) {
         metadata = new Metadata();
       }

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -167,9 +168,9 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
     private static final String KEY_METADATA = "otel.otlp.metadata";
     private ManagedChannel channel;
     private long deadlineMs = 1_000; // 1 second
-    private String endpoint;
+    @Nullable private String endpoint;
     private boolean useTls;
-    private Metadata metadata;
+    @Nullable private Metadata metadata;
 
     /**
      * Sets the managed chanel to use when communicating with the backend. Required if {@link

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/package-info.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/package-info.java
@@ -40,6 +40,10 @@
  * <ul>
  *   <li>{@code otel.otlp.metric.timeout}: to set the max waiting time allowed to send each metric
  *       batch.
+ *   <li>{@code otel.otlp.endpoint}: to set the endpoint to connect to.
+ *   <li>{@code otel.otlp.use.tls}: to set use or not TLS.
+ *   <li>{@code otel.otlp.metadata} to set key-value pairs separated by semicolon to pass as request
+ *       metadata.
  * </ul>
  *
  * <p>For environment variables, {@link io.opentelemetry.exporters.otlp.OtlpGrpcMetricExporter} will
@@ -48,6 +52,10 @@
  * <ul>
  *   <li>{@code OTEL_OTLP_METRIC_TIMEOUT}: to set the max waiting time allowed to send each metric
  *       batch.
+ *   <li>{@code OTEL_OTLP_ENDPOINT}: to set the endpoint to connect to.
+ *   <li>{@code OTEL_OTLP_USE_TLS}: to set use or not TLS.
+ *   <li>{@code OTEL_OTLP_METADATA}: to set key-value pairs separated by semicolon to pass as
+ *       request metadata.
  * </ul>
  *
  * <h2>{@link io.opentelemetry.exporters.otlp.OtlpGrpcSpanExporter}</h2>

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
@@ -66,10 +66,16 @@ public class OtlpGrpcSpanExporterTest {
   public void configTest() {
     Map<String, String> options = new HashMap<>();
     options.put("otel.otlp.span.timeout", "12");
+    options.put("otel.otlp.endpoint", "http://localhost:6553");
+    options.put("otel.otlp.use.tls", "true");
+    options.put("otel.otlp.metadata", "key=value");
     OtlpGrpcSpanExporter.Builder config = OtlpGrpcSpanExporter.newBuilder();
     OtlpGrpcSpanExporter.Builder spy = Mockito.spy(config);
     spy.fromConfigMap(options, ConfigBuilderTest.getNaming());
     Mockito.verify(spy).setDeadlineMs(12);
+    Mockito.verify(spy).setEndpoint("http://localhost:6553");
+    Mockito.verify(spy).setUseTls(true);
+    Mockito.verify(spy).addHeader("key", "value");
   }
 
   @Before


### PR DESCRIPTION
OTLP Exporter in [opentelemetry-java-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation) is not configurable to:

- useTransportSecurity instead of usePlaintext
- insert values into Metadata headers (in ClientInterceptor)
 

From PR https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/567#issuecomment-648600894
Decided to try add configuration directly to OTLP Exporter.