### PR TITLE
Remove the instrumentation library name from the prometheus metric names

### DIFF
--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporters/prometheus/MetricAdapter.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporters/prometheus/MetricAdapter.java
@@ -57,27 +57,18 @@ final class MetricAdapter {
   // Converts a MetricData to a Prometheus MetricFamilySamples.
   static MetricFamilySamples toMetricFamilySamples(MetricData metricData) {
     Descriptor descriptor = metricData.getDescriptor();
-    String fullName =
-        toMetricFullName(
-            descriptor.getName(), metricData.getInstrumentationLibraryInfo().getName());
+    String cleanMetricName = cleanMetricName(descriptor.getName());
     Collector.Type type = toMetricFamilyType(descriptor.getType());
 
     return new MetricFamilySamples(
-        fullName,
+        cleanMetricName,
         type,
         descriptor.getDescription(),
-        toSamples(fullName, descriptor, metricData.getPoints()));
+        toSamples(cleanMetricName, descriptor, metricData.getPoints()));
   }
 
-  private static String toMetricFullName(
-      String descriptorMetricName, String instrumentationLibraryName) {
-    if (instrumentationLibraryName.isEmpty()) {
-      return Collector.sanitizeMetricName(descriptorMetricName);
-    }
-
-    // Use "_" here even though the right way would be to use "." in general, but "." will be
-    // replaced with "_" anyway so one less replace call.
-    return Collector.sanitizeMetricName(instrumentationLibraryName + "_" + descriptorMetricName);
+  private static String cleanMetricName(String descriptorMetricName) {
+    return Collector.sanitizeMetricName(descriptorMetricName);
   }
 
   static Collector.Type toMetricFamilyType(MetricData.Descriptor.Type type) {

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporters/prometheus/MetricAdapterTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporters/prometheus/MetricAdapterTest.java
@@ -213,7 +213,11 @@ class MetricAdapterTest {
   void toMetricFamilySamples() {
     Descriptor descriptor =
         Descriptor.create(
-            "name", "description", "1", Descriptor.Type.MONOTONIC_DOUBLE, Labels.of("kc", "vc"));
+            "instrument.name",
+            "description",
+            "1",
+            Descriptor.Type.MONOTONIC_DOUBLE,
+            Labels.of("kc", "vc"));
 
     MetricData metricData =
         MetricData.create(
@@ -226,12 +230,12 @@ class MetricAdapterTest {
     assertThat(MetricAdapter.toMetricFamilySamples(metricData))
         .isEqualTo(
             new MetricFamilySamples(
-                "full_name",
+                "instrument_name",
                 Collector.Type.COUNTER,
                 descriptor.getDescription(),
                 ImmutableList.of(
                     new Sample(
-                        "full_name",
+                        "instrument_name",
                         ImmutableList.of("kc", "kp"),
                         ImmutableList.of("vc", "vp"),
                         5))));

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporters/prometheus/PrometheusCollectorTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporters/prometheus/PrometheusCollectorTest.java
@@ -68,7 +68,7 @@ class PrometheusCollectorTest {
     return ImmutableList.of(
         MetricData.create(
             Descriptor.create(
-                "name",
+                "grpc.name",
                 "long_description",
                 "1",
                 Descriptor.Type.MONOTONIC_LONG,
@@ -79,7 +79,7 @@ class PrometheusCollectorTest {
                 MetricData.LongPoint.create(123, 456, Labels.of("kp", "vp"), 5))),
         MetricData.create(
             Descriptor.create(
-                "name",
+                "http.name",
                 "double_description",
                 "1",
                 Descriptor.Type.MONOTONIC_DOUBLE,


### PR DESCRIPTION
Now that we've decided that the instrument name is effectively globally scoped, we shouldn't be prefixing the instrumentation library name onto the prometheus metric names.