### PR TITLE
support container id in AWS ECS plugin

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/resources/ResourceConstants.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/resources/ResourceConstants.java
@@ -50,6 +50,8 @@ public class ResourceConstants {
   public static final String LIBRARY_VERSION = "library.version";
   /** Container name. */
   public static final String CONTAINER_NAME = "container.name";
+  /** Container id. */
+  public static final String CONTAINER_ID = "container.id";
   /** Name of the image the container was built on. */
   public static final String CONTAINER_IMAGE_NAME = "container.image.name";
   /** Container image tag. */

--- a/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/DockerHelper.java
+++ b/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/DockerHelper.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.extensions.trace.aws.resource;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+class DockerHelper {
+
+  private static final Logger logger = Logger.getLogger(DockerHelper.class.getName());
+  private static final int CONTAINER_ID_LENGTH = 64;
+  private static final String DEFAULT_CGROUP_PATH = "/proc/self/cgroup";
+
+  private final String cgroupPath;
+
+  DockerHelper() {
+    this(DEFAULT_CGROUP_PATH);
+  }
+
+  @VisibleForTesting
+  DockerHelper(String cgroupPath) {
+    this.cgroupPath = cgroupPath;
+  }
+
+  /**
+   * Get docker container id from local cgroup file.
+   *
+   * @return docker container ID
+   */
+  @SuppressWarnings("DefaultCharset")
+  public String getContainerId() {
+    try (BufferedReader br = new BufferedReader(new FileReader(cgroupPath))) {
+      String line;
+      while ((line = br.readLine()) != null) {
+        if (line.length() > CONTAINER_ID_LENGTH) {
+          return line.substring(line.length() - CONTAINER_ID_LENGTH);
+        }
+      }
+    } catch (FileNotFoundException e) {
+      logger.log(Level.WARNING, "Failed to read container id, cgroup file does not exist.");
+    } catch (IOException e) {
+      logger.log(Level.WARNING, "Unable to read container id: " + e.getMessage());
+    }
+
+    return "";
+  }
+}

--- a/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/DockerHelper.java
+++ b/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/DockerHelper.java
@@ -44,7 +44,7 @@ class DockerHelper {
   /**
    * Get docker container id from local cgroup file.
    *
-   * @return docker container ID
+   * @return docker container ID. Empty string if it can`t be found.
    */
   @SuppressWarnings("DefaultCharset")
   public String getContainerId() {

--- a/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/EcsResource.java
+++ b/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/EcsResource.java
@@ -34,14 +34,16 @@ class EcsResource extends AwsResource {
   private static final String ECS_METADATA_KEY_V3 = "ECS_CONTAINER_METADATA_URI";
 
   private final Map<String, String> sysEnv;
+  private final DockerHelper dockerHelper;
 
   EcsResource() {
-    this(System.getenv());
+    this(System.getenv(), new DockerHelper());
   }
 
   @VisibleForTesting
-  EcsResource(Map<String, String> sysEnv) {
+  EcsResource(Map<String, String> sysEnv, DockerHelper dockerHelper) {
     this.sysEnv = sysEnv;
+    this.dockerHelper = dockerHelper;
   }
 
   @Override
@@ -54,9 +56,13 @@ class EcsResource extends AwsResource {
     try {
       String hostName = InetAddress.getLocalHost().getHostName();
       attrBuilders.setAttribute(ResourceConstants.CONTAINER_NAME, hostName);
-
     } catch (UnknownHostException e) {
       logger.log(Level.WARNING, "Could not get docker container name from hostname.", e);
+    }
+
+    String containerId = dockerHelper.getContainerId();
+    if (!Strings.isNullOrEmpty(containerId)) {
+      attrBuilders.setAttribute(ResourceConstants.CONTAINER_ID, containerId);
     }
 
     return attrBuilders.build();

--- a/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/DockerHelperTest.java
+++ b/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/DockerHelperTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.extensions.trace.aws.resource;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.commons.io.FileUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class DockerHelperTest {
+
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Test
+  public void testCgroupFileMissing() {
+    DockerHelper dockerHelper = new DockerHelper("a_file_never_existing");
+    assertThat(dockerHelper.getContainerId()).isEmpty();
+  }
+
+  @Test
+  public void testContainerIdMissing() throws IOException {
+    File file = tempFolder.newFile("no_container_id");
+    FileUtils.writeStringToFile(file, "13:pids:/\n" + "12:hugetlb:/\n" + "11:net_prio:/");
+
+    DockerHelper dockerHelper = new DockerHelper(file.getPath());
+    assertThat(dockerHelper.getContainerId()).isEmpty();
+  }
+
+  @Test
+  public void testGetContainerId() throws IOException {
+    File file = tempFolder.newFile("cgroup");
+    String expected = "386a1920640799b5bf5a39bd94e489e5159a88677d96ca822ce7c433ff350163";
+    FileUtils.writeStringToFile(
+        file, "dummy\n11:devices:/ecs/bbc36dd0-5ee0-4007-ba96-c590e0b278d2/" + expected);
+
+    DockerHelper dockerHelper = new DockerHelper(file.getPath());
+    assertThat(dockerHelper.getContainerId()).isEqualTo(expected);
+  }
+}

--- a/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/DockerHelperTest.java
+++ b/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/DockerHelperTest.java
@@ -18,9 +18,10 @@ package io.opentelemetry.sdk.extensions.trace.aws.resource;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
-import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -38,7 +39,8 @@ public class DockerHelperTest {
   @Test
   public void testContainerIdMissing() throws IOException {
     File file = tempFolder.newFile("no_container_id");
-    FileUtils.writeStringToFile(file, "13:pids:/\n" + "12:hugetlb:/\n" + "11:net_prio:/");
+    String content = "13:pids:/\n" + "12:hugetlb:/\n" + "11:net_prio:/";
+    Files.write(content.getBytes(Charsets.UTF_8), file);
 
     DockerHelper dockerHelper = new DockerHelper(file.getPath());
     assertThat(dockerHelper.getContainerId()).isEmpty();
@@ -48,8 +50,8 @@ public class DockerHelperTest {
   public void testGetContainerId() throws IOException {
     File file = tempFolder.newFile("cgroup");
     String expected = "386a1920640799b5bf5a39bd94e489e5159a88677d96ca822ce7c433ff350163";
-    FileUtils.writeStringToFile(
-        file, "dummy\n11:devices:/ecs/bbc36dd0-5ee0-4007-ba96-c590e0b278d2/" + expected);
+    String content = "dummy\n11:devices:/ecs/bbc36dd0-5ee0-4007-ba96-c590e0b278d2/" + expected;
+    Files.write(content.getBytes(Charsets.UTF_8), file);
 
     DockerHelper dockerHelper = new DockerHelper(file.getPath());
     assertThat(dockerHelper.getContainerId()).isEqualTo(expected);


### PR DESCRIPTION
**Description:** Add container id in AWS ECS Plugin
Container.id semantic conversions https://github.com/open-telemetry/opentelemetry-specification/pull/673

**Testing:** Verified in https://github.com/aws-samples/aws-xray-sdk-with-opentelemetry-sample/tree/both-otel-and-xray
Can get AWS service resources in Span.

**Documentation:** https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-java-configuration.html#xray-sdk-java-configuration-plugins