### PR TITLE
Add helpers to CompletableResultCode to wait for a result.

### DIFF
--- a/sdk/common/build.gradle
+++ b/sdk/common/build.gradle
@@ -20,7 +20,8 @@ dependencies {
     testCompileOnly libraries.auto_value_annotation
 
     testImplementation project(':opentelemetry-testing-internal')
-    testImplementation libraries.junit_pioneer
+    testImplementation libraries.junit_pioneer,
+            libraries.awaitility
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/export/CompletableResultCode.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/export/CompletableResultCode.java
@@ -18,6 +18,8 @@ package io.opentelemetry.sdk.common.export;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
@@ -104,6 +106,44 @@ public class CompletableResultCode {
       } else {
         this.completionActions.add(action);
       }
+    }
+    return this;
+  }
+
+  /** Returns whether this {@link CompletableResultCode} has completed. */
+  public boolean isDone() {
+    synchronized (lock) {
+      return succeeded != null;
+    }
+  }
+
+  /**
+   * Waits for the specified amount of time for this {@link CompletableResultCode} to complete. If
+   * it times out or is interrupted, the {@link CompletableResultCode} is failed.
+   *
+   * @return this {@link CompletableResultCode}
+   */
+  public CompletableResultCode join(long timeout, TimeUnit unit) {
+    synchronized (lock) {
+      if (succeeded != null) {
+        return this;
+      }
+    }
+    final CountDownLatch latch = new CountDownLatch(1);
+    whenComplete(
+        new Runnable() {
+          @Override
+          public void run() {
+            latch.countDown();
+          }
+        });
+    try {
+      if (!latch.await(timeout, unit)) {
+        fail();
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      fail();
     }
     return this;
   }

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/export/CompletableResultCode.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/export/CompletableResultCode.java
@@ -124,10 +124,8 @@ public class CompletableResultCode {
    * @return this {@link CompletableResultCode}
    */
   public CompletableResultCode join(long timeout, TimeUnit unit) {
-    synchronized (lock) {
-      if (succeeded != null) {
-        return this;
-      }
+    if (isDone()) {
+      return this;
     }
     final CountDownLatch latch = new CountDownLatch(1);
     whenComplete(

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/export/CompletableResultCodeTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/export/CompletableResultCodeTest.java
@@ -17,6 +17,7 @@
 package io.opentelemetry.sdk.common.export;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import com.google.common.util.concurrent.Uninterruptibles;
 import java.util.concurrent.CountDownLatch;
@@ -231,7 +232,8 @@ class CompletableResultCodeTest {
     thread.start();
     thread.interrupt();
     assertThat(thread.isInterrupted()).isTrue();
-    assertThat(result.isDone()).isTrue();
+    // Different thread so wait a bit for result to be propagated.
+    await().untilAsserted(() -> assertThat(result.isDone()).isTrue());
     assertThat(result.isSuccess()).isFalse();
   }
 }


### PR DESCRIPTION
In #1579 #1571 etc, we found that we do need to allow users to be able to wait for a result, perhaps in a FaaS scenario or just in a unit test. Extracted this out since I ended up needing it in another PR. Added a test for interruption since that PR too. @iNikem 