### PR TITLE
Add a toBuilder method to Labels

### DIFF
--- a/api/src/main/java/io/opentelemetry/common/ImmutableKeyValuePairs.java
+++ b/api/src/main/java/io/opentelemetry/common/ImmutableKeyValuePairs.java
@@ -136,12 +136,12 @@ abstract class ImmutableKeyValuePairs<V> implements ReadableKeyValuePairs<V> {
         new KeyValueConsumer<V>() {
           @Override
           public void consume(String key, V value) {
-            sb.append(key).append(":").append(value).append(",");
+            sb.append(key).append("=").append(value).append(", ");
           }
         });
     // get rid of that last pesky comma
     if (sb.length() > 1) {
-      sb.deleteCharAt(sb.length() - 1);
+      sb.setLength(sb.length() - 2);
     }
     sb.append("}");
     return sb.toString();

--- a/api/src/main/java/io/opentelemetry/common/ImmutableKeyValuePairs.java
+++ b/api/src/main/java/io/opentelemetry/common/ImmutableKeyValuePairs.java
@@ -128,4 +128,22 @@ abstract class ImmutableKeyValuePairs<V> implements ReadableKeyValuePairs<V> {
     data[b] = keyA;
     data[b + 1] = valueA;
   }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder("{");
+    forEach(
+        new KeyValueConsumer<V>() {
+          @Override
+          public void consume(String key, V value) {
+            sb.append(key).append(":").append(value).append(",");
+          }
+        });
+    // get rid of that last pesky comma
+    if (sb.length() > 1) {
+      sb.deleteCharAt(sb.length() - 1);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
 }

--- a/api/src/main/java/io/opentelemetry/common/Labels.java
+++ b/api/src/main/java/io/opentelemetry/common/Labels.java
@@ -110,6 +110,13 @@ public abstract class Labels extends ImmutableKeyValuePairs<String> {
     return new AutoValue_Labels_ArrayBackedLabels(sortAndFilter(data));
   }
 
+  /** Create a {@link Builder} pre-populated with the contents of this Labels instance. */
+  public Builder toBuilder() {
+    Builder builder = new Builder();
+    builder.data.addAll(data());
+    return builder;
+  }
+
   /** Creates a new {@link Builder} instance for creating arbitrary {@link Labels}. */
   public static Builder newBuilder() {
     return new Builder();

--- a/api/src/test/java/io/opentelemetry/common/ImmutableKeyValuePairsTest.java
+++ b/api/src/test/java/io/opentelemetry/common/ImmutableKeyValuePairsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.common;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+public class ImmutableKeyValuePairsTest {
+  @Test
+  public void toStringIsCorrect() {
+    assertThat(new TestPairs(Collections.emptyList()).toString()).isEqualTo("{}");
+    assertThat(new TestPairs(Arrays.asList("one", 55)).toString()).isEqualTo("{one:55}");
+    assertThat(new TestPairs(Arrays.asList("one", 55, "two", "b")).toString())
+        .isEqualTo("{one:55,two:b}");
+  }
+
+  static class TestPairs extends ImmutableKeyValuePairs<Object> {
+    private final List<Object> data;
+
+    TestPairs(List<Object> data) {
+      this.data = data;
+    }
+
+    @Override
+    List<Object> data() {
+      return data;
+    }
+  }
+}

--- a/api/src/test/java/io/opentelemetry/common/ImmutableKeyValuePairsTest.java
+++ b/api/src/test/java/io/opentelemetry/common/ImmutableKeyValuePairsTest.java
@@ -18,6 +18,7 @@ package io.opentelemetry.common;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -27,9 +28,11 @@ public class ImmutableKeyValuePairsTest {
   @Test
   public void toStringIsCorrect() {
     assertThat(new TestPairs(Collections.emptyList()).toString()).isEqualTo("{}");
-    assertThat(new TestPairs(Arrays.asList("one", 55)).toString()).isEqualTo("{one:55}");
+    assertThat(new TestPairs(Arrays.asList("one", 55)).toString()).isEqualTo("{one=55}");
     assertThat(new TestPairs(Arrays.asList("one", 55, "two", "b")).toString())
-        .isEqualTo("{one:55,two:b}");
+        .isEqualTo("{one=55, two=b}");
+    assertThat(new TestPairs(Arrays.asList("one", 55, "two", "b")).toString())
+        .isEqualTo(ImmutableMap.of("one", 55, "two", "b").toString());
   }
 
   static class TestPairs extends ImmutableKeyValuePairs<Object> {

--- a/api/src/test/java/io/opentelemetry/common/LabelsTest.java
+++ b/api/src/test/java/io/opentelemetry/common/LabelsTest.java
@@ -124,4 +124,14 @@ public class LabelsTest {
                 "key1", "value1",
                 "key2", "value2"));
   }
+
+  @Test
+  public void toBuilder() {
+    Labels initial = Labels.of("one", "a");
+    Labels second = initial.toBuilder().setLabel("two", "b").build();
+    assertThat(initial.size()).isEqualTo(1);
+    assertThat(second.size()).isEqualTo(2);
+    assertThat(initial).isEqualTo(Labels.of("one", "a"));
+    assertThat(second).isEqualTo(Labels.of("one", "a", "two", "b"));
+  }
 }


### PR DESCRIPTION
While writing some manual instrumentation, I found it very useful to keep a constant Labels instance, but then append to them when actually recording metrics (to add Span status, for instance). This method will help do that more efficiently than having to manually copy the labels from one instance to a new builder. 