### PR TITLE
fix splitting metadata key-value substring with more than one '=' sign

### DIFF
--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
@@ -291,7 +291,7 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
       String metadataValue = getStringProperty(KEY_METADATA, configMap);
       if (metadataValue != null) {
         for (String keyValueString : Splitter.on(';').split(metadataValue)) {
-          final List<String> keyValue = Splitter.on('=').splitToList(keyValueString);
+          final List<String> keyValue = Splitter.on('=').limit(2).splitToList(keyValueString);
           if (keyValue.size() == 2) {
             addHeader(keyValue.get(0), keyValue.get(1));
           }

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
@@ -291,7 +291,8 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
       String metadataValue = getStringProperty(KEY_METADATA, configMap);
       if (metadataValue != null) {
         for (String keyValueString : Splitter.on(';').split(metadataValue)) {
-          final List<String> keyValue = Splitter.on('=').limit(2).splitToList(keyValueString);
+          final List<String> keyValue = Splitter.on('=').limit(2).trimResults().omitEmptyStrings()
+              .splitToList(keyValueString);
           if (keyValue.size() == 2) {
             addHeader(keyValue.get(0), keyValue.get(1));
           }

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
@@ -291,8 +291,12 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
       String metadataValue = getStringProperty(KEY_METADATA, configMap);
       if (metadataValue != null) {
         for (String keyValueString : Splitter.on(';').split(metadataValue)) {
-          final List<String> keyValue = Splitter.on('=').limit(2).trimResults().omitEmptyStrings()
-              .splitToList(keyValueString);
+          final List<String> keyValue =
+              Splitter.on('=')
+                  .limit(2)
+                  .trimResults()
+                  .omitEmptyStrings()
+                  .splitToList(keyValueString);
           if (keyValue.size() == 2) {
             addHeader(keyValue.get(0), keyValue.get(1));
           }

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
@@ -66,7 +66,7 @@ class OtlpGrpcSpanExporterTest {
     options.put("otel.otlp.span.timeout", "12");
     options.put("otel.otlp.endpoint", "http://localhost:6553");
     options.put("otel.otlp.use.tls", "true");
-    options.put("otel.otlp.metadata", "key=value");
+    options.put("otel.otlp.metadata", "key=value;key2=value2=;key3=val=ue3");
     OtlpGrpcSpanExporter.Builder config = OtlpGrpcSpanExporter.newBuilder();
     OtlpGrpcSpanExporter.Builder spy = Mockito.spy(config);
     spy.fromConfigMap(options, ConfigBuilderTest.getNaming());
@@ -74,6 +74,8 @@ class OtlpGrpcSpanExporterTest {
     Mockito.verify(spy).setEndpoint("http://localhost:6553");
     Mockito.verify(spy).setUseTls(true);
     Mockito.verify(spy).addHeader("key", "value");
+    Mockito.verify(spy).addHeader("key2", "value2=");
+    Mockito.verify(spy).addHeader("key3", "val=ue3");
   }
 
   @BeforeEach

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
@@ -66,7 +66,7 @@ class OtlpGrpcSpanExporterTest {
     options.put("otel.otlp.span.timeout", "12");
     options.put("otel.otlp.endpoint", "http://localhost:6553");
     options.put("otel.otlp.use.tls", "true");
-    options.put("otel.otlp.metadata", "key=value;key2=value2=;key3=val=ue3");
+    options.put("otel.otlp.metadata", "key=value;key2=value2=;key3=val=ue3; key4 = value4 ;key5= ");
     OtlpGrpcSpanExporter.Builder config = OtlpGrpcSpanExporter.newBuilder();
     OtlpGrpcSpanExporter.Builder spy = Mockito.spy(config);
     spy.fromConfigMap(options, ConfigBuilderTest.getNaming());
@@ -76,6 +76,8 @@ class OtlpGrpcSpanExporterTest {
     Mockito.verify(spy).addHeader("key", "value");
     Mockito.verify(spy).addHeader("key2", "value2=");
     Mockito.verify(spy).addHeader("key3", "val=ue3");
+    Mockito.verify(spy).addHeader("key4", "value4");
+    Mockito.verify(spy, Mockito.never()).addHeader("key5", "");
   }
 
   @BeforeEach


### PR DESCRIPTION
cc @carlosalberto 