### PR TITLE
Fix SpanWrapper snapshot being incomplete.

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -206,7 +206,10 @@ final class RecordEventsReadableSpan implements ReadableSpan, Span {
           getImmutableAttributes(),
           (attributes == null) ? 0 : attributes.getTotalAddedValues(),
           totalRecordedEvents,
-          getStatusWithDefault());
+          getStatusWithDefault(),
+          name,
+          endEpochNanos,
+          hasEnded);
     }
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
@@ -33,9 +33,8 @@ import javax.annotation.concurrent.Immutable;
 /**
  * Immutable class that stores {@link SpanData} based on a {@link RecordEventsReadableSpan}.
  *
- * <p>This is a variant of the "flyweight" design pattern, to reduce overhead. We store a reference
- * to a mutable {@link RecordEventsReadableSpan} ({@code delegate}) where we use only the immutable
- * parts from and a copy of all the mutable parts.
+ * <p>This class stores a reference to a mutable {@link RecordEventsReadableSpan} ({@code delegate})
+ * which it uses only the immutable parts from, and a copy of all the mutable parts.
  *
  * <p>When adding a new field to {@link RecordEventsReadableSpan}, store a copy if and only if the
  * field is mutable in the {@link RecordEventsReadableSpan}. Otherwise retrieve it from the

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
@@ -30,6 +30,17 @@ import io.opentelemetry.trace.TraceState;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
+/**
+ * Immutable class that stores {@link SpanData} based on a {@link RecordEventsReadableSpan}.
+ *
+ * <p>This is a variant of the "flyweight" design pattern, to reduce overhead. We store a reference
+ * to a mutable {@link RecordEventsReadableSpan} ({@code delegate}) where we use only the immutable
+ * parts from and a copy of all the mutable parts.
+ *
+ * <p>When adding a new field to {@link RecordEventsReadableSpan}, store a copy if and only if the
+ * field is mutable in the {@link RecordEventsReadableSpan}. Otherwise retrieve it from the
+ * referenced {@link RecordEventsReadableSpan}.
+ */
 @Immutable
 @AutoValue
 abstract class SpanWrapper implements SpanData {

--- a/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
@@ -47,6 +47,12 @@ abstract class SpanWrapper implements SpanData {
 
   abstract Status status();
 
+  abstract String name();
+
+  abstract long endEpochNanos();
+
+  abstract boolean hasEnded();
+
   /**
    * Note: the collections that are passed into this creator method are assumed to be immutable to
    * preserve the overall immutability of the class.
@@ -58,9 +64,21 @@ abstract class SpanWrapper implements SpanData {
       ReadableAttributes attributes,
       int totalAttributeCount,
       int totalRecordedEvents,
-      Status status) {
+      Status status,
+      String name,
+      long endEpochNanos,
+      boolean hasEnded) {
     return new AutoValue_SpanWrapper(
-        delegate, links, events, attributes, totalAttributeCount, totalRecordedEvents, status);
+        delegate,
+        links,
+        events,
+        attributes,
+        totalAttributeCount,
+        totalRecordedEvents,
+        status,
+        name,
+        endEpochNanos,
+        hasEnded);
   }
 
   @Override
@@ -100,7 +118,7 @@ abstract class SpanWrapper implements SpanData {
 
   @Override
   public String getName() {
-    return delegate().getName();
+    return name();
   }
 
   @Override
@@ -135,7 +153,7 @@ abstract class SpanWrapper implements SpanData {
 
   @Override
   public long getEndEpochNanos() {
-    return delegate().getEndEpochNanos();
+    return endEpochNanos();
   }
 
   @Override
@@ -145,7 +163,7 @@ abstract class SpanWrapper implements SpanData {
 
   @Override
   public boolean getHasEnded() {
-    return delegate().hasEnded();
+    return hasEnded();
   }
 
   @Override

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -254,14 +254,21 @@ public class RecordEventsReadableSpanTest {
   }
 
   @Test
-  public void toSpanData_snapshot() {
+  public void toSpanData_SpanDataDoesNotChangeWhenModifyingSpan() {
+    // Create a span
     RecordEventsReadableSpan span = createTestSpanWithAttributes(attributes);
+
+    // Convert it to a SpanData object -- this should be an immutable snapshot.
     SpanData spanData = span.toSpanData();
+
+    // Now modify the span after creating the snapshot.
     span.setAttribute("anotherKey", "anotherValue");
     span.updateName("changedName");
     span.addEvent("newEvent");
     span.end();
 
+    // Assert that the snapshot does not reflect the modified state, but the state of the time when
+    // toSpanData was called.
     assertThat(spanData.getAttributes().size()).isEqualTo(attributes.size());
     assertThat(spanData.getAttributes().get("anotherKey")).isNull();
     assertThat(spanData.getHasEnded()).isFalse();
@@ -269,6 +276,8 @@ public class RecordEventsReadableSpanTest {
     assertThat(spanData.getName()).isEqualTo(SPAN_NAME);
     assertThat(spanData.getEvents()).isEmpty();
 
+    // Sanity check: Calling toSpanData again after modifying the span should get us the modified
+    // state.
     spanData = span.toSpanData();
     assertThat(spanData.getAttributes().size()).isEqualTo(attributes.size() + 1);
     assertThat(spanData.getAttributes().get("anotherKey"))

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -254,6 +254,32 @@ public class RecordEventsReadableSpanTest {
   }
 
   @Test
+  public void toSpanData_snapshot() {
+    RecordEventsReadableSpan span = createTestSpanWithAttributes(attributes);
+    SpanData spanData = span.toSpanData();
+    span.setAttribute("anotherKey", "anotherValue");
+    span.updateName("changedName");
+    span.addEvent("newEvent");
+    span.end();
+
+    assertThat(spanData.getAttributes().size()).isEqualTo(attributes.size());
+    assertThat(spanData.getAttributes().get("anotherKey")).isNull();
+    assertThat(spanData.getHasEnded()).isFalse();
+    assertThat(spanData.getEndEpochNanos()).isEqualTo(0);
+    assertThat(spanData.getName()).isEqualTo(SPAN_NAME);
+    assertThat(spanData.getEvents()).isEmpty();
+
+    spanData = span.toSpanData();
+    assertThat(spanData.getAttributes().size()).isEqualTo(attributes.size() + 1);
+    assertThat(spanData.getAttributes().get("anotherKey"))
+        .isEqualTo(AttributeValue.stringAttributeValue("anotherValue"));
+    assertThat(spanData.getHasEnded()).isTrue();
+    assertThat(spanData.getEndEpochNanos()).isGreaterThan(0);
+    assertThat(spanData.getName()).isEqualTo("changedName");
+    assertThat(spanData.getEvents()).hasSize(1);
+  }
+
+  @Test
   public void setStatus() {
     RecordEventsReadableSpan span = createTestSpan(Kind.CONSUMER);
     try {


### PR DESCRIPTION
Fixes #1479: `io.opentelemetry.sdk.trace.SpanWrapper` does not store the value of `hasEnded`, `name` or `endEpochNanos`, so updates to the originial Span would be inadvertedly reflected in the SpanData.

Also adds an unit test to check some other immutability properties of SpanWrapper.