### PR TITLE
Enable errorprone's ExpectedExceptionChecker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,10 +62,6 @@ configure(opentelemetryProjects) {
         // Yep, we're using an obsolete JDK.
         it.options.errorprone.disable("JdkObsolete")
 
-        // We prefer ExpectedException to assertThrows
-        it.options.errorprone.disable("ExpectedExceptionChecker")
-        // "-Xep:ExpectedExceptionRefactoring:OFF"
-
         // AutoValueImmutableFields suggests returning Guava types from API methods
         it.options.errorprone.disable("AutoValueImmutableFields")
         // "-Xep:AutoValueImmutableFields:OFF"


### PR DESCRIPTION
Since we migrated to a newer Junit (even later Junit 4 versions would have had assertThrows; AssertJ has assertThatExceptionOfType().isThrownBy) and Java 8, we can use assertThrows.

I think the actual refactoring was already done in #1489 by @anuraaga (thank you!), so this only needs to re-enable the warning.