### PR TITLE
Fix for Issue with bound instruments generating datapoints from no recordings.

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/ActiveBatcher.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/ActiveBatcher.java
@@ -43,7 +43,9 @@ final class ActiveBatcher implements Batcher {
 
   @Override
   public void batch(Labels labelSet, Aggregator aggregator, boolean mappedAggregator) {
-    batcher.batch(labelSet, aggregator, mappedAggregator);
+    if (aggregator.hasRecordings()) {
+      batcher.batch(labelSet, aggregator, mappedAggregator);
+    }
   }
 
   @Override

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/aggregator/AbstractAggregator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/aggregator/AbstractAggregator.java
@@ -16,14 +16,12 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 abstract class AbstractAggregator implements Aggregator {
   // Note: This is not 100% thread-safe. There is a race condition where recordings can
   // be made in the moment between the reset and the setting of this field's value. In those
   // cases, it is possible that a recording could be missed in a given recording interval, but
   // it should be picked up in the next, assuming that more recordings are being made.
-  private final AtomicBoolean hasRecordings = new AtomicBoolean(false);
+  private volatile boolean hasRecordings = false;
 
   @Override
   public void mergeToAndReset(Aggregator other) {
@@ -31,7 +29,7 @@ abstract class AbstractAggregator implements Aggregator {
       return;
     }
     doMergeAndReset(other);
-    hasRecordings.set(false);
+    hasRecordings = false;
   }
 
   /**
@@ -47,8 +45,8 @@ abstract class AbstractAggregator implements Aggregator {
 
   @Override
   public final void recordLong(long value) {
-    hasRecordings.set(true);
     doRecordLong(value);
+    hasRecordings = true;
   }
 
   /**
@@ -62,8 +60,8 @@ abstract class AbstractAggregator implements Aggregator {
 
   @Override
   public final void recordDouble(double value) {
-    hasRecordings.set(true);
     doRecordDouble(value);
+    hasRecordings = true;
   }
 
   /**
@@ -77,6 +75,6 @@ abstract class AbstractAggregator implements Aggregator {
 
   @Override
   public boolean hasRecordings() {
-    return hasRecordings.get();
+    return hasRecordings;
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/aggregator/Aggregator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/aggregator/Aggregator.java
@@ -57,4 +57,7 @@ public interface Aggregator {
    * @param value the new {@code double} value to be added.
    */
   void recordDouble(double value);
+
+  /** Whether there have been any recordings since this aggregator has been reset. */
+  boolean hasRecordings();
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleLastValueAggregator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleLastValueAggregator.java
@@ -68,7 +68,7 @@ public final class DoubleLastValueAggregator extends AbstractAggregator {
   }
 
   @Override
-  public void recordDouble(double value) {
+  public void doRecordDouble(double value) {
     current.set(value);
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCount.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCount.java
@@ -60,7 +60,7 @@ public final class DoubleMinMaxSumCount extends AbstractAggregator {
   }
 
   @Override
-  public void recordDouble(double value) {
+  public void doRecordDouble(double value) {
     current.record(value);
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleSumAggregator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleSumAggregator.java
@@ -56,7 +56,7 @@ public final class DoubleSumAggregator extends AbstractAggregator {
   }
 
   @Override
-  public void recordDouble(double value) {
+  public void doRecordDouble(double value) {
     current.getAndAdd(value);
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongLastValueAggregator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongLastValueAggregator.java
@@ -68,7 +68,7 @@ public final class LongLastValueAggregator extends AbstractAggregator {
   }
 
   @Override
-  public void recordLong(long value) {
+  public void doRecordLong(long value) {
     current.set(value);
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCount.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCount.java
@@ -61,7 +61,7 @@ public final class LongMinMaxSumCount extends AbstractAggregator {
   }
 
   @Override
-  public void recordLong(long value) {
+  public void doRecordLong(long value) {
     current.record(value);
   }
 

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongSumAggregator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongSumAggregator.java
@@ -56,7 +56,7 @@ public final class LongSumAggregator extends AbstractAggregator {
   }
 
   @Override
-  public void recordLong(long value) {
+  public void doRecordLong(long value) {
     current.getAndAdd(value);
   }
 }

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/aggregator/NoopAggregator.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/aggregator/NoopAggregator.java
@@ -55,5 +55,10 @@ public final class NoopAggregator implements Aggregator {
     // Noop
   }
 
+  @Override
+  public boolean hasRecordings() {
+    return false;
+  }
+
   private NoopAggregator() {}
 }

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongCounterSdkTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/LongCounterSdkTest.java
@@ -26,6 +26,7 @@ import io.opentelemetry.metrics.LongCounter;
 import io.opentelemetry.metrics.LongCounter.BoundLongCounter;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
+import io.opentelemetry.sdk.metrics.LongCounterSdk.BoundInstrument;
 import io.opentelemetry.sdk.metrics.StressTestRunner.OperationUpdater;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
@@ -73,6 +74,33 @@ class LongCounterSdkTest {
             .setDescription("My very own counter")
             .setUnit("ms")
             .build();
+    List<MetricData> metricDataList = longCounter.collectAll();
+    assertThat(metricDataList).hasSize(1);
+    MetricData metricData = metricDataList.get(0);
+    assertThat(metricData.getDescriptor())
+        .isEqualTo(
+            Descriptor.create(
+                "testCounter",
+                "My very own counter",
+                "ms",
+                Descriptor.Type.MONOTONIC_LONG,
+                Labels.of("sk1", "sv1")));
+    assertThat(metricData.getResource()).isEqualTo(RESOURCE);
+    assertThat(metricData.getInstrumentationLibraryInfo()).isEqualTo(INSTRUMENTATION_LIBRARY_INFO);
+    assertThat(metricData.getPoints()).isEmpty();
+  }
+
+  @Test
+  void collectMetrics_bound_NoRecords() {
+    LongCounterSdk longCounter =
+        testSdk
+            .longCounterBuilder("testCounter")
+            .setConstantLabels(Labels.of("sk1", "sv1"))
+            .setDescription("My very own counter")
+            .setUnit("ms")
+            .build();
+    BoundInstrument ignored = longCounter.bind(Labels.of("foo", "bar"));
+
     List<MetricData> metricDataList = longCounter.collectAll();
     assertThat(metricDataList).hasSize(1);
     MetricData metricData = metricDataList.get(0);

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/aggregator/AbstractAggregatorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/aggregator/AbstractAggregatorTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.metrics.aggregator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import io.opentelemetry.common.Labels;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+public class AbstractAggregatorTest {
+  @Test
+  void testRecordings() {
+    TestAggregator testAggregator = new TestAggregator();
+
+    assertThat(testAggregator.hasRecordings()).isFalse();
+
+    testAggregator.recordLong(22);
+    assertThat(testAggregator.hasRecordings()).isTrue();
+    assertThat(testAggregator.recordedLong.get()).isEqualTo(22);
+    assertThat(testAggregator.recordedDouble.get()).isEqualTo(0);
+
+    testAggregator.mergeToAndReset(new TestAggregator());
+
+    assertThat(testAggregator.hasRecordings()).isFalse();
+    assertThat(testAggregator.recordedLong.get()).isEqualTo(0);
+    assertThat(testAggregator.recordedDouble.get()).isEqualTo(0);
+
+    testAggregator.recordDouble(33.55);
+    assertThat(testAggregator.hasRecordings()).isTrue();
+    assertThat(testAggregator.recordedLong.get()).isEqualTo(0);
+    assertThat(testAggregator.recordedDouble.get()).isEqualTo(33.55);
+
+    testAggregator.mergeToAndReset(new TestAggregator());
+
+    assertThat(testAggregator.hasRecordings()).isFalse();
+    assertThat(testAggregator.recordedLong.get()).isEqualTo(0);
+    assertThat(testAggregator.recordedDouble.get()).isEqualTo(0);
+  }
+
+  private static class TestAggregator extends AbstractAggregator {
+    AtomicLong recordedLong = new AtomicLong();
+    AtomicDouble recordedDouble = new AtomicDouble();
+
+    @Override
+    public MetricData.Point toPoint(long startEpochNanos, long epochNanos, Labels labels) {
+      return null;
+    }
+
+    @Override
+    void doMergeAndReset(Aggregator aggregator) {
+      recordedLong.set(0);
+      recordedDouble.set(0);
+    }
+
+    @Override
+    protected void doRecordLong(long value) {
+      recordedLong.set(value);
+    }
+
+    @Override
+    protected void doRecordDouble(double value) {
+      recordedDouble.set(value);
+    }
+  }
+}

--- a/sdk/src/test/java/io/opentelemetry/sdk/metrics/aggregator/NoopAggregatorTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/metrics/aggregator/NoopAggregatorTest.java
@@ -36,5 +36,6 @@ class NoopAggregatorTest {
     aggregator.recordDouble(12.1);
     aggregator.mergeToAndReset(aggregator);
     assertThat(aggregator.toPoint(1, 2, Labels.empty())).isNull();
+    assertThat(aggregator.hasRecordings()).isFalse();
   }
 }


### PR DESCRIPTION
Fixes #1453 

The fix is to introduce an AtomicBoolean in the AbstractAggregator that tracks whether recordings have been made since the last reset was done. The ActiveBatcher queries the aggregator and if no recordings have been made, it skips generating metric points.