### PR TITLE
Fix semantic conventions link

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -408,4 +408,4 @@ tracerProvider.addSpanProcessor(BatchSpanProcessor.newBuilder(
 [OpenTelemetry Registry]: https://opentelemetry.io/registry/?s=exporter
 [OpenTelemetry Website]: https://opentelemetry.io/
 [Obtaining a Tracer]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#obtaining-a-tracer
-[Semantic Conventions]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md
+[Semantic Conventions]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/trace/semantic_conventions

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -408,4 +408,4 @@ tracerProvider.addSpanProcessor(BatchSpanProcessor.newBuilder(
 [OpenTelemetry Registry]: https://opentelemetry.io/registry/?s=exporter
 [OpenTelemetry Website]: https://opentelemetry.io/
 [Obtaining a Tracer]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#obtaining-a-tracer
-[Semantic Conventions]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/trace/semantic_conventions
+[Semantic Conventions]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions


### PR DESCRIPTION
Fixes #1426 which has a broken ["Semantic Conventions"](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md) link in the [Span Attributes section of the Quickstart guide](https://github.com/open-telemetry/opentelemetry-java/blob/master/QUICKSTART.md#span-attributes), resulting in a 404 page.

The fix points the link to the [Trace Semantic Conventions page](https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/trace/semantic_conventions).