### PR TITLE
Add semantic attribute for peer.service

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/attributes/SemanticAttributes.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/SemanticAttributes.java
@@ -47,6 +47,11 @@ public final class SemanticAttributes {
   /** Local hostname or similar. */
   public static final StringAttributeSetter NET_HOST_NAME =
       StringAttributeSetter.create("net.host.name");
+
+  /** Logical name of a remote service. */
+  public static final StringAttributeSetter PEER_SERVICE =
+      StringAttributeSetter.create("peer.service");
+
   /**
    * Username or client_id extracted from the access token or Authorization header in the inbound
    * request from outside the system.


### PR DESCRIPTION
Corresponds to https://github.com/open-telemetry/opentelemetry-specification/pull/652 which is approved and just waiting to be merged. Sending this in the hopes that it speeds up getting both merged :)