### PR TITLE
Rename ParentOrElse to ParentBased and generalize to support all cases

### DIFF
--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -249,13 +249,13 @@ public final class Samplers {
   @Immutable
   static class ParentBased implements Sampler {
     private final Sampler root;
-    private Sampler remoteParentSampled = alwaysOn();
-    private Sampler remoteParentNotSampled = alwaysOff();
-    private Sampler localParentSampled = alwaysOn();
-    private Sampler localParentNotSampled = alwaysOff();
+    private final Sampler remoteParentSampled;
+    private final Sampler remoteParentNotSampled;
+    private final Sampler localParentSampled;
+    private final Sampler localParentNotSampled;
 
     ParentBased(Sampler root) {
-      this.root = root;
+      this(root, alwaysOn(), alwaysOff(), alwaysOn(), alwaysOff());
     }
 
     ParentBased(
@@ -265,18 +265,12 @@ public final class Samplers {
         Sampler localParentSampled,
         Sampler localParentNotSampled) {
       this.root = root;
-      if (remoteParentSampled != null) {
-        this.remoteParentSampled = remoteParentSampled;
-      }
-      if (remoteParentNotSampled != null) {
-        this.remoteParentNotSampled = remoteParentNotSampled;
-      }
-      if (localParentSampled != null) {
-        this.localParentSampled = localParentSampled;
-      }
-      if (localParentNotSampled != null) {
-        this.localParentNotSampled = localParentNotSampled;
-      }
+      this.remoteParentSampled = remoteParentSampled == null ? alwaysOn() : remoteParentSampled;
+      this.remoteParentNotSampled =
+          remoteParentNotSampled == null ? alwaysOff() : remoteParentNotSampled;
+      this.localParentSampled = localParentSampled == null ? alwaysOn() : localParentSampled;
+      this.localParentNotSampled =
+          localParentNotSampled == null ? alwaysOff() : localParentNotSampled;
     }
 
     // If a parent is set, always follows the same sampling decision as the parent.

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -356,7 +356,7 @@ public final class Samplers {
             this.remoteParentSampled,
             this.remoteParentNotSampled,
             this.localParentSampled,
-            localParentNotSampled);
+            this.localParentNotSampled);
       }
 
       private Builder(Sampler root) {

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -298,7 +298,8 @@ public final class Samplers {
       private Sampler localParentNotSampled;
 
       /**
-       * Sets the {@link Sampler} to use when there is a remote parent that was sampled.
+       * Sets the {@link Sampler} to use when there is a remote parent that was sampled. If not set,
+       * defaults to always sampling if the remote parent was sampled.
        *
        * @return this Builder
        */
@@ -308,7 +309,8 @@ public final class Samplers {
       }
 
       /**
-       * Sets the {@link Sampler} to use when there is a remote parent that was not sampled.
+       * Sets the {@link Sampler} to use when there is a remote parent that was not sampled. If not
+       * set, defaults to never sampling when the remote parent isn't sampled.
        *
        * @return this Builder
        */
@@ -318,7 +320,8 @@ public final class Samplers {
       }
 
       /**
-       * Sets the {@link Sampler} to use when there is a local parent that was sampled.
+       * Sets the {@link Sampler} to use when there is a local parent that was sampled. If not set,
+       * defaults to always sampling if the local parent was sampled.
        *
        * @return this Builder
        */
@@ -328,7 +331,8 @@ public final class Samplers {
       }
 
       /**
-       * Sets the {@link Sampler} to use when there is a local parent that was not sampled.
+       * Sets the {@link Sampler} to use when there is a local parent that was not sampled. If not
+       * set, defaults to never sampling when the local parent isn't sampled.
        *
        * @return this Builder
        */

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -154,40 +154,20 @@ public final class Samplers {
    * @since 0.7.0
    */
   public static Sampler parentBased(Sampler root) {
-    return new ParentBased(root);
+    return newParentBasedBuilder(root).build();
   }
 
   /**
-   * Returns a {@link Sampler} that always makes the same decision as the parent {@link Span} to
-   * whether or not to sample. If there is no parent, the Sampler uses the provided Sampler delegate
-   * to determine the sampling decision.
+   * Returns a {@link ParentBased.Builder} that follows the parent's sampling decision if one
+   * exists, otherwise following the root sampler and other optional sampler's decision.
    *
    * @param root the required {@code Sampler} which is used to make the sampling decisions if the
    *     parent does not exist.
-   * @param remoteParentSampled the optional {@code Sampler} which is used to make the sampling
-   *     decisions if the remote parent exist and is sampled.
-   * @param remoteParentNotSampled the optional {@code Sampler} which is used to make the sampling
-   *     decisions if the remote parent exist and is not sampled.
-   * @param localParentSampled the optional {@code Sampler} which is used to make the sampling
-   *     decisions if the local parent exist and is sampled.
-   * @param localParentNotSampled the optional {@code Sampler} which is used to make the sampling
-   *     decisions if the local parent exist and is not sampled.
-   * @return a {@code Sampler} that follows the parent's sampling decision if one exists, otherwise
-   *     following the root sampler and other optional sampler's decision.
+   * @return a {@code ParentBased.Builder}
    * @since 0.8.0
    */
-  public static Sampler parentBased(
-      Sampler root,
-      Sampler remoteParentSampled,
-      Sampler remoteParentNotSampled,
-      Sampler localParentSampled,
-      Sampler localParentNotSampled) {
-    return new ParentBased(
-        root,
-        remoteParentSampled,
-        remoteParentNotSampled,
-        localParentSampled,
-        localParentNotSampled);
+  public static ParentBased.Builder newParentBasedBuilder(Sampler root) {
+    return new ParentBased.Builder(root);
   }
 
   /**
@@ -254,11 +234,7 @@ public final class Samplers {
     private final Sampler localParentSampled;
     private final Sampler localParentNotSampled;
 
-    ParentBased(Sampler root) {
-      this(root, alwaysOn(), alwaysOff(), alwaysOn(), alwaysOff());
-    }
-
-    ParentBased(
+    private ParentBased(
         Sampler root,
         Sampler remoteParentSampled,
         Sampler remoteParentNotSampled,
@@ -312,6 +288,80 @@ public final class Samplers {
           this.remoteParentNotSampled.getDescription(),
           this.localParentSampled.getDescription(),
           this.localParentNotSampled.getDescription());
+    }
+
+    static class Builder {
+      private final Sampler root;
+      private Sampler remoteParentSampled;
+      private Sampler remoteParentNotSampled;
+      private Sampler localParentSampled;
+      private Sampler localParentNotSampled;
+
+      /**
+       * Sets the remoteParentSampled. Optional.
+       *
+       * @param remoteParentSampled used to make the sampling decisions if the remote parent exist
+       *     and is sampled.
+       * @return this.
+       */
+      public Builder withRemoteParentSampled(Sampler remoteParentSampled) {
+        this.remoteParentSampled = remoteParentSampled;
+        return this;
+      }
+
+      /**
+       * Sets the remoteParentNotSampled. Optional.
+       *
+       * @param remoteParentNotSampled used to make the sampling decisions if the remote parent
+       *     exist and is not sampled.
+       * @return this.
+       */
+      public Builder withRemoteParentNotSampled(Sampler remoteParentNotSampled) {
+        this.remoteParentNotSampled = remoteParentNotSampled;
+        return this;
+      }
+
+      /**
+       * Sets the localParentSampled. Optional.
+       *
+       * @param localParentSampled used to make the sampling decisions if the local parent exist and
+       *     is sampled.
+       * @return this.
+       */
+      public Builder withLocalParentSampled(Sampler localParentSampled) {
+        this.localParentSampled = localParentSampled;
+        return this;
+      }
+
+      /**
+       * Sets the localParentNotSampled. Optional.
+       *
+       * @param localParentNotSampled used to make the sampling decisions if the local parent exist
+       *     and is not sampled.
+       * @return this.
+       */
+      public Builder withLocalParentNotSampled(Sampler localParentNotSampled) {
+        this.localParentNotSampled = localParentNotSampled;
+        return this;
+      }
+
+      /**
+       * Builds the {@link ParentBased}.
+       *
+       * @return the ParentBased sampler.
+       */
+      public ParentBased build() {
+        return new ParentBased(
+            this.root,
+            this.remoteParentSampled,
+            this.remoteParentNotSampled,
+            this.localParentSampled,
+            localParentNotSampled);
+      }
+
+      private Builder(Sampler root) {
+        this.root = root;
+      }
     }
   }
 

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -303,7 +303,7 @@ public final class Samplers {
        *
        * @return this Builder
        */
-      public Builder withRemoteParentSampled(Sampler remoteParentSampled) {
+      public Builder setRemoteParentSampled(Sampler remoteParentSampled) {
         this.remoteParentSampled = remoteParentSampled;
         return this;
       }
@@ -314,7 +314,7 @@ public final class Samplers {
        *
        * @return this Builder
        */
-      public Builder withRemoteParentNotSampled(Sampler remoteParentNotSampled) {
+      public Builder setRemoteParentNotSampled(Sampler remoteParentNotSampled) {
         this.remoteParentNotSampled = remoteParentNotSampled;
         return this;
       }
@@ -325,7 +325,7 @@ public final class Samplers {
        *
        * @return this Builder
        */
-      public Builder withLocalParentSampled(Sampler localParentSampled) {
+      public Builder setLocalParentSampled(Sampler localParentSampled) {
         this.localParentSampled = localParentSampled;
         return this;
       }
@@ -336,7 +336,7 @@ public final class Samplers {
        *
        * @return this Builder
        */
-      public Builder withLocalParentNotSampled(Sampler localParentNotSampled) {
+      public Builder setLocalParentNotSampled(Sampler localParentNotSampled) {
         this.localParentNotSampled = localParentNotSampled;
         return this;
       }

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -298,11 +298,9 @@ public final class Samplers {
       private Sampler localParentNotSampled;
 
       /**
-       * Sets the remoteParentSampled. Optional.
+       * Sets the {@link Sampler} to use when there is a remote parent that was sampled.
        *
-       * @param remoteParentSampled used to make the sampling decisions if the remote parent exist
-       *     and is sampled.
-       * @return this.
+       * @return this Builder
        */
       public Builder withRemoteParentSampled(Sampler remoteParentSampled) {
         this.remoteParentSampled = remoteParentSampled;
@@ -310,11 +308,9 @@ public final class Samplers {
       }
 
       /**
-       * Sets the remoteParentNotSampled. Optional.
+       * Sets the {@link Sampler} to use when there is a remote parent that was not sampled.
        *
-       * @param remoteParentNotSampled used to make the sampling decisions if the remote parent
-       *     exist and is not sampled.
-       * @return this.
+       * @return this Builder
        */
       public Builder withRemoteParentNotSampled(Sampler remoteParentNotSampled) {
         this.remoteParentNotSampled = remoteParentNotSampled;
@@ -322,11 +318,9 @@ public final class Samplers {
       }
 
       /**
-       * Sets the localParentSampled. Optional.
+       * Sets the {@link Sampler} to use when there is a local parent that was sampled.
        *
-       * @param localParentSampled used to make the sampling decisions if the local parent exist and
-       *     is sampled.
-       * @return this.
+       * @return this Builder
        */
       public Builder withLocalParentSampled(Sampler localParentSampled) {
         this.localParentSampled = localParentSampled;
@@ -334,11 +328,9 @@ public final class Samplers {
       }
 
       /**
-       * Sets the localParentNotSampled. Optional.
+       * Sets the {@link Sampler} to use when there is a local parent that was not sampled.
        *
-       * @param localParentNotSampled used to make the sampling decisions if the local parent exist
-       *     and is not sampled.
-       * @return this.
+       * @return this Builder
        */
       public Builder withLocalParentNotSampled(Sampler localParentNotSampled) {
         this.localParentNotSampled = localParentNotSampled;

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -153,8 +153,8 @@ public final class Samplers {
    *     following the delegate sampler's decision.
    * @since 0.7.0
    */
-  public static Sampler parentOrElse(Sampler delegateSampler) {
-    return new ParentOrElse(delegateSampler);
+  public static Sampler parentBased(Sampler delegateSampler) {
+    return new ParentBased(delegateSampler);
   }
 
   /**
@@ -214,10 +214,10 @@ public final class Samplers {
   }
 
   @Immutable
-  static class ParentOrElse implements Sampler {
+  static class ParentBased implements Sampler {
     private final Sampler delegateSampler;
 
-    ParentOrElse(Sampler delegateSampler) {
+    ParentBased(Sampler delegateSampler) {
       this.delegateSampler = delegateSampler;
     }
 
@@ -243,7 +243,7 @@ public final class Samplers {
 
     @Override
     public String getDescription() {
-      return String.format("ParentOrElse{%s}", this.delegateSampler.getDescription());
+      return String.format("ParentBased{%s}", this.delegateSampler.getDescription());
     }
   }
 

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -311,7 +311,8 @@ public final class Samplers {
     @Override
     public String getDescription() {
       return String.format(
-          "ParentBased{root:%s,remoteParentSampled:%s,remoteParentNotSampled:%s,localParentSampled:%s,localParentNotSampled:%s}",
+          "ParentBased{root:%s,remoteParentSampled:%s,remoteParentNotSampled:%s,"
+              + "localParentSampled:%s,localParentNotSampled:%s}",
           this.root.getDescription(),
           this.remoteParentSampled.getDescription(),
           this.remoteParentNotSampled.getDescription(),

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -154,7 +154,7 @@ public final class Samplers {
    * @since 0.7.0
    */
   public static Sampler parentBased(Sampler root) {
-    return newParentBasedBuilder(root).build();
+    return parentBasedBuilder(root).build();
   }
 
   /**
@@ -166,7 +166,7 @@ public final class Samplers {
    * @return a {@code ParentBased.Builder}
    * @since 0.8.0
    */
-  public static ParentBased.Builder newParentBasedBuilder(Sampler root) {
+  public static ParentBased.Builder parentBasedBuilder(Sampler root) {
     return new ParentBased.Builder(root);
   }
 

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
@@ -87,7 +87,7 @@ import javax.annotation.concurrent.Immutable;
 public abstract class TraceConfig {
   // These values are the default values for all the global parameters.
   // TODO: decide which default sampler to use
-  private static final Sampler DEFAULT_SAMPLER = Samplers.parentOrElse(Samplers.alwaysOn());
+  private static final Sampler DEFAULT_SAMPLER = Samplers.parentBased(Samplers.alwaysOn());
   private static final int DEFAULT_SPAN_MAX_NUM_ATTRIBUTES = 32;
   private static final int DEFAULT_SPAN_MAX_NUM_EVENTS = 128;
   private static final int DEFAULT_SPAN_MAX_NUM_LINKS = 32;

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -258,7 +258,9 @@ class SamplersTest {
   @Test
   void parentBasedSampler_NotSampled_Remote_Parent() {
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOff(), null, Samplers.alwaysOn(), null, null)
+            Samplers.newParentBasedBuilder(Samplers.alwaysOff())
+                .withRemoteParentNotSampled(Samplers.alwaysOn())
+                .build()
                 .shouldSample(
                     notSampledRemoteSpanContext,
                     traceId,
@@ -270,7 +272,9 @@ class SamplersTest {
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
 
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOff(), null, Samplers.alwaysOff(), null, null)
+            Samplers.newParentBasedBuilder(Samplers.alwaysOff())
+                .withRemoteParentNotSampled(Samplers.alwaysOff())
+                .build()
                 .shouldSample(
                     notSampledRemoteSpanContext,
                     traceId,
@@ -282,7 +286,9 @@ class SamplersTest {
         .isEqualTo(Decision.NOT_RECORD);
 
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOn(), null, Samplers.alwaysOff(), null, null)
+            Samplers.newParentBasedBuilder(Samplers.alwaysOn())
+                .withRemoteParentNotSampled(Samplers.alwaysOff())
+                .build()
                 .shouldSample(
                     notSampledRemoteSpanContext,
                     traceId,
@@ -294,7 +300,9 @@ class SamplersTest {
         .isEqualTo(Decision.NOT_RECORD);
 
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOn(), null, Samplers.alwaysOn(), null, null)
+            Samplers.newParentBasedBuilder(Samplers.alwaysOn())
+                .withRemoteParentNotSampled(Samplers.alwaysOn())
+                .build()
                 .shouldSample(
                     notSampledRemoteSpanContext,
                     traceId,
@@ -310,7 +318,9 @@ class SamplersTest {
   void parentBasedSampler_NotSampled_NotRemote_Parent() {
 
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOff(), null, null, null, Samplers.alwaysOn())
+            Samplers.newParentBasedBuilder(Samplers.alwaysOff())
+                .withLocalParentNotSampled(Samplers.alwaysOn())
+                .build()
                 .shouldSample(
                     notSampledSpanContext,
                     traceId,
@@ -322,7 +332,9 @@ class SamplersTest {
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
 
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOff(), null, null, null, Samplers.alwaysOff())
+            Samplers.newParentBasedBuilder(Samplers.alwaysOff())
+                .withLocalParentNotSampled(Samplers.alwaysOff())
+                .build()
                 .shouldSample(
                     notSampledSpanContext,
                     traceId,
@@ -334,7 +346,9 @@ class SamplersTest {
         .isEqualTo(Decision.NOT_RECORD);
 
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOn(), null, null, null, Samplers.alwaysOff())
+            Samplers.newParentBasedBuilder(Samplers.alwaysOn())
+                .withLocalParentNotSampled(Samplers.alwaysOff())
+                .build()
                 .shouldSample(
                     notSampledSpanContext,
                     traceId,
@@ -346,7 +360,9 @@ class SamplersTest {
         .isEqualTo(Decision.NOT_RECORD);
 
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOn(), null, null, null, Samplers.alwaysOn())
+            Samplers.newParentBasedBuilder(Samplers.alwaysOn())
+                .withLocalParentNotSampled(Samplers.alwaysOn())
+                .build()
                 .shouldSample(
                     notSampledSpanContext,
                     traceId,
@@ -361,7 +377,9 @@ class SamplersTest {
   @Test
   void parentBasedSampler_Sampled_Remote_Parent() {
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOff(), Samplers.alwaysOff(), null, null, null)
+            Samplers.newParentBasedBuilder(Samplers.alwaysOff())
+                .withRemoteParentSampled(Samplers.alwaysOff())
+                .build()
                 .shouldSample(
                     sampledRemoteSpanContext,
                     traceId,
@@ -373,7 +391,9 @@ class SamplersTest {
         .isEqualTo(Decision.NOT_RECORD);
 
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOff(), Samplers.alwaysOn(), null, null, null)
+            Samplers.newParentBasedBuilder(Samplers.alwaysOff())
+                .withRemoteParentSampled(Samplers.alwaysOn())
+                .build()
                 .shouldSample(
                     sampledRemoteSpanContext,
                     traceId,
@@ -385,7 +405,9 @@ class SamplersTest {
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
 
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOn(), Samplers.alwaysOn(), null, null, null)
+            Samplers.newParentBasedBuilder(Samplers.alwaysOn())
+                .withRemoteParentSampled(Samplers.alwaysOn())
+                .build()
                 .shouldSample(
                     sampledRemoteSpanContext,
                     traceId,
@@ -397,7 +419,9 @@ class SamplersTest {
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
 
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOn(), Samplers.alwaysOff(), null, null, null)
+            Samplers.newParentBasedBuilder(Samplers.alwaysOn())
+                .withRemoteParentSampled(Samplers.alwaysOff())
+                .build()
                 .shouldSample(
                     sampledRemoteSpanContext,
                     traceId,
@@ -412,7 +436,9 @@ class SamplersTest {
   @Test
   void parentBasedSampler_Sampled_NotRemote_Parent() {
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOff(), null, null, Samplers.alwaysOn(), null)
+            Samplers.newParentBasedBuilder(Samplers.alwaysOff())
+                .withLocalParentSampled(Samplers.alwaysOn())
+                .build()
                 .shouldSample(
                     sampledSpanContext,
                     traceId,
@@ -424,7 +450,9 @@ class SamplersTest {
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
 
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOff(), null, null, Samplers.alwaysOff(), null)
+            Samplers.newParentBasedBuilder(Samplers.alwaysOff())
+                .withLocalParentSampled(Samplers.alwaysOff())
+                .build()
                 .shouldSample(
                     sampledSpanContext,
                     traceId,
@@ -436,7 +464,9 @@ class SamplersTest {
         .isEqualTo(Decision.NOT_RECORD);
 
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOn(), null, null, Samplers.alwaysOff(), null)
+            Samplers.newParentBasedBuilder(Samplers.alwaysOn())
+                .withLocalParentSampled(Samplers.alwaysOff())
+                .build()
                 .shouldSample(
                     sampledSpanContext,
                     traceId,
@@ -448,7 +478,9 @@ class SamplersTest {
         .isEqualTo(Decision.NOT_RECORD);
 
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOn(), null, null, Samplers.alwaysOn(), null)
+            Samplers.newParentBasedBuilder(Samplers.alwaysOn())
+                .withLocalParentSampled(Samplers.alwaysOn())
+                .build()
                 .shouldSample(
                     sampledSpanContext,
                     traceId,
@@ -487,12 +519,12 @@ class SamplersTest {
         .isEqualTo(Decision.NOT_RECORD);
 
     assertThat(
-            Samplers.parentBased(
-                    Samplers.alwaysOff(),
-                    Samplers.alwaysOn(),
-                    Samplers.alwaysOn(),
-                    Samplers.alwaysOn(),
-                    Samplers.alwaysOn())
+            Samplers.newParentBasedBuilder(Samplers.alwaysOff())
+                .withRemoteParentSampled(Samplers.alwaysOn())
+                .withRemoteParentNotSampled(Samplers.alwaysOn())
+                .withLocalParentSampled(Samplers.alwaysOn())
+                .withLocalParentNotSampled(Samplers.alwaysOn())
+                .build()
                 .shouldSample(
                     invalidSpanContext,
                     traceId,

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -258,7 +258,7 @@ class SamplersTest {
   @Test
   void parentBasedSampler_NotSampled_Remote_Parent() {
     assertThat(
-            Samplers.newParentBasedBuilder(Samplers.alwaysOff())
+            Samplers.parentBasedBuilder(Samplers.alwaysOff())
                 .setRemoteParentNotSampled(Samplers.alwaysOn())
                 .build()
                 .shouldSample(
@@ -272,7 +272,7 @@ class SamplersTest {
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
 
     assertThat(
-            Samplers.newParentBasedBuilder(Samplers.alwaysOff())
+            Samplers.parentBasedBuilder(Samplers.alwaysOff())
                 .setRemoteParentNotSampled(Samplers.alwaysOff())
                 .build()
                 .shouldSample(
@@ -286,7 +286,7 @@ class SamplersTest {
         .isEqualTo(Decision.NOT_RECORD);
 
     assertThat(
-            Samplers.newParentBasedBuilder(Samplers.alwaysOn())
+            Samplers.parentBasedBuilder(Samplers.alwaysOn())
                 .setRemoteParentNotSampled(Samplers.alwaysOff())
                 .build()
                 .shouldSample(
@@ -300,7 +300,7 @@ class SamplersTest {
         .isEqualTo(Decision.NOT_RECORD);
 
     assertThat(
-            Samplers.newParentBasedBuilder(Samplers.alwaysOn())
+            Samplers.parentBasedBuilder(Samplers.alwaysOn())
                 .setRemoteParentNotSampled(Samplers.alwaysOn())
                 .build()
                 .shouldSample(
@@ -318,7 +318,7 @@ class SamplersTest {
   void parentBasedSampler_NotSampled_NotRemote_Parent() {
 
     assertThat(
-            Samplers.newParentBasedBuilder(Samplers.alwaysOff())
+            Samplers.parentBasedBuilder(Samplers.alwaysOff())
                 .setLocalParentNotSampled(Samplers.alwaysOn())
                 .build()
                 .shouldSample(
@@ -332,7 +332,7 @@ class SamplersTest {
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
 
     assertThat(
-            Samplers.newParentBasedBuilder(Samplers.alwaysOff())
+            Samplers.parentBasedBuilder(Samplers.alwaysOff())
                 .setLocalParentNotSampled(Samplers.alwaysOff())
                 .build()
                 .shouldSample(
@@ -346,7 +346,7 @@ class SamplersTest {
         .isEqualTo(Decision.NOT_RECORD);
 
     assertThat(
-            Samplers.newParentBasedBuilder(Samplers.alwaysOn())
+            Samplers.parentBasedBuilder(Samplers.alwaysOn())
                 .setLocalParentNotSampled(Samplers.alwaysOff())
                 .build()
                 .shouldSample(
@@ -360,7 +360,7 @@ class SamplersTest {
         .isEqualTo(Decision.NOT_RECORD);
 
     assertThat(
-            Samplers.newParentBasedBuilder(Samplers.alwaysOn())
+            Samplers.parentBasedBuilder(Samplers.alwaysOn())
                 .setLocalParentNotSampled(Samplers.alwaysOn())
                 .build()
                 .shouldSample(
@@ -377,7 +377,7 @@ class SamplersTest {
   @Test
   void parentBasedSampler_Sampled_Remote_Parent() {
     assertThat(
-            Samplers.newParentBasedBuilder(Samplers.alwaysOff())
+            Samplers.parentBasedBuilder(Samplers.alwaysOff())
                 .setRemoteParentSampled(Samplers.alwaysOff())
                 .build()
                 .shouldSample(
@@ -391,7 +391,7 @@ class SamplersTest {
         .isEqualTo(Decision.NOT_RECORD);
 
     assertThat(
-            Samplers.newParentBasedBuilder(Samplers.alwaysOff())
+            Samplers.parentBasedBuilder(Samplers.alwaysOff())
                 .setRemoteParentSampled(Samplers.alwaysOn())
                 .build()
                 .shouldSample(
@@ -405,7 +405,7 @@ class SamplersTest {
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
 
     assertThat(
-            Samplers.newParentBasedBuilder(Samplers.alwaysOn())
+            Samplers.parentBasedBuilder(Samplers.alwaysOn())
                 .setRemoteParentSampled(Samplers.alwaysOn())
                 .build()
                 .shouldSample(
@@ -419,7 +419,7 @@ class SamplersTest {
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
 
     assertThat(
-            Samplers.newParentBasedBuilder(Samplers.alwaysOn())
+            Samplers.parentBasedBuilder(Samplers.alwaysOn())
                 .setRemoteParentSampled(Samplers.alwaysOff())
                 .build()
                 .shouldSample(
@@ -436,7 +436,7 @@ class SamplersTest {
   @Test
   void parentBasedSampler_Sampled_NotRemote_Parent() {
     assertThat(
-            Samplers.newParentBasedBuilder(Samplers.alwaysOff())
+            Samplers.parentBasedBuilder(Samplers.alwaysOff())
                 .setLocalParentSampled(Samplers.alwaysOn())
                 .build()
                 .shouldSample(
@@ -450,7 +450,7 @@ class SamplersTest {
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
 
     assertThat(
-            Samplers.newParentBasedBuilder(Samplers.alwaysOff())
+            Samplers.parentBasedBuilder(Samplers.alwaysOff())
                 .setLocalParentSampled(Samplers.alwaysOff())
                 .build()
                 .shouldSample(
@@ -464,7 +464,7 @@ class SamplersTest {
         .isEqualTo(Decision.NOT_RECORD);
 
     assertThat(
-            Samplers.newParentBasedBuilder(Samplers.alwaysOn())
+            Samplers.parentBasedBuilder(Samplers.alwaysOn())
                 .setLocalParentSampled(Samplers.alwaysOff())
                 .build()
                 .shouldSample(
@@ -478,7 +478,7 @@ class SamplersTest {
         .isEqualTo(Decision.NOT_RECORD);
 
     assertThat(
-            Samplers.newParentBasedBuilder(Samplers.alwaysOn())
+            Samplers.parentBasedBuilder(Samplers.alwaysOn())
                 .setLocalParentSampled(Samplers.alwaysOn())
                 .build()
                 .shouldSample(
@@ -519,7 +519,7 @@ class SamplersTest {
         .isEqualTo(Decision.NOT_RECORD);
 
     assertThat(
-            Samplers.newParentBasedBuilder(Samplers.alwaysOff())
+            Samplers.parentBasedBuilder(Samplers.alwaysOff())
                 .setRemoteParentSampled(Samplers.alwaysOn())
                 .setRemoteParentNotSampled(Samplers.alwaysOn())
                 .setLocalParentSampled(Samplers.alwaysOn())

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -199,7 +199,7 @@ class SamplersTest {
 
   @Test
   void parentBasedSampler_AlwaysOn() {
-    // Sampled not remote parent.
+    // Sampled parent.
     assertThat(
             Samplers.parentBased(Samplers.alwaysOn())
                 .shouldSample(
@@ -212,8 +212,25 @@ class SamplersTest {
                 .getDecision())
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
 
+    // Not sampled parent.
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOn(), null, null, Samplers.alwaysOff(), null)
+            Samplers.parentBased(Samplers.alwaysOn())
+                .shouldSample(
+                    notSampledSpanContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
+        .isEqualTo(Decision.NOT_RECORD);
+  }
+
+  @Test
+  void parentBasedSampler_AlwaysOff() {
+    // Sampled parent.
+    assertThat(
+            Samplers.parentBased(Samplers.alwaysOff())
                 .shouldSample(
                     sampledSpanContext,
                     traceId,
@@ -222,11 +239,11 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.RECORD_AND_SAMPLED);
 
-    // Not sampled not remote parent.
+    // Not sampled parent.
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOn())
+            Samplers.parentBased(Samplers.alwaysOff())
                 .shouldSample(
                     notSampledSpanContext,
                     traceId,
@@ -236,72 +253,12 @@ class SamplersTest {
                     Collections.emptyList())
                 .getDecision())
         .isEqualTo(Decision.NOT_RECORD);
+  }
 
+  @Test
+  void parentBasedSampler_NotSampled_Remote_Parent() {
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOn(), null, null, null, Samplers.alwaysOn())
-                .shouldSample(
-                    notSampledSpanContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
-
-    // Invalid parent.
-    assertThat(
-            Samplers.parentBased(Samplers.alwaysOn())
-                .shouldSample(
-                    invalidSpanContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
-
-    assertThat(
-            Samplers.parentBased(Samplers.alwaysOn(), null, null, null, Samplers.alwaysOn())
-                .shouldSample(
-                    invalidSpanContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
-
-    // Sampled remote parent
-    assertThat(
-            Samplers.parentBased(Samplers.alwaysOn(), Samplers.alwaysOff(), null, null, null)
-                .shouldSample(
-                    sampledRemoteSpanContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
-
-    assertThat(
-            Samplers.parentBased(Samplers.alwaysOn(), Samplers.alwaysOn(), null, null, null)
-                .shouldSample(
-                    sampledRemoteSpanContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
-
-    // Not sampled remote parent
-    assertThat(
-            Samplers.parentBased(Samplers.alwaysOn(), null, Samplers.alwaysOn(), null, null)
+            Samplers.parentBased(Samplers.alwaysOff(), null, Samplers.alwaysOn(), null, null)
                 .shouldSample(
                     notSampledRemoteSpanContext,
                     traceId,
@@ -311,6 +268,18 @@ class SamplersTest {
                     Collections.emptyList())
                 .getDecision())
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
+
+    assertThat(
+            Samplers.parentBased(Samplers.alwaysOff(), null, Samplers.alwaysOff(), null, null)
+                .shouldSample(
+                    notSampledRemoteSpanContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
+        .isEqualTo(Decision.NOT_RECORD);
 
     assertThat(
             Samplers.parentBased(Samplers.alwaysOn(), null, Samplers.alwaysOff(), null, null)
@@ -323,47 +292,22 @@ class SamplersTest {
                     Collections.emptyList())
                 .getDecision())
         .isEqualTo(Decision.NOT_RECORD);
+
+    assertThat(
+            Samplers.parentBased(Samplers.alwaysOn(), null, Samplers.alwaysOn(), null, null)
+                .shouldSample(
+                    notSampledRemoteSpanContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
+        .isEqualTo(Decision.RECORD_AND_SAMPLED);
   }
 
   @Test
-  void parentBasedSampler_AlwaysOff() {
-    // Sampled not remote parent.
-    assertThat(
-            Samplers.parentBased(Samplers.alwaysOff())
-                .shouldSample(
-                    sampledSpanContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
-
-    assertThat(
-            Samplers.parentBased(Samplers.alwaysOff(), null, null, Samplers.alwaysOff(), null)
-                .shouldSample(
-                    sampledSpanContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
-
-    // Not sampled not remote parent.
-    assertThat(
-            Samplers.parentBased(Samplers.alwaysOff())
-                .shouldSample(
-                    notSampledSpanContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+  void parentBasedSampler_NotSampled_NotRemote_Parent() {
 
     assertThat(
             Samplers.parentBased(Samplers.alwaysOff(), null, null, null, Samplers.alwaysOn())
@@ -377,11 +321,10 @@ class SamplersTest {
                 .getDecision())
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
 
-    // Invalid parent.
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOff())
+            Samplers.parentBased(Samplers.alwaysOff(), null, null, null, Samplers.alwaysOff())
                 .shouldSample(
-                    invalidSpanContext,
+                    notSampledSpanContext,
                     traceId,
                     SPAN_NAME,
                     SPAN_KIND,
@@ -391,9 +334,9 @@ class SamplersTest {
         .isEqualTo(Decision.NOT_RECORD);
 
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOff(), null, null, null, Samplers.alwaysOn())
+            Samplers.parentBased(Samplers.alwaysOn(), null, null, null, Samplers.alwaysOff())
                 .shouldSample(
-                    invalidSpanContext,
+                    notSampledSpanContext,
                     traceId,
                     SPAN_NAME,
                     SPAN_KIND,
@@ -402,7 +345,21 @@ class SamplersTest {
                 .getDecision())
         .isEqualTo(Decision.NOT_RECORD);
 
-    // Sampled remote parent
+    assertThat(
+            Samplers.parentBased(Samplers.alwaysOn(), null, null, null, Samplers.alwaysOn())
+                .shouldSample(
+                    notSampledSpanContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
+        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+  }
+
+  @Test
+  void parentBasedSampler_Sampled_Remote_Parent() {
     assertThat(
             Samplers.parentBased(Samplers.alwaysOff(), Samplers.alwaysOff(), null, null, null)
                 .shouldSample(
@@ -427,11 +384,10 @@ class SamplersTest {
                 .getDecision())
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
 
-    // Not sampled remote parent
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOff(), null, Samplers.alwaysOn(), null, null)
+            Samplers.parentBased(Samplers.alwaysOn(), Samplers.alwaysOn(), null, null, null)
                 .shouldSample(
-                    notSampledRemoteSpanContext,
+                    sampledRemoteSpanContext,
                     traceId,
                     SPAN_NAME,
                     SPAN_KIND,
@@ -441,9 +397,9 @@ class SamplersTest {
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
 
     assertThat(
-            Samplers.parentBased(Samplers.alwaysOff(), null, Samplers.alwaysOff(), null, null)
+            Samplers.parentBased(Samplers.alwaysOn(), Samplers.alwaysOff(), null, null, null)
                 .shouldSample(
-                    notSampledRemoteSpanContext,
+                    sampledRemoteSpanContext,
                     traceId,
                     SPAN_NAME,
                     SPAN_KIND,
@@ -451,6 +407,113 @@ class SamplersTest {
                     Collections.emptyList())
                 .getDecision())
         .isEqualTo(Decision.NOT_RECORD);
+  }
+
+  @Test
+  void parentBasedSampler_Sampled_NotRemote_Parent() {
+    assertThat(
+            Samplers.parentBased(Samplers.alwaysOff(), null, null, Samplers.alwaysOn(), null)
+                .shouldSample(
+                    sampledSpanContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
+        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+
+    assertThat(
+            Samplers.parentBased(Samplers.alwaysOff(), null, null, Samplers.alwaysOff(), null)
+                .shouldSample(
+                    sampledSpanContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
+        .isEqualTo(Decision.NOT_RECORD);
+
+    assertThat(
+            Samplers.parentBased(Samplers.alwaysOn(), null, null, Samplers.alwaysOff(), null)
+                .shouldSample(
+                    sampledSpanContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
+        .isEqualTo(Decision.NOT_RECORD);
+
+    assertThat(
+            Samplers.parentBased(Samplers.alwaysOn(), null, null, Samplers.alwaysOn(), null)
+                .shouldSample(
+                    sampledSpanContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
+        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+  }
+
+  @Test
+  void parentBasedSampler_invalid_Parent() {
+    assertThat(
+            Samplers.parentBased(Samplers.alwaysOff())
+                .shouldSample(
+                    invalidSpanContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
+        .isEqualTo(Decision.NOT_RECORD);
+
+    assertThat(
+            Samplers.parentBased(Samplers.alwaysOff())
+                .shouldSample(
+                    invalidSpanContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
+        .isEqualTo(Decision.NOT_RECORD);
+
+    assertThat(
+            Samplers.parentBased(
+                    Samplers.alwaysOff(),
+                    Samplers.alwaysOn(),
+                    Samplers.alwaysOn(),
+                    Samplers.alwaysOn(),
+                    Samplers.alwaysOn())
+                .shouldSample(
+                    invalidSpanContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
+        .isEqualTo(Decision.NOT_RECORD);
+
+    assertThat(
+            Samplers.parentBased(Samplers.alwaysOn())
+                .shouldSample(
+                    invalidSpanContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
+        .isEqualTo(Decision.RECORD_AND_SAMPLED);
   }
 
   @Test

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -259,7 +259,7 @@ class SamplersTest {
   void parentBasedSampler_NotSampled_Remote_Parent() {
     assertThat(
             Samplers.newParentBasedBuilder(Samplers.alwaysOff())
-                .withRemoteParentNotSampled(Samplers.alwaysOn())
+                .setRemoteParentNotSampled(Samplers.alwaysOn())
                 .build()
                 .shouldSample(
                     notSampledRemoteSpanContext,
@@ -273,7 +273,7 @@ class SamplersTest {
 
     assertThat(
             Samplers.newParentBasedBuilder(Samplers.alwaysOff())
-                .withRemoteParentNotSampled(Samplers.alwaysOff())
+                .setRemoteParentNotSampled(Samplers.alwaysOff())
                 .build()
                 .shouldSample(
                     notSampledRemoteSpanContext,
@@ -287,7 +287,7 @@ class SamplersTest {
 
     assertThat(
             Samplers.newParentBasedBuilder(Samplers.alwaysOn())
-                .withRemoteParentNotSampled(Samplers.alwaysOff())
+                .setRemoteParentNotSampled(Samplers.alwaysOff())
                 .build()
                 .shouldSample(
                     notSampledRemoteSpanContext,
@@ -301,7 +301,7 @@ class SamplersTest {
 
     assertThat(
             Samplers.newParentBasedBuilder(Samplers.alwaysOn())
-                .withRemoteParentNotSampled(Samplers.alwaysOn())
+                .setRemoteParentNotSampled(Samplers.alwaysOn())
                 .build()
                 .shouldSample(
                     notSampledRemoteSpanContext,
@@ -319,7 +319,7 @@ class SamplersTest {
 
     assertThat(
             Samplers.newParentBasedBuilder(Samplers.alwaysOff())
-                .withLocalParentNotSampled(Samplers.alwaysOn())
+                .setLocalParentNotSampled(Samplers.alwaysOn())
                 .build()
                 .shouldSample(
                     notSampledSpanContext,
@@ -333,7 +333,7 @@ class SamplersTest {
 
     assertThat(
             Samplers.newParentBasedBuilder(Samplers.alwaysOff())
-                .withLocalParentNotSampled(Samplers.alwaysOff())
+                .setLocalParentNotSampled(Samplers.alwaysOff())
                 .build()
                 .shouldSample(
                     notSampledSpanContext,
@@ -347,7 +347,7 @@ class SamplersTest {
 
     assertThat(
             Samplers.newParentBasedBuilder(Samplers.alwaysOn())
-                .withLocalParentNotSampled(Samplers.alwaysOff())
+                .setLocalParentNotSampled(Samplers.alwaysOff())
                 .build()
                 .shouldSample(
                     notSampledSpanContext,
@@ -361,7 +361,7 @@ class SamplersTest {
 
     assertThat(
             Samplers.newParentBasedBuilder(Samplers.alwaysOn())
-                .withLocalParentNotSampled(Samplers.alwaysOn())
+                .setLocalParentNotSampled(Samplers.alwaysOn())
                 .build()
                 .shouldSample(
                     notSampledSpanContext,
@@ -378,7 +378,7 @@ class SamplersTest {
   void parentBasedSampler_Sampled_Remote_Parent() {
     assertThat(
             Samplers.newParentBasedBuilder(Samplers.alwaysOff())
-                .withRemoteParentSampled(Samplers.alwaysOff())
+                .setRemoteParentSampled(Samplers.alwaysOff())
                 .build()
                 .shouldSample(
                     sampledRemoteSpanContext,
@@ -392,7 +392,7 @@ class SamplersTest {
 
     assertThat(
             Samplers.newParentBasedBuilder(Samplers.alwaysOff())
-                .withRemoteParentSampled(Samplers.alwaysOn())
+                .setRemoteParentSampled(Samplers.alwaysOn())
                 .build()
                 .shouldSample(
                     sampledRemoteSpanContext,
@@ -406,7 +406,7 @@ class SamplersTest {
 
     assertThat(
             Samplers.newParentBasedBuilder(Samplers.alwaysOn())
-                .withRemoteParentSampled(Samplers.alwaysOn())
+                .setRemoteParentSampled(Samplers.alwaysOn())
                 .build()
                 .shouldSample(
                     sampledRemoteSpanContext,
@@ -420,7 +420,7 @@ class SamplersTest {
 
     assertThat(
             Samplers.newParentBasedBuilder(Samplers.alwaysOn())
-                .withRemoteParentSampled(Samplers.alwaysOff())
+                .setRemoteParentSampled(Samplers.alwaysOff())
                 .build()
                 .shouldSample(
                     sampledRemoteSpanContext,
@@ -437,7 +437,7 @@ class SamplersTest {
   void parentBasedSampler_Sampled_NotRemote_Parent() {
     assertThat(
             Samplers.newParentBasedBuilder(Samplers.alwaysOff())
-                .withLocalParentSampled(Samplers.alwaysOn())
+                .setLocalParentSampled(Samplers.alwaysOn())
                 .build()
                 .shouldSample(
                     sampledSpanContext,
@@ -451,7 +451,7 @@ class SamplersTest {
 
     assertThat(
             Samplers.newParentBasedBuilder(Samplers.alwaysOff())
-                .withLocalParentSampled(Samplers.alwaysOff())
+                .setLocalParentSampled(Samplers.alwaysOff())
                 .build()
                 .shouldSample(
                     sampledSpanContext,
@@ -465,7 +465,7 @@ class SamplersTest {
 
     assertThat(
             Samplers.newParentBasedBuilder(Samplers.alwaysOn())
-                .withLocalParentSampled(Samplers.alwaysOff())
+                .setLocalParentSampled(Samplers.alwaysOff())
                 .build()
                 .shouldSample(
                     sampledSpanContext,
@@ -479,7 +479,7 @@ class SamplersTest {
 
     assertThat(
             Samplers.newParentBasedBuilder(Samplers.alwaysOn())
-                .withLocalParentSampled(Samplers.alwaysOn())
+                .setLocalParentSampled(Samplers.alwaysOn())
                 .build()
                 .shouldSample(
                     sampledSpanContext,
@@ -520,10 +520,10 @@ class SamplersTest {
 
     assertThat(
             Samplers.newParentBasedBuilder(Samplers.alwaysOff())
-                .withRemoteParentSampled(Samplers.alwaysOn())
-                .withRemoteParentNotSampled(Samplers.alwaysOn())
-                .withLocalParentSampled(Samplers.alwaysOn())
-                .withLocalParentNotSampled(Samplers.alwaysOn())
+                .setRemoteParentSampled(Samplers.alwaysOn())
+                .setRemoteParentNotSampled(Samplers.alwaysOn())
+                .setLocalParentSampled(Samplers.alwaysOn())
+                .setLocalParentNotSampled(Samplers.alwaysOn())
                 .build()
                 .shouldSample(
                     invalidSpanContext,

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -192,10 +192,10 @@ class SamplersTest {
   }
 
   @Test
-  void parentOrElseSampler_AlwaysOn() {
+  void parentBasedSampler_AlwaysOn() {
     // Sampled parent.
     assertThat(
-            Samplers.parentOrElse(Samplers.alwaysOn())
+            Samplers.parentBased(Samplers.alwaysOn())
                 .shouldSample(
                     sampledSpanContext,
                     traceId,
@@ -208,7 +208,7 @@ class SamplersTest {
 
     // Not sampled parent.
     assertThat(
-            Samplers.parentOrElse(Samplers.alwaysOn())
+            Samplers.parentBased(Samplers.alwaysOn())
                 .shouldSample(
                     notSampledSpanContext,
                     traceId,
@@ -221,7 +221,7 @@ class SamplersTest {
 
     // Invalid parent.
     assertThat(
-            Samplers.parentOrElse(Samplers.alwaysOn())
+            Samplers.parentBased(Samplers.alwaysOn())
                 .shouldSample(
                     invalidSpanContext,
                     traceId,
@@ -234,10 +234,10 @@ class SamplersTest {
   }
 
   @Test
-  void parentOrElseSampler_AlwaysOff() {
+  void parentBasedSampler_AlwaysOff() {
     // Sampled parent.
     assertThat(
-            Samplers.parentOrElse(Samplers.alwaysOff())
+            Samplers.parentBased(Samplers.alwaysOff())
                 .shouldSample(
                     sampledSpanContext,
                     traceId,
@@ -250,7 +250,7 @@ class SamplersTest {
 
     // Not sampled parent.
     assertThat(
-            Samplers.parentOrElse(Samplers.alwaysOff())
+            Samplers.parentBased(Samplers.alwaysOff())
                 .shouldSample(
                     notSampledSpanContext,
                     traceId,
@@ -263,7 +263,7 @@ class SamplersTest {
 
     // Invalid parent.
     assertThat(
-            Samplers.parentOrElse(Samplers.alwaysOff())
+            Samplers.parentBased(Samplers.alwaysOff())
                 .shouldSample(
                     invalidSpanContext,
                     traceId,
@@ -276,9 +276,9 @@ class SamplersTest {
   }
 
   @Test
-  void parentOrElseSampler_GetDescription() {
-    assertThat(Samplers.parentOrElse(Samplers.alwaysOn()).getDescription())
-        .isEqualTo("ParentOrElse{AlwaysOnSampler}");
+  void parentBasedSampler_GetDescription() {
+    assertThat(Samplers.parentBased(Samplers.alwaysOn()).getDescription())
+        .isEqualTo("ParentBased{AlwaysOnSampler}");
   }
 
   @Test

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -457,7 +457,9 @@ class SamplersTest {
   void parentBasedSampler_GetDescription() {
     assertThat(Samplers.parentBased(Samplers.alwaysOn()).getDescription())
         .isEqualTo(
-            "ParentBased{root:AlwaysOnSampler,remoteParentSampled:AlwaysOnSampler,remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,localParentNotSampled:AlwaysOffSampler}");
+            "ParentBased{root:AlwaysOnSampler,remoteParentSampled:AlwaysOnSampler,"
+                + "remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,"
+                + "localParentNotSampled:AlwaysOffSampler}");
   }
 
   @Test

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
@@ -28,7 +28,7 @@ class TraceConfigTest {
   @Test
   void defaultTraceConfig() {
     assertThat(TraceConfig.getDefault().getSampler().getDescription())
-        .isEqualTo(Samplers.parentOrElse(Samplers.alwaysOn()).getDescription());
+        .isEqualTo(Samplers.parentBased(Samplers.alwaysOn()).getDescription());
     assertThat(TraceConfig.getDefault().getMaxNumberOfAttributes()).isEqualTo(32);
     assertThat(TraceConfig.getDefault().getMaxNumberOfEvents()).isEqualTo(128);
     assertThat(TraceConfig.getDefault().getMaxNumberOfLinks()).isEqualTo(32);


### PR DESCRIPTION
closes  [https://github.com/open-telemetry/opentelemetry-java/issues/1572](https://github.com/open-telemetry/opentelemetry-java/issues/1572)