### PR TITLE
Added InMemoryMetricExporter

### DIFF
--- a/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryMetricExporter.java
+++ b/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryMetricExporter.java
@@ -1,0 +1,83 @@
+package io.opentelemetry.exporters.inmemory;
+
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * A {@link MetricExporter} implementation that can be used to test OpenTelemetry integration.
+ */
+public class InMemoryMetricExporter implements MetricExporter {
+
+  // using LinkedBlockingQueue to avoid manual locks for thread-safe operations
+  private final Queue<MetricData> finishedMetricItems = new LinkedBlockingQueue<MetricData>();
+  private boolean isStopped = false;
+
+  private InMemoryMetricExporter() {}
+
+  /**
+   * Returns a new instance of the {@code InMemoryMetricExporter}.
+   *
+   * @return a new instance of the {@code InMemoryMetricExporter}.
+   */
+  public static InMemoryMetricExporter create() {
+    return new InMemoryMetricExporter();
+  }
+
+  /**
+   * Returns a {@code List} of the finished {@code Metric}s, represented by {@code MetricData}.
+   *
+   * @return a {@code List} of the finished {@code Metric}s.
+   */
+  public List<MetricData> getFinishedMetricItems() {
+    return Collections.unmodifiableList(new ArrayList<>(finishedMetricItems));
+  }
+
+  /**
+   * Clears the internal {@code List} of finished {@code Metric}s.
+   *
+   * <p>Does not reset the state of this exporter if already shutdown.
+   */
+  public void reset() {
+    finishedMetricItems.clear();
+  }
+
+  /**
+   * Exports the collection of {@code Metric}s into the inmemory queue.
+   * If this is called after {@code shutdown}, this will return {@code ResultCode.FAILURE}.
+   */
+  @Override
+  public ResultCode export(Collection<MetricData> metrics) {
+    if (isStopped) {
+      return ResultCode.FAILURE;
+    }
+    finishedMetricItems.addAll(metrics);
+    return ResultCode.SUCCESS;
+  }
+
+  /**
+   * The InMemory exporter does not batch metrics, so this method will immediately return with
+   * success.
+   *
+   * @return always Success
+   */
+  @Override
+  public ResultCode flush() {
+    return ResultCode.SUCCESS;
+  }
+
+  /**
+   * Clears the internal {@code List} of finished {@code Metric}s.
+   * Any subsequent call to export() function on this MetricExporter, will return {@code ResultCode.FAILURE}
+   */
+  @Override
+  public void shutdown() {
+    isStopped = true;
+    finishedMetricItems.clear();
+  }
+}

--- a/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryMetricExporter.java
+++ b/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryMetricExporter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.opentelemetry.exporters.inmemory;
 
 import io.opentelemetry.sdk.metrics.data.MetricData;
@@ -11,11 +27,68 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * A {@link MetricExporter} implementation that can be used to test OpenTelemetry integration.
+ *
+ * <p>Can be created using {@code InMemoryMetricExporter.create()}
+ *
+ * <p>Example usage:
+ *
+ * <pre><code>
+ * public class InMemoryMetricExporterExample {
+ *
+ *   // creating InMemoryMetricExporter
+ *   private final InMemoryMetricExporter exporter = InMemoryMetricExporter.create();
+ *   private final MeterSdkProvider meterSdkProvider = OpenTelemetrySdk.getMeterProvider();
+ *   private final Meter meter = meterSdkProvider.get("InMemoryMetricExporterExample");
+ *   private IntervalMetricReader intervalMetricReader;
+ *
+ *   void setup() {
+ *     intervalMetricReader =
+ *         IntervalMetricReader.builder()
+ *             .setMetricExporter(exporter)
+ *             .setMetricProducers(Collections.singletonList(meterSdkProvider.getMetricProducer()))
+ *             .setExportIntervalMillis(1000)
+ *             .build();
+ *   }
+ *
+ *   List&lt;MetricData&gt; readExportedMetrics() {
+ *     return exporter.getFinishedMetricItems();
+ *   }
+ *
+ *   void shutdown() {
+ *     intervalMetricReader.shutdown();
+ *   }
+ *
+ *   LongCounter generateLongMeter(String name) {
+ *     return meter.longCounterBuilder(name).setDescription("Sample LongCounter").build();
+ *   }
+ *
+ *   DoubleCounter generateDoubleMeter(String name) {
+ *     return meter.doubleCounterBuilder(name).setDescription("Sample DoubleCounter").build();
+ *   }
+ *
+ *
+ *   public static void main(String[] args) throws InterruptedException {
+ *     InMemoryMetricExporterExample example = new InMemoryMetricExporterExample();
+ *
+ *     example.setup();
+ *     example.generateLongMeter("counter-1");
+ *     example.generateDoubleMeter("counter-2");
+ *     example.generateLongMeter("counter-3");
+ *     // Delaying so that IntervalMetricReader could pull Metrics from MetricProducer and push them to
+ *     // MetricExporter
+ *     Thread.sleep(2000);
+ *     List&lt;MetricData&gt; metricDataList = example.readExportedMetrics();
+ *     System.out.println(metricDataList);
+ *     example.shutdown();
+ *     System.out.println("Bye");
+ *   }
+ * }
+ * </code></pre>
  */
 public class InMemoryMetricExporter implements MetricExporter {
 
   // using LinkedBlockingQueue to avoid manual locks for thread-safe operations
-  private final Queue<MetricData> finishedMetricItems = new LinkedBlockingQueue<MetricData>();
+  private final Queue<MetricData> finishedMetricItems = new LinkedBlockingQueue<>();
   private boolean isStopped = false;
 
   private InMemoryMetricExporter() {}
@@ -49,7 +122,8 @@ public class InMemoryMetricExporter implements MetricExporter {
 
   /**
    * Exports the collection of {@code Metric}s into the inmemory queue.
-   * If this is called after {@code shutdown}, this will return {@code ResultCode.FAILURE}.
+   *
+   * <p>If this is called after {@code shutdown}, this will return {@code ResultCode.FAILURE}.
    */
   @Override
   public ResultCode export(Collection<MetricData> metrics) {
@@ -73,7 +147,9 @@ public class InMemoryMetricExporter implements MetricExporter {
 
   /**
    * Clears the internal {@code List} of finished {@code Metric}s.
-   * Any subsequent call to export() function on this MetricExporter, will return {@code ResultCode.FAILURE}
+   *
+   * <p>Any subsequent call to export() function on this MetricExporter, will return {@code
+   * ResultCode.FAILURE}
    */
   @Override
   public void shutdown() {

--- a/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryMetricExporter.java
+++ b/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryMetricExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,37 +50,14 @@ import java.util.concurrent.LinkedBlockingQueue;
  *             .build();
  *   }
  *
- *   List&lt;MetricData&gt; readExportedMetrics() {
- *     return exporter.getFinishedMetricItems();
- *   }
- *
- *   void shutdown() {
- *     intervalMetricReader.shutdown();
- *   }
- *
- *   LongCounter generateLongMeter(String name) {
+ *   LongCounter generateLongCounterMeter(String name) {
  *     return meter.longCounterBuilder(name).setDescription("Sample LongCounter").build();
  *   }
  *
- *   DoubleCounter generateDoubleMeter(String name) {
- *     return meter.doubleCounterBuilder(name).setDescription("Sample DoubleCounter").build();
- *   }
- *
- *
  *   public static void main(String[] args) throws InterruptedException {
  *     InMemoryMetricExporterExample example = new InMemoryMetricExporterExample();
- *
  *     example.setup();
- *     example.generateLongMeter("counter-1");
- *     example.generateDoubleMeter("counter-2");
- *     example.generateLongMeter("counter-3");
- *     // Delaying so that IntervalMetricReader could pull Metrics from MetricProducer and push them to
- *     // MetricExporter
- *     Thread.sleep(2000);
- *     List&lt;MetricData&gt; metricDataList = example.readExportedMetrics();
- *     System.out.println(metricDataList);
- *     example.shutdown();
- *     System.out.println("Bye");
+ *     example.generateLongCounterMeter("counter-1");
  *   }
  * }
  * </code></pre>

--- a/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemoryMetricExporterTest.java
+++ b/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemoryMetricExporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemoryMetricExporterTest.java
+++ b/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemoryMetricExporterTest.java
@@ -1,0 +1,100 @@
+package io.opentelemetry.exporters.inmemory;
+
+import io.opentelemetry.common.Labels;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
+import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
+import io.opentelemetry.sdk.metrics.export.MetricExporter.ResultCode;
+import io.opentelemetry.sdk.resources.Resource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/** Unit tests for {@link InMemoryMetricExporter}. */
+@RunWith(JUnit4.class)
+public class InMemoryMetricExporterTest {
+
+  private final InMemoryMetricExporter exporter = InMemoryMetricExporter.create();
+
+  @Test
+  public void test_getFinishedMetricItems() {
+    List<MetricData> metrics = new ArrayList<MetricData>();
+    metrics.add(generateFakeMetric());
+    metrics.add(generateFakeMetric());
+    metrics.add(generateFakeMetric());
+
+    assertThat(exporter.export(metrics)).isEqualTo(ResultCode.SUCCESS);
+    List<MetricData> metricItems = exporter.getFinishedMetricItems();
+    assertThat(metricItems).isNotNull();
+    assertThat(metricItems.size()).isEqualTo(3);
+  }
+
+
+  @Test
+  public void test_reset() {
+    List<MetricData> metrics = new ArrayList<MetricData>();
+    metrics.add(generateFakeMetric());
+    metrics.add(generateFakeMetric());
+    metrics.add(generateFakeMetric());
+
+    assertThat(exporter.export(metrics)).isEqualTo(ResultCode.SUCCESS);
+    List<MetricData> metricItems = exporter.getFinishedMetricItems();
+    assertThat(metricItems).isNotNull();
+    assertThat(metricItems.size()).isEqualTo(3);
+    exporter.reset();
+    metricItems = exporter.getFinishedMetricItems();
+    assertThat(metricItems).isNotNull();
+    assertThat(metricItems.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void test_shutdown() {
+    List<MetricData> metrics = new ArrayList<MetricData>();
+    metrics.add(generateFakeMetric());
+    metrics.add(generateFakeMetric());
+    metrics.add(generateFakeMetric());
+
+    assertThat(exporter.export(metrics)).isEqualTo(ResultCode.SUCCESS);
+    exporter.shutdown();
+    List<MetricData> metricItems = exporter.getFinishedMetricItems();
+    assertThat(metricItems).isNotNull();
+    assertThat(metricItems.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void testShutdown_export() {
+    List<MetricData> metrics = new ArrayList<MetricData>();
+    metrics.add(generateFakeMetric());
+    metrics.add(generateFakeMetric());
+    metrics.add(generateFakeMetric());
+
+    assertThat(exporter.export(metrics)).isEqualTo(ResultCode.SUCCESS);
+    exporter.shutdown();
+    assertThat(exporter.export(metrics)).isEqualTo(ResultCode.FAILURE);
+  }
+
+  @Test
+  public void test_flush() {
+    assertThat(exporter.flush()).isEqualTo(ResultCode.SUCCESS);
+  }
+
+
+  private static MetricData generateFakeMetric() {
+    long startNs = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
+    long endNs = startNs + TimeUnit.MILLISECONDS.toNanos(900);
+    return MetricData.create(
+        Descriptor.create("name", "description", "1", Type.MONOTONIC_LONG, Labels.empty()),
+        Resource.getEmpty(),
+        InstrumentationLibraryInfo.getEmpty(),
+        Collections.singletonList(LongPoint.create(startNs, endNs, Labels.of("k", "v"), 5)));
+  }
+
+}

--- a/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemoryMetricExporterTest.java
+++ b/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemoryMetricExporterTest.java
@@ -1,4 +1,22 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.opentelemetry.exporters.inmemory;
+
+import static com.google.common.truth.Truth.assertThat;
 
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -8,21 +26,29 @@ import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
 import io.opentelemetry.sdk.metrics.export.MetricExporter.ResultCode;
 import io.opentelemetry.sdk.resources.Resource;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
-import static com.google.common.truth.Truth.assertThat;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /** Unit tests for {@link InMemoryMetricExporter}. */
 @RunWith(JUnit4.class)
 public class InMemoryMetricExporterTest {
 
   private final InMemoryMetricExporter exporter = InMemoryMetricExporter.create();
+
+  private static MetricData generateFakeMetric() {
+    long startNs = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
+    long endNs = startNs + TimeUnit.MILLISECONDS.toNanos(900);
+    return MetricData.create(
+        Descriptor.create("name", "description", "1", Type.MONOTONIC_LONG, Labels.empty()),
+        Resource.getEmpty(),
+        InstrumentationLibraryInfo.getEmpty(),
+        Collections.singletonList(LongPoint.create(startNs, endNs, Labels.of("k", "v"), 5)));
+  }
 
   @Test
   public void test_getFinishedMetricItems() {
@@ -36,7 +62,6 @@ public class InMemoryMetricExporterTest {
     assertThat(metricItems).isNotNull();
     assertThat(metricItems.size()).isEqualTo(3);
   }
-
 
   @Test
   public void test_reset() {
@@ -85,16 +110,4 @@ public class InMemoryMetricExporterTest {
   public void test_flush() {
     assertThat(exporter.flush()).isEqualTo(ResultCode.SUCCESS);
   }
-
-
-  private static MetricData generateFakeMetric() {
-    long startNs = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
-    long endNs = startNs + TimeUnit.MILLISECONDS.toNanos(900);
-    return MetricData.create(
-        Descriptor.create("name", "description", "1", Type.MONOTONIC_LONG, Labels.empty()),
-        Resource.getEmpty(),
-        InstrumentationLibraryInfo.getEmpty(),
-        Collections.singletonList(LongPoint.create(startNs, endNs, Labels.of("k", "v"), 5)));
-  }
-
 }


### PR DESCRIPTION
Fixes #1360 
Implemented `InMemoryMetricExporter` similar to `InMemorySpanExporter` and also added `InMemoryMetricExporterTest` for testing `InMemoryMetricExporter`. Used `LinkedBlockingQueue` for maintaining inmemory `MetricData` and avoiding manual locks for synchronization.