### PR TITLE
Fix too noisy B3 propagator

### DIFF
--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
@@ -157,7 +157,7 @@ public class AwsXRayPropagator implements HttpTextFormat {
       String trimmedPart = part.trim();
       int equalsIndex = trimmedPart.indexOf(KV_DELIMITER);
       if (equalsIndex < 0) {
-        logger.info(
+        logger.fine(
             "Error parsing X-Ray trace header. Invalid key value pair: "
                 + part
                 + " Returning INVALID span context.");
@@ -177,7 +177,7 @@ public class AwsXRayPropagator implements HttpTextFormat {
     }
 
     if (!traceId.isValid()) {
-      logger.info(
+      logger.fine(
           "Invalid TraceId in X-Ray trace header: '"
               + TRACE_HEADER_KEY
               + "' with value "
@@ -187,7 +187,7 @@ public class AwsXRayPropagator implements HttpTextFormat {
     }
 
     if (!spanId.isValid()) {
-      logger.info(
+      logger.fine(
           "Invalid ParentId in X-Ray trace header: '"
               + TRACE_HEADER_KEY
               + "' with value "
@@ -197,7 +197,7 @@ public class AwsXRayPropagator implements HttpTextFormat {
     }
 
     if (traceFlags == null) {
-      logger.info(
+      logger.fine(
           "Invalid Sampling flag in X-Ray trace header: '"
               + TRACE_HEADER_KEY
               + "' with value "

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
@@ -49,8 +49,11 @@ final class B3PropagatorExtractorMultipleHeaders implements B3PropagatorExtracto
   private static <C> SpanContext getSpanContextFromMultipleHeaders(
       C carrier, HttpTextFormat.Getter<C> getter) {
     String traceId = getter.get(carrier, TRACE_ID_HEADER);
+    if (StringUtils.isNullOrEmpty(traceId)) {
+      return SpanContext.getInvalid();
+    }
     if (!Common.isTraceIdValid(traceId)) {
-      logger.info(
+      logger.warning(
           "Invalid TraceId in B3 header: " + traceId + "'. Returning INVALID span context.");
       return SpanContext.getInvalid();
     }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
@@ -53,14 +53,14 @@ final class B3PropagatorExtractorMultipleHeaders implements B3PropagatorExtracto
       return SpanContext.getInvalid();
     }
     if (!Common.isTraceIdValid(traceId)) {
-      logger.warning(
+      logger.fine(
           "Invalid TraceId in B3 header: " + traceId + "'. Returning INVALID span context.");
       return SpanContext.getInvalid();
     }
 
     String spanId = getter.get(carrier, SPAN_ID_HEADER);
     if (!Common.isSpanIdValid(spanId)) {
-      logger.info("Invalid SpanId in B3 header: " + spanId + "'. Returning INVALID span context.");
+      logger.fine("Invalid SpanId in B3 header: " + spanId + "'. Returning INVALID span context.");
       return SpanContext.getInvalid();
     }
 

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorSingleHeader.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorSingleHeader.java
@@ -58,21 +58,21 @@ final class B3PropagatorExtractorSingleHeader implements B3PropagatorExtractor {
     // NOTE: we do not use parentSpanId
     String[] parts = value.split(COMBINED_HEADER_DELIMITER);
     if (parts.length < 2 || parts.length > 4) {
-      logger.info(
+      logger.fine(
           "Invalid combined header '" + COMBINED_HEADER + ". Returning INVALID span context.");
       return SpanContext.getInvalid();
     }
 
     String traceId = parts[0];
     if (!Common.isTraceIdValid(traceId)) {
-      logger.info(
+      logger.fine(
           "Invalid TraceId in B3 header: " + COMBINED_HEADER + ". Returning INVALID span context.");
       return SpanContext.getInvalid();
     }
 
     String spanId = parts[1];
     if (!Common.isSpanIdValid(spanId)) {
-      logger.info(
+      logger.fine(
           "Invalid SpanId in B3 header: " + COMBINED_HEADER + ". Returning INVALID span context.");
       return SpanContext.getInvalid();
     }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
@@ -131,7 +131,7 @@ public class JaegerPropagator implements HttpTextFormat {
         // the propagation value
         value = URLDecoder.decode(value, "UTF-8");
       } catch (UnsupportedEncodingException e) {
-        logger.info(
+        logger.fine(
             "Error decoding '"
                 + PROPAGATION_HEADER
                 + "' with value "
@@ -143,7 +143,7 @@ public class JaegerPropagator implements HttpTextFormat {
 
     String[] parts = value.split(String.valueOf(PROPAGATION_HEADER_DELIMITER));
     if (parts.length != 4) {
-      logger.info(
+      logger.fine(
           "Invalid header '"
               + PROPAGATION_HEADER
               + "' with value "
@@ -154,7 +154,7 @@ public class JaegerPropagator implements HttpTextFormat {
 
     String traceId = parts[0];
     if (!isTraceIdValid(traceId)) {
-      logger.info(
+      logger.fine(
           "Invalid TraceId in Jaeger header: '"
               + PROPAGATION_HEADER
               + "' with traceId "
@@ -165,7 +165,7 @@ public class JaegerPropagator implements HttpTextFormat {
 
     String spanId = parts[1];
     if (!isSpanIdValid(spanId)) {
-      logger.info(
+      logger.fine(
           "Invalid SpanId in Jaeger header: '"
               + PROPAGATION_HEADER
               + "'. Returning INVALID span context.");
@@ -174,7 +174,7 @@ public class JaegerPropagator implements HttpTextFormat {
 
     String flags = parts[3];
     if (!isFlagsValid(flags)) {
-      logger.info(
+      logger.fine(
           "Invalid Flags in Jaeger header: '"
               + PROPAGATION_HEADER
               + "'. Returning INVALID span context.");
@@ -196,7 +196,7 @@ public class JaegerPropagator implements HttpTextFormat {
           TraceState.getDefault());
     } catch (Exception e) {
       logger.log(
-          Level.INFO,
+          Level.FINE,
           "Error parsing '" + PROPAGATION_HEADER + "' header. Returning INVALID span context.",
           e);
       return SpanContext.getInvalid();


### PR DESCRIPTION
If incoming request does not have a B3 header, then `B3PropagatorExtractorMultipleHeaders` used to print a message that `Invalid TraceId in B3 header`. This is very confusing for an end user and just misleading.