### PR TITLE
Return Invalid Spans from the no-op Tracer when there is no SpanContext

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
@@ -18,7 +18,6 @@ package io.opentelemetry.trace;
 
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
-import java.util.Random;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -32,7 +31,6 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public final class DefaultSpan implements Span {
 
-  private static final Random random = new Random();
   private static final DefaultSpan INVALID = new DefaultSpan(SpanContext.getInvalid());
 
   /**
@@ -54,15 +52,6 @@ public final class DefaultSpan implements Span {
    */
   public static DefaultSpan create(SpanContext spanContext) {
     return new DefaultSpan(spanContext);
-  }
-
-  static DefaultSpan createRandom() {
-    return new DefaultSpan(
-        SpanContext.create(
-            TraceId.generateRandomId(random),
-            SpanId.generateRandomId(random),
-            TraceFlags.getDefault(),
-            TraceState.getDefault()));
   }
 
   private final SpanContext spanContext;

--- a/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
@@ -77,7 +77,7 @@ public final class DefaultTracer implements Tracer {
 
       return spanContext != null && !SpanContext.getInvalid().equals(spanContext)
           ? new DefaultSpan(spanContext)
-          : DefaultSpan.createRandom();
+          : DefaultSpan.getInvalid();
     }
 
     @Override

--- a/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
@@ -33,22 +33,14 @@ public class DefaultSpanTest {
 
   @Test
   public void hasInvalidContextAndDefaultSpanOptions() {
-    SpanContext context = DefaultSpan.createRandom().getContext();
+    SpanContext context = DefaultSpan.getInvalid().getContext();
     assertThat(context.getTraceFlags()).isEqualTo(TraceFlags.getDefault());
     assertThat(context.getTraceState()).isEqualTo(TraceState.getDefault());
   }
 
   @Test
-  public void hasUniqueTraceIdAndSpanId() {
-    DefaultSpan span1 = DefaultSpan.createRandom();
-    DefaultSpan span2 = DefaultSpan.createRandom();
-    assertThat(span1.getContext().getTraceId()).isNotEqualTo(span2.getContext().getTraceId());
-    assertThat(span1.getContext().getSpanId()).isNotEqualTo(span2.getContext().getSpanId());
-  }
-
-  @Test
   public void doNotCrash() {
-    DefaultSpan span = DefaultSpan.createRandom();
+    DefaultSpan span = DefaultSpan.getInvalid();
     span.setAttribute(
         "MyStringAttributeKey", AttributeValue.stringAttributeValue("MyStringAttributeValue"));
     span.setAttribute("MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true));
@@ -80,7 +72,7 @@ public class DefaultSpanTest {
 
   @Test
   public void defaultSpan_ToString() {
-    DefaultSpan span = DefaultSpan.createRandom();
+    DefaultSpan span = DefaultSpan.getInvalid();
     assertThat(span.toString()).isEqualTo("DefaultSpan");
   }
 

--- a/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
@@ -101,6 +101,12 @@ public class DefaultTracerTest {
   }
 
   @Test
+  public void noSpanContextMakesInvalidSpans() {
+    Span span = defaultTracer.spanBuilder(SPAN_NAME).startSpan();
+    assertThat(span.getContext()).isSameInstanceAs(SpanContext.getInvalid());
+  }
+
+  @Test
   public void testSpanContextPropagation_nullContext() {
     thrown.expect(NullPointerException.class);
     defaultTracer.spanBuilder(SPAN_NAME).setParent((Context) null);

--- a/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
@@ -54,7 +54,7 @@ public class DefaultTracerTest {
   @Test
   public void getCurrentSpan_WithSpan() {
     assertThat(defaultTracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
-    try (Scope ws = defaultTracer.withSpan(DefaultSpan.createRandom())) {
+    try (Scope ws = defaultTracer.withSpan(DefaultSpan.getInvalid())) {
       assertThat(defaultTracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
     }
     assertThat(defaultTracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);

--- a/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
@@ -36,14 +36,14 @@ public class SpanBuilderTest {
   public void doNotCrash_NoopImplementation() {
     Span.Builder spanBuilder = tracer.spanBuilder("MySpanName");
     spanBuilder.setSpanKind(Kind.SERVER);
-    spanBuilder.setParent(DefaultSpan.createRandom());
-    spanBuilder.setParent(DefaultSpan.createRandom().getContext());
+    spanBuilder.setParent(DefaultSpan.getInvalid());
+    spanBuilder.setParent(DefaultSpan.getInvalid().getContext());
     spanBuilder.setNoParent();
-    spanBuilder.addLink(DefaultSpan.createRandom().getContext());
-    spanBuilder.addLink(DefaultSpan.createRandom().getContext(), Attributes.empty());
+    spanBuilder.addLink(DefaultSpan.getInvalid().getContext());
+    spanBuilder.addLink(DefaultSpan.getInvalid().getContext(), Attributes.empty());
     spanBuilder.addLink(
         new Link() {
-          private final SpanContext spanContext = DefaultSpan.createRandom().getContext();
+          private final SpanContext spanContext = DefaultSpan.getInvalid().getContext();
 
           @Override
           public SpanContext getContext() {


### PR DESCRIPTION
Resolves #1385 