### PR TITLE
Only drop elements exported by BatchSpanProcessor

### DIFF
--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -47,8 +47,7 @@ import javax.annotation.concurrent.GuardedBy;
  * <p>All spans reported by the SDK implementation are first added to a synchronized queue (with a
  * {@code maxQueueSize} maximum size, after the size is reached spans are dropped) and exported
  * every {@code scheduleDelayMillis} to the exporter pipeline in batches of {@code
- * maxExportBatchSize}. Spans may also be dropped when it becomes time to export again, and there is
- * an export in progress.
+ * maxExportBatchSize}.
  *
  * <p>If the queue gets half full a preemptive notification is sent to a worker that exports the
  * spans to wake up and start a new export cycle.

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -82,6 +82,7 @@ import javax.annotation.concurrent.GuardedBy;
  */
 public final class BatchSpanProcessor implements SpanProcessor {
 
+  // FIXME This worker thread can be eliminated by leveraging the timer
   private static final String WORKER_THREAD_NAME =
       BatchSpanProcessor.class.getSimpleName() + "_WorkerThread";
   private static final String TIMER_THREAD_NAME =
@@ -217,7 +218,6 @@ public final class BatchSpanProcessor implements SpanProcessor {
         // avoid blocking the producer thread.
         ArrayList<ReadableSpan> spansCopy;
         synchronized (monitor) {
-          // If still maxExportBatchSize elements in the queue better to execute an extra
           do {
             // In the case of a spurious wakeup we export only if we have at least one span in
             // the batch. It is acceptable because batching is a best effort mechanism here.

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -277,7 +277,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
 
                   synchronized (monitor) {
                     // If there are still more to process and we remain pretty full...
-                    if (spansList.size() >= halfMaxQueueSize) {
+                    if (spansList.size() >= maxExportBatchSize) {
                       timer.schedule(new WorkerTask(), 0);
                     }
                   }

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -82,7 +82,6 @@ import javax.annotation.concurrent.GuardedBy;
  */
 public final class BatchSpanProcessor implements SpanProcessor {
 
-  // FIXME This worker thread can be eliminated by leveraging the timer
   private static final String TIMER_THREAD_NAME =
       BatchSpanProcessor.class.getSimpleName() + "_TimerThread";
   private final Worker worker;

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -276,8 +276,8 @@ public final class BatchSpanProcessor implements SpanProcessor {
                   exportAvailable.set(true);
 
                   synchronized (monitor) {
-                    // If there are still more to process then schedule our task immediately
-                    if (!spansList.isEmpty()) {
+                    // If there are still more to process and we remain pretty full...
+                    if (spansList.size() >= halfMaxQueueSize) {
                       timer.schedule(new WorkerTask(), 0);
                     }
                   }

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -218,19 +218,17 @@ public final class BatchSpanProcessor implements SpanProcessor {
         ArrayList<ReadableSpan> spansCopy;
         synchronized (monitor) {
           // If still maxExportBatchSize elements in the queue better to execute an extra
-          if (spansList.size() < maxExportBatchSize) {
-            do {
-              // In the case of a spurious wakeup we export only if we have at least one span in
-              // the batch. It is acceptable because batching is a best effort mechanism here.
-              try {
-                monitor.wait(scheduleDelayMillis);
-              } catch (InterruptedException ie) {
-                // Preserve the interruption status as per guidance and stop doing any work.
-                Thread.currentThread().interrupt();
-                return;
-              }
-            } while (spansList.isEmpty());
-          }
+          do {
+            // In the case of a spurious wakeup we export only if we have at least one span in
+            // the batch. It is acceptable because batching is a best effort mechanism here.
+            try {
+              monitor.wait(scheduleDelayMillis);
+            } catch (InterruptedException ie) {
+              // Preserve the interruption status as per guidance and stop doing any work.
+              Thread.currentThread().interrupt();
+              return;
+            }
+          } while (spansList.isEmpty());
           spansCopy = new ArrayList<>(spansList);
         }
         // Execute the batch export outside the synchronized to not block all producers.

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -50,8 +50,8 @@ import javax.annotation.concurrent.GuardedBy;
  * maxExportBatchSize}. Spans may also be dropped when it becomes time to export again, and there is
  * an export in progress.
  *
- * <p>If the queue gets half full a preemptive notification is sent to the worker thread that
- * exports the spans to wake up and start a new export cycle.
+ * <p>If the queue gets half full a preemptive notification is sent to a worker that exports the
+ * spans to wake up and start a new export cycle.
  *
  * <p>This batch {@link SpanProcessor} can cause high contention in a very high traffic service.
  * TODO: Add a link to the SpanProcessor that uses Disruptor as alternative with low contention.
@@ -202,10 +202,9 @@ public final class BatchSpanProcessor implements SpanProcessor {
         }
         // TODO: Record a gauge for referenced spans.
         spansList.add(span);
-        // Notify the worker thread that at half of the queue is available. It will take
-        // time anyway for the thread to wake up.
+        // Notify the worker that at half of the queue is available.
         if (spansList.size() >= halfMaxQueueSize) {
-          monitor.notifyAll();
+          timer.schedule(new WorkerTask(), 0);
         }
       }
     }

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -151,8 +151,13 @@ class TracerSdkTest {
           StressTestRunner.Operation.create(2_000, 1, new SimpleSpanOperation(tracer)));
     }
 
+    // Needs to correlate with the BatchSpanProcessor.Builder's default, which is the only thing
+    // this test can guarantee
+    final int defaultMaxQueueSize = 2048;
+
     stressTestBuilder.build().run();
-    assertThat(countingSpanExporter.numberOfSpansExported.get()).isEqualTo(8_000);
+    assertThat(countingSpanExporter.numberOfSpansExported.get())
+        .isGreaterThanOrEqualTo(defaultMaxQueueSize);
   }
 
   private static class CountingSpanProcessor implements SpanProcessor {

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -244,7 +244,6 @@ class BatchSpanProcessorTest {
     // Wait to block the worker thread in the BatchSampledSpansProcessor. This ensures that no items
     // can be removed from the queue. Need to add a span to trigger the export otherwise the
     // pipeline is never called.
-    spansToExport.add(createSampledEndedSpan("blocking_span").toSpanData());
     blockingSpanExporter.waitUntilIsBlocked();
 
     for (int i = 0; i < maxQueuedSpans; i++) {


### PR DESCRIPTION
This PR takes an approach where only the actual elements passed onto an exporter is removed from the internal buffer of spans within a `BatchSpanProcessor`. Any pressure on the buffer becoming full will result in the `BatchSpanProcessor` dropping elements as per its original design.

Prior to this PR, spans could be dropped by the `BatchSpanProcessor` without being reported.

Along the way, it occurred to me that the worker thread can be replaced by using the timer thread that we have to have. I've now affected code changes there too, which I think simplifies the `BatchSpanProcessor`.

Fixes #1566 

cc @anuraaga 