### PR TITLE
B3: Add Additional Validity Checks and tests for Trace and Span ID

### DIFF
--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3Propagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3Propagator.java
@@ -38,6 +38,7 @@ public class B3Propagator implements HttpTextFormat {
   static final String FALSE_INT = "0";
   static final String COMBINED_HEADER = "b3";
   static final String COMBINED_HEADER_DELIMITER = "-";
+  static final int MIN_TRACE_ID_LENGTH = TraceId.getSize();
   static final int MAX_TRACE_ID_LENGTH = 2 * TraceId.getSize();
   static final int MAX_SPAN_ID_LENGTH = 2 * SpanId.getSize();
 

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractor.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractor.java
@@ -18,6 +18,7 @@ package io.opentelemetry.extensions.trace.propagation;
 
 import static io.opentelemetry.extensions.trace.propagation.B3Propagator.MAX_SPAN_ID_LENGTH;
 import static io.opentelemetry.extensions.trace.propagation.B3Propagator.MAX_TRACE_ID_LENGTH;
+import static io.opentelemetry.extensions.trace.propagation.B3Propagator.MIN_TRACE_ID_LENGTH;
 import static io.opentelemetry.extensions.trace.propagation.B3Propagator.TRUE_INT;
 
 import io.grpc.Context;
@@ -27,6 +28,7 @@ import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
+import java.math.BigInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.concurrent.Immutable;
@@ -63,12 +65,25 @@ interface B3PropagatorExtractor {
       }
     }
 
+    private static boolean isHex(String value) {
+      try {
+        new BigInteger(value, 16);
+        return true;
+      } catch (NumberFormatException e) {
+        return false;
+      }
+    }
+
     static boolean isTraceIdValid(String value) {
-      return !(StringUtils.isNullOrEmpty(value) || value.length() > MAX_TRACE_ID_LENGTH);
+      return !(StringUtils.isNullOrEmpty(value)
+          || !isHex(value)
+          || (value.length() != MIN_TRACE_ID_LENGTH && value.length() != MAX_TRACE_ID_LENGTH));
     }
 
     static boolean isSpanIdValid(String value) {
-      return !(StringUtils.isNullOrEmpty(value) || value.length() > MAX_SPAN_ID_LENGTH);
+      return !(StringUtils.isNullOrEmpty(value)
+          || !isHex(value)
+          || value.length() != MAX_SPAN_ID_LENGTH);
     }
   }
 }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractor.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractor.java
@@ -28,7 +28,6 @@ import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
-import java.math.BigInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.concurrent.Immutable;
@@ -66,24 +65,24 @@ interface B3PropagatorExtractor {
     }
 
     private static boolean isHex(String value) {
-      try {
-        new BigInteger(value, 16);
-        return true;
-      } catch (NumberFormatException e) {
-        return false;
+      for (int i = 0; i < value.length(); i++) {
+        if (Character.digit(value.charAt(i), 16) == -1) {
+          return false;
+        }
       }
+      return true;
     }
 
     static boolean isTraceIdValid(String value) {
       return !(StringUtils.isNullOrEmpty(value)
-          || !isHex(value)
-          || (value.length() != MIN_TRACE_ID_LENGTH && value.length() != MAX_TRACE_ID_LENGTH));
+          || (value.length() != MIN_TRACE_ID_LENGTH && value.length() != MAX_TRACE_ID_LENGTH)
+          || !isHex(value));
     }
 
     static boolean isSpanIdValid(String value) {
       return !(StringUtils.isNullOrEmpty(value)
-          || !isHex(value)
-          || value.length() != MAX_SPAN_ID_LENGTH);
+          || value.length() != MAX_SPAN_ID_LENGTH
+          || !isHex(value));
     }
   }
 }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
@@ -51,16 +51,13 @@ final class B3PropagatorExtractorMultipleHeaders implements B3PropagatorExtracto
     String traceId = getter.get(carrier, TRACE_ID_HEADER);
     if (!Util.isTraceIdValid(traceId)) {
       logger.info(
-          "Invalid TraceId in B3 header: "
-              + TRACE_ID_HEADER
-              + "'. Returning INVALID span context.");
+          "Invalid TraceId in B3 header: " + traceId + "'. Returning INVALID span context.");
       return SpanContext.getInvalid();
     }
 
     String spanId = getter.get(carrier, SPAN_ID_HEADER);
     if (!Util.isSpanIdValid(spanId)) {
-      logger.info(
-          "Invalid SpanId in B3 header: " + SPAN_ID_HEADER + "'. Returning INVALID span context.");
+      logger.info("Invalid SpanId in B3 header: " + spanId + "'. Returning INVALID span context.");
       return SpanContext.getInvalid();
     }
 


### PR DESCRIPTION
From the B3 Spec (https://github.com/openzipkin/b3-propagation) 

`Trace identifiers are 64 or 128-bit, but all span identifiers within a trace are 64-bit`

Identifiers must also be implemented as hex-characters. 

Technically these checks were happening before (and these tests would have passed), but an exception was raised elsewhere in the code. It felt more intuitive to move the checks into this validity checking function. 