### PR TITLE
Implement thread.id and thread.name semantic attributes

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/attributes/SemanticAttributes.java
+++ b/api/src/main/java/io/opentelemetry/trace/attributes/SemanticAttributes.java
@@ -285,5 +285,11 @@ public final class SemanticAttributes {
   public static final StringAttributeSetter EXCEPTION_STACKTRACE =
       StringAttributeSetter.create("exception.stacktrace");
 
+  /** Id of the thread that has started a span, as produced by {@link Thread#getId()}. */
+  public static final LongAttributeSetter THREAD_ID = LongAttributeSetter.create("thread.id");
+  /** Name of the thread that has started a span, as produced by {@link Thread#getName()}. */
+  public static final StringAttributeSetter THREAD_NAME =
+      StringAttributeSetter.create("thread.name");
+
   private SemanticAttributes() {}
 }


### PR DESCRIPTION
This small PR implements [two new semantic attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/span-general.md#general-thread-attributes), added in https://github.com/open-telemetry/opentelemetry-specification/pull/789