### PR TITLE
Makes Export methods async

### DIFF
--- a/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryMetricExporter.java
+++ b/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryMetricExporter.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.exporters.inmemory;
 
+import io.opentelemetry.sdk.common.export.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.util.ArrayList;
@@ -103,12 +104,12 @@ public class InMemoryMetricExporter implements MetricExporter {
    * <p>If this is called after {@code shutdown}, this will return {@code ResultCode.FAILURE}.
    */
   @Override
-  public ResultCode export(Collection<MetricData> metrics) {
+  public CompletableResultCode export(Collection<MetricData> metrics) {
     if (isStopped) {
-      return ResultCode.FAILURE;
+      return CompletableResultCode.ofFailure();
     }
     finishedMetricItems.addAll(metrics);
-    return ResultCode.SUCCESS;
+    return CompletableResultCode.ofSuccess();
   }
 
   /**
@@ -118,8 +119,8 @@ public class InMemoryMetricExporter implements MetricExporter {
    * @return always Success
    */
   @Override
-  public ResultCode flush() {
-    return ResultCode.SUCCESS;
+  public CompletableResultCode flush() {
+    return CompletableResultCode.ofSuccess();
   }
 
   /**

--- a/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporter.java
+++ b/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporter.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.exporters.inmemory;
 
+import io.opentelemetry.sdk.common.export.CompletableResultCode;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.ArrayList;
@@ -85,14 +86,14 @@ public final class InMemorySpanExporter implements SpanExporter {
   }
 
   @Override
-  public ResultCode export(Collection<SpanData> spans) {
+  public CompletableResultCode export(Collection<SpanData> spans) {
     synchronized (this) {
       if (isStopped) {
-        return ResultCode.FAILURE;
+        return CompletableResultCode.ofFailure();
       }
       finishedSpanItems.addAll(spans);
     }
-    return ResultCode.SUCCESS;
+    return CompletableResultCode.ofSuccess();
   }
 
   /**
@@ -102,8 +103,8 @@ public final class InMemorySpanExporter implements SpanExporter {
    * @return always Success
    */
   @Override
-  public ResultCode flush() {
-    return ResultCode.SUCCESS;
+  public CompletableResultCode flush() {
+    return CompletableResultCode.ofSuccess();
   }
 
   @Override

--- a/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemoryMetricExporterTest.java
+++ b/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemoryMetricExporterTest.java
@@ -23,7 +23,6 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
-import io.opentelemetry.sdk.metrics.export.MetricExporter.ResultCode;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -54,7 +53,7 @@ class InMemoryMetricExporterTest {
     metrics.add(generateFakeMetric());
     metrics.add(generateFakeMetric());
 
-    assertThat(exporter.export(metrics)).isEqualTo(ResultCode.SUCCESS);
+    assertThat(exporter.export(metrics).isSuccess()).isTrue();
     List<MetricData> metricItems = exporter.getFinishedMetricItems();
     assertThat(metricItems).isNotNull();
     assertThat(metricItems.size()).isEqualTo(3);
@@ -67,7 +66,7 @@ class InMemoryMetricExporterTest {
     metrics.add(generateFakeMetric());
     metrics.add(generateFakeMetric());
 
-    assertThat(exporter.export(metrics)).isEqualTo(ResultCode.SUCCESS);
+    assertThat(exporter.export(metrics).isSuccess()).isTrue();
     List<MetricData> metricItems = exporter.getFinishedMetricItems();
     assertThat(metricItems).isNotNull();
     assertThat(metricItems.size()).isEqualTo(3);
@@ -84,7 +83,7 @@ class InMemoryMetricExporterTest {
     metrics.add(generateFakeMetric());
     metrics.add(generateFakeMetric());
 
-    assertThat(exporter.export(metrics)).isEqualTo(ResultCode.SUCCESS);
+    assertThat(exporter.export(metrics).isSuccess()).isTrue();
     exporter.shutdown();
     List<MetricData> metricItems = exporter.getFinishedMetricItems();
     assertThat(metricItems).isNotNull();
@@ -98,13 +97,13 @@ class InMemoryMetricExporterTest {
     metrics.add(generateFakeMetric());
     metrics.add(generateFakeMetric());
 
-    assertThat(exporter.export(metrics)).isEqualTo(ResultCode.SUCCESS);
+    assertThat(exporter.export(metrics).isSuccess()).isTrue();
     exporter.shutdown();
-    assertThat(exporter.export(metrics)).isEqualTo(ResultCode.FAILURE);
+    assertThat(exporter.export(metrics).isSuccess()).isFalse();
   }
 
   @Test
   void test_flush() {
-    assertThat(exporter.flush()).isEqualTo(ResultCode.SUCCESS);
+    assertThat(exporter.flush().isSuccess()).isTrue();
   }
 }

--- a/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
+++ b/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
@@ -22,7 +22,6 @@ import io.opentelemetry.sdk.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
-import io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
@@ -89,16 +88,13 @@ class InMemorySpanExporterTest {
 
   @Test
   void export_ReturnCode() {
-    assertThat(exporter.export(Collections.singletonList(makeBasicSpan())))
-        .isEqualTo(ResultCode.SUCCESS);
+    assertThat(exporter.export(Collections.singletonList(makeBasicSpan())).isSuccess()).isTrue();
     exporter.shutdown();
     // After shutdown no more export.
-    assertThat(exporter.export(Collections.singletonList(makeBasicSpan())))
-        .isEqualTo(ResultCode.FAILURE);
+    assertThat(exporter.export(Collections.singletonList(makeBasicSpan())).isSuccess()).isFalse();
     exporter.reset();
     // Reset does not do anything if already shutdown.
-    assertThat(exporter.export(Collections.singletonList(makeBasicSpan())))
-        .isEqualTo(ResultCode.FAILURE);
+    assertThat(exporter.export(Collections.singletonList(makeBasicSpan())).isSuccess()).isFalse();
   }
 
   static SpanData makeBasicSpan() {

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporter.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporter.java
@@ -21,6 +21,7 @@ import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.exporters.jaeger.proto.api_v2.Collector;
 import io.opentelemetry.exporters.jaeger.proto.api_v2.CollectorServiceGrpc;
 import io.opentelemetry.exporters.jaeger.proto.api_v2.Model;
+import io.opentelemetry.sdk.common.export.CompletableResultCode;
 import io.opentelemetry.sdk.common.export.ConfigBuilder;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
@@ -107,7 +108,7 @@ public final class JaegerGrpcSpanExporter implements SpanExporter {
    * @return the result of the operation
    */
   @Override
-  public ResultCode export(Collection<SpanData> spans) {
+  public CompletableResultCode export(Collection<SpanData> spans) {
     Collector.PostSpansRequest request =
         Collector.PostSpansRequest.newBuilder()
             .setBatch(
@@ -126,10 +127,10 @@ public final class JaegerGrpcSpanExporter implements SpanExporter {
       // for now, there's nothing to check in the response object
       //noinspection ResultOfMethodCallIgnored
       stub.postSpans(request);
-      return ResultCode.SUCCESS;
+      return CompletableResultCode.ofSuccess();
     } catch (Throwable e) {
       logger.log(Level.WARNING, "Failed to export spans", e);
-      return ResultCode.FAILURE;
+      return CompletableResultCode.ofFailure();
     }
   }
 
@@ -139,8 +140,8 @@ public final class JaegerGrpcSpanExporter implements SpanExporter {
    * @return always Success
    */
   @Override
-  public ResultCode flush() {
-    return ResultCode.SUCCESS;
+  public CompletableResultCode flush() {
+    return CompletableResultCode.ofSuccess();
   }
 
   /**

--- a/exporters/logging/src/main/java/io/opentelemetry/exporters/logging/LoggingMetricExporter.java
+++ b/exporters/logging/src/main/java/io/opentelemetry/exporters/logging/LoggingMetricExporter.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.exporters.logging;
 
+import io.opentelemetry.sdk.common.export.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.util.Collection;
@@ -27,12 +28,12 @@ public class LoggingMetricExporter implements MetricExporter {
   private static final Logger logger = Logger.getLogger(LoggingMetricExporter.class.getName());
 
   @Override
-  public ResultCode export(Collection<MetricData> metrics) {
+  public CompletableResultCode export(Collection<MetricData> metrics) {
     logger.info("Received a collection of " + metrics.size() + " metrics for export.");
     for (MetricData metricData : metrics) {
       logger.log(Level.INFO, "metric: {0}", metricData);
     }
-    return ResultCode.SUCCESS;
+    return CompletableResultCode.ofSuccess();
   }
 
   /**
@@ -41,16 +42,16 @@ public class LoggingMetricExporter implements MetricExporter {
    * @return the result of the operation
    */
   @Override
-  public ResultCode flush() {
-    ResultCode resultCode = ResultCode.SUCCESS;
+  public CompletableResultCode flush() {
+    CompletableResultCode resultCode = new CompletableResultCode();
     for (Handler handler : logger.getHandlers()) {
       try {
         handler.flush();
       } catch (Throwable t) {
-        resultCode = ResultCode.FAILURE;
+        resultCode.fail();
       }
     }
-    return resultCode;
+    return resultCode.succeed();
   }
 
   @Override

--- a/exporters/logging/src/main/java/io/opentelemetry/exporters/logging/LoggingMetricExporter.java
+++ b/exporters/logging/src/main/java/io/opentelemetry/exporters/logging/LoggingMetricExporter.java
@@ -48,7 +48,7 @@ public class LoggingMetricExporter implements MetricExporter {
       try {
         handler.flush();
       } catch (Throwable t) {
-        resultCode.fail();
+        return resultCode.fail();
       }
     }
     return resultCode.succeed();

--- a/exporters/logging/src/main/java/io/opentelemetry/exporters/logging/LoggingSpanExporter.java
+++ b/exporters/logging/src/main/java/io/opentelemetry/exporters/logging/LoggingSpanExporter.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.exporters.logging;
 
+import io.opentelemetry.sdk.common.export.CompletableResultCode;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Collection;
@@ -28,11 +29,11 @@ public class LoggingSpanExporter implements SpanExporter {
   private static final Logger logger = Logger.getLogger(LoggingSpanExporter.class.getName());
 
   @Override
-  public ResultCode export(Collection<SpanData> spans) {
+  public CompletableResultCode export(Collection<SpanData> spans) {
     for (SpanData span : spans) {
       logger.log(Level.INFO, "span: {0}", span);
     }
-    return ResultCode.SUCCESS;
+    return CompletableResultCode.ofSuccess();
   }
 
   /**
@@ -41,16 +42,16 @@ public class LoggingSpanExporter implements SpanExporter {
    * @return the result of the operation
    */
   @Override
-  public ResultCode flush() {
-    ResultCode resultCode = ResultCode.SUCCESS;
+  public CompletableResultCode flush() {
+    CompletableResultCode resultCode = new CompletableResultCode();
     for (Handler handler : logger.getHandlers()) {
       try {
         handler.flush();
       } catch (Throwable t) {
-        resultCode = ResultCode.FAILURE;
+        resultCode.fail();
       }
     }
-    return resultCode;
+    return resultCode.succeed();
   }
 
   @Override

--- a/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingSpanExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingSpanExporterTest.java
@@ -18,14 +18,13 @@ package io.opentelemetry.exporters.logging;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
+import io.opentelemetry.sdk.common.export.CompletableResultCode;
 import io.opentelemetry.sdk.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.EventImpl;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
@@ -77,8 +76,8 @@ class LoggingSpanExporterTest {
             .setTotalRecordedEvents(1)
             .setTotalRecordedLinks(0)
             .build();
-    ResultCode resultCode = exporter.export(singletonList(spanData));
-    assertEquals(ResultCode.SUCCESS, resultCode);
+    CompletableResultCode resultCode = exporter.export(singletonList(spanData));
+    assertThat(resultCode.isSuccess()).isTrue();
   }
 
   @Test

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcMetricExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcMetricExporterTest.java
@@ -36,7 +36,6 @@ import io.opentelemetry.sdk.common.export.ConfigBuilder;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
-import io.opentelemetry.sdk.metrics.export.MetricExporter.ResultCode;
 import io.opentelemetry.sdk.resources.Resource;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -98,7 +97,7 @@ class OtlpGrpcMetricExporterTest {
     OtlpGrpcMetricExporter exporter =
         OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
-      assertThat(exporter.export(Collections.singletonList(span))).isEqualTo(ResultCode.SUCCESS);
+      assertThat(exporter.export(Collections.singletonList(span)).isSuccess()).isTrue();
       assertThat(fakeCollector.getReceivedMetrics())
           .isEqualTo(MetricAdapter.toProtoResourceMetrics(Collections.singletonList(span)));
     } finally {
@@ -115,7 +114,7 @@ class OtlpGrpcMetricExporterTest {
     OtlpGrpcMetricExporter exporter =
         OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
-      assertThat(exporter.export(spans)).isEqualTo(ResultCode.SUCCESS);
+      assertThat(exporter.export(spans).isSuccess()).isTrue();
       assertThat(fakeCollector.getReceivedMetrics())
           .isEqualTo(MetricAdapter.toProtoResourceMetrics(spans));
     } finally {
@@ -129,7 +128,7 @@ class OtlpGrpcMetricExporterTest {
     OtlpGrpcMetricExporter exporter =
         OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
     exporter.shutdown();
-    assertThat(exporter.export(Collections.singletonList(span))).isEqualTo(ResultCode.FAILURE);
+    assertThat(exporter.export(Collections.singletonList(span)).isSuccess()).isFalse();
   }
 
   @Test
@@ -138,8 +137,8 @@ class OtlpGrpcMetricExporterTest {
     OtlpGrpcMetricExporter exporter =
         OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
-      assertThat(exporter.export(Collections.singletonList(generateFakeMetric())))
-          .isEqualTo(ResultCode.FAILURE);
+      assertThat(exporter.export(Collections.singletonList(generateFakeMetric())).isSuccess())
+          .isFalse();
     } finally {
       exporter.shutdown();
     }
@@ -151,8 +150,8 @@ class OtlpGrpcMetricExporterTest {
     OtlpGrpcMetricExporter exporter =
         OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
-      assertThat(exporter.export(Collections.singletonList(generateFakeMetric())))
-          .isEqualTo(ResultCode.FAILURE);
+      assertThat(exporter.export(Collections.singletonList(generateFakeMetric())).isSuccess())
+          .isFalse();
     } finally {
       exporter.shutdown();
     }
@@ -164,8 +163,8 @@ class OtlpGrpcMetricExporterTest {
     OtlpGrpcMetricExporter exporter =
         OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
-      assertThat(exporter.export(Collections.singletonList(generateFakeMetric())))
-          .isEqualTo(ResultCode.FAILURE);
+      assertThat(exporter.export(Collections.singletonList(generateFakeMetric())).isSuccess())
+          .isFalse();
     } finally {
       exporter.shutdown();
     }
@@ -177,8 +176,8 @@ class OtlpGrpcMetricExporterTest {
     OtlpGrpcMetricExporter exporter =
         OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
-      assertThat(exporter.export(Collections.singletonList(generateFakeMetric())))
-          .isEqualTo(ResultCode.FAILURE);
+      assertThat(exporter.export(Collections.singletonList(generateFakeMetric())).isSuccess())
+          .isFalse();
     } finally {
       exporter.shutdown();
     }
@@ -190,8 +189,8 @@ class OtlpGrpcMetricExporterTest {
     OtlpGrpcMetricExporter exporter =
         OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
-      assertThat(exporter.export(Collections.singletonList(generateFakeMetric())))
-          .isEqualTo(ResultCode.FAILURE);
+      assertThat(exporter.export(Collections.singletonList(generateFakeMetric())).isSuccess())
+          .isFalse();
     } finally {
       exporter.shutdown();
     }
@@ -203,8 +202,8 @@ class OtlpGrpcMetricExporterTest {
     OtlpGrpcMetricExporter exporter =
         OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
-      assertThat(exporter.export(Collections.singletonList(generateFakeMetric())))
-          .isEqualTo(ResultCode.FAILURE);
+      assertThat(exporter.export(Collections.singletonList(generateFakeMetric())).isSuccess())
+          .isFalse();
     } finally {
       exporter.shutdown();
     }
@@ -216,8 +215,8 @@ class OtlpGrpcMetricExporterTest {
     OtlpGrpcMetricExporter exporter =
         OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
-      assertThat(exporter.export(Collections.singletonList(generateFakeMetric())))
-          .isEqualTo(ResultCode.FAILURE);
+      assertThat(exporter.export(Collections.singletonList(generateFakeMetric())).isSuccess())
+          .isFalse();
     } finally {
       exporter.shutdown();
     }
@@ -228,7 +227,7 @@ class OtlpGrpcMetricExporterTest {
     OtlpGrpcMetricExporter exporter =
         OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
-      assertThat(exporter.flush()).isEqualTo(ResultCode.SUCCESS);
+      assertThat(exporter.flush().isSuccess()).isTrue();
     } finally {
       exporter.shutdown();
     }

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
@@ -32,7 +32,6 @@ import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import io.opentelemetry.sdk.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
@@ -103,7 +102,7 @@ class OtlpGrpcSpanExporterTest {
     OtlpGrpcSpanExporter exporter =
         OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
-      assertThat(exporter.export(Collections.singletonList(span))).isEqualTo(ResultCode.SUCCESS);
+      assertThat(exporter.export(Collections.singletonList(span)).isSuccess()).isTrue();
       assertThat(fakeCollector.getReceivedSpans())
           .isEqualTo(SpanAdapter.toProtoResourceSpans(Collections.singletonList(span)));
     } finally {
@@ -120,7 +119,7 @@ class OtlpGrpcSpanExporterTest {
     OtlpGrpcSpanExporter exporter =
         OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
-      assertThat(exporter.export(spans)).isEqualTo(ResultCode.SUCCESS);
+      assertThat(exporter.export(spans).isSuccess()).isTrue();
       assertThat(fakeCollector.getReceivedSpans())
           .isEqualTo(SpanAdapter.toProtoResourceSpans(spans));
     } finally {
@@ -135,7 +134,7 @@ class OtlpGrpcSpanExporterTest {
         OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
     exporter.shutdown();
     // TODO: This probably should not be retryable because we never restart the channel.
-    assertThat(exporter.export(Collections.singletonList(span))).isEqualTo(ResultCode.FAILURE);
+    assertThat(exporter.export(Collections.singletonList(span)).isSuccess()).isFalse();
   }
 
   @Test
@@ -144,8 +143,8 @@ class OtlpGrpcSpanExporterTest {
     OtlpGrpcSpanExporter exporter =
         OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
-      assertThat(exporter.export(Collections.singletonList(generateFakeSpan())))
-          .isEqualTo(ResultCode.FAILURE);
+      assertThat(exporter.export(Collections.singletonList(generateFakeSpan())).isSuccess())
+          .isFalse();
     } finally {
       exporter.shutdown();
     }
@@ -157,8 +156,8 @@ class OtlpGrpcSpanExporterTest {
     OtlpGrpcSpanExporter exporter =
         OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
-      assertThat(exporter.export(Collections.singletonList(generateFakeSpan())))
-          .isEqualTo(ResultCode.FAILURE);
+      assertThat(exporter.export(Collections.singletonList(generateFakeSpan())).isSuccess())
+          .isFalse();
     } finally {
       exporter.shutdown();
     }
@@ -170,8 +169,8 @@ class OtlpGrpcSpanExporterTest {
     OtlpGrpcSpanExporter exporter =
         OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
-      assertThat(exporter.export(Collections.singletonList(generateFakeSpan())))
-          .isEqualTo(ResultCode.FAILURE);
+      assertThat(exporter.export(Collections.singletonList(generateFakeSpan())).isSuccess())
+          .isFalse();
     } finally {
       exporter.shutdown();
     }
@@ -183,8 +182,8 @@ class OtlpGrpcSpanExporterTest {
     OtlpGrpcSpanExporter exporter =
         OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
-      assertThat(exporter.export(Collections.singletonList(generateFakeSpan())))
-          .isEqualTo(ResultCode.FAILURE);
+      assertThat(exporter.export(Collections.singletonList(generateFakeSpan())).isSuccess())
+          .isFalse();
     } finally {
       exporter.shutdown();
     }
@@ -196,8 +195,8 @@ class OtlpGrpcSpanExporterTest {
     OtlpGrpcSpanExporter exporter =
         OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
-      assertThat(exporter.export(Collections.singletonList(generateFakeSpan())))
-          .isEqualTo(ResultCode.FAILURE);
+      assertThat(exporter.export(Collections.singletonList(generateFakeSpan())).isSuccess())
+          .isFalse();
     } finally {
       exporter.shutdown();
     }
@@ -209,8 +208,8 @@ class OtlpGrpcSpanExporterTest {
     OtlpGrpcSpanExporter exporter =
         OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
-      assertThat(exporter.export(Collections.singletonList(generateFakeSpan())))
-          .isEqualTo(ResultCode.FAILURE);
+      assertThat(exporter.export(Collections.singletonList(generateFakeSpan())).isSuccess())
+          .isFalse();
     } finally {
       exporter.shutdown();
     }
@@ -222,8 +221,8 @@ class OtlpGrpcSpanExporterTest {
     OtlpGrpcSpanExporter exporter =
         OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
     try {
-      assertThat(exporter.export(Collections.singletonList(generateFakeSpan())))
-          .isEqualTo(ResultCode.FAILURE);
+      assertThat(exporter.export(Collections.singletonList(generateFakeSpan())).isSuccess())
+          .isFalse();
     } finally {
       exporter.shutdown();
     }

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporter.java
@@ -21,6 +21,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.ReadableAttributes;
 import io.opentelemetry.common.ReadableKeyValuePairs.KeyValueConsumer;
+import io.opentelemetry.sdk.common.export.CompletableResultCode;
 import io.opentelemetry.sdk.common.export.ConfigBuilder;
 import io.opentelemetry.sdk.resources.ResourceConstants;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -240,7 +241,7 @@ public final class ZipkinSpanExporter implements SpanExporter {
   }
 
   @Override
-  public ResultCode export(final Collection<SpanData> spanDataList) {
+  public CompletableResultCode export(final Collection<SpanData> spanDataList) {
     List<byte[]> encodedSpans = new ArrayList<>(spanDataList.size());
     for (SpanData spanData : spanDataList) {
       encodedSpans.add(encoder.encode(generateSpan(spanData, localEndpoint)));
@@ -249,15 +250,15 @@ public final class ZipkinSpanExporter implements SpanExporter {
       sender.sendSpans(encodedSpans).execute();
     } catch (Exception e) {
       logger.log(Level.WARNING, "Failed to export spans", e);
-      return ResultCode.FAILURE;
+      return CompletableResultCode.ofFailure();
     }
-    return ResultCode.SUCCESS;
+    return CompletableResultCode.ofSuccess();
   }
 
   @Override
-  public ResultCode flush() {
+  public CompletableResultCode flush() {
     // nothing required here
-    return ResultCode.SUCCESS;
+    return CompletableResultCode.ofSuccess();
   }
 
   @Override

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
@@ -20,11 +20,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.common.Attributes;
+import io.opentelemetry.sdk.common.export.CompletableResultCode;
 import io.opentelemetry.sdk.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.EventImpl;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
-import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
@@ -115,9 +115,9 @@ public class ZipkinSpanExporterEndToEndHttpTest {
             zipkin.httpUrl() + ENDPOINT_V2_SPANS, Encoding.JSON, SpanBytesEncoder.PROTO3);
 
     SpanData spanData = buildStandardSpan().build();
-    SpanExporter.ResultCode resultCode = zipkinSpanExporter.export(Collections.singleton(spanData));
+    CompletableResultCode resultCode = zipkinSpanExporter.export(Collections.singleton(spanData));
 
-    assertThat(resultCode).isEqualTo(SpanExporter.ResultCode.FAILURE);
+    assertThat(resultCode.isSuccess()).isFalse();
     List<Span> zipkinSpans = zipkin.getTrace(TRACE_ID);
     assertThat(zipkinSpans).isNotNull();
     assertThat(zipkinSpans).isEmpty();
@@ -139,9 +139,9 @@ public class ZipkinSpanExporterEndToEndHttpTest {
   private void exportAndVerify(ZipkinSpanExporter zipkinSpanExporter) {
 
     SpanData spanData = buildStandardSpan().build();
-    SpanExporter.ResultCode resultCode = zipkinSpanExporter.export(Collections.singleton(spanData));
+    CompletableResultCode resultCode = zipkinSpanExporter.export(Collections.singleton(spanData));
 
-    assertThat(resultCode).isEqualTo(SpanExporter.ResultCode.SUCCESS);
+    assertThat(resultCode.isSuccess()).isTrue();
     List<Span> zipkinSpans = zipkin.getTrace(TRACE_ID);
 
     assertThat(zipkinSpans).isNotNull();

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
+import io.opentelemetry.sdk.common.export.CompletableResultCode;
 import io.opentelemetry.sdk.common.export.ConfigBuilder;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.resources.ResourceConstants;
@@ -31,7 +32,6 @@ import io.opentelemetry.sdk.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.EventImpl;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
-import io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
@@ -225,11 +225,11 @@ class ZipkinSpanExporterTest {
     byte[] someBytes = new byte[0];
     when(mockEncoder.encode(buildZipkinSpan(Span.Kind.SERVER))).thenReturn(someBytes);
     when(mockSender.sendSpans(Collections.singletonList(someBytes))).thenReturn(mockZipkinCall);
-    ResultCode resultCode =
+    CompletableResultCode resultCode =
         zipkinSpanExporter.export(Collections.singleton(buildStandardSpan().build()));
 
     verify(mockZipkinCall).execute();
-    assertThat(resultCode).isEqualTo(ResultCode.SUCCESS);
+    assertThat(resultCode.isSuccess()).isTrue();
   }
 
   @Test
@@ -242,10 +242,10 @@ class ZipkinSpanExporterTest {
     when(mockSender.sendSpans(Collections.singletonList(someBytes))).thenReturn(mockZipkinCall);
     when(mockZipkinCall.execute()).thenThrow(new IOException());
 
-    ResultCode resultCode =
+    CompletableResultCode resultCode =
         zipkinSpanExporter.export(Collections.singleton(buildStandardSpan().build()));
 
-    assertThat(resultCode).isEqualTo(ResultCode.FAILURE);
+    assertThat(resultCode.isSuccess()).isFalse();
   }
 
   @Test

--- a/sdk/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
+++ b/sdk/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
@@ -21,6 +21,7 @@ import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
 
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.common.export.CompletableResultCode;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
@@ -87,13 +88,13 @@ public class SpanPipelineBenchmark {
 
   private static class NoOpSpanExporter implements SpanExporter {
     @Override
-    public ResultCode export(Collection<SpanData> spans) {
-      return ResultCode.SUCCESS;
+    public CompletableResultCode export(Collection<SpanData> spans) {
+      return CompletableResultCode.ofSuccess();
     }
 
     @Override
-    public ResultCode flush() {
-      return ResultCode.SUCCESS;
+    public CompletableResultCode flush() {
+      return CompletableResultCode.ofSuccess();
     }
 
     @Override

--- a/sdk/src/jmh/java/io/opentelemetry/sdk/trace/export/MultiSpanExporterBenchmark.java
+++ b/sdk/src/jmh/java/io/opentelemetry/sdk/trace/export/MultiSpanExporterBenchmark.java
@@ -16,9 +16,9 @@
 
 package io.opentelemetry.sdk.trace.export;
 
+import io.opentelemetry.sdk.common.export.CompletableResultCode;
 import io.opentelemetry.sdk.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
@@ -44,13 +44,13 @@ public class MultiSpanExporterBenchmark {
   private static class NoopSpanExporter implements SpanExporter {
 
     @Override
-    public ResultCode export(Collection<SpanData> spans) {
-      return ResultCode.SUCCESS;
+    public CompletableResultCode export(Collection<SpanData> spans) {
+      return CompletableResultCode.ofSuccess();
     }
 
     @Override
-    public ResultCode flush() {
-      return ResultCode.SUCCESS;
+    public CompletableResultCode flush() {
+      return CompletableResultCode.ofSuccess();
     }
 
     @Override
@@ -95,7 +95,7 @@ public class MultiSpanExporterBenchmark {
   @Warmup(iterations = 5, time = 1)
   @Measurement(iterations = 10, time = 1)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public ResultCode export() {
+  public CompletableResultCode export() {
     return exporter.export(spans);
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/common/export/CompletableResultCode.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/common/export/CompletableResultCode.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.common.export;
+
+import java.util.ArrayList;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
+/**
+ * The implementation of Export operations are often asynchronous in nature, hence the need to
+ * convey a result at a later time. CompletableResultCode facilitates this.
+ *
+ * <p>This class models JDK 8's CompletableFuture to afford migration should Open Telemetry's SDK
+ * select JDK 8 or greater as a baseline, and also to offer familiarity to developers.
+ */
+public class CompletableResultCode {
+  /** A convenience for declaring success. */
+  public static CompletableResultCode ofSuccess() {
+    return SUCCESS;
+  }
+
+  /** A convenience for declaring failure. */
+  public static CompletableResultCode ofFailure() {
+    return FAILURE;
+  }
+
+  private static final CompletableResultCode SUCCESS = new CompletableResultCode().succeed();
+  private static final CompletableResultCode FAILURE = new CompletableResultCode().fail();
+
+  public CompletableResultCode() {}
+
+  @Nullable
+  @GuardedBy("lock")
+  private Boolean succeeded = null;
+
+  @GuardedBy("lock")
+  private final ArrayList<Runnable> completionActions = new ArrayList<>();
+
+  private final Object lock = new Object();
+
+  /** The export operation finished successfully. */
+  public CompletableResultCode succeed() {
+    synchronized (lock) {
+      if (succeeded == null) {
+        succeeded = true;
+        for (Runnable action : completionActions) {
+          action.run();
+        }
+      }
+    }
+    return this;
+  }
+
+  /** The export operation finished with an error. */
+  public CompletableResultCode fail() {
+    synchronized (lock) {
+      if (succeeded == null) {
+        succeeded = false;
+        for (Runnable action : completionActions) {
+          action.run();
+        }
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Obtain the current state of completion. Generally call once completion is achieved via the
+   * thenRun method.
+   *
+   * @return the current state of completion
+   */
+  public boolean isSuccess() {
+    synchronized (lock) {
+      return succeeded != null && succeeded;
+    }
+  }
+
+  /**
+   * Perform an action on completion. Actions are guaranteed to be called only once.
+   *
+   * @param action the action to perform
+   * @return this completable result so that it may be further composed
+   */
+  public CompletableResultCode whenComplete(Runnable action) {
+    synchronized (lock) {
+      if (succeeded != null) {
+        action.run();
+      } else {
+        this.completionActions.add(action);
+      }
+    }
+    return this;
+  }
+}

--- a/sdk/src/main/java/io/opentelemetry/sdk/common/export/CompletableResultCode.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/common/export/CompletableResultCode.java
@@ -17,23 +17,24 @@
 package io.opentelemetry.sdk.common.export;
 
 import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
 /**
- * The implementation of Export operations are often asynchronous in nature, hence the need to
- * convey a result at a later time. CompletableResultCode facilitates this.
- *
- * <p>This class models JDK 8's CompletableFuture to afford migration should Open Telemetry's SDK
+ * This class models JDK 8's CompletableFuture to afford migration should Open Telemetry's SDK
  * select JDK 8 or greater as a baseline, and also to offer familiarity to developers.
+ *
+ * <p>The implementation of Export operations are often asynchronous in nature, hence the need to
+ * convey a result at a later time. CompletableResultCode facilitates this.
  */
 public class CompletableResultCode {
-  /** A convenience for declaring success. */
+  /** Returns a {@link CompletableResultCode} that has been completed successfully. */
   public static CompletableResultCode ofSuccess() {
     return SUCCESS;
   }
 
-  /** A convenience for declaring failure. */
+  /** Returns a {@link CompletableResultCode} that has been completed unsuccessfully. */
   public static CompletableResultCode ofFailure() {
     return FAILURE;
   }
@@ -48,11 +49,11 @@ public class CompletableResultCode {
   private Boolean succeeded = null;
 
   @GuardedBy("lock")
-  private final ArrayList<Runnable> completionActions = new ArrayList<>();
+  private final List<Runnable> completionActions = new ArrayList<>();
 
   private final Object lock = new Object();
 
-  /** The export operation finished successfully. */
+  /** Complete this {@link CompletableResultCode} successfully if it is not already completed. */
   public CompletableResultCode succeed() {
     synchronized (lock) {
       if (succeeded == null) {
@@ -65,7 +66,7 @@ public class CompletableResultCode {
     return this;
   }
 
-  /** The export operation finished with an error. */
+  /** Complete this {@link CompletableResultCode} unsuccessfully if it is not already completed. */
   public CompletableResultCode fail() {
     synchronized (lock) {
       if (succeeded == null) {

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/export/MetricExporter.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/export/MetricExporter.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.sdk.metrics.export;
 
+import io.opentelemetry.sdk.common.export.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.util.Collection;
 
@@ -30,35 +31,23 @@ import java.util.Collection;
 public interface MetricExporter {
 
   /**
-   * The possible results for the export method.
-   *
-   * @since 0.1.0
-   */
-  // TODO: extract this enum and unify it with SpanExporter.ResultCode
-  enum ResultCode {
-    /** The export operation finished successfully. */
-    SUCCESS,
-
-    /** The export operation finished with an error. */
-    FAILURE
-  }
-
-  /**
-   * Exports the collection of given {@link MetricData}.
+   * Exports the collection of given {@link MetricData}. Note that export operations can be
+   * performed simultaneously depending on the type of metric reader being used. However, the {@link
+   * IntervalMetricReader} will ensure that only one export can occur at a time.
    *
    * @param metrics the collection of {@link MetricData} to be exported.
-   * @return the result of the export.
-   * @since 0.1.0
+   * @return the result of the export, which is often an asynchronous operation.
    */
-  ResultCode export(Collection<MetricData> metrics);
+  CompletableResultCode export(Collection<MetricData> metrics);
 
   /**
-   * Exports the collection of {@link MetricData} that have not yet been exported.
+   * Exports the collection of {@link MetricData} that have not yet been exported. Note that flush
+   * operations can be performed simultaneously depending on the type of metric reader being used.
+   * However, the {@link IntervalMetricReader} will ensure that only one export can occur at a time.
    *
-   * @return the result of the flush.
-   * @since 0.4.0
+   * @return the result of the flush, which is often an asynchronous operation.
    */
-  ResultCode flush();
+  CompletableResultCode flush();
 
   /** Called when the associated IntervalMetricReader is shutdown. */
   void shutdown();

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
@@ -74,7 +74,6 @@ public final class SimpleSpanProcessor implements SpanProcessor {
   }
 
   @Override
-  @SuppressWarnings("BooleanParameter")
   public void onEnd(ReadableSpan span) {
     if (sampled && !span.getSpanContext().getTraceFlags().isSampled()) {
       return;

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SpanExporter.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/export/SpanExporter.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.sdk.trace.export;
 
+import io.opentelemetry.sdk.common.export.CompletableResultCode;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.Collection;
@@ -29,30 +30,25 @@ import java.util.Collection;
  */
 public interface SpanExporter {
 
-  /** The possible results for the export method. */
-  enum ResultCode {
-    /** The export operation finished successfully. */
-    SUCCESS,
-
-    /** The export operation finished with an error. */
-    FAILURE
-  }
-
   /**
-   * Called to export sampled {@code Span}s.
+   * Called to export sampled {@code Span}s. Note that export operations can be performed
+   * simultaneously depending on the type of span processor being used. However, the {@link
+   * BatchSpanProcessor} will ensure that only one export can occur at a time.
    *
    * @param spans the collection of sampled Spans to be exported.
-   * @return the result of the export.
+   * @return the result of the export, which is often an asynchronous operation.
    */
-  ResultCode export(Collection<SpanData> spans);
+  CompletableResultCode export(Collection<SpanData> spans);
 
   /**
-   * Exports the collection of sampled {@code Span}s that have not yet been exported.
+   * Exports the collection of sampled {@code Span}s that have not yet been exported. Note that
+   * export operations can be performed simultaneously depending on the type of span processor being
+   * used. However, the {@link BatchSpanProcessor} will ensure that only one export can occur at a
+   * time.
    *
-   * @return the result of the flush.
-   * @since 0.4.0
+   * @return the result of the flush, which is often an asynchronous operation.
    */
-  ResultCode flush();
+  CompletableResultCode flush();
 
   /**
    * Called when {@link TracerSdkProvider#shutdown()} is called, if this {@code SpanExporter} is

--- a/sdk/src/test/java/io/opentelemetry/sdk/common/export/CompletableResultCodeTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/common/export/CompletableResultCodeTest.java
@@ -161,4 +161,32 @@ class CompletableResultCodeTest {
 
     assertThat(resultCode.isSuccess()).isTrue();
   }
+
+  @Test
+  void whenSuccessThenFailure() throws InterruptedException {
+    CompletableResultCode resultCode = new CompletableResultCode();
+
+    CountDownLatch completions = new CountDownLatch(1);
+
+    new Thread(
+            new Runnable() {
+              @Override
+              public void run() {
+                resultCode.succeed().fail();
+              }
+            })
+        .start();
+
+    resultCode.whenComplete(
+        new Runnable() {
+          @Override
+          public void run() {
+            completions.countDown();
+          }
+        });
+
+    completions.await(3, TimeUnit.SECONDS);
+
+    assertThat(resultCode.isSuccess()).isTrue();
+  }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/common/export/CompletableResultCodeTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/common/export/CompletableResultCodeTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.common.export;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class CompletableResultCodeTest {
+
+  @Test
+  void ofSuccess() {
+    assertThat(CompletableResultCode.ofSuccess().isSuccess()).isTrue();
+  }
+
+  @Test
+  void ofFailure() {
+    assertThat(CompletableResultCode.ofFailure().isSuccess()).isFalse();
+  }
+
+  @Test
+  void succeed() throws InterruptedException {
+    CompletableResultCode resultCode = new CompletableResultCode();
+
+    CountDownLatch completions = new CountDownLatch(1);
+
+    new Thread(
+            new Runnable() {
+              @Override
+              public void run() {
+                resultCode.succeed();
+              }
+            })
+        .start();
+
+    resultCode.whenComplete(
+        new Runnable() {
+          @Override
+          public void run() {
+            completions.countDown();
+          }
+        });
+
+    completions.await(3, TimeUnit.SECONDS);
+
+    assertThat(resultCode.isSuccess()).isTrue();
+  }
+
+  @Test
+  void fail() throws InterruptedException {
+    CompletableResultCode resultCode = new CompletableResultCode();
+
+    CountDownLatch completions = new CountDownLatch(1);
+
+    new Thread(
+            new Runnable() {
+              @Override
+              public void run() {
+                resultCode.fail();
+              }
+            })
+        .start();
+
+    resultCode.whenComplete(
+        new Runnable() {
+          @Override
+          public void run() {
+            completions.countDown();
+          }
+        });
+
+    completions.await(3, TimeUnit.SECONDS);
+
+    assertThat(resultCode.isSuccess()).isFalse();
+  }
+
+  @Test
+  void whenDoublyCompleteSuccessfully() throws InterruptedException {
+    CompletableResultCode resultCode = new CompletableResultCode();
+
+    CountDownLatch completions = new CountDownLatch(2);
+
+    new Thread(
+            new Runnable() {
+              @Override
+              public void run() {
+                resultCode.succeed();
+              }
+            })
+        .start();
+
+    resultCode
+        .whenComplete(
+            new Runnable() {
+              @Override
+              public void run() {
+                completions.countDown();
+              }
+            })
+        .whenComplete(
+            new Runnable() {
+              @Override
+              public void run() {
+                completions.countDown();
+              }
+            });
+
+    completions.await(3, TimeUnit.SECONDS);
+
+    assertThat(resultCode.isSuccess()).isTrue();
+  }
+
+  @Test
+  void whenDoublyNestedComplete() throws InterruptedException {
+    CompletableResultCode resultCode = new CompletableResultCode();
+
+    CountDownLatch completions = new CountDownLatch(2);
+
+    new Thread(
+            new Runnable() {
+              @Override
+              public void run() {
+                resultCode.succeed();
+              }
+            })
+        .start();
+
+    resultCode.whenComplete(
+        new Runnable() {
+          @Override
+          public void run() {
+            completions.countDown();
+
+            resultCode.whenComplete(
+                new Runnable() {
+                  @Override
+                  public void run() {
+                    completions.countDown();
+                  }
+                });
+          }
+        });
+
+    completions.await(3, TimeUnit.SECONDS);
+
+    assertThat(resultCode.isSuccess()).isTrue();
+  }
+}

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.common.export.CompletableResultCode;
 import io.opentelemetry.sdk.common.export.ConfigBuilderTest.ConfigTester;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
@@ -117,10 +118,6 @@ class IntervalMetricReaderTest {
     try {
       assertThat(waitingMetricExporter.waitForNumberOfExports(1))
           .containsExactly(Collections.singletonList(METRIC_DATA));
-
-      assertThat(waitingMetricExporter.waitForNumberOfExports(2))
-          .containsExactly(
-              Collections.singletonList(METRIC_DATA), Collections.singletonList(METRIC_DATA));
     } finally {
       intervalMetricReader.shutdown();
     }
@@ -164,7 +161,7 @@ class IntervalMetricReaderTest {
     }
 
     @Override
-    public ResultCode export(Collection<MetricData> metricList) {
+    public CompletableResultCode export(Collection<MetricData> metricList) {
       synchronized (monitor) {
         this.exportedMetrics.add(new ArrayList<>(metricList));
         monitor.notifyAll();
@@ -172,12 +169,12 @@ class IntervalMetricReaderTest {
       if (shouldThrow) {
         throw new RuntimeException("Export Failed!");
       }
-      return ResultCode.SUCCESS;
+      return CompletableResultCode.ofSuccess();
     }
 
     @Override
-    public ResultCode flush() {
-      return ResultCode.SUCCESS;
+    public CompletableResultCode flush() {
+      return CompletableResultCode.ofSuccess();
     }
 
     @Override

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -22,6 +22,7 @@ import io.grpc.Context;
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.common.export.CompletableResultCode;
 import io.opentelemetry.sdk.trace.StressTestRunner.OperationUpdater;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
@@ -212,14 +213,14 @@ class TracerSdkTest {
     public AtomicLong numberOfSpansExported = new AtomicLong();
 
     @Override
-    public ResultCode export(Collection<SpanData> spans) {
+    public CompletableResultCode export(Collection<SpanData> spans) {
       numberOfSpansExported.addAndGet(spans.size());
-      return ResultCode.SUCCESS;
+      return CompletableResultCode.ofSuccess();
     }
 
     @Override
-    public ResultCode flush() {
-      return ResultCode.SUCCESS;
+    public CompletableResultCode flush() {
+      return CompletableResultCode.ofSuccess();
     }
 
     @Override

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -19,6 +19,7 @@ package io.opentelemetry.sdk.trace.export;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doThrow;
 
+import io.opentelemetry.sdk.common.export.CompletableResultCode;
 import io.opentelemetry.sdk.common.export.ConfigBuilderTest.ConfigTester;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.Samplers;
@@ -101,7 +102,7 @@ class BatchSpanProcessorTest {
     options.put("otel.bsp.export.timeout", "78");
     options.put("otel.bsp.export.sampled", "false");
     BatchSpanProcessor.Builder config =
-        BatchSpanProcessor.newBuilder(new WaitingSpanExporter(0))
+        BatchSpanProcessor.newBuilder(new WaitingSpanExporter(0, CompletableResultCode.ofSuccess()))
             .fromConfigMap(options, ConfigTester.getNamingDot());
     assertThat(config.getScheduleDelayMillis()).isEqualTo(12);
     assertThat(config.getMaxQueueSize()).isEqualTo(34);
@@ -113,7 +114,7 @@ class BatchSpanProcessorTest {
   @Test
   void configTest_EmptyOptions() {
     BatchSpanProcessor.Builder config =
-        BatchSpanProcessor.newBuilder(new WaitingSpanExporter(0))
+        BatchSpanProcessor.newBuilder(new WaitingSpanExporter(0, CompletableResultCode.ofSuccess()))
             .fromConfigMap(Collections.emptyMap(), ConfigTester.getNamingDot());
     assertThat(config.getScheduleDelayMillis())
         .isEqualTo(BatchSpanProcessor.Builder.DEFAULT_SCHEDULE_DELAY_MILLIS);
@@ -130,14 +131,16 @@ class BatchSpanProcessorTest {
   @Test
   void startEndRequirements() {
     BatchSpanProcessor spansProcessor =
-        BatchSpanProcessor.newBuilder(new WaitingSpanExporter(0)).build();
+        BatchSpanProcessor.newBuilder(new WaitingSpanExporter(0, CompletableResultCode.ofSuccess()))
+            .build();
     assertThat(spansProcessor.isStartRequired()).isFalse();
     assertThat(spansProcessor.isEndRequired()).isTrue();
   }
 
   @Test
   void exportDifferentSampledSpans() {
-    WaitingSpanExporter waitingSpanExporter = new WaitingSpanExporter(2);
+    WaitingSpanExporter waitingSpanExporter =
+        new WaitingSpanExporter(2, CompletableResultCode.ofSuccess());
     tracerSdkFactory.addSpanProcessor(
         BatchSpanProcessor.newBuilder(waitingSpanExporter)
             .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
@@ -151,7 +154,8 @@ class BatchSpanProcessorTest {
 
   @Test
   void exportMoreSpansThanTheBufferSize() {
-    WaitingSpanExporter waitingSpanExporter = new WaitingSpanExporter(6);
+    WaitingSpanExporter waitingSpanExporter =
+        new WaitingSpanExporter(6, CompletableResultCode.ofSuccess());
     BatchSpanProcessor batchSpanProcessor =
         BatchSpanProcessor.newBuilder(waitingSpanExporter)
             .setMaxQueueSize(6)
@@ -180,7 +184,8 @@ class BatchSpanProcessorTest {
 
   @Test
   void forceExport() {
-    WaitingSpanExporter waitingSpanExporter = new WaitingSpanExporter(1, 1);
+    WaitingSpanExporter waitingSpanExporter =
+        new WaitingSpanExporter(1, CompletableResultCode.ofSuccess(), 1);
     BatchSpanProcessor batchSpanProcessor =
         BatchSpanProcessor.newBuilder(waitingSpanExporter)
             .setMaxQueueSize(10_000)
@@ -203,8 +208,10 @@ class BatchSpanProcessorTest {
 
   @Test
   void exportSpansToMultipleServices() {
-    WaitingSpanExporter waitingSpanExporter = new WaitingSpanExporter(2);
-    WaitingSpanExporter waitingSpanExporter2 = new WaitingSpanExporter(2);
+    WaitingSpanExporter waitingSpanExporter =
+        new WaitingSpanExporter(2, CompletableResultCode.ofSuccess());
+    WaitingSpanExporter waitingSpanExporter2 =
+        new WaitingSpanExporter(2, CompletableResultCode.ofSuccess());
     tracerSdkFactory.addSpanProcessor(
         BatchSpanProcessor.newBuilder(
                 MultiSpanExporter.create(Arrays.asList(waitingSpanExporter, waitingSpanExporter2)))
@@ -222,7 +229,8 @@ class BatchSpanProcessorTest {
   @Test
   void exportMoreSpansThanTheMaximumLimit() {
     final int maxQueuedSpans = 8;
-    WaitingSpanExporter waitingSpanExporter = new WaitingSpanExporter(maxQueuedSpans);
+    WaitingSpanExporter waitingSpanExporter =
+        new WaitingSpanExporter(maxQueuedSpans, CompletableResultCode.ofSuccess());
     BatchSpanProcessor batchSpanProcessor =
         BatchSpanProcessor.newBuilder(
                 MultiSpanExporter.create(Arrays.asList(blockingSpanExporter, waitingSpanExporter)))
@@ -283,7 +291,8 @@ class BatchSpanProcessorTest {
 
   @Test
   void serviceHandlerThrowsException() {
-    WaitingSpanExporter waitingSpanExporter = new WaitingSpanExporter(1);
+    WaitingSpanExporter waitingSpanExporter =
+        new WaitingSpanExporter(1, CompletableResultCode.ofSuccess());
     doThrow(new IllegalArgumentException("No export for you."))
         .when(mockServiceHandler)
         .export(ArgumentMatchers.anyList());
@@ -304,19 +313,36 @@ class BatchSpanProcessorTest {
 
   @Test
   @Timeout(5)
-  public void exporterTimesOut() throws Exception {
+  public void exporterTimesOut() throws InterruptedException {
     final CountDownLatch interruptMarker = new CountDownLatch(1);
     WaitingSpanExporter waitingSpanExporter =
-        new WaitingSpanExporter(1) {
+        new WaitingSpanExporter(1, new CompletableResultCode()) {
           @Override
-          public ResultCode export(Collection<SpanData> spans) {
-            ResultCode result = super.export(spans);
-            try {
-              // sleep longer than the configured timout of 100ms
-              Thread.sleep(1000);
-            } catch (InterruptedException e) {
-              interruptMarker.countDown();
-            }
+          public CompletableResultCode export(Collection<SpanData> spans) {
+            CompletableResultCode result = super.export(spans);
+            Thread exporterThread =
+                new Thread(
+                    new Runnable() {
+                      @Override
+                      public void run() {
+                        try {
+                          // sleep longer than the configured timeout of 100ms
+                          Thread.sleep(1000);
+                        } catch (InterruptedException e) {
+                          interruptMarker.countDown();
+                        }
+                      }
+                    });
+            exporterThread.start();
+            result.whenComplete(
+                new Runnable() {
+                  @Override
+                  public void run() {
+                    if (!result.isSuccess()) {
+                      exporterThread.interrupt();
+                    }
+                  }
+                });
             return result;
           }
         };
@@ -342,7 +368,8 @@ class BatchSpanProcessorTest {
 
   @Test
   void exportNotSampledSpans() {
-    WaitingSpanExporter waitingSpanExporter = new WaitingSpanExporter(1);
+    WaitingSpanExporter waitingSpanExporter =
+        new WaitingSpanExporter(1, CompletableResultCode.ofSuccess());
     BatchSpanProcessor batchSpanProcessor =
         BatchSpanProcessor.newBuilder(waitingSpanExporter)
             .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
@@ -398,7 +425,8 @@ class BatchSpanProcessorTest {
   @Test
   @Timeout(10)
   public void shutdownFlushes() {
-    WaitingSpanExporter waitingSpanExporter = new WaitingSpanExporter(1);
+    WaitingSpanExporter waitingSpanExporter =
+        new WaitingSpanExporter(1, CompletableResultCode.ofSuccess());
     // Set the export delay to zero, for no timeout, in order to confirm the #flush() below works
 
     tracerSdkFactory.addSpanProcessor(
@@ -428,7 +456,7 @@ class BatchSpanProcessorTest {
     State state = State.WAIT_TO_BLOCK;
 
     @Override
-    public ResultCode export(Collection<SpanData> spanDataList) {
+    public CompletableResultCode export(Collection<SpanData> spanDataList) {
       synchronized (monitor) {
         while (state != State.UNBLOCKED) {
           try {
@@ -441,12 +469,12 @@ class BatchSpanProcessorTest {
           }
         }
       }
-      return ResultCode.SUCCESS;
+      return CompletableResultCode.ofSuccess();
     }
 
     @Override
-    public ResultCode flush() {
-      return ResultCode.SUCCESS;
+    public CompletableResultCode flush() {
+      return CompletableResultCode.ofSuccess();
     }
 
     private void waitUntilIsBlocked() {
@@ -478,17 +506,19 @@ class BatchSpanProcessorTest {
 
     private final List<SpanData> spanDataList = new ArrayList<>();
     private final int numberToWaitFor;
+    private final CompletableResultCode exportResultCode;
     private CountDownLatch countDownLatch;
     private int timeout = 10;
     private final AtomicBoolean shutDownCalled = new AtomicBoolean(false);
 
-    WaitingSpanExporter(int numberToWaitFor) {
+    WaitingSpanExporter(int numberToWaitFor, CompletableResultCode exportResultCode) {
       countDownLatch = new CountDownLatch(numberToWaitFor);
       this.numberToWaitFor = numberToWaitFor;
+      this.exportResultCode = exportResultCode;
     }
 
-    WaitingSpanExporter(int numberToWaitFor, int timeout) {
-      this(numberToWaitFor);
+    WaitingSpanExporter(int numberToWaitFor, CompletableResultCode exportResultCode, int timeout) {
+      this(numberToWaitFor, exportResultCode);
       this.timeout = timeout;
     }
 
@@ -514,17 +544,17 @@ class BatchSpanProcessorTest {
     }
 
     @Override
-    public ResultCode export(Collection<SpanData> spans) {
+    public CompletableResultCode export(Collection<SpanData> spans) {
       this.spanDataList.addAll(spans);
       for (int i = 0; i < spans.size(); i++) {
         countDownLatch.countDown();
       }
-      return ResultCode.SUCCESS;
+      return exportResultCode;
     }
 
     @Override
-    public ResultCode flush() {
-      return ResultCode.SUCCESS;
+    public CompletableResultCode flush() {
+      return CompletableResultCode.ofSuccess();
     }
 
     @Override

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/MultiSpanExporterTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/MultiSpanExporterTest.java
@@ -18,13 +18,10 @@ package io.opentelemetry.sdk.trace.export;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.same;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
+import io.opentelemetry.sdk.common.export.CompletableResultCode;
 import io.opentelemetry.sdk.trace.TestUtils;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -32,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 /** Unit tests for {@link MultiSpanExporterTest}. */
@@ -58,16 +56,17 @@ class MultiSpanExporterTest {
     SpanExporter multiSpanExporter =
         MultiSpanExporter.create(Collections.singletonList(spanExporter1));
 
-    when(spanExporter1.export(same(SPAN_LIST))).thenReturn(ResultCode.SUCCESS);
-    assertThat(multiSpanExporter.export(SPAN_LIST)).isEqualTo(ResultCode.SUCCESS);
-    verify(spanExporter1).export(same(SPAN_LIST));
+    Mockito.when(spanExporter1.export(same(SPAN_LIST)))
+        .thenReturn(CompletableResultCode.ofSuccess());
+    assertThat(multiSpanExporter.export(SPAN_LIST).isSuccess()).isTrue();
+    Mockito.verify(spanExporter1).export(same(SPAN_LIST));
 
-    when(spanExporter1.flush()).thenReturn(ResultCode.SUCCESS);
-    assertThat(multiSpanExporter.flush()).isEqualTo(ResultCode.SUCCESS);
-    verify(spanExporter1).flush();
+    Mockito.when(spanExporter1.flush()).thenReturn(CompletableResultCode.ofSuccess());
+    assertThat(multiSpanExporter.flush().isSuccess()).isTrue();
+    Mockito.verify(spanExporter1).flush();
 
     multiSpanExporter.shutdown();
-    verify(spanExporter1).shutdown();
+    Mockito.verify(spanExporter1).shutdown();
   }
 
   @Test
@@ -75,21 +74,23 @@ class MultiSpanExporterTest {
     SpanExporter multiSpanExporter =
         MultiSpanExporter.create(Arrays.asList(spanExporter1, spanExporter2));
 
-    when(spanExporter1.export(same(SPAN_LIST))).thenReturn(ResultCode.SUCCESS);
-    when(spanExporter2.export(same(SPAN_LIST))).thenReturn(ResultCode.SUCCESS);
-    assertThat(multiSpanExporter.export(SPAN_LIST)).isEqualTo(ResultCode.SUCCESS);
-    verify(spanExporter1).export(same(SPAN_LIST));
-    verify(spanExporter2).export(same(SPAN_LIST));
+    Mockito.when(spanExporter1.export(same(SPAN_LIST)))
+        .thenReturn(CompletableResultCode.ofSuccess());
+    Mockito.when(spanExporter2.export(same(SPAN_LIST)))
+        .thenReturn(CompletableResultCode.ofSuccess());
+    assertThat(multiSpanExporter.export(SPAN_LIST).isSuccess()).isTrue();
+    Mockito.verify(spanExporter1).export(same(SPAN_LIST));
+    Mockito.verify(spanExporter2).export(same(SPAN_LIST));
 
-    when(spanExporter1.flush()).thenReturn(ResultCode.SUCCESS);
-    when(spanExporter2.flush()).thenReturn(ResultCode.SUCCESS);
-    assertThat(multiSpanExporter.flush()).isEqualTo(ResultCode.SUCCESS);
-    verify(spanExporter1).flush();
-    verify(spanExporter2).flush();
+    Mockito.when(spanExporter1.flush()).thenReturn(CompletableResultCode.ofSuccess());
+    Mockito.when(spanExporter2.flush()).thenReturn(CompletableResultCode.ofSuccess());
+    assertThat(multiSpanExporter.flush().isSuccess()).isTrue();
+    Mockito.verify(spanExporter1).flush();
+    Mockito.verify(spanExporter2).flush();
 
     multiSpanExporter.shutdown();
-    verify(spanExporter1).shutdown();
-    verify(spanExporter2).shutdown();
+    Mockito.verify(spanExporter1).shutdown();
+    Mockito.verify(spanExporter2).shutdown();
   }
 
   @Test
@@ -97,17 +98,19 @@ class MultiSpanExporterTest {
     SpanExporter multiSpanExporter =
         MultiSpanExporter.create(Arrays.asList(spanExporter1, spanExporter2));
 
-    when(spanExporter1.export(same(SPAN_LIST))).thenReturn(ResultCode.SUCCESS);
-    when(spanExporter2.export(same(SPAN_LIST))).thenReturn(ResultCode.FAILURE);
-    assertThat(multiSpanExporter.export(SPAN_LIST)).isEqualTo(ResultCode.FAILURE);
-    verify(spanExporter1).export(same(SPAN_LIST));
-    verify(spanExporter2).export(same(SPAN_LIST));
+    Mockito.when(spanExporter1.export(same(SPAN_LIST)))
+        .thenReturn(CompletableResultCode.ofSuccess());
+    Mockito.when(spanExporter2.export(same(SPAN_LIST)))
+        .thenReturn(CompletableResultCode.ofFailure());
+    assertThat(multiSpanExporter.export(SPAN_LIST).isSuccess()).isFalse();
+    Mockito.verify(spanExporter1).export(same(SPAN_LIST));
+    Mockito.verify(spanExporter2).export(same(SPAN_LIST));
 
-    when(spanExporter1.flush()).thenReturn(ResultCode.SUCCESS);
-    when(spanExporter2.flush()).thenReturn(ResultCode.FAILURE);
-    assertThat(multiSpanExporter.flush()).isEqualTo(ResultCode.FAILURE);
-    verify(spanExporter1).flush();
-    verify(spanExporter2).flush();
+    Mockito.when(spanExporter1.flush()).thenReturn(CompletableResultCode.ofSuccess());
+    Mockito.when(spanExporter2.flush()).thenReturn(CompletableResultCode.ofFailure());
+    assertThat(multiSpanExporter.flush().isSuccess()).isFalse();
+    Mockito.verify(spanExporter1).flush();
+    Mockito.verify(spanExporter2).flush();
   }
 
   @Test
@@ -115,18 +118,19 @@ class MultiSpanExporterTest {
     SpanExporter multiSpanExporter =
         MultiSpanExporter.create(Arrays.asList(spanExporter1, spanExporter2));
 
-    doThrow(new IllegalArgumentException("No export for you."))
+    Mockito.doThrow(new IllegalArgumentException("No export for you."))
         .when(spanExporter1)
         .export(ArgumentMatchers.anyList());
-    when(spanExporter2.export(same(SPAN_LIST))).thenReturn(ResultCode.SUCCESS);
-    assertThat(multiSpanExporter.export(SPAN_LIST)).isEqualTo(ResultCode.FAILURE);
-    verify(spanExporter1).export(same(SPAN_LIST));
-    verify(spanExporter2).export(same(SPAN_LIST));
+    Mockito.when(spanExporter2.export(same(SPAN_LIST)))
+        .thenReturn(CompletableResultCode.ofSuccess());
+    assertThat(multiSpanExporter.export(SPAN_LIST).isSuccess()).isFalse();
+    Mockito.verify(spanExporter1).export(same(SPAN_LIST));
+    Mockito.verify(spanExporter2).export(same(SPAN_LIST));
 
-    doThrow(new IllegalArgumentException("No flush for you.")).when(spanExporter1).flush();
-    when(spanExporter2.flush()).thenReturn(ResultCode.SUCCESS);
-    assertThat(multiSpanExporter.flush()).isEqualTo(ResultCode.FAILURE);
-    verify(spanExporter1).flush();
-    verify(spanExporter2).flush();
+    Mockito.doThrow(new IllegalArgumentException("No flush for you.")).when(spanExporter1).flush();
+    Mockito.when(spanExporter2.flush()).thenReturn(CompletableResultCode.ofSuccess());
+    assertThat(multiSpanExporter.flush().isSuccess()).isFalse();
+    Mockito.verify(spanExporter1).flush();
+    Mockito.verify(spanExporter2).flush();
   }
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.opentelemetry.sdk.common.export.CompletableResultCode;
 import io.opentelemetry.sdk.common.export.ConfigBuilderTest.ConfigTester;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.Samplers;
@@ -135,7 +136,8 @@ class SimpleSpanProcessorTest {
 
   @Test
   void tracerSdk_NotSampled_Span() {
-    WaitingSpanExporter waitingSpanExporter = new WaitingSpanExporter(1);
+    WaitingSpanExporter waitingSpanExporter =
+        new WaitingSpanExporter(1, CompletableResultCode.ofSuccess());
 
     tracerSdkFactory.addSpanProcessor(
         BatchSpanProcessor.newBuilder(waitingSpanExporter)


### PR DESCRIPTION
This PR recognises that the export and flush methods of span and trace exporters can be, and often are, implemented with long-lived operations over networks. We, therefore, see that these method return types are represented using a `CompletableResultCode` type that can be completed asynchronously for either failure or success scenarios. In either instance, the export code can now perform actions on failure and success. In the case of failure, which can also constitute a cancellation by an upstream component (such as a batch span processor), an exporter can now interrupt its threads or perform any other action it needs to. This approach of handling failure is also safer than what now exists, which is for an upstream component to interrupt a thread.

The PR approach is focused on changing the signatures within the export methods now, while we can still introduce API-breaking changes. The implementation of the existing exporters mostly assumes a blocking interaction as before. The remaining internal exporter behaviour can be modified in the future if required and without affecting the API. One exception to this is the `OtlpGrpcMetricExporter` where @anuraaga kindly updated it to become async.

For further background information on this change, see #https://github.com/open-telemetry/opentelemetry-java/issues/1422, which also refers to spec clarification via https://github.com/open-telemetry/opentelemetry-specification/pull/707.