### PR TITLE
Fix to export entire batch sequentially instead of dropping spans.

### DIFF
--- a/sdk/tracing/build.gradle
+++ b/sdk/tracing/build.gradle
@@ -24,7 +24,8 @@ dependencies {
     testCompile project(path: ':opentelemetry-sdk-common', configuration: 'testClasses')
 
     testImplementation project(':opentelemetry-testing-internal')
-    testImplementation libraries.junit_pioneer
+    testImplementation libraries.junit_pioneer,
+            libraries.awaitility
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -272,6 +272,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
         }
       } else {
         logger.log(Level.FINE, "Exporter busy. Dropping spans.");
+        droppedSpans.add(spanList.size());
       }
     }
 

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -39,7 +39,6 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import org.junit.jupiter.api.AfterEach;
@@ -517,8 +516,6 @@ class BatchSpanProcessorTest {
 
     private final List<SpanData> exported = new ArrayList<>();
 
-    private final AtomicInteger pending = new AtomicInteger();
-
     private volatile boolean succeeded;
 
     List<SpanData> getExported() {
@@ -532,7 +529,6 @@ class BatchSpanProcessorTest {
 
     @Override
     public CompletableResultCode export(Collection<SpanData> spans) {
-      pending.incrementAndGet();
       exported.addAll(spans);
       if (succeeded) {
         return CompletableResultCode.ofSuccess();


### PR DESCRIPTION
The `BatchSpanProcessor` has two aspects, a queue size and a batch size. When time comes, it tries to export the entire queue, sending a batch at a time. Because of our exporter availability check, though, batches within one flush of the queue are mostly guaranteed to not be sent, instead we should make sure these batches are sent out sequentially.

