### PR TITLE
Return Span from DefaultSpan factories.

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
@@ -39,7 +39,7 @@ public final class DefaultSpan implements Span {
    * @return a {@code DefaultSpan} with an invalid {@code SpanContext}.
    * @since 0.1.0
    */
-  public static DefaultSpan getInvalid() {
+  public static Span getInvalid() {
     return INVALID;
   }
 
@@ -50,7 +50,7 @@ public final class DefaultSpan implements Span {
    * @return a {@link DefaultSpan}.
    * @since 0.1.0
    */
-  public static DefaultSpan create(SpanContext spanContext) {
+  public static Span create(SpanContext spanContext) {
     return new DefaultSpan(spanContext);
   }
 

--- a/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
@@ -34,7 +34,7 @@ class DefaultSpanTest {
 
   @Test
   void doNotCrash() {
-    DefaultSpan span = DefaultSpan.getInvalid();
+    Span span = DefaultSpan.getInvalid();
     span.setAttribute(
         "MyStringAttributeKey", AttributeValue.stringAttributeValue("MyStringAttributeValue"));
     span.setAttribute("MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true));
@@ -67,7 +67,7 @@ class DefaultSpanTest {
 
   @Test
   void defaultSpan_ToString() {
-    DefaultSpan span = DefaultSpan.getInvalid();
+    Span span = DefaultSpan.getInvalid();
     assertThat(span.toString()).isEqualTo("DefaultSpan");
   }
 


### PR DESCRIPTION
#1135 talks about hiding `DefaultSpan` completely. I couldn't quite find a good home for the factory methods (maybe `DefaultTracer`?) but it seems like a good idea.

In the meantime, it's more important to make the return type of the factories generic because users should definitely not have to care whether a span is a `DefaultSpan` or not. In practice, the return value of `DefaultSpan` makes it difficult to bridge them in auto instrumentation.

https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/764