### PR TITLE
Add Attributes.toBuilder

### DIFF
--- a/api/src/main/java/io/opentelemetry/common/Attributes.java
+++ b/api/src/main/java/io/opentelemetry/common/Attributes.java
@@ -44,6 +44,11 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeValue>
 
     @Override
     abstract List<Object> data();
+
+    @Override
+    public Builder toBuilder() {
+      return new Builder(new ArrayList<>(data()));
+    }
   }
 
   /** Returns a {@link Attributes} instance with no attributes. */
@@ -122,17 +127,28 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeValue>
     return new AutoValue_Attributes_ArrayBackedAttributes(sortAndFilter(data));
   }
 
-  /** Creates a new {@link Builder} instance for creating arbitrary {@link Attributes}. */
+  /** Returns a new {@link Builder} instance for creating arbitrary {@link Attributes}. */
   public static Builder newBuilder() {
     return new Builder();
   }
+
+  /** Returns a new {@link Builder} instance populated with the data of this {@link Attributes}. */
+  public abstract Builder toBuilder();
 
   /**
    * Enables the creation of an {@link Attributes} instance with an arbitrary number of key-value
    * pairs.
    */
   public static class Builder {
-    private final List<Object> data = new ArrayList<>();
+    private final List<Object> data;
+
+    private Builder() {
+      data = new ArrayList<>();
+    }
+
+    private Builder(List<Object> data) {
+      this.data = data;
+    }
 
     /** Create the {@link Attributes} from this. */
     public Attributes build() {

--- a/api/src/test/java/io/opentelemetry/common/AttributesTest.java
+++ b/api/src/test/java/io/opentelemetry/common/AttributesTest.java
@@ -210,14 +210,13 @@ class AttributesTest {
             .setAttribute("dog", "bark")
             .build();
     assertThat(fromEmpty).isEqualTo(filled);
+    // Original not mutated.
+    assertThat(Attributes.empty().isEmpty()).isTrue();
 
-    Attributes fromPartial =
-        Attributes.newBuilder()
-            .setAttribute("cat", "meow")
-            .build()
-            .toBuilder()
-            .setAttribute("dog", "bark")
-            .build();
+    Attributes partial = Attributes.newBuilder().setAttribute("cat", "meow").build();
+    Attributes fromPartial = partial.toBuilder().setAttribute("dog", "bark").build();
     assertThat(fromPartial).isEqualTo(filled);
+    // Original not mutated.
+    assertThat(partial).isEqualTo(Attributes.newBuilder().setAttribute("cat", "meow").build());
   }
 }

--- a/api/src/test/java/io/opentelemetry/common/AttributesTest.java
+++ b/api/src/test/java/io/opentelemetry/common/AttributesTest.java
@@ -197,4 +197,27 @@ class AttributesTest {
     assertThat(threeElements.get("string")).isEqualTo(stringAttributeValue("value"));
     assertThat(threeElements.get("long")).isEqualTo(longAttributeValue(1L));
   }
+
+  @Test
+  void toBuilder() {
+    Attributes filled =
+        Attributes.newBuilder().setAttribute("cat", "meow").setAttribute("dog", "bark").build();
+
+    Attributes fromEmpty =
+        Attributes.empty()
+            .toBuilder()
+            .setAttribute("cat", "meow")
+            .setAttribute("dog", "bark")
+            .build();
+    assertThat(fromEmpty).isEqualTo(filled);
+
+    Attributes fromPartial =
+        Attributes.newBuilder()
+            .setAttribute("cat", "meow")
+            .build()
+            .toBuilder()
+            .setAttribute("dog", "bark")
+            .build();
+    assertThat(fromPartial).isEqualTo(filled);
+  }
 }


### PR DESCRIPTION
It's fairly easy to imagine wanting to add attributes to an existing `Attributes`, maybe storing a base in a config and tweaking at runtime.

Side effect is `Builder` constructor is made non-public which was probably intended.