### PR TITLE
Get rid of TraceId/SpanId wrappers, and have the SpanContext hold the ids

### DIFF
--- a/api/src/jmh/java/io/opentelemetry/trace/propagation/HttpTraceContextInjectBenchmark.java
+++ b/api/src/jmh/java/io/opentelemetry/trace/propagation/HttpTraceContextInjectBenchmark.java
@@ -20,9 +20,7 @@ import io.grpc.Context;
 import io.opentelemetry.context.propagation.HttpTextFormat.Setter;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.SpanContext;
-import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
-import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
 import io.opentelemetry.trace.TracingContextUtils;
 import java.util.ArrayList;
@@ -83,11 +81,7 @@ public class HttpTraceContextInjectBenchmark {
     byte sampledTraceOptionsBytes = 1;
     TraceFlags sampledTraceOptions = TraceFlags.fromByte(sampledTraceOptionsBytes);
     TraceState traceStateDefault = TraceState.builder().build();
-    return SpanContext.create(
-        TraceId.bytesFromLowerBase16(traceId, 0),
-        SpanId.bytesFromLowerBase16(spanId, 0),
-        sampledTraceOptions,
-        traceStateDefault);
+    return SpanContext.create(traceId, spanId, sampledTraceOptions, traceStateDefault);
   }
 
   private static List<Context> createContexts(List<SpanContext> spanContexts) {

--- a/api/src/jmh/java/io/opentelemetry/trace/propagation/HttpTraceContextInjectBenchmark.java
+++ b/api/src/jmh/java/io/opentelemetry/trace/propagation/HttpTraceContextInjectBenchmark.java
@@ -84,8 +84,8 @@ public class HttpTraceContextInjectBenchmark {
     TraceFlags sampledTraceOptions = TraceFlags.fromByte(sampledTraceOptionsBytes);
     TraceState traceStateDefault = TraceState.builder().build();
     return SpanContext.create(
-        TraceId.fromLowerBase16(traceId, 0),
-        SpanId.fromLowerBase16(spanId, 0),
+        TraceId.bytesFromLowerBase16(traceId, 0),
+        SpanId.bytesFromLowerBase16(spanId, 0),
         sampledTraceOptions,
         traceStateDefault);
   }

--- a/api/src/main/java/io/opentelemetry/trace/BigendianEncoding.java
+++ b/api/src/main/java/io/opentelemetry/trace/BigendianEncoding.java
@@ -138,6 +138,15 @@ final class BigendianEncoding {
     byteToBase16(value, dest, destOffset);
   }
 
+  static byte[] bytesFromBase16(CharSequence value, int srcOffset, int charactersToRead) {
+    CharSequence part = value.subSequence(srcOffset, srcOffset + charactersToRead);
+    byte[] result = new byte[charactersToRead / 2];
+    for (int i = 0; i < charactersToRead; i += 2) {
+      result[i / 2] = byteFromBase16String(part, i);
+    }
+    return result;
+  }
+
   /**
    * Decodes the specified two character sequence, and returns the resulting {@code byte}.
    *
@@ -165,9 +174,9 @@ final class BigendianEncoding {
     dest[destOffset + 1] = ENCODING[b | 0x100];
   }
 
-  public static boolean isValidBase16String(String value) {
-    char[] chars = value.toCharArray();
-    for (char b : chars) {
+  public static boolean isValidBase16String(CharSequence value) {
+    for (int i = 0; i < value.length(); i++) {
+      char b = value.charAt(i);
       // 48..57 && 97..102 are valid
       if (!Character.isDigit(b) && (b < 97 || b > 102)) {
         return false;
@@ -177,4 +186,12 @@ final class BigendianEncoding {
   }
 
   private BigendianEncoding() {}
+
+  public static CharSequence toLowerBase16(byte[] bytes) {
+    char[] chars = new char[bytes.length * 2];
+    for (int i = 0; i < bytes.length; i++) {
+      byteToBase16(bytes[i], chars, i * 2);
+    }
+    return new String(chars);
+  }
 }

--- a/api/src/main/java/io/opentelemetry/trace/BigendianEncoding.java
+++ b/api/src/main/java/io/opentelemetry/trace/BigendianEncoding.java
@@ -165,5 +165,16 @@ final class BigendianEncoding {
     dest[destOffset + 1] = ENCODING[b | 0x100];
   }
 
+  public static boolean isValidBase16String(String value) {
+    char[] chars = value.toCharArray();
+    for (char b : chars) {
+      // 48..57 && 97..102 are valid
+      if (!Character.isDigit(b) && (b < 97 || b > 102)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   private BigendianEncoding() {}
 }

--- a/api/src/main/java/io/opentelemetry/trace/SpanContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanContext.java
@@ -59,7 +59,7 @@ public abstract class SpanContext {
    * @since 0.1.0
    */
   public static SpanContext create(
-      TraceId traceId, SpanId spanId, TraceFlags traceFlags, TraceState traceState) {
+      byte[] traceId, byte[] spanId, TraceFlags traceFlags, TraceState traceState) {
     return new AutoValue_SpanContext(traceId, spanId, traceFlags, traceState, /* remote=*/ false);
   }
 
@@ -75,7 +75,7 @@ public abstract class SpanContext {
    * @since 0.1.0
    */
   public static SpanContext createFromRemoteParent(
-      TraceId traceId, SpanId spanId, TraceFlags traceFlags, TraceState traceState) {
+      byte[] traceId, byte[] spanId, TraceFlags traceFlags, TraceState traceState) {
     return new AutoValue_SpanContext(traceId, spanId, traceFlags, traceState, /* remote=*/ true);
   }
 
@@ -85,7 +85,8 @@ public abstract class SpanContext {
    * @return the trace identifier associated with this {@code SpanContext}.
    * @since 0.1.0
    */
-  public abstract TraceId getTraceId();
+  @SuppressWarnings("mutable")
+  public abstract byte[] getTraceId();
 
   /**
    * Returns the span identifier associated with this {@code SpanContext}.
@@ -93,7 +94,8 @@ public abstract class SpanContext {
    * @return the span identifier associated with this {@code SpanContext}.
    * @since 0.1.0
    */
-  public abstract SpanId getSpanId();
+  @SuppressWarnings("mutable")
+  public abstract byte[] getSpanId();
 
   /**
    * Returns the {@code TraceFlags} associated with this {@code SpanContext}.
@@ -118,7 +120,7 @@ public abstract class SpanContext {
    * @since 0.1.0
    */
   public boolean isValid() {
-    return getTraceId().isValid() && getSpanId().isValid();
+    return TraceId.isValid(getTraceId()) && SpanId.isValid(getSpanId());
   }
 
   /**

--- a/api/src/main/java/io/opentelemetry/trace/SpanContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanContext.java
@@ -86,7 +86,24 @@ public abstract class SpanContext {
    * @since 0.1.0
    */
   @SuppressWarnings("mutable")
-  public abstract byte[] getTraceId();
+  abstract byte[] getTraceId();
+
+  /**
+   * Returns the trace identifier associated with this {@code SpanContext}.
+   *
+   * @return the trace identifier associated with this {@code SpanContext}.
+   * @since 0.1.0
+   */
+  public byte[] traceId() {
+    byte[] result = new byte[16];
+    copyTraceId(result, 0);
+    return result;
+  }
+
+  /** javadoc me. */
+  public void copyTraceId(byte[] destination, int destOffset) {
+    System.arraycopy(getTraceId(), 0, destination, destOffset, 16);
+  }
 
   /**
    * Returns the span identifier associated with this {@code SpanContext}.
@@ -95,7 +112,24 @@ public abstract class SpanContext {
    * @since 0.1.0
    */
   @SuppressWarnings("mutable")
-  public abstract byte[] getSpanId();
+  abstract byte[] getSpanId();
+
+  /**
+   * Returns the span identifier associated with this {@code SpanContext}.
+   *
+   * @return the span identifier associated with this {@code SpanContext}.
+   * @since 0.1.0
+   */
+  public byte[] spanId() {
+    byte[] result = new byte[8];
+    copySpanId(result, 0);
+    return result;
+  }
+
+  /** javadoc me. */
+  public void copySpanId(byte[] destination, int destOffset) {
+    System.arraycopy(getSpanId(), 0, destination, destOffset, 8);
+  }
 
   /**
    * Returns the {@code TraceFlags} associated with this {@code SpanContext}.

--- a/api/src/main/java/io/opentelemetry/trace/SpanContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanContext.java
@@ -60,7 +60,36 @@ public abstract class SpanContext {
    */
   public static SpanContext create(
       CharSequence traceId, CharSequence spanId, TraceFlags traceFlags, TraceState traceState) {
-    return new AutoValue_SpanContext(traceId, spanId, traceFlags, traceState, /* remote=*/ false);
+    return create(traceId, 0, spanId, 0, traceFlags, traceState, /* remote=*/ false);
+  }
+
+  /**
+   * Creates a new {@code SpanContext} with the given identifiers and options.
+   *
+   * @param traceId the trace identifier of the span context.
+   * @param traceIdOffset the offset at which the traceId starts.
+   * @param spanId the span identifier of the span context.
+   * @param spanIdOffset the offset at which the spanId starts.
+   * @param traceFlags the trace options for the span context.
+   * @param traceState the trace state for the span context.
+   * @return a new {@code SpanContext} with the given identifiers and options.
+   * @since 0.1.0
+   */
+  @SuppressWarnings("InconsistentOverloads")
+  public static SpanContext create(
+      CharSequence traceId,
+      int traceIdOffset,
+      CharSequence spanId,
+      int spanIdOffset,
+      TraceFlags traceFlags,
+      TraceState traceState,
+      boolean remote) {
+    return new AutoValue_SpanContext(
+        traceId.subSequence(traceIdOffset, traceIdOffset + 32).toString(),
+        spanId.subSequence(spanIdOffset, spanIdOffset + 16).toString(),
+        traceFlags,
+        traceState,
+        /* remote=*/ remote);
   }
 
   /**
@@ -76,7 +105,7 @@ public abstract class SpanContext {
    */
   public static SpanContext createFromRemoteParent(
       CharSequence traceId, CharSequence spanId, TraceFlags traceFlags, TraceState traceState) {
-    return new AutoValue_SpanContext(traceId, spanId, traceFlags, traceState, /* remote=*/ true);
+    return create(traceId, 0, spanId, 0, traceFlags, traceState, /* remote=*/ true);
   }
 
   /**
@@ -85,7 +114,7 @@ public abstract class SpanContext {
    * @return the trace identifier associated with this {@code SpanContext}.
    * @since 0.1.0
    */
-  public abstract CharSequence getTraceId();
+  public abstract String getTraceIdAsBase16();
 
   /**
    * Returns the span identifier associated with this {@code SpanContext}.
@@ -93,7 +122,7 @@ public abstract class SpanContext {
    * @return the span identifier associated with this {@code SpanContext}.
    * @since 0.1.0
    */
-  public abstract CharSequence getSpanId();
+  public abstract String getSpanIdAsBase16();
 
   /**
    * Returns the {@code TraceFlags} associated with this {@code SpanContext}.
@@ -118,7 +147,7 @@ public abstract class SpanContext {
    * @since 0.1.0
    */
   public boolean isValid() {
-    return TraceId.isValid(getTraceId()) && SpanId.isValid(getSpanId());
+    return TraceId.isValid(getTraceIdAsBase16()) && SpanId.isValid(getSpanIdAsBase16());
   }
 
   /**

--- a/api/src/main/java/io/opentelemetry/trace/SpanContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanContext.java
@@ -67,7 +67,7 @@ public abstract class SpanContext {
 
   /**
    * todo: javadoc me. This one has all the options for how ids are represented. The Strings taking
-   * precendence over the longs, if you're asking for the base16 versions
+   * precedence over the longs, if you're asking for the base16 versions
    */
   @SuppressWarnings("InconsistentOverloads")
   public static SpanContext create(

--- a/api/src/main/java/io/opentelemetry/trace/SpanContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanContext.java
@@ -17,6 +17,7 @@
 package io.opentelemetry.trace;
 
 import com.google.auto.value.AutoValue;
+import java.util.Arrays;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -95,14 +96,7 @@ public abstract class SpanContext {
    * @since 0.1.0
    */
   public byte[] traceId() {
-    byte[] result = new byte[16];
-    copyTraceId(result, 0);
-    return result;
-  }
-
-  /** javadoc me. */
-  public void copyTraceId(byte[] destination, int destOffset) {
-    System.arraycopy(getTraceId(), 0, destination, destOffset, 16);
+    return Arrays.copyOf(getTraceId(), 16);
   }
 
   /**
@@ -121,14 +115,7 @@ public abstract class SpanContext {
    * @since 0.1.0
    */
   public byte[] spanId() {
-    byte[] result = new byte[8];
-    copySpanId(result, 0);
-    return result;
-  }
-
-  /** javadoc me. */
-  public void copySpanId(byte[] destination, int destOffset) {
-    System.arraycopy(getSpanId(), 0, destination, destOffset, 8);
+    return Arrays.copyOf(getSpanId(), 8);
   }
 
   /**

--- a/api/src/main/java/io/opentelemetry/trace/SpanContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanContext.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.trace;
 
 import com.google.auto.value.AutoValue;
-import java.util.Arrays;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -60,7 +59,7 @@ public abstract class SpanContext {
    * @since 0.1.0
    */
   public static SpanContext create(
-      byte[] traceId, byte[] spanId, TraceFlags traceFlags, TraceState traceState) {
+      String traceId, String spanId, TraceFlags traceFlags, TraceState traceState) {
     return new AutoValue_SpanContext(traceId, spanId, traceFlags, traceState, /* remote=*/ false);
   }
 
@@ -76,7 +75,7 @@ public abstract class SpanContext {
    * @since 0.1.0
    */
   public static SpanContext createFromRemoteParent(
-      byte[] traceId, byte[] spanId, TraceFlags traceFlags, TraceState traceState) {
+      String traceId, String spanId, TraceFlags traceFlags, TraceState traceState) {
     return new AutoValue_SpanContext(traceId, spanId, traceFlags, traceState, /* remote=*/ true);
   }
 
@@ -87,7 +86,7 @@ public abstract class SpanContext {
    * @since 0.1.0
    */
   @SuppressWarnings("mutable")
-  abstract byte[] getTraceId();
+  abstract String getTraceId();
 
   /**
    * Returns the trace identifier associated with this {@code SpanContext}.
@@ -95,8 +94,8 @@ public abstract class SpanContext {
    * @return the trace identifier associated with this {@code SpanContext}.
    * @since 0.1.0
    */
-  public byte[] traceId() {
-    return Arrays.copyOf(getTraceId(), 16);
+  public String traceId() {
+    return getTraceId();
   }
 
   /**
@@ -106,7 +105,7 @@ public abstract class SpanContext {
    * @since 0.1.0
    */
   @SuppressWarnings("mutable")
-  abstract byte[] getSpanId();
+  abstract String getSpanId();
 
   /**
    * Returns the span identifier associated with this {@code SpanContext}.
@@ -114,8 +113,8 @@ public abstract class SpanContext {
    * @return the span identifier associated with this {@code SpanContext}.
    * @since 0.1.0
    */
-  public byte[] spanId() {
-    return Arrays.copyOf(getSpanId(), 8);
+  public String spanId() {
+    return getSpanId();
   }
 
   /**

--- a/api/src/main/java/io/opentelemetry/trace/SpanContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanContext.java
@@ -59,7 +59,7 @@ public abstract class SpanContext {
    * @since 0.1.0
    */
   public static SpanContext create(
-      String traceId, String spanId, TraceFlags traceFlags, TraceState traceState) {
+      CharSequence traceId, CharSequence spanId, TraceFlags traceFlags, TraceState traceState) {
     return new AutoValue_SpanContext(traceId, spanId, traceFlags, traceState, /* remote=*/ false);
   }
 
@@ -75,7 +75,7 @@ public abstract class SpanContext {
    * @since 0.1.0
    */
   public static SpanContext createFromRemoteParent(
-      String traceId, String spanId, TraceFlags traceFlags, TraceState traceState) {
+      CharSequence traceId, CharSequence spanId, TraceFlags traceFlags, TraceState traceState) {
     return new AutoValue_SpanContext(traceId, spanId, traceFlags, traceState, /* remote=*/ true);
   }
 
@@ -85,18 +85,7 @@ public abstract class SpanContext {
    * @return the trace identifier associated with this {@code SpanContext}.
    * @since 0.1.0
    */
-  @SuppressWarnings("mutable")
-  abstract String getTraceId();
-
-  /**
-   * Returns the trace identifier associated with this {@code SpanContext}.
-   *
-   * @return the trace identifier associated with this {@code SpanContext}.
-   * @since 0.1.0
-   */
-  public String traceId() {
-    return getTraceId();
-  }
+  public abstract CharSequence getTraceId();
 
   /**
    * Returns the span identifier associated with this {@code SpanContext}.
@@ -104,18 +93,7 @@ public abstract class SpanContext {
    * @return the span identifier associated with this {@code SpanContext}.
    * @since 0.1.0
    */
-  @SuppressWarnings("mutable")
-  abstract String getSpanId();
-
-  /**
-   * Returns the span identifier associated with this {@code SpanContext}.
-   *
-   * @return the span identifier associated with this {@code SpanContext}.
-   * @since 0.1.0
-   */
-  public String spanId() {
-    return getSpanId();
-  }
+  public abstract CharSequence getSpanId();
 
   /**
    * Returns the {@code TraceFlags} associated with this {@code SpanContext}.

--- a/api/src/main/java/io/opentelemetry/trace/SpanId.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanId.java
@@ -16,44 +16,23 @@
 
 package io.opentelemetry.trace;
 
-import io.opentelemetry.internal.Utils;
 import java.util.Random;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * A class that represents a span identifier. A valid span identifier is an 8-byte array with at
- * least one non-zero byte.
+ * Helper methods for dealing with a span identifier. A valid span identifier is an 8-byte array
+ * with at least one non-zero byte.
  *
  * @since 0.1.0
  */
 @Immutable
-public final class SpanId implements Comparable<SpanId> {
+public final class SpanId {
+  private SpanId() {}
 
   private static final int SIZE = 8;
   private static final int BASE16_SIZE = 2 * SIZE;
   private static final long INVALID_ID = 0;
   public static final String INVALID = "0000000000000000";
-
-  // The internal representation of the SpanId.
-  private final long id;
-
-  /**
-   * Constructs a {@code SpanId} whose representation is specified by a long value.
-   *
-   * <p>There is no restriction on the specified value, other than the already established validity
-   * rules applying to {@code SpanId}. Specifying 0 for this value will effectively make the new
-   * {@code SpanId} invalid.
-   *
-   * <p>This is equivalent to calling {@link #fromBytes(byte[], int)} with the specified value
-   * stored as big-endian.
-   *
-   * @param id the long representation of the {@code TraceId}.
-   * @since 0.1.0
-   */
-  public SpanId(long id) {
-    this.id = id;
-  }
 
   /**
    * Returns the size in bytes of the {@code SpanId}.
@@ -71,7 +50,7 @@ public final class SpanId implements Comparable<SpanId> {
    * @return the invalid {@code SpanId}.
    * @since 0.1.0
    */
-  public static String getInvalid() {
+  public static CharSequence getInvalid() {
     return INVALID;
   }
 
@@ -81,54 +60,19 @@ public final class SpanId implements Comparable<SpanId> {
    * @param random The random number generator.
    * @return a valid new {@code SpanId}.
    */
-  static String generateRandomId(Random random) {
+  static CharSequence generateRandomId(Random random) {
     long id;
     do {
       id = random.nextLong();
     } while (id == INVALID_ID);
-    byte[] result = new byte[8];
-    BigendianEncoding.longToByteArray(id, result, 0);
-    return toLowerBase16(result);
+    return fromLong(id);
   }
 
-  /**
-   * Returns a {@code SpanId} whose representation is copied from the {@code src} beginning at the
-   * {@code srcOffset} offset.
-   *
-   * @param src the buffer where the representation of the {@code SpanId} is copied.
-   * @param srcOffset the offset in the buffer where the representation of the {@code SpanId}
-   *     begins.
-   * @return a {@code SpanId} whose representation is copied from the buffer.
-   * @throws NullPointerException if {@code src} is null.
-   * @throws IndexOutOfBoundsException if {@code srcOffset+SpanId.getSize()} is greater than {@code
-   *     src.length}.
-   * @since 0.1.0
-   */
-  public static SpanId fromBytes(byte[] src, int srcOffset) {
-    Utils.checkNotNull(src, "src");
-    return new SpanId(BigendianEncoding.longFromByteArray(src, srcOffset));
-  }
-
-  /** javadoc me. */
-  public static String fromLong(long id) {
-    byte[] result = new byte[8];
-    BigendianEncoding.longToByteArray(id, result, 0);
-    return toLowerBase16(result);
-  }
-
-  /**
-   * Copies the byte array representations of the {@code SpanId} into the {@code dest} beginning at
-   * the {@code destOffset} offset.
-   *
-   * @param dest the destination buffer.
-   * @param destOffset the starting offset in the destination buffer.
-   * @throws NullPointerException if {@code dest} is null.
-   * @throws IndexOutOfBoundsException if {@code destOffset+SpanId.getSize()} is greater than {@code
-   *     dest.length}.
-   * @since 0.1.0
-   */
-  public void copyBytesTo(byte[] dest, int destOffset) {
-    BigendianEncoding.longToByteArray(id, dest, destOffset);
+  /** Converts the long id value into a base-16 representation of it. */
+  public static CharSequence fromLong(long id) {
+    char[] chars = new char[BASE16_SIZE];
+    BigendianEncoding.longToBase16String(id, chars, 0);
+    return new String(chars);
   }
 
   /**
@@ -144,32 +88,7 @@ public final class SpanId implements Comparable<SpanId> {
    * @since 0.1.0
    */
   public static byte[] bytesFromLowerBase16(CharSequence src, int srcOffset) {
-    Utils.checkNotNull(src, "src");
-    byte[] result = new byte[8];
-    // todo: optimize me
-    long value = BigendianEncoding.longFromBase16String(src, srcOffset);
-    BigendianEncoding.longToByteArray(value, result, 0);
-    return result;
-  }
-
-  /**
-   * Copies the lowercase base16 representations of the {@code SpanId} into the {@code dest}
-   * beginning at the {@code destOffset} offset.
-   *
-   * @param dest the destination buffer.
-   * @param destOffset the starting offset in the destination buffer.
-   * @throws IndexOutOfBoundsException if {@code destOffset + 2 * SpanId.getSize()} is greater than
-   *     {@code dest.length}.
-   * @since 0.1.0
-   */
-  public void copyLowerBase16To(char[] dest, int destOffset) {
-    BigendianEncoding.longToBase16String(id, dest, destOffset);
-  }
-
-  /** javadoc me. */
-  public static void copyLowerBase16Into(byte[] spanId, char[] dest, int destOffset) {
-    BigendianEncoding.longToBase16String(
-        BigendianEncoding.longFromByteArray(spanId, 0), dest, destOffset);
+    return BigendianEncoding.bytesFromBase16(src, srcOffset, BASE16_SIZE);
   }
 
   /**
@@ -179,64 +98,14 @@ public final class SpanId implements Comparable<SpanId> {
    * @return {@code true} if the span identifier is valid.
    * @since 0.1.0
    */
-  public boolean isValid() {
-    return id != INVALID_ID;
-  }
-
-  /** javadoc me. */
-  public static boolean isValid(String spanId) {
+  public static boolean isValid(CharSequence spanId) {
     return (spanId.length() == BASE16_SIZE)
-        && !INVALID.equals(spanId)
+        && !INVALID.contentEquals(spanId)
         && BigendianEncoding.isValidBase16String(spanId);
   }
 
-  /**
-   * Returns the lowercase base16 encoding of this {@code SpanId}.
-   *
-   * @return the lowercase base16 encoding of this {@code SpanId}.
-   * @since 0.1.0
-   */
-  public String toLowerBase16() {
-    char[] chars = new char[BASE16_SIZE];
-    copyLowerBase16To(chars, 0);
-    return new String(chars);
-  }
-
-  /** javadoc me. */
-  public static String toLowerBase16(byte[] spanId) {
-    char[] chars = new char[BASE16_SIZE];
-    copyLowerBase16Into(spanId, chars, 0);
-    return new String(chars);
-  }
-
-  @Override
-  public boolean equals(@Nullable Object obj) {
-    if (obj == this) {
-      return true;
-    }
-
-    if (!(obj instanceof SpanId)) {
-      return false;
-    }
-
-    SpanId that = (SpanId) obj;
-    return id == that.id;
-  }
-
-  @Override
-  public int hashCode() {
-    // Copied from Long.hashCode in java8.
-    return (int) (id ^ (id >>> 32));
-  }
-
-  @Override
-  public String toString() {
-    return "SpanId{spanId=" + toLowerBase16() + "}";
-  }
-
-  @Override
-  public int compareTo(SpanId that) {
-    // Copied from Long.compare in java8.
-    return (id < that.id) ? -1 : ((id == that.id) ? 0 : 1);
+  /** Encode the bytes as base-16 (hex), padded with '0's on the left. */
+  public static CharSequence toLowerBase16(byte[] spanId) {
+    return BigendianEncoding.toLowerBase16(spanId);
   }
 }

--- a/api/src/main/java/io/opentelemetry/trace/SpanId.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanId.java
@@ -17,6 +17,7 @@
 package io.opentelemetry.trace;
 
 import io.opentelemetry.internal.Utils;
+import java.util.Arrays;
 import java.util.Random;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -33,7 +34,7 @@ public final class SpanId implements Comparable<SpanId> {
   private static final int SIZE = 8;
   private static final int BASE16_SIZE = 2 * SIZE;
   private static final long INVALID_ID = 0;
-  private static final SpanId INVALID = new SpanId(INVALID_ID);
+  private static final byte[] INVALID = new byte[8];
 
   // The internal representation of the SpanId.
   private final long id;
@@ -71,7 +72,7 @@ public final class SpanId implements Comparable<SpanId> {
    * @return the invalid {@code SpanId}.
    * @since 0.1.0
    */
-  public static SpanId getInvalid() {
+  public static byte[] getInvalid() {
     return INVALID;
   }
 
@@ -81,12 +82,14 @@ public final class SpanId implements Comparable<SpanId> {
    * @param random The random number generator.
    * @return a valid new {@code SpanId}.
    */
-  static SpanId generateRandomId(Random random) {
+  static byte[] generateRandomId(Random random) {
     long id;
     do {
       id = random.nextLong();
     } while (id == INVALID_ID);
-    return new SpanId(id);
+    byte[] result = new byte[8];
+    BigendianEncoding.longToByteArray(id, result, 0);
+    return result;
   }
 
   /**
@@ -105,6 +108,13 @@ public final class SpanId implements Comparable<SpanId> {
   public static SpanId fromBytes(byte[] src, int srcOffset) {
     Utils.checkNotNull(src, "src");
     return new SpanId(BigendianEncoding.longFromByteArray(src, srcOffset));
+  }
+
+  /** javadoc me. */
+  public static byte[] fromLong(long id) {
+    byte[] result = new byte[8];
+    BigendianEncoding.longToByteArray(id, result, 0);
+    return result;
   }
 
   /**
@@ -134,9 +144,13 @@ public final class SpanId implements Comparable<SpanId> {
    *     srcOffset}.
    * @since 0.1.0
    */
-  public static SpanId fromLowerBase16(CharSequence src, int srcOffset) {
+  public static byte[] bytesFromLowerBase16(CharSequence src, int srcOffset) {
     Utils.checkNotNull(src, "src");
-    return new SpanId(BigendianEncoding.longFromBase16String(src, srcOffset));
+    byte[] result = new byte[8];
+    // todo: optimize me
+    long value = BigendianEncoding.longFromBase16String(src, srcOffset);
+    BigendianEncoding.longToByteArray(value, result, 0);
+    return result;
   }
 
   /**
@@ -153,6 +167,12 @@ public final class SpanId implements Comparable<SpanId> {
     BigendianEncoding.longToBase16String(id, dest, destOffset);
   }
 
+  /** javadoc me. */
+  public static void copyLowerBase16Into(byte[] spanId, char[] dest, int destOffset) {
+    BigendianEncoding.longToBase16String(
+        BigendianEncoding.longFromByteArray(spanId, 0), dest, destOffset);
+  }
+
   /**
    * Returns whether the span identifier is valid. A valid span identifier is an 8-byte array with
    * at least one non-zero byte.
@@ -164,6 +184,11 @@ public final class SpanId implements Comparable<SpanId> {
     return id != INVALID_ID;
   }
 
+  /** javadoc me. */
+  public static boolean isValid(byte[] spanId) {
+    return (spanId.length == SpanId.getSize()) && !Arrays.equals(spanId, SpanId.getInvalid());
+  }
+
   /**
    * Returns the lowercase base16 encoding of this {@code SpanId}.
    *
@@ -173,6 +198,13 @@ public final class SpanId implements Comparable<SpanId> {
   public String toLowerBase16() {
     char[] chars = new char[BASE16_SIZE];
     copyLowerBase16To(chars, 0);
+    return new String(chars);
+  }
+
+  /** javadoc me. */
+  public static String toLowerBase16(byte[] spanId) {
+    char[] chars = new char[BASE16_SIZE];
+    copyLowerBase16Into(spanId, chars, 0);
     return new String(chars);
   }
 

--- a/api/src/main/java/io/opentelemetry/trace/SpanId.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanId.java
@@ -34,7 +34,6 @@ public final class SpanId implements Comparable<SpanId> {
   private static final int SIZE = 8;
   private static final int BASE16_SIZE = 2 * SIZE;
   private static final long INVALID_ID = 0;
-  private static final byte[] INVALID = new byte[8];
 
   // The internal representation of the SpanId.
   private final long id;
@@ -73,7 +72,7 @@ public final class SpanId implements Comparable<SpanId> {
    * @since 0.1.0
    */
   public static byte[] getInvalid() {
-    return INVALID;
+    return new byte[8];
   }
 
   /**

--- a/api/src/main/java/io/opentelemetry/trace/SpanId.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanId.java
@@ -27,6 +27,8 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public final class SpanId {
+  private static final ThreadLocal<char[]> charBuffer = new ThreadLocal<>();
+
   private SpanId() {}
 
   private static final int SIZE = 8;
@@ -70,9 +72,18 @@ public final class SpanId {
 
   /** Converts the long id value into a base-16 representation of it. */
   public static CharSequence fromLong(long id) {
-    char[] chars = new char[BASE16_SIZE];
+    char[] chars = getBuffer();
     BigendianEncoding.longToBase16String(id, chars, 0);
     return new String(chars);
+  }
+
+  private static char[] getBuffer() {
+    char[] chars = charBuffer.get();
+    if (chars == null) {
+      chars = new char[BASE16_SIZE];
+      charBuffer.set(chars);
+    }
+    return chars;
   }
 
   /**

--- a/api/src/main/java/io/opentelemetry/trace/SpanId.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanId.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.trace;
 
 import io.opentelemetry.internal.Utils;
-import java.util.Arrays;
 import java.util.Random;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -34,6 +33,7 @@ public final class SpanId implements Comparable<SpanId> {
   private static final int SIZE = 8;
   private static final int BASE16_SIZE = 2 * SIZE;
   private static final long INVALID_ID = 0;
+  public static final String INVALID = "0000000000000000";
 
   // The internal representation of the SpanId.
   private final long id;
@@ -71,8 +71,8 @@ public final class SpanId implements Comparable<SpanId> {
    * @return the invalid {@code SpanId}.
    * @since 0.1.0
    */
-  public static byte[] getInvalid() {
-    return new byte[8];
+  public static String getInvalid() {
+    return INVALID;
   }
 
   /**
@@ -81,14 +81,14 @@ public final class SpanId implements Comparable<SpanId> {
    * @param random The random number generator.
    * @return a valid new {@code SpanId}.
    */
-  static byte[] generateRandomId(Random random) {
+  static String generateRandomId(Random random) {
     long id;
     do {
       id = random.nextLong();
     } while (id == INVALID_ID);
     byte[] result = new byte[8];
     BigendianEncoding.longToByteArray(id, result, 0);
-    return result;
+    return toLowerBase16(result);
   }
 
   /**
@@ -110,10 +110,10 @@ public final class SpanId implements Comparable<SpanId> {
   }
 
   /** javadoc me. */
-  public static byte[] fromLong(long id) {
+  public static String fromLong(long id) {
     byte[] result = new byte[8];
     BigendianEncoding.longToByteArray(id, result, 0);
-    return result;
+    return toLowerBase16(result);
   }
 
   /**
@@ -184,8 +184,10 @@ public final class SpanId implements Comparable<SpanId> {
   }
 
   /** javadoc me. */
-  public static boolean isValid(byte[] spanId) {
-    return (spanId.length == SpanId.getSize()) && !Arrays.equals(spanId, SpanId.getInvalid());
+  public static boolean isValid(String spanId) {
+    return (spanId.length() == BASE16_SIZE)
+        && !INVALID.equals(spanId)
+        && BigendianEncoding.isValidBase16String(spanId);
   }
 
   /**

--- a/api/src/main/java/io/opentelemetry/trace/TraceId.java
+++ b/api/src/main/java/io/opentelemetry/trace/TraceId.java
@@ -34,7 +34,6 @@ public final class TraceId implements Comparable<TraceId> {
   private static final int SIZE = 16;
   private static final int BASE16_SIZE = 2 * BigendianEncoding.LONG_BASE16;
   private static final long INVALID_ID = 0;
-  private static final byte[] INVALID = new byte[16];
 
   // The internal representation of the TraceId.
   private final long idHi;
@@ -77,7 +76,7 @@ public final class TraceId implements Comparable<TraceId> {
    * @since 0.1.0
    */
   public static byte[] getInvalid() {
-    return INVALID;
+    return new byte[16];
   }
 
   /**

--- a/api/src/main/java/io/opentelemetry/trace/TraceId.java
+++ b/api/src/main/java/io/opentelemetry/trace/TraceId.java
@@ -18,46 +18,22 @@ package io.opentelemetry.trace;
 
 import io.opentelemetry.internal.Utils;
 import java.util.Random;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * A class that represents a trace identifier. A valid trace identifier is a 16-byte array with at
- * least one non-zero byte.
+ * Helper methods for dealing with a trace identifier. A valid trace identifier is a 16-byte array
+ * with at least one non-zero byte.
  *
  * @since 0.1.0
  */
 @Immutable
-public final class TraceId implements Comparable<TraceId> {
-
+public final class TraceId {
   private static final int SIZE_IN_BYTES = 16;
   private static final int BASE16_SIZE = 2 * BigendianEncoding.LONG_BASE16;
   private static final long INVALID_ID = 0;
   public static final String INVALID = "00000000000000000000000000000000";
 
-  // The internal representation of the TraceId.
-  private final long idHi;
-  private final long idLo;
-
-  /**
-   * Constructs a {@code TraceId} whose representation is specified by two long values representing
-   * the lower and higher parts.
-   *
-   * <p>There is no restriction on the specified values, other than the already established validity
-   * rules applying to {@code TraceId}. Specifying 0 for both values will effectively make the new
-   * {@code TraceId} invalid.
-   *
-   * <p>This is equivalent to calling {@link #fromBytes(byte[], int)} with the specified values
-   * stored as big-endian.
-   *
-   * @param idHi the higher part of the {@code TraceId}.
-   * @param idLo the lower part of the {@code TraceId}.
-   * @since 0.1.0
-   */
-  public TraceId(long idHi, long idLo) {
-    this.idHi = idHi;
-    this.idLo = idLo;
-  }
+  private TraceId() {}
 
   /**
    * Returns the size in bytes of the {@code TraceId}.
@@ -75,7 +51,7 @@ public final class TraceId implements Comparable<TraceId> {
    * @return the invalid {@code TraceId}.
    * @since 0.1.0
    */
-  public static String getInvalid() {
+  public static CharSequence getInvalid() {
     return INVALID;
   }
 
@@ -85,7 +61,7 @@ public final class TraceId implements Comparable<TraceId> {
    * @param random the random number generator.
    * @return a new valid {@code TraceId}.
    */
-  static String generateRandomId(Random random) {
+  static CharSequence generateRandomId(Random random) {
     long idHi;
     long idLo;
     do {
@@ -100,47 +76,25 @@ public final class TraceId implements Comparable<TraceId> {
   }
 
   /**
-   * Returns a {@code TraceId} whose representation is copied from the {@code src} beginning at the
-   * {@code srcOffset} offset.
+   * Constructs a {@code TraceId} whose representation is specified by two long values representing
+   * the lower and higher parts.
    *
-   * @param src the buffer where the representation of the {@code TraceId} is copied.
-   * @param srcOffset the offset in the buffer where the representation of the {@code TraceId}
-   *     begins.
-   * @return a {@code TraceId} whose representation is copied from the buffer.
-   * @throws NullPointerException if {@code src} is null.
-   * @throws IndexOutOfBoundsException if {@code srcOffset+TraceId.getSize()} is greater than {@code
-   *     src.length}.
+   * <p>There is no restriction on the specified values, other than the already established validity
+   * rules applying to {@code TraceId}. Specifying 0 for both values will effectively make the new
+   * {@code TraceId} invalid.
+   *
+   * <p>This is equivalent to calling {@link #toLowerBase16(byte[])} with the specified values
+   * stored as big-endian.
+   *
+   * @param idHi the higher part of the {@code TraceId}.
+   * @param idLo the lower part of the {@code TraceId}.
    * @since 0.1.0
    */
-  public static TraceId fromBytes(byte[] src, int srcOffset) {
-    Utils.checkNotNull(src, "src");
-    return new TraceId(
-        BigendianEncoding.longFromByteArray(src, srcOffset),
-        BigendianEncoding.longFromByteArray(src, srcOffset + BigendianEncoding.LONG_BYTES));
-  }
-
-  /** javadoc me. */
-  public static String fromLongs(long idHi, long idLo) {
-    byte[] result = new byte[16];
-    BigendianEncoding.longToByteArray(idHi, result, 0);
-    BigendianEncoding.longToByteArray(idLo, result, 8);
-    return toLowerBase16(result);
-  }
-
-  /**
-   * Copies the byte array representations of the {@code TraceId} into the {@code dest} beginning at
-   * the {@code destOffset} offset.
-   *
-   * @param dest the destination buffer.
-   * @param destOffset the starting offset in the destination buffer.
-   * @throws NullPointerException if {@code dest} is null.
-   * @throws IndexOutOfBoundsException if {@code destOffset+TraceId.getSize()} is greater than
-   *     {@code dest.length}.
-   * @since 0.1.0
-   */
-  public void copyBytesTo(byte[] dest, int destOffset) {
-    BigendianEncoding.longToByteArray(idHi, dest, destOffset);
-    BigendianEncoding.longToByteArray(idLo, dest, destOffset + BigendianEncoding.LONG_BYTES);
+  public static CharSequence fromLongs(long idHi, long idLo) {
+    char[] chars = new char[BASE16_SIZE];
+    BigendianEncoding.longToBase16String(idHi, chars, 0);
+    BigendianEncoding.longToBase16String(idLo, chars, 16);
+    return new String(chars);
   }
 
   /**
@@ -155,26 +109,9 @@ public final class TraceId implements Comparable<TraceId> {
    *     srcOffset}.
    * @since 0.1.0
    */
-  public static TraceId fromLowerBase16(CharSequence src, int srcOffset) {
-    Utils.checkNotNull(src, "src");
-    return new TraceId(
-        BigendianEncoding.longFromBase16String(src, srcOffset),
-        BigendianEncoding.longFromBase16String(src, srcOffset + BigendianEncoding.LONG_BASE16));
-  }
-
-  /** javadoc me. */
   public static byte[] bytesFromLowerBase16(CharSequence src, int srcOffset) {
     Utils.checkNotNull(src, "src");
-    byte[] result = new byte[16];
-
-    // todo: optimize me
-    long hi = BigendianEncoding.longFromBase16String(src, srcOffset);
-    long lo =
-        BigendianEncoding.longFromBase16String(src, srcOffset + BigendianEncoding.LONG_BASE16);
-
-    BigendianEncoding.longToByteArray(hi, result, 0);
-    BigendianEncoding.longToByteArray(lo, result, 8);
-    return result;
+    return BigendianEncoding.bytesFromBase16(src, srcOffset, BASE16_SIZE);
   }
 
   /**
@@ -187,12 +124,6 @@ public final class TraceId implements Comparable<TraceId> {
    *     {@code dest.length}.
    * @since 0.1.0
    */
-  public void copyLowerBase16To(char[] dest, int destOffset) {
-    BigendianEncoding.longToBase16String(idHi, dest, destOffset);
-    BigendianEncoding.longToBase16String(idLo, dest, destOffset + BASE16_SIZE / 2);
-  }
-
-  /** javadoc me. */
   public static void copyLowerBase16Into(byte[] traceId, char[] dest, int destOffset) {
     BigendianEncoding.longToBase16String(
         BigendianEncoding.longFromByteArray(traceId, 0), dest, destOffset);
@@ -207,14 +138,9 @@ public final class TraceId implements Comparable<TraceId> {
    * @return {@code true} if the {@code TraceId} is valid.
    * @since 0.1.0
    */
-  public boolean isValid() {
-    return idHi != INVALID_ID || idLo != INVALID_ID;
-  }
-
-  /** javadoc me. */
-  public static boolean isValid(String traceId) {
+  public static boolean isValid(CharSequence traceId) {
     return (traceId.length() == BASE16_SIZE)
-        && !traceId.equals(INVALID)
+        && !INVALID.contentEquals(traceId)
         && BigendianEncoding.isValidBase16String(traceId);
   }
 
@@ -224,31 +150,10 @@ public final class TraceId implements Comparable<TraceId> {
    * @return the lowercase base16 encoding of this {@code TraceId}.
    * @since 0.1.0
    */
-  public String toLowerBase16() {
-    char[] chars = new char[BASE16_SIZE];
-    copyLowerBase16To(chars, 0);
-    return new String(chars);
-  }
-
-  /** javadoc me. */
-  public static String toLowerBase16(byte[] traceId) {
+  public static CharSequence toLowerBase16(byte[] traceId) {
     char[] chars = new char[BASE16_SIZE];
     copyLowerBase16Into(traceId, chars, 0);
     return new String(chars);
-  }
-
-  @Override
-  public boolean equals(@Nullable Object obj) {
-    if (obj == this) {
-      return true;
-    }
-
-    if (!(obj instanceof TraceId)) {
-      return false;
-    }
-
-    TraceId that = (TraceId) obj;
-    return idHi == that.idHi && idLo == that.idLo;
   }
 
   /**
@@ -259,37 +164,7 @@ public final class TraceId implements Comparable<TraceId> {
    *
    * @return the rightmost 8 bytes of the trace-id as a long value.
    */
-  public long getTraceRandomPart() {
-    return idLo;
-  }
-
-  public static long getTraceIdRandomPart(String traceId) {
-    byte[] bytes = bytesFromLowerBase16(traceId, 0);
-    return BigendianEncoding.longFromByteArray(bytes, 8);
-  }
-
-  @Override
-  public int hashCode() {
-    // Copied from Arrays.hashCode(long[])
-    int result = 1;
-    result = 31 * result + ((int) (idHi ^ (idHi >>> 32)));
-    result = 31 * result + ((int) (idLo ^ (idLo >>> 32)));
-    return result;
-  }
-
-  @Override
-  public String toString() {
-    return "TraceId{traceId=" + toLowerBase16() + "}";
-  }
-
-  @Override
-  public int compareTo(TraceId that) {
-    if (idHi == that.idHi) {
-      if (idLo == that.idLo) {
-        return 0;
-      }
-      return idLo < that.idLo ? -1 : 1;
-    }
-    return idHi < that.idHi ? -1 : 1;
+  public static long getTraceIdRandomPart(CharSequence traceId) {
+    return BigendianEncoding.longFromBase16String(traceId, BigendianEncoding.LONG_BASE16);
   }
 }

--- a/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
@@ -94,12 +94,12 @@ public class HttpTraceContext implements HttpTextFormat {
     chars[0] = VERSION.charAt(0);
     chars[1] = VERSION.charAt(1);
     chars[2] = TRACEPARENT_DELIMITER;
-    byte[] traceId = spanContext.getTraceId();
+    byte[] traceId = spanContext.traceId();
     TraceId.copyLowerBase16Into(traceId, chars, TRACE_ID_OFFSET);
 
     chars[SPAN_ID_OFFSET - 1] = TRACEPARENT_DELIMITER;
 
-    byte[] spanId = spanContext.getSpanId();
+    byte[] spanId = spanContext.spanId();
     SpanId.copyLowerBase16Into(spanId, chars, SPAN_ID_OFFSET);
     chars[TRACE_OPTION_OFFSET - 1] = TRACEPARENT_DELIMITER;
     spanContext.getTraceFlags().copyLowerBase16To(chars, TRACE_OPTION_OFFSET);
@@ -156,8 +156,8 @@ public class HttpTraceContext implements HttpTextFormat {
     try {
       TraceState traceState = extractTraceState(traceStateHeader);
       return SpanContext.createFromRemoteParent(
-          contextFromParentHeader.getTraceId(),
-          contextFromParentHeader.getSpanId(),
+          contextFromParentHeader.traceId(),
+          contextFromParentHeader.spanId(),
           contextFromParentHeader.getTraceFlags(),
           traceState);
     } catch (IllegalArgumentException e) {

--- a/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
@@ -95,14 +95,14 @@ public class HttpTraceContext implements HttpTextFormat {
     chars[1] = VERSION.charAt(1);
     chars[2] = TRACEPARENT_DELIMITER;
 
-    CharSequence traceId = spanContext.getTraceId();
+    CharSequence traceId = spanContext.getTraceIdAsBase16();
     for (int i = 0; i < traceId.length(); i++) {
       chars[TRACE_ID_OFFSET + i] = traceId.charAt(i);
     }
 
     chars[SPAN_ID_OFFSET - 1] = TRACEPARENT_DELIMITER;
 
-    CharSequence spanId = spanContext.getSpanId();
+    CharSequence spanId = spanContext.getSpanIdAsBase16();
     for (int i = 0; i < spanId.length(); i++) {
       chars[SPAN_ID_OFFSET + i] = spanId.charAt(i);
     }
@@ -162,8 +162,8 @@ public class HttpTraceContext implements HttpTextFormat {
     try {
       TraceState traceState = extractTraceState(traceStateHeader);
       return SpanContext.createFromRemoteParent(
-          contextFromParentHeader.getTraceId(),
-          contextFromParentHeader.getSpanId(),
+          contextFromParentHeader.getTraceIdAsBase16(),
+          contextFromParentHeader.getSpanIdAsBase16(),
           contextFromParentHeader.getTraceFlags(),
           traceState);
     } catch (IllegalArgumentException e) {

--- a/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
@@ -94,15 +94,17 @@ public class HttpTraceContext implements HttpTextFormat {
     chars[0] = VERSION.charAt(0);
     chars[1] = VERSION.charAt(1);
     chars[2] = TRACEPARENT_DELIMITER;
-    String traceId = spanContext.traceId();
+    String traceId = (String) spanContext.getTraceId();
 
     System.arraycopy(traceId.toCharArray(), 0, chars, TRACE_ID_OFFSET, TraceId.getSize() * 2);
 
     chars[SPAN_ID_OFFSET - 1] = TRACEPARENT_DELIMITER;
 
-    String spanId = spanContext.spanId();
-
-    System.arraycopy(spanId.toCharArray(), 0, chars, SPAN_ID_OFFSET, SpanId.getSize() * 2);
+    CharSequence spanId = spanContext.getSpanId();
+    for (int i = 0; i < spanId.length(); i++) {
+      chars[SPAN_ID_OFFSET + i] = spanId.charAt(i);
+    }
+    //    System.arraycopy(spanId.toCharArray(), 0, chars, SPAN_ID_OFFSET, SpanId.getSize() * 2);
     chars[TRACE_OPTION_OFFSET - 1] = TRACEPARENT_DELIMITER;
     spanContext.getTraceFlags().copyLowerBase16To(chars, TRACE_OPTION_OFFSET);
     setter.set(carrier, TRACE_PARENT, new String(chars, 0, TRACEPARENT_HEADER_SIZE));
@@ -158,8 +160,8 @@ public class HttpTraceContext implements HttpTextFormat {
     try {
       TraceState traceState = extractTraceState(traceStateHeader);
       return SpanContext.createFromRemoteParent(
-          contextFromParentHeader.traceId(),
-          contextFromParentHeader.spanId(),
+          contextFromParentHeader.getTraceId(),
+          contextFromParentHeader.getSpanId(),
           contextFromParentHeader.getTraceFlags(),
           traceState);
     } catch (IllegalArgumentException e) {

--- a/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
@@ -94,9 +94,13 @@ public class HttpTraceContext implements HttpTextFormat {
     chars[0] = VERSION.charAt(0);
     chars[1] = VERSION.charAt(1);
     chars[2] = TRACEPARENT_DELIMITER;
-    spanContext.getTraceId().copyLowerBase16To(chars, TRACE_ID_OFFSET);
+    byte[] traceId = spanContext.getTraceId();
+    TraceId.copyLowerBase16Into(traceId, chars, TRACE_ID_OFFSET);
+
     chars[SPAN_ID_OFFSET - 1] = TRACEPARENT_DELIMITER;
-    spanContext.getSpanId().copyLowerBase16To(chars, SPAN_ID_OFFSET);
+
+    byte[] spanId = spanContext.getSpanId();
+    SpanId.copyLowerBase16Into(spanId, chars, SPAN_ID_OFFSET);
     chars[TRACE_OPTION_OFFSET - 1] = TRACEPARENT_DELIMITER;
     spanContext.getTraceFlags().copyLowerBase16To(chars, TRACE_OPTION_OFFSET);
     setter.set(carrier, TRACE_PARENT, new String(chars, 0, TRACEPARENT_HEADER_SIZE));
@@ -178,8 +182,8 @@ public class HttpTraceContext implements HttpTextFormat {
     }
 
     try {
-      TraceId traceId = TraceId.fromLowerBase16(traceparent, TRACE_ID_OFFSET);
-      SpanId spanId = SpanId.fromLowerBase16(traceparent, SPAN_ID_OFFSET);
+      byte[] traceId = TraceId.bytesFromLowerBase16(traceparent, TRACE_ID_OFFSET);
+      byte[] spanId = SpanId.bytesFromLowerBase16(traceparent, SPAN_ID_OFFSET);
       TraceFlags traceFlags = TraceFlags.fromLowerBase16(traceparent, TRACE_OPTION_OFFSET);
       return SpanContext.createFromRemoteParent(traceId, spanId, traceFlags, TRACE_STATE_DEFAULT);
     } catch (IllegalArgumentException e) {

--- a/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
@@ -94,9 +94,11 @@ public class HttpTraceContext implements HttpTextFormat {
     chars[0] = VERSION.charAt(0);
     chars[1] = VERSION.charAt(1);
     chars[2] = TRACEPARENT_DELIMITER;
-    String traceId = (String) spanContext.getTraceId();
 
-    System.arraycopy(traceId.toCharArray(), 0, chars, TRACE_ID_OFFSET, TraceId.getSize() * 2);
+    CharSequence traceId = spanContext.getTraceId();
+    for (int i = 0; i < traceId.length(); i++) {
+      chars[TRACE_ID_OFFSET + i] = traceId.charAt(i);
+    }
 
     chars[SPAN_ID_OFFSET - 1] = TRACEPARENT_DELIMITER;
 
@@ -104,7 +106,7 @@ public class HttpTraceContext implements HttpTextFormat {
     for (int i = 0; i < spanId.length(); i++) {
       chars[SPAN_ID_OFFSET + i] = spanId.charAt(i);
     }
-    //    System.arraycopy(spanId.toCharArray(), 0, chars, SPAN_ID_OFFSET, SpanId.getSize() * 2);
+
     chars[TRACE_OPTION_OFFSET - 1] = TRACEPARENT_DELIMITER;
     spanContext.getTraceFlags().copyLowerBase16To(chars, TRACE_OPTION_OFFSET);
     setter.set(carrier, TRACE_PARENT, new String(chars, 0, TRACEPARENT_HEADER_SIZE));

--- a/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.grpc.Context;
 import io.opentelemetry.context.ContextUtils;
 import io.opentelemetry.context.Scope;
-import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link DefaultTracer}. */
@@ -37,8 +36,8 @@ class DefaultTracerTest {
   private static final byte[] spanBytes = new byte[] {0, 0, 0, 0, 0, 0, 0, 'a'};
   private static final SpanContext spanContext =
       SpanContext.create(
-          new String(firstBytes, StandardCharsets.US_ASCII),
-          new String(spanBytes, StandardCharsets.US_ASCII),
+          TraceId.toLowerBase16(firstBytes),
+          SpanId.toLowerBase16(spanBytes),
           TraceFlags.getDefault(),
           TraceState.getDefault());
 

--- a/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.grpc.Context;
 import io.opentelemetry.context.ContextUtils;
 import io.opentelemetry.context.Scope;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link DefaultTracer}. */
@@ -35,7 +36,11 @@ class DefaultTracerTest {
       new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'a'};
   private static final byte[] spanBytes = new byte[] {0, 0, 0, 0, 0, 0, 0, 'a'};
   private static final SpanContext spanContext =
-      SpanContext.create(firstBytes, spanBytes, TraceFlags.getDefault(), TraceState.getDefault());
+      SpanContext.create(
+          new String(firstBytes, StandardCharsets.US_ASCII),
+          new String(spanBytes, StandardCharsets.US_ASCII),
+          TraceFlags.getDefault(),
+          TraceState.getDefault());
 
   @Test
   void defaultGetCurrentSpan() {

--- a/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
@@ -33,12 +33,9 @@ class DefaultTracerTest {
   private static final String SPAN_NAME = "MySpanName";
   private static final byte[] firstBytes =
       new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'a'};
+  private static final byte[] spanBytes = new byte[] {0, 0, 0, 0, 0, 0, 0, 'a'};
   private static final SpanContext spanContext =
-      SpanContext.create(
-          TraceId.fromBytes(firstBytes, 0),
-          SpanId.fromBytes(firstBytes, 8),
-          TraceFlags.getDefault(),
-          TraceState.getDefault());
+      SpanContext.create(firstBytes, spanBytes, TraceFlags.getDefault(), TraceState.getDefault());
 
   @Test
   void defaultGetCurrentSpan() {

--- a/api/src/test/java/io/opentelemetry/trace/SpanContextTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanContextTest.java
@@ -24,15 +24,15 @@ import org.junit.jupiter.api.Test;
 class SpanContextTest {
   private static final byte[] firstTraceIdBytes =
       new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'a'};
-  private static final String FIRST_TRACE_ID = TraceId.toLowerBase16(firstTraceIdBytes);
+  private static final CharSequence FIRST_TRACE_ID = TraceId.toLowerBase16(firstTraceIdBytes);
   private static final byte[] secondTraceIdBytes =
       new byte[] {0, 0, 0, 0, 0, 0, 0, '0', 0, 0, 0, 0, 0, 0, 0, 0};
-  private static final String SECOND_TRACE_ID = TraceId.toLowerBase16(secondTraceIdBytes);
+  private static final CharSequence SECOND_TRACE_ID = TraceId.toLowerBase16(secondTraceIdBytes);
 
   private static final byte[] firstSpanIdBytes = new byte[] {0, 0, 0, 0, 0, 0, 0, 'a'};
-  private static final String FIRST_SPAN_ID = SpanId.toLowerBase16(firstSpanIdBytes);
+  private static final CharSequence FIRST_SPAN_ID = SpanId.toLowerBase16(firstSpanIdBytes);
   private static final byte[] secondSpanIdBytes = new byte[] {'0', 0, 0, 0, 0, 0, 0, 0};
-  private static final String SECOND_SPAN_ID = SpanId.toLowerBase16(secondSpanIdBytes);
+  private static final CharSequence SECOND_SPAN_ID = SpanId.toLowerBase16(secondSpanIdBytes);
   private static final TraceState FIRST_TRACE_STATE =
       TraceState.builder().set("foo", "bar").build();
   private static final TraceState SECOND_TRACE_STATE =
@@ -55,8 +55,10 @@ class SpanContextTest {
 
   @Test
   void invalidSpanContext() {
-    assertThat(SpanContext.getInvalid().getTraceId()).isEqualTo(TraceId.getInvalid());
-    assertThat(SpanContext.getInvalid().getSpanId()).isEqualTo(SpanId.getInvalid());
+    assertThat(SpanContext.getInvalid().getTraceId().toString())
+        .isEqualTo(TraceId.getInvalid().toString());
+    assertThat(SpanContext.getInvalid().getSpanId().toString())
+        .isEqualTo(SpanId.getInvalid().toString());
     assertThat(SpanContext.getInvalid().getTraceFlags()).isEqualTo(TraceFlags.getDefault());
   }
 
@@ -79,14 +81,14 @@ class SpanContextTest {
 
   @Test
   void getTraceId() {
-    assertThat(first.getTraceId()).isEqualTo(FIRST_TRACE_ID);
-    assertThat(second.getTraceId()).isEqualTo(SECOND_TRACE_ID);
+    assertThat(first.getTraceId().toString()).isEqualTo(FIRST_TRACE_ID.toString());
+    assertThat(second.getTraceId().toString()).isEqualTo(SECOND_TRACE_ID.toString());
   }
 
   @Test
   void getSpanId() {
-    assertThat(first.getSpanId()).isEqualTo(FIRST_SPAN_ID);
-    assertThat(second.getSpanId()).isEqualTo(SECOND_SPAN_ID);
+    assertThat(first.getSpanId().toString()).isEqualTo(FIRST_SPAN_ID.toString());
+    assertThat(second.getSpanId().toString()).isEqualTo(SECOND_SPAN_ID.toString());
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/trace/SpanContextTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanContextTest.java
@@ -55,9 +55,9 @@ class SpanContextTest {
 
   @Test
   void invalidSpanContext() {
-    assertThat(SpanContext.getInvalid().getTraceId().toString())
+    assertThat(SpanContext.getInvalid().getTraceIdAsBase16().toString())
         .isEqualTo(TraceId.getInvalid().toString());
-    assertThat(SpanContext.getInvalid().getSpanId().toString())
+    assertThat(SpanContext.getInvalid().getSpanIdAsBase16().toString())
         .isEqualTo(SpanId.getInvalid().toString());
     assertThat(SpanContext.getInvalid().getTraceFlags()).isEqualTo(TraceFlags.getDefault());
   }
@@ -81,14 +81,14 @@ class SpanContextTest {
 
   @Test
   void getTraceId() {
-    assertThat(first.getTraceId().toString()).isEqualTo(FIRST_TRACE_ID.toString());
-    assertThat(second.getTraceId().toString()).isEqualTo(SECOND_TRACE_ID.toString());
+    assertThat(first.getTraceIdAsBase16().toString()).isEqualTo(FIRST_TRACE_ID.toString());
+    assertThat(second.getTraceIdAsBase16().toString()).isEqualTo(SECOND_TRACE_ID.toString());
   }
 
   @Test
   void getSpanId() {
-    assertThat(first.getSpanId().toString()).isEqualTo(FIRST_SPAN_ID.toString());
-    assertThat(second.getSpanId().toString()).isEqualTo(SECOND_SPAN_ID.toString());
+    assertThat(first.getSpanIdAsBase16().toString()).isEqualTo(FIRST_SPAN_ID.toString());
+    assertThat(second.getSpanIdAsBase16().toString()).isEqualTo(SECOND_SPAN_ID.toString());
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/trace/SpanContextTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanContextTest.java
@@ -35,20 +35,17 @@ class SpanContextTest {
   private static final TraceState EMPTY_TRACE_STATE = TraceState.builder().build();
   private static final SpanContext first =
       SpanContext.create(
-          TraceId.fromBytes(firstTraceIdBytes, 0),
-          SpanId.fromBytes(firstSpanIdBytes, 0),
-          TraceFlags.getDefault(),
-          FIRST_TRACE_STATE);
+          firstTraceIdBytes, firstSpanIdBytes, TraceFlags.getDefault(), FIRST_TRACE_STATE);
   private static final SpanContext second =
       SpanContext.create(
-          TraceId.fromBytes(secondTraceIdBytes, 0),
-          SpanId.fromBytes(secondSpanIdBytes, 0),
+          secondTraceIdBytes,
+          secondSpanIdBytes,
           TraceFlags.builder().setIsSampled(true).build(),
           SECOND_TRACE_STATE);
   private static final SpanContext remote =
       SpanContext.createFromRemoteParent(
-          TraceId.fromBytes(secondTraceIdBytes, 0),
-          SpanId.fromBytes(secondSpanIdBytes, 0),
+          secondTraceIdBytes,
+          secondSpanIdBytes,
           TraceFlags.builder().setIsSampled(true).build(),
           EMPTY_TRACE_STATE);
 
@@ -64,7 +61,7 @@ class SpanContextTest {
     assertThat(SpanContext.getInvalid().isValid()).isFalse();
     assertThat(
             SpanContext.create(
-                    TraceId.fromBytes(firstTraceIdBytes, 0),
+                    firstTraceIdBytes,
                     SpanId.getInvalid(),
                     TraceFlags.getDefault(),
                     EMPTY_TRACE_STATE)
@@ -73,7 +70,7 @@ class SpanContextTest {
     assertThat(
             SpanContext.create(
                     TraceId.getInvalid(),
-                    SpanId.fromBytes(firstSpanIdBytes, 0),
+                    firstSpanIdBytes,
                     TraceFlags.getDefault(),
                     EMPTY_TRACE_STATE)
                 .isValid())
@@ -84,14 +81,14 @@ class SpanContextTest {
 
   @Test
   void getTraceId() {
-    assertThat(first.getTraceId()).isEqualTo(TraceId.fromBytes(firstTraceIdBytes, 0));
-    assertThat(second.getTraceId()).isEqualTo(TraceId.fromBytes(secondTraceIdBytes, 0));
+    assertThat(first.getTraceId()).isEqualTo(firstTraceIdBytes);
+    assertThat(second.getTraceId()).isEqualTo(secondTraceIdBytes);
   }
 
   @Test
   void getSpanId() {
-    assertThat(first.getSpanId()).isEqualTo(SpanId.fromBytes(firstSpanIdBytes, 0));
-    assertThat(second.getSpanId()).isEqualTo(SpanId.fromBytes(secondSpanIdBytes, 0));
+    assertThat(first.getSpanId()).isEqualTo(firstSpanIdBytes);
+    assertThat(second.getSpanId()).isEqualTo(secondSpanIdBytes);
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/trace/SpanContextTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanContextTest.java
@@ -24,28 +24,32 @@ import org.junit.jupiter.api.Test;
 class SpanContextTest {
   private static final byte[] firstTraceIdBytes =
       new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'a'};
+  private static final String FIRST_TRACE_ID = TraceId.toLowerBase16(firstTraceIdBytes);
   private static final byte[] secondTraceIdBytes =
       new byte[] {0, 0, 0, 0, 0, 0, 0, '0', 0, 0, 0, 0, 0, 0, 0, 0};
+  private static final String SECOND_TRACE_ID = TraceId.toLowerBase16(secondTraceIdBytes);
+
   private static final byte[] firstSpanIdBytes = new byte[] {0, 0, 0, 0, 0, 0, 0, 'a'};
+  private static final String FIRST_SPAN_ID = SpanId.toLowerBase16(firstSpanIdBytes);
   private static final byte[] secondSpanIdBytes = new byte[] {'0', 0, 0, 0, 0, 0, 0, 0};
+  private static final String SECOND_SPAN_ID = SpanId.toLowerBase16(secondSpanIdBytes);
   private static final TraceState FIRST_TRACE_STATE =
       TraceState.builder().set("foo", "bar").build();
   private static final TraceState SECOND_TRACE_STATE =
       TraceState.builder().set("foo", "baz").build();
   private static final TraceState EMPTY_TRACE_STATE = TraceState.builder().build();
   private static final SpanContext first =
-      SpanContext.create(
-          firstTraceIdBytes, firstSpanIdBytes, TraceFlags.getDefault(), FIRST_TRACE_STATE);
+      SpanContext.create(FIRST_TRACE_ID, FIRST_SPAN_ID, TraceFlags.getDefault(), FIRST_TRACE_STATE);
   private static final SpanContext second =
       SpanContext.create(
-          secondTraceIdBytes,
-          secondSpanIdBytes,
+          SECOND_TRACE_ID,
+          SECOND_SPAN_ID,
           TraceFlags.builder().setIsSampled(true).build(),
           SECOND_TRACE_STATE);
   private static final SpanContext remote =
       SpanContext.createFromRemoteParent(
-          secondTraceIdBytes,
-          secondSpanIdBytes,
+          SECOND_TRACE_ID,
+          SECOND_SPAN_ID,
           TraceFlags.builder().setIsSampled(true).build(),
           EMPTY_TRACE_STATE);
 
@@ -61,18 +65,12 @@ class SpanContextTest {
     assertThat(SpanContext.getInvalid().isValid()).isFalse();
     assertThat(
             SpanContext.create(
-                    firstTraceIdBytes,
-                    SpanId.getInvalid(),
-                    TraceFlags.getDefault(),
-                    EMPTY_TRACE_STATE)
+                    FIRST_TRACE_ID, SpanId.getInvalid(), TraceFlags.getDefault(), EMPTY_TRACE_STATE)
                 .isValid())
         .isFalse();
     assertThat(
             SpanContext.create(
-                    TraceId.getInvalid(),
-                    firstSpanIdBytes,
-                    TraceFlags.getDefault(),
-                    EMPTY_TRACE_STATE)
+                    TraceId.getInvalid(), FIRST_SPAN_ID, TraceFlags.getDefault(), EMPTY_TRACE_STATE)
                 .isValid())
         .isFalse();
     assertThat(first.isValid()).isTrue();
@@ -81,14 +79,14 @@ class SpanContextTest {
 
   @Test
   void getTraceId() {
-    assertThat(first.getTraceId()).isEqualTo(firstTraceIdBytes);
-    assertThat(second.getTraceId()).isEqualTo(secondTraceIdBytes);
+    assertThat(first.getTraceId()).isEqualTo(FIRST_TRACE_ID);
+    assertThat(second.getTraceId()).isEqualTo(SECOND_TRACE_ID);
   }
 
   @Test
   void getSpanId() {
-    assertThat(first.getSpanId()).isEqualTo(firstSpanIdBytes);
-    assertThat(second.getSpanId()).isEqualTo(secondSpanIdBytes);
+    assertThat(first.getSpanId()).isEqualTo(FIRST_SPAN_ID);
+    assertThat(second.getSpanId()).isEqualTo(SECOND_SPAN_ID);
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/trace/SpanIdTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanIdTest.java
@@ -33,20 +33,22 @@ class SpanIdTest {
   @Test
   void isValid() {
     assertThat(SpanId.isValid(SpanId.getInvalid())).isFalse();
-    assertThat(SpanId.isValid(firstBytes)).isTrue();
-    assertThat(SpanId.isValid(secondBytes)).isTrue();
+    assertThat(SpanId.isValid(SpanId.toLowerBase16(firstBytes))).isTrue();
+    assertThat(SpanId.isValid(SpanId.toLowerBase16(secondBytes))).isTrue();
+    assertThat(SpanId.isValid("000000000000z000")).isFalse();
   }
 
   @Test
   void fromLowerBase16() {
-    assertThat(SpanId.bytesFromLowerBase16("0000000000000000", 0)).isEqualTo(SpanId.getInvalid());
+    assertThat(SpanId.toLowerBase16(SpanId.bytesFromLowerBase16("0000000000000000", 0)))
+        .isEqualTo(SpanId.getInvalid());
     assertThat(SpanId.bytesFromLowerBase16("0000000000000061", 0)).isEqualTo(firstBytes);
     assertThat(SpanId.bytesFromLowerBase16("ff00000000000041", 0)).isEqualTo(secondBytes);
   }
 
   @Test
   void fromLowerBase16_WithOffset() {
-    assertThat(SpanId.bytesFromLowerBase16("XX0000000000000000AA", 2))
+    assertThat(SpanId.toLowerBase16(SpanId.bytesFromLowerBase16("XX0000000000000000AA", 2)))
         .isEqualTo(SpanId.getInvalid());
     assertThat(SpanId.bytesFromLowerBase16("YY0000000000000061BB", 2)).isEqualTo(firstBytes);
     assertThat(SpanId.bytesFromLowerBase16("ZZff00000000000041CC", 2)).isEqualTo(secondBytes);
@@ -54,7 +56,7 @@ class SpanIdTest {
 
   @Test
   void toLowerBase16() {
-    assertThat(SpanId.toLowerBase16(SpanId.getInvalid())).isEqualTo("0000000000000000");
+    assertThat(SpanId.getInvalid()).isEqualTo("0000000000000000");
     assertThat(SpanId.toLowerBase16(firstBytes)).isEqualTo("0000000000000061");
     assertThat(SpanId.toLowerBase16(secondBytes)).isEqualTo("ff00000000000041");
   }
@@ -78,7 +80,7 @@ class SpanIdTest {
 
   @Test
   void spanId_ToString() {
-    assertThat(SpanId.toLowerBase16(SpanId.getInvalid())).contains("0000000000000000");
+    assertThat(SpanId.getInvalid()).contains("0000000000000000");
     assertThat(SpanId.toLowerBase16(firstBytes)).contains("0000000000000061");
     assertThat(SpanId.toLowerBase16(secondBytes)).contains("ff00000000000041");
   }

--- a/api/src/test/java/io/opentelemetry/trace/SpanIdTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanIdTest.java
@@ -18,17 +18,12 @@ package io.opentelemetry.trace;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.testing.EqualsTester;
-import java.nio.ByteBuffer;
-import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link SpanId}. */
 class SpanIdTest {
   private static final byte[] firstBytes = new byte[] {0, 0, 0, 0, 0, 0, 0, 'a'};
   private static final byte[] secondBytes = new byte[] {(byte) 0xFF, 0, 0, 0, 0, 0, 0, 'A'};
-  private static final SpanId first = new SpanId(ByteBuffer.wrap(firstBytes).getLong());
-  private static final SpanId second = SpanId.fromBytes(secondBytes, 0);
 
   @Test
   void isValid() {
@@ -40,48 +35,32 @@ class SpanIdTest {
 
   @Test
   void fromLowerBase16() {
-    assertThat(SpanId.toLowerBase16(SpanId.bytesFromLowerBase16("0000000000000000", 0)))
-        .isEqualTo(SpanId.getInvalid());
+    assertThat(SpanId.toLowerBase16(SpanId.bytesFromLowerBase16("0000000000000000", 0)).toString())
+        .isEqualTo(SpanId.getInvalid().toString());
     assertThat(SpanId.bytesFromLowerBase16("0000000000000061", 0)).isEqualTo(firstBytes);
     assertThat(SpanId.bytesFromLowerBase16("ff00000000000041", 0)).isEqualTo(secondBytes);
   }
 
   @Test
   void fromLowerBase16_WithOffset() {
-    assertThat(SpanId.toLowerBase16(SpanId.bytesFromLowerBase16("XX0000000000000000AA", 2)))
-        .isEqualTo(SpanId.getInvalid());
+    assertThat(
+            SpanId.toLowerBase16(SpanId.bytesFromLowerBase16("XX0000000000000000AA", 2)).toString())
+        .isEqualTo(SpanId.getInvalid().toString());
     assertThat(SpanId.bytesFromLowerBase16("YY0000000000000061BB", 2)).isEqualTo(firstBytes);
     assertThat(SpanId.bytesFromLowerBase16("ZZff00000000000041CC", 2)).isEqualTo(secondBytes);
   }
 
   @Test
-  void toLowerBase16() {
-    assertThat(SpanId.getInvalid()).isEqualTo("0000000000000000");
-    assertThat(SpanId.toLowerBase16(firstBytes)).isEqualTo("0000000000000061");
-    assertThat(SpanId.toLowerBase16(secondBytes)).isEqualTo("ff00000000000041");
-  }
-
-  @Test
-  void spanId_CompareTo() {
-    assertThat(first.compareTo(second)).isGreaterThan(0);
-    assertThat(second.compareTo(first)).isLessThan(0);
-    assertThat(first.compareTo(SpanId.fromBytes(firstBytes, 0))).isEqualTo(0);
-  }
-
-  @Test
-  void spanId_EqualsAndHashCode() {
-    EqualsTester tester = new EqualsTester();
-    tester.addEqualityGroup(
-        first, SpanId.fromBytes(Arrays.copyOf(firstBytes, firstBytes.length), 0));
-    tester.addEqualityGroup(
-        second, SpanId.fromBytes(Arrays.copyOf(secondBytes, secondBytes.length), 0));
-    tester.testEquals();
+  public void toLowerBase16() {
+    assertThat(SpanId.getInvalid().toString()).isEqualTo("0000000000000000");
+    assertThat(SpanId.toLowerBase16(firstBytes).toString()).isEqualTo("0000000000000061");
+    assertThat(SpanId.toLowerBase16(secondBytes).toString()).isEqualTo("ff00000000000041");
   }
 
   @Test
   void spanId_ToString() {
-    assertThat(SpanId.getInvalid()).contains("0000000000000000");
-    assertThat(SpanId.toLowerBase16(firstBytes)).contains("0000000000000061");
-    assertThat(SpanId.toLowerBase16(secondBytes)).contains("ff00000000000041");
+    assertThat(SpanId.getInvalid().toString()).contains("0000000000000000");
+    assertThat(SpanId.toLowerBase16(firstBytes).toString()).contains("0000000000000061");
+    assertThat(SpanId.toLowerBase16(secondBytes).toString()).contains("ff00000000000041");
   }
 }

--- a/api/src/test/java/io/opentelemetry/trace/SpanIdTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanIdTest.java
@@ -69,7 +69,6 @@ class SpanIdTest {
   @Test
   void spanId_EqualsAndHashCode() {
     EqualsTester tester = new EqualsTester();
-    tester.addEqualityGroup(SpanId.getInvalid(), SpanId.getInvalid());
     tester.addEqualityGroup(
         first, SpanId.fromBytes(Arrays.copyOf(firstBytes, firstBytes.length), 0));
     tester.addEqualityGroup(

--- a/api/src/test/java/io/opentelemetry/trace/SpanIdTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanIdTest.java
@@ -32,30 +32,31 @@ class SpanIdTest {
 
   @Test
   void isValid() {
-    assertThat(SpanId.getInvalid().isValid()).isFalse();
-    assertThat(first.isValid()).isTrue();
-    assertThat(second.isValid()).isTrue();
+    assertThat(SpanId.isValid(SpanId.getInvalid())).isFalse();
+    assertThat(SpanId.isValid(firstBytes)).isTrue();
+    assertThat(SpanId.isValid(secondBytes)).isTrue();
   }
 
   @Test
   void fromLowerBase16() {
-    assertThat(SpanId.fromLowerBase16("0000000000000000", 0)).isEqualTo(SpanId.getInvalid());
-    assertThat(SpanId.fromLowerBase16("0000000000000061", 0)).isEqualTo(first);
-    assertThat(SpanId.fromLowerBase16("ff00000000000041", 0)).isEqualTo(second);
+    assertThat(SpanId.bytesFromLowerBase16("0000000000000000", 0)).isEqualTo(SpanId.getInvalid());
+    assertThat(SpanId.bytesFromLowerBase16("0000000000000061", 0)).isEqualTo(firstBytes);
+    assertThat(SpanId.bytesFromLowerBase16("ff00000000000041", 0)).isEqualTo(secondBytes);
   }
 
   @Test
   void fromLowerBase16_WithOffset() {
-    assertThat(SpanId.fromLowerBase16("XX0000000000000000AA", 2)).isEqualTo(SpanId.getInvalid());
-    assertThat(SpanId.fromLowerBase16("YY0000000000000061BB", 2)).isEqualTo(first);
-    assertThat(SpanId.fromLowerBase16("ZZff00000000000041CC", 2)).isEqualTo(second);
+    assertThat(SpanId.bytesFromLowerBase16("XX0000000000000000AA", 2))
+        .isEqualTo(SpanId.getInvalid());
+    assertThat(SpanId.bytesFromLowerBase16("YY0000000000000061BB", 2)).isEqualTo(firstBytes);
+    assertThat(SpanId.bytesFromLowerBase16("ZZff00000000000041CC", 2)).isEqualTo(secondBytes);
   }
 
   @Test
   void toLowerBase16() {
-    assertThat(SpanId.getInvalid().toLowerBase16()).isEqualTo("0000000000000000");
-    assertThat(first.toLowerBase16()).isEqualTo("0000000000000061");
-    assertThat(second.toLowerBase16()).isEqualTo("ff00000000000041");
+    assertThat(SpanId.toLowerBase16(SpanId.getInvalid())).isEqualTo("0000000000000000");
+    assertThat(SpanId.toLowerBase16(firstBytes)).isEqualTo("0000000000000061");
+    assertThat(SpanId.toLowerBase16(secondBytes)).isEqualTo("ff00000000000041");
   }
 
   @Test
@@ -78,8 +79,8 @@ class SpanIdTest {
 
   @Test
   void spanId_ToString() {
-    assertThat(SpanId.getInvalid().toString()).contains("0000000000000000");
-    assertThat(first.toString()).contains("0000000000000061");
-    assertThat(second.toString()).contains("ff00000000000041");
+    assertThat(SpanId.toLowerBase16(SpanId.getInvalid())).contains("0000000000000000");
+    assertThat(SpanId.toLowerBase16(firstBytes)).contains("0000000000000061");
+    assertThat(SpanId.toLowerBase16(secondBytes)).contains("ff00000000000041");
   }
 }

--- a/api/src/test/java/io/opentelemetry/trace/TraceIdTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TraceIdTest.java
@@ -118,7 +118,6 @@ class TraceIdTest {
   @Test
   void traceId_EqualsAndHashCode() {
     EqualsTester tester = new EqualsTester();
-    tester.addEqualityGroup(TraceId.getInvalid(), TraceId.getInvalid());
     tester.addEqualityGroup(
         first, TraceId.fromBytes(Arrays.copyOf(firstBytes, firstBytes.length), 0));
     tester.addEqualityGroup(

--- a/api/src/test/java/io/opentelemetry/trace/TraceIdTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TraceIdTest.java
@@ -45,6 +45,8 @@ class TraceIdTest {
     assertThat(TraceId.isValid(TraceId.getInvalid())).isFalse();
     assertThat(first.isValid()).isTrue();
     assertThat(second.isValid()).isTrue();
+
+    assertThat(TraceId.isValid("000000000000004z0000000000000016")).isFalse();
   }
 
   @Test
@@ -82,7 +84,9 @@ class TraceIdTest {
 
   @Test
   void fromLowerBase16() {
-    assertThat(TraceId.bytesFromLowerBase16("00000000000000000000000000000000", 0))
+    assertThat(
+            TraceId.toLowerBase16(
+                TraceId.bytesFromLowerBase16("00000000000000000000000000000000", 0)))
         .isEqualTo(TraceId.getInvalid());
     assertThat(TraceId.bytesFromLowerBase16("00000000000000000000000000000061", 0))
         .isEqualTo(firstBytes);
@@ -92,7 +96,9 @@ class TraceIdTest {
 
   @Test
   void fromLowerBase16_WithOffset() {
-    assertThat(TraceId.bytesFromLowerBase16("XX00000000000000000000000000000000CC", 2))
+    assertThat(
+            TraceId.toLowerBase16(
+                TraceId.bytesFromLowerBase16("XX00000000000000000000000000000000CC", 2)))
         .isEqualTo(TraceId.getInvalid());
     assertThat(TraceId.bytesFromLowerBase16("YY00000000000000000000000000000061AA", 2))
         .isEqualTo(firstBytes);
@@ -102,8 +108,7 @@ class TraceIdTest {
 
   @Test
   void toLowerBase16() {
-    assertThat(TraceId.toLowerBase16(TraceId.getInvalid()))
-        .isEqualTo("00000000000000000000000000000000");
+    assertThat(TraceId.getInvalid()).isEqualTo("00000000000000000000000000000000");
     assertThat(TraceId.toLowerBase16(firstBytes)).isEqualTo("00000000000000000000000000000061");
     assertThat(TraceId.toLowerBase16(secondBytes)).isEqualTo("ff000000000000000000000000000041");
   }
@@ -127,8 +132,7 @@ class TraceIdTest {
 
   @Test
   void traceId_ToString() {
-    assertThat(TraceId.toLowerBase16(TraceId.getInvalid()))
-        .contains("00000000000000000000000000000000");
+    assertThat(TraceId.getInvalid()).contains("00000000000000000000000000000000");
     assertThat(TraceId.toLowerBase16(firstBytes)).contains("00000000000000000000000000000061");
     assertThat(TraceId.toLowerBase16(secondBytes)).contains("ff000000000000000000000000000041");
   }

--- a/api/src/test/java/io/opentelemetry/trace/TraceIdTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TraceIdTest.java
@@ -18,9 +18,7 @@ package io.opentelemetry.trace;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.testing.EqualsTester;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link TraceId}. */
@@ -29,10 +27,10 @@ class TraceIdTest {
       new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'a'};
   private static final byte[] secondBytes =
       new byte[] {(byte) 0xFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'A'};
-  private static final TraceId first = TraceId.fromBytes(firstBytes, 0);
+  private static final CharSequence first = TraceId.toLowerBase16(firstBytes);
 
-  private static final TraceId second =
-      new TraceId(
+  private static final CharSequence second =
+      TraceId.fromLongs(
           ByteBuffer.wrap(secondBytes).getLong(), ByteBuffer.wrap(secondBytes, 8, 8).getLong());
 
   @Test
@@ -43,8 +41,8 @@ class TraceIdTest {
   @Test
   void isValid() {
     assertThat(TraceId.isValid(TraceId.getInvalid())).isFalse();
-    assertThat(first.isValid()).isTrue();
-    assertThat(second.isValid()).isTrue();
+    assertThat(TraceId.isValid(first)).isTrue();
+    assertThat(TraceId.isValid(second)).isTrue();
 
     assertThat(TraceId.isValid("000000000000004z0000000000000016")).isFalse();
   }
@@ -54,8 +52,8 @@ class TraceIdTest {
     byte[] id = {
       0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x00
     };
-    TraceId traceid = TraceId.fromBytes(id, 0);
-    assertThat(traceid.getTraceRandomPart()).isEqualTo(0x090A0B0C0D0E0F00L);
+    CharSequence traceid = TraceId.toLowerBase16(id);
+    assertThat(TraceId.getTraceIdRandomPart(traceid)).isEqualTo(0x090A0B0C0D0E0F00L);
   }
 
   @Test
@@ -78,16 +76,17 @@ class TraceIdTest {
       0x0F,
       0x00
     };
-    TraceId traceid = TraceId.fromBytes(id, 0);
-    assertThat(traceid.getTraceRandomPart()).isEqualTo(0xFF0A0B0C0D0E0F00L);
+    CharSequence traceid = TraceId.toLowerBase16(id);
+    assertThat(TraceId.getTraceIdRandomPart(traceid)).isEqualTo(0xFF0A0B0C0D0E0F00L);
   }
 
   @Test
   void fromLowerBase16() {
     assertThat(
             TraceId.toLowerBase16(
-                TraceId.bytesFromLowerBase16("00000000000000000000000000000000", 0)))
-        .isEqualTo(TraceId.getInvalid());
+                    TraceId.bytesFromLowerBase16("00000000000000000000000000000000", 0))
+                .toString())
+        .isEqualTo(TraceId.getInvalid().toString());
     assertThat(TraceId.bytesFromLowerBase16("00000000000000000000000000000061", 0))
         .isEqualTo(firstBytes);
     assertThat(TraceId.bytesFromLowerBase16("ff000000000000000000000000000041", 0))
@@ -98,8 +97,9 @@ class TraceIdTest {
   void fromLowerBase16_WithOffset() {
     assertThat(
             TraceId.toLowerBase16(
-                TraceId.bytesFromLowerBase16("XX00000000000000000000000000000000CC", 2)))
-        .isEqualTo(TraceId.getInvalid());
+                    TraceId.bytesFromLowerBase16("XX00000000000000000000000000000000CC", 2))
+                .toString())
+        .isEqualTo(TraceId.getInvalid().toString());
     assertThat(TraceId.bytesFromLowerBase16("YY00000000000000000000000000000061AA", 2))
         .isEqualTo(firstBytes);
     assertThat(TraceId.bytesFromLowerBase16("ZZff000000000000000000000000000041BB", 2))
@@ -107,33 +107,11 @@ class TraceIdTest {
   }
 
   @Test
-  void toLowerBase16() {
-    assertThat(TraceId.getInvalid()).isEqualTo("00000000000000000000000000000000");
-    assertThat(TraceId.toLowerBase16(firstBytes)).isEqualTo("00000000000000000000000000000061");
-    assertThat(TraceId.toLowerBase16(secondBytes)).isEqualTo("ff000000000000000000000000000041");
-  }
-
-  @Test
-  void traceId_CompareTo() {
-    assertThat(first.compareTo(second)).isGreaterThan(0);
-    assertThat(second.compareTo(first)).isLessThan(0);
-    assertThat(first.compareTo(TraceId.fromBytes(firstBytes, 0))).isEqualTo(0);
-  }
-
-  @Test
-  void traceId_EqualsAndHashCode() {
-    EqualsTester tester = new EqualsTester();
-    tester.addEqualityGroup(
-        first, TraceId.fromBytes(Arrays.copyOf(firstBytes, firstBytes.length), 0));
-    tester.addEqualityGroup(
-        second, TraceId.fromBytes(Arrays.copyOf(secondBytes, secondBytes.length), 0));
-    tester.testEquals();
-  }
-
-  @Test
-  void traceId_ToString() {
-    assertThat(TraceId.getInvalid()).contains("00000000000000000000000000000000");
-    assertThat(TraceId.toLowerBase16(firstBytes)).contains("00000000000000000000000000000061");
-    assertThat(TraceId.toLowerBase16(secondBytes)).contains("ff000000000000000000000000000041");
+  public void toLowerBase16() {
+    assertThat(TraceId.getInvalid().toString()).isEqualTo("00000000000000000000000000000000");
+    assertThat(TraceId.toLowerBase16(firstBytes).toString())
+        .isEqualTo("00000000000000000000000000000061");
+    assertThat(TraceId.toLowerBase16(secondBytes).toString())
+        .isEqualTo("ff000000000000000000000000000041");
   }
 }

--- a/api/src/test/java/io/opentelemetry/trace/TraceIdTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TraceIdTest.java
@@ -30,18 +30,19 @@ class TraceIdTest {
   private static final byte[] secondBytes =
       new byte[] {(byte) 0xFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'A'};
   private static final TraceId first = TraceId.fromBytes(firstBytes, 0);
+
   private static final TraceId second =
       new TraceId(
           ByteBuffer.wrap(secondBytes).getLong(), ByteBuffer.wrap(secondBytes, 8, 8).getLong());
 
   @Test
   void invalidTraceId() {
-    assertThat(TraceId.getInvalid().getTraceRandomPart()).isEqualTo(0);
+    assertThat(TraceId.getTraceIdRandomPart(TraceId.getInvalid())).isEqualTo(0);
   }
 
   @Test
   void isValid() {
-    assertThat(TraceId.getInvalid().isValid()).isFalse();
+    assertThat(TraceId.isValid(TraceId.getInvalid())).isFalse();
     assertThat(first.isValid()).isTrue();
     assertThat(second.isValid()).isTrue();
   }
@@ -81,26 +82,30 @@ class TraceIdTest {
 
   @Test
   void fromLowerBase16() {
-    assertThat(TraceId.fromLowerBase16("00000000000000000000000000000000", 0))
+    assertThat(TraceId.bytesFromLowerBase16("00000000000000000000000000000000", 0))
         .isEqualTo(TraceId.getInvalid());
-    assertThat(TraceId.fromLowerBase16("00000000000000000000000000000061", 0)).isEqualTo(first);
-    assertThat(TraceId.fromLowerBase16("ff000000000000000000000000000041", 0)).isEqualTo(second);
+    assertThat(TraceId.bytesFromLowerBase16("00000000000000000000000000000061", 0))
+        .isEqualTo(firstBytes);
+    assertThat(TraceId.bytesFromLowerBase16("ff000000000000000000000000000041", 0))
+        .isEqualTo(secondBytes);
   }
 
   @Test
   void fromLowerBase16_WithOffset() {
-    assertThat(TraceId.fromLowerBase16("XX00000000000000000000000000000000CC", 2))
+    assertThat(TraceId.bytesFromLowerBase16("XX00000000000000000000000000000000CC", 2))
         .isEqualTo(TraceId.getInvalid());
-    assertThat(TraceId.fromLowerBase16("YY00000000000000000000000000000061AA", 2)).isEqualTo(first);
-    assertThat(TraceId.fromLowerBase16("ZZff000000000000000000000000000041BB", 2))
-        .isEqualTo(second);
+    assertThat(TraceId.bytesFromLowerBase16("YY00000000000000000000000000000061AA", 2))
+        .isEqualTo(firstBytes);
+    assertThat(TraceId.bytesFromLowerBase16("ZZff000000000000000000000000000041BB", 2))
+        .isEqualTo(secondBytes);
   }
 
   @Test
   void toLowerBase16() {
-    assertThat(TraceId.getInvalid().toLowerBase16()).isEqualTo("00000000000000000000000000000000");
-    assertThat(first.toLowerBase16()).isEqualTo("00000000000000000000000000000061");
-    assertThat(second.toLowerBase16()).isEqualTo("ff000000000000000000000000000041");
+    assertThat(TraceId.toLowerBase16(TraceId.getInvalid()))
+        .isEqualTo("00000000000000000000000000000000");
+    assertThat(TraceId.toLowerBase16(firstBytes)).isEqualTo("00000000000000000000000000000061");
+    assertThat(TraceId.toLowerBase16(secondBytes)).isEqualTo("ff000000000000000000000000000041");
   }
 
   @Test
@@ -123,8 +128,9 @@ class TraceIdTest {
 
   @Test
   void traceId_ToString() {
-    assertThat(TraceId.getInvalid().toString()).contains("00000000000000000000000000000000");
-    assertThat(first.toString()).contains("00000000000000000000000000000061");
-    assertThat(second.toString()).contains("ff000000000000000000000000000041");
+    assertThat(TraceId.toLowerBase16(TraceId.getInvalid()))
+        .contains("00000000000000000000000000000000");
+    assertThat(TraceId.toLowerBase16(firstBytes)).contains("00000000000000000000000000000061");
+    assertThat(TraceId.toLowerBase16(secondBytes)).contains("ff000000000000000000000000000041");
   }
 }

--- a/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
@@ -44,9 +44,9 @@ class HttpTraceContextTest {
   private static final TraceState TRACE_STATE_NOT_DEFAULT =
       TraceState.builder().set("foo", "bar").set("bar", "baz").build();
   private static final String TRACE_ID_BASE16 = "ff000000000000000000000000000041";
-  private static final TraceId TRACE_ID = TraceId.fromLowerBase16(TRACE_ID_BASE16, 0);
+  private static final byte[] TRACE_ID = TraceId.bytesFromLowerBase16(TRACE_ID_BASE16, 0);
   private static final String SPAN_ID_BASE16 = "ff00000000000041";
-  private static final SpanId SPAN_ID = SpanId.fromLowerBase16(SPAN_ID_BASE16, 0);
+  private static final byte[] SPAN_ID = SpanId.bytesFromLowerBase16(SPAN_ID_BASE16, 0);
   private static final byte SAMPLED_TRACE_OPTIONS_BYTES = 1;
   private static final TraceFlags SAMPLED_TRACE_OPTIONS =
       TraceFlags.fromByte(SAMPLED_TRACE_OPTIONS_BYTES);

--- a/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
@@ -44,9 +44,7 @@ class HttpTraceContextTest {
   private static final TraceState TRACE_STATE_NOT_DEFAULT =
       TraceState.builder().set("foo", "bar").set("bar", "baz").build();
   private static final String TRACE_ID_BASE16 = "ff000000000000000000000000000041";
-  private static final byte[] TRACE_ID = TraceId.bytesFromLowerBase16(TRACE_ID_BASE16, 0);
   private static final String SPAN_ID_BASE16 = "ff00000000000041";
-  private static final byte[] SPAN_ID = SpanId.bytesFromLowerBase16(SPAN_ID_BASE16, 0);
   private static final byte SAMPLED_TRACE_OPTIONS_BYTES = 1;
   private static final TraceFlags SAMPLED_TRACE_OPTIONS =
       TraceFlags.fromByte(SAMPLED_TRACE_OPTIONS_BYTES);
@@ -82,7 +80,8 @@ class HttpTraceContextTest {
     final Map<String, String> carrier = new LinkedHashMap<>();
     Context context =
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
+            SpanContext.create(
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
             Context.current());
     httpTraceContext.inject(
         context,
@@ -112,7 +111,8 @@ class HttpTraceContextTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     Context context =
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
+            SpanContext.create(
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
             Context.current());
     httpTraceContext.inject(context, carrier, setter);
     assertThat(carrier).containsExactly(entry(TRACE_PARENT, TRACEPARENT_HEADER_SAMPLED));
@@ -123,7 +123,8 @@ class HttpTraceContextTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     Context context =
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT),
+            SpanContext.create(
+                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE_DEFAULT),
             Context.current());
     httpTraceContext.inject(context, carrier, setter);
     assertThat(carrier).containsExactly(entry(TRACE_PARENT, TRACEPARENT_HEADER_NOT_SAMPLED));
@@ -134,7 +135,8 @@ class HttpTraceContextTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     Context context =
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_NOT_DEFAULT),
+            SpanContext.create(
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE_NOT_DEFAULT),
             Context.current());
     httpTraceContext.inject(context, carrier, setter);
     assertThat(carrier)
@@ -148,7 +150,8 @@ class HttpTraceContextTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     Context context =
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_NOT_DEFAULT),
+            SpanContext.create(
+                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE_NOT_DEFAULT),
             Context.current());
     httpTraceContext.inject(context, carrier, setter);
     assertThat(carrier)
@@ -173,7 +176,7 @@ class HttpTraceContextTest {
     assertThat(getSpanContext(httpTraceContext.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
   }
 
   @Test
@@ -183,7 +186,7 @@ class HttpTraceContextTest {
     assertThat(getSpanContext(httpTraceContext.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
   }
 
   @Test
@@ -194,7 +197,7 @@ class HttpTraceContextTest {
     assertThat(getSpanContext(httpTraceContext.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_NOT_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE_NOT_DEFAULT));
   }
 
   @Test
@@ -205,7 +208,7 @@ class HttpTraceContextTest {
     assertThat(getSpanContext(httpTraceContext.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_NOT_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE_NOT_DEFAULT));
   }
 
   @Test
@@ -215,7 +218,7 @@ class HttpTraceContextTest {
     assertThat(getSpanContext(httpTraceContext.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
   }
 
   @Test
@@ -226,7 +229,7 @@ class HttpTraceContextTest {
     assertThat(getSpanContext(httpTraceContext.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
   }
 
   @Test
@@ -237,7 +240,7 @@ class HttpTraceContextTest {
     assertThat(getSpanContext(httpTraceContext.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_NOT_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE_NOT_DEFAULT));
   }
 
   @Test
@@ -305,7 +308,7 @@ class HttpTraceContextTest {
     assertThat(getSpanContext(httpTraceContext.extract(Context.current(), invalidHeaders, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
   }
 
   @Test
@@ -316,7 +319,7 @@ class HttpTraceContextTest {
     assertThat(getSpanContext(httpTraceContext.extract(Context.current(), invalidHeaders, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
   }
 
   @Test
@@ -327,7 +330,7 @@ class HttpTraceContextTest {
     assertThat(getSpanContext(httpTraceContext.extract(Context.current(), invalidHeaders, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
   }
 
   @Test

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/Adapter.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/Adapter.java
@@ -265,8 +265,8 @@ final class Adapter {
   @VisibleForTesting
   static Model.SpanRef toSpanRef(Link link) {
     Model.SpanRef.Builder builder = Model.SpanRef.newBuilder();
-    builder.setTraceId(TraceProtoUtils.toProtoTraceId(link.getContext().traceId()));
-    builder.setSpanId(TraceProtoUtils.toProtoSpanId(link.getContext().spanId()));
+    builder.setTraceId(TraceProtoUtils.toProtoTraceId((String) link.getContext().getTraceId()));
+    builder.setSpanId(TraceProtoUtils.toProtoSpanId(link.getContext().getSpanId()));
 
     // we can assume that all links are *follows from*
     // https://github.com/open-telemetry/opentelemetry-java/issues/475

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/Adapter.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/Adapter.java
@@ -28,6 +28,7 @@ import io.opentelemetry.sdk.extensions.otproto.TraceProtoUtils;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
+import io.opentelemetry.trace.SpanId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -83,7 +84,7 @@ final class Adapter {
     target.addAllReferences(toSpanRefs(span.getLinks()));
 
     // add the parent span
-    if (span.getParentSpanId().isValid()) {
+    if (SpanId.isValid(span.getParentSpanId())) {
       target.addReferences(
           Model.SpanRef.newBuilder()
               .setTraceId(TraceProtoUtils.toProtoTraceId(span.getTraceId()))

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/Adapter.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/Adapter.java
@@ -265,8 +265,8 @@ final class Adapter {
   @VisibleForTesting
   static Model.SpanRef toSpanRef(Link link) {
     Model.SpanRef.Builder builder = Model.SpanRef.newBuilder();
-    builder.setTraceId(TraceProtoUtils.toProtoTraceId(link.getContext().getTraceId()));
-    builder.setSpanId(TraceProtoUtils.toProtoSpanId(link.getContext().getSpanId()));
+    builder.setTraceId(TraceProtoUtils.toProtoTraceId(link.getContext().traceId()));
+    builder.setSpanId(TraceProtoUtils.toProtoSpanId(link.getContext().spanId()));
 
     // we can assume that all links are *follows from*
     // https://github.com/open-telemetry/opentelemetry-java/issues/475

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/Adapter.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/Adapter.java
@@ -265,8 +265,8 @@ final class Adapter {
   @VisibleForTesting
   static Model.SpanRef toSpanRef(Link link) {
     Model.SpanRef.Builder builder = Model.SpanRef.newBuilder();
-    builder.setTraceId(TraceProtoUtils.toProtoTraceId((String) link.getContext().getTraceId()));
-    builder.setSpanId(TraceProtoUtils.toProtoSpanId(link.getContext().getSpanId()));
+    builder.setTraceId(TraceProtoUtils.toProtoTraceId(link.getContext().getTraceIdAsBase16()));
+    builder.setSpanId(TraceProtoUtils.toProtoSpanId(link.getContext().getSpanIdAsBase16()));
 
     // we can assume that all links are *follows from*
     // https://github.com/open-telemetry/opentelemetry-java/issues/475

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
@@ -227,9 +227,11 @@ class AdapterTest {
 
     // verify
     assertEquals(
-        TraceProtoUtils.toProtoSpanId(SpanId.fromLowerBase16(SPAN_ID, 0)), spanRef.getSpanId());
+        TraceProtoUtils.toProtoSpanId(SpanId.bytesFromLowerBase16(SPAN_ID, 0)),
+        spanRef.getSpanId());
     assertEquals(
-        TraceProtoUtils.toProtoTraceId(TraceId.fromLowerBase16(TRACE_ID, 0)), spanRef.getTraceId());
+        TraceProtoUtils.toProtoTraceId(TraceId.bytesFromLowerBase16(TRACE_ID, 0)),
+        spanRef.getTraceId());
     assertEquals(Model.SpanRefType.FOLLOWS_FROM, spanRef.getRefType());
   }
 
@@ -240,8 +242,8 @@ class AdapterTest {
     SpanData span =
         TestSpanData.newBuilder()
             .setHasEnded(true)
-            .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
-            .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
+            .setTraceId(TraceId.bytesFromLowerBase16(TRACE_ID, 0))
+            .setSpanId(SpanId.bytesFromLowerBase16(SPAN_ID, 0))
             .setName("GET /api/endpoint")
             .setStartEpochNanos(TimeUnit.MILLISECONDS.toNanos(startMs))
             .setEndEpochNanos(TimeUnit.MILLISECONDS.toNanos(endMs))
@@ -267,8 +269,8 @@ class AdapterTest {
     SpanData span =
         TestSpanData.newBuilder()
             .setHasEnded(true)
-            .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
-            .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
+            .setTraceId(TraceId.bytesFromLowerBase16(TRACE_ID, 0))
+            .setSpanId(SpanId.bytesFromLowerBase16(SPAN_ID, 0))
             .setName("GET /api/endpoint")
             .setStartEpochNanos(TimeUnit.MILLISECONDS.toNanos(startMs))
             .setEndEpochNanos(TimeUnit.MILLISECONDS.toNanos(endMs))
@@ -303,9 +305,9 @@ class AdapterTest {
 
     return TestSpanData.newBuilder()
         .setHasEnded(true)
-        .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
-        .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
-        .setParentSpanId(SpanId.fromLowerBase16(PARENT_SPAN_ID, 0))
+        .setTraceId(TraceId.bytesFromLowerBase16(TRACE_ID, 0))
+        .setSpanId(SpanId.bytesFromLowerBase16(SPAN_ID, 0))
+        .setParentSpanId(SpanId.bytesFromLowerBase16(PARENT_SPAN_ID, 0))
         .setName("GET /api/endpoint")
         .setStartEpochNanos(TimeUnit.MILLISECONDS.toNanos(startMs))
         .setEndEpochNanos(TimeUnit.MILLISECONDS.toNanos(endMs))
@@ -322,8 +324,8 @@ class AdapterTest {
 
   private static SpanContext createSpanContext(String traceId, String spanId) {
     return SpanContext.create(
-        TraceId.fromLowerBase16(traceId, 0),
-        SpanId.fromLowerBase16(spanId, 0),
+        TraceId.bytesFromLowerBase16(traceId, 0),
+        SpanId.bytesFromLowerBase16(spanId, 0),
         TraceFlags.builder().build(),
         TraceState.builder().build());
   }
@@ -343,10 +345,10 @@ class AdapterTest {
     for (Model.SpanRef spanRef : jaegerSpan.getReferencesList()) {
       if (Model.SpanRefType.FOLLOWS_FROM.equals(spanRef.getRefType())) {
         assertEquals(
-            TraceProtoUtils.toProtoTraceId(TraceId.fromLowerBase16(LINK_TRACE_ID, 0)),
+            TraceProtoUtils.toProtoTraceId(TraceId.bytesFromLowerBase16(LINK_TRACE_ID, 0)),
             spanRef.getTraceId());
         assertEquals(
-            TraceProtoUtils.toProtoSpanId(SpanId.fromLowerBase16(LINK_SPAN_ID, 0)),
+            TraceProtoUtils.toProtoSpanId(SpanId.bytesFromLowerBase16(LINK_SPAN_ID, 0)),
             spanRef.getSpanId());
         found = true;
       }
@@ -359,10 +361,10 @@ class AdapterTest {
     for (Model.SpanRef spanRef : jaegerSpan.getReferencesList()) {
       if (Model.SpanRefType.CHILD_OF.equals(spanRef.getRefType())) {
         assertEquals(
-            TraceProtoUtils.toProtoTraceId(TraceId.fromLowerBase16(TRACE_ID, 0)),
+            TraceProtoUtils.toProtoTraceId(TraceId.bytesFromLowerBase16(TRACE_ID, 0)),
             spanRef.getTraceId());
         assertEquals(
-            TraceProtoUtils.toProtoSpanId(SpanId.fromLowerBase16(PARENT_SPAN_ID, 0)),
+            TraceProtoUtils.toProtoSpanId(SpanId.bytesFromLowerBase16(PARENT_SPAN_ID, 0)),
             spanRef.getSpanId());
         found = true;
       }

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
@@ -34,10 +34,8 @@ import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
-import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.TraceFlags;
-import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
 import java.util.Collection;
 import java.util.Collections;
@@ -226,12 +224,8 @@ class AdapterTest {
     Model.SpanRef spanRef = Adapter.toSpanRef(link);
 
     // verify
-    assertEquals(
-        TraceProtoUtils.toProtoSpanId(SpanId.bytesFromLowerBase16(SPAN_ID, 0)),
-        spanRef.getSpanId());
-    assertEquals(
-        TraceProtoUtils.toProtoTraceId(TraceId.bytesFromLowerBase16(TRACE_ID, 0)),
-        spanRef.getTraceId());
+    assertEquals(TraceProtoUtils.toProtoSpanId(SPAN_ID), spanRef.getSpanId());
+    assertEquals(TraceProtoUtils.toProtoTraceId(TRACE_ID), spanRef.getTraceId());
     assertEquals(Model.SpanRefType.FOLLOWS_FROM, spanRef.getRefType());
   }
 
@@ -242,8 +236,8 @@ class AdapterTest {
     SpanData span =
         TestSpanData.newBuilder()
             .setHasEnded(true)
-            .setTraceId(TraceId.bytesFromLowerBase16(TRACE_ID, 0))
-            .setSpanId(SpanId.bytesFromLowerBase16(SPAN_ID, 0))
+            .setTraceId(TRACE_ID)
+            .setSpanId(SPAN_ID)
             .setName("GET /api/endpoint")
             .setStartEpochNanos(TimeUnit.MILLISECONDS.toNanos(startMs))
             .setEndEpochNanos(TimeUnit.MILLISECONDS.toNanos(endMs))
@@ -269,8 +263,8 @@ class AdapterTest {
     SpanData span =
         TestSpanData.newBuilder()
             .setHasEnded(true)
-            .setTraceId(TraceId.bytesFromLowerBase16(TRACE_ID, 0))
-            .setSpanId(SpanId.bytesFromLowerBase16(SPAN_ID, 0))
+            .setTraceId(TRACE_ID)
+            .setSpanId(SPAN_ID)
             .setName("GET /api/endpoint")
             .setStartEpochNanos(TimeUnit.MILLISECONDS.toNanos(startMs))
             .setEndEpochNanos(TimeUnit.MILLISECONDS.toNanos(endMs))
@@ -305,9 +299,9 @@ class AdapterTest {
 
     return TestSpanData.newBuilder()
         .setHasEnded(true)
-        .setTraceId(TraceId.bytesFromLowerBase16(TRACE_ID, 0))
-        .setSpanId(SpanId.bytesFromLowerBase16(SPAN_ID, 0))
-        .setParentSpanId(SpanId.bytesFromLowerBase16(PARENT_SPAN_ID, 0))
+        .setTraceId(TRACE_ID)
+        .setSpanId(SPAN_ID)
+        .setParentSpanId(PARENT_SPAN_ID)
         .setName("GET /api/endpoint")
         .setStartEpochNanos(TimeUnit.MILLISECONDS.toNanos(startMs))
         .setEndEpochNanos(TimeUnit.MILLISECONDS.toNanos(endMs))
@@ -324,10 +318,7 @@ class AdapterTest {
 
   private static SpanContext createSpanContext(String traceId, String spanId) {
     return SpanContext.create(
-        TraceId.bytesFromLowerBase16(traceId, 0),
-        SpanId.bytesFromLowerBase16(spanId, 0),
-        TraceFlags.builder().build(),
-        TraceState.builder().build());
+        traceId, spanId, TraceFlags.builder().build(), TraceState.builder().build());
   }
 
   @Nullable
@@ -344,12 +335,8 @@ class AdapterTest {
     boolean found = false;
     for (Model.SpanRef spanRef : jaegerSpan.getReferencesList()) {
       if (Model.SpanRefType.FOLLOWS_FROM.equals(spanRef.getRefType())) {
-        assertEquals(
-            TraceProtoUtils.toProtoTraceId(TraceId.bytesFromLowerBase16(LINK_TRACE_ID, 0)),
-            spanRef.getTraceId());
-        assertEquals(
-            TraceProtoUtils.toProtoSpanId(SpanId.bytesFromLowerBase16(LINK_SPAN_ID, 0)),
-            spanRef.getSpanId());
+        assertEquals(TraceProtoUtils.toProtoTraceId(LINK_TRACE_ID), spanRef.getTraceId());
+        assertEquals(TraceProtoUtils.toProtoSpanId(LINK_SPAN_ID), spanRef.getSpanId());
         found = true;
       }
     }
@@ -360,12 +347,8 @@ class AdapterTest {
     boolean found = false;
     for (Model.SpanRef spanRef : jaegerSpan.getReferencesList()) {
       if (Model.SpanRefType.CHILD_OF.equals(spanRef.getRefType())) {
-        assertEquals(
-            TraceProtoUtils.toProtoTraceId(TraceId.bytesFromLowerBase16(TRACE_ID, 0)),
-            spanRef.getTraceId());
-        assertEquals(
-            TraceProtoUtils.toProtoSpanId(SpanId.bytesFromLowerBase16(PARENT_SPAN_ID, 0)),
-            spanRef.getSpanId());
+        assertEquals(TraceProtoUtils.toProtoTraceId(TRACE_ID), spanRef.getTraceId());
+        assertEquals(TraceProtoUtils.toProtoSpanId(PARENT_SPAN_ID), spanRef.getSpanId());
         found = true;
       }
     }

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporterTest.java
@@ -37,9 +37,7 @@ import io.opentelemetry.sdk.extensions.otproto.TraceProtoUtils;
 import io.opentelemetry.sdk.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.Span.Kind;
-import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
-import io.opentelemetry.trace.TraceId;
 import java.net.InetAddress;
 import java.util.Collections;
 import java.util.HashMap;
@@ -90,8 +88,8 @@ class JaegerGrpcSpanExporterTest {
     SpanData span =
         TestSpanData.newBuilder()
             .setHasEnded(true)
-            .setTraceId(TraceId.bytesFromLowerBase16(TRACE_ID, 0))
-            .setSpanId(SpanId.bytesFromLowerBase16(SPAN_ID, 0))
+            .setTraceId(TRACE_ID)
+            .setSpanId(SPAN_ID)
             .setName("GET /api/endpoint")
             .setStartEpochNanos(TimeUnit.MILLISECONDS.toNanos(startMs))
             .setEndEpochNanos(TimeUnit.MILLISECONDS.toNanos(endMs))
@@ -113,12 +111,8 @@ class JaegerGrpcSpanExporterTest {
     Model.Batch batch = requestCaptor.getValue().getBatch();
     assertEquals(1, batch.getSpansCount());
     assertEquals("GET /api/endpoint", batch.getSpans(0).getOperationName());
-    assertEquals(
-        TraceProtoUtils.toProtoTraceId(TraceId.bytesFromLowerBase16(TRACE_ID, 0)),
-        batch.getSpans(0).getTraceId());
-    assertEquals(
-        TraceProtoUtils.toProtoSpanId(SpanId.bytesFromLowerBase16(SPAN_ID, 0)),
-        batch.getSpans(0).getSpanId());
+    assertEquals(TraceProtoUtils.toProtoTraceId(TRACE_ID), batch.getSpans(0).getTraceId());
+    assertEquals(TraceProtoUtils.toProtoSpanId(SPAN_ID), batch.getSpans(0).getSpanId());
     assertEquals("test", batch.getProcess().getServiceName());
     assertEquals(3, batch.getProcess().getTagsCount());
 

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporterTest.java
@@ -90,8 +90,8 @@ class JaegerGrpcSpanExporterTest {
     SpanData span =
         TestSpanData.newBuilder()
             .setHasEnded(true)
-            .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
-            .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
+            .setTraceId(TraceId.bytesFromLowerBase16(TRACE_ID, 0))
+            .setSpanId(SpanId.bytesFromLowerBase16(SPAN_ID, 0))
             .setName("GET /api/endpoint")
             .setStartEpochNanos(TimeUnit.MILLISECONDS.toNanos(startMs))
             .setEndEpochNanos(TimeUnit.MILLISECONDS.toNanos(endMs))
@@ -114,10 +114,10 @@ class JaegerGrpcSpanExporterTest {
     assertEquals(1, batch.getSpansCount());
     assertEquals("GET /api/endpoint", batch.getSpans(0).getOperationName());
     assertEquals(
-        TraceProtoUtils.toProtoTraceId(TraceId.fromLowerBase16(TRACE_ID, 0)),
+        TraceProtoUtils.toProtoTraceId(TraceId.bytesFromLowerBase16(TRACE_ID, 0)),
         batch.getSpans(0).getTraceId());
     assertEquals(
-        TraceProtoUtils.toProtoSpanId(SpanId.fromLowerBase16(SPAN_ID, 0)),
+        TraceProtoUtils.toProtoSpanId(SpanId.bytesFromLowerBase16(SPAN_ID, 0)),
         batch.getSpans(0).getSpanId());
     assertEquals("test", batch.getProcess().getServiceName());
     assertEquals(3, batch.getProcess().getTagsCount());

--- a/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingSpanExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingSpanExporterTest.java
@@ -61,8 +61,8 @@ class LoggingSpanExporterTest {
     SpanData spanData =
         TestSpanData.newBuilder()
             .setHasEnded(true)
-            .setTraceId(new TraceId(1234L, 6789L))
-            .setSpanId(new SpanId(9876L))
+            .setTraceId(TraceId.fromLongs(1234L, 6789L))
+            .setSpanId(SpanId.fromLong(9876L))
             .setStartEpochNanos(epochNanos)
             .setEndEpochNanos(epochNanos + 1000)
             .setStatus(Status.OK)

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/SpanAdapter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/SpanAdapter.java
@@ -158,8 +158,8 @@ final class SpanAdapter {
 
   static Span.Link toProtoSpanLink(Link link) {
     final Span.Link.Builder builder = Span.Link.newBuilder();
-    builder.setTraceId(TraceProtoUtils.toProtoTraceId(link.getContext().getTraceId()));
-    builder.setSpanId(TraceProtoUtils.toProtoSpanId(link.getContext().getSpanId()));
+    builder.setTraceId(TraceProtoUtils.toProtoTraceId(link.getContext().getTraceIdAsBase16()));
+    builder.setSpanId(TraceProtoUtils.toProtoSpanId(link.getContext().getSpanIdAsBase16()));
     // TODO: Set TraceState;
     Attributes attributes = link.getAttributes();
     attributes.forEach(

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/SpanAdapter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/SpanAdapter.java
@@ -157,8 +157,8 @@ final class SpanAdapter {
 
   static Span.Link toProtoSpanLink(Link link) {
     final Span.Link.Builder builder = Span.Link.newBuilder();
-    builder.setTraceId(TraceProtoUtils.toProtoTraceId(link.getContext().traceId()));
-    builder.setSpanId(TraceProtoUtils.toProtoSpanId(link.getContext().spanId()));
+    builder.setTraceId(TraceProtoUtils.toProtoTraceId((String) link.getContext().getTraceId()));
+    builder.setSpanId(TraceProtoUtils.toProtoSpanId(link.getContext().getSpanId()));
     // TODO: Set TraceState;
     Attributes attributes = link.getAttributes();
     attributes.forEach(

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/SpanAdapter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/SpanAdapter.java
@@ -32,6 +32,7 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
 import io.opentelemetry.trace.Span.Kind;
+import io.opentelemetry.trace.SpanId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -157,7 +158,7 @@ final class SpanAdapter {
 
   static Span.Link toProtoSpanLink(Link link) {
     final Span.Link.Builder builder = Span.Link.newBuilder();
-    builder.setTraceId(TraceProtoUtils.toProtoTraceId((String) link.getContext().getTraceId()));
+    builder.setTraceId(TraceProtoUtils.toProtoTraceId(link.getContext().getTraceId()));
     builder.setSpanId(TraceProtoUtils.toProtoSpanId(link.getContext().getSpanId()));
     // TODO: Set TraceState;
     Attributes attributes = link.getAttributes();

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/SpanAdapter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/SpanAdapter.java
@@ -157,8 +157,8 @@ final class SpanAdapter {
 
   static Span.Link toProtoSpanLink(Link link) {
     final Span.Link.Builder builder = Span.Link.newBuilder();
-    builder.setTraceId(TraceProtoUtils.toProtoTraceId(link.getContext().getTraceId()));
-    builder.setSpanId(TraceProtoUtils.toProtoSpanId(link.getContext().getSpanId()));
+    builder.setTraceId(TraceProtoUtils.toProtoTraceId(link.getContext().traceId()));
+    builder.setSpanId(TraceProtoUtils.toProtoSpanId(link.getContext().spanId()));
     // TODO: Set TraceState;
     Attributes attributes = link.getAttributes();
     attributes.forEach(

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/SpanAdapter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/SpanAdapter.java
@@ -91,7 +91,7 @@ final class SpanAdapter {
     builder.setTraceId(TraceProtoUtils.toProtoTraceId(spanData.getTraceId()));
     builder.setSpanId(TraceProtoUtils.toProtoSpanId(spanData.getSpanId()));
     // TODO: Set TraceState;
-    if (spanData.getParentSpanId().isValid()) {
+    if (SpanId.isValid(spanData.getParentSpanId())) {
       builder.setParentSpanId(TraceProtoUtils.toProtoSpanId(spanData.getParentSpanId()));
     }
     builder.setName(spanData.getName());

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
@@ -34,9 +34,7 @@ import io.opentelemetry.sdk.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode;
 import io.opentelemetry.trace.Span.Kind;
-import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
-import io.opentelemetry.trace.TraceId;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -235,8 +233,8 @@ class OtlpGrpcSpanExporterTest {
     long endNs = startNs + duration;
     return TestSpanData.newBuilder()
         .setHasEnded(true)
-        .setTraceId(TraceId.bytesFromLowerBase16(TRACE_ID, 0))
-        .setSpanId(SpanId.bytesFromLowerBase16(SPAN_ID, 0))
+        .setTraceId(TRACE_ID)
+        .setSpanId(SPAN_ID)
         .setName("GET /api/endpoint")
         .setStartEpochNanos(startNs)
         .setEndEpochNanos(endNs)

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
@@ -235,8 +235,8 @@ class OtlpGrpcSpanExporterTest {
     long endNs = startNs + duration;
     return TestSpanData.newBuilder()
         .setHasEnded(true)
-        .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
-        .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
+        .setTraceId(TraceId.bytesFromLowerBase16(TRACE_ID, 0))
+        .setSpanId(SpanId.bytesFromLowerBase16(SPAN_ID, 0))
         .setName("GET /api/endpoint")
         .setStartEpochNanos(startNs)
         .setEndEpochNanos(endNs)

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
@@ -43,9 +43,9 @@ import org.junit.jupiter.api.Test;
 class SpanAdapterTest {
   private static final byte[] TRACE_ID_BYTES =
       new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4};
-  private static final String TRACE_ID = TraceId.toLowerBase16(TRACE_ID_BYTES);
+  private static final CharSequence TRACE_ID = TraceId.toLowerBase16(TRACE_ID_BYTES);
   private static final byte[] SPAN_ID_BYTES = new byte[] {0, 0, 0, 0, 4, 3, 2, 1};
-  private static final String SPAN_ID = SpanId.toLowerBase16(SPAN_ID_BYTES);
+  private static final CharSequence SPAN_ID = SpanId.toLowerBase16(SPAN_ID_BYTES);
 
   private static final TraceState TRACE_STATE = TraceState.builder().build();
   private static final SpanContext SPAN_CONTEXT =

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
@@ -34,7 +34,6 @@ import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
-import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -43,13 +42,14 @@ import org.junit.jupiter.api.Test;
 class SpanAdapterTest {
   private static final byte[] TRACE_ID_BYTES =
       new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4};
-  private static final TraceId TRACE_ID = TraceId.fromBytes(TRACE_ID_BYTES, 0);
   private static final byte[] SPAN_ID_BYTES = new byte[] {0, 0, 0, 0, 4, 3, 2, 1};
-  private static final SpanId SPAN_ID = SpanId.fromBytes(SPAN_ID_BYTES, 0);
   private static final TraceState TRACE_STATE = TraceState.builder().build();
   private static final SpanContext SPAN_CONTEXT =
       SpanContext.create(
-          TRACE_ID, SPAN_ID, TraceFlags.builder().setIsSampled(true).build(), TRACE_STATE);
+          TRACE_ID_BYTES,
+          SPAN_ID_BYTES,
+          TraceFlags.builder().setIsSampled(true).build(),
+          TRACE_STATE);
 
   @Test
   void toProtoSpan() {
@@ -57,8 +57,8 @@ class SpanAdapterTest {
         SpanAdapter.toProtoSpan(
             TestSpanData.newBuilder()
                 .setHasEnded(true)
-                .setTraceId(TRACE_ID)
-                .setSpanId(SPAN_ID)
+                .setTraceId(TRACE_ID_BYTES)
+                .setSpanId(SPAN_ID_BYTES)
                 .setParentSpanId(SpanId.getInvalid())
                 .setName("GET /api/endpoint")
                 .setKind(Kind.SERVER)

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
@@ -34,6 +34,7 @@ import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
+import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -42,14 +43,14 @@ import org.junit.jupiter.api.Test;
 class SpanAdapterTest {
   private static final byte[] TRACE_ID_BYTES =
       new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4};
+  private static final String TRACE_ID = TraceId.toLowerBase16(TRACE_ID_BYTES);
   private static final byte[] SPAN_ID_BYTES = new byte[] {0, 0, 0, 0, 4, 3, 2, 1};
+  private static final String SPAN_ID = SpanId.toLowerBase16(SPAN_ID_BYTES);
+
   private static final TraceState TRACE_STATE = TraceState.builder().build();
   private static final SpanContext SPAN_CONTEXT =
       SpanContext.create(
-          TRACE_ID_BYTES,
-          SPAN_ID_BYTES,
-          TraceFlags.builder().setIsSampled(true).build(),
-          TRACE_STATE);
+          TRACE_ID, SPAN_ID, TraceFlags.builder().setIsSampled(true).build(), TRACE_STATE);
 
   @Test
   void toProtoSpan() {
@@ -57,8 +58,8 @@ class SpanAdapterTest {
         SpanAdapter.toProtoSpan(
             TestSpanData.newBuilder()
                 .setHasEnded(true)
-                .setTraceId(TRACE_ID_BYTES)
-                .setSpanId(SPAN_ID_BYTES)
+                .setTraceId(TRACE_ID)
+                .setSpanId(SPAN_ID)
                 .setParentSpanId(SpanId.getInvalid())
                 .setName("GET /api/endpoint")
                 .setKind(Kind.SERVER)

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporter.java
@@ -27,7 +27,9 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.trace.Span.Kind;
+import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
+import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.attributes.SemanticAttributes;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -127,16 +129,16 @@ public final class ZipkinSpanExporter implements SpanExporter {
 
     final Span.Builder spanBuilder =
         Span.newBuilder()
-            .traceId(spanData.getTraceId().toLowerBase16())
-            .id(spanData.getSpanId().toLowerBase16())
+            .traceId(TraceId.toLowerBase16(spanData.getTraceId()))
+            .id(SpanId.toLowerBase16(spanData.getSpanId()))
             .kind(toSpanKind(spanData))
             .name(spanData.getName())
             .timestamp(toEpochMicros(spanData.getStartEpochNanos()))
             .duration(endTimestamp - startTimestamp)
             .localEndpoint(endpoint);
 
-    if (spanData.getParentSpanId().isValid()) {
-      spanBuilder.parentId(spanData.getParentSpanId().toLowerBase16());
+    if (SpanId.isValid(spanData.getParentSpanId())) {
+      spanBuilder.parentId(SpanId.toLowerBase16(spanData.getParentSpanId()));
     }
 
     ReadableAttributes spanAttributes = spanData.getAttributes();

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporter.java
@@ -29,7 +29,6 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
-import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.attributes.SemanticAttributes;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -129,8 +128,8 @@ public final class ZipkinSpanExporter implements SpanExporter {
 
     final Span.Builder spanBuilder =
         Span.newBuilder()
-            .traceId(TraceId.toLowerBase16(spanData.getTraceId()))
-            .id(SpanId.toLowerBase16(spanData.getSpanId()))
+            .traceId(spanData.getTraceId())
+            .id(spanData.getSpanId())
             .kind(toSpanKind(spanData))
             .name(spanData.getName())
             .timestamp(toEpochMicros(spanData.getStartEpochNanos()))
@@ -138,7 +137,7 @@ public final class ZipkinSpanExporter implements SpanExporter {
             .localEndpoint(endpoint);
 
     if (SpanId.isValid(spanData.getParentSpanId())) {
-      spanBuilder.parentId(SpanId.toLowerBase16(spanData.getParentSpanId()));
+      spanBuilder.parentId(spanData.getParentSpanId());
     }
 
     ReadableAttributes spanAttributes = spanData.getAttributes();

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporter.java
@@ -128,8 +128,8 @@ public final class ZipkinSpanExporter implements SpanExporter {
 
     final Span.Builder spanBuilder =
         Span.newBuilder()
-            .traceId(spanData.getTraceId())
-            .id(spanData.getSpanId())
+            .traceId(spanData.getTraceId().toString())
+            .id(spanData.getSpanId().toString())
             .kind(toSpanKind(spanData))
             .name(spanData.getName())
             .timestamp(toEpochMicros(spanData.getStartEpochNanos()))
@@ -137,7 +137,7 @@ public final class ZipkinSpanExporter implements SpanExporter {
             .localEndpoint(endpoint);
 
     if (SpanId.isValid(spanData.getParentSpanId())) {
-      spanBuilder.parentId(spanData.getParentSpanId());
+      spanBuilder.parentId(spanData.getParentSpanId().toString());
     }
 
     ReadableAttributes spanAttributes = spanData.getAttributes();

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
@@ -151,9 +151,9 @@ public class ZipkinSpanExporterEndToEndHttpTest {
 
   private static TestSpanData.Builder buildStandardSpan() {
     return TestSpanData.newBuilder()
-        .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
-        .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
-        .setParentSpanId(SpanId.fromLowerBase16(PARENT_SPAN_ID, 0))
+        .setTraceId(TraceId.bytesFromLowerBase16(TRACE_ID, 0))
+        .setSpanId(SpanId.bytesFromLowerBase16(SPAN_ID, 0))
+        .setParentSpanId(SpanId.bytesFromLowerBase16(PARENT_SPAN_ID, 0))
         .setTraceFlags(TraceFlags.builder().setIsSampled(true).build())
         .setStatus(Status.OK)
         .setKind(Kind.SERVER)

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
@@ -26,10 +26,8 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.trace.Span.Kind;
-import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.TraceFlags;
-import io.opentelemetry.trace.TraceId;
 import java.util.Collections;
 import java.util.List;
 import org.junit.Rule;
@@ -151,9 +149,9 @@ public class ZipkinSpanExporterEndToEndHttpTest {
 
   private static TestSpanData.Builder buildStandardSpan() {
     return TestSpanData.newBuilder()
-        .setTraceId(TraceId.bytesFromLowerBase16(TRACE_ID, 0))
-        .setSpanId(SpanId.bytesFromLowerBase16(SPAN_ID, 0))
-        .setParentSpanId(SpanId.bytesFromLowerBase16(PARENT_SPAN_ID, 0))
+        .setTraceId(TRACE_ID)
+        .setSpanId(SPAN_ID)
+        .setParentSpanId(PARENT_SPAN_ID)
         .setTraceFlags(TraceFlags.builder().setIsSampled(true).build())
         .setStatus(Status.OK)
         .setKind(Kind.SERVER)

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterTest.java
@@ -33,10 +33,8 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode;
 import io.opentelemetry.trace.Span.Kind;
-import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.TraceFlags;
-import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.attributes.SemanticAttributes;
 import java.io.IOException;
 import java.util.Collections;
@@ -273,9 +271,9 @@ class ZipkinSpanExporterTest {
 
   private static TestSpanData.Builder buildStandardSpan() {
     return TestSpanData.newBuilder()
-        .setTraceId(TraceId.bytesFromLowerBase16(TRACE_ID, 0))
-        .setSpanId(SpanId.bytesFromLowerBase16(SPAN_ID, 0))
-        .setParentSpanId(SpanId.bytesFromLowerBase16(PARENT_SPAN_ID, 0))
+        .setTraceId(TRACE_ID)
+        .setSpanId(SPAN_ID)
+        .setParentSpanId(PARENT_SPAN_ID)
         .setTraceFlags(TraceFlags.builder().setIsSampled(true).build())
         .setStatus(Status.OK)
         .setKind(Kind.SERVER)

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterTest.java
@@ -273,9 +273,9 @@ class ZipkinSpanExporterTest {
 
   private static TestSpanData.Builder buildStandardSpan() {
     return TestSpanData.newBuilder()
-        .setTraceId(TraceId.fromLowerBase16(TRACE_ID, 0))
-        .setSpanId(SpanId.fromLowerBase16(SPAN_ID, 0))
-        .setParentSpanId(SpanId.fromLowerBase16(PARENT_SPAN_ID, 0))
+        .setTraceId(TraceId.bytesFromLowerBase16(TRACE_ID, 0))
+        .setSpanId(SpanId.bytesFromLowerBase16(SPAN_ID, 0))
+        .setParentSpanId(SpanId.bytesFromLowerBase16(PARENT_SPAN_ID, 0))
         .setTraceFlags(TraceFlags.builder().setIsSampled(true).build())
         .setStatus(Status.OK)
         .setKind(Kind.SERVER)

--- a/extensions/logging/log4j2_extensions/src/main/java/io/opentelemetry/contrib/logging/log4j2/TraceContextDataProvider.java
+++ b/extensions/logging/log4j2_extensions/src/main/java/io/opentelemetry/contrib/logging/log4j2/TraceContextDataProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.logging.log4j2;
+
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.TracingContextUtils;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.logging.log4j.core.util.ContextDataProvider;
+
+/**
+ * This ContextDataProvider is loaded via the ServiceProvider facility. {@link #supplyContextData()}
+ * is called when a log entry is created.
+ */
+public class TraceContextDataProvider implements ContextDataProvider {
+  /**
+   * This method is called on the creation of a log event, and is called in the same thread as the
+   * call to the logger. This allows us to pull out request correlation information and make it
+   * available to a layout, even if the logger is using an {@link
+   * org.apache.logging.log4j.core.appender.AsyncAppender}
+   *
+   * @return A map containing string versions of the traceid, spanid, and traceflags which can then
+   *     be accessed from layout components
+   * @see OpenTelemetryJsonLayout
+   */
+  @Override
+  public Map<String, String> supplyContextData() {
+    Span span = TracingContextUtils.getCurrentSpan();
+    Map<String, String> map = new HashMap<>();
+    if (span != null && span.getContext().isValid()) {
+      SpanContext context = span.getContext();
+      if (context != null && context.isValid()) {
+        map.put("traceid", span.getContext().getTraceId().toString());
+        map.put("spanid", span.getContext().getSpanId().toString());
+        map.put("traceflags", span.getContext().getTraceFlags().toLowerBase16());
+      }
+    }
+    return map;
+  }
+}

--- a/extensions/logging/log4j2_extensions/src/test/java/io/opentelemetry/contrib/logging/log4j2/OpenTelemetryJsonLayoutTest.java
+++ b/extensions/logging/log4j2_extensions/src/test/java/io/opentelemetry/contrib/logging/log4j2/OpenTelemetryJsonLayoutTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.logging.log4j2;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.gson.Gson;
+import io.opentelemetry.OpenTelemetry;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.Tracer;
+import java.util.List;
+import java.util.Map;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.junit.LoggerContextRule;
+import org.apache.logging.log4j.test.appender.ListAppender;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class OpenTelemetryJsonLayoutTest {
+  @Rule public LoggerContextRule init = new LoggerContextRule("OpenTelemetryJsonLayoutConfig.xml");
+  private final Gson gson = new Gson();
+
+  @Test
+  public void testOpenTelemetryJsonLayoutDefaults() {
+    Logger logger = init.getLogger("DefaultJsonLogger");
+    ListAppender appender = init.getListAppender("Defaults");
+    double logTime = System.currentTimeMillis();
+
+    // First log outside a span
+    logger.warn("test");
+
+    // Now with an open span
+    Tracer tracer = OpenTelemetry.getTracer("JsonLayoutTest");
+    Span span = tracer.spanBuilder("a_span").startSpan();
+    try (Scope scope = tracer.withSpan(span)) {
+      logger.error("test 2");
+    }
+
+    List<String> messages = appender.getMessages();
+    String first = messages.get(0);
+    Map<?, ?> data = gson.fromJson(first, Map.class);
+    assertThat(data.get("body")).isEqualTo("test");
+    assertThat(data.get("name")).isEqualTo("DefaultJsonLogger");
+    Map<?, ?> time = (Map<?, ?>) data.get("timestamp");
+    double eventTime = (Double) time.get("millis");
+    assertThat(eventTime - logTime).isAtMost(100);
+    assertThat(data.get("severitytext")).isEqualTo("WARN");
+    assertThat(data.get("severitynumber")).isEqualTo(13);
+
+    assertThat(data.get("traceid")).isNull();
+
+    String second = messages.get(1);
+    data = gson.fromJson(second, Map.class);
+    assertThat(span.getContext().getTraceId().toString()).isEqualTo(data.get("traceid"));
+    assertThat(span.getContext().getSpanId().toString()).isEqualTo(data.get("spanid"));
+    assertThat(span.getContext().getTraceFlags().toLowerBase16()).isEqualTo(data.get("traceflags"));
+  }
+}

--- a/extensions/logging/log4j2_extensions/src/test/java/io/opentelemetry/contrib/logging/log4j2/TraceContextDataProviderTest.java
+++ b/extensions/logging/log4j2_extensions/src/test/java/io/opentelemetry/contrib/logging/log4j2/TraceContextDataProviderTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.logging.log4j2;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.gson.Gson;
+import io.opentelemetry.OpenTelemetry;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.Tracer;
+import java.util.List;
+import java.util.Map;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.junit.LoggerContextRule;
+import org.apache.logging.log4j.test.appender.ListAppender;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TraceContextDataProviderTest {
+  @Rule public LoggerContextRule init = new LoggerContextRule("ContextDataProviderTestConfig.xml");
+
+  @Test
+  public void testLayoutWrapperSync() {
+    final Logger logger = init.getLogger("SyncDataProviderTest");
+    final ListAppender appender = init.getListAppender("SyncList");
+    logger.warn("Test message");
+    Tracer tracer = OpenTelemetry.getTracerProvider().get("ot_trace_dataprovider_test");
+    Span span = tracer.spanBuilder("dataprovider_test").startSpan();
+    String traceId = span.getContext().getTraceId().toString();
+    try (Scope scope = tracer.withSpan(span)) {
+      logger.warn("hello");
+    }
+    final List<String> events = appender.getMessages();
+    assertThat(events.size()).isEqualTo(2);
+    String withTrace = events.get(1);
+    assertThat(withTrace).contains(traceId);
+
+    String withoutTrace = events.get(0);
+    assertThat(withoutTrace).contains("traceid=''");
+  }
+
+  @Test
+  public void testLayoutWrapperAsync() throws InterruptedException {
+    final Logger logger = init.getLogger("AsyncContextDataProviderTest");
+    final ListAppender appender = init.getListAppender("AsyncList");
+    Tracer tracer = OpenTelemetry.getTracerProvider().get("ot_trace_lookup_test");
+    Span span = tracer.spanBuilder("lookup_test").startSpan();
+    String traceId = span.getContext().getTraceId().toString();
+    try (Scope scope = tracer.withSpan(span)) {
+      logger.warn("hello");
+    }
+    Thread.sleep(15); // Default wait for log4j is 10ms
+    final List<String> events = appender.getMessages();
+    assertThat(events.size()).isEqualTo(1);
+    String withTrace = events.get(0);
+
+    assertThat(withTrace).contains(String.format("traceid='%s'", traceId));
+  }
+
+  @Test
+  public void testLayoutWrapperJson() {
+    final Logger logger = init.getLogger("JsonContextDataProviderTest");
+    final ListAppender appender = init.getListAppender("JsonList");
+    Tracer tracer = OpenTelemetry.getTracerProvider().get("ot_trace_lookup_test");
+    Span span = tracer.spanBuilder("lookup_test").startSpan();
+    String traceId = span.getContext().getTraceId().toString();
+    String spanId = span.getContext().getSpanId().toString();
+    try (Scope scope = tracer.withSpan(span)) {
+      logger.warn("hello");
+    }
+    final List<String> events = appender.getMessages();
+    assertThat(events.size()).isEqualTo(1);
+    String withTrace = events.get(0);
+
+    Gson gson = new Gson();
+    Map<?, ?> parsed = gson.fromJson(withTrace, Map.class);
+    assertThat(parsed).containsEntry("traceid", traceId);
+    assertThat(parsed).containsEntry("spanid", spanId);
+    assertThat(parsed).containsEntry("traceflags", "01");
+  }
+}

--- a/extensions/trace_propagators/src/jmh/java/io/opentelemetry/extensions/trace/propagation/PropagatorContextInjectBenchmark.java
+++ b/extensions/trace_propagators/src/jmh/java/io/opentelemetry/extensions/trace/propagation/PropagatorContextInjectBenchmark.java
@@ -20,9 +20,7 @@ import io.grpc.Context;
 import io.opentelemetry.context.propagation.HttpTextFormat;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.SpanContext;
-import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
-import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
 import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Arrays;
@@ -92,11 +90,7 @@ public class PropagatorContextInjectBenchmark {
       byte sampledTraceOptionsBytes = 1;
       TraceFlags sampledTraceOptions = TraceFlags.fromByte(sampledTraceOptionsBytes);
       TraceState traceStateDefault = TraceState.builder().build();
-      return SpanContext.create(
-          TraceId.bytesFromLowerBase16(traceId, 0),
-          SpanId.bytesFromLowerBase16(spanId, 0),
-          sampledTraceOptions,
-          traceStateDefault);
+      return SpanContext.create(traceId, spanId, sampledTraceOptions, traceStateDefault);
     }
   }
 

--- a/extensions/trace_propagators/src/jmh/java/io/opentelemetry/extensions/trace/propagation/PropagatorContextInjectBenchmark.java
+++ b/extensions/trace_propagators/src/jmh/java/io/opentelemetry/extensions/trace/propagation/PropagatorContextInjectBenchmark.java
@@ -93,8 +93,8 @@ public class PropagatorContextInjectBenchmark {
       TraceFlags sampledTraceOptions = TraceFlags.fromByte(sampledTraceOptionsBytes);
       TraceState traceStateDefault = TraceState.builder().build();
       return SpanContext.create(
-          TraceId.fromLowerBase16(traceId, 0),
-          SpanId.fromLowerBase16(spanId, 0),
+          TraceId.bytesFromLowerBase16(traceId, 0),
+          SpanId.bytesFromLowerBase16(spanId, 0),
           sampledTraceOptions,
           traceStateDefault);
     }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
@@ -26,7 +26,6 @@ import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
 import io.opentelemetry.trace.TracingContextUtils;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -176,7 +175,6 @@ public class AwsXRayPropagator implements HttpTextFormat {
       }
       // TODO: Put the arbitrary TraceHeader keys in OT trace state
     }
-    System.out.println("traceId = " + Arrays.toString(traceId));
     if (!TraceId.isValid(traceId)) {
       logger.fine(
           "Invalid TraceId in X-Ray trace header: '"

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
@@ -93,14 +93,14 @@ public class AwsXRayPropagator implements HttpTextFormat {
 
     SpanContext spanContext = span.getContext();
 
-    String otTraceId = (String) spanContext.getTraceId();
+    String otTraceId = spanContext.getTraceIdAsBase16();
     String xrayTraceId =
         TRACE_ID_VERSION
             + TRACE_ID_DELIMITER
             + otTraceId.substring(0, TRACE_ID_FIRST_PART_LENGTH)
             + TRACE_ID_DELIMITER
             + otTraceId.substring(TRACE_ID_FIRST_PART_LENGTH);
-    CharSequence parentId = spanContext.getSpanId();
+    CharSequence parentId = spanContext.getSpanIdAsBase16();
     char samplingFlag = spanContext.getTraceFlags().isSampled() ? IS_SAMPLED : NOT_SAMPLED;
     // TODO: Add OT trace state to the X-Ray trace header
 

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
@@ -94,14 +94,14 @@ public class AwsXRayPropagator implements HttpTextFormat {
 
     SpanContext spanContext = span.getContext();
 
-    String otTraceId = TraceId.toLowerBase16(spanContext.getTraceId());
+    String otTraceId = TraceId.toLowerBase16(spanContext.traceId());
     String xrayTraceId =
         TRACE_ID_VERSION
             + TRACE_ID_DELIMITER
             + otTraceId.substring(0, TRACE_ID_FIRST_PART_LENGTH)
             + TRACE_ID_DELIMITER
             + otTraceId.substring(TRACE_ID_FIRST_PART_LENGTH);
-    String parentId = SpanId.toLowerBase16(spanContext.getSpanId());
+    String parentId = SpanId.toLowerBase16(spanContext.spanId());
     char samplingFlag = spanContext.getTraceFlags().isSampled() ? IS_SAMPLED : NOT_SAMPLED;
     // TODO: Add OT trace state to the X-Ray trace header
 

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
@@ -93,14 +93,14 @@ public class AwsXRayPropagator implements HttpTextFormat {
 
     SpanContext spanContext = span.getContext();
 
-    String otTraceId = spanContext.traceId();
+    String otTraceId = (String) spanContext.getTraceId();
     String xrayTraceId =
         TRACE_ID_VERSION
             + TRACE_ID_DELIMITER
             + otTraceId.substring(0, TRACE_ID_FIRST_PART_LENGTH)
             + TRACE_ID_DELIMITER
             + otTraceId.substring(TRACE_ID_FIRST_PART_LENGTH);
-    String parentId = spanContext.spanId();
+    CharSequence parentId = spanContext.getSpanId();
     char samplingFlag = spanContext.getTraceFlags().isSampled() ? IS_SAMPLED : NOT_SAMPLED;
     // TODO: Add OT trace state to the X-Ray trace header
 
@@ -138,8 +138,8 @@ public class AwsXRayPropagator implements HttpTextFormat {
       return SpanContext.getInvalid();
     }
 
-    String traceId = TraceId.getInvalid();
-    String spanId = SpanId.getInvalid();
+    CharSequence traceId = TraceId.getInvalid();
+    CharSequence spanId = SpanId.getInvalid();
     TraceFlags traceFlags = TraceFlags.getDefault();
 
     int pos = 0;
@@ -208,7 +208,7 @@ public class AwsXRayPropagator implements HttpTextFormat {
     return SpanContext.createFromRemoteParent(traceId, spanId, traceFlags, TraceState.getDefault());
   }
 
-  private static String parseTraceId(String xrayTraceId) {
+  private static CharSequence parseTraceId(String xrayTraceId) {
     if (xrayTraceId.length() != TRACE_ID_LENGTH) {
       return TraceId.getInvalid();
     }
@@ -232,7 +232,7 @@ public class AwsXRayPropagator implements HttpTextFormat {
     return epochPart + uniquePart;
   }
 
-  private static String parseSpanId(String xrayParentId) {
+  private static CharSequence parseSpanId(String xrayParentId) {
     if (xrayParentId.length() != PARENT_ID_LENGTH) {
       return SpanId.getInvalid();
     }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
@@ -39,8 +39,8 @@ final class B3PropagatorInjectorMultipleHeaders implements B3PropagatorInjector 
     SpanContext spanContext = span.getContext();
     String sampled = spanContext.getTraceFlags().isSampled() ? Common.TRUE_INT : Common.FALSE_INT;
 
-    setter.set(carrier, B3Propagator.TRACE_ID_HEADER, spanContext.traceId());
-    setter.set(carrier, B3Propagator.SPAN_ID_HEADER, spanContext.spanId());
+    setter.set(carrier, B3Propagator.TRACE_ID_HEADER, (String) spanContext.getTraceId());
+    setter.set(carrier, B3Propagator.SPAN_ID_HEADER, spanContext.getSpanId().toString());
     setter.set(carrier, B3Propagator.SAMPLED_HEADER, sampled);
   }
 }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
@@ -20,8 +20,6 @@ import io.grpc.Context;
 import io.opentelemetry.context.propagation.HttpTextFormat;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
-import io.opentelemetry.trace.SpanId;
-import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
@@ -41,8 +39,8 @@ final class B3PropagatorInjectorMultipleHeaders implements B3PropagatorInjector 
     SpanContext spanContext = span.getContext();
     String sampled = spanContext.getTraceFlags().isSampled() ? Common.TRUE_INT : Common.FALSE_INT;
 
-    setter.set(carrier, B3Propagator.TRACE_ID_HEADER, TraceId.toLowerBase16(spanContext.traceId()));
-    setter.set(carrier, B3Propagator.SPAN_ID_HEADER, SpanId.toLowerBase16(spanContext.spanId()));
+    setter.set(carrier, B3Propagator.TRACE_ID_HEADER, spanContext.traceId());
+    setter.set(carrier, B3Propagator.SPAN_ID_HEADER, spanContext.spanId());
     setter.set(carrier, B3Propagator.SAMPLED_HEADER, sampled);
   }
 }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
@@ -20,6 +20,8 @@ import io.grpc.Context;
 import io.opentelemetry.context.propagation.HttpTextFormat;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
@@ -39,8 +41,9 @@ final class B3PropagatorInjectorMultipleHeaders implements B3PropagatorInjector 
     SpanContext spanContext = span.getContext();
     String sampled = spanContext.getTraceFlags().isSampled() ? Common.TRUE_INT : Common.FALSE_INT;
 
-    setter.set(carrier, B3Propagator.TRACE_ID_HEADER, spanContext.getTraceId().toLowerBase16());
-    setter.set(carrier, B3Propagator.SPAN_ID_HEADER, spanContext.getSpanId().toLowerBase16());
+    setter.set(
+        carrier, B3Propagator.TRACE_ID_HEADER, TraceId.toLowerBase16(spanContext.getTraceId()));
+    setter.set(carrier, B3Propagator.SPAN_ID_HEADER, SpanId.toLowerBase16(spanContext.getSpanId()));
     setter.set(carrier, B3Propagator.SAMPLED_HEADER, sampled);
   }
 }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
@@ -41,9 +41,8 @@ final class B3PropagatorInjectorMultipleHeaders implements B3PropagatorInjector 
     SpanContext spanContext = span.getContext();
     String sampled = spanContext.getTraceFlags().isSampled() ? Common.TRUE_INT : Common.FALSE_INT;
 
-    setter.set(
-        carrier, B3Propagator.TRACE_ID_HEADER, TraceId.toLowerBase16(spanContext.getTraceId()));
-    setter.set(carrier, B3Propagator.SPAN_ID_HEADER, SpanId.toLowerBase16(spanContext.getSpanId()));
+    setter.set(carrier, B3Propagator.TRACE_ID_HEADER, TraceId.toLowerBase16(spanContext.traceId()));
+    setter.set(carrier, B3Propagator.SPAN_ID_HEADER, SpanId.toLowerBase16(spanContext.spanId()));
     setter.set(carrier, B3Propagator.SAMPLED_HEADER, sampled);
   }
 }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
@@ -39,8 +39,8 @@ final class B3PropagatorInjectorMultipleHeaders implements B3PropagatorInjector 
     SpanContext spanContext = span.getContext();
     String sampled = spanContext.getTraceFlags().isSampled() ? Common.TRUE_INT : Common.FALSE_INT;
 
-    setter.set(carrier, B3Propagator.TRACE_ID_HEADER, (String) spanContext.getTraceId());
-    setter.set(carrier, B3Propagator.SPAN_ID_HEADER, spanContext.getSpanId().toString());
+    setter.set(carrier, B3Propagator.TRACE_ID_HEADER, spanContext.getTraceIdAsBase16());
+    setter.set(carrier, B3Propagator.SPAN_ID_HEADER, spanContext.getSpanIdAsBase16().toString());
     setter.set(carrier, B3Propagator.SAMPLED_HEADER, sampled);
   }
 }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorSingleHeader.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorSingleHeader.java
@@ -50,9 +50,9 @@ final class B3PropagatorInjectorSingleHeader implements B3PropagatorInjector {
     SpanContext spanContext = span.getContext();
 
     char[] chars = new char[COMBINED_HEADER_SIZE];
-    spanContext.getTraceId().copyLowerBase16To(chars, 0);
+    TraceId.copyLowerBase16Into(spanContext.getTraceId(), chars, 0);
     chars[SPAN_ID_OFFSET - 1] = B3Propagator.COMBINED_HEADER_DELIMITER_CHAR;
-    spanContext.getSpanId().copyLowerBase16To(chars, SPAN_ID_OFFSET);
+    SpanId.copyLowerBase16Into(spanContext.getSpanId(), chars, SPAN_ID_OFFSET);
     chars[SAMPLED_FLAG_OFFSET - 1] = B3Propagator.COMBINED_HEADER_DELIMITER_CHAR;
     chars[SAMPLED_FLAG_OFFSET] =
         spanContext.getTraceFlags().isSampled()

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorSingleHeader.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorSingleHeader.java
@@ -50,9 +50,9 @@ final class B3PropagatorInjectorSingleHeader implements B3PropagatorInjector {
     SpanContext spanContext = span.getContext();
 
     char[] chars = new char[COMBINED_HEADER_SIZE];
-    TraceId.copyLowerBase16Into(spanContext.getTraceId(), chars, 0);
+    TraceId.copyLowerBase16Into(spanContext.traceId(), chars, 0);
     chars[SPAN_ID_OFFSET - 1] = B3Propagator.COMBINED_HEADER_DELIMITER_CHAR;
-    SpanId.copyLowerBase16Into(spanContext.getSpanId(), chars, SPAN_ID_OFFSET);
+    SpanId.copyLowerBase16Into(spanContext.spanId(), chars, SPAN_ID_OFFSET);
     chars[SAMPLED_FLAG_OFFSET - 1] = B3Propagator.COMBINED_HEADER_DELIMITER_CHAR;
     chars[SAMPLED_FLAG_OFFSET] =
         spanContext.getTraceFlags().isSampled()

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorSingleHeader.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorSingleHeader.java
@@ -50,16 +50,12 @@ final class B3PropagatorInjectorSingleHeader implements B3PropagatorInjector {
     SpanContext spanContext = span.getContext();
 
     char[] chars = new char[COMBINED_HEADER_SIZE];
-    System.arraycopy(
-        ((String) spanContext.getTraceId()).toCharArray(), 0, chars, 0, TraceId.getSize() * 2);
+    String traceId = spanContext.getTraceIdAsBase16();
+    System.arraycopy(traceId.toCharArray(), 0, chars, 0, TRACE_ID_HEX_SIZE);
     chars[SPAN_ID_OFFSET - 1] = B3Propagator.COMBINED_HEADER_DELIMITER_CHAR;
 
-    CharSequence spanId = spanContext.getSpanId();
-    //    System.arraycopy(
-    //        spanId.toCharArray(), 0, chars, SPAN_ID_OFFSET, SpanId.getSize() * 2);
-    for (int i = 0; i < spanId.length(); i++) {
-      chars[SPAN_ID_OFFSET + i] = spanId.charAt(i);
-    }
+    String spanId = spanContext.getSpanIdAsBase16();
+    System.arraycopy(spanId.toCharArray(), 0, chars, SPAN_ID_OFFSET, SpanId.getSize() * 2);
 
     chars[SAMPLED_FLAG_OFFSET - 1] = B3Propagator.COMBINED_HEADER_DELIMITER_CHAR;
     chars[SAMPLED_FLAG_OFFSET] =

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorSingleHeader.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorSingleHeader.java
@@ -50,11 +50,17 @@ final class B3PropagatorInjectorSingleHeader implements B3PropagatorInjector {
     SpanContext spanContext = span.getContext();
 
     char[] chars = new char[COMBINED_HEADER_SIZE];
-    System.arraycopy(spanContext.traceId().toCharArray(), 0, chars, 0, TraceId.getSize() * 2);
+    System.arraycopy(
+        ((String) spanContext.getTraceId()).toCharArray(), 0, chars, 0, TraceId.getSize() * 2);
     chars[SPAN_ID_OFFSET - 1] = B3Propagator.COMBINED_HEADER_DELIMITER_CHAR;
 
-    System.arraycopy(
-        spanContext.spanId().toCharArray(), 0, chars, SPAN_ID_OFFSET, SpanId.getSize() * 2);
+    CharSequence spanId = spanContext.getSpanId();
+    //    System.arraycopy(
+    //        spanId.toCharArray(), 0, chars, SPAN_ID_OFFSET, SpanId.getSize() * 2);
+    for (int i = 0; i < spanId.length(); i++) {
+      chars[SPAN_ID_OFFSET + i] = spanId.charAt(i);
+    }
+
     chars[SAMPLED_FLAG_OFFSET - 1] = B3Propagator.COMBINED_HEADER_DELIMITER_CHAR;
     chars[SAMPLED_FLAG_OFFSET] =
         spanContext.getTraceFlags().isSampled()

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorSingleHeader.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorSingleHeader.java
@@ -50,9 +50,11 @@ final class B3PropagatorInjectorSingleHeader implements B3PropagatorInjector {
     SpanContext spanContext = span.getContext();
 
     char[] chars = new char[COMBINED_HEADER_SIZE];
-    TraceId.copyLowerBase16Into(spanContext.traceId(), chars, 0);
+    System.arraycopy(spanContext.traceId().toCharArray(), 0, chars, 0, TraceId.getSize() * 2);
     chars[SPAN_ID_OFFSET - 1] = B3Propagator.COMBINED_HEADER_DELIMITER_CHAR;
-    SpanId.copyLowerBase16Into(spanContext.spanId(), chars, SPAN_ID_OFFSET);
+
+    System.arraycopy(
+        spanContext.spanId().toCharArray(), 0, chars, SPAN_ID_OFFSET, SpanId.getSize() * 2);
     chars[SAMPLED_FLAG_OFFSET - 1] = B3Propagator.COMBINED_HEADER_DELIMITER_CHAR;
     chars[SAMPLED_FLAG_OFFSET] =
         spanContext.getTraceFlags().isSampled()

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/Common.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/Common.java
@@ -52,8 +52,8 @@ final class Common {
               : NOT_SAMPLED_FLAGS;
 
       return SpanContext.createFromRemoteParent(
-          TraceId.fromLowerBase16(StringUtils.padLeft(traceId, MAX_TRACE_ID_LENGTH), 0),
-          SpanId.fromLowerBase16(spanId, 0),
+          StringUtils.padLeft(traceId, MAX_TRACE_ID_LENGTH),
+          spanId,
           traceFlags,
           TraceState.getDefault());
     } catch (Exception e) {

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
@@ -95,13 +95,13 @@ public class JaegerPropagator implements HttpTextFormat {
 
     char[] chars = new char[PROPAGATION_HEADER_SIZE];
 
-    CharSequence traceId = spanContext.getTraceId();
+    CharSequence traceId = spanContext.getTraceIdAsBase16();
     for (int i = 0; i < traceId.length(); i++) {
       chars[i] = traceId.charAt(i);
     }
 
     chars[SPAN_ID_OFFSET - 1] = PROPAGATION_HEADER_DELIMITER;
-    CharSequence spanId = spanContext.getSpanId();
+    CharSequence spanId = spanContext.getSpanIdAsBase16();
     for (int i = 0; i < spanId.length(); i++) {
       chars[SPAN_ID_OFFSET + i] = spanId.charAt(i);
     }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
@@ -94,16 +94,17 @@ public class JaegerPropagator implements HttpTextFormat {
     SpanContext spanContext = span.getContext();
 
     char[] chars = new char[PROPAGATION_HEADER_SIZE];
-    System.arraycopy(
-        ((String) spanContext.getTraceId()).toCharArray(), 0, chars, 0, TraceId.getSize() * 2);
+
+    CharSequence traceId = spanContext.getTraceId();
+    for (int i = 0; i < traceId.length(); i++) {
+      chars[i] = traceId.charAt(i);
+    }
 
     chars[SPAN_ID_OFFSET - 1] = PROPAGATION_HEADER_DELIMITER;
     CharSequence spanId = spanContext.getSpanId();
     for (int i = 0; i < spanId.length(); i++) {
       chars[SPAN_ID_OFFSET + i] = spanId.charAt(i);
     }
-    //    System.arraycopy(
-    //        spanId.toCharArray(), 0, chars, SPAN_ID_OFFSET, SpanId.getSize() * 2);
 
     chars[PARENT_SPAN_ID_OFFSET - 1] = PROPAGATION_HEADER_DELIMITER;
     chars[PARENT_SPAN_ID_OFFSET] = DEPRECATED_PARENT_SPAN;

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
@@ -94,11 +94,16 @@ public class JaegerPropagator implements HttpTextFormat {
     SpanContext spanContext = span.getContext();
 
     char[] chars = new char[PROPAGATION_HEADER_SIZE];
-    System.arraycopy(spanContext.traceId().toCharArray(), 0, chars, 0, TraceId.getSize() * 2);
+    System.arraycopy(
+        ((String) spanContext.getTraceId()).toCharArray(), 0, chars, 0, TraceId.getSize() * 2);
 
     chars[SPAN_ID_OFFSET - 1] = PROPAGATION_HEADER_DELIMITER;
-    System.arraycopy(
-        spanContext.spanId().toCharArray(), 0, chars, SPAN_ID_OFFSET, SpanId.getSize() * 2);
+    CharSequence spanId = spanContext.getSpanId();
+    for (int i = 0; i < spanId.length(); i++) {
+      chars[SPAN_ID_OFFSET + i] = spanId.charAt(i);
+    }
+    //    System.arraycopy(
+    //        spanId.toCharArray(), 0, chars, SPAN_ID_OFFSET, SpanId.getSize() * 2);
 
     chars[PARENT_SPAN_ID_OFFSET - 1] = PROPAGATION_HEADER_DELIMITER;
     chars[PARENT_SPAN_ID_OFFSET] = DEPRECATED_PARENT_SPAN;

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
@@ -94,10 +94,10 @@ public class JaegerPropagator implements HttpTextFormat {
     SpanContext spanContext = span.getContext();
 
     char[] chars = new char[PROPAGATION_HEADER_SIZE];
-    TraceId.copyLowerBase16Into(spanContext.getTraceId(), chars, 0);
+    TraceId.copyLowerBase16Into(spanContext.traceId(), chars, 0);
 
     chars[SPAN_ID_OFFSET - 1] = PROPAGATION_HEADER_DELIMITER;
-    SpanId.copyLowerBase16Into(spanContext.getSpanId(), chars, SPAN_ID_OFFSET);
+    SpanId.copyLowerBase16Into(spanContext.spanId(), chars, SPAN_ID_OFFSET);
     chars[PARENT_SPAN_ID_OFFSET - 1] = PROPAGATION_HEADER_DELIMITER;
     chars[PARENT_SPAN_ID_OFFSET] = DEPRECATED_PARENT_SPAN;
     chars[SAMPLED_FLAG_OFFSET - 1] = PROPAGATION_HEADER_DELIMITER;

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
@@ -94,9 +94,10 @@ public class JaegerPropagator implements HttpTextFormat {
     SpanContext spanContext = span.getContext();
 
     char[] chars = new char[PROPAGATION_HEADER_SIZE];
-    spanContext.getTraceId().copyLowerBase16To(chars, 0);
+    TraceId.copyLowerBase16Into(spanContext.getTraceId(), chars, 0);
+
     chars[SPAN_ID_OFFSET - 1] = PROPAGATION_HEADER_DELIMITER;
-    spanContext.getSpanId().copyLowerBase16To(chars, SPAN_ID_OFFSET);
+    SpanId.copyLowerBase16Into(spanContext.getSpanId(), chars, SPAN_ID_OFFSET);
     chars[PARENT_SPAN_ID_OFFSET - 1] = PROPAGATION_HEADER_DELIMITER;
     chars[PARENT_SPAN_ID_OFFSET] = DEPRECATED_PARENT_SPAN;
     chars[SAMPLED_FLAG_OFFSET - 1] = PROPAGATION_HEADER_DELIMITER;
@@ -190,8 +191,8 @@ public class JaegerPropagator implements HttpTextFormat {
       TraceFlags traceFlags = ((flagsInt & 1) == 1) ? SAMPLED_FLAGS : NOT_SAMPLED_FLAGS;
 
       return SpanContext.createFromRemoteParent(
-          TraceId.fromLowerBase16(StringUtils.padLeft(traceId, MAX_TRACE_ID_LENGTH), 0),
-          SpanId.fromLowerBase16(StringUtils.padLeft(spanId, MAX_SPAN_ID_LENGTH), 0),
+          TraceId.bytesFromLowerBase16(StringUtils.padLeft(traceId, MAX_TRACE_ID_LENGTH), 0),
+          SpanId.bytesFromLowerBase16(StringUtils.padLeft(spanId, MAX_SPAN_ID_LENGTH), 0),
           traceFlags,
           TraceState.getDefault());
     } catch (Exception e) {

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagator.java
@@ -74,8 +74,8 @@ public class OtTracerPropagator implements HttpTextFormat {
     if (!spanContext.isValid()) {
       return;
     }
-    setter.set(carrier, TRACE_ID_HEADER, spanContext.getTraceId().toString());
-    setter.set(carrier, SPAN_ID_HEADER, spanContext.getSpanId().toString());
+    setter.set(carrier, TRACE_ID_HEADER, spanContext.getTraceIdAsBase16().toString());
+    setter.set(carrier, SPAN_ID_HEADER, spanContext.getSpanIdAsBase16().toString());
     setter.set(carrier, SAMPLED_HEADER, String.valueOf(spanContext.getTraceFlags().isSampled()));
   }
 

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagatorTest.java
@@ -37,11 +37,11 @@ import org.junit.jupiter.api.Test;
 class AwsXRayPropagatorTest {
 
   private static final String TRACE_ID_BASE16 = "8a3c60f7d188f8fa79d48a391a778fa6";
-  private static final TraceId TRACE_ID = TraceId.fromLowerBase16(TRACE_ID_BASE16, 0);
+  private static final byte[] TRACE_ID = TraceId.bytesFromLowerBase16(TRACE_ID_BASE16, 0);
   private static final TraceState TRACE_STATE_DEFAULT = TraceState.getDefault();
 
   private static final String SPAN_ID_BASE16 = "53995c3f42cd8ad8";
-  private static final SpanId SPAN_ID = SpanId.fromLowerBase16(SPAN_ID_BASE16, 0);
+  private static final byte[] SPAN_ID = SpanId.bytesFromLowerBase16(SPAN_ID_BASE16, 0);
   private static final TraceFlags SAMPLED_TRACE_FLAG =
       TraceFlags.builder().setIsSampled(true).build();
 

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagatorTest.java
@@ -23,9 +23,7 @@ import io.grpc.Context;
 import io.opentelemetry.context.propagation.HttpTextFormat;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.SpanContext;
-import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
-import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
 import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Collections;
@@ -37,11 +35,9 @@ import org.junit.jupiter.api.Test;
 class AwsXRayPropagatorTest {
 
   private static final String TRACE_ID_BASE16 = "8a3c60f7d188f8fa79d48a391a778fa6";
-  private static final byte[] TRACE_ID = TraceId.bytesFromLowerBase16(TRACE_ID_BASE16, 0);
   private static final TraceState TRACE_STATE_DEFAULT = TraceState.getDefault();
 
   private static final String SPAN_ID_BASE16 = "53995c3f42cd8ad8";
-  private static final byte[] SPAN_ID = SpanId.bytesFromLowerBase16(SPAN_ID_BASE16, 0);
   private static final TraceFlags SAMPLED_TRACE_FLAG =
       TraceFlags.builder().setIsSampled(true).build();
 
@@ -61,7 +57,8 @@ class AwsXRayPropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     xrayPropagator.inject(
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_FLAG, TRACE_STATE_DEFAULT),
+            SpanContext.create(
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_FLAG, TRACE_STATE_DEFAULT),
             Context.current()),
         carrier,
         setter);
@@ -77,7 +74,8 @@ class AwsXRayPropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     xrayPropagator.inject(
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT),
+            SpanContext.create(
+                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE_DEFAULT),
             Context.current()),
         carrier,
         setter);
@@ -94,8 +92,8 @@ class AwsXRayPropagatorTest {
     xrayPropagator.inject(
         withSpanContext(
             SpanContext.create(
-                TRACE_ID,
-                SPAN_ID,
+                TRACE_ID_BASE16,
+                SPAN_ID_BASE16,
                 TraceFlags.getDefault(),
                 TraceState.builder().set("foo", "bar").build()),
             Context.current()),
@@ -128,7 +126,7 @@ class AwsXRayPropagatorTest {
     assertThat(getSpanContext(xrayPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_FLAG, TRACE_STATE_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_FLAG, TRACE_STATE_DEFAULT));
   }
 
   @Test
@@ -141,7 +139,7 @@ class AwsXRayPropagatorTest {
     assertThat(getSpanContext(xrayPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
   }
 
   @Test
@@ -154,7 +152,7 @@ class AwsXRayPropagatorTest {
     assertThat(getSpanContext(xrayPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_FLAG, TRACE_STATE_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_FLAG, TRACE_STATE_DEFAULT));
   }
 
   @Test
@@ -168,7 +166,7 @@ class AwsXRayPropagatorTest {
     assertThat(getSpanContext(xrayPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_FLAG, TRACE_STATE_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_FLAG, TRACE_STATE_DEFAULT));
   }
 
   @Test

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
@@ -40,9 +40,11 @@ class B3PropagatorTest {
 
   private static final TraceState TRACE_STATE_DEFAULT = TraceState.builder().build();
   private static final String TRACE_ID = "ff000000000000000000000000000041";
+  private static final String TRACE_ID_ALL_ZERO = "00000000000000000000000000000000";
   private static final String SHORT_TRACE_ID = "ff00000000000000";
-  private static final String PADDED_SHORT_TRACE_ID = "0000000000000000ff00000000000000";
+  private static final String SHORT_TRACE_ID_FULL = StringUtils.padLeft(SHORT_TRACE_ID, 32);
   private static final String SPAN_ID = "ff00000000000041";
+  private static final String SPAN_ID_ALL_ZERO = "0000000000000000";
   private static final byte SAMPLED_TRACE_OPTIONS_BYTES = 1;
   private static final TraceFlags SAMPLED_TRACE_OPTIONS =
       TraceFlags.fromByte(SAMPLED_TRACE_OPTIONS_BYTES);
@@ -182,7 +184,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                PADDED_SHORT_TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
   }
 
   @Test
@@ -195,7 +197,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                PADDED_SHORT_TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
   }
 
   @Test
@@ -208,14 +210,14 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                PADDED_SHORT_TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
   }
 
   @Test
   void extract_InvalidTraceId_NotHex() {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
-    invalidHeaders.put(B3Propagator.TRACE_ID_HEADER, "g" + TRACE_ID_BASE16.substring(1));
-    invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    invalidHeaders.put(B3Propagator.TRACE_ID_HEADER, "g" + TRACE_ID.substring(1));
+    invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID);
     invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameAs(SpanContext.getInvalid());
@@ -224,7 +226,7 @@ class B3PropagatorTest {
   @Test
   void extract_InvalidTraceId_TooShort() {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
-    invalidHeaders.put(B3Propagator.TRACE_ID_HEADER, TRACE_ID_BASE16.substring(2));
+    invalidHeaders.put(B3Propagator.TRACE_ID_HEADER, TRACE_ID.substring(2));
     invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID);
     invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
@@ -245,7 +247,7 @@ class B3PropagatorTest {
   void extract_InvalidTraceId_AllZero() {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(B3Propagator.TRACE_ID_HEADER, TRACE_ID_ALL_ZERO);
-    invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID);
     invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameAs(SpanContext.getInvalid());
@@ -254,8 +256,8 @@ class B3PropagatorTest {
   @Test
   void extract_InvalidSpanId_NotHex() {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
-    invalidHeaders.put(B3Propagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
-    invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, "g" + SPAN_ID_BASE16.substring(1));
+    invalidHeaders.put(B3Propagator.TRACE_ID_HEADER, TRACE_ID);
+    invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, "g" + SPAN_ID.substring(1));
     invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameAs(SpanContext.getInvalid());
@@ -264,8 +266,8 @@ class B3PropagatorTest {
   @Test
   void extract_InvalidSpanId_TooShort() {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
-    invalidHeaders.put(B3Propagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
-    invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16.substring(2));
+    invalidHeaders.put(B3Propagator.TRACE_ID_HEADER, TRACE_ID);
+    invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID.substring(2));
     invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameAs(SpanContext.getInvalid());
@@ -275,7 +277,7 @@ class B3PropagatorTest {
   void extract_InvalidSpanId_TooLong() {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(B3Propagator.TRACE_ID_HEADER, TRACE_ID);
-    invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16 + "00");
+    invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID + "00");
     invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameAs(SpanContext.getInvalid());
@@ -347,8 +349,7 @@ class B3PropagatorTest {
   @Test
   void extract_SampledContext_Int_SingleHeader() {
     Map<String, String> carrier = new LinkedHashMap<>();
-    carrier.put(
-        B3Propagator.COMBINED_HEADER, TRACE_ID + "-" + SPAN_ID + "-" + Common.TRUE_INT);
+    carrier.put(B3Propagator.COMBINED_HEADER, TRACE_ID + "-" + SPAN_ID + "-" + Common.TRUE_INT);
 
     assertThat(getSpanContext(b3PropagatorSingleHeader.extract(Context.current(), carrier, getter)))
         .isEqualTo(
@@ -360,8 +361,7 @@ class B3PropagatorTest {
   void extract_SampledContext_DebugFlag_SingleHeader() {
     Map<String, String> carrier = new LinkedHashMap<>();
     carrier.put(
-        B3Propagator.COMBINED_HEADER,
-        TRACE_ID + "-" + SPAN_ID + "-" + Common.TRUE_INT + "-" + "0");
+        B3Propagator.COMBINED_HEADER, TRACE_ID + "-" + SPAN_ID + "-" + Common.TRUE_INT + "-" + "0");
 
     assertThat(getSpanContext(b3PropagatorSingleHeader.extract(Context.current(), carrier, getter)))
         .isEqualTo(
@@ -394,8 +394,7 @@ class B3PropagatorTest {
   @Test
   void extract_NotSampledContext_SingleHeader() {
     Map<String, String> carrier = new LinkedHashMap<>();
-    carrier.put(
-        B3Propagator.COMBINED_HEADER, TRACE_ID + "-" + SPAN_ID + "-" + Common.FALSE_INT);
+    carrier.put(B3Propagator.COMBINED_HEADER, TRACE_ID + "-" + SPAN_ID + "-" + Common.FALSE_INT);
 
     assertThat(getSpanContext(b3PropagatorSingleHeader.extract(Context.current(), carrier, getter)))
         .isEqualTo(
@@ -412,7 +411,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3PropagatorSingleHeader.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                PADDED_SHORT_TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
   }
 
   @Test
@@ -425,7 +424,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3PropagatorSingleHeader.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                PADDED_SHORT_TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
   }
 
   @Test
@@ -436,7 +435,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3PropagatorSingleHeader.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                PADDED_SHORT_TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
   }
 
   @Test
@@ -448,20 +447,19 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3PropagatorSingleHeader.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                PADDED_SHORT_TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
   }
 
   @Test
   void extract_NotSampledContext_SingleHeader_Short_TraceId() {
     Map<String, String> carrier = new LinkedHashMap<>();
     carrier.put(
-        B3Propagator.COMBINED_HEADER,
-        SHORT_TRACE_ID + "-" + SPAN_ID + "-" + Common.FALSE_INT);
+        B3Propagator.COMBINED_HEADER, SHORT_TRACE_ID + "-" + SPAN_ID + "-" + Common.FALSE_INT);
 
     assertThat(getSpanContext(b3PropagatorSingleHeader.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                PADDED_SHORT_TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
   }
 
   @Test
@@ -516,8 +514,7 @@ class B3PropagatorTest {
   void extract_InvalidSpanId_SingleHeader() {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(
-        B3Propagator.COMBINED_HEADER,
-        TRACE_ID + "-" + "abcdefghijklmnop" + "-" + Common.TRUE_INT);
+        B3Propagator.COMBINED_HEADER, TRACE_ID + "-" + "abcdefghijklmnop" + "-" + Common.TRUE_INT);
 
     assertThat(
             getSpanContext(
@@ -549,8 +546,7 @@ class B3PropagatorTest {
   void extract_TooManyParts_SingleHeader() {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(
-        B3Propagator.COMBINED_HEADER,
-        TRACE_ID + "-" + SPAN_ID + "-" + Common.TRUE_INT + "-extra");
+        B3Propagator.COMBINED_HEADER, TRACE_ID + "-" + SPAN_ID + "-" + Common.TRUE_INT + "-extra");
 
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameAs(SpanContext.getInvalid());

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
@@ -41,13 +41,13 @@ class B3PropagatorTest {
   private static final TraceState TRACE_STATE_DEFAULT = TraceState.builder().build();
   private static final String TRACE_ID_BASE16 = "ff000000000000000000000000000041";
   private static final String TRACE_ID_ALL_ZERO = "00000000000000000000000000000000";
-  private static final TraceId TRACE_ID = TraceId.fromLowerBase16(TRACE_ID_BASE16, 0);
+  private static final byte[] TRACE_ID = TraceId.bytesFromLowerBase16(TRACE_ID_BASE16, 0);
   private static final String SHORT_TRACE_ID_BASE16 = "ff00000000000000";
-  private static final TraceId SHORT_TRACE_ID =
-      TraceId.fromLowerBase16(StringUtils.padLeft(SHORT_TRACE_ID_BASE16, 32), 0);
+  private static final byte[] SHORT_TRACE_ID =
+      TraceId.bytesFromLowerBase16(StringUtils.padLeft(SHORT_TRACE_ID_BASE16, 32), 0);
   private static final String SPAN_ID_BASE16 = "ff00000000000041";
   private static final String SPAN_ID_ALL_ZERO = "0000000000000000";
-  private static final SpanId SPAN_ID = SpanId.fromLowerBase16(SPAN_ID_BASE16, 0);
+  private static final byte[] SPAN_ID = SpanId.bytesFromLowerBase16(SPAN_ID_BASE16, 0);
   private static final byte SAMPLED_TRACE_OPTIONS_BYTES = 1;
   private static final TraceFlags SAMPLED_TRACE_OPTIONS =
       TraceFlags.fromByte(SAMPLED_TRACE_OPTIONS_BYTES);

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagatorTest.java
@@ -48,13 +48,14 @@ class JaegerPropagatorTest {
   private static final long TRACE_ID_HI = 77L;
   private static final long TRACE_ID_LOW = 22L;
   private static final String TRACE_ID_BASE16 = "000000000000004d0000000000000016";
-  private static final TraceId TRACE_ID = new TraceId(TRACE_ID_HI, TRACE_ID_LOW);
+  private static final byte[] TRACE_ID = TraceId.fromLongs(TRACE_ID_HI, TRACE_ID_LOW);
   private static final long SHORT_TRACE_ID_HI = 0L;
   private static final long SHORT_TRACE_ID_LOW = 2322222L;
-  private static final TraceId SHORT_TRACE_ID = new TraceId(SHORT_TRACE_ID_HI, SHORT_TRACE_ID_LOW);
+  private static final byte[] SHORT_TRACE_ID =
+      TraceId.fromLongs(SHORT_TRACE_ID_HI, SHORT_TRACE_ID_LOW);
   private static final String SPAN_ID_BASE16 = "0000000000017c29";
   private static final long SPAN_ID_LONG = 97321L;
-  private static final SpanId SPAN_ID = new SpanId(SPAN_ID_LONG);
+  private static final byte[] SPAN_ID = SpanId.fromLong(SPAN_ID_LONG);
   private static final long DEPRECATED_PARENT_SPAN_LONG = 0L;
   private static final byte SAMPLED_TRACE_OPTIONS_BYTES = 1;
   private static final TraceFlags SAMPLED_TRACE_OPTIONS =

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagatorTest.java
@@ -48,14 +48,14 @@ class JaegerPropagatorTest {
   private static final long TRACE_ID_HI = 77L;
   private static final long TRACE_ID_LOW = 22L;
   private static final String TRACE_ID_BASE16 = "000000000000004d0000000000000016";
-  private static final byte[] TRACE_ID = TraceId.fromLongs(TRACE_ID_HI, TRACE_ID_LOW);
+  private static final String TRACE_ID = TraceId.fromLongs(TRACE_ID_HI, TRACE_ID_LOW);
   private static final long SHORT_TRACE_ID_HI = 0L;
   private static final long SHORT_TRACE_ID_LOW = 2322222L;
-  private static final byte[] SHORT_TRACE_ID =
+  private static final String SHORT_TRACE_ID =
       TraceId.fromLongs(SHORT_TRACE_ID_HI, SHORT_TRACE_ID_LOW);
   private static final String SPAN_ID_BASE16 = "0000000000017c29";
   private static final long SPAN_ID_LONG = 97321L;
-  private static final byte[] SPAN_ID = SpanId.fromLong(SPAN_ID_LONG);
+  private static final String SPAN_ID = SpanId.fromLong(SPAN_ID_LONG);
   private static final long DEPRECATED_PARENT_SPAN_LONG = 0L;
   private static final byte SAMPLED_TRACE_OPTIONS_BYTES = 1;
   private static final TraceFlags SAMPLED_TRACE_OPTIONS =

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagatorTest.java
@@ -48,14 +48,14 @@ class JaegerPropagatorTest {
   private static final long TRACE_ID_HI = 77L;
   private static final long TRACE_ID_LOW = 22L;
   private static final String TRACE_ID_BASE16 = "000000000000004d0000000000000016";
-  private static final String TRACE_ID = TraceId.fromLongs(TRACE_ID_HI, TRACE_ID_LOW);
+  private static final CharSequence TRACE_ID = TraceId.fromLongs(TRACE_ID_HI, TRACE_ID_LOW);
   private static final long SHORT_TRACE_ID_HI = 0L;
   private static final long SHORT_TRACE_ID_LOW = 2322222L;
-  private static final String SHORT_TRACE_ID =
+  private static final CharSequence SHORT_TRACE_ID =
       TraceId.fromLongs(SHORT_TRACE_ID_HI, SHORT_TRACE_ID_LOW);
   private static final String SPAN_ID_BASE16 = "0000000000017c29";
   private static final long SPAN_ID_LONG = 97321L;
-  private static final String SPAN_ID = SpanId.fromLong(SPAN_ID_LONG);
+  private static final CharSequence SPAN_ID = SpanId.fromLong(SPAN_ID_LONG);
   private static final long DEPRECATED_PARENT_SPAN_LONG = 0L;
   private static final byte SAMPLED_TRACE_OPTIONS_BYTES = 1;
   private static final TraceFlags SAMPLED_TRACE_OPTIONS =

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagatorTest.java
@@ -37,13 +37,10 @@ import org.junit.jupiter.api.Test;
 class OtTracerPropagatorTest {
 
   private static final TraceState TRACE_STATE_DEFAULT = TraceState.builder().build();
-  private static final String TRACE_ID_BASE16 = "ff000000000000000000000000000041";
-  private static final TraceId TRACE_ID = TraceId.fromLowerBase16(TRACE_ID_BASE16, 0);
-  private static final String SHORT_TRACE_ID_BASE16 = "ff00000000000000";
-  private static final TraceId SHORT_TRACE_ID =
-      TraceId.fromLowerBase16(StringUtils.padLeft(SHORT_TRACE_ID_BASE16, 32), 0);
-  private static final String SPAN_ID_BASE16 = "ff00000000000041";
-  private static final SpanId SPAN_ID = SpanId.fromLowerBase16(SPAN_ID_BASE16, 0);
+  private static final String TRACE_ID = "ff000000000000000000000000000041";
+  private static final String SHORT_TRACE_ID = "ff00000000000000";
+  private static final String SHORT_TRACE_ID_FULL = "0000000000000000ff00000000000000";
+  private static final String SPAN_ID = "ff00000000000041";
   private static final byte SAMPLED_TRACE_OPTIONS_BYTES = 1;
   private static final TraceFlags SAMPLED_TRACE_OPTIONS =
       TraceFlags.fromByte(SAMPLED_TRACE_OPTIONS_BYTES);
@@ -84,8 +81,8 @@ class OtTracerPropagatorTest {
             Context.current()),
         carrier,
         setter);
-    assertThat(carrier).containsEntry(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
-    assertThat(carrier).containsEntry(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    assertThat(carrier).containsEntry(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID);
+    assertThat(carrier).containsEntry(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
     assertThat(carrier).containsEntry(OtTracerPropagator.SAMPLED_HEADER, "true");
   }
 
@@ -98,8 +95,8 @@ class OtTracerPropagatorTest {
             Context.current()),
         null,
         (Setter<Map<String, String>>) (ignored, key, value) -> carrier.put(key, value));
-    assertThat(carrier).containsEntry(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
-    assertThat(carrier).containsEntry(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    assertThat(carrier).containsEntry(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID);
+    assertThat(carrier).containsEntry(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
     assertThat(carrier).containsEntry(OtTracerPropagator.SAMPLED_HEADER, "true");
   }
 
@@ -112,8 +109,8 @@ class OtTracerPropagatorTest {
             Context.current()),
         carrier,
         setter);
-    assertThat(carrier).containsEntry(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
-    assertThat(carrier).containsEntry(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    assertThat(carrier).containsEntry(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID);
+    assertThat(carrier).containsEntry(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
     assertThat(carrier).containsEntry(OtTracerPropagator.SAMPLED_HEADER, "false");
   }
 
@@ -128,8 +125,8 @@ class OtTracerPropagatorTest {
   @Test
   void extract_SampledContext_Int() {
     Map<String, String> carrier = new LinkedHashMap<>();
-    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
-    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID);
+    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
     carrier.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
 
     assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
@@ -141,8 +138,8 @@ class OtTracerPropagatorTest {
   @Test
   void extract_SampledContext_Bool() {
     Map<String, String> carrier = new LinkedHashMap<>();
-    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
-    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID);
+    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
     carrier.put(OtTracerPropagator.SAMPLED_HEADER, "true");
 
     assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
@@ -154,8 +151,8 @@ class OtTracerPropagatorTest {
   @Test
   void extract_NotSampledContext() {
     Map<String, String> carrier = new LinkedHashMap<>();
-    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
-    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID);
+    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
     carrier.put(OtTracerPropagator.SAMPLED_HEADER, Common.FALSE_INT);
 
     assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
@@ -167,47 +164,47 @@ class OtTracerPropagatorTest {
   @Test
   void extract_SampledContext_Int_Short_TraceId() {
     Map<String, String> carrier = new LinkedHashMap<>();
-    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, SHORT_TRACE_ID_BASE16);
-    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, SHORT_TRACE_ID);
+    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
     carrier.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
 
     assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                SHORT_TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
   }
 
   @Test
   void extract_SampledContext_Bool_Short_TraceId() {
     Map<String, String> carrier = new LinkedHashMap<>();
-    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, SHORT_TRACE_ID_BASE16);
-    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, SHORT_TRACE_ID);
+    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
     carrier.put(OtTracerPropagator.SAMPLED_HEADER, "true");
 
     assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                SHORT_TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
   }
 
   @Test
   void extract_NotSampledContext_Short_TraceId() {
     Map<String, String> carrier = new LinkedHashMap<>();
-    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, SHORT_TRACE_ID_BASE16);
-    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, SHORT_TRACE_ID);
+    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
     carrier.put(OtTracerPropagator.SAMPLED_HEADER, Common.FALSE_INT);
 
     assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                SHORT_TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
   }
 
   @Test
   void extract_InvalidTraceId() {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(OtTracerPropagator.TRACE_ID_HEADER, "abcdefghijklmnopabcdefghijklmnop");
-    invalidHeaders.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    invalidHeaders.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
     invalidHeaders.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameAs(SpanContext.getInvalid());
@@ -216,8 +213,8 @@ class OtTracerPropagatorTest {
   @Test
   void extract_InvalidTraceId_Size() {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
-    invalidHeaders.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_BASE16 + "00");
-    invalidHeaders.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    invalidHeaders.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID + "00");
+    invalidHeaders.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
     invalidHeaders.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameAs(SpanContext.getInvalid());
@@ -226,7 +223,7 @@ class OtTracerPropagatorTest {
   @Test
   void extract_InvalidSpanId() {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
-    invalidHeaders.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
+    invalidHeaders.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID);
     invalidHeaders.put(OtTracerPropagator.SPAN_ID_HEADER, "abcdefghijklmnop");
     invalidHeaders.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(propagator.extract(Context.current(), invalidHeaders, getter)))
@@ -236,7 +233,7 @@ class OtTracerPropagatorTest {
   @Test
   void extract_InvalidSpanId_Size() {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
-    invalidHeaders.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
+    invalidHeaders.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID);
     invalidHeaders.put(OtTracerPropagator.SPAN_ID_HEADER, "abcdefghijklmnop" + "00");
     invalidHeaders.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(propagator.extract(Context.current(), invalidHeaders, getter)))

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagatorTest.java
@@ -50,8 +50,8 @@ class TraceMultiPropagatorTest {
   private static final Span SPAN =
       DefaultSpan.create(
           SpanContext.createFromRemoteParent(
-              new TraceId(1245, 67890),
-              new SpanId(12345),
+              TraceId.fromLongs(1245, 67890),
+              SpanId.fromLong(12345),
               TraceFlags.getDefault(),
               TraceState.getDefault()));
 

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
@@ -69,12 +69,12 @@ final class SpanContextShim extends BaseShimObject implements SpanContext {
 
   @Override
   public String toTraceId() {
-    return TraceId.toLowerBase16(context.getTraceId());
+    return TraceId.toLowerBase16(context.traceId());
   }
 
   @Override
   public String toSpanId() {
-    return SpanId.toLowerBase16(context.getSpanId());
+    return SpanId.toLowerBase16(context.spanId());
   }
 
   @Override

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
@@ -19,8 +19,6 @@ package io.opentelemetry.opentracingshim;
 import io.opentelemetry.correlationcontext.CorrelationContext;
 import io.opentelemetry.correlationcontext.Entry;
 import io.opentelemetry.correlationcontext.EntryMetadata;
-import io.opentelemetry.trace.SpanId;
-import io.opentelemetry.trace.TraceId;
 import io.opentracing.SpanContext;
 import java.util.Iterator;
 import java.util.Map;
@@ -69,12 +67,12 @@ final class SpanContextShim extends BaseShimObject implements SpanContext {
 
   @Override
   public String toTraceId() {
-    return TraceId.toLowerBase16(context.traceId());
+    return context.traceId();
   }
 
   @Override
   public String toSpanId() {
-    return SpanId.toLowerBase16(context.spanId());
+    return context.spanId();
   }
 
   @Override

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
@@ -67,12 +67,12 @@ final class SpanContextShim extends BaseShimObject implements SpanContext {
 
   @Override
   public String toTraceId() {
-    return context.traceId();
+    return context.getTraceId().toString();
   }
 
   @Override
   public String toSpanId() {
-    return context.spanId();
+    return context.getSpanId().toString();
   }
 
   @Override

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
@@ -67,12 +67,12 @@ final class SpanContextShim extends BaseShimObject implements SpanContext {
 
   @Override
   public String toTraceId() {
-    return context.getTraceId().toString();
+    return context.getTraceIdAsBase16();
   }
 
   @Override
   public String toSpanId() {
-    return context.getSpanId().toString();
+    return context.getSpanIdAsBase16().toString();
   }
 
   @Override

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
@@ -19,6 +19,8 @@ package io.opentelemetry.opentracingshim;
 import io.opentelemetry.correlationcontext.CorrelationContext;
 import io.opentelemetry.correlationcontext.Entry;
 import io.opentelemetry.correlationcontext.EntryMetadata;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceId;
 import io.opentracing.SpanContext;
 import java.util.Iterator;
 import java.util.Map;
@@ -67,12 +69,12 @@ final class SpanContextShim extends BaseShimObject implements SpanContext {
 
   @Override
   public String toTraceId() {
-    return context.getTraceId().toString();
+    return TraceId.toLowerBase16(context.getTraceId());
   }
 
   @Override
   public String toSpanId() {
-    return context.getSpanId().toString();
+    return SpanId.toLowerBase16(context.getSpanId());
   }
 
   @Override

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
@@ -59,8 +59,8 @@ class SpanShimTest {
     SpanContextShim contextShim = (SpanContextShim) spanShim.context();
     assertNotNull(contextShim);
     assertEquals(contextShim.getSpanContext(), span.getContext());
-    assertEquals(contextShim.toTraceId(), span.getContext().getTraceId().toString());
-    assertEquals(contextShim.toSpanId(), span.getContext().getSpanId().toString());
+    assertEquals(contextShim.toTraceId(), TraceId.toLowerBase16(span.getContext().getTraceId()));
+    assertEquals(contextShim.toSpanId(), SpanId.toLowerBase16(span.getContext().getSpanId()));
     assertFalse(contextShim.baggageItems().iterator().hasNext());
   }
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
@@ -59,8 +59,8 @@ class SpanShimTest {
     SpanContextShim contextShim = (SpanContextShim) spanShim.context();
     assertNotNull(contextShim);
     assertEquals(contextShim.getSpanContext(), span.getContext());
-    assertEquals(contextShim.toTraceId(), TraceId.toLowerBase16(span.getContext().traceId()));
-    assertEquals(contextShim.toSpanId(), SpanId.toLowerBase16(span.getContext().spanId()));
+    assertEquals(contextShim.toTraceId(), span.getContext().traceId());
+    assertEquals(contextShim.toSpanId(), span.getContext().spanId());
     assertFalse(contextShim.baggageItems().iterator().hasNext());
   }
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
@@ -59,8 +59,8 @@ class SpanShimTest {
     SpanContextShim contextShim = (SpanContextShim) spanShim.context();
     assertNotNull(contextShim);
     assertEquals(contextShim.getSpanContext(), span.getContext());
-    assertEquals(contextShim.toTraceId(), TraceId.toLowerBase16(span.getContext().getTraceId()));
-    assertEquals(contextShim.toSpanId(), SpanId.toLowerBase16(span.getContext().getSpanId()));
+    assertEquals(contextShim.toTraceId(), TraceId.toLowerBase16(span.getContext().traceId()));
+    assertEquals(contextShim.toSpanId(), SpanId.toLowerBase16(span.getContext().spanId()));
     assertFalse(contextShim.baggageItems().iterator().hasNext());
   }
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
@@ -59,8 +59,8 @@ class SpanShimTest {
     SpanContextShim contextShim = (SpanContextShim) spanShim.context();
     assertNotNull(contextShim);
     assertEquals(contextShim.getSpanContext(), span.getContext());
-    assertEquals(contextShim.toTraceId(), span.getContext().traceId());
-    assertEquals(contextShim.toSpanId(), span.getContext().spanId());
+    assertEquals(contextShim.toTraceId(), span.getContext().getTraceId().toString());
+    assertEquals(contextShim.toSpanId(), span.getContext().getSpanId().toString());
     assertFalse(contextShim.baggageItems().iterator().hasNext());
   }
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
@@ -59,8 +59,8 @@ class SpanShimTest {
     SpanContextShim contextShim = (SpanContextShim) spanShim.context();
     assertNotNull(contextShim);
     assertEquals(contextShim.getSpanContext(), span.getContext());
-    assertEquals(contextShim.toTraceId(), span.getContext().getTraceId().toString());
-    assertEquals(contextShim.toSpanId(), span.getContext().getSpanId().toString());
+    assertEquals(contextShim.toTraceId(), span.getContext().getTraceIdAsBase16().toString());
+    assertEquals(contextShim.toSpanId(), span.getContext().getSpanIdAsBase16().toString());
     assertFalse(contextShim.baggageItems().iterator().hasNext());
   }
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/TestUtils.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/TestUtils.java
@@ -179,8 +179,12 @@ public final class TestUtils {
     for (int i = 0; i < spans.size() - 1; i++) {
       // TODO - Include nanos in this comparison.
       assertTrue(spans.get(spans.size() - 1).getEndEpochNanos() >= spans.get(i).getEndEpochNanos());
-      assertEquals(spans.get(spans.size() - 1).getTraceId(), spans.get(i).getTraceId());
-      assertEquals(spans.get(spans.size() - 1).getSpanId(), spans.get(i).getParentSpanId());
+      assertEquals(
+          spans.get(spans.size() - 1).getTraceId().toString(),
+          spans.get(i).getTraceId().toString());
+      assertEquals(
+          spans.get(spans.size() - 1).getSpanId().toString(),
+          spans.get(i).getParentSpanId().toString());
     }
   }
 }

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/TestUtils.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/TestUtils.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.opentracingshim.testbed;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
 
 import io.opentelemetry.common.AttributeValue;
@@ -179,8 +179,8 @@ public final class TestUtils {
     for (int i = 0; i < spans.size() - 1; i++) {
       // TODO - Include nanos in this comparison.
       assertTrue(spans.get(spans.size() - 1).getEndEpochNanos() >= spans.get(i).getEndEpochNanos());
-      assertEquals(spans.get(spans.size() - 1).getTraceId(), spans.get(i).getTraceId());
-      assertEquals(spans.get(spans.size() - 1).getSpanId(), spans.get(i).getParentSpanId());
+      assertArrayEquals(spans.get(spans.size() - 1).getTraceId(), spans.get(i).getTraceId());
+      assertArrayEquals(spans.get(spans.size() - 1).getSpanId(), spans.get(i).getParentSpanId());
     }
   }
 }

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/TestUtils.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/TestUtils.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.opentracingshim.testbed;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import io.opentelemetry.common.AttributeValue;
@@ -179,8 +179,8 @@ public final class TestUtils {
     for (int i = 0; i < spans.size() - 1; i++) {
       // TODO - Include nanos in this comparison.
       assertTrue(spans.get(spans.size() - 1).getEndEpochNanos() >= spans.get(i).getEndEpochNanos());
-      assertArrayEquals(spans.get(spans.size() - 1).getTraceId(), spans.get(i).getTraceId());
-      assertArrayEquals(spans.get(spans.size() - 1).getSpanId(), spans.get(i).getParentSpanId());
+      assertEquals(spans.get(spans.size() - 1).getTraceId(), spans.get(i).getTraceId());
+      assertEquals(spans.get(spans.size() - 1).getSpanId(), spans.get(i).getParentSpanId());
     }
   }
 }

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/activespanreplacement/ActiveSpanReplacementTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/activespanreplacement/ActiveSpanReplacementTest.java
@@ -69,11 +69,11 @@ class ActiveSpanReplacementTest {
     assertEquals("task", spans.get(2).getName());
 
     // task/subtask are part of the same trace, and subtask is a child of task
-    assertEquals(spans.get(1).getTraceId(), spans.get(2).getTraceId());
-    assertEquals(spans.get(2).getSpanId(), spans.get(1).getParentSpanId());
+    assertEquals(spans.get(1).getTraceId().toString(), spans.get(2).getTraceId().toString());
+    assertEquals(spans.get(2).getSpanId().toString(), spans.get(1).getParentSpanId().toString());
 
     // initial task is not related in any way to those two tasks
-    assertNotEquals(spans.get(0).getTraceId(), spans.get(1).getTraceId());
+    assertNotEquals(spans.get(0).getTraceId().toString(), spans.get(1).getTraceId().toString());
     assertFalse(SpanId.isValid(spans.get(0).getParentSpanId()));
 
     assertNull(tracer.scopeManager().activeSpan());

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/activespanreplacement/ActiveSpanReplacementTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/activespanreplacement/ActiveSpanReplacementTest.java
@@ -30,6 +30,7 @@ import io.opentelemetry.opentracingshim.TraceShim;
 import io.opentelemetry.sdk.correlationcontext.CorrelationContextManagerSdk;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.trace.SpanId;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
@@ -73,7 +74,7 @@ class ActiveSpanReplacementTest {
 
     // initial task is not related in any way to those two tasks
     assertNotEquals(spans.get(0).getTraceId(), spans.get(1).getTraceId());
-    assertFalse(spans.get(0).getParentSpanId().isValid());
+    assertFalse(SpanId.isValid(spans.get(0).getParentSpanId()));
 
     assertNull(tracer.scopeManager().activeSpan());
   }

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/activespanreplacement/ActiveSpanReplacementTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/activespanreplacement/ActiveSpanReplacementTest.java
@@ -20,7 +20,6 @@ import static io.opentelemetry.opentracingshim.testbed.TestUtils.finishedSpansSi
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.sleep;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -70,8 +69,8 @@ class ActiveSpanReplacementTest {
     assertEquals("task", spans.get(2).getName());
 
     // task/subtask are part of the same trace, and subtask is a child of task
-    assertArrayEquals(spans.get(1).getTraceId(), spans.get(2).getTraceId());
-    assertArrayEquals(spans.get(2).getSpanId(), spans.get(1).getParentSpanId());
+    assertEquals(spans.get(1).getTraceId(), spans.get(2).getTraceId());
+    assertEquals(spans.get(2).getSpanId(), spans.get(1).getParentSpanId());
 
     // initial task is not related in any way to those two tasks
     assertNotEquals(spans.get(0).getTraceId(), spans.get(1).getTraceId());

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/activespanreplacement/ActiveSpanReplacementTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/activespanreplacement/ActiveSpanReplacementTest.java
@@ -20,6 +20,7 @@ import static io.opentelemetry.opentracingshim.testbed.TestUtils.finishedSpansSi
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.sleep;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -69,8 +70,8 @@ class ActiveSpanReplacementTest {
     assertEquals("task", spans.get(2).getName());
 
     // task/subtask are part of the same trace, and subtask is a child of task
-    assertEquals(spans.get(1).getTraceId(), spans.get(2).getTraceId());
-    assertEquals(spans.get(2).getSpanId(), spans.get(1).getParentSpanId());
+    assertArrayEquals(spans.get(1).getTraceId(), spans.get(2).getTraceId());
+    assertArrayEquals(spans.get(2).getSpanId(), spans.get(1).getParentSpanId());
 
     // initial task is not related in any way to those two tasks
     assertNotEquals(spans.get(0).getTraceId(), spans.get(1).getTraceId());

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/actorpropagation/ActorPropagationTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/actorpropagation/ActorPropagationTest.java
@@ -87,7 +87,8 @@ class ActorPropagationTest {
 
       List<SpanData> finished = inMemoryTracing.getSpanExporter().getFinishedSpanItems();
       assertThat(finished.size()).isEqualTo(3);
-      assertThat(finished.get(0).getTraceId()).isEqualTo(finished.get(1).getTraceId());
+      assertThat(finished.get(0).getTraceId().toString())
+          .isEqualTo(finished.get(1).getTraceId().toString());
       assertThat(getByKind(finished, Kind.CONSUMER)).hasSize(2);
       assertThat(getOneByKind(finished, Kind.PRODUCER)).isNotNull();
 
@@ -129,7 +130,8 @@ class ActorPropagationTest {
       assertThat(message2).isEqualTo("received my message 2");
 
       assertThat(finished.size()).isEqualTo(3);
-      assertThat(finished.get(0).getTraceId()).isEqualTo(finished.get(1).getTraceId());
+      assertThat(finished.get(0).getTraceId().toString())
+          .isEqualTo(finished.get(1).getTraceId().toString());
       assertThat(getByKind(finished, Kind.CONSUMER)).hasSize(2);
       assertThat(getOneByKind(finished, Kind.PRODUCER)).isNotNull();
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/clientserver/TestClientServerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/clientserver/TestClientServerTest.java
@@ -20,6 +20,7 @@ import static io.opentelemetry.opentracingshim.testbed.TestUtils.finishedSpansSi
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.sortByStartTime;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -71,7 +72,7 @@ class TestClientServerTest {
     assertEquals(2, finished.size());
 
     finished = sortByStartTime(finished);
-    assertEquals(finished.get(0).getTraceId(), finished.get(1).getTraceId());
+    assertArrayEquals(finished.get(0).getTraceId(), finished.get(1).getTraceId());
     assertEquals(Kind.CLIENT, finished.get(0).getKind());
     assertEquals(Kind.SERVER, finished.get(1).getKind());
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/clientserver/TestClientServerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/clientserver/TestClientServerTest.java
@@ -20,7 +20,6 @@ import static io.opentelemetry.opentracingshim.testbed.TestUtils.finishedSpansSi
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.sortByStartTime;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -72,7 +71,7 @@ class TestClientServerTest {
     assertEquals(2, finished.size());
 
     finished = sortByStartTime(finished);
-    assertArrayEquals(finished.get(0).getTraceId(), finished.get(1).getTraceId());
+    assertEquals(finished.get(0).getTraceId(), finished.get(1).getTraceId());
     assertEquals(Kind.CLIENT, finished.get(0).getKind());
     assertEquals(Kind.SERVER, finished.get(1).getKind());
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/clientserver/TestClientServerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/clientserver/TestClientServerTest.java
@@ -71,7 +71,7 @@ class TestClientServerTest {
     assertEquals(2, finished.size());
 
     finished = sortByStartTime(finished);
-    assertEquals(finished.get(0).getTraceId(), finished.get(1).getTraceId());
+    assertEquals(finished.get(0).getTraceId().toString(), finished.get(1).getTraceId().toString());
     assertEquals(Kind.CLIENT, finished.get(0).getKind());
     assertEquals(Kind.SERVER, finished.get(1).getKind());
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/concurrentcommonrequesthandler/HandlerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/concurrentcommonrequesthandler/HandlerTest.java
@@ -73,7 +73,8 @@ class HandlerTest {
       assertEquals(Kind.CLIENT, spanData.getKind());
     }
 
-    assertNotEquals(finished.get(0).getTraceId(), finished.get(1).getTraceId());
+    assertNotEquals(
+        finished.get(0).getTraceId().toString(), finished.get(1).getTraceId().toString());
     assertFalse(SpanId.isValid(finished.get(0).getParentSpanId()));
     assertFalse(SpanId.isValid(finished.get(1).getParentSpanId()));
 
@@ -102,7 +103,7 @@ class HandlerTest {
 
     // Here check that there is no parent-child relation although it should be because child is
     // created when parent is active
-    assertNotEquals(parent.getSpanId(), child.getParentSpanId());
+    assertNotEquals(parent.getSpanId().toString(), child.getParentSpanId().toString());
   }
 
   /**
@@ -135,9 +136,9 @@ class HandlerTest {
     assertNotNull(parent);
 
     // now there is parent/child relation between first and second span:
-    assertEquals(parent.getSpanId(), finished.get(1).getParentSpanId());
+    assertEquals(parent.getSpanId().toString(), finished.get(1).getParentSpanId().toString());
 
     // third span should not have parent, but it has, damn it
-    assertEquals(parent.getSpanId(), finished.get(2).getParentSpanId());
+    assertEquals(parent.getSpanId().toString(), finished.get(2).getParentSpanId().toString());
   }
 }

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/concurrentcommonrequesthandler/HandlerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/concurrentcommonrequesthandler/HandlerTest.java
@@ -30,6 +30,7 @@ import io.opentelemetry.sdk.correlationcontext.CorrelationContextManagerSdk;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.Span.Kind;
+import io.opentelemetry.trace.SpanId;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
@@ -73,8 +74,8 @@ class HandlerTest {
     }
 
     assertNotEquals(finished.get(0).getTraceId(), finished.get(1).getTraceId());
-    assertFalse(finished.get(0).getParentSpanId().isValid());
-    assertFalse(finished.get(1).getParentSpanId().isValid());
+    assertFalse(SpanId.isValid(finished.get(0).getParentSpanId()));
+    assertFalse(SpanId.isValid(finished.get(1).getParentSpanId()));
 
     assertNull(tracer.scopeManager().activeSpan());
   }

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/concurrentcommonrequesthandler/HandlerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/concurrentcommonrequesthandler/HandlerTest.java
@@ -18,7 +18,6 @@ package io.opentelemetry.opentracingshim.testbed.concurrentcommonrequesthandler;
 
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.getOneByName;
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.sortByStartTime;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -136,9 +135,9 @@ class HandlerTest {
     assertNotNull(parent);
 
     // now there is parent/child relation between first and second span:
-    assertArrayEquals(parent.getSpanId(), finished.get(1).getParentSpanId());
+    assertEquals(parent.getSpanId(), finished.get(1).getParentSpanId());
 
     // third span should not have parent, but it has, damn it
-    assertArrayEquals(parent.getSpanId(), finished.get(2).getParentSpanId());
+    assertEquals(parent.getSpanId(), finished.get(2).getParentSpanId());
   }
 }

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/concurrentcommonrequesthandler/HandlerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/concurrentcommonrequesthandler/HandlerTest.java
@@ -18,6 +18,7 @@ package io.opentelemetry.opentracingshim.testbed.concurrentcommonrequesthandler;
 
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.getOneByName;
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.sortByStartTime;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -135,9 +136,9 @@ class HandlerTest {
     assertNotNull(parent);
 
     // now there is parent/child relation between first and second span:
-    assertEquals(parent.getSpanId(), finished.get(1).getParentSpanId());
+    assertArrayEquals(parent.getSpanId(), finished.get(1).getParentSpanId());
 
     // third span should not have parent, but it has, damn it
-    assertEquals(parent.getSpanId(), finished.get(2).getParentSpanId());
+    assertArrayEquals(parent.getSpanId(), finished.get(2).getParentSpanId());
   }
 }

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/multiplecallbacks/MultipleCallbacksTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/multiplecallbacks/MultipleCallbacksTest.java
@@ -19,6 +19,7 @@ package io.opentelemetry.opentracingshim.testbed.multiplecallbacks;
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.finishedSpansSize;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -73,8 +74,8 @@ class MultipleCallbacksTest {
 
     SpanData parentSpan = spans.get(0);
     for (int i = 1; i < 4; i++) {
-      assertEquals(parentSpan.getTraceId(), spans.get(i).getTraceId());
-      assertEquals(parentSpan.getSpanId(), spans.get(i).getParentSpanId());
+      assertArrayEquals(parentSpan.getTraceId(), spans.get(i).getTraceId());
+      assertArrayEquals(parentSpan.getSpanId(), spans.get(i).getParentSpanId());
     }
 
     assertNull(tracer.scopeManager().activeSpan());

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/multiplecallbacks/MultipleCallbacksTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/multiplecallbacks/MultipleCallbacksTest.java
@@ -73,8 +73,8 @@ class MultipleCallbacksTest {
 
     SpanData parentSpan = spans.get(0);
     for (int i = 1; i < 4; i++) {
-      assertEquals(parentSpan.getTraceId(), spans.get(i).getTraceId());
-      assertEquals(parentSpan.getSpanId(), spans.get(i).getParentSpanId());
+      assertEquals(parentSpan.getTraceId().toString(), spans.get(i).getTraceId().toString());
+      assertEquals(parentSpan.getSpanId().toString(), spans.get(i).getParentSpanId().toString());
     }
 
     assertNull(tracer.scopeManager().activeSpan());

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/multiplecallbacks/MultipleCallbacksTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/multiplecallbacks/MultipleCallbacksTest.java
@@ -19,7 +19,6 @@ package io.opentelemetry.opentracingshim.testbed.multiplecallbacks;
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.finishedSpansSize;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -74,8 +73,8 @@ class MultipleCallbacksTest {
 
     SpanData parentSpan = spans.get(0);
     for (int i = 1; i < 4; i++) {
-      assertArrayEquals(parentSpan.getTraceId(), spans.get(i).getTraceId());
-      assertArrayEquals(parentSpan.getSpanId(), spans.get(i).getParentSpanId());
+      assertEquals(parentSpan.getTraceId(), spans.get(i).getTraceId());
+      assertEquals(parentSpan.getSpanId(), spans.get(i).getParentSpanId());
     }
 
     assertNull(tracer.scopeManager().activeSpan());

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/promisepropagation/PromisePropagationTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/promisepropagation/PromisePropagationTest.java
@@ -115,7 +115,7 @@ class PromisePropagationTest {
 
       assertThat(getByAttr(finished, component, "success")).hasSize(2);
 
-      SpanId parentId = spanExamplePromise.get(0).getSpanId();
+      byte[] parentId = spanExamplePromise.get(0).getSpanId();
       for (SpanData span : getByAttr(finished, component, "success")) {
         assertThat(span.getParentSpanId()).isEqualTo(parentId);
       }

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/promisepropagation/PromisePropagationTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/promisepropagation/PromisePropagationTest.java
@@ -111,18 +111,19 @@ class PromisePropagationTest {
       String component = Tags.COMPONENT.getKey();
       List<SpanData> spanExamplePromise = getByAttr(finished, component, "example-promises");
       assertThat(spanExamplePromise).hasSize(1);
-      assertThat(spanExamplePromise.get(0).getParentSpanId()).isEqualTo(SpanId.getInvalid());
+      assertThat(spanExamplePromise.get(0).getParentSpanId().toString())
+          .isEqualTo(SpanId.getInvalid().toString());
 
       assertThat(getByAttr(finished, component, "success")).hasSize(2);
 
-      String parentId = spanExamplePromise.get(0).getSpanId();
+      CharSequence parentId = spanExamplePromise.get(0).getSpanId();
       for (SpanData span : getByAttr(finished, component, "success")) {
-        assertThat(span.getParentSpanId()).isEqualTo(parentId);
+        assertThat(span.getParentSpanId().toString()).isEqualTo(parentId.toString());
       }
 
       List<SpanData> spanError = getByAttr(finished, component, "error");
       assertThat(spanError).hasSize(1);
-      assertThat(spanError.get(0).getParentSpanId()).isEqualTo(parentId);
+      assertThat(spanError.get(0).getParentSpanId().toString()).isEqualTo(parentId.toString());
     }
   }
 }

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/promisepropagation/PromisePropagationTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/promisepropagation/PromisePropagationTest.java
@@ -115,7 +115,7 @@ class PromisePropagationTest {
 
       assertThat(getByAttr(finished, component, "success")).hasSize(2);
 
-      byte[] parentId = spanExamplePromise.get(0).getSpanId();
+      String parentId = spanExamplePromise.get(0).getSpanId();
       for (SpanData span : getByAttr(finished, component, "success")) {
         assertThat(span.getParentSpanId()).isEqualTo(parentId);
       }

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/suspendresumepropagation/SuspendResumePropagationTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/suspendresumepropagation/SuspendResumePropagationTest.java
@@ -23,6 +23,7 @@ import io.opentelemetry.opentracingshim.TraceShim;
 import io.opentelemetry.sdk.correlationcontext.CorrelationContextManagerSdk;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.trace.SpanId;
 import io.opentracing.Tracer;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,7 +66,7 @@ class SuspendResumePropagationTest {
     assertThat(finished.get(0).getName()).isEqualTo("job 1");
     assertThat(finished.get(1).getName()).isEqualTo("job 2");
 
-    assertThat(finished.get(0).getParentSpanId().isValid()).isFalse();
-    assertThat(finished.get(1).getParentSpanId().isValid()).isFalse();
+    assertThat(SpanId.isValid(finished.get(0).getParentSpanId())).isFalse();
+    assertThat(SpanId.isValid(finished.get(1).getParentSpanId())).isFalse();
   }
 }

--- a/sdk/src/jmh/java/io/opentelemetry/sdk/trace/export/MultiSpanExporterBenchmark.java
+++ b/sdk/src/jmh/java/io/opentelemetry/sdk/trace/export/MultiSpanExporterBenchmark.java
@@ -77,8 +77,8 @@ public class MultiSpanExporterBenchmark {
     for (int i = 0; i < spans.length; i++) {
       spans[i] =
           TestSpanData.newBuilder()
-              .setTraceId(new TraceId(1, 1))
-              .setSpanId(new SpanId(1))
+              .setTraceId(TraceId.fromLongs(1, 1))
+              .setSpanId(SpanId.fromLong(1))
               .setName("noop")
               .setKind(Span.Kind.CLIENT)
               .setStartEpochNanos(1)

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/IdsGenerator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/IdsGenerator.java
@@ -29,12 +29,12 @@ public interface IdsGenerator {
    *
    * @return a new valid {@code SpanId}.
    */
-  String generateSpanId();
+  CharSequence generateSpanId();
 
   /**
    * Generates a new valid {@code TraceId}.
    *
    * @return a new valid {@code TraceId}.
    */
-  String generateTraceId();
+  CharSequence generateTraceId();
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/IdsGenerator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/IdsGenerator.java
@@ -29,12 +29,12 @@ public interface IdsGenerator {
    *
    * @return a new valid {@code SpanId}.
    */
-  byte[] generateSpanId();
+  String generateSpanId();
 
   /**
    * Generates a new valid {@code TraceId}.
    *
    * @return a new valid {@code TraceId}.
    */
-  byte[] generateTraceId();
+  String generateTraceId();
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/IdsGenerator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/IdsGenerator.java
@@ -29,12 +29,12 @@ public interface IdsGenerator {
    *
    * @return a new valid {@code SpanId}.
    */
-  SpanId generateSpanId();
+  byte[] generateSpanId();
 
   /**
    * Generates a new valid {@code TraceId}.
    *
    * @return a new valid {@code TraceId}.
    */
-  TraceId generateTraceId();
+  byte[] generateTraceId();
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
@@ -50,7 +50,7 @@ public final class RandomIdsGenerator implements IdsGenerator {
     return new TraceIdWrapper(idHi, idLo);
   }
 
-  private static final class TraceIdWrapper implements CharSequence {
+  static final class TraceIdWrapper implements CharSequence {
     private final long idHi;
     private final long idLo;
     private volatile CharSequence chars;
@@ -75,6 +75,14 @@ public final class RandomIdsGenerator implements IdsGenerator {
       return getCharSequence().subSequence(start, end);
     }
 
+    public long getIdHi() {
+      return idHi;
+    }
+
+    public long getIdLo() {
+      return idLo;
+    }
+
     @Override
     public String toString() {
       return getCharSequence().toString();
@@ -88,7 +96,7 @@ public final class RandomIdsGenerator implements IdsGenerator {
     }
   }
 
-  private static final class SpanIdWrapper implements CharSequence {
+  static final class SpanIdWrapper implements CharSequence {
     private final long id;
     private volatile CharSequence chars;
 
@@ -109,6 +117,10 @@ public final class RandomIdsGenerator implements IdsGenerator {
     @Override
     public CharSequence subSequence(int start, int end) {
       return getCharSequence().subSequence(start, end);
+    }
+
+    public long getId() {
+      return id;
     }
 
     @Override

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
@@ -29,17 +29,17 @@ public final class RandomIdsGenerator implements IdsGenerator {
   private static final long INVALID_ID = 0;
 
   @Override
-  public SpanId generateSpanId() {
+  public byte[] generateSpanId() {
     long id;
     ThreadLocalRandom random = ThreadLocalRandom.current();
     do {
       id = random.nextLong();
     } while (id == INVALID_ID);
-    return new SpanId(id);
+    return SpanId.fromLong(id);
   }
 
   @Override
-  public TraceId generateTraceId() {
+  public byte[] generateTraceId() {
     long idHi;
     long idLo;
     ThreadLocalRandom random = ThreadLocalRandom.current();
@@ -47,6 +47,6 @@ public final class RandomIdsGenerator implements IdsGenerator {
       idHi = random.nextLong();
       idLo = random.nextLong();
     } while (idHi == INVALID_ID && idLo == INVALID_ID);
-    return new TraceId(idHi, idLo);
+    return TraceId.fromLongs(idHi, idLo);
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
@@ -29,7 +29,7 @@ public final class RandomIdsGenerator implements IdsGenerator {
   private static final long INVALID_ID = 0;
 
   @Override
-  public byte[] generateSpanId() {
+  public String generateSpanId() {
     long id;
     ThreadLocalRandom random = ThreadLocalRandom.current();
     do {
@@ -39,7 +39,7 @@ public final class RandomIdsGenerator implements IdsGenerator {
   }
 
   @Override
-  public byte[] generateTraceId() {
+  public String generateTraceId() {
     long idHi;
     long idLo;
     ThreadLocalRandom random = ThreadLocalRandom.current();

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
@@ -29,7 +29,7 @@ public final class RandomIdsGenerator implements IdsGenerator {
   private static final long INVALID_ID = 0;
 
   @Override
-  public String generateSpanId() {
+  public CharSequence generateSpanId() {
     long id;
     ThreadLocalRandom random = ThreadLocalRandom.current();
     do {
@@ -39,7 +39,7 @@ public final class RandomIdsGenerator implements IdsGenerator {
   }
 
   @Override
-  public String generateTraceId() {
+  public CharSequence generateTraceId() {
     long idHi;
     long idLo;
     ThreadLocalRandom random = ThreadLocalRandom.current();

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
@@ -35,7 +35,7 @@ public final class RandomIdsGenerator implements IdsGenerator {
     do {
       id = random.nextLong();
     } while (id == INVALID_ID);
-    return SpanId.fromLong(id);
+    return new SpanIdWrapper(id);
   }
 
   @Override
@@ -47,6 +47,80 @@ public final class RandomIdsGenerator implements IdsGenerator {
       idHi = random.nextLong();
       idLo = random.nextLong();
     } while (idHi == INVALID_ID && idLo == INVALID_ID);
-    return TraceId.fromLongs(idHi, idLo);
+    return new TraceIdWrapper(idHi, idLo);
+  }
+
+  private static final class TraceIdWrapper implements CharSequence {
+    private final long idHi;
+    private final long idLo;
+    private volatile CharSequence chars;
+
+    private TraceIdWrapper(long idHi, long idLo) {
+      this.idHi = idHi;
+      this.idLo = idLo;
+    }
+
+    @Override
+    public int length() {
+      return 32;
+    }
+
+    @Override
+    public char charAt(int index) {
+      return getCharSequence().charAt(index);
+    }
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+      return getCharSequence().subSequence(start, end);
+    }
+
+    @Override
+    public String toString() {
+      return getCharSequence().toString();
+    }
+
+    private CharSequence getCharSequence() {
+      if (chars == null) {
+        chars = TraceId.fromLongs(idHi, idLo);
+      }
+      return chars;
+    }
+  }
+
+  private static final class SpanIdWrapper implements CharSequence {
+    private final long id;
+    private volatile CharSequence chars;
+
+    private SpanIdWrapper(long id) {
+      this.id = id;
+    }
+
+    @Override
+    public int length() {
+      return 16;
+    }
+
+    @Override
+    public char charAt(int index) {
+      return getCharSequence().charAt(index);
+    }
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+      return getCharSequence().subSequence(start, end);
+    }
+
+    @Override
+    public String toString() {
+      return getCharSequence().toString();
+    }
+
+    private CharSequence getCharSequence() {
+      if (chars == null) {
+        chars = SpanId.fromLong(id);
+      }
+      return chars;
+    }
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -605,9 +605,9 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     }
     StringBuilder sb = new StringBuilder();
     sb.append("RecordEventsReadableSpan{traceId=");
-    sb.append(context.getTraceId());
+    sb.append(context.getTraceIdAsBase16());
     sb.append(", spanId=");
-    sb.append(context.getSpanId());
+    sb.append(context.getSpanIdAsBase16());
     sb.append(", parentSpanId=");
     sb.append(parentSpanId);
     sb.append(", name=");

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -62,7 +62,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   // Contains the identifiers associated with this Span.
   private final SpanContext context;
   // The parent SpanId of this span. Invalid if this is a root span.
-  private final String parentSpanId;
+  private final CharSequence parentSpanId;
   // True if the parent is on a different process.
   private final boolean hasRemoteParent;
   // Handler called when the span starts and ends.
@@ -114,7 +114,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
       String name,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
       Kind kind,
-      String parentSpanId,
+      CharSequence parentSpanId,
       boolean hasRemoteParent,
       TraceConfig traceConfig,
       SpanProcessor spanProcessor,
@@ -164,7 +164,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
       String name,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
       Kind kind,
-      @Nullable String parentSpanId,
+      @Nullable CharSequence parentSpanId,
       boolean hasRemoteParent,
       TraceConfig traceConfig,
       SpanProcessor spanProcessor,
@@ -503,7 +503,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     }
   }
 
-  String getParentSpanId() {
+  CharSequence getParentSpanId() {
     return parentSpanId;
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -62,7 +62,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   // Contains the identifiers associated with this Span.
   private final SpanContext context;
   // The parent SpanId of this span. Invalid if this is a root span.
-  private final SpanId parentSpanId;
+  private final byte[] parentSpanId;
   // True if the parent is on a different process.
   private final boolean hasRemoteParent;
   // Handler called when the span starts and ends.
@@ -114,7 +114,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
       String name,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
       Kind kind,
-      SpanId parentSpanId,
+      byte[] parentSpanId,
       boolean hasRemoteParent,
       TraceConfig traceConfig,
       SpanProcessor spanProcessor,
@@ -164,7 +164,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
       String name,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
       Kind kind,
-      @Nullable SpanId parentSpanId,
+      @Nullable byte[] parentSpanId,
       boolean hasRemoteParent,
       TraceConfig traceConfig,
       SpanProcessor spanProcessor,
@@ -503,7 +503,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     }
   }
 
-  SpanId getParentSpanId() {
+  byte[] getParentSpanId() {
     return parentSpanId;
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -62,7 +62,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
   // Contains the identifiers associated with this Span.
   private final SpanContext context;
   // The parent SpanId of this span. Invalid if this is a root span.
-  private final byte[] parentSpanId;
+  private final String parentSpanId;
   // True if the parent is on a different process.
   private final boolean hasRemoteParent;
   // Handler called when the span starts and ends.
@@ -114,7 +114,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
       String name,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
       Kind kind,
-      byte[] parentSpanId,
+      String parentSpanId,
       boolean hasRemoteParent,
       TraceConfig traceConfig,
       SpanProcessor spanProcessor,
@@ -164,7 +164,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
       String name,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
       Kind kind,
-      @Nullable byte[] parentSpanId,
+      @Nullable String parentSpanId,
       boolean hasRemoteParent,
       TraceConfig traceConfig,
       SpanProcessor spanProcessor,
@@ -503,7 +503,7 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
     }
   }
 
-  byte[] getParentSpanId() {
+  String getParentSpanId() {
     return parentSpanId;
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/Sampler.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/Sampler.java
@@ -51,7 +51,7 @@ public interface Sampler {
    */
   SamplingResult shouldSample(
       @Nullable SpanContext parentContext,
-      TraceId traceId,
+      byte[] traceId,
       String name,
       Kind spanKind,
       ReadableAttributes attributes,
@@ -76,7 +76,7 @@ public interface Sampler {
   }
 
   /**
-   * Sampling result returned by {@link Sampler#shouldSample(SpanContext, TraceId, String, Kind,
+   * Sampling result returned by {@link Sampler#shouldSample(SpanContext, byte[], String, Kind,
    * ReadableAttributes, List)}.
    *
    * @since 0.1.0

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/Sampler.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/Sampler.java
@@ -51,7 +51,7 @@ public interface Sampler {
    */
   SamplingResult shouldSample(
       @Nullable SpanContext parentContext,
-      String traceId,
+      CharSequence traceId,
       String name,
       Kind spanKind,
       ReadableAttributes attributes,
@@ -76,8 +76,8 @@ public interface Sampler {
   }
 
   /**
-   * Sampling result returned by {@link Sampler#shouldSample(SpanContext, String, String, Kind,
-   * ReadableAttributes, List)}.
+   * Sampling result returned by {@link Sampler#shouldSample(SpanContext, CharSequence, String,
+   * Kind, ReadableAttributes, List)}.
    *
    * @since 0.1.0
    */

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/Sampler.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/Sampler.java
@@ -51,7 +51,7 @@ public interface Sampler {
    */
   SamplingResult shouldSample(
       @Nullable SpanContext parentContext,
-      byte[] traceId,
+      String traceId,
       String name,
       Kind spanKind,
       ReadableAttributes attributes,
@@ -76,7 +76,7 @@ public interface Sampler {
   }
 
   /**
-   * Sampling result returned by {@link Sampler#shouldSample(SpanContext, byte[], String, Kind,
+   * Sampling result returned by {@link Sampler#shouldSample(SpanContext, String, String, Kind,
    * ReadableAttributes, List)}.
    *
    * @since 0.1.0

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -177,7 +177,7 @@ public final class Samplers {
     @Override
     public SamplingResult shouldSample(
         @Nullable SpanContext parentContext,
-        TraceId traceId,
+        byte[] traceId,
         String name,
         Kind spanKind,
         ReadableAttributes attributes,
@@ -199,7 +199,7 @@ public final class Samplers {
     @Override
     public SamplingResult shouldSample(
         @Nullable SpanContext parentContext,
-        TraceId traceId,
+        byte[] traceId,
         String name,
         Kind spanKind,
         ReadableAttributes attributes,
@@ -293,7 +293,7 @@ public final class Samplers {
     @Override
     public final SamplingResult shouldSample(
         @Nullable SpanContext parentContext,
-        TraceId traceId,
+        byte[] traceId,
         String name,
         Kind spanKind,
         ReadableAttributes attributes,
@@ -318,7 +318,7 @@ public final class Samplers {
       // while allowing for a (very) small chance of *not* sampling if the id == Long.MAX_VALUE.
       // This is considered a reasonable tradeoff for the simplicity/performance requirements (this
       // code is executed in-line for every Span creation).
-      return Math.abs(traceId.getTraceRandomPart()) < getIdUpperBound()
+      return Math.abs(TraceId.getTraceIdRandomPart(traceId)) < getIdUpperBound()
           ? getPositiveSamplingResult()
           : getNegativeSamplingResult();
     }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -177,7 +177,7 @@ public final class Samplers {
     @Override
     public SamplingResult shouldSample(
         @Nullable SpanContext parentContext,
-        byte[] traceId,
+        String traceId,
         String name,
         Kind spanKind,
         ReadableAttributes attributes,
@@ -199,7 +199,7 @@ public final class Samplers {
     @Override
     public SamplingResult shouldSample(
         @Nullable SpanContext parentContext,
-        byte[] traceId,
+        String traceId,
         String name,
         Kind spanKind,
         ReadableAttributes attributes,
@@ -293,7 +293,7 @@ public final class Samplers {
     @Override
     public final SamplingResult shouldSample(
         @Nullable SpanContext parentContext,
-        byte[] traceId,
+        String traceId,
         String name,
         Kind spanKind,
         ReadableAttributes attributes,

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -226,7 +226,7 @@ public final class Samplers {
     @Override
     public SamplingResult shouldSample(
         @Nullable SpanContext parentContext,
-        TraceId traceId,
+        CharSequence traceId,
         String name,
         Kind spanKind,
         ReadableAttributes attributes,

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -177,7 +177,7 @@ public final class Samplers {
     @Override
     public SamplingResult shouldSample(
         @Nullable SpanContext parentContext,
-        String traceId,
+        CharSequence traceId,
         String name,
         Kind spanKind,
         ReadableAttributes attributes,
@@ -199,7 +199,7 @@ public final class Samplers {
     @Override
     public SamplingResult shouldSample(
         @Nullable SpanContext parentContext,
-        String traceId,
+        CharSequence traceId,
         String name,
         Kind spanKind,
         ReadableAttributes attributes,
@@ -293,7 +293,7 @@ public final class Samplers {
     @Override
     public final SamplingResult shouldSample(
         @Nullable SpanContext parentContext,
-        String traceId,
+        CharSequence traceId,
         String name,
         Kind spanKind,
         ReadableAttributes attributes,

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -34,9 +34,7 @@ import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanContext;
-import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
-import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
 import io.opentelemetry.trace.TracingContextUtils;
 import java.util.ArrayList;
@@ -210,8 +208,8 @@ final class SpanBuilderSdk implements Span.Builder {
   @Override
   public Span startSpan() {
     SpanContext parentContext = parent(parentType, parent, remoteParent);
-    TraceId traceId;
-    SpanId spanId = idsGenerator.generateSpanId();
+    byte[] traceId;
+    byte[] spanId = idsGenerator.generateSpanId();
     TraceState traceState = TraceState.getDefault();
     if (parentContext == null || !parentContext.isValid()) {
       // New root span.

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -208,8 +208,8 @@ final class SpanBuilderSdk implements Span.Builder {
   @Override
   public Span startSpan() {
     SpanContext parentContext = parent(parentType, parent, remoteParent);
-    byte[] traceId;
-    byte[] spanId = idsGenerator.generateSpanId();
+    String traceId;
+    String spanId = idsGenerator.generateSpanId();
     TraceState traceState = TraceState.getDefault();
     if (parentContext == null || !parentContext.isValid()) {
       // New root span.

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -208,8 +208,8 @@ final class SpanBuilderSdk implements Span.Builder {
   @Override
   public Span startSpan() {
     SpanContext parentContext = parent(parentType, parent, remoteParent);
-    String traceId;
-    String spanId = idsGenerator.generateSpanId();
+    CharSequence traceId;
+    CharSequence spanId = idsGenerator.generateSpanId();
     TraceState traceState = TraceState.getDefault();
     if (parentContext == null || !parentContext.isValid()) {
       // New root span.
@@ -218,7 +218,7 @@ final class SpanBuilderSdk implements Span.Builder {
       parentContext = null;
     } else {
       // New child span.
-      traceId = parentContext.traceId();
+      traceId = (String) parentContext.getTraceId();
       traceState = parentContext.getTraceState();
     }
     List<io.opentelemetry.trace.Link> immutableLinks =
@@ -272,7 +272,7 @@ final class SpanBuilderSdk implements Span.Builder {
         spanName,
         instrumentationLibraryInfo,
         spanKind,
-        parentContext != null ? parentContext.spanId() : null,
+        parentContext != null ? parentContext.getSpanId() : null,
         parentContext != null && parentContext.isRemote(),
         traceConfig,
         spanProcessor,

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -218,7 +218,7 @@ final class SpanBuilderSdk implements Span.Builder {
       parentContext = null;
     } else {
       // New child span.
-      traceId = parentContext.getTraceId();
+      traceId = parentContext.getTraceIdAsBase16();
       traceState = parentContext.getTraceState();
     }
     List<io.opentelemetry.trace.Link> immutableLinks =
@@ -272,7 +272,7 @@ final class SpanBuilderSdk implements Span.Builder {
         spanName,
         instrumentationLibraryInfo,
         spanKind,
-        parentContext != null ? parentContext.getSpanId() : null,
+        parentContext != null ? parentContext.getSpanIdAsBase16() : null,
         parentContext != null && parentContext.isRemote(),
         traceConfig,
         spanProcessor,

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -27,6 +27,8 @@ import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.MonotonicClock;
 import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.RandomIdsGenerator.SpanIdWrapper;
+import io.opentelemetry.sdk.trace.RandomIdsGenerator.TraceIdWrapper;
 import io.opentelemetry.sdk.trace.Sampler.SamplingResult;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
@@ -236,14 +238,9 @@ final class SpanBuilderSdk implements Span.Builder {
                 parentContext, traceId, spanName, spanKind, immutableAttributes, immutableLinks);
     Sampler.Decision samplingDecision = samplingResult.getDecision();
 
-    SpanContext spanContext =
-        SpanContext.create(
-            traceId,
-            spanId,
-            Samplers.isSampled(samplingDecision)
-                ? TRACE_OPTIONS_SAMPLED
-                : TRACE_OPTIONS_NOT_SAMPLED,
-            traceState);
+    TraceFlags traceFlags =
+        Samplers.isSampled(samplingDecision) ? TRACE_OPTIONS_SAMPLED : TRACE_OPTIONS_NOT_SAMPLED;
+    SpanContext spanContext = createSpanContext(traceId, spanId, traceState, traceFlags);
 
     if (!Samplers.isRecording(samplingDecision)) {
       return DefaultSpan.create(spanContext);
@@ -282,6 +279,34 @@ final class SpanBuilderSdk implements Span.Builder {
         immutableLinks,
         totalNumberOfLinksAdded,
         startEpochNanos);
+  }
+
+  private static SpanContext createSpanContext(
+      CharSequence traceId, CharSequence spanId, TraceState traceState, TraceFlags traceFlags) {
+    if (traceId instanceof TraceIdWrapper) {
+      if (spanId instanceof SpanIdWrapper) {
+        return SpanContext.create(
+            null,
+            ((TraceIdWrapper) traceId).getIdHi(),
+            ((TraceIdWrapper) traceId).getIdHi(),
+            null,
+            ((SpanIdWrapper) spanId).getId(),
+            traceFlags,
+            traceState,
+            /* remote=*/ false);
+      } else {
+        return SpanContext.create(
+            null,
+            ((TraceIdWrapper) traceId).getIdHi(),
+            ((TraceIdWrapper) traceId).getIdHi(),
+            spanId.toString(),
+            0,
+            traceFlags,
+            traceState,
+            /* remote=*/ false);
+      }
+    }
+    return SpanContext.create(traceId, spanId, traceFlags, traceState);
   }
 
   private static Clock getClock(Span parent, Clock clock) {

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -218,7 +218,7 @@ final class SpanBuilderSdk implements Span.Builder {
       parentContext = null;
     } else {
       // New child span.
-      traceId = parentContext.getTraceId();
+      traceId = parentContext.traceId();
       traceState = parentContext.getTraceState();
     }
     List<io.opentelemetry.trace.Link> immutableLinks =
@@ -272,7 +272,7 @@ final class SpanBuilderSdk implements Span.Builder {
         spanName,
         instrumentationLibraryInfo,
         spanKind,
-        parentContext != null ? parentContext.getSpanId() : null,
+        parentContext != null ? parentContext.spanId() : null,
         parentContext != null && parentContext.isRemote(),
         traceConfig,
         spanProcessor,

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -218,7 +218,7 @@ final class SpanBuilderSdk implements Span.Builder {
       parentContext = null;
     } else {
       // New child span.
-      traceId = (String) parentContext.getTraceId();
+      traceId = parentContext.getTraceId();
       traceState = parentContext.getTraceState();
     }
     List<io.opentelemetry.trace.Link> immutableLinks =

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
@@ -92,13 +92,13 @@ abstract class SpanWrapper implements SpanData {
 
   @Override
   @Memoized
-  public byte[] getTraceId() {
+  public String getTraceId() {
     return delegate().getContext().traceId();
   }
 
   @Override
   @Memoized
-  public byte[] getSpanId() {
+  public String getSpanId() {
     return delegate().getContext().spanId();
   }
 
@@ -113,7 +113,7 @@ abstract class SpanWrapper implements SpanData {
   }
 
   @Override
-  public byte[] getParentSpanId() {
+  public String getParentSpanId() {
     return delegate().getParentSpanId();
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
@@ -17,6 +17,7 @@
 package io.opentelemetry.sdk.trace;
 
 import com.google.auto.value.AutoValue;
+import com.google.auto.value.extension.memoized.Memoized;
 import io.opentelemetry.common.ReadableAttributes;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
@@ -90,11 +91,13 @@ abstract class SpanWrapper implements SpanData {
   }
 
   @Override
+  @Memoized
   public byte[] getTraceId() {
     return delegate().getContext().traceId();
   }
 
   @Override
+  @Memoized
   public byte[] getSpanId() {
     return delegate().getContext().spanId();
   }

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
@@ -91,12 +91,12 @@ abstract class SpanWrapper implements SpanData {
 
   @Override
   public byte[] getTraceId() {
-    return delegate().getContext().getTraceId();
+    return delegate().getContext().traceId();
   }
 
   @Override
   public byte[] getSpanId() {
-    return delegate().getContext().getSpanId();
+    return delegate().getContext().spanId();
   }
 
   @Override

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
@@ -22,10 +22,8 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.Span.Kind;
-import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.TraceFlags;
-import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
@@ -92,12 +90,12 @@ abstract class SpanWrapper implements SpanData {
   }
 
   @Override
-  public TraceId getTraceId() {
+  public byte[] getTraceId() {
     return delegate().getContext().getTraceId();
   }
 
   @Override
-  public SpanId getSpanId() {
+  public byte[] getSpanId() {
     return delegate().getContext().getSpanId();
   }
 
@@ -112,7 +110,7 @@ abstract class SpanWrapper implements SpanData {
   }
 
   @Override
-  public SpanId getParentSpanId() {
+  public byte[] getParentSpanId() {
     return delegate().getParentSpanId();
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
@@ -92,14 +92,14 @@ abstract class SpanWrapper implements SpanData {
 
   @Override
   @Memoized
-  public String getTraceId() {
-    return delegate().getContext().traceId();
+  public CharSequence getTraceId() {
+    return delegate().getContext().getTraceId();
   }
 
   @Override
   @Memoized
-  public String getSpanId() {
-    return delegate().getContext().spanId();
+  public CharSequence getSpanId() {
+    return delegate().getContext().getSpanId();
   }
 
   @Override
@@ -113,7 +113,7 @@ abstract class SpanWrapper implements SpanData {
   }
 
   @Override
-  public String getParentSpanId() {
+  public CharSequence getParentSpanId() {
     return delegate().getParentSpanId();
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
@@ -93,13 +93,13 @@ abstract class SpanWrapper implements SpanData {
   @Override
   @Memoized
   public CharSequence getTraceId() {
-    return delegate().getContext().getTraceId();
+    return delegate().getContext().getTraceIdAsBase16();
   }
 
   @Override
   @Memoized
   public CharSequence getSpanId() {
-    return delegate().getContext().getSpanId();
+    return delegate().getContext().getSpanIdAsBase16();
   }
 
   @Override

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
@@ -44,15 +44,14 @@ public interface SpanData {
    * @return the trace id.
    */
   @SuppressWarnings("mutable")
-  byte[] getTraceId();
+  String getTraceId();
 
   /**
    * Gets the span id for this span.
    *
    * @return the span id.
    */
-  @SuppressWarnings("mutable")
-  byte[] getSpanId();
+  String getSpanId();
 
   /**
    * Gets the trace flags for this span.
@@ -75,8 +74,7 @@ public interface SpanData {
    * @return the parent {@code SpanId} or an invalid SpanId if this is a root {@code Span}.
    * @since 0.1.0
    */
-  @SuppressWarnings("mutable")
-  byte[] getParentSpanId();
+  String getParentSpanId();
 
   /**
    * Returns the resource of this {@code Span}.

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
@@ -44,14 +44,14 @@ public interface SpanData {
    * @return the trace id.
    */
   @SuppressWarnings("mutable")
-  String getTraceId();
+  CharSequence getTraceId();
 
   /**
    * Gets the span id for this span.
    *
    * @return the span id.
    */
-  String getSpanId();
+  CharSequence getSpanId();
 
   /**
    * Gets the trace flags for this span.
@@ -74,7 +74,7 @@ public interface SpanData {
    * @return the parent {@code SpanId} or an invalid SpanId if this is a root {@code Span}.
    * @since 0.1.0
    */
-  String getParentSpanId();
+  CharSequence getParentSpanId();
 
   /**
    * Returns the resource of this {@code Span}.

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
@@ -24,10 +24,8 @@ import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanContext;
-import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.TraceFlags;
-import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
@@ -45,14 +43,16 @@ public interface SpanData {
    *
    * @return the trace id.
    */
-  TraceId getTraceId();
+  @SuppressWarnings("mutable")
+  byte[] getTraceId();
 
   /**
    * Gets the span id for this span.
    *
    * @return the span id.
    */
-  SpanId getSpanId();
+  @SuppressWarnings("mutable")
+  byte[] getSpanId();
 
   /**
    * Gets the trace flags for this span.
@@ -75,7 +75,8 @@ public interface SpanData {
    * @return the parent {@code SpanId} or an invalid SpanId if this is a root {@code Span}.
    * @since 0.1.0
    */
-  SpanId getParentSpanId();
+  @SuppressWarnings("mutable")
+  byte[] getParentSpanId();
 
   /**
    * Returns the resource of this {@code Span}.

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
@@ -30,10 +30,10 @@ class RandomIdsGeneratorTest {
 
     // Can't assert values but can assert they're valid, try a lot as a sort of fuzz check.
     for (int i = 0; i < 1000; i++) {
-      byte[] traceId = generator.generateTraceId();
+      String traceId = generator.generateTraceId();
       assertThat(traceId).isNotEqualTo(TraceId.getInvalid());
 
-      byte[] spanId = generator.generateSpanId();
+      String spanId = generator.generateSpanId();
       assertThat(spanId).isNotEqualTo(SpanId.getInvalid());
     }
   }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
@@ -30,11 +30,11 @@ class RandomIdsGeneratorTest {
 
     // Can't assert values but can assert they're valid, try a lot as a sort of fuzz check.
     for (int i = 0; i < 1000; i++) {
-      String traceId = generator.generateTraceId();
-      assertThat(traceId).isNotEqualTo(TraceId.getInvalid());
+      CharSequence traceId = generator.generateTraceId();
+      assertThat(traceId.toString()).isNotEqualTo(TraceId.getInvalid().toString());
 
-      String spanId = generator.generateSpanId();
-      assertThat(spanId).isNotEqualTo(SpanId.getInvalid());
+      CharSequence spanId = generator.generateSpanId();
+      assertThat(spanId.toString()).isNotEqualTo(SpanId.getInvalid().toString());
     }
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
@@ -30,10 +30,10 @@ class RandomIdsGeneratorTest {
 
     // Can't assert values but can assert they're valid, try a lot as a sort of fuzz check.
     for (int i = 0; i < 1000; i++) {
-      TraceId traceId = generator.generateTraceId();
+      byte[] traceId = generator.generateTraceId();
       assertThat(traceId).isNotEqualTo(TraceId.getInvalid());
 
-      SpanId spanId = generator.generateSpanId();
+      byte[] spanId = generator.generateSpanId();
       assertThat(spanId).isNotEqualTo(SpanId.getInvalid());
     }
   }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -65,9 +65,9 @@ class RecordEventsReadableSpanTest {
   private static final long START_EPOCH_NANOS = 1000_123_789_654L;
 
   private final IdsGenerator idsGenerator = new RandomIdsGenerator();
-  private final byte[] traceId = idsGenerator.generateTraceId();
-  private final byte[] spanId = idsGenerator.generateSpanId();
-  private final byte[] parentSpanId = idsGenerator.generateSpanId();
+  private final String traceId = idsGenerator.generateTraceId();
+  private final String spanId = idsGenerator.generateSpanId();
+  private final String parentSpanId = idsGenerator.generateSpanId();
   private final SpanContext spanContext =
       SpanContext.create(traceId, spanId, TraceFlags.getDefault(), TraceState.getDefault());
   private final Resource resource = Resource.getEmpty();
@@ -734,7 +734,7 @@ class RecordEventsReadableSpanTest {
   private RecordEventsReadableSpan createTestSpan(
       Kind kind,
       TraceConfig config,
-      @Nullable byte[] parentSpanId,
+      @Nullable String parentSpanId,
       @Nullable AttributesMap attributes,
       List<io.opentelemetry.trace.Link> links) {
 
@@ -808,9 +808,9 @@ class RecordEventsReadableSpanTest {
   void testAsSpanData() {
     String name = "GreatSpan";
     Kind kind = Kind.SERVER;
-    byte[] traceId = this.traceId;
-    byte[] spanId = this.spanId;
-    byte[] parentSpanId = this.parentSpanId;
+    String traceId = this.traceId;
+    String spanId = this.spanId;
+    String parentSpanId = this.parentSpanId;
     TraceConfig traceConfig = TraceConfig.getDefault();
     SpanProcessor spanProcessor = NoopSpanProcessor.getInstance();
     TestClock clock = TestClock.create();

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -36,7 +36,6 @@ import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.TraceFlags;
-import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -66,9 +65,9 @@ class RecordEventsReadableSpanTest {
   private static final long START_EPOCH_NANOS = 1000_123_789_654L;
 
   private final IdsGenerator idsGenerator = new RandomIdsGenerator();
-  private final TraceId traceId = idsGenerator.generateTraceId();
-  private final SpanId spanId = idsGenerator.generateSpanId();
-  private final SpanId parentSpanId = idsGenerator.generateSpanId();
+  private final byte[] traceId = idsGenerator.generateTraceId();
+  private final byte[] spanId = idsGenerator.generateSpanId();
+  private final byte[] parentSpanId = idsGenerator.generateSpanId();
   private final SpanContext spanContext =
       SpanContext.create(traceId, spanId, TraceFlags.getDefault(), TraceState.getDefault());
   private final Resource resource = Resource.getEmpty();
@@ -236,7 +235,7 @@ class RecordEventsReadableSpanTest {
       span.end();
     }
     SpanData spanData = span.toSpanData();
-    assertThat(spanData.getParentSpanId().isValid()).isFalse();
+    assertThat(SpanId.isValid(spanData.getParentSpanId())).isFalse();
   }
 
   @Test
@@ -735,7 +734,7 @@ class RecordEventsReadableSpanTest {
   private RecordEventsReadableSpan createTestSpan(
       Kind kind,
       TraceConfig config,
-      @Nullable SpanId parentSpanId,
+      @Nullable byte[] parentSpanId,
       @Nullable AttributesMap attributes,
       List<io.opentelemetry.trace.Link> links) {
 
@@ -809,9 +808,9 @@ class RecordEventsReadableSpanTest {
   void testAsSpanData() {
     String name = "GreatSpan";
     Kind kind = Kind.SERVER;
-    TraceId traceId = this.traceId;
-    SpanId spanId = this.spanId;
-    SpanId parentSpanId = this.parentSpanId;
+    byte[] traceId = this.traceId;
+    byte[] spanId = this.spanId;
+    byte[] parentSpanId = this.parentSpanId;
     TraceConfig traceConfig = TraceConfig.getDefault();
     SpanProcessor spanProcessor = NoopSpanProcessor.getInstance();
     TestClock clock = TestClock.create();

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -65,9 +65,9 @@ class RecordEventsReadableSpanTest {
   private static final long START_EPOCH_NANOS = 1000_123_789_654L;
 
   private final IdsGenerator idsGenerator = new RandomIdsGenerator();
-  private final String traceId = idsGenerator.generateTraceId();
-  private final String spanId = idsGenerator.generateSpanId();
-  private final String parentSpanId = idsGenerator.generateSpanId();
+  private final CharSequence traceId = idsGenerator.generateTraceId();
+  private final CharSequence spanId = idsGenerator.generateSpanId();
+  private final CharSequence parentSpanId = idsGenerator.generateSpanId();
   private final SpanContext spanContext =
       SpanContext.create(traceId, spanId, TraceFlags.getDefault(), TraceState.getDefault());
   private final Resource resource = Resource.getEmpty();
@@ -734,7 +734,7 @@ class RecordEventsReadableSpanTest {
   private RecordEventsReadableSpan createTestSpan(
       Kind kind,
       TraceConfig config,
-      @Nullable String parentSpanId,
+      @Nullable CharSequence parentSpanId,
       @Nullable AttributesMap attributes,
       List<io.opentelemetry.trace.Link> links) {
 
@@ -783,9 +783,9 @@ class RecordEventsReadableSpanTest {
       long endEpochNanos,
       Status status,
       boolean hasEnded) {
-    assertThat(spanData.getTraceId()).isEqualTo(traceId);
-    assertThat(spanData.getSpanId()).isEqualTo(spanId);
-    assertThat(spanData.getParentSpanId()).isEqualTo(parentSpanId);
+    assertThat(spanData.getTraceId().toString()).isEqualTo(traceId.toString());
+    assertThat(spanData.getSpanId().toString()).isEqualTo(spanId.toString());
+    assertThat(spanData.getParentSpanId().toString()).isEqualTo(parentSpanId.toString());
     assertThat(spanData.getHasRemoteParent()).isEqualTo(EXPECTED_HAS_REMOTE_PARENT);
     assertThat(spanData.getTraceState()).isEqualTo(TraceState.getDefault());
     assertThat(spanData.getResource()).isEqualTo(resource);
@@ -808,9 +808,9 @@ class RecordEventsReadableSpanTest {
   void testAsSpanData() {
     String name = "GreatSpan";
     Kind kind = Kind.SERVER;
-    String traceId = this.traceId;
-    String spanId = this.spanId;
-    String parentSpanId = this.parentSpanId;
+    CharSequence traceId = this.traceId;
+    CharSequence spanId = this.spanId;
+    CharSequence parentSpanId = this.parentSpanId;
     TraceConfig traceConfig = TraceConfig.getDefault();
     SpanProcessor spanProcessor = NoopSpanProcessor.getInstance();
     TestClock clock = TestClock.create();

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -40,8 +40,8 @@ class SamplersTest {
   private static final Span.Kind SPAN_KIND = Span.Kind.INTERNAL;
   private static final int NUM_SAMPLE_TRIES = 1000;
   private final IdsGenerator idsGenerator = new RandomIdsGenerator();
-  private final String traceId = idsGenerator.generateTraceId();
-  private final String parentSpanId = idsGenerator.generateSpanId();
+  private final CharSequence traceId = idsGenerator.generateTraceId();
+  private final CharSequence parentSpanId = idsGenerator.generateSpanId();
   private final TraceState traceState = TraceState.builder().build();
   private final SpanContext sampledSpanContext =
       SpanContext.create(
@@ -384,7 +384,7 @@ class SamplersTest {
     final Sampler defaultProbability = Samplers.Probability.create(0.0001);
     // This traceId will not be sampled by the Probability Sampler because the last 8 bytes as long
     // is not less than probability * Long.MAX_VALUE;
-    String notSampledtraceId =
+    CharSequence notSampledtraceId =
         TraceId.toLowerBase16(
             new byte[] {
               0,
@@ -418,7 +418,7 @@ class SamplersTest {
             Attributes.of(Samplers.SAMPLING_PROBABILITY.key(), doubleAttributeValue(0.0001)));
     // This traceId will be sampled by the Probability Sampler because the last 8 bytes as long
     // is less than probability * Long.MAX_VALUE;
-    String sampledtraceId =
+    CharSequence sampledtraceId =
         TraceId.toLowerBase16(
             new byte[] {
               (byte) 0x00,

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -28,6 +28,7 @@ import io.opentelemetry.sdk.trace.data.SpanData.Link;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.TraceFlags;
+import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
 import java.util.Collections;
 import java.util.List;
@@ -39,8 +40,8 @@ class SamplersTest {
   private static final Span.Kind SPAN_KIND = Span.Kind.INTERNAL;
   private static final int NUM_SAMPLE_TRIES = 1000;
   private final IdsGenerator idsGenerator = new RandomIdsGenerator();
-  private final byte[] traceId = idsGenerator.generateTraceId();
-  private final byte[] parentSpanId = idsGenerator.generateSpanId();
+  private final String traceId = idsGenerator.generateTraceId();
+  private final String parentSpanId = idsGenerator.generateSpanId();
   private final TraceState traceState = TraceState.builder().build();
   private final SpanContext sampledSpanContext =
       SpanContext.create(
@@ -383,25 +384,26 @@ class SamplersTest {
     final Sampler defaultProbability = Samplers.Probability.create(0.0001);
     // This traceId will not be sampled by the Probability Sampler because the last 8 bytes as long
     // is not less than probability * Long.MAX_VALUE;
-    byte[] notSampledtraceId =
-        new byte[] {
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          (byte) 0x8F,
-          (byte) 0xFF,
-          (byte) 0xFF,
-          (byte) 0xFF,
-          (byte) 0xFF,
-          (byte) 0xFF,
-          (byte) 0xFF,
-          (byte) 0xFF
-        };
+    String notSampledtraceId =
+        TraceId.toLowerBase16(
+            new byte[] {
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              (byte) 0x8F,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF
+            });
     SamplingResult samplingResult1 =
         defaultProbability.shouldSample(
             null,
@@ -416,25 +418,26 @@ class SamplersTest {
             Attributes.of(Samplers.SAMPLING_PROBABILITY.key(), doubleAttributeValue(0.0001)));
     // This traceId will be sampled by the Probability Sampler because the last 8 bytes as long
     // is less than probability * Long.MAX_VALUE;
-    byte[] sampledtraceId =
-        new byte[] {
-          (byte) 0x00,
-          (byte) 0x00,
-          (byte) 0xFF,
-          (byte) 0xFF,
-          (byte) 0xFF,
-          (byte) 0xFF,
-          (byte) 0xFF,
-          (byte) 0xFF,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0
-        };
+    String sampledtraceId =
+        TraceId.toLowerBase16(
+            new byte[] {
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0
+            });
     SamplingResult samplingResult2 =
         defaultProbability.shouldSample(
             null,

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -27,9 +27,7 @@ import io.opentelemetry.sdk.trace.Sampler.SamplingResult;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
-import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
-import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
 import java.util.Collections;
 import java.util.List;
@@ -41,8 +39,8 @@ class SamplersTest {
   private static final Span.Kind SPAN_KIND = Span.Kind.INTERNAL;
   private static final int NUM_SAMPLE_TRIES = 1000;
   private final IdsGenerator idsGenerator = new RandomIdsGenerator();
-  private final TraceId traceId = idsGenerator.generateTraceId();
-  private final SpanId parentSpanId = idsGenerator.generateSpanId();
+  private final byte[] traceId = idsGenerator.generateTraceId();
+  private final byte[] parentSpanId = idsGenerator.generateSpanId();
   private final TraceState traceState = TraceState.builder().build();
   private final SpanContext sampledSpanContext =
       SpanContext.create(
@@ -385,27 +383,25 @@ class SamplersTest {
     final Sampler defaultProbability = Samplers.Probability.create(0.0001);
     // This traceId will not be sampled by the Probability Sampler because the last 8 bytes as long
     // is not less than probability * Long.MAX_VALUE;
-    TraceId notSampledtraceId =
-        TraceId.fromBytes(
-            new byte[] {
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              (byte) 0x8F,
-              (byte) 0xFF,
-              (byte) 0xFF,
-              (byte) 0xFF,
-              (byte) 0xFF,
-              (byte) 0xFF,
-              (byte) 0xFF,
-              (byte) 0xFF
-            },
-            0);
+    byte[] notSampledtraceId =
+        new byte[] {
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          (byte) 0x8F,
+          (byte) 0xFF,
+          (byte) 0xFF,
+          (byte) 0xFF,
+          (byte) 0xFF,
+          (byte) 0xFF,
+          (byte) 0xFF,
+          (byte) 0xFF
+        };
     SamplingResult samplingResult1 =
         defaultProbability.shouldSample(
             null,
@@ -420,27 +416,25 @@ class SamplersTest {
             Attributes.of(Samplers.SAMPLING_PROBABILITY.key(), doubleAttributeValue(0.0001)));
     // This traceId will be sampled by the Probability Sampler because the last 8 bytes as long
     // is less than probability * Long.MAX_VALUE;
-    TraceId sampledtraceId =
-        TraceId.fromBytes(
-            new byte[] {
-              (byte) 0x00,
-              (byte) 0x00,
-              (byte) 0xFF,
-              (byte) 0xFF,
-              (byte) 0xFF,
-              (byte) 0xFF,
-              (byte) 0xFF,
-              (byte) 0xFF,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0
-            },
-            0);
+    byte[] sampledtraceId =
+        new byte[] {
+          (byte) 0x00,
+          (byte) 0x00,
+          (byte) 0xFF,
+          (byte) 0xFF,
+          (byte) 0xFF,
+          (byte) 0xFF,
+          (byte) 0xFF,
+          (byte) 0xFF,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0
+        };
     SamplingResult samplingResult2 =
         defaultProbability.shouldSample(
             null,

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -47,8 +47,8 @@ class SpanBuilderSdkTest {
   private static final String SPAN_NAME = "span_name";
   private final SpanContext sampledSpanContext =
       SpanContext.create(
-          new TraceId(1000, 1000),
-          new SpanId(3000),
+          TraceId.fromLongs(1000, 1000),
+          SpanId.fromLong(3000),
           TraceFlags.builder().setIsSampled(true).build(),
           TraceState.getDefault());
 
@@ -162,8 +162,8 @@ class SpanBuilderSdkTest {
       // this test to pass.
       spanBuilder.addLink(
           SpanContext.create(
-              new TraceId(2000, 2000),
-              new SpanId(4000),
+              TraceId.fromLongs(2000, 2000),
+              SpanId.fromLong(4000),
               TraceFlags.builder().setIsSampled(true).build(),
               TraceState.getDefault()));
       assertThat(span.toSpanData().getLinks())
@@ -553,7 +553,7 @@ class SpanBuilderSdkTest {
                       @Override
                       public SamplingResult shouldSample(
                           @Nullable SpanContext parentContext,
-                          TraceId traceId,
+                          byte[] traceId,
                           String name,
                           Kind spanKind,
                           ReadableAttributes attributes,
@@ -756,7 +756,7 @@ class SpanBuilderSdkTest {
             tracerSdk.spanBuilder(SPAN_NAME).setParent(parent.getContext()).startSpan();
     try {
       assertThat(span.getContext().getTraceId()).isNotEqualTo(parent.getContext().getTraceId());
-      assertFalse(span.toSpanData().getParentSpanId().isValid());
+      assertFalse(SpanId.isValid(span.toSpanData().getParentSpanId()));
     } finally {
       span.end();
     }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -553,7 +553,7 @@ class SpanBuilderSdkTest {
                       @Override
                       public SamplingResult shouldSample(
                           @Nullable SpanContext parentContext,
-                          byte[] traceId,
+                          String traceId,
                           String name,
                           Kind spanKind,
                           ReadableAttributes attributes,

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -553,7 +553,7 @@ class SpanBuilderSdkTest {
                       @Override
                       public SamplingResult shouldSample(
                           @Nullable SpanContext parentContext,
-                          String traceId,
+                          CharSequence traceId,
                           String name,
                           Kind spanKind,
                           ReadableAttributes attributes,
@@ -611,7 +611,8 @@ class SpanBuilderSdkTest {
     try (Scope ignored = tracerSdk.withSpan(parent)) {
       Span span = tracerSdk.spanBuilder(SPAN_NAME).setNoParent().startSpan();
       try {
-        assertThat(span.getContext().traceId()).isNotEqualTo(parent.getContext().traceId());
+        assertThat(span.getContext().getTraceId().toString())
+            .isNotEqualTo(parent.getContext().getTraceId().toString());
 
         Span spanNoParent =
             tracerSdk
@@ -621,7 +622,8 @@ class SpanBuilderSdkTest {
                 .setNoParent()
                 .startSpan();
         try {
-          assertThat(span.getContext().traceId()).isNotEqualTo(parent.getContext().traceId());
+          assertThat(span.getContext().getTraceId().toString())
+              .isNotEqualTo(parent.getContext().getTraceId().toString());
         } finally {
           spanNoParent.end();
         }
@@ -641,8 +643,10 @@ class SpanBuilderSdkTest {
           (RecordEventsReadableSpan)
               tracerSdk.spanBuilder(SPAN_NAME).setNoParent().setParent(parent).startSpan();
       try {
-        assertThat(span.getContext().traceId()).isEqualTo(parent.getContext().traceId());
-        assertThat(span.toSpanData().getParentSpanId()).isEqualTo(parent.getContext().spanId());
+        assertThat(span.getContext().getTraceId().toString())
+            .isEqualTo(parent.getContext().getTraceId().toString());
+        assertThat(span.toSpanData().getParentSpanId().toString())
+            .isEqualTo(parent.getContext().getSpanId().toString());
 
         RecordEventsReadableSpan span2 =
             (RecordEventsReadableSpan)
@@ -652,7 +656,8 @@ class SpanBuilderSdkTest {
                     .setParent(parent.getContext())
                     .startSpan();
         try {
-          assertThat(span2.getContext().traceId()).isEqualTo(parent.getContext().traceId());
+          assertThat(span2.getContext().getTraceId().toString())
+              .isEqualTo(parent.getContext().getTraceId().toString());
         } finally {
           span2.end();
         }
@@ -677,8 +682,10 @@ class SpanBuilderSdkTest {
                   .setParent(parent.getContext())
                   .startSpan();
       try {
-        assertThat(span.getContext().traceId()).isEqualTo(parent.getContext().traceId());
-        assertThat(span.toSpanData().getParentSpanId()).isEqualTo(parent.getContext().spanId());
+        assertThat(span.getContext().getTraceId().toString())
+            .isEqualTo(parent.getContext().getTraceId().toString());
+        assertThat(span.toSpanData().getParentSpanId().toString())
+            .isEqualTo(parent.getContext().getSpanId().toString());
       } finally {
         span.end();
       }
@@ -737,8 +744,10 @@ class SpanBuilderSdkTest {
       RecordEventsReadableSpan span =
           (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).startSpan();
       try {
-        assertThat(span.getContext().traceId()).isEqualTo(parent.getContext().traceId());
-        assertThat(span.toSpanData().getParentSpanId()).isEqualTo(parent.getContext().spanId());
+        assertThat(span.getContext().getTraceId().toString())
+            .isEqualTo(parent.getContext().getTraceId().toString());
+        assertThat(span.toSpanData().getParentSpanId().toString())
+            .isEqualTo(parent.getContext().getSpanId().toString());
       } finally {
         span.end();
       }
@@ -755,7 +764,8 @@ class SpanBuilderSdkTest {
         (RecordEventsReadableSpan)
             tracerSdk.spanBuilder(SPAN_NAME).setParent(parent.getContext()).startSpan();
     try {
-      assertThat(span.getContext().traceId()).isNotEqualTo(parent.getContext().traceId());
+      assertThat(span.getContext().getTraceId().toString())
+          .isNotEqualTo(parent.getContext().getTraceId().toString());
       assertFalse(SpanId.isValid(span.toSpanData().getParentSpanId()));
     } finally {
       span.end();

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -703,8 +703,10 @@ class SpanBuilderSdkTest {
           (RecordEventsReadableSpan)
               tracerSdk.spanBuilder(SPAN_NAME).setNoParent().setParent(context).startSpan();
       try {
-        assertThat(span.getContext().getTraceId()).isEqualTo(parent.getContext().getTraceId());
-        assertThat(span.toSpanData().getParentSpanId()).isEqualTo(parent.getContext().getSpanId());
+        assertThat(span.getContext().getTraceId().toString())
+            .isEqualTo(parent.getContext().getTraceId().toString());
+        assertThat(span.toSpanData().getParentSpanId().toString())
+            .isEqualTo(parent.getContext().getSpanId().toString());
       } finally {
         span.end();
       }
@@ -726,9 +728,10 @@ class SpanBuilderSdkTest {
       }
 
       try {
-        assertThat(span.getContext().getTraceId()).isNotEqualTo(parent.getContext().getTraceId());
-        assertThat(span.toSpanData().getParentSpanId())
-            .isNotEqualTo(parent.getContext().getSpanId());
+        assertThat(span.getContext().getTraceId().toString())
+            .isNotEqualTo(parent.getContext().getTraceId().toString());
+        assertThat(span.toSpanData().getParentSpanId().toString())
+            .isNotEqualTo(parent.getContext().getSpanId().toString());
       } finally {
         span.end();
       }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -611,8 +611,8 @@ class SpanBuilderSdkTest {
     try (Scope ignored = tracerSdk.withSpan(parent)) {
       Span span = tracerSdk.spanBuilder(SPAN_NAME).setNoParent().startSpan();
       try {
-        assertThat(span.getContext().getTraceId().toString())
-            .isNotEqualTo(parent.getContext().getTraceId().toString());
+        assertThat(span.getContext().getTraceIdAsBase16().toString())
+            .isNotEqualTo(parent.getContext().getTraceIdAsBase16().toString());
 
         Span spanNoParent =
             tracerSdk
@@ -622,8 +622,8 @@ class SpanBuilderSdkTest {
                 .setNoParent()
                 .startSpan();
         try {
-          assertThat(span.getContext().getTraceId().toString())
-              .isNotEqualTo(parent.getContext().getTraceId().toString());
+          assertThat(span.getContext().getTraceIdAsBase16().toString())
+              .isNotEqualTo(parent.getContext().getTraceIdAsBase16().toString());
         } finally {
           spanNoParent.end();
         }
@@ -643,10 +643,10 @@ class SpanBuilderSdkTest {
           (RecordEventsReadableSpan)
               tracerSdk.spanBuilder(SPAN_NAME).setNoParent().setParent(parent).startSpan();
       try {
-        assertThat(span.getContext().getTraceId().toString())
-            .isEqualTo(parent.getContext().getTraceId().toString());
+        assertThat(span.getContext().getTraceIdAsBase16().toString())
+            .isEqualTo(parent.getContext().getTraceIdAsBase16().toString());
         assertThat(span.toSpanData().getParentSpanId().toString())
-            .isEqualTo(parent.getContext().getSpanId().toString());
+            .isEqualTo(parent.getContext().getSpanIdAsBase16().toString());
 
         RecordEventsReadableSpan span2 =
             (RecordEventsReadableSpan)
@@ -656,8 +656,8 @@ class SpanBuilderSdkTest {
                     .setParent(parent.getContext())
                     .startSpan();
         try {
-          assertThat(span2.getContext().getTraceId().toString())
-              .isEqualTo(parent.getContext().getTraceId().toString());
+          assertThat(span2.getContext().getTraceIdAsBase16().toString())
+              .isEqualTo(parent.getContext().getTraceIdAsBase16().toString());
         } finally {
           span2.end();
         }
@@ -682,10 +682,10 @@ class SpanBuilderSdkTest {
                   .setParent(parent.getContext())
                   .startSpan();
       try {
-        assertThat(span.getContext().getTraceId().toString())
-            .isEqualTo(parent.getContext().getTraceId().toString());
+        assertThat(span.getContext().getTraceIdAsBase16().toString())
+            .isEqualTo(parent.getContext().getTraceIdAsBase16().toString());
         assertThat(span.toSpanData().getParentSpanId().toString())
-            .isEqualTo(parent.getContext().getSpanId().toString());
+            .isEqualTo(parent.getContext().getSpanIdAsBase16().toString());
       } finally {
         span.end();
       }
@@ -703,10 +703,10 @@ class SpanBuilderSdkTest {
           (RecordEventsReadableSpan)
               tracerSdk.spanBuilder(SPAN_NAME).setNoParent().setParent(context).startSpan();
       try {
-        assertThat(span.getContext().getTraceId().toString())
-            .isEqualTo(parent.getContext().getTraceId().toString());
+        assertThat(span.getContext().getTraceIdAsBase16().toString())
+            .isEqualTo(parent.getContext().getTraceIdAsBase16().toString());
         assertThat(span.toSpanData().getParentSpanId().toString())
-            .isEqualTo(parent.getContext().getSpanId().toString());
+            .isEqualTo(parent.getContext().getSpanIdAsBase16().toString());
       } finally {
         span.end();
       }
@@ -728,10 +728,10 @@ class SpanBuilderSdkTest {
       }
 
       try {
-        assertThat(span.getContext().getTraceId().toString())
-            .isNotEqualTo(parent.getContext().getTraceId().toString());
+        assertThat(span.getContext().getTraceIdAsBase16().toString())
+            .isNotEqualTo(parent.getContext().getTraceIdAsBase16().toString());
         assertThat(span.toSpanData().getParentSpanId().toString())
-            .isNotEqualTo(parent.getContext().getSpanId().toString());
+            .isNotEqualTo(parent.getContext().getSpanIdAsBase16().toString());
       } finally {
         span.end();
       }
@@ -747,10 +747,10 @@ class SpanBuilderSdkTest {
       RecordEventsReadableSpan span =
           (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).startSpan();
       try {
-        assertThat(span.getContext().getTraceId().toString())
-            .isEqualTo(parent.getContext().getTraceId().toString());
+        assertThat(span.getContext().getTraceIdAsBase16().toString())
+            .isEqualTo(parent.getContext().getTraceIdAsBase16().toString());
         assertThat(span.toSpanData().getParentSpanId().toString())
-            .isEqualTo(parent.getContext().getSpanId().toString());
+            .isEqualTo(parent.getContext().getSpanIdAsBase16().toString());
       } finally {
         span.end();
       }
@@ -767,8 +767,8 @@ class SpanBuilderSdkTest {
         (RecordEventsReadableSpan)
             tracerSdk.spanBuilder(SPAN_NAME).setParent(parent.getContext()).startSpan();
     try {
-      assertThat(span.getContext().getTraceId().toString())
-          .isNotEqualTo(parent.getContext().getTraceId().toString());
+      assertThat(span.getContext().getTraceIdAsBase16().toString())
+          .isNotEqualTo(parent.getContext().getTraceIdAsBase16().toString());
       assertFalse(SpanId.isValid(span.toSpanData().getParentSpanId()));
     } finally {
       span.end();

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -611,7 +611,7 @@ class SpanBuilderSdkTest {
     try (Scope ignored = tracerSdk.withSpan(parent)) {
       Span span = tracerSdk.spanBuilder(SPAN_NAME).setNoParent().startSpan();
       try {
-        assertThat(span.getContext().getTraceId()).isNotEqualTo(parent.getContext().getTraceId());
+        assertThat(span.getContext().traceId()).isNotEqualTo(parent.getContext().traceId());
 
         Span spanNoParent =
             tracerSdk
@@ -621,7 +621,7 @@ class SpanBuilderSdkTest {
                 .setNoParent()
                 .startSpan();
         try {
-          assertThat(span.getContext().getTraceId()).isNotEqualTo(parent.getContext().getTraceId());
+          assertThat(span.getContext().traceId()).isNotEqualTo(parent.getContext().traceId());
         } finally {
           spanNoParent.end();
         }
@@ -641,8 +641,8 @@ class SpanBuilderSdkTest {
           (RecordEventsReadableSpan)
               tracerSdk.spanBuilder(SPAN_NAME).setNoParent().setParent(parent).startSpan();
       try {
-        assertThat(span.getContext().getTraceId()).isEqualTo(parent.getContext().getTraceId());
-        assertThat(span.toSpanData().getParentSpanId()).isEqualTo(parent.getContext().getSpanId());
+        assertThat(span.getContext().traceId()).isEqualTo(parent.getContext().traceId());
+        assertThat(span.toSpanData().getParentSpanId()).isEqualTo(parent.getContext().spanId());
 
         RecordEventsReadableSpan span2 =
             (RecordEventsReadableSpan)
@@ -652,7 +652,7 @@ class SpanBuilderSdkTest {
                     .setParent(parent.getContext())
                     .startSpan();
         try {
-          assertThat(span2.getContext().getTraceId()).isEqualTo(parent.getContext().getTraceId());
+          assertThat(span2.getContext().traceId()).isEqualTo(parent.getContext().traceId());
         } finally {
           span2.end();
         }
@@ -677,8 +677,8 @@ class SpanBuilderSdkTest {
                   .setParent(parent.getContext())
                   .startSpan();
       try {
-        assertThat(span.getContext().getTraceId()).isEqualTo(parent.getContext().getTraceId());
-        assertThat(span.toSpanData().getParentSpanId()).isEqualTo(parent.getContext().getSpanId());
+        assertThat(span.getContext().traceId()).isEqualTo(parent.getContext().traceId());
+        assertThat(span.toSpanData().getParentSpanId()).isEqualTo(parent.getContext().spanId());
       } finally {
         span.end();
       }
@@ -737,8 +737,8 @@ class SpanBuilderSdkTest {
       RecordEventsReadableSpan span =
           (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).startSpan();
       try {
-        assertThat(span.getContext().getTraceId()).isEqualTo(parent.getContext().getTraceId());
-        assertThat(span.toSpanData().getParentSpanId()).isEqualTo(parent.getContext().getSpanId());
+        assertThat(span.getContext().traceId()).isEqualTo(parent.getContext().traceId());
+        assertThat(span.toSpanData().getParentSpanId()).isEqualTo(parent.getContext().spanId());
       } finally {
         span.end();
       }
@@ -755,7 +755,7 @@ class SpanBuilderSdkTest {
         (RecordEventsReadableSpan)
             tracerSdk.spanBuilder(SPAN_NAME).setParent(parent.getContext()).startSpan();
     try {
-      assertThat(span.getContext().getTraceId()).isNotEqualTo(parent.getContext().getTraceId());
+      assertThat(span.getContext().traceId()).isNotEqualTo(parent.getContext().traceId());
       assertFalse(SpanId.isValid(span.toSpanData().getParentSpanId()));
     } finally {
       span.end();

--- a/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/AwsXRayIdsGenerator.java
+++ b/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/AwsXRayIdsGenerator.java
@@ -37,12 +37,12 @@ public class AwsXRayIdsGenerator implements IdsGenerator {
   private static final RandomIdsGenerator RANDOM_IDS_GENERATOR = new RandomIdsGenerator();
 
   @Override
-  public byte[] generateSpanId() {
+  public String generateSpanId() {
     return RANDOM_IDS_GENERATOR.generateSpanId();
   }
 
   @Override
-  public byte[] generateTraceId() {
+  public String generateTraceId() {
     // hi - 4 bytes timestamp, 4 bytes random
     // low - 8 bytes random.
     // Since we include timestamp, impossible to be invalid.

--- a/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/AwsXRayIdsGenerator.java
+++ b/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/AwsXRayIdsGenerator.java
@@ -18,7 +18,6 @@ package io.opentelemetry.sdk.extensions.trace.aws;
 
 import io.opentelemetry.sdk.trace.IdsGenerator;
 import io.opentelemetry.sdk.trace.RandomIdsGenerator;
-import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceId;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
@@ -38,12 +37,12 @@ public class AwsXRayIdsGenerator implements IdsGenerator {
   private static final RandomIdsGenerator RANDOM_IDS_GENERATOR = new RandomIdsGenerator();
 
   @Override
-  public SpanId generateSpanId() {
+  public byte[] generateSpanId() {
     return RANDOM_IDS_GENERATOR.generateSpanId();
   }
 
   @Override
-  public TraceId generateTraceId() {
+  public byte[] generateTraceId() {
     // hi - 4 bytes timestamp, 4 bytes random
     // low - 8 bytes random.
     // Since we include timestamp, impossible to be invalid.
@@ -54,6 +53,6 @@ public class AwsXRayIdsGenerator implements IdsGenerator {
 
     long lowRandom = random.nextLong();
 
-    return new TraceId(timestampSecs << 32 | hiRandom, lowRandom);
+    return TraceId.fromLongs(timestampSecs << 32 | hiRandom, lowRandom);
   }
 }

--- a/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/AwsXRayIdsGenerator.java
+++ b/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/AwsXRayIdsGenerator.java
@@ -37,12 +37,12 @@ public class AwsXRayIdsGenerator implements IdsGenerator {
   private static final RandomIdsGenerator RANDOM_IDS_GENERATOR = new RandomIdsGenerator();
 
   @Override
-  public String generateSpanId() {
+  public CharSequence generateSpanId() {
     return RANDOM_IDS_GENERATOR.generateSpanId();
   }
 
   @Override
-  public String generateTraceId() {
+  public CharSequence generateTraceId() {
     // hi - 4 bytes timestamp, 4 bytes random
     // low - 8 bytes random.
     // Since we include timestamp, impossible to be invalid.

--- a/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/AwsXRayIdsGeneratorTest.java
+++ b/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/AwsXRayIdsGeneratorTest.java
@@ -36,10 +36,10 @@ class AwsXRayIdsGeneratorTest {
   void shouldGenerateValidIds() {
     AwsXRayIdsGenerator generator = new AwsXRayIdsGenerator();
     for (int i = 0; i < 1000; i++) {
-      TraceId traceId = generator.generateTraceId();
-      assertThat(traceId.isValid()).isTrue();
-      SpanId spanId = generator.generateSpanId();
-      assertThat(spanId.isValid()).isTrue();
+      byte[] traceId = generator.generateTraceId();
+      assertThat(TraceId.isValid(traceId)).isTrue();
+      byte[] spanId = generator.generateSpanId();
+      assertThat(SpanId.isValid(spanId)).isTrue();
     }
   }
 
@@ -47,8 +47,8 @@ class AwsXRayIdsGeneratorTest {
   void shouldGenerateTraceIdsWithTimestampsWithAllowedXrayTimeRange() {
     AwsXRayIdsGenerator generator = new AwsXRayIdsGenerator();
     for (int i = 0; i < 1000; i++) {
-      TraceId traceId = generator.generateTraceId();
-      long unixSeconds = Long.valueOf(traceId.toLowerBase16().substring(0, 8), 16);
+      byte[] traceId = generator.generateTraceId();
+      long unixSeconds = Long.valueOf(TraceId.toLowerBase16(traceId).substring(0, 8), 16);
       long ts = unixSeconds * 1000L;
       long currentTs = System.currentTimeMillis();
       assertThat(ts).isLessThanOrEqualTo(currentTs);
@@ -61,8 +61,8 @@ class AwsXRayIdsGeneratorTest {
   void shouldGenerateUniqueIdsInMultithreadedEnvironment()
       throws BrokenBarrierException, InterruptedException {
     AwsXRayIdsGenerator generator = new AwsXRayIdsGenerator();
-    Set<TraceId> traceIds = new CopyOnWriteArraySet<>();
-    Set<SpanId> spanIds = new CopyOnWriteArraySet<>();
+    Set<byte[]> traceIds = new CopyOnWriteArraySet<>();
+    Set<byte[]> spanIds = new CopyOnWriteArraySet<>();
     int threads = 8;
     int generations = 128;
     CyclicBarrier barrier = new CyclicBarrier(threads + 1);
@@ -81,15 +81,15 @@ class AwsXRayIdsGeneratorTest {
     private final int generations;
     private final IdsGenerator idsGenerator;
     private final CyclicBarrier barrier;
-    private final Set<TraceId> traceIds;
-    private final Set<SpanId> spanIds;
+    private final Set<byte[]> traceIds;
+    private final Set<byte[]> spanIds;
 
     GenerateRunner(
         int generations,
         IdsGenerator idsGenerator,
         CyclicBarrier barrier,
-        Set<TraceId> traceIds,
-        Set<SpanId> spanIds) {
+        Set<byte[]> traceIds,
+        Set<byte[]> spanIds) {
       this.generations = generations;
       this.idsGenerator = idsGenerator;
       this.barrier = barrier;

--- a/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/AwsXRayIdsGeneratorTest.java
+++ b/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/AwsXRayIdsGeneratorTest.java
@@ -36,9 +36,9 @@ class AwsXRayIdsGeneratorTest {
   void shouldGenerateValidIds() {
     AwsXRayIdsGenerator generator = new AwsXRayIdsGenerator();
     for (int i = 0; i < 1000; i++) {
-      byte[] traceId = generator.generateTraceId();
+      String traceId = generator.generateTraceId();
       assertThat(TraceId.isValid(traceId)).isTrue();
-      byte[] spanId = generator.generateSpanId();
+      String spanId = generator.generateSpanId();
       assertThat(SpanId.isValid(spanId)).isTrue();
     }
   }
@@ -47,8 +47,8 @@ class AwsXRayIdsGeneratorTest {
   void shouldGenerateTraceIdsWithTimestampsWithAllowedXrayTimeRange() {
     AwsXRayIdsGenerator generator = new AwsXRayIdsGenerator();
     for (int i = 0; i < 1000; i++) {
-      byte[] traceId = generator.generateTraceId();
-      long unixSeconds = Long.valueOf(TraceId.toLowerBase16(traceId).substring(0, 8), 16);
+      String traceId = generator.generateTraceId();
+      long unixSeconds = Long.valueOf(traceId.substring(0, 8), 16);
       long ts = unixSeconds * 1000L;
       long currentTs = System.currentTimeMillis();
       assertThat(ts).isLessThanOrEqualTo(currentTs);
@@ -61,8 +61,8 @@ class AwsXRayIdsGeneratorTest {
   void shouldGenerateUniqueIdsInMultithreadedEnvironment()
       throws BrokenBarrierException, InterruptedException {
     AwsXRayIdsGenerator generator = new AwsXRayIdsGenerator();
-    Set<byte[]> traceIds = new CopyOnWriteArraySet<>();
-    Set<byte[]> spanIds = new CopyOnWriteArraySet<>();
+    Set<String> traceIds = new CopyOnWriteArraySet<>();
+    Set<String> spanIds = new CopyOnWriteArraySet<>();
     int threads = 8;
     int generations = 128;
     CyclicBarrier barrier = new CyclicBarrier(threads + 1);
@@ -81,15 +81,15 @@ class AwsXRayIdsGeneratorTest {
     private final int generations;
     private final IdsGenerator idsGenerator;
     private final CyclicBarrier barrier;
-    private final Set<byte[]> traceIds;
-    private final Set<byte[]> spanIds;
+    private final Set<String> traceIds;
+    private final Set<String> spanIds;
 
     GenerateRunner(
         int generations,
         IdsGenerator idsGenerator,
         CyclicBarrier barrier,
-        Set<byte[]> traceIds,
-        Set<byte[]> spanIds) {
+        Set<String> traceIds,
+        Set<String> spanIds) {
       this.generations = generations;
       this.idsGenerator = idsGenerator;
       this.barrier = barrier;

--- a/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/AwsXRayIdsGeneratorTest.java
+++ b/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/AwsXRayIdsGeneratorTest.java
@@ -36,9 +36,9 @@ class AwsXRayIdsGeneratorTest {
   void shouldGenerateValidIds() {
     AwsXRayIdsGenerator generator = new AwsXRayIdsGenerator();
     for (int i = 0; i < 1000; i++) {
-      String traceId = generator.generateTraceId();
+      CharSequence traceId = generator.generateTraceId();
       assertThat(TraceId.isValid(traceId)).isTrue();
-      String spanId = generator.generateSpanId();
+      CharSequence spanId = generator.generateSpanId();
       assertThat(SpanId.isValid(spanId)).isTrue();
     }
   }
@@ -47,8 +47,8 @@ class AwsXRayIdsGeneratorTest {
   void shouldGenerateTraceIdsWithTimestampsWithAllowedXrayTimeRange() {
     AwsXRayIdsGenerator generator = new AwsXRayIdsGenerator();
     for (int i = 0; i < 1000; i++) {
-      String traceId = generator.generateTraceId();
-      long unixSeconds = Long.valueOf(traceId.substring(0, 8), 16);
+      CharSequence traceId = generator.generateTraceId();
+      long unixSeconds = Long.valueOf(traceId.subSequence(0, 8).toString(), 16);
       long ts = unixSeconds * 1000L;
       long currentTs = System.currentTimeMillis();
       assertThat(ts).isLessThanOrEqualTo(currentTs);
@@ -61,8 +61,8 @@ class AwsXRayIdsGeneratorTest {
   void shouldGenerateUniqueIdsInMultithreadedEnvironment()
       throws BrokenBarrierException, InterruptedException {
     AwsXRayIdsGenerator generator = new AwsXRayIdsGenerator();
-    Set<String> traceIds = new CopyOnWriteArraySet<>();
-    Set<String> spanIds = new CopyOnWriteArraySet<>();
+    Set<CharSequence> traceIds = new CopyOnWriteArraySet<>();
+    Set<CharSequence> spanIds = new CopyOnWriteArraySet<>();
     int threads = 8;
     int generations = 128;
     CyclicBarrier barrier = new CyclicBarrier(threads + 1);
@@ -81,15 +81,15 @@ class AwsXRayIdsGeneratorTest {
     private final int generations;
     private final IdsGenerator idsGenerator;
     private final CyclicBarrier barrier;
-    private final Set<String> traceIds;
-    private final Set<String> spanIds;
+    private final Set<CharSequence> traceIds;
+    private final Set<CharSequence> spanIds;
 
     GenerateRunner(
         int generations,
         IdsGenerator idsGenerator,
         CyclicBarrier barrier,
-        Set<String> traceIds,
-        Set<String> spanIds) {
+        Set<CharSequence> traceIds,
+        Set<CharSequence> spanIds) {
       this.generations = generations;
       this.idsGenerator = idsGenerator;
       this.barrier = barrier;

--- a/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/JaegerRemoteSampler.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/JaegerRemoteSampler.java
@@ -30,7 +30,6 @@ import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.trace.Link;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanContext;
-import io.opentelemetry.trace.TraceId;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -80,7 +79,7 @@ public class JaegerRemoteSampler implements Sampler {
   @Override
   public SamplingResult shouldSample(
       @Nullable SpanContext parentContext,
-      TraceId traceId,
+      byte[] traceId,
       String name,
       Kind spanKind,
       ReadableAttributes attributes,

--- a/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/JaegerRemoteSampler.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/JaegerRemoteSampler.java
@@ -79,7 +79,7 @@ public class JaegerRemoteSampler implements Sampler {
   @Override
   public SamplingResult shouldSample(
       @Nullable SpanContext parentContext,
-      byte[] traceId,
+      String traceId,
       String name,
       Kind spanKind,
       ReadableAttributes attributes,

--- a/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/JaegerRemoteSampler.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/JaegerRemoteSampler.java
@@ -79,7 +79,7 @@ public class JaegerRemoteSampler implements Sampler {
   @Override
   public SamplingResult shouldSample(
       @Nullable SpanContext parentContext,
-      String traceId,
+      CharSequence traceId,
       String name,
       Kind spanKind,
       ReadableAttributes attributes,

--- a/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/PerOperationSampler.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/PerOperationSampler.java
@@ -23,7 +23,6 @@ import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.trace.Link;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanContext;
-import io.opentelemetry.trace.TraceId;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +48,7 @@ class PerOperationSampler implements Sampler {
   @Override
   public SamplingResult shouldSample(
       @Nullable SpanContext parentContext,
-      TraceId traceId,
+      byte[] traceId,
       String name,
       Kind spanKind,
       ReadableAttributes attributes,

--- a/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/PerOperationSampler.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/PerOperationSampler.java
@@ -48,7 +48,7 @@ class PerOperationSampler implements Sampler {
   @Override
   public SamplingResult shouldSample(
       @Nullable SpanContext parentContext,
-      byte[] traceId,
+      String traceId,
       String name,
       Kind spanKind,
       ReadableAttributes attributes,

--- a/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/PerOperationSampler.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/PerOperationSampler.java
@@ -48,7 +48,7 @@ class PerOperationSampler implements Sampler {
   @Override
   public SamplingResult shouldSample(
       @Nullable SpanContext parentContext,
-      String traceId,
+      CharSequence traceId,
       String name,
       Kind spanKind,
       ReadableAttributes attributes,

--- a/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSampler.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSampler.java
@@ -26,7 +26,6 @@ import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.trace.Link;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanContext;
-import io.opentelemetry.trace.TraceId;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -64,7 +63,7 @@ class RateLimitingSampler implements Sampler {
   @Override
   public SamplingResult shouldSample(
       @Nullable SpanContext parentContext,
-      TraceId traceId,
+      byte[] traceId,
       String name,
       Kind spanKind,
       ReadableAttributes attributes,

--- a/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSampler.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSampler.java
@@ -63,7 +63,7 @@ class RateLimitingSampler implements Sampler {
   @Override
   public SamplingResult shouldSample(
       @Nullable SpanContext parentContext,
-      String traceId,
+      CharSequence traceId,
       String name,
       Kind spanKind,
       ReadableAttributes attributes,

--- a/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSampler.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSampler.java
@@ -63,7 +63,7 @@ class RateLimitingSampler implements Sampler {
   @Override
   public SamplingResult shouldSample(
       @Nullable SpanContext parentContext,
-      byte[] traceId,
+      String traceId,
       String name,
       Kind spanKind,
       ReadableAttributes attributes,

--- a/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSamplerTest.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSamplerTest.java
@@ -35,8 +35,8 @@ import org.junit.jupiter.api.Test;
 class RateLimitingSamplerTest {
   private static final String SPAN_NAME = "MySpanName";
   private static final Span.Kind SPAN_KIND = Span.Kind.INTERNAL;
-  private final byte[] traceId = TraceId.fromLongs(150, 150);
-  private final byte[] parentSpanId = SpanId.fromLong(250);
+  private final String traceId = TraceId.fromLongs(150, 150);
+  private final String parentSpanId = SpanId.fromLong(250);
   private final TraceState traceState = TraceState.builder().build();
   private final SpanContext sampledSpanContext =
       SpanContext.create(

--- a/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSamplerTest.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSamplerTest.java
@@ -35,8 +35,8 @@ import org.junit.jupiter.api.Test;
 class RateLimitingSamplerTest {
   private static final String SPAN_NAME = "MySpanName";
   private static final Span.Kind SPAN_KIND = Span.Kind.INTERNAL;
-  private final TraceId traceId = new TraceId(150, 150);
-  private final SpanId parentSpanId = new SpanId(250);
+  private final byte[] traceId = TraceId.fromLongs(150, 150);
+  private final byte[] parentSpanId = SpanId.fromLong(250);
   private final TraceState traceState = TraceState.builder().build();
   private final SpanContext sampledSpanContext =
       SpanContext.create(

--- a/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSamplerTest.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSamplerTest.java
@@ -35,8 +35,8 @@ import org.junit.jupiter.api.Test;
 class RateLimitingSamplerTest {
   private static final String SPAN_NAME = "MySpanName";
   private static final Span.Kind SPAN_KIND = Span.Kind.INTERNAL;
-  private final String traceId = TraceId.fromLongs(150, 150);
-  private final String parentSpanId = SpanId.fromLong(250);
+  private final CharSequence traceId = TraceId.fromLongs(150, 150);
+  private final CharSequence parentSpanId = SpanId.fromLong(250);
   private final TraceState traceState = TraceState.builder().build();
   private final SpanContext sampledSpanContext =
       SpanContext.create(

--- a/sdk_extensions/otproto/src/main/java/io/opentelemetry/sdk/extensions/otproto/TraceProtoUtils.java
+++ b/sdk_extensions/otproto/src/main/java/io/opentelemetry/sdk/extensions/otproto/TraceProtoUtils.java
@@ -21,8 +21,6 @@ import io.opentelemetry.proto.trace.v1.ConstantSampler;
 import io.opentelemetry.sdk.trace.Sampler;
 import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
-import io.opentelemetry.trace.SpanId;
-import io.opentelemetry.trace.TraceId;
 
 /** Utilities for converting various objects to protobuf representations. */
 public final class TraceProtoUtils {
@@ -34,10 +32,8 @@ public final class TraceProtoUtils {
    * @param spanId the spanId to convert.
    * @return a ByteString representation.
    */
-  public static ByteString toProtoSpanId(SpanId spanId) {
-    byte[] spanIdBytes = new byte[SpanId.getSize()];
-    spanId.copyBytesTo(spanIdBytes, 0);
-    return ByteString.copyFrom(spanIdBytes);
+  public static ByteString toProtoSpanId(byte[] spanId) {
+    return ByteString.copyFrom(spanId);
   }
 
   /**
@@ -46,10 +42,8 @@ public final class TraceProtoUtils {
    * @param traceId the traceId to convert.
    * @return a ByteString representation.
    */
-  public static ByteString toProtoTraceId(TraceId traceId) {
-    byte[] traceIdBytes = new byte[TraceId.getSize()];
-    traceId.copyBytesTo(traceIdBytes, 0);
-    return ByteString.copyFrom(traceIdBytes);
+  public static ByteString toProtoTraceId(byte[] traceId) {
+    return ByteString.copyFrom(traceId);
   }
 
   /**

--- a/sdk_extensions/otproto/src/main/java/io/opentelemetry/sdk/extensions/otproto/TraceProtoUtils.java
+++ b/sdk_extensions/otproto/src/main/java/io/opentelemetry/sdk/extensions/otproto/TraceProtoUtils.java
@@ -21,6 +21,8 @@ import io.opentelemetry.proto.trace.v1.ConstantSampler;
 import io.opentelemetry.sdk.trace.Sampler;
 import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceId;
 
 /** Utilities for converting various objects to protobuf representations. */
 public final class TraceProtoUtils {
@@ -32,8 +34,8 @@ public final class TraceProtoUtils {
    * @param spanId the spanId to convert.
    * @return a ByteString representation.
    */
-  public static ByteString toProtoSpanId(byte[] spanId) {
-    return ByteString.copyFrom(spanId);
+  public static ByteString toProtoSpanId(String spanId) {
+    return ByteString.copyFrom(SpanId.bytesFromLowerBase16(spanId, 0));
   }
 
   /**
@@ -42,8 +44,8 @@ public final class TraceProtoUtils {
    * @param traceId the traceId to convert.
    * @return a ByteString representation.
    */
-  public static ByteString toProtoTraceId(byte[] traceId) {
-    return ByteString.copyFrom(traceId);
+  public static ByteString toProtoTraceId(String traceId) {
+    return ByteString.copyFrom(TraceId.bytesFromLowerBase16(traceId, 0));
   }
 
   /**

--- a/sdk_extensions/otproto/src/main/java/io/opentelemetry/sdk/extensions/otproto/TraceProtoUtils.java
+++ b/sdk_extensions/otproto/src/main/java/io/opentelemetry/sdk/extensions/otproto/TraceProtoUtils.java
@@ -34,7 +34,7 @@ public final class TraceProtoUtils {
    * @param spanId the spanId to convert.
    * @return a ByteString representation.
    */
-  public static ByteString toProtoSpanId(String spanId) {
+  public static ByteString toProtoSpanId(CharSequence spanId) {
     return ByteString.copyFrom(SpanId.bytesFromLowerBase16(spanId, 0));
   }
 
@@ -44,7 +44,7 @@ public final class TraceProtoUtils {
    * @param traceId the traceId to convert.
    * @return a ByteString representation.
    */
-  public static ByteString toProtoTraceId(String traceId) {
+  public static ByteString toProtoTraceId(CharSequence traceId) {
     return ByteString.copyFrom(TraceId.bytesFromLowerBase16(traceId, 0));
   }
 

--- a/sdk_extensions/otproto/src/test/java/io/opentelemetry/sdk/extensions/otproto/TraceProtoUtilsTest.java
+++ b/sdk_extensions/otproto/src/test/java/io/opentelemetry/sdk/extensions/otproto/TraceProtoUtilsTest.java
@@ -24,6 +24,8 @@ import io.opentelemetry.proto.trace.v1.ConstantSampler.ConstantDecision;
 import io.opentelemetry.proto.trace.v1.ProbabilitySampler;
 import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceId;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link TraceProtoUtils}. */
@@ -46,13 +48,15 @@ class TraceProtoUtilsTest {
   @Test
   void toProtoTraceId() {
     ByteString expected = ByteString.copyFrom(TRACE_ID_BYTES);
-    assertThat(TraceProtoUtils.toProtoTraceId(TRACE_ID_BYTES)).isEqualTo(expected);
+    assertThat(TraceProtoUtils.toProtoTraceId(TraceId.toLowerBase16(TRACE_ID_BYTES)))
+        .isEqualTo(expected);
   }
 
   @Test
   void toProtoSpanId() {
     ByteString expected = ByteString.copyFrom(SPAN_ID_BYTES);
-    assertThat(TraceProtoUtils.toProtoSpanId(SPAN_ID_BYTES)).isEqualTo(expected);
+    assertThat(TraceProtoUtils.toProtoSpanId(SpanId.toLowerBase16(SPAN_ID_BYTES)))
+        .isEqualTo(expected);
   }
 
   @Test

--- a/sdk_extensions/otproto/src/test/java/io/opentelemetry/sdk/extensions/otproto/TraceProtoUtilsTest.java
+++ b/sdk_extensions/otproto/src/test/java/io/opentelemetry/sdk/extensions/otproto/TraceProtoUtilsTest.java
@@ -24,8 +24,6 @@ import io.opentelemetry.proto.trace.v1.ConstantSampler.ConstantDecision;
 import io.opentelemetry.proto.trace.v1.ProbabilitySampler;
 import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
-import io.opentelemetry.trace.SpanId;
-import io.opentelemetry.trace.TraceId;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link TraceProtoUtils}. */
@@ -43,20 +41,18 @@ class TraceProtoUtilsTest {
 
   private static final byte[] TRACE_ID_BYTES =
       new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'a'};
-  private static final TraceId TRACE_ID = TraceId.fromBytes(TRACE_ID_BYTES, 0);
   private static final byte[] SPAN_ID_BYTES = new byte[] {0, 0, 0, 0, 0, 0, 0, 'b'};
-  private static final SpanId SPAN_ID = SpanId.fromBytes(SPAN_ID_BYTES, 0);
 
   @Test
   void toProtoTraceId() {
     ByteString expected = ByteString.copyFrom(TRACE_ID_BYTES);
-    assertThat(TraceProtoUtils.toProtoTraceId(TRACE_ID)).isEqualTo(expected);
+    assertThat(TraceProtoUtils.toProtoTraceId(TRACE_ID_BYTES)).isEqualTo(expected);
   }
 
   @Test
   void toProtoSpanId() {
     ByteString expected = ByteString.copyFrom(SPAN_ID_BYTES);
-    assertThat(TraceProtoUtils.toProtoSpanId(SPAN_ID)).isEqualTo(expected);
+    assertThat(TraceProtoUtils.toProtoSpanId(SPAN_ID_BYTES)).isEqualTo(expected);
   }
 
   @Test

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/TestUtils.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/TestUtils.java
@@ -178,8 +178,10 @@ public final class TestUtils {
       // TODO - Include nanos in this comparison.
       assertThat(spans.get(spans.size() - 1).getEndEpochNanos() >= spans.get(i).getEndEpochNanos())
           .isTrue();
-      assertThat(spans.get(spans.size() - 1).getTraceId()).isEqualTo(spans.get(i).getTraceId());
-      assertThat(spans.get(spans.size() - 1).getSpanId()).isEqualTo(spans.get(i).getParentSpanId());
+      assertThat(spans.get(spans.size() - 1).getTraceId().toString())
+          .isEqualTo(spans.get(i).getTraceId().toString());
+      assertThat(spans.get(spans.size() - 1).getSpanId().toString())
+          .isEqualTo(spans.get(i).getParentSpanId().toString());
     }
   }
 }

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/activespanreplacement/ActiveSpanReplacementTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/activespanreplacement/ActiveSpanReplacementTest.java
@@ -65,12 +65,15 @@ class ActiveSpanReplacementTest {
     assertThat(spans.get(2).getName()).isEqualTo("task");
 
     // task/subtask are part of the same trace, and subtask is a child of task
-    assertThat(spans.get(1).getTraceId()).isEqualTo(spans.get(2).getTraceId());
-    assertThat(spans.get(2).getSpanId()).isEqualTo(spans.get(1).getParentSpanId());
+    assertThat(spans.get(1).getTraceId().toString())
+        .isEqualTo(spans.get(2).getTraceId().toString());
+    assertThat(spans.get(2).getSpanId().toString())
+        .isEqualTo(spans.get(1).getParentSpanId().toString());
 
     // initial task is not related in any way to those two tasks
-    assertThat(spans.get(0).getTraceId()).isNotEqualTo(spans.get(1).getTraceId());
-    assertThat(spans.get(0).getParentSpanId()).isEqualTo(SpanId.getInvalid());
+    assertThat(spans.get(0).getTraceId().toString())
+        .isNotEqualTo(spans.get(1).getTraceId().toString());
+    assertThat(spans.get(0).getParentSpanId().toString()).isEqualTo(SpanId.getInvalid().toString());
 
     assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
   }

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/actorpropagation/ActorPropagationTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/actorpropagation/ActorPropagationTest.java
@@ -80,7 +80,8 @@ class ActorPropagationTest {
 
       List<SpanData> finished = inMemoryTracing.getSpanExporter().getFinishedSpanItems();
       assertThat(finished.size()).isEqualTo(3);
-      assertThat(finished.get(0).getTraceId()).isEqualTo(finished.get(1).getTraceId());
+      assertThat(finished.get(0).getTraceId().toString())
+          .isEqualTo(finished.get(1).getTraceId().toString());
       assertThat(TestUtils.getByKind(finished, Span.Kind.CONSUMER)).hasSize(2);
       assertThat(TestUtils.getOneByKind(finished, Span.Kind.PRODUCER)).isNotNull();
 
@@ -121,7 +122,8 @@ class ActorPropagationTest {
       assertThat(message2).isEqualTo("received my message 2");
 
       assertThat(finished.size()).isEqualTo(3);
-      assertThat(finished.get(0).getTraceId()).isEqualTo(finished.get(1).getTraceId());
+      assertThat(finished.get(0).getTraceId().toString())
+          .isEqualTo(finished.get(1).getTraceId().toString());
       assertThat(TestUtils.getByKind(finished, Span.Kind.CONSUMER)).hasSize(2);
       assertThat(TestUtils.getOneByKind(finished, Span.Kind.PRODUCER)).isNotNull();
 

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/clientserver/TestClientServerTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/clientserver/TestClientServerTest.java
@@ -69,7 +69,8 @@ class TestClientServerTest {
     assertEquals(2, finished.size());
 
     finished = TestUtils.sortByStartTime(finished);
-    assertThat(finished.get(0).getTraceId()).isEqualTo(finished.get(1).getTraceId());
+    assertThat(finished.get(0).getTraceId().toString())
+        .isEqualTo(finished.get(1).getTraceId().toString());
     assertThat(finished.get(0).getKind()).isEqualTo(Kind.CLIENT);
     assertThat(finished.get(1).getKind()).isEqualTo(Kind.SERVER);
 

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/concurrentcommonrequesthandler/HandlerTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/concurrentcommonrequesthandler/HandlerTest.java
@@ -66,9 +66,12 @@ class HandlerTest {
       assertThat(spanProto.getKind()).isEqualTo(Span.Kind.CLIENT);
     }
 
-    assertThat(finished.get(0).getTraceId()).isNotEqualTo(finished.get(1).getTraceId());
-    assertThat(finished.get(0).getParentSpanId()).isEqualTo(SpanId.getInvalid());
-    assertThat(finished.get(1).getParentSpanId()).isEqualTo(SpanId.getInvalid());
+    assertThat(finished.get(0).getTraceId().toString())
+        .isNotEqualTo(finished.get(1).getTraceId().toString());
+    assertThat(finished.get(0).getParentSpanId().toString())
+        .isEqualTo(SpanId.getInvalid().toString());
+    assertThat(finished.get(1).getParentSpanId().toString())
+        .isEqualTo(SpanId.getInvalid().toString());
 
     assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
   }
@@ -95,7 +98,7 @@ class HandlerTest {
 
     // Here check that there is no parent-child relation although it should be because child is
     // created when parent is active
-    assertThat(parent.getSpanId()).isNotEqualTo(child.getParentSpanId());
+    assertThat(parent.getSpanId().toString()).isNotEqualTo(child.getParentSpanId().toString());
   }
 
   /**
@@ -128,9 +131,11 @@ class HandlerTest {
     assertThat(parent).isNotNull();
 
     // now there is parent/child relation between first and second span:
-    assertThat(finished.get(1).getParentSpanId()).isEqualTo(parent.getSpanId());
+    assertThat(finished.get(1).getParentSpanId().toString())
+        .isEqualTo(parent.getSpanId().toString());
 
     // third span should not have parent, but it has, damn it
-    assertThat(finished.get(2).getParentSpanId()).isEqualTo(parent.getSpanId());
+    assertThat(finished.get(2).getParentSpanId().toString())
+        .isEqualTo(parent.getSpanId().toString());
   }
 }

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/multiplecallbacks/MultipleCallbacksTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/multiplecallbacks/MultipleCallbacksTest.java
@@ -71,8 +71,10 @@ class MultipleCallbacksTest {
 
     SpanData parentSpan = spans.get(0);
     for (int i = 1; i < 4; i++) {
-      assertThat(spans.get(i).getTraceId()).isEqualTo(parentSpan.getTraceId());
-      assertThat(spans.get(i).getParentSpanId()).isEqualTo(parentSpan.getSpanId());
+      assertThat(spans.get(i).getTraceId().toString())
+          .isEqualTo(parentSpan.getTraceId().toString());
+      assertThat(spans.get(i).getParentSpanId().toString())
+          .isEqualTo(parentSpan.getSpanId().toString());
     }
 
     assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/promisepropagation/PromisePropagationTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/promisepropagation/PromisePropagationTest.java
@@ -110,14 +110,14 @@ class PromisePropagationTest {
       List<SpanData> successSpans = TestUtils.getByAttr(finished, component, "success");
       assertThat(successSpans).hasSize(2);
 
-      String parentId = parentSpanProto.getSpanId();
+      CharSequence parentId = parentSpanProto.getSpanId();
       for (SpanData span : successSpans) {
-        assertThat(span.getParentSpanId()).isEqualTo(parentId);
+        assertThat(span.getParentSpanId().toString()).isEqualTo(parentId.toString());
       }
 
       SpanData errorSpan = TestUtils.getOneByAttr(finished, component, "error");
       assertThat(errorSpan).isNotNull();
-      assertThat(errorSpan.getParentSpanId()).isEqualTo(parentId);
+      assertThat(errorSpan.getParentSpanId().toString()).isEqualTo(parentId.toString());
     }
   }
 }

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/promisepropagation/PromisePropagationTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/promisepropagation/PromisePropagationTest.java
@@ -106,11 +106,11 @@ class PromisePropagationTest {
       String component = "component";
       SpanData parentSpanProto = TestUtils.getOneByAttr(finished, component, "example-promises");
       assertThat(parentSpanProto).isNotNull();
-      assertThat(parentSpanProto.getParentSpanId().isValid()).isFalse();
+      assertThat(SpanId.isValid(parentSpanProto.getParentSpanId())).isFalse();
       List<SpanData> successSpans = TestUtils.getByAttr(finished, component, "success");
       assertThat(successSpans).hasSize(2);
 
-      SpanId parentId = parentSpanProto.getSpanId();
+      byte[] parentId = parentSpanProto.getSpanId();
       for (SpanData span : successSpans) {
         assertThat(span.getParentSpanId()).isEqualTo(parentId);
       }

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/promisepropagation/PromisePropagationTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/promisepropagation/PromisePropagationTest.java
@@ -110,7 +110,7 @@ class PromisePropagationTest {
       List<SpanData> successSpans = TestUtils.getByAttr(finished, component, "success");
       assertThat(successSpans).hasSize(2);
 
-      byte[] parentId = parentSpanProto.getSpanId();
+      String parentId = parentSpanProto.getSpanId();
       for (SpanData span : successSpans) {
         assertThat(span.getParentSpanId()).isEqualTo(parentId);
       }

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/suspendresumepropagation/SuspendResumePropagationTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/suspendresumepropagation/SuspendResumePropagationTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Tracer;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,7 +62,7 @@ class SuspendResumePropagationTest {
     assertThat(finished.get(0).getName()).isEqualTo("job 1");
     assertThat(finished.get(1).getName()).isEqualTo("job 2");
 
-    assertThat(finished.get(0).getParentSpanId().isValid()).isFalse();
-    assertThat(finished.get(1).getParentSpanId().isValid()).isFalse();
+    assertThat(SpanId.isValid(finished.get(0).getParentSpanId())).isFalse();
+    assertThat(SpanId.isValid(finished.get(1).getParentSpanId())).isFalse();
   }
 }

--- a/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/TracezSpanProcessor.java
+++ b/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/TracezSpanProcessor.java
@@ -19,7 +19,6 @@ package io.opentelemetry.sdk.extensions.zpages;
 import io.opentelemetry.sdk.common.export.ConfigBuilder;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
-import io.opentelemetry.trace.SpanId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
@@ -48,7 +47,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 final class TracezSpanProcessor implements SpanProcessor {
-  private final ConcurrentMap<SpanId, ReadableSpan> runningSpanCache;
+  private final ConcurrentMap<String, ReadableSpan> runningSpanCache;
   private final ConcurrentMap<String, TracezSpanBuckets> completedSpanCache;
   private final boolean sampled;
 
@@ -65,7 +64,7 @@ final class TracezSpanProcessor implements SpanProcessor {
 
   @Override
   public void onStart(ReadableSpan span) {
-    runningSpanCache.put(span.getSpanContext().getSpanId(), span);
+    runningSpanCache.put(span.getSpanContext().getSpanId().toString(), span);
   }
 
   @Override
@@ -75,7 +74,7 @@ final class TracezSpanProcessor implements SpanProcessor {
 
   @Override
   public void onEnd(ReadableSpan span) {
-    runningSpanCache.remove(span.getSpanContext().getSpanId());
+    runningSpanCache.remove(span.getSpanContext().getSpanId().toString());
     if (!sampled || span.getSpanContext().getTraceFlags().isSampled()) {
       completedSpanCache.putIfAbsent(span.getName(), new TracezSpanBuckets());
       completedSpanCache.get(span.getName()).addToBucket(span);

--- a/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/TracezSpanProcessor.java
+++ b/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/TracezSpanProcessor.java
@@ -64,7 +64,7 @@ final class TracezSpanProcessor implements SpanProcessor {
 
   @Override
   public void onStart(ReadableSpan span) {
-    runningSpanCache.put(span.getSpanContext().getSpanId().toString(), span);
+    runningSpanCache.put(span.getSpanContext().getSpanIdAsBase16().toString(), span);
   }
 
   @Override
@@ -74,7 +74,7 @@ final class TracezSpanProcessor implements SpanProcessor {
 
   @Override
   public void onEnd(ReadableSpan span) {
-    runningSpanCache.remove(span.getSpanContext().getSpanId().toString());
+    runningSpanCache.remove(span.getSpanContext().getSpanIdAsBase16().toString());
     if (!sampled || span.getSpanContext().getTraceFlags().isSampled()) {
       completedSpanCache.putIfAbsent(span.getName(), new TracezSpanBuckets());
       completedSpanCache.get(span.getName()).addToBucket(span);

--- a/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/TracezZPageHandler.java
+++ b/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/TracezZPageHandler.java
@@ -309,11 +309,9 @@ final class TracezZPageHandler extends ZPageHandler {
             + "TraceId: <b style=\"color:%s;\">%s</b> "
             + " | SpanId: %s | ParentSpanId: %s</b></pre></td>",
         span.getTraceFlags().isSampled() ? SAMPLED_TRACE_ID_COLOR : NOT_SAMPLED_TRACE_ID_COLOR,
-        span.getTraceId().toLowerBase16(),
-        span.getSpanId().toLowerBase16(),
-        (span.getParentSpanId() == null
-            ? SpanId.getInvalid().toLowerBase16()
-            : span.getParentSpanId().toLowerBase16()));
+        span.getTraceId(),
+        span.getSpanId(),
+        (span.getParentSpanId() == null ? SpanId.getInvalid() : span.getParentSpanId()));
     out.print("</tr>");
     zebraStripe = !zebraStripe;
 

--- a/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/ZPageServer.java
+++ b/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/ZPageServer.java
@@ -90,7 +90,7 @@ public final class ZPageServer {
   /** Function that adds the {@link TracezSpanProcessor} to the {@link TracerSdkProvider}. */
   private static void addTracezSpanProcessor() {
     if (isTracezSpanProcesserAdded.compareAndSet(
-        /* expectedValue= */ false, /* newValue= */ true)) {
+        /* expectedValue=*/ false, /* newValue=*/ true)) {
       tracerProvider.addSpanProcessor(tracezSpanProcessor);
     }
   }

--- a/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/ZPageServer.java
+++ b/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/ZPageServer.java
@@ -89,8 +89,7 @@ public final class ZPageServer {
 
   /** Function that adds the {@link TracezSpanProcessor} to the {@link TracerSdkProvider}. */
   private static void addTracezSpanProcessor() {
-    if (isTracezSpanProcesserAdded.compareAndSet(
-        /* expectedValue=*/ false, /* newValue=*/ true)) {
+    if (isTracezSpanProcesserAdded.compareAndSet(/* expectedValue=*/ false, /* newValue=*/ true)) {
       tracerProvider.addSpanProcessor(tracezSpanProcessor);
     }
   }

--- a/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TracezZPageHandlerTest.java
+++ b/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TracezZPageHandlerTest.java
@@ -287,8 +287,9 @@ class TracezZPageHandlerTest {
     assertThat(output.toString()).contains("<h2>Span Details</h2>");
     assertThat(output.toString()).contains("<b> Span Name: " + RUNNING_SPAN + "</b>");
     assertThat(output.toString()).contains("<b> Number of running: 1");
-    assertThat(output.toString()).contains(runningSpan.getContext().getTraceId().toString());
-    assertThat(output.toString()).contains(runningSpan.getContext().getSpanId().toString());
+    assertThat(output.toString())
+        .contains(runningSpan.getContext().getTraceIdAsBase16().toString());
+    assertThat(output.toString()).contains(runningSpan.getContext().getSpanIdAsBase16().toString());
 
     runningSpan.end();
   }
@@ -311,10 +312,14 @@ class TracezZPageHandlerTest {
     assertThat(output.toString()).contains("<h2>Span Details</h2>");
     assertThat(output.toString()).contains("<b> Span Name: " + LATENCY_SPAN + "</b>");
     assertThat(output.toString()).contains("<b> Number of latency samples: 2");
-    assertThat(output.toString()).contains(latencySpan1.getContext().getTraceId().toString());
-    assertThat(output.toString()).contains(latencySpan1.getContext().getSpanId().toString());
-    assertThat(output.toString()).contains(latencySpan2.getContext().getTraceId().toString());
-    assertThat(output.toString()).contains(latencySpan2.getContext().getSpanId().toString());
+    assertThat(output.toString())
+        .contains(latencySpan1.getContext().getTraceIdAsBase16().toString());
+    assertThat(output.toString())
+        .contains(latencySpan1.getContext().getSpanIdAsBase16().toString());
+    assertThat(output.toString())
+        .contains(latencySpan2.getContext().getTraceIdAsBase16().toString());
+    assertThat(output.toString())
+        .contains(latencySpan2.getContext().getSpanIdAsBase16().toString());
   }
 
   @Test
@@ -335,10 +340,10 @@ class TracezZPageHandlerTest {
     assertThat(output.toString()).contains("<h2>Span Details</h2>");
     assertThat(output.toString()).contains("<b> Span Name: " + ERROR_SPAN + "</b>");
     assertThat(output.toString()).contains("<b> Number of error samples: 2");
-    assertThat(output.toString()).contains(errorSpan1.getContext().getTraceId().toString());
-    assertThat(output.toString()).contains(errorSpan1.getContext().getSpanId().toString());
-    assertThat(output.toString()).contains(errorSpan2.getContext().getTraceId().toString());
-    assertThat(output.toString()).contains(errorSpan2.getContext().getSpanId().toString());
+    assertThat(output.toString()).contains(errorSpan1.getContext().getTraceIdAsBase16().toString());
+    assertThat(output.toString()).contains(errorSpan1.getContext().getSpanIdAsBase16().toString());
+    assertThat(output.toString()).contains(errorSpan2.getContext().getTraceIdAsBase16().toString());
+    assertThat(output.toString()).contains(errorSpan2.getContext().getSpanIdAsBase16().toString());
   }
 
   @Test

--- a/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TracezZPageHandlerTest.java
+++ b/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TracezZPageHandlerTest.java
@@ -287,8 +287,8 @@ class TracezZPageHandlerTest {
     assertThat(output.toString()).contains("<h2>Span Details</h2>");
     assertThat(output.toString()).contains("<b> Span Name: " + RUNNING_SPAN + "</b>");
     assertThat(output.toString()).contains("<b> Number of running: 1");
-    assertThat(output.toString()).contains(runningSpan.getContext().getTraceId().toLowerBase16());
-    assertThat(output.toString()).contains(runningSpan.getContext().getSpanId().toLowerBase16());
+    assertThat(output.toString()).contains(runningSpan.getContext().getTraceId().toString());
+    assertThat(output.toString()).contains(runningSpan.getContext().getSpanId().toString());
 
     runningSpan.end();
   }
@@ -311,10 +311,10 @@ class TracezZPageHandlerTest {
     assertThat(output.toString()).contains("<h2>Span Details</h2>");
     assertThat(output.toString()).contains("<b> Span Name: " + LATENCY_SPAN + "</b>");
     assertThat(output.toString()).contains("<b> Number of latency samples: 2");
-    assertThat(output.toString()).contains(latencySpan1.getContext().getTraceId().toLowerBase16());
-    assertThat(output.toString()).contains(latencySpan1.getContext().getSpanId().toLowerBase16());
-    assertThat(output.toString()).contains(latencySpan2.getContext().getTraceId().toLowerBase16());
-    assertThat(output.toString()).contains(latencySpan2.getContext().getSpanId().toLowerBase16());
+    assertThat(output.toString()).contains(latencySpan1.getContext().getTraceId().toString());
+    assertThat(output.toString()).contains(latencySpan1.getContext().getSpanId().toString());
+    assertThat(output.toString()).contains(latencySpan2.getContext().getTraceId().toString());
+    assertThat(output.toString()).contains(latencySpan2.getContext().getSpanId().toString());
   }
 
   @Test
@@ -335,10 +335,10 @@ class TracezZPageHandlerTest {
     assertThat(output.toString()).contains("<h2>Span Details</h2>");
     assertThat(output.toString()).contains("<b> Span Name: " + ERROR_SPAN + "</b>");
     assertThat(output.toString()).contains("<b> Number of error samples: 2");
-    assertThat(output.toString()).contains(errorSpan1.getContext().getTraceId().toLowerBase16());
-    assertThat(output.toString()).contains(errorSpan1.getContext().getSpanId().toLowerBase16());
-    assertThat(output.toString()).contains(errorSpan2.getContext().getTraceId().toLowerBase16());
-    assertThat(output.toString()).contains(errorSpan2.getContext().getSpanId().toLowerBase16());
+    assertThat(output.toString()).contains(errorSpan1.getContext().getTraceId().toString());
+    assertThat(output.toString()).contains(errorSpan1.getContext().getSpanId().toString());
+    assertThat(output.toString()).contains(errorSpan2.getContext().getTraceId().toString());
+    assertThat(output.toString()).contains(errorSpan2.getContext().getSpanId().toString());
   }
 
   @Test

--- a/testing_internal/src/main/java/io/opentelemetry/sdk/trace/TestSpanData.java
+++ b/testing_internal/src/main/java/io/opentelemetry/sdk/trace/TestSpanData.java
@@ -98,7 +98,7 @@ public abstract class TestSpanData implements SpanData {
      * @return this builder (for chaining).
      */
     @SuppressWarnings("mutable")
-    public abstract Builder setTraceId(byte[] traceId);
+    public abstract Builder setTraceId(String traceId);
 
     /**
      * Set the span id on this builder.
@@ -107,7 +107,7 @@ public abstract class TestSpanData implements SpanData {
      * @return this builder (for chaining).
      */
     @SuppressWarnings("mutable")
-    public abstract Builder setSpanId(byte[] spanId);
+    public abstract Builder setSpanId(String spanId);
 
     /**
      * Set the {@link TraceFlags} on this builder.
@@ -132,7 +132,7 @@ public abstract class TestSpanData implements SpanData {
      * @return this.
      * @since 0.1.0
      */
-    public abstract Builder setParentSpanId(byte[] parentSpanId);
+    public abstract Builder setParentSpanId(String parentSpanId);
 
     /**
      * Set the {@link Resource} associated with this span. Must not be null.

--- a/testing_internal/src/main/java/io/opentelemetry/sdk/trace/TestSpanData.java
+++ b/testing_internal/src/main/java/io/opentelemetry/sdk/trace/TestSpanData.java
@@ -27,7 +27,6 @@ import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.TraceFlags;
-import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -98,7 +97,8 @@ public abstract class TestSpanData implements SpanData {
      * @param traceId the trace id.
      * @return this builder (for chaining).
      */
-    public abstract Builder setTraceId(TraceId traceId);
+    @SuppressWarnings("mutable")
+    public abstract Builder setTraceId(byte[] traceId);
 
     /**
      * Set the span id on this builder.
@@ -106,7 +106,8 @@ public abstract class TestSpanData implements SpanData {
      * @param spanId the span id.
      * @return this builder (for chaining).
      */
-    public abstract Builder setSpanId(SpanId spanId);
+    @SuppressWarnings("mutable")
+    public abstract Builder setSpanId(byte[] spanId);
 
     /**
      * Set the {@link TraceFlags} on this builder.
@@ -131,7 +132,7 @@ public abstract class TestSpanData implements SpanData {
      * @return this.
      * @since 0.1.0
      */
-    public abstract Builder setParentSpanId(SpanId parentSpanId);
+    public abstract Builder setParentSpanId(byte[] parentSpanId);
 
     /**
      * Set the {@link Resource} associated with this span. Must not be null.

--- a/testing_internal/src/main/java/io/opentelemetry/sdk/trace/TestSpanData.java
+++ b/testing_internal/src/main/java/io/opentelemetry/sdk/trace/TestSpanData.java
@@ -98,7 +98,7 @@ public abstract class TestSpanData implements SpanData {
      * @return this builder (for chaining).
      */
     @SuppressWarnings("mutable")
-    public abstract Builder setTraceId(String traceId);
+    public abstract Builder setTraceId(CharSequence traceId);
 
     /**
      * Set the span id on this builder.
@@ -107,7 +107,7 @@ public abstract class TestSpanData implements SpanData {
      * @return this builder (for chaining).
      */
     @SuppressWarnings("mutable")
-    public abstract Builder setSpanId(String spanId);
+    public abstract Builder setSpanId(CharSequence spanId);
 
     /**
      * Set the {@link TraceFlags} on this builder.
@@ -132,7 +132,7 @@ public abstract class TestSpanData implements SpanData {
      * @return this.
      * @since 0.1.0
      */
-    public abstract Builder setParentSpanId(String parentSpanId);
+    public abstract Builder setParentSpanId(CharSequence parentSpanId);
 
     /**
      * Set the {@link Resource} associated with this span. Must not be null.

--- a/testing_internal/src/test/java/io/opentelemetry/sdk/trace/TestSpanDataTest.java
+++ b/testing_internal/src/test/java/io/opentelemetry/sdk/trace/TestSpanDataTest.java
@@ -43,7 +43,7 @@ class TestSpanDataTest {
   void defaultValues() {
     SpanData spanData = createBasicSpanBuilder().build();
 
-    assertThat(spanData.getParentSpanId().isValid()).isFalse();
+    assertThat(SpanId.isValid(spanData.getParentSpanId())).isFalse();
     assertThat(spanData.getAttributes()).isEqualTo(Attributes.empty());
     assertThat(spanData.getEvents()).isEqualTo(emptyList());
     assertThat(spanData.getLinks()).isEqualTo(emptyList());
@@ -106,8 +106,8 @@ class TestSpanDataTest {
 
   private static SpanData createSpanDataWithMutableCollections() {
     return createBasicSpanBuilder()
-        .setLinks(new ArrayList<Link>())
-        .setEvents(new ArrayList<SpanData.Event>())
+        .setLinks(new ArrayList<>())
+        .setEvents(new ArrayList<>())
         .build();
   }
 


### PR DESCRIPTION
This hasn't been optimized, but it is all functionally working, according to the tests.

Another prototype for #1314 