### PR TITLE
Allow Resource to be updated in TracerSdkProvider.

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdkProvider.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSdkProvider.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.sdk.trace;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.ComponentRegistry;
@@ -38,8 +39,8 @@ import java.util.logging.Logger;
  */
 public class TracerSdkProvider implements TracerProvider {
   private static final Logger logger = Logger.getLogger(TracerProvider.class.getName());
-  private final TracerSharedState sharedState;
   private final TracerSdkComponentRegistry tracerSdkComponentRegistry;
+  @VisibleForTesting final TracerSharedState sharedState;
 
   /**
    * Returns a new {@link Builder} for {@link TracerSdkProvider}.
@@ -87,6 +88,17 @@ public class TracerSdkProvider implements TracerProvider {
    */
   public void updateActiveTraceConfig(TraceConfig traceConfig) {
     sharedState.updateActiveTraceConfig(traceConfig);
+  }
+
+  /**
+   * Updates the {@link Resource} for this {@code TracerSdkProvider}.
+   *
+   * @param resource the new {@code Resource}.
+   * @since 0.7.0
+   */
+  public void updateResource(Resource resource) {
+    Objects.requireNonNull(resource, "resource");
+    sharedState.updateResource(resource);
   }
 
   /**

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSharedState.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/TracerSharedState.java
@@ -28,10 +28,10 @@ final class TracerSharedState {
   private final Object lock = new Object();
   private final Clock clock;
   private final IdsGenerator idsGenerator;
-  private final Resource resource;
 
   // Reads and writes are atomic for reference variables. Use volatile to ensure that these
   // operations are visible on other CPUs as well.
+  private volatile Resource resource;
   private volatile TraceConfig activeTraceConfig = TraceConfig.getDefault();
   private volatile SpanProcessor activeSpanProcessor = NoopSpanProcessor.getInstance();
   private volatile boolean isStopped = false;
@@ -55,6 +55,16 @@ final class TracerSharedState {
 
   Resource getResource() {
     return resource;
+  }
+
+  /**
+   * Updates the {@link Resource}.
+   *
+   * @param resource the new {@code Resource}.
+   * @since 0.7.0
+   */
+  void updateResource(Resource resource) {
+    this.resource = resource;
   }
 
   /**

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkProviderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkProviderTest.java
@@ -115,6 +115,19 @@ public class TracerSdkProviderTest {
   }
 
   @Test
+  public void updateResource() {
+    tracerFactory.updateResource(Resource.getEmpty());
+    assertThat(tracerFactory.sharedState.getResource()).isSameInstanceAs(Resource.getEmpty());
+  }
+
+  @Test
+  public void updateResource_Null() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("resource");
+    tracerFactory.updateResource(null);
+  }
+
+  @Test
   public void shutdown() {
     tracerFactory.shutdown();
     Mockito.verify(spanProcessor, Mockito.times(1)).shutdown();


### PR DESCRIPTION
This is a small change to allow `Resource` to be updated at any time in `TracerSdkProvider` - we have been discussing doing a more general (single) initialization, but this change makes sense IMHO as we already allow the user to update the tracer config info. For reference - Python also allows this to be updated.

Opinions on this?