### PR TITLE
Add documentation to make it clear that the MetricProducer cannot be shared across exporters

### DIFF
--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdkProvider.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdkProvider.java
@@ -64,7 +64,7 @@ public final class MeterSdkProvider implements MeterProvider {
    * MeterSdkProvider}.
    *
    * <p>WARNING: A MetricProducer is stateful. It will only return changes since the last time it
-   * was access. This means that if more than one {@link
+   * was accessed. This means that if more than one {@link
    * io.opentelemetry.sdk.metrics.export.MetricExporter} has a handle to this MetricProducer, the
    * two exporters will not receive the same metric data to export.
    *

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdkProvider.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdkProvider.java
@@ -63,6 +63,11 @@ public final class MeterSdkProvider implements MeterProvider {
    * Returns the {@link MetricProducer} that can be used to retrieve metrics from this {@code
    * MeterSdkProvider}.
    *
+   * <p>WARNING: A MetricProducer is stateful. It will only return changes since the last time it
+   * was access. This means that if more than one {@link
+   * io.opentelemetry.sdk.metrics.export.MetricExporter} has a handle to this MetricProducer, the
+   * two exporters will not receive the same metric data to export.
+   *
    * @return the {@link MetricProducer} that can be used to retrieve metrics from this {@code
    *     MeterSdkProvider}.
    */

--- a/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdkProvider.java
+++ b/sdk/src/main/java/io/opentelemetry/sdk/metrics/MeterSdkProvider.java
@@ -66,7 +66,7 @@ public final class MeterSdkProvider implements MeterProvider {
    * <p>WARNING: A MetricProducer is stateful. It will only return changes since the last time it
    * was accessed. This means that if more than one {@link
    * io.opentelemetry.sdk.metrics.export.MetricExporter} has a handle to this MetricProducer, the
-   * two exporters will not receive the same metric data to export.
+   * two exporters will not receive copies of the same metric data to export.
    *
    * @return the {@link MetricProducer} that can be used to retrieve metrics from this {@code
    *     MeterSdkProvider}.


### PR DESCRIPTION
It doesn't exactly fix the underlying issue in #1439 (that will probably take a redesign), but it at least documents it more clearly to reduce surprise.