### PR TITLE
Change default sampler to ParentOrElse(AlwaysOn)

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -243,7 +243,7 @@ public final class Samplers {
 
     @Override
     public String getDescription() {
-      return String.format("ParentOrElseSampler-%s", this.delegateSampler.getDescription());
+      return String.format("ParentOrElse{%s}", this.delegateSampler.getDescription());
     }
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
@@ -83,7 +83,7 @@ import javax.annotation.concurrent.Immutable;
 public abstract class TraceConfig {
   // These values are the default values for all the global parameters.
   // TODO: decide which default sampler to use
-  private static final Sampler DEFAULT_SAMPLER = Samplers.alwaysOn();
+  private static final Sampler DEFAULT_SAMPLER = Samplers.parentOrElse(Samplers.alwaysOn());
   private static final int DEFAULT_SPAN_MAX_NUM_ATTRIBUTES = 32;
   private static final int DEFAULT_SPAN_MAX_NUM_EVENTS = 128;
   private static final int DEFAULT_SPAN_MAX_NUM_LINKS = 32;

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -282,7 +282,7 @@ public class SamplersTest {
   @Test
   public void parentOrElseSampler_GetDescription() {
     assertThat(Samplers.parentOrElse(Samplers.alwaysOn()).getDescription())
-        .isEqualTo("ParentOrElseSampler-AlwaysOnSampler");
+        .isEqualTo("ParentOrElse{AlwaysOnSampler}");
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
@@ -33,7 +33,8 @@ public class TraceConfigTest {
 
   @Test
   public void defaultTraceConfig() {
-    assertThat(TraceConfig.getDefault().getSampler()).isEqualTo(Samplers.alwaysOn());
+    assertThat(TraceConfig.getDefault().getSampler().getDescription())
+        .isEqualTo(Samplers.parentOrElse(Samplers.alwaysOn()).getDescription());
     assertThat(TraceConfig.getDefault().getMaxNumberOfAttributes()).isEqualTo(32);
     assertThat(TraceConfig.getDefault().getMaxNumberOfEvents()).isEqualTo(128);
     assertThat(TraceConfig.getDefault().getMaxNumberOfLinks()).isEqualTo(32);


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java/issues/1445 and implements the changes outlined in https://github.com/open-telemetry/opentelemetry-specification/issues/728