### PR TITLE
More fully document the MetricProducer class

### DIFF
--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporters/prometheus/PrometheusCollector.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporters/prometheus/PrometheusCollector.java
@@ -33,7 +33,7 @@ public final class PrometheusCollector extends Collector {
 
   @Override
   public List<MetricFamilySamples> collect() {
-    Collection<MetricData> allMetrics = metricProducer.getAllMetrics();
+    Collection<MetricData> allMetrics = metricProducer.collectAllMetrics();
     List<MetricFamilySamples> allSamples = new ArrayList<>(allMetrics.size());
     for (MetricData metricData : allMetrics) {
       allSamples.add(MetricAdapter.toMetricFamilySamples(metricData));

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporters/prometheus/PrometheusCollectorTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporters/prometheus/PrometheusCollectorTest.java
@@ -55,7 +55,7 @@ public class PrometheusCollectorTest {
 
   @Test
   public void registerToDefault() throws IOException {
-    when(metricProducer.getAllMetrics()).thenReturn(generateTestData());
+    when(metricProducer.collectAllMetrics()).thenReturn(generateTestData());
     StringWriter stringWriter = new StringWriter();
     TextFormat.write004(stringWriter, CollectorRegistry.defaultRegistry.metricFamilySamples());
     assertThat(stringWriter.toString())

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
@@ -61,6 +61,10 @@ abstract class AbstractInstrument implements Instrument {
     return activeBatcher;
   }
 
+  /**
+   * Collects records from all the entries (labelSet, Bound) that changed since the last {@link
+   * AbstractInstrument#collectAll()} call.
+   */
   abstract List<MetricData> collectAll();
 
   @Override

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
@@ -104,6 +104,10 @@ final class MeterSdk implements Meter {
     return new BatchRecorderSdk(keyValuePairs);
   }
 
+  /**
+   * Collects all the metric recordings that changed since the last {@link MeterSdk#collectAll()}
+   * call.
+   */
   Collection<MetricData> collectAll() {
     InstrumentRegistry instrumentRegistry = meterSharedState.getInstrumentRegistry();
     Collection<AbstractInstrument> instruments = instrumentRegistry.getInstruments();

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdkProvider.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdkProvider.java
@@ -146,7 +146,7 @@ public final class MeterSdkProvider implements MeterProvider {
     }
 
     @Override
-    public Collection<MetricData> getAllMetrics() {
+    public Collection<MetricData> collectAllMetrics() {
       Collection<MeterSdk> meters = registry.getComponents();
       List<MetricData> result = new ArrayList<>(meters.size());
       for (MeterSdk meter : meters) {

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
@@ -209,7 +209,7 @@ public final class IntervalMetricReader {
       try {
         List<MetricData> metricsList = new ArrayList<>();
         for (MetricProducer metricProducer : internalState.getMetricProducers()) {
-          metricsList.addAll(metricProducer.getAllMetrics());
+          metricsList.addAll(metricProducer.collectAllMetrics());
         }
         internalState.getMetricExporter().export(Collections.unmodifiableList(metricsList));
       } catch (Exception e) {

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/export/MetricProducer.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/export/MetricProducer.java
@@ -21,18 +21,22 @@ import java.util.Collection;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * {@code MetricProducer} is the interface that all "pull based" metric libraries should implement
- * in order to make data available to the OpenTelemetry exporters.
+ * {@code MetricProducer} is the interface that is used to make metric data available to the
+ * OpenTelemetry exporters. Implementations should be stateful, in that each call to {@link
+ * #collectAllMetrics()} will return any metric generated since the last call was made.
+ *
+ * <p>Implementations must be thread-safe.
  *
  * @since 0.3.0
  */
 @ThreadSafe
 public interface MetricProducer {
   /**
-   * Returns a collection of produced {@link MetricData}s to be exported.
+   * Returns a collection of produced {@link MetricData}s to be exported. This will only be those
+   * metrics that have been produced since the last time this method was called.
    *
    * @return a collection of produced {@link MetricData}s to be exported.
    * @since 0.17
    */
-  Collection<MetricData> getAllMetrics();
+  Collection<MetricData> collectAllMetrics();
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkRegistryTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkRegistryTest.java
@@ -102,7 +102,7 @@ public class MeterSdkRegistryTest {
     LongCounterSdk longCounter2 = meterSdk2.longCounterBuilder("testLongCounter").build();
     longCounter2.add(10, Labels.empty());
 
-    assertThat(meterRegistry.getMetricProducer().getAllMetrics())
+    assertThat(meterRegistry.getMetricProducer().collectAllMetrics())
         .containsExactly(
             MetricData.create(
                 Descriptor.create("testLongCounter", "", "1", Type.MONOTONIC_LONG, Labels.empty()),

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
@@ -63,7 +63,7 @@ public class IntervalMetricReaderTest {
   @Before
   public void setup() {
     MockitoAnnotations.initMocks(this);
-    when(metricProducer.getAllMetrics()).thenReturn(Collections.singletonList(METRIC_DATA));
+    when(metricProducer.collectAllMetrics()).thenReturn(Collections.singletonList(METRIC_DATA));
   }
 
   @Test


### PR DESCRIPTION
- renamed the misleading method name for getting metric data.
- added javadoc in places where it was missing to clarify implementation details

resolves #1405 