### PR TITLE
feat(extensions): ot-tracer propagator

### DIFF
--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3Propagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3Propagator.java
@@ -18,8 +18,6 @@ package io.opentelemetry.extensions.trace.propagation;
 
 import io.grpc.Context;
 import io.opentelemetry.context.propagation.HttpTextFormat;
-import io.opentelemetry.trace.SpanId;
-import io.opentelemetry.trace.TraceId;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -34,13 +32,8 @@ public class B3Propagator implements HttpTextFormat {
   static final String TRACE_ID_HEADER = "X-B3-TraceId";
   static final String SPAN_ID_HEADER = "X-B3-SpanId";
   static final String SAMPLED_HEADER = "X-B3-Sampled";
-  static final String TRUE_INT = "1";
-  static final String FALSE_INT = "0";
   static final String COMBINED_HEADER = "b3";
   static final String COMBINED_HEADER_DELIMITER = "-";
-  static final int MIN_TRACE_ID_LENGTH = TraceId.getSize();
-  static final int MAX_TRACE_ID_LENGTH = 2 * TraceId.getSize();
-  static final int MAX_SPAN_ID_LENGTH = 2 * SpanId.getSize();
 
   static final char COMBINED_HEADER_DELIMITER_CHAR = '-';
   static final char IS_SAMPLED = '1';

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractor.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractor.java
@@ -16,73 +16,12 @@
 
 package io.opentelemetry.extensions.trace.propagation;
 
-import static io.opentelemetry.extensions.trace.propagation.B3Propagator.MAX_SPAN_ID_LENGTH;
-import static io.opentelemetry.extensions.trace.propagation.B3Propagator.MAX_TRACE_ID_LENGTH;
-import static io.opentelemetry.extensions.trace.propagation.B3Propagator.MIN_TRACE_ID_LENGTH;
-import static io.opentelemetry.extensions.trace.propagation.B3Propagator.TRUE_INT;
-
 import io.grpc.Context;
 import io.opentelemetry.context.propagation.HttpTextFormat;
-import io.opentelemetry.trace.SpanContext;
-import io.opentelemetry.trace.SpanId;
-import io.opentelemetry.trace.TraceFlags;
-import io.opentelemetry.trace.TraceId;
-import io.opentelemetry.trace.TraceState;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
 interface B3PropagatorExtractor {
 
   <C> Context extract(Context context, C carrier, HttpTextFormat.Getter<C> getter);
-
-  @Immutable
-  class Util {
-    private static final Logger logger = Logger.getLogger(Util.class.getName());
-    private static final TraceFlags SAMPLED_FLAGS = TraceFlags.builder().setIsSampled(true).build();
-    private static final TraceFlags NOT_SAMPLED_FLAGS =
-        TraceFlags.builder().setIsSampled(false).build();
-
-    private Util() {}
-
-    static SpanContext buildSpanContext(String traceId, String spanId, String sampled) {
-      try {
-        TraceFlags traceFlags =
-            TRUE_INT.equals(sampled) || Boolean.parseBoolean(sampled) // accept either "1" or "true"
-                ? SAMPLED_FLAGS
-                : NOT_SAMPLED_FLAGS;
-
-        return SpanContext.createFromRemoteParent(
-            TraceId.fromLowerBase16(StringUtils.padLeft(traceId, MAX_TRACE_ID_LENGTH), 0),
-            SpanId.fromLowerBase16(spanId, 0),
-            traceFlags,
-            TraceState.getDefault());
-      } catch (Exception e) {
-        logger.log(Level.INFO, "Error parsing B3 header. Returning INVALID span context.", e);
-        return SpanContext.getInvalid();
-      }
-    }
-
-    private static boolean isHex(String value) {
-      for (int i = 0; i < value.length(); i++) {
-        if (Character.digit(value.charAt(i), 16) == -1) {
-          return false;
-        }
-      }
-      return true;
-    }
-
-    static boolean isTraceIdValid(String value) {
-      return !(StringUtils.isNullOrEmpty(value)
-          || (value.length() != MIN_TRACE_ID_LENGTH && value.length() != MAX_TRACE_ID_LENGTH)
-          || !isHex(value));
-    }
-
-    static boolean isSpanIdValid(String value) {
-      return !(StringUtils.isNullOrEmpty(value)
-          || value.length() != MAX_SPAN_ID_LENGTH
-          || !isHex(value));
-    }
-  }
 }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
@@ -49,19 +49,19 @@ final class B3PropagatorExtractorMultipleHeaders implements B3PropagatorExtracto
   private static <C> SpanContext getSpanContextFromMultipleHeaders(
       C carrier, HttpTextFormat.Getter<C> getter) {
     String traceId = getter.get(carrier, TRACE_ID_HEADER);
-    if (!Util.isTraceIdValid(traceId)) {
+    if (!Common.isTraceIdValid(traceId)) {
       logger.info(
           "Invalid TraceId in B3 header: " + traceId + "'. Returning INVALID span context.");
       return SpanContext.getInvalid();
     }
 
     String spanId = getter.get(carrier, SPAN_ID_HEADER);
-    if (!Util.isSpanIdValid(spanId)) {
+    if (!Common.isSpanIdValid(spanId)) {
       logger.info("Invalid SpanId in B3 header: " + spanId + "'. Returning INVALID span context.");
       return SpanContext.getInvalid();
     }
 
     String sampled = getter.get(carrier, SAMPLED_HEADER);
-    return Util.buildSpanContext(traceId, spanId, sampled);
+    return Common.buildSpanContext(traceId, spanId, sampled);
   }
 }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorSingleHeader.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorSingleHeader.java
@@ -64,14 +64,14 @@ final class B3PropagatorExtractorSingleHeader implements B3PropagatorExtractor {
     }
 
     String traceId = parts[0];
-    if (!Util.isTraceIdValid(traceId)) {
+    if (!Common.isTraceIdValid(traceId)) {
       logger.info(
           "Invalid TraceId in B3 header: " + COMBINED_HEADER + ". Returning INVALID span context.");
       return SpanContext.getInvalid();
     }
 
     String spanId = parts[1];
-    if (!Util.isSpanIdValid(spanId)) {
+    if (!Common.isSpanIdValid(spanId)) {
       logger.info(
           "Invalid SpanId in B3 header: " + COMBINED_HEADER + ". Returning INVALID span context.");
       return SpanContext.getInvalid();
@@ -79,6 +79,6 @@ final class B3PropagatorExtractorSingleHeader implements B3PropagatorExtractor {
 
     String sampled = parts.length >= 3 ? parts[2] : null;
 
-    return Util.buildSpanContext(traceId, spanId, sampled);
+    return Common.buildSpanContext(traceId, spanId, sampled);
   }
 }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
@@ -37,8 +37,7 @@ final class B3PropagatorInjectorMultipleHeaders implements B3PropagatorInjector 
     }
 
     SpanContext spanContext = span.getContext();
-    String sampled =
-        spanContext.getTraceFlags().isSampled() ? B3Propagator.TRUE_INT : B3Propagator.FALSE_INT;
+    String sampled = spanContext.getTraceFlags().isSampled() ? Common.TRUE_INT : Common.FALSE_INT;
 
     setter.set(carrier, B3Propagator.TRACE_ID_HEADER, spanContext.getTraceId().toLowerBase16());
     setter.set(carrier, B3Propagator.SPAN_ID_HEADER, spanContext.getSpanId().toLowerBase16());

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/Common.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/Common.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.extensions.trace.propagation;
+
+import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceFlags;
+import io.opentelemetry.trace.TraceId;
+import io.opentelemetry.trace.TraceState;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * This set of common propagator utils is currently only used by the OtTracerPropagator and the
+ * B3Propagator.
+ */
+@Immutable
+final class Common {
+  private static final Logger logger = Logger.getLogger(Common.class.getName());
+
+  static final String TRUE_INT = "1";
+  static final String FALSE_INT = "0";
+  static final int MAX_TRACE_ID_LENGTH = 2 * TraceId.getSize();
+  static final int MAX_SPAN_ID_LENGTH = 2 * SpanId.getSize();
+  static final int MIN_TRACE_ID_LENGTH = TraceId.getSize();
+  private static final TraceFlags SAMPLED_FLAGS = TraceFlags.builder().setIsSampled(true).build();
+  private static final TraceFlags NOT_SAMPLED_FLAGS =
+      TraceFlags.builder().setIsSampled(false).build();
+
+  private Common() {}
+
+  static SpanContext buildSpanContext(String traceId, String spanId, String sampled) {
+    try {
+      TraceFlags traceFlags =
+          TRUE_INT.equals(sampled) || Boolean.parseBoolean(sampled) // accept either "1" or "true"
+              ? SAMPLED_FLAGS
+              : NOT_SAMPLED_FLAGS;
+
+      return SpanContext.createFromRemoteParent(
+          TraceId.fromLowerBase16(StringUtils.padLeft(traceId, MAX_TRACE_ID_LENGTH), 0),
+          SpanId.fromLowerBase16(spanId, 0),
+          traceFlags,
+          TraceState.getDefault());
+    } catch (Exception e) {
+      logger.log(Level.INFO, "Error parsing header. Returning INVALID span context.", e);
+      return SpanContext.getInvalid();
+    }
+  }
+
+  private static boolean isHex(String value) {
+    for (int i = 0; i < value.length(); i++) {
+      if (Character.digit(value.charAt(i), 16) == -1) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static boolean isTraceIdValid(String value) {
+    return !(StringUtils.isNullOrEmpty(value)
+        || (value.length() != MIN_TRACE_ID_LENGTH && value.length() != MAX_TRACE_ID_LENGTH)
+        || !isHex(value));
+  }
+
+  static boolean isSpanIdValid(String value) {
+    return !(StringUtils.isNullOrEmpty(value)
+        || value.length() != MAX_SPAN_ID_LENGTH
+        || !isHex(value));
+  }
+}

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagator.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.extensions.trace.propagation;
+
+import io.grpc.Context;
+import io.opentelemetry.context.propagation.HttpTextFormat;
+import io.opentelemetry.trace.DefaultSpan;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.TracingContextUtils;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * Implementation of the Lightstep propagation protocol. Context is propagated through 3 headers,
+ * ot-tracer-traceid, ot-tracer-span-id, and ot-tracer-sampled. Baggage is not supported in this
+ * implementation. IDs are sent as hex strings and sampled is sent as true or false. See <a
+ * href=https://github.com/lightstep/lightstep-tracer-java-common/blob/master/common/src/main/java/com/lightstep/tracer/shared/TextMapPropagator.java>Lightstep
+ * TextMapPropagator</a>.
+ */
+@Immutable
+public class OtTracerPropagator implements HttpTextFormat {
+
+  static final String TRACE_ID_HEADER = "ot-tracer-traceid";
+  static final String SPAN_ID_HEADER = "ot-tracer-spanid";
+  static final String SAMPLED_HEADER = "ot-tracer-sampled";
+  private static final List<String> FIELDS =
+      Collections.unmodifiableList(Arrays.asList(TRACE_ID_HEADER, SPAN_ID_HEADER, SAMPLED_HEADER));
+
+  private static final OtTracerPropagator INSTANCE = new OtTracerPropagator();
+
+  private OtTracerPropagator() {
+    // singleton
+  }
+
+  public static OtTracerPropagator getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public List<String> fields() {
+    return FIELDS;
+  }
+
+  @Override
+  public <C> void inject(Context context, C carrier, Setter<C> setter) {
+    if (context == null || setter == null) {
+      return;
+    }
+    final Span span = TracingContextUtils.getSpanWithoutDefault(context);
+    if (span == null) {
+      return;
+    }
+    final SpanContext spanContext = span.getContext();
+    if (!spanContext.isValid()) {
+      return;
+    }
+    setter.set(carrier, TRACE_ID_HEADER, spanContext.getTraceId().toLowerBase16());
+    setter.set(carrier, SPAN_ID_HEADER, spanContext.getSpanId().toLowerBase16());
+    setter.set(carrier, SAMPLED_HEADER, String.valueOf(spanContext.getTraceFlags().isSampled()));
+  }
+
+  @Override
+  public <C> Context extract(Context context, C carrier, Getter<C> getter) {
+    if (context == null || getter == null) {
+      return context;
+    }
+    String traceId = getter.get(carrier, TRACE_ID_HEADER);
+    String spanId = getter.get(carrier, SPAN_ID_HEADER);
+    String sampled = getter.get(carrier, SAMPLED_HEADER);
+    SpanContext spanContext = buildSpanContext(traceId, spanId, sampled);
+    if (!spanContext.isValid()) {
+      return context;
+    }
+    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+  }
+
+  static SpanContext buildSpanContext(String traceId, String spanId, String sampled) {
+    if (!Common.isTraceIdValid(traceId) || !Common.isSpanIdValid(spanId)) {
+      return SpanContext.getInvalid();
+    }
+    return Common.buildSpanContext(traceId, spanId, sampled);
+  }
+}

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
@@ -149,7 +149,7 @@ public class B3PropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     carrier.put(B3Propagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
     carrier.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
-    carrier.put(B3Propagator.SAMPLED_HEADER, B3Propagator.TRUE_INT);
+    carrier.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
 
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
@@ -175,7 +175,7 @@ public class B3PropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     carrier.put(B3Propagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
     carrier.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
-    carrier.put(B3Propagator.SAMPLED_HEADER, B3Propagator.FALSE_INT);
+    carrier.put(B3Propagator.SAMPLED_HEADER, Common.FALSE_INT);
 
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
@@ -188,7 +188,7 @@ public class B3PropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     carrier.put(B3Propagator.TRACE_ID_HEADER, SHORT_TRACE_ID_BASE16);
     carrier.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
-    carrier.put(B3Propagator.SAMPLED_HEADER, B3Propagator.TRUE_INT);
+    carrier.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
 
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
@@ -214,7 +214,7 @@ public class B3PropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     carrier.put(B3Propagator.TRACE_ID_HEADER, SHORT_TRACE_ID_BASE16);
     carrier.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
-    carrier.put(B3Propagator.SAMPLED_HEADER, B3Propagator.FALSE_INT);
+    carrier.put(B3Propagator.SAMPLED_HEADER, Common.FALSE_INT);
 
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
@@ -227,7 +227,7 @@ public class B3PropagatorTest {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(B3Propagator.TRACE_ID_HEADER, "g" + TRACE_ID_BASE16.substring(1));
     invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
-    invalidHeaders.put(B3Propagator.SAMPLED_HEADER, B3Propagator.TRUE_INT);
+    invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameInstanceAs(SpanContext.getInvalid());
   }
@@ -237,7 +237,7 @@ public class B3PropagatorTest {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(B3Propagator.TRACE_ID_HEADER, TRACE_ID_BASE16.substring(2));
     invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
-    invalidHeaders.put(B3Propagator.SAMPLED_HEADER, B3Propagator.TRUE_INT);
+    invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameInstanceAs(SpanContext.getInvalid());
   }
@@ -247,7 +247,7 @@ public class B3PropagatorTest {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(B3Propagator.TRACE_ID_HEADER, TRACE_ID_BASE16 + "00");
     invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
-    invalidHeaders.put(B3Propagator.SAMPLED_HEADER, B3Propagator.TRUE_INT);
+    invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameInstanceAs(SpanContext.getInvalid());
   }
@@ -257,7 +257,7 @@ public class B3PropagatorTest {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(B3Propagator.TRACE_ID_HEADER, TRACE_ID_ALL_ZERO);
     invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
-    invalidHeaders.put(B3Propagator.SAMPLED_HEADER, B3Propagator.TRUE_INT);
+    invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameInstanceAs(SpanContext.getInvalid());
   }
@@ -267,7 +267,7 @@ public class B3PropagatorTest {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(B3Propagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
     invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, "g" + SPAN_ID_BASE16.substring(1));
-    invalidHeaders.put(B3Propagator.SAMPLED_HEADER, B3Propagator.TRUE_INT);
+    invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameInstanceAs(SpanContext.getInvalid());
   }
@@ -277,7 +277,7 @@ public class B3PropagatorTest {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(B3Propagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
     invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16.substring(2));
-    invalidHeaders.put(B3Propagator.SAMPLED_HEADER, B3Propagator.TRUE_INT);
+    invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameInstanceAs(SpanContext.getInvalid());
   }
@@ -287,7 +287,7 @@ public class B3PropagatorTest {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(B3Propagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
     invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16 + "00");
-    invalidHeaders.put(B3Propagator.SAMPLED_HEADER, B3Propagator.TRUE_INT);
+    invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameInstanceAs(SpanContext.getInvalid());
   }
@@ -297,7 +297,7 @@ public class B3PropagatorTest {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(B3Propagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
     invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_ALL_ZERO);
-    invalidHeaders.put(B3Propagator.SAMPLED_HEADER, B3Propagator.TRUE_INT);
+    invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameInstanceAs(SpanContext.getInvalid());
   }
@@ -362,7 +362,7 @@ public class B3PropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     carrier.put(
         B3Propagator.COMBINED_HEADER,
-        TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-" + B3Propagator.TRUE_INT);
+        TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-" + Common.TRUE_INT);
 
     assertThat(getSpanContext(b3PropagatorSingleHeader.extract(Context.current(), carrier, getter)))
         .isEqualTo(
@@ -375,7 +375,7 @@ public class B3PropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     carrier.put(
         B3Propagator.COMBINED_HEADER,
-        TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-" + B3Propagator.TRUE_INT + "-" + "0");
+        TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-" + Common.TRUE_INT + "-" + "0");
 
     assertThat(getSpanContext(b3PropagatorSingleHeader.extract(Context.current(), carrier, getter)))
         .isEqualTo(
@@ -413,7 +413,7 @@ public class B3PropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     carrier.put(
         B3Propagator.COMBINED_HEADER,
-        TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-" + B3Propagator.FALSE_INT);
+        TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-" + Common.FALSE_INT);
 
     assertThat(getSpanContext(b3PropagatorSingleHeader.extract(Context.current(), carrier, getter)))
         .isEqualTo(
@@ -426,7 +426,7 @@ public class B3PropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     carrier.put(
         B3Propagator.COMBINED_HEADER,
-        SHORT_TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-" + B3Propagator.TRUE_INT);
+        SHORT_TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-" + Common.TRUE_INT);
 
     assertThat(getSpanContext(b3PropagatorSingleHeader.extract(Context.current(), carrier, getter)))
         .isEqualTo(
@@ -439,7 +439,7 @@ public class B3PropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     carrier.put(
         B3Propagator.COMBINED_HEADER,
-        SHORT_TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-" + B3Propagator.TRUE_INT + "-" + "0");
+        SHORT_TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-" + Common.TRUE_INT + "-" + "0");
 
     assertThat(getSpanContext(b3PropagatorSingleHeader.extract(Context.current(), carrier, getter)))
         .isEqualTo(
@@ -477,7 +477,7 @@ public class B3PropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     carrier.put(
         B3Propagator.COMBINED_HEADER,
-        SHORT_TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-" + B3Propagator.FALSE_INT);
+        SHORT_TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-" + Common.FALSE_INT);
 
     assertThat(getSpanContext(b3PropagatorSingleHeader.extract(Context.current(), carrier, getter)))
         .isEqualTo(
@@ -512,7 +512,7 @@ public class B3PropagatorTest {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(
         B3Propagator.COMBINED_HEADER,
-        "abcdefghijklmnopabcdefghijklmnop" + "-" + SPAN_ID_BASE16 + "-" + B3Propagator.TRUE_INT);
+        "abcdefghijklmnopabcdefghijklmnop" + "-" + SPAN_ID_BASE16 + "-" + Common.TRUE_INT);
 
     assertThat(
             getSpanContext(
@@ -525,12 +525,7 @@ public class B3PropagatorTest {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(
         B3Propagator.COMBINED_HEADER,
-        "abcdefghijklmnopabcdefghijklmnop"
-            + "00"
-            + "-"
-            + SPAN_ID_BASE16
-            + "-"
-            + B3Propagator.TRUE_INT);
+        "abcdefghijklmnopabcdefghijklmnop" + "00" + "-" + SPAN_ID_BASE16 + "-" + Common.TRUE_INT);
 
     assertThat(
             getSpanContext(
@@ -543,7 +538,7 @@ public class B3PropagatorTest {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(
         B3Propagator.COMBINED_HEADER,
-        TRACE_ID_BASE16 + "-" + "abcdefghijklmnop" + "-" + B3Propagator.TRUE_INT);
+        TRACE_ID_BASE16 + "-" + "abcdefghijklmnop" + "-" + Common.TRUE_INT);
 
     assertThat(
             getSpanContext(
@@ -556,7 +551,7 @@ public class B3PropagatorTest {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(
         B3Propagator.COMBINED_HEADER,
-        TRACE_ID_BASE16 + "-" + "abcdefghijklmnop" + "00" + "-" + B3Propagator.TRUE_INT);
+        TRACE_ID_BASE16 + "-" + "abcdefghijklmnop" + "00" + "-" + Common.TRUE_INT);
 
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameInstanceAs(SpanContext.getInvalid());
@@ -576,7 +571,7 @@ public class B3PropagatorTest {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(
         B3Propagator.COMBINED_HEADER,
-        TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-" + B3Propagator.TRUE_INT + "-extra");
+        TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-" + Common.TRUE_INT + "-extra");
 
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameInstanceAs(SpanContext.getInvalid());

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagatorTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.extensions.trace.propagation;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.grpc.Context;
+import io.opentelemetry.context.propagation.HttpTextFormat.Getter;
+import io.opentelemetry.context.propagation.HttpTextFormat.Setter;
+import io.opentelemetry.trace.DefaultSpan;
+import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.SpanId;
+import io.opentelemetry.trace.TraceFlags;
+import io.opentelemetry.trace.TraceId;
+import io.opentelemetry.trace.TraceState;
+import io.opentelemetry.trace.TracingContextUtils;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class OtTracerPropagatorTest {
+
+  private static final TraceState TRACE_STATE_DEFAULT = TraceState.builder().build();
+  private static final String TRACE_ID_BASE16 = "ff000000000000000000000000000041";
+  private static final TraceId TRACE_ID = TraceId.fromLowerBase16(TRACE_ID_BASE16, 0);
+  private static final String SHORT_TRACE_ID_BASE16 = "ff00000000000000";
+  private static final TraceId SHORT_TRACE_ID =
+      TraceId.fromLowerBase16(StringUtils.padLeft(SHORT_TRACE_ID_BASE16, 32), 0);
+  private static final String SPAN_ID_BASE16 = "ff00000000000041";
+  private static final SpanId SPAN_ID = SpanId.fromLowerBase16(SPAN_ID_BASE16, 0);
+  private static final byte SAMPLED_TRACE_OPTIONS_BYTES = 1;
+  private static final TraceFlags SAMPLED_TRACE_OPTIONS =
+      TraceFlags.fromByte(SAMPLED_TRACE_OPTIONS_BYTES);
+  private static final Setter<Map<String, String>> setter = Map::put;
+  private static final Getter<Map<String, String>> getter = Map::get;
+  private final OtTracerPropagator propagator = OtTracerPropagator.getInstance();
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private static SpanContext getSpanContext(Context context) {
+    return TracingContextUtils.getSpan(context).getContext();
+  }
+
+  private static Context withSpanContext(SpanContext spanContext, Context context) {
+    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+  }
+
+  @Test
+  public void inject_invalidContext() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    propagator.inject(
+        withSpanContext(
+            SpanContext.create(
+                TraceId.getInvalid(),
+                SpanId.getInvalid(),
+                SAMPLED_TRACE_OPTIONS,
+                TraceState.builder().set("foo", "bar").build()),
+            Context.current()),
+        carrier,
+        setter);
+    assertThat(carrier).isEmpty();
+  }
+
+  @Test
+  public void inject_SampledContext() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    propagator.inject(
+        withSpanContext(
+            SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
+            Context.current()),
+        carrier,
+        setter);
+    assertThat(carrier).containsEntry(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
+    assertThat(carrier).containsEntry(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    assertThat(carrier).containsEntry(OtTracerPropagator.SAMPLED_HEADER, "true");
+  }
+
+  @Test
+  public void inject_SampledContext_nullCarrierUsage() {
+    final Map<String, String> carrier = new LinkedHashMap<>();
+    propagator.inject(
+        withSpanContext(
+            SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
+            Context.current()),
+        null,
+        (Setter<Map<String, String>>) (ignored, key, value) -> carrier.put(key, value));
+    assertThat(carrier).containsEntry(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
+    assertThat(carrier).containsEntry(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    assertThat(carrier).containsEntry(OtTracerPropagator.SAMPLED_HEADER, "true");
+  }
+
+  @Test
+  public void inject_NotSampledContext() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    propagator.inject(
+        withSpanContext(
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT),
+            Context.current()),
+        carrier,
+        setter);
+    assertThat(carrier).containsEntry(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
+    assertThat(carrier).containsEntry(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    assertThat(carrier).containsEntry(OtTracerPropagator.SAMPLED_HEADER, "false");
+  }
+
+  @Test
+  public void extract_Nothing() {
+    // Context remains untouched.
+    assertThat(
+            propagator.extract(Context.current(), Collections.<String, String>emptyMap(), Map::get))
+        .isSameInstanceAs(Context.current());
+  }
+
+  @Test
+  public void extract_SampledContext_Int() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
+    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    carrier.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
+
+    assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
+        .isEqualTo(
+            SpanContext.createFromRemoteParent(
+                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+  }
+
+  @Test
+  public void extract_SampledContext_Bool() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
+    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    carrier.put(OtTracerPropagator.SAMPLED_HEADER, "true");
+
+    assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
+        .isEqualTo(
+            SpanContext.createFromRemoteParent(
+                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+  }
+
+  @Test
+  public void extract_NotSampledContext() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
+    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    carrier.put(OtTracerPropagator.SAMPLED_HEADER, Common.FALSE_INT);
+
+    assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
+        .isEqualTo(
+            SpanContext.createFromRemoteParent(
+                TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+  }
+
+  @Test
+  public void extract_SampledContext_Int_Short_TraceId() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, SHORT_TRACE_ID_BASE16);
+    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    carrier.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
+
+    assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
+        .isEqualTo(
+            SpanContext.createFromRemoteParent(
+                SHORT_TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+  }
+
+  @Test
+  public void extract_SampledContext_Bool_Short_TraceId() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, SHORT_TRACE_ID_BASE16);
+    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    carrier.put(OtTracerPropagator.SAMPLED_HEADER, "true");
+
+    assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
+        .isEqualTo(
+            SpanContext.createFromRemoteParent(
+                SHORT_TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+  }
+
+  @Test
+  public void extract_NotSampledContext_Short_TraceId() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, SHORT_TRACE_ID_BASE16);
+    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    carrier.put(OtTracerPropagator.SAMPLED_HEADER, Common.FALSE_INT);
+
+    assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
+        .isEqualTo(
+            SpanContext.createFromRemoteParent(
+                SHORT_TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+  }
+
+  @Test
+  public void extract_InvalidTraceId() {
+    Map<String, String> invalidHeaders = new LinkedHashMap<>();
+    invalidHeaders.put(OtTracerPropagator.TRACE_ID_HEADER, "abcdefghijklmnopabcdefghijklmnop");
+    invalidHeaders.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    invalidHeaders.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
+    assertThat(getSpanContext(propagator.extract(Context.current(), invalidHeaders, getter)))
+        .isSameInstanceAs(SpanContext.getInvalid());
+  }
+
+  @Test
+  public void extract_InvalidTraceId_Size() {
+    Map<String, String> invalidHeaders = new LinkedHashMap<>();
+    invalidHeaders.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_BASE16 + "00");
+    invalidHeaders.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
+    invalidHeaders.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
+    assertThat(getSpanContext(propagator.extract(Context.current(), invalidHeaders, getter)))
+        .isSameInstanceAs(SpanContext.getInvalid());
+  }
+
+  @Test
+  public void extract_InvalidSpanId() {
+    Map<String, String> invalidHeaders = new LinkedHashMap<>();
+    invalidHeaders.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
+    invalidHeaders.put(OtTracerPropagator.SPAN_ID_HEADER, "abcdefghijklmnop");
+    invalidHeaders.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
+    assertThat(getSpanContext(propagator.extract(Context.current(), invalidHeaders, getter)))
+        .isSameInstanceAs(SpanContext.getInvalid());
+  }
+
+  @Test
+  public void extract_InvalidSpanId_Size() {
+    Map<String, String> invalidHeaders = new LinkedHashMap<>();
+    invalidHeaders.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_BASE16);
+    invalidHeaders.put(OtTracerPropagator.SPAN_ID_HEADER, "abcdefghijklmnop" + "00");
+    invalidHeaders.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
+    assertThat(getSpanContext(propagator.extract(Context.current(), invalidHeaders, getter)))
+        .isSameInstanceAs(SpanContext.getInvalid());
+  }
+
+  @Test
+  public void extract_emptyCarrier() {
+    Map<String, String> emptyHeaders = new HashMap<>();
+    assertThat(getSpanContext(propagator.extract(Context.current(), emptyHeaders, getter)))
+        .isEqualTo(SpanContext.getInvalid());
+  }
+}


### PR DESCRIPTION
supports propagation headers used by lightstep tracers, copied from the lightstep tracer and the b3 opentelemetry propagator (in this package).

I couldn't find the issue again, but I remember reading that these were welcome in the extensions module. If someone remembers which issue the ot-tracer headers were mentioned feel free to tag it here.

