### PR TITLE
Migrate from Truth to AssertJ

### DIFF
--- a/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
+++ b/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -77,16 +77,15 @@ class OpenTelemetryTest {
   @Test
   void testDefault() {
     assertThat(OpenTelemetry.getTracerProvider()).isInstanceOf(DefaultTracerProvider.class);
-    assertThat(OpenTelemetry.getTracerProvider())
-        .isSameInstanceAs(OpenTelemetry.getTracerProvider());
+    assertThat(OpenTelemetry.getTracerProvider()).isSameAs(OpenTelemetry.getTracerProvider());
     assertThat(OpenTelemetry.getMeterProvider()).isInstanceOf(DefaultMeterProvider.class);
-    assertThat(OpenTelemetry.getMeterProvider()).isSameInstanceAs(OpenTelemetry.getMeterProvider());
+    assertThat(OpenTelemetry.getMeterProvider()).isSameAs(OpenTelemetry.getMeterProvider());
     assertThat(OpenTelemetry.getCorrelationContextManager())
         .isInstanceOf(DefaultCorrelationContextManager.class);
     assertThat(OpenTelemetry.getCorrelationContextManager())
-        .isSameInstanceAs(OpenTelemetry.getCorrelationContextManager());
+        .isSameAs(OpenTelemetry.getCorrelationContextManager());
     assertThat(OpenTelemetry.getPropagators()).isInstanceOf(DefaultContextPropagators.class);
-    assertThat(OpenTelemetry.getPropagators()).isSameInstanceAs(OpenTelemetry.getPropagators());
+    assertThat(OpenTelemetry.getPropagators()).isSameAs(OpenTelemetry.getPropagators());
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/common/AttributeValueTest.java
+++ b/api/src/test/java/io/opentelemetry/common/AttributeValueTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.common;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.testing.EqualsTester;
 import org.junit.jupiter.api.Test;

--- a/api/src/test/java/io/opentelemetry/common/AttributesTest.java
+++ b/api/src/test/java/io/opentelemetry/common/AttributesTest.java
@@ -16,12 +16,13 @@
 
 package io.opentelemetry.common;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.common.AttributeValue.arrayAttributeValue;
 import static io.opentelemetry.common.AttributeValue.booleanAttributeValue;
 import static io.opentelemetry.common.AttributeValue.doubleAttributeValue;
 import static io.opentelemetry.common.AttributeValue.longAttributeValue;
 import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -43,7 +44,8 @@ class AttributesTest {
     attributes.forEach(entriesSeen::put);
 
     assertThat(entriesSeen)
-        .containsExactly("key1", stringAttributeValue("value1"), "key2", longAttributeValue(333));
+        .containsExactly(
+            entry("key1", stringAttributeValue("value1")), entry("key2", longAttributeValue(333)));
   }
 
   @Test
@@ -52,7 +54,7 @@ class AttributesTest {
 
     Attributes attributes = Attributes.of("key", stringAttributeValue("value"));
     attributes.forEach(entriesSeen::put);
-    assertThat(entriesSeen).containsExactly("key", stringAttributeValue("value"));
+    assertThat(entriesSeen).containsExactly(entry("key", stringAttributeValue("value")));
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/common/ImmutableKeyValuePairsTest.java
+++ b/api/src/test/java/io/opentelemetry/common/ImmutableKeyValuePairsTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.common;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;

--- a/api/src/test/java/io/opentelemetry/common/LabelsTest.java
+++ b/api/src/test/java/io/opentelemetry/common/LabelsTest.java
@@ -16,7 +16,8 @@
 
 package io.opentelemetry.common;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -36,7 +37,7 @@ class LabelsTest {
 
     labels.forEach(entriesSeen::put);
 
-    assertThat(entriesSeen).containsExactly("key1", "value1", "key2", "value2");
+    assertThat(entriesSeen).containsExactly(entry("key1", "value1"), entry("key2", "value2"));
   }
 
   @Test
@@ -46,7 +47,7 @@ class LabelsTest {
     Labels labels = Labels.of("key", "value");
     labels.forEach(entriesSeen::put);
 
-    assertThat(entriesSeen).containsExactly("key", "value");
+    assertThat(entriesSeen).containsExactly(entry("key", "value"));
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/correlationcontext/CorrelationsContextUtilsTest.java
+++ b/api/src/test/java/io/opentelemetry/correlationcontext/CorrelationsContextUtilsTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.correlationcontext;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.grpc.Context;
 import org.junit.jupiter.api.Test;
@@ -26,7 +26,7 @@ class CorrelationsContextUtilsTest {
   @Test
   void testGetCurrentCorrelationContext_Default() {
     CorrelationContext corrContext = CorrelationsContextUtils.getCurrentCorrelationContext();
-    assertThat(corrContext).isSameInstanceAs(EmptyCorrelationContext.getInstance());
+    assertThat(corrContext).isSameAs(EmptyCorrelationContext.getInstance());
   }
 
   @Test
@@ -36,8 +36,7 @@ class CorrelationsContextUtilsTest {
     Context orig =
         CorrelationsContextUtils.withCorrelationContext(corrContext, Context.current()).attach();
     try {
-      assertThat(CorrelationsContextUtils.getCurrentCorrelationContext())
-          .isSameInstanceAs(corrContext);
+      assertThat(CorrelationsContextUtils.getCurrentCorrelationContext()).isSameAs(corrContext);
     } finally {
       Context.current().detach(orig);
     }
@@ -47,7 +46,7 @@ class CorrelationsContextUtilsTest {
   void testGetCorrelationContext_DefaultContext() {
     CorrelationContext corrContext =
         CorrelationsContextUtils.getCorrelationContext(Context.current());
-    assertThat(corrContext).isSameInstanceAs(EmptyCorrelationContext.getInstance());
+    assertThat(corrContext).isSameAs(EmptyCorrelationContext.getInstance());
   }
 
   @Test
@@ -56,8 +55,7 @@ class CorrelationsContextUtilsTest {
         DefaultCorrelationContextManager.getInstance().contextBuilder().build();
     Context context =
         CorrelationsContextUtils.withCorrelationContext(corrContext, Context.current());
-    assertThat(CorrelationsContextUtils.getCorrelationContext(context))
-        .isSameInstanceAs(corrContext);
+    assertThat(CorrelationsContextUtils.getCorrelationContext(context)).isSameAs(corrContext);
   }
 
   @Test
@@ -73,7 +71,6 @@ class CorrelationsContextUtilsTest {
         DefaultCorrelationContextManager.getInstance().contextBuilder().build();
     Context context =
         CorrelationsContextUtils.withCorrelationContext(corrContext, Context.current());
-    assertThat(CorrelationsContextUtils.getCorrelationContext(context))
-        .isSameInstanceAs(corrContext);
+    assertThat(CorrelationsContextUtils.getCorrelationContext(context)).isSameAs(corrContext);
   }
 }

--- a/api/src/test/java/io/opentelemetry/correlationcontext/DefaultCorrelationContextManagerTest.java
+++ b/api/src/test/java/io/opentelemetry/correlationcontext/DefaultCorrelationContextManagerTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.correlationcontext;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.grpc.Context;
@@ -54,7 +54,7 @@ class DefaultCorrelationContextManagerTest {
   @Test
   void getCurrentContext_DefaultContext() {
     assertThat(defaultCorrelationContextManager.getCurrentContext())
-        .isSameInstanceAs(EmptyCorrelationContext.getInstance());
+        .isSameAs(EmptyCorrelationContext.getInstance());
   }
 
   @Test
@@ -73,42 +73,41 @@ class DefaultCorrelationContextManagerTest {
   @Test
   void withContext() {
     assertThat(defaultCorrelationContextManager.getCurrentContext())
-        .isSameInstanceAs(EmptyCorrelationContext.getInstance());
+        .isSameAs(EmptyCorrelationContext.getInstance());
     try (Scope wtm = defaultCorrelationContextManager.withContext(DIST_CONTEXT)) {
-      assertThat(defaultCorrelationContextManager.getCurrentContext())
-          .isSameInstanceAs(DIST_CONTEXT);
+      assertThat(defaultCorrelationContextManager.getCurrentContext()).isSameAs(DIST_CONTEXT);
     }
     assertThat(defaultCorrelationContextManager.getCurrentContext())
-        .isSameInstanceAs(EmptyCorrelationContext.getInstance());
+        .isSameAs(EmptyCorrelationContext.getInstance());
   }
 
   @Test
   void withContext_nullContext() {
     assertThat(defaultCorrelationContextManager.getCurrentContext())
-        .isSameInstanceAs(EmptyCorrelationContext.getInstance());
+        .isSameAs(EmptyCorrelationContext.getInstance());
     try (Scope wtm = defaultCorrelationContextManager.withContext(null)) {
       assertThat(defaultCorrelationContextManager.getCurrentContext())
-          .isSameInstanceAs(EmptyCorrelationContext.getInstance());
+          .isSameAs(EmptyCorrelationContext.getInstance());
     }
     assertThat(defaultCorrelationContextManager.getCurrentContext())
-        .isSameInstanceAs(EmptyCorrelationContext.getInstance());
+        .isSameAs(EmptyCorrelationContext.getInstance());
   }
 
   @Test
   void withContextUsingWrap() {
     Runnable runnable;
     try (Scope wtm = defaultCorrelationContextManager.withContext(DIST_CONTEXT)) {
-      assertThat(defaultCorrelationContextManager.getCurrentContext())
-          .isSameInstanceAs(DIST_CONTEXT);
+      assertThat(defaultCorrelationContextManager.getCurrentContext()).isSameAs(DIST_CONTEXT);
       runnable =
           Context.current()
               .wrap(
-                  () ->
-                      assertThat(defaultCorrelationContextManager.getCurrentContext())
-                          .isSameInstanceAs(DIST_CONTEXT));
+                  () -> {
+                    assertThat(defaultCorrelationContextManager.getCurrentContext())
+                        .isSameAs(DIST_CONTEXT);
+                  });
     }
     assertThat(defaultCorrelationContextManager.getCurrentContext())
-        .isSameInstanceAs(EmptyCorrelationContext.getInstance());
+        .isSameAs(EmptyCorrelationContext.getInstance());
     // When we run the runnable we will have the CorrelationContext in the current Context.
     runnable.run();
   }

--- a/api/src/test/java/io/opentelemetry/correlationcontext/EntryMetadataTest.java
+++ b/api/src/test/java/io/opentelemetry/correlationcontext/EntryMetadataTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.correlationcontext;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.testing.EqualsTester;
 import io.opentelemetry.correlationcontext.EntryMetadata.EntryTtl;

--- a/api/src/test/java/io/opentelemetry/correlationcontext/EntryTest.java
+++ b/api/src/test/java/io/opentelemetry/correlationcontext/EntryTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.correlationcontext;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.testing.EqualsTester;

--- a/api/src/test/java/io/opentelemetry/internal/StringUtilsTest.java
+++ b/api/src/test/java/io/opentelemetry/internal/StringUtilsTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.internal;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 

--- a/api/src/test/java/io/opentelemetry/internal/TemporaryBuffersTest.java
+++ b/api/src/test/java/io/opentelemetry/internal/TemporaryBuffersTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.internal;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
@@ -26,11 +26,11 @@ class TemporaryBuffersTest {
   void chars() {
     TemporaryBuffers.clearChars();
     char[] buffer10 = TemporaryBuffers.chars(10);
-    assertThat(buffer10).hasLength(10);
+    assertThat(buffer10).hasSize(10);
     char[] buffer8 = TemporaryBuffers.chars(8);
     // Buffer was reused even though smaller.
-    assertThat(buffer8).isSameInstanceAs(buffer10);
+    assertThat(buffer8).isSameAs(buffer10);
     char[] buffer20 = TemporaryBuffers.chars(20);
-    assertThat(buffer20).hasLength(20);
+    assertThat(buffer20).hasSize(20);
   }
 }

--- a/api/src/test/java/io/opentelemetry/metrics/DefaultMeterTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/DefaultMeterTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.OpenTelemetry;
 import org.junit.jupiter.api.Test;
@@ -26,15 +26,13 @@ class DefaultMeterTest {
   void expectDefaultMeter() {
     assertThat(OpenTelemetry.getMeterProvider()).isInstanceOf(DefaultMeterProvider.class);
     assertThat(OpenTelemetry.getMeter("test")).isInstanceOf(DefaultMeter.class);
-    assertThat(OpenTelemetry.getMeter("test")).isSameInstanceAs(DefaultMeter.getInstance());
-    assertThat(OpenTelemetry.getMeter("test", "0.1.0"))
-        .isSameInstanceAs(DefaultMeter.getInstance());
+    assertThat(OpenTelemetry.getMeter("test")).isSameAs(DefaultMeter.getInstance());
+    assertThat(OpenTelemetry.getMeter("test", "0.1.0")).isSameAs(DefaultMeter.getInstance());
   }
 
   @Test
   void expectDefaultMeterProvider() {
-    assertThat(OpenTelemetry.getMeterProvider())
-        .isSameInstanceAs(DefaultMeterProvider.getInstance());
+    assertThat(OpenTelemetry.getMeterProvider()).isSameAs(DefaultMeterProvider.getInstance());
     assertThat(OpenTelemetry.getMeterProvider().get("test")).isInstanceOf(DefaultMeter.class);
     assertThat(OpenTelemetry.getMeterProvider().get("test", "0.1.0"))
         .isInstanceOf(DefaultMeter.class);

--- a/api/src/test/java/io/opentelemetry/trace/BigendianEncodingTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/BigendianEncodingTest.java
@@ -16,10 +16,10 @@
 
 package io.opentelemetry.trace;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.trace.BigendianEncoding.LONG_BASE16;
 import static io.opentelemetry.trace.BigendianEncoding.LONG_BYTES;
 import static java.nio.CharBuffer.wrap;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.CharBuffer;

--- a/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.trace;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;

--- a/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.trace;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.grpc.Context;
@@ -82,7 +82,7 @@ class DefaultTracerTest {
   @Test
   void testSpanContextPropagationExplicitParent() {
     Span span = defaultTracer.spanBuilder(SPAN_NAME).setParent(spanContext).startSpan();
-    assertThat(span.getContext()).isSameInstanceAs(spanContext);
+    assertThat(span.getContext()).isSameAs(spanContext);
   }
 
   @Test
@@ -90,13 +90,13 @@ class DefaultTracerTest {
     DefaultSpan parent = new DefaultSpan(spanContext);
 
     Span span = defaultTracer.spanBuilder(SPAN_NAME).setParent(parent).startSpan();
-    assertThat(span.getContext()).isSameInstanceAs(spanContext);
+    assertThat(span.getContext()).isSameAs(spanContext);
   }
 
   @Test
   void noSpanContextMakesInvalidSpans() {
     Span span = defaultTracer.spanBuilder(SPAN_NAME).startSpan();
-    assertThat(span.getContext()).isSameInstanceAs(SpanContext.getInvalid());
+    assertThat(span.getContext()).isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -111,7 +111,7 @@ class DefaultTracerTest {
     Context context = TracingContextUtils.withSpan(new DefaultSpan(spanContext), Context.current());
 
     Span span = defaultTracer.spanBuilder(SPAN_NAME).setParent(context).startSpan();
-    assertThat(span.getContext()).isSameInstanceAs(spanContext);
+    assertThat(span.getContext()).isSameAs(spanContext);
   }
 
   @Test
@@ -119,7 +119,7 @@ class DefaultTracerTest {
     DefaultSpan parent = new DefaultSpan(spanContext);
     try (Scope scope = defaultTracer.withSpan(parent)) {
       Span span = defaultTracer.spanBuilder(SPAN_NAME).startSpan();
-      assertThat(span.getContext()).isSameInstanceAs(spanContext);
+      assertThat(span.getContext()).isSameAs(spanContext);
     }
   }
 
@@ -129,7 +129,7 @@ class DefaultTracerTest {
         TracingContextUtils.withSpan(DefaultSpan.create(spanContext), Context.current());
     try (Scope scope = ContextUtils.withScopedContext(context)) {
       Span span = defaultTracer.spanBuilder(SPAN_NAME).startSpan();
-      assertThat(span.getContext()).isSameInstanceAs(spanContext);
+      assertThat(span.getContext()).isSameAs(spanContext);
     }
   }
 }

--- a/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.trace;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.common.AttributeValue;

--- a/api/src/test/java/io/opentelemetry/trace/SpanContextTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanContextTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.trace;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 

--- a/api/src/test/java/io/opentelemetry/trace/SpanIdTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanIdTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.trace;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.testing.EqualsTester;
 import java.nio.ByteBuffer;

--- a/api/src/test/java/io/opentelemetry/trace/StatusTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/StatusTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.trace;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.testing.EqualsTester;
 import org.junit.jupiter.api.Test;

--- a/api/src/test/java/io/opentelemetry/trace/TraceFlagsTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TraceFlagsTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.trace;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.testing.EqualsTester;
 import org.junit.jupiter.api.Test;
@@ -29,14 +29,14 @@ class TraceFlagsTest {
 
   @Test
   void getByte() {
-    assertThat(TraceFlags.getDefault().getByte()).isEqualTo(0);
-    assertThat(TraceFlags.builder().setIsSampled(false).build().getByte()).isEqualTo(0);
-    assertThat(TraceFlags.builder().setIsSampled(true).build().getByte()).isEqualTo(1);
+    assertThat(TraceFlags.getDefault().getByte()).isZero();
+    assertThat(TraceFlags.builder().setIsSampled(false).build().getByte()).isZero();
+    assertThat(TraceFlags.builder().setIsSampled(true).build().getByte()).isOne();
     assertThat(TraceFlags.builder().setIsSampled(true).setIsSampled(false).build().getByte())
-        .isEqualTo(0);
-    assertThat(TraceFlags.fromByte(FIRST_BYTE).getByte()).isEqualTo(-1);
-    assertThat(TraceFlags.fromByte(SECOND_BYTE).getByte()).isEqualTo(1);
-    assertThat(TraceFlags.fromByte(THIRD_BYTE).getByte()).isEqualTo(6);
+        .isZero();
+    assertThat(TraceFlags.fromByte(FIRST_BYTE).getByte()).isEqualTo((byte) -1);
+    assertThat(TraceFlags.fromByte(SECOND_BYTE).getByte()).isOne();
+    assertThat(TraceFlags.fromByte(THIRD_BYTE).getByte()).isEqualTo((byte) 6);
   }
 
   @Test
@@ -66,7 +66,7 @@ class TraceFlagsTest {
                 .setIsSampled(true)
                 .build()
                 .getByte())
-        .isEqualTo(6 | 1);
+        .isEqualTo((byte) (6 | 1));
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/trace/TraceIdTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TraceIdTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.trace;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.testing.EqualsTester;
 import java.nio.ByteBuffer;

--- a/api/src/test/java/io/opentelemetry/trace/TraceStateTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TraceStateTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.trace;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.testing.EqualsTester;
@@ -52,7 +52,7 @@ class TraceStateTest {
     assertThat(secondTraceState.getEntries())
         .containsExactly(TraceState.Entry.create(SECOND_KEY, SECOND_VALUE));
     assertThat(multiValueTraceState.getEntries())
-        .containsExactly(
+        .containsExactlyInAnyOrder(
             TraceState.Entry.create(FIRST_KEY, FIRST_VALUE),
             TraceState.Entry.create(SECOND_KEY, SECOND_VALUE));
   }
@@ -193,7 +193,7 @@ class TraceStateTest {
                 .set(SECOND_KEY, FIRST_VALUE) // add a new entry
                 .build()
                 .getEntries())
-        .containsExactly(
+        .containsExactlyInAnyOrder(
             TraceState.Entry.create(FIRST_KEY, SECOND_VALUE),
             TraceState.Entry.create(SECOND_KEY, FIRST_VALUE));
   }

--- a/api/src/test/java/io/opentelemetry/trace/TraceStateTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TraceStateTest.java
@@ -194,9 +194,9 @@ class TraceStateTest {
                 .set(SECOND_KEY, FIRST_VALUE) // add a new entry
                 .build()
                 .getEntries())
-        .containsExactlyInAnyOrder(
-            TraceState.Entry.create(FIRST_KEY, SECOND_VALUE),
-            TraceState.Entry.create(SECOND_KEY, FIRST_VALUE));
+        .containsExactly(
+            TraceState.Entry.create(SECOND_KEY, FIRST_VALUE),
+            TraceState.Entry.create(FIRST_KEY, SECOND_VALUE));
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/trace/TraceStateTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TraceStateTest.java
@@ -51,10 +51,11 @@ class TraceStateTest {
         .containsExactly(TraceState.Entry.create(FIRST_KEY, FIRST_VALUE));
     assertThat(secondTraceState.getEntries())
         .containsExactly(TraceState.Entry.create(SECOND_KEY, SECOND_VALUE));
+    // Reverse order of input.
     assertThat(multiValueTraceState.getEntries())
-        .containsExactlyInAnyOrder(
-            TraceState.Entry.create(FIRST_KEY, FIRST_VALUE),
-            TraceState.Entry.create(SECOND_KEY, SECOND_VALUE));
+        .containsExactly(
+            TraceState.Entry.create(SECOND_KEY, SECOND_VALUE),
+            TraceState.Entry.create(FIRST_KEY, FIRST_VALUE));
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/trace/TracingContextUtilsTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TracingContextUtilsTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.trace;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.grpc.Context;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ public final class TracingContextUtilsTest {
   @Test
   void testGetCurrentSpan_Default() {
     Span span = TracingContextUtils.getCurrentSpan();
-    assertThat(span).isSameInstanceAs(DefaultSpan.getInvalid());
+    assertThat(span).isSameAs(DefaultSpan.getInvalid());
   }
 
   @Test
@@ -35,7 +35,7 @@ public final class TracingContextUtilsTest {
     Span span = DefaultSpan.create(SpanContext.getInvalid());
     Context orig = TracingContextUtils.withSpan(span, Context.current()).attach();
     try {
-      assertThat(TracingContextUtils.getCurrentSpan()).isSameInstanceAs(span);
+      assertThat(TracingContextUtils.getCurrentSpan()).isSameAs(span);
     } finally {
       Context.current().detach(orig);
     }
@@ -44,14 +44,14 @@ public final class TracingContextUtilsTest {
   @Test
   void testGetSpan_DefaultContext() {
     Span span = TracingContextUtils.getSpan(Context.current());
-    assertThat(span).isSameInstanceAs(DefaultSpan.getInvalid());
+    assertThat(span).isSameAs(DefaultSpan.getInvalid());
   }
 
   @Test
   void testGetSpan_ExplicitContext() {
     Span span = DefaultSpan.create(SpanContext.getInvalid());
     Context context = TracingContextUtils.withSpan(span, Context.current());
-    assertThat(TracingContextUtils.getSpan(context)).isSameInstanceAs(span);
+    assertThat(TracingContextUtils.getSpan(context)).isSameAs(span);
   }
 
   @Test
@@ -64,6 +64,6 @@ public final class TracingContextUtilsTest {
   void testGetSpanWithoutDefault_ExplicitContext() {
     Span span = DefaultSpan.create(SpanContext.getInvalid());
     Context context = TracingContextUtils.withSpan(span, Context.current());
-    assertThat(TracingContextUtils.getSpanWithoutDefault(context)).isSameInstanceAs(span);
+    assertThat(TracingContextUtils.getSpanWithoutDefault(context)).isSameAs(span);
   }
 }

--- a/api/src/test/java/io/opentelemetry/trace/attributes/BooleanAttributeSetterTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/attributes/BooleanAttributeSetterTest.java
@@ -16,8 +16,8 @@
 
 package io.opentelemetry.trace.attributes;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.common.AttributeValue.booleanAttributeValue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.Attributes;
 import org.junit.jupiter.api.Test;

--- a/api/src/test/java/io/opentelemetry/trace/attributes/DoubleAttributeSetterTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/attributes/DoubleAttributeSetterTest.java
@@ -16,8 +16,8 @@
 
 package io.opentelemetry.trace.attributes;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.common.AttributeValue.doubleAttributeValue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.Attributes;
 import org.junit.jupiter.api.Test;

--- a/api/src/test/java/io/opentelemetry/trace/attributes/LongAttributeSetterTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/attributes/LongAttributeSetterTest.java
@@ -16,8 +16,8 @@
 
 package io.opentelemetry.trace.attributes;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.common.AttributeValue.longAttributeValue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.Attributes;
 import org.junit.jupiter.api.Test;

--- a/api/src/test/java/io/opentelemetry/trace/attributes/SemanticAttributesTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/attributes/SemanticAttributesTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.trace.attributes;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.trace.Span;
 import java.lang.reflect.Field;

--- a/api/src/test/java/io/opentelemetry/trace/attributes/StringAttributeSetterTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/attributes/StringAttributeSetterTest.java
@@ -16,8 +16,8 @@
 
 package io.opentelemetry.trace.attributes;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.Attributes;
 import org.junit.jupiter.api.Test;

--- a/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
@@ -16,9 +16,10 @@
 
 package io.opentelemetry.trace.propagation;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.trace.propagation.HttpTraceContext.TRACE_PARENT;
 import static io.opentelemetry.trace.propagation.HttpTraceContext.TRACE_STATE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import io.grpc.Context;
 import io.opentelemetry.context.propagation.HttpTextFormat.Getter;
@@ -87,7 +88,7 @@ class HttpTraceContextTest {
         context,
         null,
         (Setter<Map<String, String>>) (ignored, key, value) -> carrier.put(key, value));
-    assertThat(carrier).containsExactly(TRACE_PARENT, TRACEPARENT_HEADER_SAMPLED);
+    assertThat(carrier).containsExactly(entry(TRACE_PARENT, TRACEPARENT_HEADER_SAMPLED));
   }
 
   @Test
@@ -114,7 +115,7 @@ class HttpTraceContextTest {
             SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
             Context.current());
     httpTraceContext.inject(context, carrier, setter);
-    assertThat(carrier).containsExactly(TRACE_PARENT, TRACEPARENT_HEADER_SAMPLED);
+    assertThat(carrier).containsExactly(entry(TRACE_PARENT, TRACEPARENT_HEADER_SAMPLED));
   }
 
   @Test
@@ -125,7 +126,7 @@ class HttpTraceContextTest {
             SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT),
             Context.current());
     httpTraceContext.inject(context, carrier, setter);
-    assertThat(carrier).containsExactly(TRACE_PARENT, TRACEPARENT_HEADER_NOT_SAMPLED);
+    assertThat(carrier).containsExactly(entry(TRACE_PARENT, TRACEPARENT_HEADER_NOT_SAMPLED));
   }
 
   @Test
@@ -138,7 +139,8 @@ class HttpTraceContextTest {
     httpTraceContext.inject(context, carrier, setter);
     assertThat(carrier)
         .containsExactly(
-            TRACE_PARENT, TRACEPARENT_HEADER_SAMPLED, TRACE_STATE, TRACESTATE_NOT_DEFAULT_ENCODING);
+            entry(TRACE_PARENT, TRACEPARENT_HEADER_SAMPLED),
+            entry(TRACE_STATE, TRACESTATE_NOT_DEFAULT_ENCODING));
   }
 
   @Test
@@ -151,10 +153,8 @@ class HttpTraceContextTest {
     httpTraceContext.inject(context, carrier, setter);
     assertThat(carrier)
         .containsExactly(
-            TRACE_PARENT,
-            TRACEPARENT_HEADER_NOT_SAMPLED,
-            TRACE_STATE,
-            TRACESTATE_NOT_DEFAULT_ENCODING);
+            entry(TRACE_PARENT, TRACEPARENT_HEADER_NOT_SAMPLED),
+            entry(TRACE_STATE, TRACESTATE_NOT_DEFAULT_ENCODING));
   }
 
   @Test
@@ -163,7 +163,7 @@ class HttpTraceContextTest {
     assertThat(
             httpTraceContext.extract(
                 Context.current(), Collections.<String, String>emptyMap(), Map::get))
-        .isSameInstanceAs(Context.current());
+        .isSameAs(Context.current());
   }
 
   @Test
@@ -245,7 +245,7 @@ class HttpTraceContextTest {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(TRACE_PARENT, "");
     assertThat(getSpanContext(httpTraceContext.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -254,7 +254,7 @@ class HttpTraceContextTest {
     invalidHeaders.put(
         TRACE_PARENT, "00-" + "abcdefghijklmnopabcdefghijklmnop" + "-" + SPAN_ID_BASE16 + "-01");
     assertThat(getSpanContext(httpTraceContext.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -262,7 +262,7 @@ class HttpTraceContextTest {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(TRACE_PARENT, "00-" + TRACE_ID_BASE16 + "00-" + SPAN_ID_BASE16 + "-01");
     assertThat(getSpanContext(httpTraceContext.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -270,7 +270,7 @@ class HttpTraceContextTest {
     Map<String, String> invalidHeaders = new HashMap<>();
     invalidHeaders.put(TRACE_PARENT, "00-" + TRACE_ID_BASE16 + "-" + "abcdefghijklmnop" + "-01");
     assertThat(getSpanContext(httpTraceContext.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -278,7 +278,7 @@ class HttpTraceContextTest {
     Map<String, String> invalidHeaders = new HashMap<>();
     invalidHeaders.put(TRACE_PARENT, "00-" + TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "00-01");
     assertThat(getSpanContext(httpTraceContext.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -286,7 +286,7 @@ class HttpTraceContextTest {
     Map<String, String> invalidHeaders = new HashMap<>();
     invalidHeaders.put(TRACE_PARENT, "00-" + TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-gh");
     assertThat(getSpanContext(httpTraceContext.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -294,7 +294,7 @@ class HttpTraceContextTest {
     Map<String, String> invalidHeaders = new HashMap<>();
     invalidHeaders.put(TRACE_PARENT, "00-" + TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-0100");
     assertThat(getSpanContext(httpTraceContext.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -345,6 +345,6 @@ class HttpTraceContextTest {
   void extract_emptyCarrier() {
     Map<String, String> emptyHeaders = new HashMap<>();
     assertThat(getSpanContext(httpTraceContext.extract(Context.current(), emptyHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -156,6 +156,7 @@ configure(opentelemetryProjects) {
                 opentracing             : "io.opentracing:opentracing-api:${opentracingVersion}",
 
                 // Test dependencies.
+                assertj                 : "org.assertj:assertj-core:3.16.1",
                 guava_testlib           : "com.google.guava:guava-testlib",
                 junit                   : 'junit:junit:4.12',
                 junit_pioneer           : 'org.junit-pioneer:junit-pioneer:0.7.0',
@@ -164,7 +165,6 @@ configure(opentelemetryProjects) {
                 junit_vintage_engine    : 'org.junit.vintage:junit-vintage-engine',
                 mockito                 : "org.mockito:mockito-core:${mockitoVersion}",
                 mockito_junit_jupiter   : "org.mockito:mockito-junit-jupiter:${mockitoVersion}",
-                truth                   : 'com.google.truth:truth:1.0.1',
                 system_rules            : 'com.github.stefanbirkner:system-rules:1.19.0', // env and system properties
                 slf4jsimple             : 'org.slf4j:slf4j-simple:1.7.25', // Compatibility layer
                 awaitility              : 'org.awaitility:awaitility:3.0.0', // Compatibility layer
@@ -216,7 +216,7 @@ configure(opentelemetryProjects) {
         testImplementation libraries.junit_jupiter_api,
                 libraries.mockito,
                 libraries.mockito_junit_jupiter,
-                libraries.truth,
+                libraries.assertj,
                 libraries.guava_testlib
 
         testRuntimeOnly libraries.junit_jupiter_engine,

--- a/context_prop/src/test/java/io/opentelemetry/context/ContextUtilsTest.java
+++ b/context_prop/src/test/java/io/opentelemetry/context/ContextUtilsTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.context;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.grpc.Context;

--- a/context_prop/src/test/java/io/opentelemetry/context/propagation/DefaultPropagatorsTest.java
+++ b/context_prop/src/test/java/io/opentelemetry/context/propagation/DefaultPropagatorsTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.context.propagation;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.grpc.Context;
@@ -89,7 +89,7 @@ class DefaultPropagatorsTest {
     assertThat(map).isEmpty();
 
     assertThat(propagators.getHttpTextFormat().extract(context, map, MapGetter.INSTANCE))
-        .isSameInstanceAs(context);
+        .isSameAs(context);
   }
 
   private static class CustomHttpTextFormat implements HttpTextFormat {

--- a/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemoryMetricExporterTest.java
+++ b/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemoryMetricExporterTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.exporters.inmemory;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;

--- a/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
+++ b/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.exporters.inmemory;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;

--- a/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemoryTracingTest.java
+++ b/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemoryTracingTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.exporters.inmemory;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.sdk.trace.Samplers;
@@ -36,7 +36,7 @@ class InMemoryTracingTest {
 
   @Test
   void defaultInstance() {
-    assertThat(tracing.getTracerProvider()).isSameInstanceAs(tracerSdkProvider);
+    assertThat(tracing.getTracerProvider()).isSameAs(tracerSdkProvider);
     assertThat(tracing.getSpanExporter().getFinishedSpanItems()).hasSize(0);
   }
 

--- a/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingMetricExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingMetricExporterTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.exporters.logging;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;

--- a/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingSpanExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingSpanExporterTest.java
@@ -16,8 +16,8 @@
 
 package io.opentelemetry.exporters.logging;
 
-import static com.google.common.truth.Truth.assertThat;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.common.AttributeValue;

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/CommonAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/CommonAdapterTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.exporters.otlp;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.proto.common.v1.AnyValue;

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/MetricAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/MetricAdapterTest.java
@@ -16,8 +16,8 @@
 
 package io.opentelemetry.exporters.otlp;
 
-import static com.google.common.truth.Truth.assertThat;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.common.AttributeValue;
@@ -429,7 +429,7 @@ class MetricAdapterTest {
                         Resource.getEmpty(),
                         InstrumentationLibraryInfo.getEmpty(),
                         Collections.emptyList()))))
-        .containsExactly(
+        .containsExactlyInAnyOrder(
             ResourceMetrics.newBuilder()
                 .setResource(resourceProto)
                 .addAllInstrumentationLibraryMetrics(

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcMetricExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcMetricExporterTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.exporters.otlp;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.grpc.ManagedChannel;
 import io.grpc.Status;

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.exporters.otlp;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.grpc.ManagedChannel;
 import io.grpc.Status.Code;

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/ResourceAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/ResourceAdapterTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.exporters.otlp;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
@@ -42,7 +42,7 @@ class ResourceAdapterTest {
                             "key_double",
                             AttributeValue.doubleAttributeValue(100.3))))
                 .getAttributesList())
-        .containsExactly(
+        .containsExactlyInAnyOrder(
             KeyValue.newBuilder()
                 .setKey("key_bool")
                 .setValue(AnyValue.newBuilder().setBoolValue(true).build())

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.exporters.otlp;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.ByteString;
 import io.opentelemetry.common.AttributeValue;

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporters/prometheus/MetricAdapterTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporters/prometheus/MetricAdapterTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.exporters.prometheus;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.common.AttributeValue;

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporters/prometheus/PrometheusCollectorTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporters/prometheus/PrometheusCollectorTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.exporters.prometheus;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.exporters.zipkin;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.common.Attributes;

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterTest.java
@@ -16,8 +16,8 @@
 
 package io.opentelemetry.exporters.zipkin;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/extensions/logging/log4j2_extensions/src/test/java/io/opentelemetry/contrib/logging/log4j2/OpenTelemetryJsonLayoutTest.java
+++ b/extensions/logging/log4j2_extensions/src/test/java/io/opentelemetry/contrib/logging/log4j2/OpenTelemetryJsonLayoutTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.contrib.logging.log4j2;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.gson.Gson;
 import io.opentelemetry.OpenTelemetry;
@@ -58,9 +58,9 @@ public class OpenTelemetryJsonLayoutTest {
     assertThat(data.get("name")).isEqualTo("DefaultJsonLogger");
     Map<?, ?> time = (Map<?, ?>) data.get("timestamp");
     double eventTime = (Double) time.get("millis");
-    assertThat(eventTime - logTime).isAtMost(100);
+    assertThat(eventTime - logTime).isLessThanOrEqualTo(100);
     assertThat(data.get("severitytext")).isEqualTo("WARN");
-    assertThat(data.get("severitynumber")).isEqualTo(13);
+    assertThat(data.get("severitynumber")).isEqualTo(13.0);
 
     assertThat(data.get("traceid")).isNull();
 

--- a/extensions/logging/log4j2_extensions/src/test/java/io/opentelemetry/contrib/logging/log4j2/TraceContextDataProviderTest.java
+++ b/extensions/logging/log4j2_extensions/src/test/java/io/opentelemetry/contrib/logging/log4j2/TraceContextDataProviderTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.contrib.logging.log4j2;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.gson.Gson;
 import io.opentelemetry.OpenTelemetry;
@@ -88,7 +88,8 @@ public class TraceContextDataProviderTest {
     String withTrace = events.get(0);
 
     Gson gson = new Gson();
-    Map<?, ?> parsed = gson.fromJson(withTrace, Map.class);
+    @SuppressWarnings("unchecked")
+    Map<String, String> parsed = (Map<String, String>) gson.fromJson(withTrace, Map.class);
     assertThat(parsed).containsEntry("traceid", traceId);
     assertThat(parsed).containsEntry("spanid", spanId);
     assertThat(parsed).containsEntry("traceflags", "01");

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagatorTest.java
@@ -16,8 +16,8 @@
 
 package io.opentelemetry.extensions.trace.propagation;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.extensions.trace.propagation.AwsXRayPropagator.TRACE_HEADER_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.grpc.Context;
 import io.opentelemetry.context.propagation.HttpTextFormat;
@@ -115,7 +115,7 @@ class AwsXRayPropagatorTest {
     assertThat(
             xrayPropagator.extract(
                 Context.current(), Collections.<String, String>emptyMap(), Map::get))
-        .isSameInstanceAs(Context.current());
+        .isSameAs(Context.current());
   }
 
   @Test
@@ -177,7 +177,7 @@ class AwsXRayPropagatorTest {
     invalidHeaders.put(TRACE_HEADER_KEY, "");
 
     assertThat(getSpanContext(xrayPropagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -188,7 +188,7 @@ class AwsXRayPropagatorTest {
         "Root=abcdefghijklmnopabcdefghijklmnop;Parent=53995c3f42cd8ad8;Sampled=0");
 
     assertThat(getSpanContext(xrayPropagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -199,7 +199,7 @@ class AwsXRayPropagatorTest {
         "Root=1-8a3c60f7-d188f8fa79d48a391a778fa600;Parent=53995c3f42cd8ad8;Sampled=0");
 
     assertThat(getSpanContext(xrayPropagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -210,7 +210,7 @@ class AwsXRayPropagatorTest {
         "Root=1-8a3c60f7-d188f8fa79d48a391a778fa6;Parent=abcdefghijklmnop;Sampled=0");
 
     assertThat(getSpanContext(xrayPropagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -221,7 +221,7 @@ class AwsXRayPropagatorTest {
         "Root=1-8a3c60f7-d188f8fa79d48a391a778fa6;Parent=53995c3f42cd8ad800;Sampled=0");
 
     assertThat(getSpanContext(xrayPropagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -232,7 +232,7 @@ class AwsXRayPropagatorTest {
         "Root=1-8a3c60f7-d188f8fa79d48a391a778fa6;Parent=53995c3f42cd8ad8;Sampled=");
 
     assertThat(getSpanContext(xrayPropagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -243,7 +243,7 @@ class AwsXRayPropagatorTest {
         "Root=1-8a3c60f7-d188f8fa79d48a391a778fa6;Parent=53995c3f42cd8ad8;Sampled=10220");
 
     assertThat(getSpanContext(xrayPropagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -254,7 +254,7 @@ class AwsXRayPropagatorTest {
         "Root=1-8a3c60f7-d188f8fa79d48a391a778fa6;Parent=53995c3f42cd8ad8;Sampled=a");
 
     assertThat(getSpanContext(xrayPropagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.extensions.trace.propagation;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.grpc.Context;
 import io.opentelemetry.context.propagation.HttpTextFormat.Getter;
@@ -135,7 +135,7 @@ class B3PropagatorTest {
     assertThat(
             b3Propagator.extract(
                 Context.current(), Collections.<String, String>emptyMap(), Map::get))
-        .isSameInstanceAs(Context.current());
+        .isSameAs(Context.current());
   }
 
   @Test
@@ -223,7 +223,7 @@ class B3PropagatorTest {
     invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
     invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -233,7 +233,7 @@ class B3PropagatorTest {
     invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
     invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -243,7 +243,7 @@ class B3PropagatorTest {
     invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
     invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -253,7 +253,7 @@ class B3PropagatorTest {
     invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
     invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -263,7 +263,7 @@ class B3PropagatorTest {
     invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, "g" + SPAN_ID_BASE16.substring(1));
     invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -273,7 +273,7 @@ class B3PropagatorTest {
     invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16.substring(2));
     invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -283,7 +283,7 @@ class B3PropagatorTest {
     invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_BASE16 + "00");
     invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -293,7 +293,7 @@ class B3PropagatorTest {
     invalidHeaders.put(B3Propagator.SPAN_ID_HEADER, SPAN_ID_ALL_ZERO);
     invalidHeaders.put(B3Propagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -348,7 +348,7 @@ class B3PropagatorTest {
     assertThat(
             b3PropagatorSingleHeader.extract(
                 Context.current(), Collections.<String, String>emptyMap(), Map::get))
-        .isSameInstanceAs(Context.current());
+        .isSameAs(Context.current());
   }
 
   @Test
@@ -487,7 +487,7 @@ class B3PropagatorTest {
     assertThat(
             getSpanContext(
                 b3PropagatorSingleHeader.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -498,7 +498,7 @@ class B3PropagatorTest {
     assertThat(
             getSpanContext(
                 b3PropagatorSingleHeader.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -511,7 +511,7 @@ class B3PropagatorTest {
     assertThat(
             getSpanContext(
                 b3PropagatorSingleHeader.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -524,7 +524,7 @@ class B3PropagatorTest {
     assertThat(
             getSpanContext(
                 b3PropagatorSingleHeader.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -537,7 +537,7 @@ class B3PropagatorTest {
     assertThat(
             getSpanContext(
                 b3PropagatorSingleHeader.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -548,7 +548,7 @@ class B3PropagatorTest {
         TRACE_ID_BASE16 + "-" + "abcdefghijklmnop" + "00" + "-" + Common.TRUE_INT);
 
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -557,7 +557,7 @@ class B3PropagatorTest {
     invalidHeaders.put(B3Propagator.COMBINED_HEADER, TRACE_ID_BASE16);
 
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -568,7 +568,7 @@ class B3PropagatorTest {
         TRACE_ID_BASE16 + "-" + SPAN_ID_BASE16 + "-" + Common.TRUE_INT + "-extra");
 
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagatorTest.java
@@ -16,10 +16,10 @@
 
 package io.opentelemetry.extensions.trace.propagation;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.extensions.trace.propagation.JaegerPropagator.DEPRECATED_PARENT_SPAN;
 import static io.opentelemetry.extensions.trace.propagation.JaegerPropagator.PROPAGATION_HEADER;
 import static io.opentelemetry.extensions.trace.propagation.JaegerPropagator.PROPAGATION_HEADER_DELIMITER;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.grpc.Context;
 import io.jaegertracing.internal.JaegerSpanContext;
@@ -152,7 +152,7 @@ class JaegerPropagatorTest {
     assertThat(
             jaegerPropagator.extract(
                 Context.current(), Collections.<String, String>emptyMap(), Map::get))
-        .isSameInstanceAs(Context.current());
+        .isSameAs(Context.current());
   }
 
   @Test
@@ -161,7 +161,7 @@ class JaegerPropagatorTest {
     invalidHeaders.put(PROPAGATION_HEADER, "");
 
     assertThat(getSpanContext(jaegerPropagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -170,7 +170,7 @@ class JaegerPropagatorTest {
     invalidHeaders.put(PROPAGATION_HEADER, "aa:bb:cc");
 
     assertThat(getSpanContext(jaegerPropagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -179,7 +179,7 @@ class JaegerPropagatorTest {
     invalidHeaders.put(PROPAGATION_HEADER, "aa:bb:cc:dd:ee");
 
     assertThat(getSpanContext(jaegerPropagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -191,7 +191,7 @@ class JaegerPropagatorTest {
             "abcdefghijklmnopabcdefghijklmnop", SPAN_ID_BASE16, DEPRECATED_PARENT_SPAN, "0"));
 
     assertThat(getSpanContext(jaegerPropagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -203,7 +203,7 @@ class JaegerPropagatorTest {
             TRACE_ID_BASE16 + "00", SPAN_ID_BASE16, DEPRECATED_PARENT_SPAN, "0"));
 
     assertThat(getSpanContext(jaegerPropagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -215,7 +215,7 @@ class JaegerPropagatorTest {
             TRACE_ID_BASE16, "abcdefghijklmnop", DEPRECATED_PARENT_SPAN, "0"));
 
     assertThat(getSpanContext(jaegerPropagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -227,7 +227,7 @@ class JaegerPropagatorTest {
             TRACE_ID_BASE16, SPAN_ID_BASE16 + "00", DEPRECATED_PARENT_SPAN, "0"));
 
     assertThat(getSpanContext(jaegerPropagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -238,7 +238,7 @@ class JaegerPropagatorTest {
         generateTraceIdHeaderValue(TRACE_ID_BASE16, SPAN_ID_BASE16, DEPRECATED_PARENT_SPAN, ""));
 
     assertThat(getSpanContext(jaegerPropagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -250,7 +250,7 @@ class JaegerPropagatorTest {
             TRACE_ID_BASE16, SPAN_ID_BASE16, DEPRECATED_PARENT_SPAN, "10220"));
 
     assertThat(getSpanContext(jaegerPropagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -262,7 +262,7 @@ class JaegerPropagatorTest {
             TRACE_ID_BASE16, SPAN_ID_BASE16, DEPRECATED_PARENT_SPAN, "abcdefr"));
 
     assertThat(getSpanContext(jaegerPropagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagatorTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.extensions.trace.propagation;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.grpc.Context;
 import io.opentelemetry.context.propagation.HttpTextFormat.Getter;
@@ -122,7 +122,7 @@ class OtTracerPropagatorTest {
     // Context remains untouched.
     assertThat(
             propagator.extract(Context.current(), Collections.<String, String>emptyMap(), Map::get))
-        .isSameInstanceAs(Context.current());
+        .isSameAs(Context.current());
   }
 
   @Test
@@ -210,7 +210,7 @@ class OtTracerPropagatorTest {
     invalidHeaders.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
     invalidHeaders.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(propagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -220,7 +220,7 @@ class OtTracerPropagatorTest {
     invalidHeaders.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID_BASE16);
     invalidHeaders.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(propagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -230,7 +230,7 @@ class OtTracerPropagatorTest {
     invalidHeaders.put(OtTracerPropagator.SPAN_ID_HEADER, "abcdefghijklmnop");
     invalidHeaders.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(propagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -240,7 +240,7 @@ class OtTracerPropagatorTest {
     invalidHeaders.put(OtTracerPropagator.SPAN_ID_HEADER, "abcdefghijklmnop" + "00");
     invalidHeaders.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(propagator.extract(Context.current(), invalidHeaders, getter)))
-        .isSameInstanceAs(SpanContext.getInvalid());
+        .isSameAs(SpanContext.getInvalid());
   }
 
   @Test

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/StringUtilsTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/StringUtilsTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.extensions.trace.propagation;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagatorTest.java
@@ -16,9 +16,9 @@
 
 package io.opentelemetry.extensions.trace.propagation;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.trace.TracingContextUtils.getSpan;
 import static io.opentelemetry.trace.TracingContextUtils.withSpan;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -128,7 +128,7 @@ class TraceMultiPropagatorTest {
 
     Context context = Context.current();
     Context resContext = prop.extract(context, carrier, Map::get);
-    assertThat(context).isSameInstanceAs(resContext);
+    assertThat(context).isSameAs(resContext);
   }
 
   @Test

--- a/extensions/trace_utils/src/test/java/io/opentelemetry/extensions/trace/CurrentSpanUtilsTest.java
+++ b/extensions/trace_utils/src/test/java/io/opentelemetry/extensions/trace/CurrentSpanUtilsTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.extensions.trace;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -69,7 +69,7 @@ class CurrentSpanUtilsTest {
     Runnable runnable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
-          assertThat(getCurrentSpan()).isSameInstanceAs(span);
+          assertThat(getCurrentSpan()).isSameAs(span);
         };
     CurrentSpanUtils.withSpan(span, false, runnable).run();
     verifyNoInteractions(span);
@@ -82,7 +82,7 @@ class CurrentSpanUtilsTest {
     Runnable runnable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
-          assertThat(getCurrentSpan()).isSameInstanceAs(span);
+          assertThat(getCurrentSpan()).isSameAs(span);
         };
     CurrentSpanUtils.withSpan(span, true, runnable).run();
     verify(span).end();
@@ -96,7 +96,7 @@ class CurrentSpanUtilsTest {
     Runnable runnable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
-          assertThat(getCurrentSpan()).isSameInstanceAs(span);
+          assertThat(getCurrentSpan()).isSameAs(span);
           throw error;
         };
     executeRunnableAndExpectError(runnable, error);
@@ -112,7 +112,7 @@ class CurrentSpanUtilsTest {
     Runnable runnable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
-          assertThat(getCurrentSpan()).isSameInstanceAs(span);
+          assertThat(getCurrentSpan()).isSameAs(span);
           throw error;
         };
     executeRunnableAndExpectError(runnable, error);
@@ -128,7 +128,7 @@ class CurrentSpanUtilsTest {
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
-          assertThat(getCurrentSpan()).isSameInstanceAs(span);
+          assertThat(getCurrentSpan()).isSameAs(span);
           return ret;
         };
     assertThat(CurrentSpanUtils.withSpan(span, false, callable).call()).isEqualTo(ret);
@@ -143,7 +143,7 @@ class CurrentSpanUtilsTest {
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
-          assertThat(getCurrentSpan()).isSameInstanceAs(span);
+          assertThat(getCurrentSpan()).isSameAs(span);
           return ret;
         };
     assertThat(CurrentSpanUtils.withSpan(span, true, callable).call()).isEqualTo(ret);
@@ -158,7 +158,7 @@ class CurrentSpanUtilsTest {
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
-          assertThat(getCurrentSpan()).isSameInstanceAs(span);
+          assertThat(getCurrentSpan()).isSameAs(span);
           throw exception;
         };
     executeCallableAndExpectError(callable, exception);
@@ -174,7 +174,7 @@ class CurrentSpanUtilsTest {
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
-          assertThat(getCurrentSpan()).isSameInstanceAs(span);
+          assertThat(getCurrentSpan()).isSameAs(span);
           throw exception;
         };
     executeCallableAndExpectError(callable, exception);
@@ -190,7 +190,7 @@ class CurrentSpanUtilsTest {
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
-          assertThat(getCurrentSpan()).isSameInstanceAs(span);
+          assertThat(getCurrentSpan()).isSameAs(span);
           throw error;
         };
     executeCallableAndExpectError(callable, error);
@@ -206,7 +206,7 @@ class CurrentSpanUtilsTest {
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
-          assertThat(getCurrentSpan()).isSameInstanceAs(span);
+          assertThat(getCurrentSpan()).isSameAs(span);
           throw error;
         };
     executeCallableAndExpectError(callable, error);

--- a/opentracing_shim/build.gradle
+++ b/opentracing_shim/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testImplementation project(':opentelemetry-sdk'),
             project(':opentelemetry-exporters-inmemory'),
             libraries.junit,
-            libraries.truth,
+            libraries.assertj,
             libraries.slf4jsimple,
             libraries.awaitility
 }

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/actorpropagation/ActorPropagationTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/actorpropagation/ActorPropagationTest.java
@@ -16,9 +16,9 @@
 
 package io.opentelemetry.opentracingshim.testbed.actorpropagation;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.getByKind;
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.getOneByKind;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
 import io.opentelemetry.opentracingshim.TraceShim;

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/promisepropagation/PromisePropagationTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/promisepropagation/PromisePropagationTest.java
@@ -16,8 +16,8 @@
 
 package io.opentelemetry.opentracingshim.testbed.promisepropagation;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.getByAttr;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
 import io.opentelemetry.opentracingshim.TraceShim;
@@ -101,7 +101,7 @@ class PromisePropagationTest {
       phaser.arriveAndAwaitAdvance(); // wait for results to be set
       assertThat(successResult1.get()).isEqualTo("success!");
       assertThat(successResult2.get()).isEqualTo("success!");
-      assertThat(errorResult.get()).hasMessageThat().isEqualTo("some error.");
+      assertThat(errorResult.get()).hasMessage("some error.");
 
       phaser.arriveAndAwaitAdvance(); // wait for traces to be reported
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/suspendresumepropagation/SuspendResumePropagationTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/suspendresumepropagation/SuspendResumePropagationTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.opentracingshim.testbed.suspendresumepropagation;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
 import io.opentelemetry.opentracingshim.TraceShim;

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     annotationProcessor libraries.auto_value
 
     testAnnotationProcessor libraries.auto_value
+    testCompileOnly libraries.auto_value_annotation
 
     testImplementation libraries.junit_pioneer
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.OpenTelemetry;
 import org.junit.jupiter.api.Test;
@@ -26,11 +26,10 @@ class OpenTelemetrySdkTest {
   @Test
   void testDefault() {
     assertThat(OpenTelemetrySdk.getTracerProvider().get(""))
-        .isSameInstanceAs(OpenTelemetry.getTracerProvider().get(""));
+        .isSameAs(OpenTelemetry.getTracerProvider().get(""));
     assertThat(OpenTelemetrySdk.getCorrelationContextManager())
-        .isSameInstanceAs(OpenTelemetry.getCorrelationContextManager());
-    assertThat(OpenTelemetrySdk.getMeterProvider())
-        .isSameInstanceAs(OpenTelemetry.getMeterProvider());
+        .isSameAs(OpenTelemetry.getCorrelationContextManager());
+    assertThat(OpenTelemetrySdk.getMeterProvider()).isSameAs(OpenTelemetry.getMeterProvider());
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfoTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfoTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.common;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;

--- a/sdk/src/test/java/io/opentelemetry/sdk/common/export/ConfigBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/common/export/ConfigBuilderTest.java
@@ -16,7 +16,8 @@
 
 package io.opentelemetry.sdk.common.export;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import io.opentelemetry.sdk.common.export.ConfigBuilder.NamingConvention;
 import java.util.Collections;
@@ -146,7 +147,7 @@ public class ConfigBuilderTest {
     map.put("loWer_cAsE", "4");
     Map<String, String> normalized = NamingConvention.DOT.normalize(map);
     assertThat(normalized.size()).isEqualTo(2);
-    assertThat(normalized).containsExactly("lower.case", "3", "lower_case", "4");
+    assertThat(normalized).containsOnly(entry("lower.case", "3"), entry("lower_case", "4"));
   }
 
   @Test
@@ -158,7 +159,7 @@ public class ConfigBuilderTest {
     map.put("loWer_cAsE", "4");
     Map<String, String> normalized = NamingConvention.ENV_VAR.normalize(map);
     assertThat(normalized.size()).isEqualTo(1);
-    assertThat(normalized).containsExactly("lower.case", "3");
+    assertThat(normalized).containsExactly(entry("lower.case", "3"));
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/correlationcontext/CorrelationContextManagerSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/correlationcontext/CorrelationContextManagerSdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.correlationcontext;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.grpc.Context;
 import io.opentelemetry.context.Scope;
@@ -43,8 +43,7 @@ class CorrelationContextManagerSdkTest {
 
   @Test
   void testGetCurrentContext_DefaultContext() {
-    assertThat(contextManager.getCurrentContext())
-        .isSameInstanceAs(EmptyCorrelationContext.getInstance());
+    assertThat(contextManager.getCurrentContext()).isSameAs(EmptyCorrelationContext.getInstance());
   }
 
   @Test
@@ -62,28 +61,26 @@ class CorrelationContextManagerSdkTest {
 
   @Test
   void testWithCorrelationContext() {
-    assertThat(contextManager.getCurrentContext())
-        .isSameInstanceAs(EmptyCorrelationContext.getInstance());
+    assertThat(contextManager.getCurrentContext()).isSameAs(EmptyCorrelationContext.getInstance());
     try (Scope wtm = contextManager.withContext(distContext)) {
-      assertThat(contextManager.getCurrentContext()).isSameInstanceAs(distContext);
+      assertThat(contextManager.getCurrentContext()).isSameAs(distContext);
     }
-    assertThat(contextManager.getCurrentContext())
-        .isSameInstanceAs(EmptyCorrelationContext.getInstance());
+    assertThat(contextManager.getCurrentContext()).isSameAs(EmptyCorrelationContext.getInstance());
   }
 
   @Test
   void testWithCorrelationContextUsingWrap() {
     Runnable runnable;
     try (Scope wtm = contextManager.withContext(distContext)) {
-      assertThat(contextManager.getCurrentContext()).isSameInstanceAs(distContext);
+      assertThat(contextManager.getCurrentContext()).isSameAs(distContext);
       runnable =
           Context.current()
               .wrap(
-                  () ->
-                      assertThat(contextManager.getCurrentContext()).isSameInstanceAs(distContext));
+                  () -> {
+                    assertThat(contextManager.getCurrentContext()).isSameAs(distContext);
+                  });
     }
-    assertThat(contextManager.getCurrentContext())
-        .isSameInstanceAs(EmptyCorrelationContext.getInstance());
+    assertThat(contextManager.getCurrentContext()).isSameAs(EmptyCorrelationContext.getInstance());
     // When we run the runnable we will have the CorrelationContext in the current Context.
     runnable.run();
   }

--- a/sdk/src/test/java/io/opentelemetry/sdk/correlationcontext/CorrelationContextSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/correlationcontext/CorrelationContextSdkTest.java
@@ -16,8 +16,8 @@
 
 package io.opentelemetry.sdk.correlationcontext;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.sdk.correlationcontext.CorrelationContextTestUtil.listToCorrelationContext;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.testing.EqualsTester;

--- a/sdk/src/test/java/io/opentelemetry/sdk/correlationcontext/ScopedCorrelationContextTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/correlationcontext/ScopedCorrelationContextTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.correlationcontext;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.correlationcontext.CorrelationContext;
@@ -60,7 +60,7 @@ class ScopedCorrelationContextTest {
     CorrelationContext scopedEntries =
         contextManager.contextBuilder().put(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION).build();
     try (Scope scope = contextManager.withContext(scopedEntries)) {
-      assertThat(contextManager.getCurrentContext()).isSameInstanceAs(scopedEntries);
+      assertThat(contextManager.getCurrentContext()).isSameAs(scopedEntries);
     }
     assertThat(contextManager.getCurrentContext().getEntries()).isEmpty();
   }
@@ -76,10 +76,10 @@ class ScopedCorrelationContextTest {
               .put(KEY_2, VALUE_2, METADATA_UNLIMITED_PROPAGATION)
               .build();
       assertThat(newEntries.getEntries())
-          .containsExactly(
+          .containsExactlyInAnyOrder(
               Entry.create(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION),
               Entry.create(KEY_2, VALUE_2, METADATA_UNLIMITED_PROPAGATION));
-      assertThat(contextManager.getCurrentContext()).isSameInstanceAs(scopedDistContext);
+      assertThat(contextManager.getCurrentContext()).isSameAs(scopedDistContext);
     }
   }
 
@@ -91,7 +91,7 @@ class ScopedCorrelationContextTest {
     try (Scope scope = contextManager.withContext(scopedDistContext)) {
       assertThat(contextManager.getCurrentContext().getEntries())
           .containsExactly(Entry.create(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION));
-      assertThat(contextManager.getCurrentContext()).isSameInstanceAs(scopedDistContext);
+      assertThat(contextManager.getCurrentContext()).isSameAs(scopedDistContext);
     }
     assertThat(contextManager.getCurrentContext().getEntries()).isEmpty();
   }
@@ -108,12 +108,12 @@ class ScopedCorrelationContextTest {
               .build();
       try (Scope scope2 = contextManager.withContext(innerDistContext)) {
         assertThat(contextManager.getCurrentContext().getEntries())
-            .containsExactly(
+            .containsExactlyInAnyOrder(
                 Entry.create(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION),
                 Entry.create(KEY_2, VALUE_2, METADATA_UNLIMITED_PROPAGATION));
-        assertThat(contextManager.getCurrentContext()).isSameInstanceAs(innerDistContext);
+        assertThat(contextManager.getCurrentContext()).isSameAs(innerDistContext);
       }
-      assertThat(contextManager.getCurrentContext()).isSameInstanceAs(scopedDistContext);
+      assertThat(contextManager.getCurrentContext()).isSameAs(scopedDistContext);
     }
   }
 
@@ -134,13 +134,13 @@ class ScopedCorrelationContextTest {
               .build();
       try (Scope scope2 = contextManager.withContext(innerDistContext)) {
         assertThat(contextManager.getCurrentContext().getEntries())
-            .containsExactly(
+            .containsExactlyInAnyOrder(
                 Entry.create(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION),
                 Entry.create(KEY_2, VALUE_4, METADATA_NO_PROPAGATION),
                 Entry.create(KEY_3, VALUE_3, METADATA_NO_PROPAGATION));
-        assertThat(contextManager.getCurrentContext()).isSameInstanceAs(innerDistContext);
+        assertThat(contextManager.getCurrentContext()).isSameAs(innerDistContext);
       }
-      assertThat(contextManager.getCurrentContext()).isSameInstanceAs(scopedDistContext);
+      assertThat(contextManager.getCurrentContext()).isSameAs(scopedDistContext);
     }
   }
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/correlationcontext/spi/CorrelationContextManagerFactorySdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/correlationcontext/spi/CorrelationContextManagerFactorySdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.correlationcontext.spi;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.sdk.correlationcontext.CorrelationContextManagerSdk;

--- a/sdk/src/test/java/io/opentelemetry/sdk/internal/ComponentRegistryTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/internal/ComponentRegistryTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.internal;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -50,28 +50,27 @@ class ComponentRegistryTest {
 
   @Test
   void getSameInstanceForSameName_WithoutVersion() {
+    assertThat(registry.get(INSTRUMENTATION_NAME)).isSameAs(registry.get(INSTRUMENTATION_NAME));
     assertThat(registry.get(INSTRUMENTATION_NAME))
-        .isSameInstanceAs(registry.get(INSTRUMENTATION_NAME));
-    assertThat(registry.get(INSTRUMENTATION_NAME))
-        .isSameInstanceAs(registry.get(INSTRUMENTATION_NAME, null));
+        .isSameAs(registry.get(INSTRUMENTATION_NAME, null));
   }
 
   @Test
   void getSameInstanceForSameName_WithVersion() {
     assertThat(registry.get(INSTRUMENTATION_NAME, INSTRUMENTATION_VERSION))
-        .isSameInstanceAs(registry.get(INSTRUMENTATION_NAME, INSTRUMENTATION_VERSION));
+        .isSameAs(registry.get(INSTRUMENTATION_NAME, INSTRUMENTATION_VERSION));
   }
 
   @Test
   void getDifferentInstancesForDifferentNames() {
     assertThat(registry.get(INSTRUMENTATION_NAME, INSTRUMENTATION_VERSION))
-        .isNotSameInstanceAs(registry.get(INSTRUMENTATION_NAME + "_2", INSTRUMENTATION_VERSION));
+        .isNotSameAs(registry.get(INSTRUMENTATION_NAME + "_2", INSTRUMENTATION_VERSION));
   }
 
   @Test
   void getDifferentInstancesForDifferentVersions() {
     assertThat(registry.get(INSTRUMENTATION_NAME, INSTRUMENTATION_VERSION))
-        .isNotSameInstanceAs(registry.get(INSTRUMENTATION_NAME, INSTRUMENTATION_VERSION + "_1"));
+        .isNotSameAs(registry.get(INSTRUMENTATION_NAME, INSTRUMENTATION_VERSION + "_1"));
   }
 
   private static final class TestComponent {

--- a/sdk/src/test/java/io/opentelemetry/sdk/internal/MonotonicClockTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/internal/MonotonicClockTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.internal;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/internal/TestClockTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/internal/TestClockTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.internal;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractBoundInstrumentTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractBoundInstrumentTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
 import org.junit.jupiter.api.BeforeEach;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
@@ -16,9 +16,9 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.sdk.metrics.AbstractInstrument.Builder.ERROR_MESSAGE_INVALID_NAME;
 import static io.opentelemetry.sdk.metrics.AbstractInstrument.Builder.NAME_MAX_LENGTH;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.common.Labels;
@@ -152,8 +152,8 @@ class AbstractInstrumentBuilderTest {
             .setUnit(UNIT)
             .setConstantLabels(CONSTANT_LABELS);
     assertThat(testInstrumentBuilder.getMeterProviderSharedState())
-        .isSameInstanceAs(METER_PROVIDER_SHARED_STATE);
-    assertThat(testInstrumentBuilder.getMeterSharedState()).isSameInstanceAs(METER_SHARED_STATE);
+        .isSameAs(METER_PROVIDER_SHARED_STATE);
+    assertThat(testInstrumentBuilder.getMeterSharedState()).isSameAs(METER_SHARED_STATE);
 
     TestInstrument testInstrument = testInstrumentBuilder.build();
     assertThat(testInstrument).isInstanceOf(TestInstrument.class);

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -52,11 +52,10 @@ class AbstractInstrumentTest {
     TestInstrument testInstrument =
         new TestInstrument(
             INSTRUMENT_DESCRIPTOR, METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE, ACTIVE_BATCHER);
-    assertThat(testInstrument.getDescriptor()).isSameInstanceAs(INSTRUMENT_DESCRIPTOR);
-    assertThat(testInstrument.getMeterProviderSharedState())
-        .isSameInstanceAs(METER_PROVIDER_SHARED_STATE);
-    assertThat(testInstrument.getMeterSharedState()).isSameInstanceAs(METER_SHARED_STATE);
-    assertThat(testInstrument.getActiveBatcher()).isSameInstanceAs(ACTIVE_BATCHER);
+    assertThat(testInstrument.getDescriptor()).isSameAs(INSTRUMENT_DESCRIPTOR);
+    assertThat(testInstrument.getMeterProviderSharedState()).isSameAs(METER_PROVIDER_SHARED_STATE);
+    assertThat(testInstrument.getMeterSharedState()).isSameAs(METER_SHARED_STATE);
+    assertThat(testInstrument.getActiveBatcher()).isSameAs(ACTIVE_BATCHER);
   }
 
   private static final class TestInstrument extends AbstractInstrument {

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/BatchRecorderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/BatchRecorderSdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.common.AttributeValue;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleCounterSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleCounterSdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.common.AttributeValue;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleSumObserverSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleSumObserverSdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownCounterSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownCounterSdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.common.AttributeValue;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownSumObserverSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownSumObserverSdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueObserverSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueObserverSdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.common.AttributeValue;
@@ -164,7 +164,7 @@ class DoubleValueRecorderSdkTest {
       assertThat(metricDataList).hasSize(1);
       MetricData metricData = metricDataList.get(0);
       assertThat(metricData.getPoints())
-          .containsExactly(
+          .containsExactlyInAnyOrder(
               SummaryPoint.create(
                   startTime,
                   firstCollect,
@@ -190,7 +190,7 @@ class DoubleValueRecorderSdkTest {
       assertThat(metricDataList).hasSize(1);
       metricData = metricDataList.get(0);
       assertThat(metricData.getPoints())
-          .containsExactly(
+          .containsExactlyInAnyOrder(
               SummaryPoint.create(
                   startTime + SECOND_NANOS,
                   secondCollect,

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/InstrumentRegistryTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/InstrumentRegistryTest.java
@@ -16,8 +16,8 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.sdk.common.InstrumentationLibraryInfo.getEmpty;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.common.Labels;
@@ -61,9 +61,9 @@ class InstrumentRegistryTest {
         new TestInstrument(
             INSTRUMENT_DESCRIPTOR, METER_PROVIDER_SHARED_STATE, meterSharedState, ACTIVE_BATCHER);
     assertThat(meterSharedState.getInstrumentRegistry().register(testInstrument))
-        .isSameInstanceAs(testInstrument);
+        .isSameAs(testInstrument);
     assertThat(meterSharedState.getInstrumentRegistry().register(testInstrument))
-        .isSameInstanceAs(testInstrument);
+        .isSameAs(testInstrument);
     assertThat(
             meterSharedState
                 .getInstrumentRegistry()
@@ -73,7 +73,7 @@ class InstrumentRegistryTest {
                         METER_PROVIDER_SHARED_STATE,
                         meterSharedState,
                         ACTIVE_BATCHER)))
-        .isSameInstanceAs(testInstrument);
+        .isSameAs(testInstrument);
   }
 
   @Test
@@ -83,7 +83,7 @@ class InstrumentRegistryTest {
         new TestInstrument(
             INSTRUMENT_DESCRIPTOR, METER_PROVIDER_SHARED_STATE, meterSharedState, ACTIVE_BATCHER);
     assertThat(meterSharedState.getInstrumentRegistry().register(testInstrument))
-        .isSameInstanceAs(testInstrument);
+        .isSameAs(testInstrument);
 
     assertThrows(
         IllegalArgumentException.class,
@@ -106,7 +106,7 @@ class InstrumentRegistryTest {
         new TestInstrument(
             INSTRUMENT_DESCRIPTOR, METER_PROVIDER_SHARED_STATE, meterSharedState, ACTIVE_BATCHER);
     assertThat(meterSharedState.getInstrumentRegistry().register(testInstrument))
-        .isSameInstanceAs(testInstrument);
+        .isSameAs(testInstrument);
 
     assertThrows(
         IllegalArgumentException.class,

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongCounterSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongCounterSdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.common.AttributeValue;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongSumObserverSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongSumObserverSdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownCounterSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownCounterSdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.common.AttributeValue;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownSumObserverSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownSumObserverSdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongValueObserverSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongValueObserverSdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.common.AttributeValue;
@@ -164,7 +164,7 @@ class LongValueRecorderSdkTest {
       MetricData metricData = metricDataList.get(0);
       assertThat(metricData.getPoints()).hasSize(2);
       assertThat(metricData.getPoints())
-          .containsExactly(
+          .containsExactlyInAnyOrder(
               SummaryPoint.create(
                   startTime, firstCollect, Labels.empty(), 2, -2, valueAtPercentiles(-14, 12)),
               SummaryPoint.create(
@@ -186,7 +186,7 @@ class LongValueRecorderSdkTest {
       metricData = metricDataList.get(0);
       assertThat(metricData.getPoints()).hasSize(2);
       assertThat(metricData.getPoints())
-          .containsExactly(
+          .containsExactlyInAnyOrder(
               SummaryPoint.create(
                   startTime + SECOND_NANOS,
                   secondCollect,

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkRegistryTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkRegistryTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
@@ -66,14 +66,13 @@ class MeterSdkRegistryTest {
 
   @Test
   void getSameInstanceForSameName_WithoutVersion() {
-    assertThat(meterRegistry.get("test")).isSameInstanceAs(meterRegistry.get("test"));
-    assertThat(meterRegistry.get("test")).isSameInstanceAs(meterRegistry.get("test", null));
+    assertThat(meterRegistry.get("test")).isSameAs(meterRegistry.get("test"));
+    assertThat(meterRegistry.get("test")).isSameAs(meterRegistry.get("test", null));
   }
 
   @Test
   void getSameInstanceForSameName_WithVersion() {
-    assertThat(meterRegistry.get("test", "version"))
-        .isSameInstanceAs(meterRegistry.get("test", "version"));
+    assertThat(meterRegistry.get("test", "version")).isSameAs(meterRegistry.get("test", "version"));
   }
 
   @Test
@@ -94,7 +93,7 @@ class MeterSdkRegistryTest {
     longCounter2.add(10, Labels.empty());
 
     assertThat(meterRegistry.getMetricProducer().collectAllMetrics())
-        .containsExactly(
+        .containsExactlyInAnyOrder(
             MetricData.create(
                 Descriptor.create(
                     "testLongCounter", "", "1", Descriptor.Type.MONOTONIC_LONG, Labels.empty()),

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.common.AttributeValue;
@@ -67,7 +67,7 @@ class MeterSdkTest {
                 .setDescription("My very own counter")
                 .setUnit("metric tonnes")
                 .build())
-        .isSameInstanceAs(longCounter);
+        .isSameAs(longCounter);
 
     assertThrows(
         IllegalArgumentException.class,
@@ -93,7 +93,7 @@ class MeterSdkTest {
                 .setDescription("My very own counter")
                 .setUnit("metric tonnes")
                 .build())
-        .isSameInstanceAs(longUpDownCounter);
+        .isSameAs(longUpDownCounter);
 
     assertThrows(
         IllegalArgumentException.class,
@@ -119,7 +119,7 @@ class MeterSdkTest {
                 .setDescription("My very own counter")
                 .setUnit("metric tonnes")
                 .build())
-        .isSameInstanceAs(longValueRecorder);
+        .isSameAs(longValueRecorder);
 
     assertThrows(
         IllegalArgumentException.class,
@@ -145,7 +145,7 @@ class MeterSdkTest {
                 .setDescription("My very own counter")
                 .setUnit("metric tonnes")
                 .build())
-        .isSameInstanceAs(longObserver);
+        .isSameAs(longObserver);
 
     assertThrows(
         IllegalArgumentException.class,
@@ -171,7 +171,7 @@ class MeterSdkTest {
                 .setDescription("My very own counter")
                 .setUnit("metric tonnes")
                 .build())
-        .isSameInstanceAs(longObserver);
+        .isSameAs(longObserver);
 
     assertThrows(
         IllegalArgumentException.class,
@@ -197,7 +197,7 @@ class MeterSdkTest {
                 .setDescription("My very own counter")
                 .setUnit("metric tonnes")
                 .build())
-        .isSameInstanceAs(doubleCounter);
+        .isSameAs(doubleCounter);
 
     assertThrows(
         IllegalArgumentException.class,
@@ -223,7 +223,7 @@ class MeterSdkTest {
                 .setDescription("My very own counter")
                 .setUnit("metric tonnes")
                 .build())
-        .isSameInstanceAs(doubleUpDownCounter);
+        .isSameAs(doubleUpDownCounter);
 
     assertThrows(
         IllegalArgumentException.class,
@@ -249,7 +249,7 @@ class MeterSdkTest {
                 .setDescription("My very own ValueRecorder")
                 .setUnit("metric tonnes")
                 .build())
-        .isSameInstanceAs(doubleValueRecorder);
+        .isSameAs(doubleValueRecorder);
 
     assertThrows(
         IllegalArgumentException.class,
@@ -275,7 +275,7 @@ class MeterSdkTest {
                 .setDescription("My very own counter")
                 .setUnit("metric tonnes")
                 .build())
-        .isSameInstanceAs(doubleObserver);
+        .isSameAs(doubleObserver);
 
     assertThrows(
         IllegalArgumentException.class,
@@ -301,7 +301,7 @@ class MeterSdkTest {
                 .setDescription("My very own counter")
                 .setUnit("metric tonnes")
                 .build())
-        .isSameInstanceAs(doubleObserver);
+        .isSameAs(doubleObserver);
 
     assertThrows(
         IllegalArgumentException.class,
@@ -333,7 +333,7 @@ class MeterSdkTest {
     // testSdk.doubleSumObserverBuilder("testDoubleSumObserver").build();
 
     assertThat(testSdk.collectAll())
-        .containsExactly(
+        .containsExactlyInAnyOrder(
             MetricData.create(
                 Descriptor.create(
                     "testLongCounter", "", "1", Descriptor.Type.MONOTONIC_LONG, Labels.empty()),

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleLastValueAggregatorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleLastValueAggregatorTest.java
@@ -16,7 +16,8 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
 
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
@@ -41,25 +42,25 @@ class DoubleLastValueAggregatorTest {
   void multipleRecords() {
     Aggregator aggregator = DoubleLastValueAggregator.getFactory().getAggregator();
     aggregator.recordDouble(12.1);
-    assertThat(getPoint(aggregator).getValue()).isWithin(1e-6).of(12.1);
+    assertThat(getPoint(aggregator).getValue()).isCloseTo(12.1, offset(1e-6));
     aggregator.recordDouble(13.1);
     aggregator.recordDouble(14.1);
-    assertThat(getPoint(aggregator).getValue()).isWithin(1e-6).of(14.1);
+    assertThat(getPoint(aggregator).getValue()).isCloseTo(14.1, offset(1e-6));
   }
 
   @Test
   void mergeAndReset() {
     Aggregator aggregator = DoubleLastValueAggregator.getFactory().getAggregator();
     aggregator.recordDouble(13.1);
-    assertThat(getPoint(aggregator).getValue()).isWithin(1e-6).of(13.1);
+    assertThat(getPoint(aggregator).getValue()).isCloseTo(13.1, offset(1e-6));
     Aggregator mergedAggregator = DoubleLastValueAggregator.getFactory().getAggregator();
     aggregator.mergeToAndReset(mergedAggregator);
     assertNullPoint(aggregator);
-    assertThat(getPoint(mergedAggregator).getValue()).isWithin(1e-6).of(13.1);
+    assertThat(getPoint(mergedAggregator).getValue()).isCloseTo(13.1, offset(1e-6));
     aggregator.recordDouble(12.1);
     aggregator.mergeToAndReset(mergedAggregator);
     assertNullPoint(aggregator);
-    assertThat(getPoint(mergedAggregator).getValue()).isWithin(1e-6).of(12.1);
+    assertThat(getPoint(mergedAggregator).getValue()).isCloseTo(12.1, offset(1e-6));
   }
 
   private static DoublePoint getPoint(Aggregator aggregator) {

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountTest.java
@@ -16,7 +16,8 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
 
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.metrics.data.MetricData.SummaryPoint;
@@ -113,7 +114,7 @@ class DoubleMinMaxSumCountTest {
     assertThat(actual.getEpochNanos()).isEqualTo(100);
     assertThat(actual.getLabels()).isEqualTo(Labels.empty());
     assertThat(actual.getCount()).isEqualTo(numberOfThreads * numberOfUpdates);
-    assertThat(actual.getSum()).isWithin(0.001).of(102000d);
+    assertThat(actual.getSum()).isCloseTo(102000d, offset(0.001));
     List<ValueAtPercentile> percentileValues = actual.getPercentileValues();
     assertThat(percentileValues).isEqualTo(createPercentiles(1.1d, 23.1d));
   }

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleSumAggregatorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleSumAggregatorTest.java
@@ -16,7 +16,8 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
 
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
@@ -34,7 +35,7 @@ class DoubleSumAggregatorTest {
   @Test
   void toPoint() {
     Aggregator aggregator = DoubleSumAggregator.getFactory().getAggregator();
-    assertThat(getPoint(aggregator).getValue()).isWithin(1e-6).of(0);
+    assertThat(getPoint(aggregator).getValue()).isCloseTo(0, offset(1e-6));
   }
 
   @Test
@@ -45,7 +46,7 @@ class DoubleSumAggregatorTest {
     aggregator.recordDouble(12.1);
     aggregator.recordDouble(12.1);
     aggregator.recordDouble(12.1);
-    assertThat(getPoint(aggregator).getValue()).isWithin(1e-6).of(12.1 * 5);
+    assertThat(getPoint(aggregator).getValue()).isCloseTo(12.1 * 5, offset(1e-6));
   }
 
   @Test
@@ -57,7 +58,7 @@ class DoubleSumAggregatorTest {
     aggregator.recordDouble(12.1);
     aggregator.recordDouble(12.3);
     aggregator.recordDouble(-11.3);
-    assertThat(getPoint(aggregator).getValue()).isWithin(1e-6).of(14.1);
+    assertThat(getPoint(aggregator).getValue()).isCloseTo(14.1, offset(1e-6));
   }
 
   @Test
@@ -65,16 +66,16 @@ class DoubleSumAggregatorTest {
     Aggregator aggregator = DoubleSumAggregator.getFactory().getAggregator();
     aggregator.recordDouble(13.1);
     aggregator.recordDouble(12.1);
-    assertThat(getPoint(aggregator).getValue()).isWithin(1e-6).of(25.2);
+    assertThat(getPoint(aggregator).getValue()).isCloseTo(25.2, offset(1e-6));
     Aggregator mergedAggregator = DoubleSumAggregator.getFactory().getAggregator();
     aggregator.mergeToAndReset(mergedAggregator);
-    assertThat(getPoint(aggregator).getValue()).isWithin(1e-6).of(0);
-    assertThat(getPoint(mergedAggregator).getValue()).isWithin(1e-6).of(25.2);
+    assertThat(getPoint(aggregator).getValue()).isCloseTo(0, offset(1e-6));
+    assertThat(getPoint(mergedAggregator).getValue()).isCloseTo(25.2, offset(1e-6));
     aggregator.recordDouble(12.1);
     aggregator.recordDouble(-25.2);
     aggregator.mergeToAndReset(mergedAggregator);
-    assertThat(getPoint(aggregator).getValue()).isWithin(1e-6).of(0);
-    assertThat(getPoint(mergedAggregator).getValue()).isWithin(1e-6).of(12.1);
+    assertThat(getPoint(aggregator).getValue()).isCloseTo(0, offset(1e-6));
+    assertThat(getPoint(mergedAggregator).getValue()).isCloseTo(12.1, offset(1e-6));
   }
 
   private static DoublePoint getPoint(Aggregator aggregator) {

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongLastValueAggregatorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongLastValueAggregatorTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.metrics.data.MetricData.SummaryPoint;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongSumAggregatorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongSumAggregatorTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/aggregator/NoopAggregatorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/aggregator/NoopAggregatorTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.Labels;
 import org.junit.jupiter.api.Test;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/data/MetricDataDescriptorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/data/MetricDataDescriptorTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics.data;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.common.Labels;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/data/MetricDataTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/data/MetricDataTest.java
@@ -16,8 +16,8 @@
 
 package io.opentelemetry.sdk.metrics.data;
 
-import static com.google.common.truth.Truth.assertThat;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.common.Labels;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics.export;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.common.Labels;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/spi/MeterProviderFactorySdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/spi/MeterProviderFactorySdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics.spi;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.sdk.metrics.MeterSdkProvider;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/view/CountAggregationTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/view/CountAggregationTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics.view;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.metrics.aggregator.NoopAggregator;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/view/LastValueAggregationTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/view/LastValueAggregationTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics.view;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.metrics.aggregator.DoubleLastValueAggregator;
 import io.opentelemetry.sdk.metrics.aggregator.LongLastValueAggregator;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/view/MinMaxSumCountAggregationTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/view/MinMaxSumCountAggregationTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics.view;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.metrics.aggregator.DoubleMinMaxSumCount;
 import io.opentelemetry.sdk.metrics.aggregator.LongMinMaxSumCount;

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/view/SumAggregationTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/view/SumAggregationTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.metrics.view;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.metrics.aggregator.DoubleSumAggregator;
 import io.opentelemetry.sdk.metrics.aggregator.LongSumAggregator;

--- a/sdk/src/test/java/io/opentelemetry/sdk/resources/EnvAutodetectResourceTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/resources/EnvAutodetectResourceTest.java
@@ -16,8 +16,8 @@
 
 package io.opentelemetry.sdk.resources;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.Attributes;
 import org.junit.jupiter.api.Test;

--- a/sdk/src/test/java/io/opentelemetry/sdk/resources/ResourceTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/resources/ResourceTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.resources;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.testing.EqualsTester;
 import io.opentelemetry.common.AttributeValue;

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/MultiSpanProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/MultiSpanProcessorTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.trace;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.times;

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/NoopSpanProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/NoopSpanProcessorTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.trace;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.trace;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceId;

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -16,8 +16,8 @@
 
 package io.opentelemetry.sdk.trace;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.common.AttributeValue;
@@ -143,7 +143,7 @@ class RecordEventsReadableSpanTest {
 
     Link resultingLink = span.toSpanData().getLinks().get(0);
     assertThat(resultingLink.getTotalAttributeCount()).isEqualTo(1);
-    assertThat(resultingLink.getContext()).isSameInstanceAs(spanContext);
+    assertThat(resultingLink.getContext()).isSameAs(spanContext);
     assertThat(resultingLink.getAttributes()).isEqualTo(attributes);
   }
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -16,8 +16,8 @@
 
 package io.opentelemetry.sdk.trace;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.common.AttributeValue.doubleAttributeValue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.common.AttributeValue;
@@ -54,9 +54,9 @@ class SamplersTest {
   @Test
   void emptySamplingDecision() {
     assertThat(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLED))
-        .isSameInstanceAs(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLED));
+        .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLED));
     assertThat(Samplers.emptySamplingResult(Sampler.Decision.NOT_RECORD))
-        .isSameInstanceAs(Samplers.emptySamplingResult(Sampler.Decision.NOT_RECORD));
+        .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.NOT_RECORD));
 
     assertThat(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLED).getDecision())
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
@@ -74,9 +74,9 @@ class SamplersTest {
   @Test
   void samplingDecisionEmpty() {
     assertThat(Samplers.samplingResult(Sampler.Decision.RECORD_AND_SAMPLED, Attributes.empty()))
-        .isSameInstanceAs(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLED));
+        .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLED));
     assertThat(Samplers.samplingResult(Sampler.Decision.NOT_RECORD, Attributes.empty()))
-        .isSameInstanceAs(Samplers.emptySamplingResult(Sampler.Decision.NOT_RECORD));
+        .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.NOT_RECORD));
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.trace;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -717,7 +717,7 @@ class SpanBuilderSdkTest {
       RecordEventsReadableSpan span =
           (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).setParent(parent).startSpan();
 
-      assertThat(span.getClock()).isSameInstanceAs(((RecordEventsReadableSpan) parent).getClock());
+      assertThat(span.getClock()).isSameAs(((RecordEventsReadableSpan) parent).getClock());
     } finally {
       parent.end();
     }
@@ -730,7 +730,7 @@ class SpanBuilderSdkTest {
       RecordEventsReadableSpan span =
           (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).startSpan();
 
-      assertThat(span.getClock()).isSameInstanceAs(((RecordEventsReadableSpan) parent).getClock());
+      assertThat(span.getClock()).isSameAs(((RecordEventsReadableSpan) parent).getClock());
     } finally {
       parent.end();
     }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TimedEventTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TimedEventTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.trace;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkProviderTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkProviderTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.trace;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
@@ -83,14 +83,13 @@ class TracerSdkProviderTest {
 
   @Test
   void getSameInstanceForSameName_WithoutVersion() {
-    assertThat(tracerFactory.get("test")).isSameInstanceAs(tracerFactory.get("test"));
-    assertThat(tracerFactory.get("test")).isSameInstanceAs(tracerFactory.get("test", null));
+    assertThat(tracerFactory.get("test")).isSameAs(tracerFactory.get("test"));
+    assertThat(tracerFactory.get("test")).isSameAs(tracerFactory.get("test", null));
   }
 
   @Test
   void getSameInstanceForSameName_WithVersion() {
-    assertThat(tracerFactory.get("test", "version"))
-        .isSameInstanceAs(tracerFactory.get("test", "version"));
+    assertThat(tracerFactory.get("test", "version")).isSameAs(tracerFactory.get("test", "version"));
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.trace;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.grpc.Context;
 import io.opentelemetry.common.AttributeValue;
@@ -76,7 +76,7 @@ class TracerSdkTest {
     Context origContext = TracingContextUtils.withSpan(span, Context.current()).attach();
     // Make sure context is detached even if test fails.
     try {
-      assertThat(tracer.getCurrentSpan()).isSameInstanceAs(span);
+      assertThat(tracer.getCurrentSpan()).isSameAs(span);
     } finally {
       Context.current().detach(origContext);
     }
@@ -96,7 +96,7 @@ class TracerSdkTest {
   void getCurrentSpan_WithSpan() {
     assertThat(tracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
     try (Scope ignored = tracer.withSpan(span)) {
-      assertThat(tracer.getCurrentSpan()).isSameInstanceAs(span);
+      assertThat(tracer.getCurrentSpan()).isSameAs(span);
     }
     assertThat(tracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
   }

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.trace.config;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.sdk.trace.Samplers;

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/data/TestSpanDataTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/data/TestSpanDataTest.java
@@ -16,8 +16,8 @@
 
 package io.opentelemetry.sdk.trace.data;
 
-import static com.google.common.truth.Truth.assertThat;
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.common.Attributes;
@@ -48,7 +48,7 @@ class TestSpanDataTest {
     assertThat(spanData.getEvents()).isEqualTo(emptyList());
     assertThat(spanData.getLinks()).isEqualTo(emptyList());
     assertThat(spanData.getInstrumentationLibraryInfo())
-        .isSameInstanceAs(InstrumentationLibraryInfo.getEmpty());
+        .isSameAs(InstrumentationLibraryInfo.getEmpty());
     assertThat(spanData.getHasRemoteParent()).isFalse();
   }
 

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.trace.export;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doThrow;
 
 import io.opentelemetry.sdk.common.export.ConfigBuilderTest.ConfigTester;
@@ -260,7 +260,7 @@ class BatchSpanProcessorTest {
     // While we wait for maxQueuedSpans we ensure that the queue is also empty after this.
     List<SpanData> exported = waitingSpanExporter.waitForExport();
     assertThat(exported).isNotNull();
-    assertThat(exported).containsExactlyElementsIn(spansToExport);
+    assertThat(exported).containsExactlyElementsOf(spansToExport);
     exported.clear();
     spansToExport.clear();
 
@@ -278,7 +278,7 @@ class BatchSpanProcessorTest {
 
     exported = waitingSpanExporter.waitForExport();
     assertThat(exported).isNotNull();
-    assertThat(exported).containsExactlyElementsIn(spansToExport);
+    assertThat(exported).containsExactlyElementsOf(spansToExport);
   }
 
   @Test

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/MultiSpanExporterTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/MultiSpanExporterTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.trace.export;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.trace.export;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;

--- a/sdk/src/test/java/io/opentelemetry/sdk/trace/spi/TracerProviderFactorySdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/trace/spi/TracerProviderFactorySdkTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.trace.spi;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;

--- a/sdk_extensions/async_processor/src/test/java/io/opentelemetry/sdk/extensions/trace/export/DisruptorAsyncSpanProcessorTest.java
+++ b/sdk_extensions/async_processor/src/test/java/io/opentelemetry/sdk/extensions/trace/export/DisruptorAsyncSpanProcessorTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.trace.export;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.common.export.ConfigBuilder;
 import io.opentelemetry.sdk.trace.MultiSpanProcessor;

--- a/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/AwsXRayIdsGeneratorTest.java
+++ b/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/AwsXRayIdsGeneratorTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.trace.aws;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.trace.IdsGenerator;
 import io.opentelemetry.trace.SpanId;
@@ -51,7 +51,7 @@ class AwsXRayIdsGeneratorTest {
       long unixSeconds = Long.valueOf(traceId.toLowerBase16().substring(0, 8), 16);
       long ts = unixSeconds * 1000L;
       long currentTs = System.currentTimeMillis();
-      assertThat(ts).isAtMost(currentTs);
+      assertThat(ts).isLessThanOrEqualTo(currentTs);
       long month = 86400000L * 30L;
       assertThat(ts).isGreaterThan(currentTs - month);
     }

--- a/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/AwsResourceTest.java
+++ b/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/AwsResourceTest.java
@@ -16,9 +16,9 @@
 
 package io.opentelemetry.sdk.extensions.trace.aws.resource;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.common.AttributeValue.booleanAttributeValue;
 import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.common.Attributes;

--- a/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/BeanstalkResourceTest.java
+++ b/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/BeanstalkResourceTest.java
@@ -16,8 +16,8 @@
 
 package io.opentelemetry.sdk.extensions.trace.aws.resource;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;

--- a/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/DockerHelperTest.java
+++ b/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/DockerHelperTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.trace.aws.resource;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;

--- a/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/Ec2ResourceTest.java
+++ b/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/Ec2ResourceTest.java
@@ -28,7 +28,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import io.opentelemetry.common.Attributes;

--- a/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/EcsResourceTest.java
+++ b/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/EcsResourceTest.java
@@ -16,8 +16,8 @@
 
 package io.opentelemetry.sdk.extensions.trace.aws.resource;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.common.Attributes;

--- a/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSamplerTest.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSamplerTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.trace.jaeger.sampler;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.common.AttributeValue;

--- a/sdk_extensions/otproto/src/test/java/io/opentelemetry/sdk/extensions/otproto/TraceProtoUtilsTest.java
+++ b/sdk_extensions/otproto/src/test/java/io/opentelemetry/sdk/extensions/otproto/TraceProtoUtilsTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.otproto;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.ByteString;
 import io.opentelemetry.proto.trace.v1.ConstantSampler;

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/TestUtils.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/TestUtils.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.trace.testbed;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.exporters.inmemory.InMemorySpanExporter;

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/activespanreplacement/ActiveSpanReplacementTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/activespanreplacement/ActiveSpanReplacementTest.java
@@ -16,9 +16,9 @@
 
 package io.opentelemetry.sdk.extensions.trace.testbed.activespanreplacement;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.sdk.extensions.trace.testbed.TestUtils.finishedSpansSize;
 import static io.opentelemetry.sdk.extensions.trace.testbed.TestUtils.sleep;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -72,7 +72,7 @@ class ActiveSpanReplacementTest {
     assertThat(spans.get(0).getTraceId()).isNotEqualTo(spans.get(1).getTraceId());
     assertThat(spans.get(0).getParentSpanId()).isEqualTo(SpanId.getInvalid());
 
-    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
   }
 
   private void submitAnotherTask(final Span initialSpan) {

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/actorpropagation/ActorPropagationTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/actorpropagation/ActorPropagationTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.trace.testbed.actorpropagation;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
@@ -84,7 +84,7 @@ class ActorPropagationTest {
       assertThat(TestUtils.getByKind(finished, Span.Kind.CONSUMER)).hasSize(2);
       assertThat(TestUtils.getOneByKind(finished, Span.Kind.PRODUCER)).isNotNull();
 
-      assertThat(tracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.getInvalid());
+      assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
     }
   }
 
@@ -125,7 +125,7 @@ class ActorPropagationTest {
       assertThat(TestUtils.getByKind(finished, Span.Kind.CONSUMER)).hasSize(2);
       assertThat(TestUtils.getOneByKind(finished, Span.Kind.PRODUCER)).isNotNull();
 
-      assertThat(tracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.getInvalid());
+      assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
     }
   }
 }

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/clientserver/TestClientServerTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/clientserver/TestClientServerTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.trace.testbed.clientserver;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -73,6 +73,6 @@ class TestClientServerTest {
     assertThat(finished.get(0).getKind()).isEqualTo(Kind.CLIENT);
     assertThat(finished.get(1).getKind()).isEqualTo(Kind.SERVER);
 
-    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
   }
 }

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/concurrentcommonrequesthandler/HandlerTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/concurrentcommonrequesthandler/HandlerTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.trace.testbed.concurrentcommonrequesthandler;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
@@ -70,7 +70,7 @@ class HandlerTest {
     assertThat(finished.get(0).getParentSpanId()).isEqualTo(SpanId.getInvalid());
     assertThat(finished.get(1).getParentSpanId()).isEqualTo(SpanId.getInvalid());
 
-    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
   }
 
   /** Active parent is not picked up by child. */

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/errorreporting/ErrorReportingTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/errorreporting/ErrorReportingTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.trace.testbed.errorreporting;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -58,7 +58,7 @@ public final class ErrorReportingTest {
       span.end();
     }
 
-    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
 
     List<SpanData> spans = inMemoryTracing.getSpanExporter().getFinishedSpanItems();
     assertThat(spans).hasSize(1);
@@ -111,7 +111,7 @@ public final class ErrorReportingTest {
     span.setStatus(Status.UNKNOWN); // Could not fetch anything.
     span.end();
 
-    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
 
     List<SpanData> spans = inMemoryTracing.getSpanExporter().getFinishedSpanItems();
     assertThat(spans).hasSize(1);

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/latespanfinish/LateSpanFinishTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/latespanfinish/LateSpanFinishTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.trace.testbed.latespanfinish;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
@@ -62,7 +62,7 @@ public final class LateSpanFinishTest {
 
     TestUtils.assertSameTrace(spans);
 
-    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
   }
 
   /*

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/listenerperrequest/ListenerTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/listenerperrequest/ListenerTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.trace.testbed.listenerperrequest;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
@@ -44,6 +44,6 @@ class ListenerTest {
     assertThat(finished).hasSize(1);
     assertThat(finished.get(0).getKind()).isEqualTo(Kind.CLIENT);
 
-    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
   }
 }

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/multiplecallbacks/MultipleCallbacksTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/multiplecallbacks/MultipleCallbacksTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.trace.testbed.multiplecallbacks;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -75,6 +75,6 @@ class MultipleCallbacksTest {
       assertThat(spans.get(i).getParentSpanId()).isEqualTo(parentSpan.getSpanId());
     }
 
-    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
   }
 }

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/nestedcallbacks/NestedCallbacksTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/nestedcallbacks/NestedCallbacksTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.trace.testbed.nestedcallbacks;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -64,7 +64,7 @@ public final class NestedCallbacksTest {
       assertThat(attrs.get("key" + i).getStringValue()).isEqualTo(Integer.toString(i));
     }
 
-    assertThat(tracer.getCurrentSpan()).isSameInstanceAs(DefaultSpan.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
   }
 
   private void submitCallbacks(final Span span) {

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/promisepropagation/PromisePropagationTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/promisepropagation/PromisePropagationTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.trace.testbed.promisepropagation;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/suspendresumepropagation/SuspendResumePropagationTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/suspendresumepropagation/SuspendResumePropagationTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.trace.testbed.suspendresumepropagation;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;

--- a/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/IndexZPageHandlerTest.java
+++ b/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/IndexZPageHandlerTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.zpages;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/SpanBucketTest.java
+++ b/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/SpanBucketTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.zpages;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
@@ -49,9 +49,9 @@ class SpanBucketTest {
     /* The latency SpanBucket should have the most recent LATENCY_BUCKET_SIZE spans */
     assertThat(latencyBucket.size()).isEqualTo(LATENCY_BUCKET_SIZE);
     assertThat(bucketSpans.size()).isEqualTo(LATENCY_BUCKET_SIZE);
-    assertThat(bucketSpans).doesNotContain(spans[0]);
+    assertThat(bucketSpans).doesNotContain((ReadableSpan) spans[0]);
     for (int i = 1; i < LATENCY_BUCKET_SIZE + 1; i++) {
-      assertThat(bucketSpans).contains(spans[i]);
+      assertThat(bucketSpans).contains((ReadableSpan) spans[i]);
     }
   }
 
@@ -69,9 +69,9 @@ class SpanBucketTest {
     /* The error SpanBucket should have the most recent ERROR_BUCKET_SIZE spans */
     assertThat(errorBucket.size()).isEqualTo(ERROR_BUCKET_SIZE);
     assertThat(bucketSpans.size()).isEqualTo(ERROR_BUCKET_SIZE);
-    assertThat(bucketSpans).doesNotContain(spans[0]);
+    assertThat(bucketSpans).doesNotContain((ReadableSpan) spans[0]);
     for (int i = 1; i < ERROR_BUCKET_SIZE + 1; i++) {
-      assertThat(bucketSpans).contains(spans[i]);
+      assertThat(bucketSpans).contains((ReadableSpan) spans[i]);
     }
   }
 

--- a/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TraceConfigzZPageHandlerTest.java
+++ b/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TraceConfigzZPageHandlerTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.zpages;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.sdk.OpenTelemetrySdk;

--- a/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TracezDataAggregatorTest.java
+++ b/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TracezDataAggregatorTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.zpages;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.trace.ReadableSpan;
@@ -128,7 +128,7 @@ public final class TracezDataAggregatorTest {
     /* getRunningSpans should return a List with all 3 spans */
     List<SpanData> spans = dataAggregator.getRunningSpans(SPAN_NAME_ONE);
     assertThat(spans)
-        .containsExactly(
+        .containsExactlyInAnyOrder(
             ((ReadableSpan) span1).toSpanData(),
             ((ReadableSpan) span2).toSpanData(),
             ((ReadableSpan) span3).toSpanData());

--- a/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TracezSpanProcessorTest.java
+++ b/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TracezSpanProcessorTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.zpages;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.sdk.trace.ReadableSpan;

--- a/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TracezZPageHandlerTest.java
+++ b/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TracezZPageHandlerTest.java
@@ -17,7 +17,7 @@
 package io.opentelemetry.sdk.extensions.zpages;
 
 import static com.google.common.net.UrlEscapers.urlFormParameterEscaper;
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.sdk.internal.TestClock;

--- a/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/ZPageHttpHandlerTest.java
+++ b/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/ZPageHttpHandlerTest.java
@@ -16,7 +16,8 @@
 
 package io.opentelemetry.sdk.extensions.zpages;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -36,6 +37,6 @@ public final class ZPageHttpHandlerTest {
     URI uri =
         new URI("http://localhost:8000/tracez/tracez?zspanname=Test&ztype=1&zsubtype=5&noval");
     assertThat(ZPageHttpHandler.parseQueryMap(uri))
-        .containsExactly("zspanname", "Test", "ztype", "1", "zsubtype", "5");
+        .containsOnly(entry("zspanname", "Test"), entry("ztype", "1"), entry("zsubtype", "5"));
   }
 }

--- a/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/ZPageServerTest.java
+++ b/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/ZPageServerTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.zpages;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;


### PR DESCRIPTION
See #1452 for motivation, this should be a benefit for new contributor experience.

I used IntelliJ replace in path to replace imports and some obvious differences like `.isSameInstanceAs` -> `.isSameAs` and manually updated map assertions for `entry` (assertj is typesafe) and fixed failing list assertions to assert with any order, truth defaults to allowing any order and assertj defaults to exact order.