### PR TITLE
Add the "semver:" prefix to the version in the resource.

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/resources/Resource.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/resources/Resource.java
@@ -51,7 +51,7 @@ public abstract class Resource {
           Attributes.newBuilder()
               .setAttribute("telemetry.sdk.name", "opentelemetry")
               .setAttribute("telemetry.sdk.language", "java")
-              .setAttribute("telemetry.sdk.version", readVersion())
+              .setAttribute("telemetry.sdk.version", "semver:" + readVersion())
               .build());
   private static final Resource DEFAULT =
       new EnvAutodetectResource.Builder()

--- a/sdk/src/test/java/io/opentelemetry/sdk/resources/ResourceTest.java
+++ b/sdk/src/test/java/io/opentelemetry/sdk/resources/ResourceTest.java
@@ -152,5 +152,6 @@ class ResourceTest {
     assertThat(attributes.get("telemetry.sdk.language"))
         .isEqualTo(AttributeValue.stringAttributeValue("java"));
     assertThat(attributes.get("telemetry.sdk.version").getStringValue()).isNotNull();
+    assertThat(attributes.get("telemetry.sdk.version").getStringValue()).startsWith("semver:");
   }
 }


### PR DESCRIPTION
By the spec (https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/README.md#version-attributes), versions should be prefixed with "semver:" when the version uses semantic versioning.