### PR TITLE
Use OkHttpSender by default in ZipkinSpanExporter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,7 @@ configure(opentelemetryProjects) {
                 protobuf                : "com.google.protobuf:protobuf-java",
                 protobuf_util           : "com.google.protobuf:protobuf-java-util",
                 zipkin_reporter         : "io.zipkin.reporter2:zipkin-reporter",
-                zipkin_urlconnection    : "io.zipkin.reporter2:zipkin-sender-urlconnection",
+                zipkin_okhttp           : "io.zipkin.reporter2:zipkin-sender-okhttp3",
 
                 // Compatibility layer
                 opentracing             : "io.opentracing:opentracing-api:${opentracingVersion}",

--- a/exporters/zipkin/build.gradle
+++ b/exporters/zipkin/build.gradle
@@ -16,11 +16,11 @@ dependencies {
     annotationProcessor libraries.auto_value
 
     implementation libraries.zipkin_reporter,
-            libraries.zipkin_urlconnection
+            libraries.zipkin_okhttp
 
     testImplementation libraries.guava,
             libraries.zipkin_junit
-    
+
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
 }

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporter.java
@@ -45,7 +45,7 @@ import zipkin2.Span;
 import zipkin2.codec.BytesEncoder;
 import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.reporter.Sender;
-import zipkin2.reporter.urlconnection.URLConnectionSender;
+import zipkin2.reporter.okhttp3.OkHttpSender;
 
 /**
  * This class was based on the OpenCensus zipkin exporter code at
@@ -245,7 +245,7 @@ public final class ZipkinSpanExporter implements SpanExporter {
     }
     try {
       sender.sendSpans(encodedSpans).execute();
-    } catch (IOException e) {
+    } catch (Exception e) {
       return ResultCode.FAILURE;
     }
     return ResultCode.SUCCESS;
@@ -279,10 +279,13 @@ public final class ZipkinSpanExporter implements SpanExporter {
   public static final class Builder extends ConfigBuilder<Builder> {
     private static final String KEY_SERVICE_NAME = "otel.zipkin.service.name";
     private static final String KEY_ENDPOINT = "otel.zipkin.endpoint";
+    private static final String DEFAULT_SERVICE_NAME = "unknown";
+    private static final String DEFAULT_ENDPOINT = "http://localhost:9411/api/v2/spans";
 
     private BytesEncoder<Span> encoder = SpanBytesEncoder.JSON_V2;
     private Sender sender;
-    private String serviceName;
+    private String serviceName = DEFAULT_SERVICE_NAME;
+    private String endpoint = DEFAULT_ENDPOINT;
 
     /**
      * Label of the remote node in the service graph, such as "favstar". Avoid names with variables
@@ -311,7 +314,7 @@ public final class ZipkinSpanExporter implements SpanExporter {
 
     /**
      * Sets the Zipkin sender. Implements the client side of the span transport. A {@link
-     * URLConnectionSender} is a good default.
+     * OkHttpSender} is a good default.
      *
      * <p>The {@link Sender#close()} method will be called when the exporter is shut down.
      *
@@ -339,16 +342,16 @@ public final class ZipkinSpanExporter implements SpanExporter {
     }
 
     /**
-     * Sets the zipkin endpoint. This will use the endpoint to assign a {@link URLConnectionSender}
+     * Sets the zipkin endpoint. This will use the endpoint to assign a {@link OkHttpSender}
      * instance to this builder.
      *
      * @param endpoint The Zipkin endpoint URL, ex. "http://zipkinhost:9411/api/v2/spans".
      * @return this.
-     * @see URLConnectionSender
+     * @see OkHttpSender
      * @since 0.4.0
      */
     public Builder setEndpoint(String endpoint) {
-      setSender(URLConnectionSender.create(endpoint));
+      this.endpoint = endpoint;
       return this;
     }
 
@@ -380,6 +383,9 @@ public final class ZipkinSpanExporter implements SpanExporter {
      * @since 0.4.0
      */
     public ZipkinSpanExporter build() {
+      if (sender == null) {
+        sender = OkHttpSender.create(endpoint);
+      }
       return new ZipkinSpanExporter(this.encoder, this.sender, this.serviceName);
     }
   }

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
@@ -41,7 +41,7 @@ import zipkin2.Span;
 import zipkin2.codec.Encoding;
 import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.junit.ZipkinRule;
-import zipkin2.reporter.urlconnection.URLConnectionSender;
+import zipkin2.reporter.okhttp3.OkHttpSender;
 
 /**
  * Tests which use Zipkin's {@link ZipkinRule} to verify that the {@link ZipkinSpanExporter} can
@@ -129,7 +129,7 @@ public class ZipkinSpanExporterEndToEndHttpTest {
   private static ZipkinSpanExporter buildZipkinExporter(
       String endpoint, Encoding encoding, SpanBytesEncoder encoder) {
     return ZipkinSpanExporter.newBuilder()
-        .setSender(URLConnectionSender.newBuilder().endpoint(endpoint).encoding(encoding).build())
+        .setSender(OkHttpSender.newBuilder().endpoint(endpoint).encoding(encoding).build())
         .setServiceName(SERVICE_NAME)
         .setEncoder(encoder)
         .build();


### PR DESCRIPTION
Unfortunately, this makes the `zipkin-sender-okhttp3` dependency required.

I'm not sure if it's possible to make `OkHttpSender` the default while also giving users the option to shed it from their dependencies if they need to use something small (`URLConnectionSender`).

Maybe it's not a good idea to have any default Sender, and instead require users to bring their own?

Would close #1409