### PR TITLE
Call initTracer just once at beginning of main in http example

### DIFF
--- a/examples/http/src/main/java/io/opentelemetry/example/http/HttpClient.java
+++ b/examples/http/src/main/java/io/opentelemetry/example/http/HttpClient.java
@@ -49,7 +49,7 @@ public class HttpClient {
         }
       };
 
-  private void initTracer() {
+  private static void initTracer() {
     // Get the tracer
     TracerSdkProvider tracerProvider = OpenTelemetrySdk.getTracerProvider();
     // Show that multiple exporters can be used
@@ -59,8 +59,6 @@ public class HttpClient {
   }
 
   private HttpClient() throws Exception {
-    initTracer();
-
     // Connect to the server locally
     int port = 8080;
     URL url = new URL("http://127.0.0.1:" + port);
@@ -121,6 +119,8 @@ public class HttpClient {
    * @param args It is not required.
    */
   public static void main(String[] args) {
+    initTracer();
+
     // Perform request every 5s
     Thread t =
         new Thread() {

--- a/examples/http/src/main/java/io/opentelemetry/example/http/HttpClient.java
+++ b/examples/http/src/main/java/io/opentelemetry/example/http/HttpClient.java
@@ -49,7 +49,7 @@ public class HttpClient {
         }
       };
 
-  private static void initTracer() {
+  private static void initTracerSdk() {
     // Get the tracer
     TracerSdkProvider tracerProvider = OpenTelemetrySdk.getTracerProvider();
     // Show that multiple exporters can be used
@@ -119,7 +119,7 @@ public class HttpClient {
    * @param args It is not required.
    */
   public static void main(String[] args) {
-    initTracer();
+    initTracerSdk();
 
     // Perform request every 5s
     Thread t =


### PR DESCRIPTION
This fixes a bug where each time a new HttpClient is instantiated, it adds a new SpanExporter to the
global OpenTelemetry SDK instance.