### PR TITLE
Return a readable tostring for attribute setters.

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/attributes/BooleanAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/BooleanAttributeSetter.java
@@ -81,4 +81,9 @@ public final class BooleanAttributeSetter {
   public void set(Attributes.Builder attributesBuilder, boolean value) {
     attributesBuilder.setAttribute(key(), value);
   }
+
+  @Override
+  public String toString() {
+    return key();
+  }
 }

--- a/api/src/main/java/io/opentelemetry/trace/attributes/DoubleAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/DoubleAttributeSetter.java
@@ -81,4 +81,9 @@ public final class DoubleAttributeSetter {
   public void set(Attributes.Builder attributesBuilder, double value) {
     attributesBuilder.setAttribute(key(), value);
   }
+
+  @Override
+  public String toString() {
+    return key();
+  }
 }

--- a/api/src/main/java/io/opentelemetry/trace/attributes/LongAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/LongAttributeSetter.java
@@ -81,4 +81,9 @@ public final class LongAttributeSetter {
   public void set(Attributes.Builder attributesBuilder, long value) {
     attributesBuilder.setAttribute(key(), value);
   }
+
+  @Override
+  public String toString() {
+    return key();
+  }
 }

--- a/api/src/main/java/io/opentelemetry/trace/attributes/StringAttributeSetter.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/StringAttributeSetter.java
@@ -82,4 +82,9 @@ public final class StringAttributeSetter {
   public void set(Attributes.Builder attributesBuilder, @Nullable String value) {
     attributesBuilder.setAttribute(key(), value);
   }
+
+  @Override
+  public String toString() {
+    return key();
+  }
 }

--- a/api/src/test/java/io/opentelemetry/trace/attributes/BooleanAttributeSetterTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/attributes/BooleanAttributeSetterTest.java
@@ -27,6 +27,8 @@ public class BooleanAttributeSetterTest {
   @Test
   public void attributesBuilder() {
     BooleanAttributeSetter setter = BooleanAttributeSetter.create("there?");
+    assertThat(setter.key()).isEqualTo("there?");
+    assertThat(setter.toString()).isEqualTo("there?");
     Attributes.Builder attributes = Attributes.newBuilder();
     setter.set(attributes, true);
     assertThat(attributes.build().get("there?")).isEqualTo(booleanAttributeValue(true));

--- a/api/src/test/java/io/opentelemetry/trace/attributes/DoubleAttributeSetterTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/attributes/DoubleAttributeSetterTest.java
@@ -27,6 +27,8 @@ public class DoubleAttributeSetterTest {
   @Test
   public void attributesBuilder() {
     DoubleAttributeSetter setter = DoubleAttributeSetter.create("how much?");
+    assertThat(setter.key()).isEqualTo("how much?");
+    assertThat(setter.toString()).isEqualTo("how much?");
     Attributes.Builder attributes = Attributes.newBuilder();
     setter.set(attributes, 10.0);
     assertThat(attributes.build().get("how much?")).isEqualTo(doubleAttributeValue(10.0));

--- a/api/src/test/java/io/opentelemetry/trace/attributes/LongAttributeSetterTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/attributes/LongAttributeSetterTest.java
@@ -27,6 +27,8 @@ public class LongAttributeSetterTest {
   @Test
   public void attributesBuilder() {
     LongAttributeSetter setter = LongAttributeSetter.create("how much?");
+    assertThat(setter.key()).isEqualTo("how much?");
+    assertThat(setter.toString()).isEqualTo("how much?");
     Attributes.Builder attributes = Attributes.newBuilder();
     setter.set(attributes, 10);
     assertThat(attributes.build().get("how much?")).isEqualTo(longAttributeValue(10));

--- a/api/src/test/java/io/opentelemetry/trace/attributes/StringAttributeSetterTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/attributes/StringAttributeSetterTest.java
@@ -27,6 +27,8 @@ public class StringAttributeSetterTest {
   @Test
   public void attributesBuilder() {
     StringAttributeSetter setter = StringAttributeSetter.create("hello?");
+    assertThat(setter.key()).isEqualTo("hello?");
+    assertThat(setter.toString()).isEqualTo("hello?");
     Attributes.Builder attributes = Attributes.newBuilder();
     setter.set(attributes, "world");
     assertThat(attributes.build().get("hello?")).isEqualTo(stringAttributeValue("world"));


### PR DESCRIPTION
This is particularly helpful in unit tests / IDE debug.