### PR TITLE
Don't add runtime-dependency on javax-annotations.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -219,7 +219,7 @@ configure(opentelemetryProjects) {
         if (JavaVersion.current().isJava9Compatible()) {
             // Workaround for @javax.annotation.Generated
             // see: https://github.com/grpc/grpc-java/issues/3633
-            compile("javax.annotation:javax.annotation-api:1.3.2")
+            compileOnly libraries.javax_annotations
         }
 
         test {


### PR DESCRIPTION
compileOnly seems to be enough.

Also note that `JavaVersion.current()` returns the JVM running gradle. Which should be OK if we have compile-time troubles, but the final pom/runtime dependencies should only depend on the target Java version. That could be retrieved using `JavaVersion.toVersion(it.targetCompatibility)` inside a JavaCompile task configuration, but it seems we don't need that here.

Note that this broke execution on Java 7 when the instrumented app would try to use some annotation that is also delivered in that dependency. E.g. an older Jetty would fail loading a servlet because of `java.lang.UnsupportedClassVersionError` in `javax/annotation/security/RunAs`. We should make sure to (also) use the java11-built library in the Java 7 integration test.