### PR TITLE
Convert Attributes and AttributeValue into interfaces

### DIFF
--- a/api/src/main/java/io/opentelemetry/common/ArrayBackedAttributes.java
+++ b/api/src/main/java/io/opentelemetry/common/ArrayBackedAttributes.java
@@ -14,16 +14,28 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.sdk.resources;
+package io.opentelemetry.common;
 
-import io.opentelemetry.common.AttributeValue;
-import io.opentelemetry.common.Attributes;
+import com.google.auto.value.AutoValue;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.concurrent.Immutable;
 
-public class TestResourceProvider extends ResourceProvider {
+@AutoValue
+@Immutable
+abstract class ArrayBackedAttributes extends ImmutableKeyValuePairs<AttributeValue>
+    implements Attributes {
+  ArrayBackedAttributes() {}
+
+  static Attributes create(List<Object> data) {
+    return new AutoValue_ArrayBackedAttributes(data);
+  }
 
   @Override
-  protected Attributes getAttributes() {
-    return Attributes.Factory.of(
-        "providerAttribute", AttributeValue.Factory.longAttributeValue(42));
+  abstract List<Object> data();
+
+  @Override
+  public Attributes.Builder toBuilder() {
+    return new Attributes.Builder(new ArrayList<>(data()));
   }
 }

--- a/api/src/main/java/io/opentelemetry/common/AttributeValue.java
+++ b/api/src/main/java/io/opentelemetry/common/AttributeValue.java
@@ -16,12 +16,7 @@
 
 package io.opentelemetry.common;
 
-import com.google.auto.value.AutoValue;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -32,14 +27,14 @@ import javax.annotation.concurrent.Immutable;
  * @since 0.1.0
  */
 @Immutable
-public abstract class AttributeValue {
+public interface AttributeValue {
 
   /**
    * An enum that represents all the possible value types for an {@code AttributeValue}.
    *
    * @since 0.1.0
    */
-  public enum Type {
+  enum Type {
     STRING,
     BOOLEAN,
     LONG,
@@ -50,95 +45,97 @@ public abstract class AttributeValue {
     DOUBLE_ARRAY
   }
 
-  /**
-   * Returns an {@code AttributeValue} with a string value.
-   *
-   * @param stringValue The new value.
-   * @return an {@code AttributeValue} with a string value.
-   * @since 0.1.0
-   */
-  public static AttributeValue stringAttributeValue(String stringValue) {
-    return AttributeValueString.create(stringValue);
-  }
+  class Factory {
+    private Factory() {}
 
-  /**
-   * Returns an {@code AttributeValue} with a boolean value.
-   *
-   * @param booleanValue The new value.
-   * @return an {@code AttributeValue} with a boolean value.
-   * @since 0.1.0
-   */
-  public static AttributeValue booleanAttributeValue(boolean booleanValue) {
-    return AttributeValueBoolean.create(booleanValue);
-  }
+    /**
+     * Returns an {@code AttributeValue} with a string value.
+     *
+     * @param stringValue The new value.
+     * @return an {@code AttributeValue} with a string value.
+     * @since 0.1.0
+     */
+    public static AttributeValue stringAttributeValue(String stringValue) {
+      return AttributeValueString.create(stringValue);
+    }
 
-  /**
-   * Returns an {@code AttributeValue} with a long value.
-   *
-   * @param longValue The new value.
-   * @return an {@code AttributeValue} with a long value.
-   * @since 0.1.0
-   */
-  public static AttributeValue longAttributeValue(long longValue) {
-    return AttributeValueLong.create(longValue);
-  }
+    /**
+     * Returns an {@code AttributeValue} with a boolean value.
+     *
+     * @param booleanValue The new value.
+     * @return an {@code AttributeValue} with a boolean value.
+     * @since 0.1.0
+     */
+    public static AttributeValue booleanAttributeValue(boolean booleanValue) {
+      return AttributeValueBoolean.create(booleanValue);
+    }
 
-  /**
-   * Returns an {@code AttributeValue} with a double value.
-   *
-   * @param doubleValue The new value.
-   * @return an {@code AttributeValue} with a double value.
-   * @since 0.1.0
-   */
-  public static AttributeValue doubleAttributeValue(double doubleValue) {
-    return AttributeValueDouble.create(doubleValue);
-  }
+    /**
+     * Returns an {@code AttributeValue} with a long value.
+     *
+     * @param longValue The new value.
+     * @return an {@code AttributeValue} with a long value.
+     * @since 0.1.0
+     */
+    public static AttributeValue longAttributeValue(long longValue) {
+      return AttributeValueLong.create(longValue);
+    }
 
-  /**
-   * Returns an {@code AttributeValue} with a String array value.
-   *
-   * @param stringValues The new values.
-   * @return an {@code AttributeValue} with a String array value.
-   * @since 0.3.0
-   */
-  public static AttributeValue arrayAttributeValue(String... stringValues) {
-    return AttributeValueStringArray.create(stringValues);
-  }
+    /**
+     * Returns an {@code AttributeValue} with a double value.
+     *
+     * @param doubleValue The new value.
+     * @return an {@code AttributeValue} with a double value.
+     * @since 0.1.0
+     */
+    public static AttributeValue doubleAttributeValue(double doubleValue) {
+      return AttributeValueDouble.create(doubleValue);
+    }
 
-  /**
-   * Returns an {@code AttributeValue} with a boolean array value.
-   *
-   * @param booleanValues The new values.
-   * @return an {@code AttributeValue} with a boolean array value.
-   * @since 0.3.0
-   */
-  public static AttributeValue arrayAttributeValue(Boolean... booleanValues) {
-    return AttributeValueBooleanArray.create(booleanValues);
-  }
+    /**
+     * Returns an {@code AttributeValue} with a String array value.
+     *
+     * @param stringValues The new values.
+     * @return an {@code AttributeValue} with a String array value.
+     * @since 0.3.0
+     */
+    public static AttributeValue arrayAttributeValue(String... stringValues) {
+      return AttributeValueStringArray.create(stringValues);
+    }
 
-  /**
-   * Returns an {@code AttributeValue} with a long array value.
-   *
-   * @param longValues The new values.
-   * @return an {@code AttributeValue} with a long array value.
-   * @since 0.3.0
-   */
-  public static AttributeValue arrayAttributeValue(Long... longValues) {
-    return AttributeValueLongArray.create(longValues);
-  }
+    /**
+     * Returns an {@code AttributeValue} with a boolean array value.
+     *
+     * @param booleanValues The new values.
+     * @return an {@code AttributeValue} with a boolean array value.
+     * @since 0.3.0
+     */
+    public static AttributeValue arrayAttributeValue(Boolean... booleanValues) {
+      return AttributeValueBooleanArray.create(booleanValues);
+    }
 
-  /**
-   * Returns an {@code AttributeValue} with a double array value.
-   *
-   * @param doubleValues The new values.
-   * @return an {@code AttributeValue} with a double array value.
-   * @since 0.3.0
-   */
-  public static AttributeValue arrayAttributeValue(Double... doubleValues) {
-    return AttributeValueDoubleArray.create(doubleValues);
-  }
+    /**
+     * Returns an {@code AttributeValue} with a long array value.
+     *
+     * @param longValues The new values.
+     * @return an {@code AttributeValue} with a long array value.
+     * @since 0.3.0
+     */
+    public static AttributeValue arrayAttributeValue(Long... longValues) {
+      return AttributeValueLongArray.create(longValues);
+    }
 
-  AttributeValue() {}
+    /**
+     * Returns an {@code AttributeValue} with a double array value.
+     *
+     * @param doubleValues The new values.
+     * @return an {@code AttributeValue} with a double array value.
+     * @since 0.3.0
+     */
+    public static AttributeValue arrayAttributeValue(Double... doubleValues) {
+      return AttributeValueDoubleArray.create(doubleValues);
+    }
+  }
 
   /**
    * Returns the string value of this {@code AttributeValue}. An UnsupportedOperationException will
@@ -147,10 +144,7 @@ public abstract class AttributeValue {
    * @return the string value of this {@code AttributeValue}.
    * @since 0.1.0
    */
-  public String getStringValue() {
-    throw new UnsupportedOperationException(
-        String.format("This type can only return %s data", getType().name()));
-  }
+  String getStringValue();
 
   /**
    * Returns the boolean value of this {@code AttributeValue}. An UnsupportedOperationException will
@@ -159,10 +153,7 @@ public abstract class AttributeValue {
    * @return the boolean value of this {@code AttributeValue}.
    * @since 0.1.0
    */
-  public boolean getBooleanValue() {
-    throw new UnsupportedOperationException(
-        String.format("This type can only return %s data", getType().name()));
-  }
+  boolean getBooleanValue();
 
   /**
    * Returns the long value of this {@code AttributeValue}. An UnsupportedOperationException will be
@@ -171,10 +162,7 @@ public abstract class AttributeValue {
    * @return the long value of this {@code AttributeValue}.
    * @since 0.1.0
    */
-  public long getLongValue() {
-    throw new UnsupportedOperationException(
-        String.format("This type can only return %s data", getType().name()));
-  }
+  long getLongValue();
 
   /**
    * Returns the double value of this {@code AttributeValue}. An UnsupportedOperationException will
@@ -183,10 +171,7 @@ public abstract class AttributeValue {
    * @return the double value of this {@code AttributeValue}.
    * @since 0.1.0
    */
-  public double getDoubleValue() {
-    throw new UnsupportedOperationException(
-        String.format("This type can only return %s data", getType().name()));
-  }
+  double getDoubleValue();
 
   /**
    * Returns the String array value of this {@code AttributeValue}. An UnsupportedOperationException
@@ -195,10 +180,7 @@ public abstract class AttributeValue {
    * @return the array values of this {@code AttributeValue}.
    * @since 0.3.0
    */
-  public List<String> getStringArrayValue() {
-    throw new UnsupportedOperationException(
-        String.format("This type can only return %s data", getType().name()));
-  }
+  List<String> getStringArrayValue();
 
   /**
    * Returns the boolean array value of this {@code AttributeValue}. An
@@ -207,10 +189,7 @@ public abstract class AttributeValue {
    * @return the array values of this {@code AttributeValue}.
    * @since 0.3.0
    */
-  public List<Boolean> getBooleanArrayValue() {
-    throw new UnsupportedOperationException(
-        String.format("This type can only return %s data", getType().name()));
-  }
+  List<Boolean> getBooleanArrayValue();
 
   /**
    * Returns the long array value of this {@code AttributeValue}. An UnsupportedOperationException
@@ -219,10 +198,7 @@ public abstract class AttributeValue {
    * @return the array values of this {@code AttributeValue}.
    * @since 0.3.0
    */
-  public List<Long> getLongArrayValue() {
-    throw new UnsupportedOperationException(
-        String.format("This type can only return %s data", getType().name()));
-  }
+  List<Long> getLongArrayValue();
 
   /**
    * Returns the double array value of this {@code AttributeValue}. An UnsupportedOperationException
@@ -231,10 +207,7 @@ public abstract class AttributeValue {
    * @return the array values of this {@code AttributeValue}.
    * @since 0.3.0
    */
-  public List<Double> getDoubleArrayValue() {
-    throw new UnsupportedOperationException(
-        String.format("This type can only return %s data", getType().name()));
-  }
+  List<Double> getDoubleArrayValue();
 
   /**
    * Returns a {@code Type} corresponding to the underlying value of this {@code AttributeValue}.
@@ -242,7 +215,7 @@ public abstract class AttributeValue {
    * @return the {@code Type} for the value of this {@code AttributeValue}.
    * @since 0.1.0
    */
-  public abstract Type getType();
+  Type getType();
 
   /**
    * Returns {@code true} if the {@code AttributeValue} contains a {@code null} value.
@@ -250,219 +223,5 @@ public abstract class AttributeValue {
    * @return {@code true} if the {@code AttributeValue} contains a {@code null} value.
    * @since 0.8.0
    */
-  public boolean isNull() {
-    return false;
-  }
-
-  @Immutable
-  @AutoValue
-  abstract static class AttributeValueString extends AttributeValue {
-
-    AttributeValueString() {}
-
-    static AttributeValue create(String stringValue) {
-      return new AutoValue_AttributeValue_AttributeValueString(stringValue);
-    }
-
-    @Override
-    public final Type getType() {
-      return Type.STRING;
-    }
-
-    @Override
-    public boolean isNull() {
-      return getStringValue() == null;
-    }
-
-    @Override
-    @Nullable
-    public abstract String getStringValue();
-  }
-
-  @Immutable
-  @AutoValue
-  abstract static class AttributeValueBoolean extends AttributeValue {
-
-    AttributeValueBoolean() {}
-
-    static AttributeValue create(boolean booleanValue) {
-      return new AutoValue_AttributeValue_AttributeValueBoolean(booleanValue);
-    }
-
-    @Override
-    public final Type getType() {
-      return Type.BOOLEAN;
-    }
-
-    @Override
-    public abstract boolean getBooleanValue();
-  }
-
-  @Immutable
-  @AutoValue
-  abstract static class AttributeValueLong extends AttributeValue {
-
-    AttributeValueLong() {}
-
-    static AttributeValue create(long longValue) {
-      return new AutoValue_AttributeValue_AttributeValueLong(longValue);
-    }
-
-    @Override
-    public final Type getType() {
-      return Type.LONG;
-    }
-
-    @Override
-    public abstract long getLongValue();
-  }
-
-  @Immutable
-  @AutoValue
-  abstract static class AttributeValueDouble extends AttributeValue {
-
-    AttributeValueDouble() {}
-
-    static AttributeValue create(double doubleValue) {
-      return new AutoValue_AttributeValue_AttributeValueDouble(doubleValue);
-    }
-
-    @Override
-    public final Type getType() {
-      return Type.DOUBLE;
-    }
-
-    @Override
-    public abstract double getDoubleValue();
-  }
-
-  @Immutable
-  @AutoValue
-  abstract static class AttributeValueStringArray extends AttributeValue {
-
-    private static final AttributeValue EMPTY =
-        new AutoValue_AttributeValue_AttributeValueStringArray(Collections.<String>emptyList());
-
-    AttributeValueStringArray() {}
-
-    static AttributeValue create(String... stringValues) {
-      if (stringValues == null) {
-        return EMPTY;
-      }
-      return new AutoValue_AttributeValue_AttributeValueStringArray(
-          Collections.unmodifiableList(Arrays.asList(stringValues)));
-    }
-
-    @Override
-    public final Type getType() {
-      return Type.STRING_ARRAY;
-    }
-
-    @Override
-    public boolean isNull() {
-      return this == EMPTY;
-    }
-
-    @Override
-    public abstract List<String> getStringArrayValue();
-  }
-
-  @Immutable
-  @AutoValue
-  abstract static class AttributeValueBooleanArray extends AttributeValue {
-
-    private static final AttributeValue EMPTY =
-        new AutoValue_AttributeValue_AttributeValueBooleanArray(Collections.<Boolean>emptyList());
-
-    AttributeValueBooleanArray() {}
-
-    static AttributeValue create(Boolean... booleanValues) {
-      if (booleanValues == null) {
-        return EMPTY;
-      }
-      List<Boolean> values = new ArrayList<>(booleanValues.length);
-      values.addAll(Arrays.asList(booleanValues));
-      return new AutoValue_AttributeValue_AttributeValueBooleanArray(
-          Collections.unmodifiableList(values));
-    }
-
-    @Override
-    public final Type getType() {
-      return Type.BOOLEAN_ARRAY;
-    }
-
-    @Override
-    public boolean isNull() {
-      return this == EMPTY;
-    }
-
-    @Override
-    public abstract List<Boolean> getBooleanArrayValue();
-  }
-
-  @Immutable
-  @AutoValue
-  abstract static class AttributeValueLongArray extends AttributeValue {
-
-    private static final AttributeValue EMPTY =
-        new AutoValue_AttributeValue_AttributeValueLongArray(Collections.<Long>emptyList());
-
-    AttributeValueLongArray() {}
-
-    static AttributeValue create(Long... longValues) {
-      if (longValues == null) {
-        return EMPTY;
-      }
-      List<Long> values = new ArrayList<>(longValues.length);
-      values.addAll(Arrays.asList(longValues));
-      return new AutoValue_AttributeValue_AttributeValueLongArray(
-          Collections.unmodifiableList(values));
-    }
-
-    @Override
-    public final Type getType() {
-      return Type.LONG_ARRAY;
-    }
-
-    @Override
-    public boolean isNull() {
-      return this == EMPTY;
-    }
-
-    @Override
-    public abstract List<Long> getLongArrayValue();
-  }
-
-  @Immutable
-  @AutoValue
-  abstract static class AttributeValueDoubleArray extends AttributeValue {
-
-    private static final AttributeValue EMPTY =
-        new AutoValue_AttributeValue_AttributeValueDoubleArray(Collections.<Double>emptyList());
-
-    AttributeValueDoubleArray() {}
-
-    static AttributeValue create(Double... doubleValues) {
-      if (doubleValues == null) {
-        return EMPTY;
-      }
-      List<Double> values = new ArrayList<>(doubleValues.length);
-      values.addAll(Arrays.asList(doubleValues));
-      return new AutoValue_AttributeValue_AttributeValueDoubleArray(
-          Collections.unmodifiableList(values));
-    }
-
-    @Override
-    public final Type getType() {
-      return Type.DOUBLE_ARRAY;
-    }
-
-    @Override
-    public boolean isNull() {
-      return this == EMPTY;
-    }
-
-    @Override
-    public abstract List<Double> getDoubleArrayValue();
-  }
+  boolean isNull();
 }

--- a/api/src/main/java/io/opentelemetry/common/AttributeValueBoolean.java
+++ b/api/src/main/java/io/opentelemetry/common/AttributeValueBoolean.java
@@ -14,16 +14,26 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.sdk.resources;
+package io.opentelemetry.common;
 
-import io.opentelemetry.common.AttributeValue;
-import io.opentelemetry.common.Attributes;
+import com.google.auto.value.AutoValue;
+import javax.annotation.concurrent.Immutable;
 
-public class TestResourceProvider extends ResourceProvider {
+@Immutable
+@AutoValue
+abstract class AttributeValueBoolean extends BaseAttributeValue {
+
+  AttributeValueBoolean() {}
+
+  static AttributeValue create(boolean booleanValue) {
+    return new AutoValue_AttributeValueBoolean(booleanValue);
+  }
 
   @Override
-  protected Attributes getAttributes() {
-    return Attributes.Factory.of(
-        "providerAttribute", AttributeValue.Factory.longAttributeValue(42));
+  public final Type getType() {
+    return Type.BOOLEAN;
   }
+
+  @Override
+  public abstract boolean getBooleanValue();
 }

--- a/api/src/main/java/io/opentelemetry/common/AttributeValueBooleanArray.java
+++ b/api/src/main/java/io/opentelemetry/common/AttributeValueBooleanArray.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.common;
+
+import com.google.auto.value.AutoValue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@AutoValue
+abstract class AttributeValueBooleanArray extends BaseAttributeValue {
+
+  private static final AttributeValue EMPTY =
+      new AutoValue_AttributeValueBooleanArray(Collections.<Boolean>emptyList());
+
+  AttributeValueBooleanArray() {}
+
+  static AttributeValue create(Boolean... booleanValues) {
+    if (booleanValues == null) {
+      return EMPTY;
+    }
+    List<Boolean> values = new ArrayList<>(booleanValues.length);
+    values.addAll(Arrays.asList(booleanValues));
+    return new AutoValue_AttributeValueBooleanArray(Collections.unmodifiableList(values));
+  }
+
+  @Override
+  public final Type getType() {
+    return Type.BOOLEAN_ARRAY;
+  }
+
+  @Override
+  public boolean isNull() {
+    return this == EMPTY;
+  }
+
+  @Override
+  public abstract List<Boolean> getBooleanArrayValue();
+}

--- a/api/src/main/java/io/opentelemetry/common/AttributeValueDouble.java
+++ b/api/src/main/java/io/opentelemetry/common/AttributeValueDouble.java
@@ -14,16 +14,26 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.sdk.resources;
+package io.opentelemetry.common;
 
-import io.opentelemetry.common.AttributeValue;
-import io.opentelemetry.common.Attributes;
+import com.google.auto.value.AutoValue;
+import javax.annotation.concurrent.Immutable;
 
-public class TestResourceProvider extends ResourceProvider {
+@Immutable
+@AutoValue
+abstract class AttributeValueDouble extends BaseAttributeValue {
+
+  AttributeValueDouble() {}
+
+  static AttributeValue create(double doubleValue) {
+    return new AutoValue_AttributeValueDouble(doubleValue);
+  }
 
   @Override
-  protected Attributes getAttributes() {
-    return Attributes.Factory.of(
-        "providerAttribute", AttributeValue.Factory.longAttributeValue(42));
+  public final Type getType() {
+    return Type.DOUBLE;
   }
+
+  @Override
+  public abstract double getDoubleValue();
 }

--- a/api/src/main/java/io/opentelemetry/common/AttributeValueDoubleArray.java
+++ b/api/src/main/java/io/opentelemetry/common/AttributeValueDoubleArray.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.common;
+
+import com.google.auto.value.AutoValue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@AutoValue
+abstract class AttributeValueDoubleArray extends BaseAttributeValue {
+
+  private static final AttributeValue EMPTY =
+      new AutoValue_AttributeValueDoubleArray(Collections.<Double>emptyList());
+
+  AttributeValueDoubleArray() {}
+
+  static AttributeValue create(Double... doubleValues) {
+    if (doubleValues == null) {
+      return EMPTY;
+    }
+    List<Double> values = new ArrayList<>(doubleValues.length);
+    values.addAll(Arrays.asList(doubleValues));
+    return new AutoValue_AttributeValueDoubleArray(Collections.unmodifiableList(values));
+  }
+
+  @Override
+  public final Type getType() {
+    return Type.DOUBLE_ARRAY;
+  }
+
+  @Override
+  public boolean isNull() {
+    return this == EMPTY;
+  }
+
+  @Override
+  public abstract List<Double> getDoubleArrayValue();
+}

--- a/api/src/main/java/io/opentelemetry/common/AttributeValueLong.java
+++ b/api/src/main/java/io/opentelemetry/common/AttributeValueLong.java
@@ -14,16 +14,26 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.sdk.resources;
+package io.opentelemetry.common;
 
-import io.opentelemetry.common.AttributeValue;
-import io.opentelemetry.common.Attributes;
+import com.google.auto.value.AutoValue;
+import javax.annotation.concurrent.Immutable;
 
-public class TestResourceProvider extends ResourceProvider {
+@Immutable
+@AutoValue
+abstract class AttributeValueLong extends BaseAttributeValue {
+
+  AttributeValueLong() {}
+
+  static AttributeValue create(long longValue) {
+    return new AutoValue_AttributeValueLong(longValue);
+  }
 
   @Override
-  protected Attributes getAttributes() {
-    return Attributes.Factory.of(
-        "providerAttribute", AttributeValue.Factory.longAttributeValue(42));
+  public final Type getType() {
+    return Type.LONG;
   }
+
+  @Override
+  public abstract long getLongValue();
 }

--- a/api/src/main/java/io/opentelemetry/common/AttributeValueLongArray.java
+++ b/api/src/main/java/io/opentelemetry/common/AttributeValueLongArray.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.common;
+
+import com.google.auto.value.AutoValue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@AutoValue
+abstract class AttributeValueLongArray extends BaseAttributeValue {
+
+  private static final AttributeValue EMPTY =
+      new AutoValue_AttributeValueLongArray(Collections.<Long>emptyList());
+
+  AttributeValueLongArray() {}
+
+  static AttributeValue create(Long... longValues) {
+    if (longValues == null) {
+      return EMPTY;
+    }
+    List<Long> values = new ArrayList<>(longValues.length);
+    values.addAll(Arrays.asList(longValues));
+    return new AutoValue_AttributeValueLongArray(Collections.unmodifiableList(values));
+  }
+
+  @Override
+  public final Type getType() {
+    return Type.LONG_ARRAY;
+  }
+
+  @Override
+  public boolean isNull() {
+    return this == EMPTY;
+  }
+
+  @Override
+  public abstract List<Long> getLongArrayValue();
+}

--- a/api/src/main/java/io/opentelemetry/common/AttributeValueString.java
+++ b/api/src/main/java/io/opentelemetry/common/AttributeValueString.java
@@ -14,16 +14,33 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.sdk.resources;
+package io.opentelemetry.common;
 
-import io.opentelemetry.common.AttributeValue;
-import io.opentelemetry.common.Attributes;
+import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
 
-public class TestResourceProvider extends ResourceProvider {
+@Immutable
+@AutoValue
+abstract class AttributeValueString extends BaseAttributeValue {
+
+  AttributeValueString() {}
+
+  static AttributeValue create(String stringValue) {
+    return new AutoValue_AttributeValueString(stringValue);
+  }
 
   @Override
-  protected Attributes getAttributes() {
-    return Attributes.Factory.of(
-        "providerAttribute", AttributeValue.Factory.longAttributeValue(42));
+  public final Type getType() {
+    return Type.STRING;
   }
+
+  @Override
+  public boolean isNull() {
+    return getStringValue() == null;
+  }
+
+  @Override
+  @Nullable
+  public abstract String getStringValue();
 }

--- a/api/src/main/java/io/opentelemetry/common/AttributeValueStringArray.java
+++ b/api/src/main/java/io/opentelemetry/common/AttributeValueStringArray.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.common;
+
+import com.google.auto.value.AutoValue;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@AutoValue
+abstract class AttributeValueStringArray extends BaseAttributeValue {
+
+  private static final AttributeValue EMPTY =
+      new AutoValue_AttributeValueStringArray(Collections.<String>emptyList());
+
+  AttributeValueStringArray() {}
+
+  static AttributeValue create(String... stringValues) {
+    if (stringValues == null) {
+      return EMPTY;
+    }
+    return new AutoValue_AttributeValueStringArray(
+        Collections.unmodifiableList(Arrays.asList(stringValues)));
+  }
+
+  @Override
+  public final Type getType() {
+    return Type.STRING_ARRAY;
+  }
+
+  @Override
+  public boolean isNull() {
+    return this == EMPTY;
+  }
+
+  @Override
+  public abstract List<String> getStringArrayValue();
+}

--- a/api/src/main/java/io/opentelemetry/common/Attributes.java
+++ b/api/src/main/java/io/opentelemetry/common/Attributes.java
@@ -16,14 +16,13 @@
 
 package io.opentelemetry.common;
 
-import static io.opentelemetry.common.AttributeValue.arrayAttributeValue;
-import static io.opentelemetry.common.AttributeValue.booleanAttributeValue;
-import static io.opentelemetry.common.AttributeValue.doubleAttributeValue;
-import static io.opentelemetry.common.AttributeValue.longAttributeValue;
-import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.arrayAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.booleanAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.doubleAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.longAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static io.opentelemetry.common.ImmutableKeyValuePairs.sortAndFilter;
 
-import com.google.auto.value.AutoValue;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -37,21 +36,6 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public interface Attributes extends ReadableAttributes {
   Attributes EMPTY = Factory.newBuilder().build();
-
-  @AutoValue
-  @Immutable
-  abstract class ArrayBackedAttributes extends ImmutableKeyValuePairs<AttributeValue>
-      implements Attributes {
-    ArrayBackedAttributes() {}
-
-    @Override
-    abstract List<Object> data();
-
-    @Override
-    public Builder toBuilder() {
-      return new Builder(new ArrayList<>(data()));
-    }
-  }
 
   class Factory {
     private Factory() {}
@@ -129,7 +113,7 @@ public interface Attributes extends ReadableAttributes {
     }
 
     private static Attributes sortAndFilterToAttributes(Object... data) {
-      return new AutoValue_Attributes_ArrayBackedAttributes(sortAndFilter(data));
+      return ArrayBackedAttributes.create(sortAndFilter(data));
     }
 
     /** Returns a new {@link Builder} instance for creating arbitrary {@link Attributes}. */
@@ -165,7 +149,7 @@ public interface Attributes extends ReadableAttributes {
       data = new ArrayList<>();
     }
 
-    private Builder(List<Object> data) {
+    Builder(List<Object> data) {
       this.data = data;
     }
 

--- a/api/src/main/java/io/opentelemetry/common/Attributes.java
+++ b/api/src/main/java/io/opentelemetry/common/Attributes.java
@@ -21,6 +21,7 @@ import static io.opentelemetry.common.AttributeValue.booleanAttributeValue;
 import static io.opentelemetry.common.AttributeValue.doubleAttributeValue;
 import static io.opentelemetry.common.AttributeValue.longAttributeValue;
 import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
+import static io.opentelemetry.common.ImmutableKeyValuePairs.sortAndFilter;
 
 import com.google.auto.value.AutoValue;
 import java.util.ArrayList;
@@ -34,13 +35,13 @@ import javax.annotation.concurrent.Immutable;
  * <p>The keys are {@link String}s and the values are {@link AttributeValue} instances.
  */
 @Immutable
-public abstract class Attributes extends ImmutableKeyValuePairs<AttributeValue>
-    implements ReadableAttributes {
-  private static final Attributes EMPTY = Attributes.newBuilder().build();
+public interface Attributes extends ReadableAttributes {
+  Attributes EMPTY = Factory.newBuilder().build();
 
   @AutoValue
   @Immutable
-  abstract static class ArrayBackedAttributes extends Attributes {
+  abstract class ArrayBackedAttributes extends ImmutableKeyValuePairs<AttributeValue>
+      implements Attributes {
     ArrayBackedAttributes() {}
 
     @Override
@@ -52,108 +53,112 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeValue>
     }
   }
 
-  /** Returns a {@link Attributes} instance with no attributes. */
-  public static Attributes empty() {
-    return EMPTY;
-  }
+  class Factory {
+    private Factory() {}
 
-  /** Returns a {@link Attributes} instance with a single key-value pair. */
-  public static Attributes of(String key, AttributeValue value) {
-    return sortAndFilterToAttributes(key, value);
-  }
+    /** Returns a {@link Attributes} instance with no attributes. */
+    public static Attributes empty() {
+      return EMPTY;
+    }
 
-  /**
-   * Returns a {@link Attributes} instance with two key-value pairs. Order of the keys is not
-   * preserved. Duplicate keys will be removed.
-   */
-  public static Attributes of(
-      String key1, AttributeValue value1, String key2, AttributeValue value2) {
-    return sortAndFilterToAttributes(key1, value1, key2, value2);
-  }
+    /** Returns a {@link Attributes} instance with a single key-value pair. */
+    public static Attributes of(String key, AttributeValue value) {
+      return sortAndFilterToAttributes(key, value);
+    }
 
-  /**
-   * Returns a {@link Attributes} instance with three key-value pairs. Order of the keys is not
-   * preserved. Duplicate keys will be removed.
-   */
-  public static Attributes of(
-      String key1,
-      AttributeValue value1,
-      String key2,
-      AttributeValue value2,
-      String key3,
-      AttributeValue value3) {
-    return sortAndFilterToAttributes(key1, value1, key2, value2, key3, value3);
-  }
+    /**
+     * Returns a {@link Attributes} instance with two key-value pairs. Order of the keys is not
+     * preserved. Duplicate keys will be removed.
+     */
+    public static Attributes of(
+        String key1, AttributeValue value1, String key2, AttributeValue value2) {
+      return sortAndFilterToAttributes(key1, value1, key2, value2);
+    }
 
-  /**
-   * Returns a {@link Attributes} instance with four key-value pairs. Order of the keys is not
-   * preserved. Duplicate keys will be removed.
-   */
-  public static Attributes of(
-      String key1,
-      AttributeValue value1,
-      String key2,
-      AttributeValue value2,
-      String key3,
-      AttributeValue value3,
-      String key4,
-      AttributeValue value4) {
-    return sortAndFilterToAttributes(key1, value1, key2, value2, key3, value3, key4, value4);
-  }
+    /**
+     * Returns a {@link Attributes} instance with three key-value pairs. Order of the keys is not
+     * preserved. Duplicate keys will be removed.
+     */
+    public static Attributes of(
+        String key1,
+        AttributeValue value1,
+        String key2,
+        AttributeValue value2,
+        String key3,
+        AttributeValue value3) {
+      return sortAndFilterToAttributes(key1, value1, key2, value2, key3, value3);
+    }
 
-  /**
-   * Returns a {@link Attributes} instance with five key-value pairs. Order of the keys is not
-   * preserved. Duplicate keys will be removed.
-   */
-  public static Attributes of(
-      String key1,
-      AttributeValue value1,
-      String key2,
-      AttributeValue value2,
-      String key3,
-      AttributeValue value3,
-      String key4,
-      AttributeValue value4,
-      String key5,
-      AttributeValue value5) {
-    return sortAndFilterToAttributes(
-        key1, value1,
-        key2, value2,
-        key3, value3,
-        key4, value4,
-        key5, value5);
-  }
+    /**
+     * Returns a {@link Attributes} instance with four key-value pairs. Order of the keys is not
+     * preserved. Duplicate keys will be removed.
+     */
+    public static Attributes of(
+        String key1,
+        AttributeValue value1,
+        String key2,
+        AttributeValue value2,
+        String key3,
+        AttributeValue value3,
+        String key4,
+        AttributeValue value4) {
+      return sortAndFilterToAttributes(key1, value1, key2, value2, key3, value3, key4, value4);
+    }
 
-  private static Attributes sortAndFilterToAttributes(Object... data) {
-    return new AutoValue_Attributes_ArrayBackedAttributes(sortAndFilter(data));
-  }
+    /**
+     * Returns a {@link Attributes} instance with five key-value pairs. Order of the keys is not
+     * preserved. Duplicate keys will be removed.
+     */
+    public static Attributes of(
+        String key1,
+        AttributeValue value1,
+        String key2,
+        AttributeValue value2,
+        String key3,
+        AttributeValue value3,
+        String key4,
+        AttributeValue value4,
+        String key5,
+        AttributeValue value5) {
+      return sortAndFilterToAttributes(
+          key1, value1,
+          key2, value2,
+          key3, value3,
+          key4, value4,
+          key5, value5);
+    }
 
-  /** Returns a new {@link Builder} instance for creating arbitrary {@link Attributes}. */
-  public static Builder newBuilder() {
-    return new Builder();
-  }
+    private static Attributes sortAndFilterToAttributes(Object... data) {
+      return new AutoValue_Attributes_ArrayBackedAttributes(sortAndFilter(data));
+    }
 
-  /** Returns a new {@link Builder} instance from ReadableAttributes. */
-  public static Builder newBuilder(ReadableAttributes attributes) {
-    final Builder builder = new Builder();
-    attributes.forEach(
-        new KeyValueConsumer<AttributeValue>() {
-          @Override
-          public void consume(String key, AttributeValue value) {
-            builder.setAttribute(key, value);
-          }
-        });
-    return builder;
+    /** Returns a new {@link Builder} instance for creating arbitrary {@link Attributes}. */
+    public static Builder newBuilder() {
+      return new Builder();
+    }
+
+    /** Returns a new {@link Builder} instance from ReadableAttributes. */
+    public static Builder newBuilder(ReadableAttributes attributes) {
+      final Builder builder = new Builder();
+      attributes.forEach(
+          new KeyValueConsumer<AttributeValue>() {
+            @Override
+            public void consume(String key, AttributeValue value) {
+              builder.setAttribute(key, value);
+            }
+          });
+      return builder;
+    }
   }
 
   /** Returns a new {@link Builder} instance populated with the data of this {@link Attributes}. */
-  public abstract Builder toBuilder();
+  Builder toBuilder();
 
   /**
    * Enables the creation of an {@link Attributes} instance with an arbitrary number of key-value
    * pairs.
    */
-  public static class Builder {
+  class Builder {
     private final List<Object> data;
 
     private Builder() {
@@ -166,7 +171,7 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeValue>
 
     /** Create the {@link Attributes} from this. */
     public Attributes build() {
-      return sortAndFilterToAttributes(data.toArray());
+      return Factory.sortAndFilterToAttributes(data.toArray());
     }
 
     /**

--- a/api/src/main/java/io/opentelemetry/common/BaseAttributeValue.java
+++ b/api/src/main/java/io/opentelemetry/common/BaseAttributeValue.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.common;
+
+import java.util.List;
+
+abstract class BaseAttributeValue implements AttributeValue {
+  @Override
+  public String getStringValue() {
+    throw new UnsupportedOperationException(
+        String.format("This type can only return %s data", getType().name()));
+  }
+
+  @Override
+  public boolean getBooleanValue() {
+    throw new UnsupportedOperationException(
+        String.format("This type can only return %s data", getType().name()));
+  }
+
+  @Override
+  public long getLongValue() {
+    throw new UnsupportedOperationException(
+        String.format("This type can only return %s data", getType().name()));
+  }
+
+  @Override
+  public double getDoubleValue() {
+    throw new UnsupportedOperationException(
+        String.format("This type can only return %s data", getType().name()));
+  }
+
+  @Override
+  public List<String> getStringArrayValue() {
+    throw new UnsupportedOperationException(
+        String.format("This type can only return %s data", getType().name()));
+  }
+
+  @Override
+  public List<Boolean> getBooleanArrayValue() {
+    throw new UnsupportedOperationException(
+        String.format("This type can only return %s data", getType().name()));
+  }
+
+  @Override
+  public List<Long> getLongArrayValue() {
+    throw new UnsupportedOperationException(
+        String.format("This type can only return %s data", getType().name()));
+  }
+
+  @Override
+  public List<Double> getDoubleArrayValue() {
+    throw new UnsupportedOperationException(
+        String.format("This type can only return %s data", getType().name()));
+  }
+
+  @Override
+  public boolean isNull() {
+    return false;
+  }
+}

--- a/api/src/main/java/io/opentelemetry/internal/StringUtils.java
+++ b/api/src/main/java/io/opentelemetry/internal/StringUtils.java
@@ -92,14 +92,14 @@ public final class StringUtils {
         newStrings[i] = truncateToSize(string, limit);
       }
 
-      return AttributeValue.arrayAttributeValue(newStrings);
+      return AttributeValue.Factory.arrayAttributeValue(newStrings);
     }
 
     String string = value.getStringValue();
     // Don't allocate new AttributeValue if not needed
     return (string == null || string.length() <= limit)
         ? value
-        : AttributeValue.stringAttributeValue(string.substring(0, limit));
+        : AttributeValue.Factory.stringAttributeValue(string.substring(0, limit));
   }
 
   @Nullable

--- a/api/src/test/java/io/opentelemetry/common/AttributeValueTest.java
+++ b/api/src/test/java/io/opentelemetry/common/AttributeValueTest.java
@@ -27,70 +27,76 @@ class AttributeValueTest {
   void attributeValue_EqualsAndHashCode() {
     EqualsTester tester = new EqualsTester();
     tester.addEqualityGroup(
-        AttributeValue.stringAttributeValue("MyStringAttributeValue"),
-        AttributeValue.stringAttributeValue("MyStringAttributeValue"));
-    tester.addEqualityGroup(AttributeValue.stringAttributeValue("MyStringAttributeDiffValue"));
+        AttributeValue.Factory.stringAttributeValue("MyStringAttributeValue"),
+        AttributeValue.Factory.stringAttributeValue("MyStringAttributeValue"));
     tester.addEqualityGroup(
-        AttributeValue.booleanAttributeValue(true), AttributeValue.booleanAttributeValue(true));
-    tester.addEqualityGroup(AttributeValue.booleanAttributeValue(false));
+        AttributeValue.Factory.stringAttributeValue("MyStringAttributeDiffValue"));
     tester.addEqualityGroup(
-        AttributeValue.longAttributeValue(123456L), AttributeValue.longAttributeValue(123456L));
-    tester.addEqualityGroup(AttributeValue.longAttributeValue(1234567L));
+        AttributeValue.Factory.booleanAttributeValue(true),
+        AttributeValue.Factory.booleanAttributeValue(true));
+    tester.addEqualityGroup(AttributeValue.Factory.booleanAttributeValue(false));
     tester.addEqualityGroup(
-        AttributeValue.doubleAttributeValue(1.23456), AttributeValue.doubleAttributeValue(1.23456));
-    tester.addEqualityGroup(AttributeValue.doubleAttributeValue(1.234567));
+        AttributeValue.Factory.longAttributeValue(123456L),
+        AttributeValue.Factory.longAttributeValue(123456L));
+    tester.addEqualityGroup(AttributeValue.Factory.longAttributeValue(1234567L));
     tester.addEqualityGroup(
-        AttributeValue.arrayAttributeValue(
+        AttributeValue.Factory.doubleAttributeValue(1.23456),
+        AttributeValue.Factory.doubleAttributeValue(1.23456));
+    tester.addEqualityGroup(AttributeValue.Factory.doubleAttributeValue(1.234567));
+    tester.addEqualityGroup(
+        AttributeValue.Factory.arrayAttributeValue(
             "MyArrayStringAttributeValue1", "MyArrayStringAttributeValue2"),
-        AttributeValue.arrayAttributeValue(
+        AttributeValue.Factory.arrayAttributeValue(
             "MyArrayStringAttributeValue1", "MyArrayStringAttributeValue2"));
-    tester.addEqualityGroup(AttributeValue.arrayAttributeValue("MyArrayStringAttributeDiffValue"));
     tester.addEqualityGroup(
-        AttributeValue.arrayAttributeValue(true, false, true),
-        AttributeValue.arrayAttributeValue(true, false, true));
-    tester.addEqualityGroup(AttributeValue.arrayAttributeValue(false));
+        AttributeValue.Factory.arrayAttributeValue("MyArrayStringAttributeDiffValue"));
     tester.addEqualityGroup(
-        AttributeValue.arrayAttributeValue(123456L, 7890L),
-        AttributeValue.arrayAttributeValue(123456L, 7890L));
-    tester.addEqualityGroup(AttributeValue.arrayAttributeValue(1234567L));
+        AttributeValue.Factory.arrayAttributeValue(true, false, true),
+        AttributeValue.Factory.arrayAttributeValue(true, false, true));
+    tester.addEqualityGroup(AttributeValue.Factory.arrayAttributeValue(false));
     tester.addEqualityGroup(
-        AttributeValue.arrayAttributeValue(1.23456, 7.890),
-        AttributeValue.arrayAttributeValue(1.23456, 7.890));
-    tester.addEqualityGroup(AttributeValue.arrayAttributeValue(1.234567));
+        AttributeValue.Factory.arrayAttributeValue(123456L, 7890L),
+        AttributeValue.Factory.arrayAttributeValue(123456L, 7890L));
+    tester.addEqualityGroup(AttributeValue.Factory.arrayAttributeValue(1234567L));
+    tester.addEqualityGroup(
+        AttributeValue.Factory.arrayAttributeValue(1.23456, 7.890),
+        AttributeValue.Factory.arrayAttributeValue(1.23456, 7.890));
+    tester.addEqualityGroup(AttributeValue.Factory.arrayAttributeValue(1.234567));
     tester.testEquals();
   }
 
   @Test
   void doNotCrashOnNull() {
-    AttributeValue.stringAttributeValue(null);
-    AttributeValue.arrayAttributeValue((String[]) null);
-    AttributeValue.arrayAttributeValue((Boolean[]) null);
-    AttributeValue.arrayAttributeValue((Long[]) null);
-    AttributeValue.arrayAttributeValue((Double[]) null);
+    AttributeValue.Factory.stringAttributeValue(null);
+    AttributeValue.Factory.arrayAttributeValue((String[]) null);
+    AttributeValue.Factory.arrayAttributeValue((Boolean[]) null);
+    AttributeValue.Factory.arrayAttributeValue((Long[]) null);
+    AttributeValue.Factory.arrayAttributeValue((Double[]) null);
   }
 
   @Test
   void attributeValue_ToString() {
-    AttributeValue attribute = AttributeValue.stringAttributeValue("MyStringAttributeValue");
+    AttributeValue attribute =
+        AttributeValue.Factory.stringAttributeValue("MyStringAttributeValue");
     assertThat(attribute.toString()).contains("MyStringAttributeValue");
-    attribute = AttributeValue.booleanAttributeValue(true);
+    attribute = AttributeValue.Factory.booleanAttributeValue(true);
     assertThat(attribute.toString()).contains("true");
-    attribute = AttributeValue.longAttributeValue(123456L);
+    attribute = AttributeValue.Factory.longAttributeValue(123456L);
     assertThat(attribute.toString()).contains("123456");
-    attribute = AttributeValue.doubleAttributeValue(1.23456);
+    attribute = AttributeValue.Factory.doubleAttributeValue(1.23456);
     assertThat(attribute.toString()).contains("1.23456");
     attribute =
-        AttributeValue.arrayAttributeValue(
+        AttributeValue.Factory.arrayAttributeValue(
             "MyArrayStringAttributeValue1", "MyArrayStringAttributeValue2");
     assertThat(attribute.toString()).contains("MyArrayStringAttributeValue1");
     assertThat(attribute.toString()).contains("MyArrayStringAttributeValue2");
-    attribute = AttributeValue.arrayAttributeValue(true, false);
+    attribute = AttributeValue.Factory.arrayAttributeValue(true, false);
     assertThat(attribute.toString()).contains("true");
     assertThat(attribute.toString()).contains("false");
-    attribute = AttributeValue.arrayAttributeValue(12345L, 67890L);
+    attribute = AttributeValue.Factory.arrayAttributeValue(12345L, 67890L);
     assertThat(attribute.toString()).contains("12345");
     assertThat(attribute.toString()).contains("67890");
-    attribute = AttributeValue.arrayAttributeValue(1.2345, 6.789);
+    attribute = AttributeValue.Factory.arrayAttributeValue(1.2345, 6.789);
     assertThat(attribute.toString()).contains("1.2345");
     assertThat(attribute.toString()).contains("6.789");
   }
@@ -99,16 +105,16 @@ class AttributeValueTest {
   void arrayAttributeValue_nullValuesWithinArray() {
     AttributeValue attribute;
 
-    attribute = AttributeValue.arrayAttributeValue("string", null, "", "string");
+    attribute = AttributeValue.Factory.arrayAttributeValue("string", null, "", "string");
     assertThat(attribute.getStringArrayValue().size()).isEqualTo(4);
 
-    attribute = AttributeValue.arrayAttributeValue(10L, null, 20L);
+    attribute = AttributeValue.Factory.arrayAttributeValue(10L, null, 20L);
     assertThat(attribute.getLongArrayValue().size()).isEqualTo(3);
 
-    attribute = AttributeValue.arrayAttributeValue(true, null, false);
+    attribute = AttributeValue.Factory.arrayAttributeValue(true, null, false);
     assertThat(attribute.getBooleanArrayValue().size()).isEqualTo(3);
 
-    attribute = AttributeValue.arrayAttributeValue(1.2, null, 3.4);
+    attribute = AttributeValue.Factory.arrayAttributeValue(1.2, null, 3.4);
     assertThat(attribute.getDoubleArrayValue().size()).isEqualTo(3);
   }
 }

--- a/api/src/test/java/io/opentelemetry/common/AttributesTest.java
+++ b/api/src/test/java/io/opentelemetry/common/AttributesTest.java
@@ -37,7 +37,7 @@ class AttributesTest {
     final Map<String, AttributeValue> entriesSeen = new HashMap<>();
 
     Attributes attributes =
-        Attributes.of(
+        Attributes.Factory.of(
             "key1", stringAttributeValue("value1"),
             "key2", AttributeValue.longAttributeValue(333));
 
@@ -52,7 +52,7 @@ class AttributesTest {
   void forEach_singleAttribute() {
     final Map<String, AttributeValue> entriesSeen = new HashMap<>();
 
-    Attributes attributes = Attributes.of("key", stringAttributeValue("value"));
+    Attributes attributes = Attributes.Factory.of("key", stringAttributeValue("value"));
     attributes.forEach(entriesSeen::put);
     assertThat(entriesSeen).containsExactly(entry("key", stringAttributeValue("value")));
   }
@@ -60,7 +60,7 @@ class AttributesTest {
   @Test
   void forEach_empty() {
     final AtomicBoolean sawSomething = new AtomicBoolean(false);
-    Attributes emptyAttributes = Attributes.empty();
+    Attributes emptyAttributes = Attributes.Factory.empty();
     emptyAttributes.forEach((key, value) -> sawSomething.set(true));
     assertThat(sawSomething.get()).isFalse();
   }
@@ -68,25 +68,25 @@ class AttributesTest {
   @Test
   void orderIndependentEquality() {
     Attributes one =
-        Attributes.of(
+        Attributes.Factory.of(
             "key1", stringAttributeValue("value1"),
             "key2", stringAttributeValue("value2"));
     Attributes two =
-        Attributes.of(
+        Attributes.Factory.of(
             "key2", stringAttributeValue("value2"),
             "key1", stringAttributeValue("value1"));
 
     assertThat(one).isEqualTo(two);
 
     Attributes three =
-        Attributes.of(
+        Attributes.Factory.of(
             "key1", stringAttributeValue("value1"),
             "key2", stringAttributeValue("value2"),
             "", stringAttributeValue("empty"),
             "key3", stringAttributeValue("value3"),
             "key4", stringAttributeValue("value4"));
     Attributes four =
-        Attributes.of(
+        Attributes.Factory.of(
             null,
             stringAttributeValue("null"),
             "key2",
@@ -104,10 +104,10 @@ class AttributesTest {
   @Test
   void deduplication() {
     Attributes one =
-        Attributes.of(
+        Attributes.Factory.of(
             "key1", stringAttributeValue("value1"),
             "key1", stringAttributeValue("valueX"));
-    Attributes two = Attributes.of("key1", stringAttributeValue("value1"));
+    Attributes two = Attributes.Factory.of("key1", stringAttributeValue("value1"));
 
     assertThat(one).isEqualTo(two);
   }
@@ -115,7 +115,8 @@ class AttributesTest {
   @Test
   void emptyAndNullKey() {
     Attributes noAttributes =
-        Attributes.of("", stringAttributeValue("empty"), null, stringAttributeValue("null"));
+        Attributes.Factory.of(
+            "", stringAttributeValue("empty"), null, stringAttributeValue("null"));
 
     assertThat(noAttributes.size()).isEqualTo(0);
   }
@@ -123,7 +124,7 @@ class AttributesTest {
   @Test
   void builder() {
     Attributes attributes =
-        Attributes.newBuilder()
+        Attributes.Factory.newBuilder()
             .setAttribute("string", "value1")
             .setAttribute("long", 100)
             .setAttribute("double", 33.44)
@@ -132,18 +133,18 @@ class AttributesTest {
             .build();
 
     Attributes wantAttributes =
-        Attributes.of(
+        Attributes.Factory.of(
             "string", stringAttributeValue("value1"),
             "long", longAttributeValue(100),
             "double", doubleAttributeValue(33.44),
             "boolean", booleanAttributeValue(false));
     assertThat(attributes).isEqualTo(wantAttributes);
 
-    Attributes.Builder newAttributes = Attributes.newBuilder(attributes);
+    Attributes.Builder newAttributes = Attributes.Factory.newBuilder(attributes);
     newAttributes.setAttribute("newKey", "newValue");
     assertThat(newAttributes.build())
         .isEqualTo(
-            Attributes.of(
+            Attributes.Factory.of(
                 "string", stringAttributeValue("value1"),
                 "long", longAttributeValue(100),
                 "double", doubleAttributeValue(33.44),
@@ -156,7 +157,7 @@ class AttributesTest {
   @Test
   void builder_arrayTypes() {
     Attributes attributes =
-        Attributes.newBuilder()
+        Attributes.Factory.newBuilder()
             .setAttribute("string", "value1", "value2")
             .setAttribute("long", 100L, 200L)
             .setAttribute("double", 33.44, -44.33)
@@ -167,7 +168,7 @@ class AttributesTest {
 
     assertThat(attributes)
         .isEqualTo(
-            Attributes.of(
+            Attributes.Factory.of(
                 "string", arrayAttributeValue("value1", "value2"),
                 "long", arrayAttributeValue(100L, 200L),
                 "double", arrayAttributeValue(33.44, -44.33),
@@ -176,17 +177,17 @@ class AttributesTest {
 
   @Test
   void get_Null() {
-    assertThat(Attributes.empty().get("foo")).isNull();
-    assertThat(Attributes.of("key", stringAttributeValue("value")).get("foo")).isNull();
+    assertThat(Attributes.Factory.empty().get("foo")).isNull();
+    assertThat(Attributes.Factory.of("key", stringAttributeValue("value")).get("foo")).isNull();
   }
 
   @Test
   void get() {
-    assertThat(Attributes.of("key", stringAttributeValue("value")).get("key"))
+    assertThat(Attributes.Factory.of("key", stringAttributeValue("value")).get("key"))
         .isEqualTo(stringAttributeValue("value"));
-    assertThat(Attributes.of("key", stringAttributeValue("value")).get("value")).isNull();
+    assertThat(Attributes.Factory.of("key", stringAttributeValue("value")).get("value")).isNull();
     Attributes threeElements =
-        Attributes.of(
+        Attributes.Factory.of(
             "string", stringAttributeValue("value"),
             "boolean", booleanAttributeValue(true),
             "long", longAttributeValue(1L));
@@ -194,13 +195,13 @@ class AttributesTest {
     assertThat(threeElements.get("string")).isEqualTo(stringAttributeValue("value"));
     assertThat(threeElements.get("long")).isEqualTo(longAttributeValue(1L));
     Attributes twoElements =
-        Attributes.of(
+        Attributes.Factory.of(
             "string", stringAttributeValue("value"),
             "boolean", booleanAttributeValue(true));
     assertThat(twoElements.get("boolean")).isEqualTo(booleanAttributeValue(true));
     assertThat(twoElements.get("string")).isEqualTo(stringAttributeValue("value"));
     Attributes fourElements =
-        Attributes.of(
+        Attributes.Factory.of(
             "string", stringAttributeValue("value"),
             "boolean", booleanAttributeValue(true),
             "long", longAttributeValue(1L),
@@ -214,28 +215,32 @@ class AttributesTest {
   @Test
   void toBuilder() {
     Attributes filled =
-        Attributes.newBuilder().setAttribute("cat", "meow").setAttribute("dog", "bark").build();
+        Attributes.Factory.newBuilder()
+            .setAttribute("cat", "meow")
+            .setAttribute("dog", "bark")
+            .build();
 
     Attributes fromEmpty =
-        Attributes.empty()
+        Attributes.Factory.empty()
             .toBuilder()
             .setAttribute("cat", "meow")
             .setAttribute("dog", "bark")
             .build();
     assertThat(fromEmpty).isEqualTo(filled);
     // Original not mutated.
-    assertThat(Attributes.empty().isEmpty()).isTrue();
+    assertThat(Attributes.Factory.empty().isEmpty()).isTrue();
 
-    Attributes partial = Attributes.newBuilder().setAttribute("cat", "meow").build();
+    Attributes partial = Attributes.Factory.newBuilder().setAttribute("cat", "meow").build();
     Attributes fromPartial = partial.toBuilder().setAttribute("dog", "bark").build();
     assertThat(fromPartial).isEqualTo(filled);
     // Original not mutated.
-    assertThat(partial).isEqualTo(Attributes.newBuilder().setAttribute("cat", "meow").build());
+    assertThat(partial)
+        .isEqualTo(Attributes.Factory.newBuilder().setAttribute("cat", "meow").build());
   }
 
   @Test
   void deleteByNull() {
-    Attributes.Builder attributes = Attributes.newBuilder();
+    Attributes.Builder attributes = Attributes.Factory.newBuilder();
     attributes.setAttribute("attrValue", AttributeValue.stringAttributeValue("attrValue"));
     attributes.setAttribute("string", "string");
     attributes.setAttribute("long", 10);

--- a/api/src/test/java/io/opentelemetry/common/AttributesTest.java
+++ b/api/src/test/java/io/opentelemetry/common/AttributesTest.java
@@ -16,11 +16,11 @@
 
 package io.opentelemetry.common;
 
-import static io.opentelemetry.common.AttributeValue.arrayAttributeValue;
-import static io.opentelemetry.common.AttributeValue.booleanAttributeValue;
-import static io.opentelemetry.common.AttributeValue.doubleAttributeValue;
-import static io.opentelemetry.common.AttributeValue.longAttributeValue;
-import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.arrayAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.booleanAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.doubleAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.longAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
@@ -39,7 +39,7 @@ class AttributesTest {
     Attributes attributes =
         Attributes.Factory.of(
             "key1", stringAttributeValue("value1"),
-            "key2", AttributeValue.longAttributeValue(333));
+            "key2", AttributeValue.Factory.longAttributeValue(333));
 
     attributes.forEach(entriesSeen::put);
 
@@ -241,7 +241,7 @@ class AttributesTest {
   @Test
   void deleteByNull() {
     Attributes.Builder attributes = Attributes.Factory.newBuilder();
-    attributes.setAttribute("attrValue", AttributeValue.stringAttributeValue("attrValue"));
+    attributes.setAttribute("attrValue", AttributeValue.Factory.stringAttributeValue("attrValue"));
     attributes.setAttribute("string", "string");
     attributes.setAttribute("long", 10);
     attributes.setAttribute("double", 1.0);

--- a/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
@@ -50,10 +50,10 @@ class DefaultSpanTest {
     span.addEvent("event", 0);
     span.addEvent(
         "event",
-        Attributes.of("MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true)));
+        Attributes.Factory.of("MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true)));
     span.addEvent(
         "event",
-        Attributes.of("MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true)),
+        Attributes.Factory.of("MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true)),
         0);
     span.addEvent(new TestEvent());
     span.addEvent(new TestEvent(), 0);
@@ -79,7 +79,7 @@ class DefaultSpanTest {
 
     @Override
     public Attributes getAttributes() {
-      return Attributes.empty();
+      return Attributes.Factory.empty();
     }
   }
 }

--- a/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
@@ -36,24 +36,30 @@ class DefaultSpanTest {
   void doNotCrash() {
     Span span = DefaultSpan.getInvalid();
     span.setAttribute(
-        "MyStringAttributeKey", AttributeValue.stringAttributeValue("MyStringAttributeValue"));
-    span.setAttribute("MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true));
-    span.setAttribute("MyLongAttributeKey", AttributeValue.longAttributeValue(123));
+        "MyStringAttributeKey",
+        AttributeValue.Factory.stringAttributeValue("MyStringAttributeValue"));
+    span.setAttribute("MyBooleanAttributeKey", AttributeValue.Factory.booleanAttributeValue(true));
+    span.setAttribute("MyLongAttributeKey", AttributeValue.Factory.longAttributeValue(123));
     span.setAttribute("NullString", (String) null);
     span.setAttribute("EmptyString", "");
-    span.setAttribute("NullArrayString", AttributeValue.arrayAttributeValue((String[]) null));
-    span.setAttribute("NullArrayBoolean", AttributeValue.arrayAttributeValue((Boolean[]) null));
-    span.setAttribute("NullArrayLong", AttributeValue.arrayAttributeValue((Long[]) null));
-    span.setAttribute("NullArrayDouble", AttributeValue.arrayAttributeValue((Double[]) null));
+    span.setAttribute(
+        "NullArrayString", AttributeValue.Factory.arrayAttributeValue((String[]) null));
+    span.setAttribute(
+        "NullArrayBoolean", AttributeValue.Factory.arrayAttributeValue((Boolean[]) null));
+    span.setAttribute("NullArrayLong", AttributeValue.Factory.arrayAttributeValue((Long[]) null));
+    span.setAttribute(
+        "NullArrayDouble", AttributeValue.Factory.arrayAttributeValue((Double[]) null));
     span.setAttribute(null, (String) null);
     span.addEvent("event");
     span.addEvent("event", 0);
     span.addEvent(
         "event",
-        Attributes.Factory.of("MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true)));
+        Attributes.Factory.of(
+            "MyBooleanAttributeKey", AttributeValue.Factory.booleanAttributeValue(true)));
     span.addEvent(
         "event",
-        Attributes.Factory.of("MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true)),
+        Attributes.Factory.of(
+            "MyBooleanAttributeKey", AttributeValue.Factory.booleanAttributeValue(true)),
         0);
     span.addEvent(new TestEvent());
     span.addEvent(new TestEvent(), 0);

--- a/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
@@ -36,7 +36,7 @@ class SpanBuilderTest {
     spanBuilder.setParent(DefaultSpan.getInvalid().getContext());
     spanBuilder.setNoParent();
     spanBuilder.addLink(DefaultSpan.getInvalid().getContext());
-    spanBuilder.addLink(DefaultSpan.getInvalid().getContext(), Attributes.empty());
+    spanBuilder.addLink(DefaultSpan.getInvalid().getContext(), Attributes.Factory.empty());
     spanBuilder.addLink(
         new Link() {
           private final SpanContext spanContext = DefaultSpan.getInvalid().getContext();
@@ -48,7 +48,7 @@ class SpanBuilderTest {
 
           @Override
           public Attributes getAttributes() {
-            return Attributes.empty();
+            return Attributes.Factory.empty();
           }
         });
     spanBuilder.setAttribute("key", "value");

--- a/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
@@ -55,7 +55,7 @@ class SpanBuilderTest {
     spanBuilder.setAttribute("key", 12345L);
     spanBuilder.setAttribute("key", .12345);
     spanBuilder.setAttribute("key", true);
-    spanBuilder.setAttribute("key", AttributeValue.stringAttributeValue("value"));
+    spanBuilder.setAttribute("key", AttributeValue.Factory.stringAttributeValue("value"));
     spanBuilder.setStartTimestamp(12345L);
     assertThat(spanBuilder.startSpan()).isInstanceOf(DefaultSpan.class);
   }

--- a/api/src/test/java/io/opentelemetry/trace/attributes/BooleanAttributeSetterTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/attributes/BooleanAttributeSetterTest.java
@@ -29,7 +29,7 @@ class BooleanAttributeSetterTest {
     BooleanAttributeSetter setter = BooleanAttributeSetter.create("there?");
     assertThat(setter.key()).isEqualTo("there?");
     assertThat(setter.toString()).isEqualTo("there?");
-    Attributes.Builder attributes = Attributes.newBuilder();
+    Attributes.Builder attributes = Attributes.Factory.newBuilder();
     setter.set(attributes, true);
     assertThat(attributes.build().get("there?")).isEqualTo(booleanAttributeValue(true));
   }

--- a/api/src/test/java/io/opentelemetry/trace/attributes/BooleanAttributeSetterTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/attributes/BooleanAttributeSetterTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.trace.attributes;
 
-import static io.opentelemetry.common.AttributeValue.booleanAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.booleanAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.Attributes;

--- a/api/src/test/java/io/opentelemetry/trace/attributes/DoubleAttributeSetterTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/attributes/DoubleAttributeSetterTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.trace.attributes;
 
-import static io.opentelemetry.common.AttributeValue.doubleAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.doubleAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.Attributes;

--- a/api/src/test/java/io/opentelemetry/trace/attributes/DoubleAttributeSetterTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/attributes/DoubleAttributeSetterTest.java
@@ -29,7 +29,7 @@ class DoubleAttributeSetterTest {
     DoubleAttributeSetter setter = DoubleAttributeSetter.create("how much?");
     assertThat(setter.key()).isEqualTo("how much?");
     assertThat(setter.toString()).isEqualTo("how much?");
-    Attributes.Builder attributes = Attributes.newBuilder();
+    Attributes.Builder attributes = Attributes.Factory.newBuilder();
     setter.set(attributes, 10.0);
     assertThat(attributes.build().get("how much?")).isEqualTo(doubleAttributeValue(10.0));
   }

--- a/api/src/test/java/io/opentelemetry/trace/attributes/LongAttributeSetterTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/attributes/LongAttributeSetterTest.java
@@ -29,7 +29,7 @@ class LongAttributeSetterTest {
     LongAttributeSetter setter = LongAttributeSetter.create("how much?");
     assertThat(setter.key()).isEqualTo("how much?");
     assertThat(setter.toString()).isEqualTo("how much?");
-    Attributes.Builder attributes = Attributes.newBuilder();
+    Attributes.Builder attributes = Attributes.Factory.newBuilder();
     setter.set(attributes, 10);
     assertThat(attributes.build().get("how much?")).isEqualTo(longAttributeValue(10));
   }

--- a/api/src/test/java/io/opentelemetry/trace/attributes/LongAttributeSetterTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/attributes/LongAttributeSetterTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.trace.attributes;
 
-import static io.opentelemetry.common.AttributeValue.longAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.longAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.Attributes;

--- a/api/src/test/java/io/opentelemetry/trace/attributes/StringAttributeSetterTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/attributes/StringAttributeSetterTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.trace.attributes;
 
-import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.Attributes;

--- a/api/src/test/java/io/opentelemetry/trace/attributes/StringAttributeSetterTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/attributes/StringAttributeSetterTest.java
@@ -29,7 +29,7 @@ class StringAttributeSetterTest {
     StringAttributeSetter setter = StringAttributeSetter.create("hello?");
     assertThat(setter.key()).isEqualTo("hello?");
     assertThat(setter.toString()).isEqualTo("hello?");
-    Attributes.Builder attributes = Attributes.newBuilder();
+    Attributes.Builder attributes = Attributes.Factory.newBuilder();
     setter.set(attributes, "world");
     assertThat(attributes.build().get("hello?")).isEqualTo(stringAttributeValue("world"));
   }

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/Adapter.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/Adapter.java
@@ -130,7 +130,7 @@ final class Adapter {
     }
 
     if (!span.getStatus().isOk()) {
-      target.addTags(toKeyValue(KEY_ERROR, AttributeValue.booleanAttributeValue(true)));
+      target.addTags(toKeyValue(KEY_ERROR, AttributeValue.Factory.booleanAttributeValue(true)));
     }
 
     return target.build();

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
@@ -147,7 +147,7 @@ class AdapterTest {
   @Test
   void testKeyValues() {
     // prepare
-    AttributeValue valueB = AttributeValue.booleanAttributeValue(true);
+    AttributeValue valueB = AttributeValue.Factory.booleanAttributeValue(true);
 
     // test
     Collection<Model.KeyValue> keyValues =
@@ -161,14 +161,14 @@ class AdapterTest {
   @Test
   void testKeyValue() {
     // prepare
-    AttributeValue valueB = AttributeValue.booleanAttributeValue(true);
-    AttributeValue valueD = AttributeValue.doubleAttributeValue(1.);
-    AttributeValue valueI = AttributeValue.longAttributeValue(2);
-    AttributeValue valueS = AttributeValue.stringAttributeValue("foobar");
-    AttributeValue valueArrayB = AttributeValue.arrayAttributeValue(true, false);
-    AttributeValue valueArrayD = AttributeValue.arrayAttributeValue(1.2345, 6.789);
-    AttributeValue valueArrayI = AttributeValue.arrayAttributeValue(12345L, 67890L);
-    AttributeValue valueArrayS = AttributeValue.arrayAttributeValue("foobar", "barfoo");
+    AttributeValue valueB = AttributeValue.Factory.booleanAttributeValue(true);
+    AttributeValue valueD = AttributeValue.Factory.doubleAttributeValue(1.);
+    AttributeValue valueI = AttributeValue.Factory.longAttributeValue(2);
+    AttributeValue valueS = AttributeValue.Factory.stringAttributeValue("foobar");
+    AttributeValue valueArrayB = AttributeValue.Factory.arrayAttributeValue(true, false);
+    AttributeValue valueArrayD = AttributeValue.Factory.arrayAttributeValue(1.2345, 6.789);
+    AttributeValue valueArrayI = AttributeValue.Factory.arrayAttributeValue(12345L, 67890L);
+    AttributeValue valueArrayS = AttributeValue.Factory.arrayAttributeValue("foobar", "barfoo");
 
     // test
     Model.KeyValue kvB = Adapter.toKeyValue("valueB", valueB);
@@ -259,9 +259,9 @@ class AdapterTest {
     Attributes attributes =
         Attributes.Factory.of(
             "error.type",
-            AttributeValue.stringAttributeValue(this.getClass().getName()),
+            AttributeValue.Factory.stringAttributeValue(this.getClass().getName()),
             "error.message",
-            AttributeValue.stringAttributeValue("server error"));
+            AttributeValue.Factory.stringAttributeValue("server error"));
     long startMs = System.currentTimeMillis();
     long endMs = startMs + 900;
     SpanData span =
@@ -290,13 +290,13 @@ class AdapterTest {
 
   private static EventImpl getTimedEvent() {
     long epochNanos = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
-    AttributeValue valueS = AttributeValue.stringAttributeValue("bar");
+    AttributeValue valueS = AttributeValue.Factory.stringAttributeValue("bar");
     Attributes attributes = Attributes.Factory.of("foo", valueS);
     return EventImpl.create(epochNanos, "the log message", attributes);
   }
 
   private static SpanData getSpanData(long startMs, long endMs) {
-    AttributeValue valueB = AttributeValue.booleanAttributeValue(true);
+    AttributeValue valueB = AttributeValue.Factory.booleanAttributeValue(true);
     Attributes attributes = Attributes.Factory.of("valueB", valueB);
 
     Link link = Link.create(createSpanContext(LINK_TRACE_ID, LINK_SPAN_ID), attributes);

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
@@ -257,7 +257,7 @@ class AdapterTest {
   @Test
   void testSpanError() {
     Attributes attributes =
-        Attributes.of(
+        Attributes.Factory.of(
             "error.type",
             AttributeValue.stringAttributeValue(this.getClass().getName()),
             "error.message",
@@ -291,13 +291,13 @@ class AdapterTest {
   private static EventImpl getTimedEvent() {
     long epochNanos = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
     AttributeValue valueS = AttributeValue.stringAttributeValue("bar");
-    Attributes attributes = Attributes.of("foo", valueS);
+    Attributes attributes = Attributes.Factory.of("foo", valueS);
     return EventImpl.create(epochNanos, "the log message", attributes);
   }
 
   private static SpanData getSpanData(long startMs, long endMs) {
     AttributeValue valueB = AttributeValue.booleanAttributeValue(true);
-    Attributes attributes = Attributes.of("valueB", valueB);
+    Attributes attributes = Attributes.Factory.of("valueB", valueB);
 
     Link link = Link.create(createSpanContext(LINK_TRACE_ID, LINK_SPAN_ID), attributes);
 
@@ -309,13 +309,13 @@ class AdapterTest {
         .setName("GET /api/endpoint")
         .setStartEpochNanos(TimeUnit.MILLISECONDS.toNanos(startMs))
         .setEndEpochNanos(TimeUnit.MILLISECONDS.toNanos(endMs))
-        .setAttributes(Attributes.of("valueB", valueB))
+        .setAttributes(Attributes.Factory.of("valueB", valueB))
         .setEvents(Collections.singletonList(getTimedEvent()))
         .setTotalRecordedEvents(1)
         .setLinks(Collections.singletonList(link))
         .setTotalRecordedLinks(1)
         .setKind(Span.Kind.SERVER)
-        .setResource(Resource.create(Attributes.empty()))
+        .setResource(Resource.create(Attributes.Factory.empty()))
         .setStatus(Status.OK)
         .build();
   }

--- a/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingMetricExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingMetricExporterTest.java
@@ -59,7 +59,8 @@ class LoggingMetricExporterTest {
 
     long nowEpochNanos = System.currentTimeMillis() * 1000 * 1000;
     Resource resource =
-        Resource.create(Attributes.of("host", AttributeValue.stringAttributeValue("localhost")));
+        Resource.create(
+            Attributes.Factory.of("host", AttributeValue.stringAttributeValue("localhost")));
     InstrumentationLibraryInfo instrumentationLibraryInfo =
         InstrumentationLibraryInfo.create("manualInstrumentation", "1.0");
     exporter.export(

--- a/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingMetricExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingMetricExporterTest.java
@@ -60,7 +60,8 @@ class LoggingMetricExporterTest {
     long nowEpochNanos = System.currentTimeMillis() * 1000 * 1000;
     Resource resource =
         Resource.create(
-            Attributes.Factory.of("host", AttributeValue.stringAttributeValue("localhost")));
+            Attributes.Factory.of(
+                "host", AttributeValue.Factory.stringAttributeValue("localhost")));
     InstrumentationLibraryInfo instrumentationLibraryInfo =
         InstrumentationLibraryInfo.create("manualInstrumentation", "1.0");
     exporter.export(

--- a/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingSpanExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingSpanExporterTest.java
@@ -73,7 +73,7 @@ class LoggingSpanExporterTest {
                         epochNanos + 500,
                         "somethingHappenedHere",
                         Attributes.Factory.of(
-                            "important", AttributeValue.booleanAttributeValue(true)))))
+                            "important", AttributeValue.Factory.booleanAttributeValue(true)))))
             .setTotalRecordedEvents(1)
             .setTotalRecordedLinks(0)
             .build();

--- a/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingSpanExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingSpanExporterTest.java
@@ -72,7 +72,8 @@ class LoggingSpanExporterTest {
                     EventImpl.create(
                         epochNanos + 500,
                         "somethingHappenedHere",
-                        Attributes.of("important", AttributeValue.booleanAttributeValue(true)))))
+                        Attributes.Factory.of(
+                            "important", AttributeValue.booleanAttributeValue(true)))))
             .setTotalRecordedEvents(1)
             .setTotalRecordedLinks(0)
             .build();

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/CommonAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/CommonAdapterTest.java
@@ -30,7 +30,9 @@ import org.junit.jupiter.api.Test;
 class CommonAdapterTest {
   @Test
   void toProtoAttribute_Bool() {
-    assertThat(CommonAdapter.toProtoAttribute("key", AttributeValue.booleanAttributeValue(true)))
+    assertThat(
+            CommonAdapter.toProtoAttribute(
+                "key", AttributeValue.Factory.booleanAttributeValue(true)))
         .isEqualTo(
             KeyValue.newBuilder()
                 .setKey("key")
@@ -41,7 +43,8 @@ class CommonAdapterTest {
   @Test
   void toProtoAttribute_BoolArray() {
     assertThat(
-            CommonAdapter.toProtoAttribute("key", AttributeValue.arrayAttributeValue(true, false)))
+            CommonAdapter.toProtoAttribute(
+                "key", AttributeValue.Factory.arrayAttributeValue(true, false)))
         .isEqualTo(
             KeyValue.newBuilder()
                 .setKey("key")
@@ -58,7 +61,9 @@ class CommonAdapterTest {
 
   @Test
   void toProtoAttribute_String() {
-    assertThat(CommonAdapter.toProtoAttribute("key", AttributeValue.stringAttributeValue("string")))
+    assertThat(
+            CommonAdapter.toProtoAttribute(
+                "key", AttributeValue.Factory.stringAttributeValue("string")))
         .isEqualTo(
             KeyValue.newBuilder()
                 .setKey("key")
@@ -70,7 +75,7 @@ class CommonAdapterTest {
   void toProtoAttribute_StringArray() {
     assertThat(
             CommonAdapter.toProtoAttribute(
-                "key", AttributeValue.arrayAttributeValue("string1", "string2")))
+                "key", AttributeValue.Factory.arrayAttributeValue("string1", "string2")))
         .isEqualTo(
             KeyValue.newBuilder()
                 .setKey("key")
@@ -87,7 +92,8 @@ class CommonAdapterTest {
 
   @Test
   void toProtoAttribute_Int() {
-    assertThat(CommonAdapter.toProtoAttribute("key", AttributeValue.longAttributeValue(100)))
+    assertThat(
+            CommonAdapter.toProtoAttribute("key", AttributeValue.Factory.longAttributeValue(100)))
         .isEqualTo(
             KeyValue.newBuilder()
                 .setKey("key")
@@ -98,7 +104,8 @@ class CommonAdapterTest {
   @Test
   void toProtoAttribute_IntArray() {
     assertThat(
-            CommonAdapter.toProtoAttribute("key", AttributeValue.arrayAttributeValue(100L, 200L)))
+            CommonAdapter.toProtoAttribute(
+                "key", AttributeValue.Factory.arrayAttributeValue(100L, 200L)))
         .isEqualTo(
             KeyValue.newBuilder()
                 .setKey("key")
@@ -115,7 +122,9 @@ class CommonAdapterTest {
 
   @Test
   void toProtoAttribute_Double() {
-    assertThat(CommonAdapter.toProtoAttribute("key", AttributeValue.doubleAttributeValue(100.3)))
+    assertThat(
+            CommonAdapter.toProtoAttribute(
+                "key", AttributeValue.Factory.doubleAttributeValue(100.3)))
         .isEqualTo(
             KeyValue.newBuilder()
                 .setKey("key")
@@ -126,7 +135,8 @@ class CommonAdapterTest {
   @Test
   void toProtoAttribute_DoubleArray() {
     assertThat(
-            CommonAdapter.toProtoAttribute("key", AttributeValue.arrayAttributeValue(100.3, 200.5)))
+            CommonAdapter.toProtoAttribute(
+                "key", AttributeValue.Factory.arrayAttributeValue(100.3, 200.5)))
         .isEqualTo(
             KeyValue.newBuilder()
                 .setKey("key")

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/MetricAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/MetricAdapterTest.java
@@ -382,7 +382,8 @@ class MetricAdapterTest {
         Descriptor.create(
             "name", "description", "1", Descriptor.Type.MONOTONIC_DOUBLE, Labels.of("k", "v"));
     Resource resource =
-        Resource.create(Attributes.Factory.of("ka", AttributeValue.stringAttributeValue("va")));
+        Resource.create(
+            Attributes.Factory.of("ka", AttributeValue.Factory.stringAttributeValue("va")));
     io.opentelemetry.proto.resource.v1.Resource resourceProto =
         io.opentelemetry.proto.resource.v1.Resource.newBuilder()
             .addAllAttributes(

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/MetricAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/MetricAdapterTest.java
@@ -382,7 +382,7 @@ class MetricAdapterTest {
         Descriptor.create(
             "name", "description", "1", Descriptor.Type.MONOTONIC_DOUBLE, Labels.of("k", "v"));
     Resource resource =
-        Resource.create(Attributes.of("ka", AttributeValue.stringAttributeValue("va")));
+        Resource.create(Attributes.Factory.of("ka", AttributeValue.stringAttributeValue("va")));
     io.opentelemetry.proto.resource.v1.Resource resourceProto =
         io.opentelemetry.proto.resource.v1.Resource.newBuilder()
             .addAllAttributes(

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/ResourceAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/ResourceAdapterTest.java
@@ -34,13 +34,13 @@ class ResourceAdapterTest {
                     Resource.create(
                         Attributes.Factory.of(
                             "key_bool",
-                            AttributeValue.booleanAttributeValue(true),
+                            AttributeValue.Factory.booleanAttributeValue(true),
                             "key_string",
-                            AttributeValue.stringAttributeValue("string"),
+                            AttributeValue.Factory.stringAttributeValue("string"),
                             "key_int",
-                            AttributeValue.longAttributeValue(100),
+                            AttributeValue.Factory.longAttributeValue(100),
                             "key_double",
-                            AttributeValue.doubleAttributeValue(100.3))))
+                            AttributeValue.Factory.doubleAttributeValue(100.3))))
                 .getAttributesList())
         .containsExactlyInAnyOrder(
             KeyValue.newBuilder()

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/ResourceAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/ResourceAdapterTest.java
@@ -32,7 +32,7 @@ class ResourceAdapterTest {
     assertThat(
             ResourceAdapter.toProtoResource(
                     Resource.create(
-                        Attributes.of(
+                        Attributes.Factory.of(
                             "key_bool",
                             AttributeValue.booleanAttributeValue(true),
                             "key_string",

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
@@ -65,7 +65,8 @@ class SpanAdapterTest {
                 .setStartEpochNanos(12345)
                 .setEndEpochNanos(12349)
                 .setAttributes(
-                    Attributes.Factory.of("key", AttributeValue.booleanAttributeValue(true)))
+                    Attributes.Factory.of(
+                        "key", AttributeValue.Factory.booleanAttributeValue(true)))
                 .setTotalAttributeCount(2)
                 .setEvents(
                     Collections.singletonList(
@@ -246,7 +247,7 @@ class SpanAdapterTest {
                     12345,
                     "test_with_attributes",
                     Attributes.Factory.of(
-                        "key_string", AttributeValue.stringAttributeValue("string")),
+                        "key_string", AttributeValue.Factory.stringAttributeValue("string")),
                     5)))
         .isEqualTo(
             Span.Event.newBuilder()
@@ -278,7 +279,7 @@ class SpanAdapterTest {
                 Link.create(
                     SPAN_CONTEXT,
                     Attributes.Factory.of(
-                        "key_string", AttributeValue.stringAttributeValue("string")),
+                        "key_string", AttributeValue.Factory.stringAttributeValue("string")),
                     5)))
         .isEqualTo(
             Span.Link.newBuilder()

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
@@ -64,11 +64,12 @@ class SpanAdapterTest {
                 .setKind(Kind.SERVER)
                 .setStartEpochNanos(12345)
                 .setEndEpochNanos(12349)
-                .setAttributes(Attributes.of("key", AttributeValue.booleanAttributeValue(true)))
+                .setAttributes(
+                    Attributes.Factory.of("key", AttributeValue.booleanAttributeValue(true)))
                 .setTotalAttributeCount(2)
                 .setEvents(
                     Collections.singletonList(
-                        EventImpl.create(12347, "my_event", Attributes.empty())))
+                        EventImpl.create(12347, "my_event", Attributes.Factory.empty())))
                 .setTotalRecordedEvents(3)
                 .setLinks(Collections.singletonList(Link.create(SPAN_CONTEXT)))
                 .setTotalRecordedLinks(2)
@@ -229,7 +230,7 @@ class SpanAdapterTest {
   void toProtoSpanEvent_WithoutAttributes() {
     assertThat(
             SpanAdapter.toProtoSpanEvent(
-                EventImpl.create(12345, "test_without_attributes", Attributes.empty())))
+                EventImpl.create(12345, "test_without_attributes", Attributes.Factory.empty())))
         .isEqualTo(
             Span.Event.newBuilder()
                 .setTimeUnixNano(12345)
@@ -244,7 +245,8 @@ class SpanAdapterTest {
                 EventImpl.create(
                     12345,
                     "test_with_attributes",
-                    Attributes.of("key_string", AttributeValue.stringAttributeValue("string")),
+                    Attributes.Factory.of(
+                        "key_string", AttributeValue.stringAttributeValue("string")),
                     5)))
         .isEqualTo(
             Span.Event.newBuilder()
@@ -275,7 +277,8 @@ class SpanAdapterTest {
             SpanAdapter.toProtoSpanLink(
                 Link.create(
                     SPAN_CONTEXT,
-                    Attributes.of("key_string", AttributeValue.stringAttributeValue("string")),
+                    Attributes.Factory.of(
+                        "key_string", AttributeValue.stringAttributeValue("string")),
                     5)))
         .isEqualTo(
             Span.Link.newBuilder()

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporters/prometheus/MetricAdapterTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporters/prometheus/MetricAdapterTest.java
@@ -222,7 +222,8 @@ class MetricAdapterTest {
     MetricData metricData =
         MetricData.create(
             descriptor,
-            Resource.create(Attributes.Factory.of("kr", AttributeValue.stringAttributeValue("vr"))),
+            Resource.create(
+                Attributes.Factory.of("kr", AttributeValue.Factory.stringAttributeValue("vr"))),
             InstrumentationLibraryInfo.create("full", "version"),
             Collections.singletonList(
                 MetricData.DoublePoint.create(123, 456, Labels.of("kp", "vp"), 5)));

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporters/prometheus/MetricAdapterTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporters/prometheus/MetricAdapterTest.java
@@ -222,7 +222,7 @@ class MetricAdapterTest {
     MetricData metricData =
         MetricData.create(
             descriptor,
-            Resource.create(Attributes.of("kr", AttributeValue.stringAttributeValue("vr"))),
+            Resource.create(Attributes.Factory.of("kr", AttributeValue.stringAttributeValue("vr"))),
             InstrumentationLibraryInfo.create("full", "version"),
             Collections.singletonList(
                 MetricData.DoublePoint.create(123, 456, Labels.of("kp", "vp"), 5)));

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporters/prometheus/PrometheusCollectorTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporters/prometheus/PrometheusCollectorTest.java
@@ -73,7 +73,8 @@ class PrometheusCollectorTest {
                 "1",
                 Descriptor.Type.MONOTONIC_LONG,
                 Labels.of("kc", "vc")),
-            Resource.create(Attributes.Factory.of("kr", AttributeValue.stringAttributeValue("vr"))),
+            Resource.create(
+                Attributes.Factory.of("kr", AttributeValue.Factory.stringAttributeValue("vr"))),
             InstrumentationLibraryInfo.create("grpc", "version"),
             Collections.singletonList(
                 MetricData.LongPoint.create(123, 456, Labels.of("kp", "vp"), 5))),
@@ -84,7 +85,8 @@ class PrometheusCollectorTest {
                 "1",
                 Descriptor.Type.MONOTONIC_DOUBLE,
                 Labels.of("kc", "vc")),
-            Resource.create(Attributes.Factory.of("kr", AttributeValue.stringAttributeValue("vr"))),
+            Resource.create(
+                Attributes.Factory.of("kr", AttributeValue.Factory.stringAttributeValue("vr"))),
             InstrumentationLibraryInfo.create("http", "version"),
             Collections.singletonList(
                 MetricData.DoublePoint.create(123, 456, Labels.of("kp", "vp"), 3.5))));

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporters/prometheus/PrometheusCollectorTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporters/prometheus/PrometheusCollectorTest.java
@@ -73,7 +73,7 @@ class PrometheusCollectorTest {
                 "1",
                 Descriptor.Type.MONOTONIC_LONG,
                 Labels.of("kc", "vc")),
-            Resource.create(Attributes.of("kr", AttributeValue.stringAttributeValue("vr"))),
+            Resource.create(Attributes.Factory.of("kr", AttributeValue.stringAttributeValue("vr"))),
             InstrumentationLibraryInfo.create("grpc", "version"),
             Collections.singletonList(
                 MetricData.LongPoint.create(123, 456, Labels.of("kp", "vp"), 5))),
@@ -84,7 +84,7 @@ class PrometheusCollectorTest {
                 "1",
                 Descriptor.Type.MONOTONIC_DOUBLE,
                 Labels.of("kc", "vc")),
-            Resource.create(Attributes.of("kr", AttributeValue.stringAttributeValue("vr"))),
+            Resource.create(Attributes.Factory.of("kr", AttributeValue.stringAttributeValue("vr"))),
             InstrumentationLibraryInfo.create("http", "version"),
             Collections.singletonList(
                 MetricData.DoublePoint.create(123, 456, Labels.of("kp", "vp"), 3.5))));

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
@@ -55,11 +55,11 @@ public class ZipkinSpanExporterEndToEndHttpTest {
   private static final long END_EPOCH_NANOS = 1505855799_465726528L;
   private static final long RECEIVED_TIMESTAMP_NANOS = 1505855799_433901068L;
   private static final long SENT_TIMESTAMP_NANOS = 1505855799_459486280L;
-  private static final Attributes attributes = Attributes.empty();
+  private static final Attributes attributes = Attributes.Factory.empty();
   private static final List<Event> annotations =
       ImmutableList.of(
-          EventImpl.create(RECEIVED_TIMESTAMP_NANOS, "RECEIVED", Attributes.empty()),
-          EventImpl.create(SENT_TIMESTAMP_NANOS, "SENT", Attributes.empty()));
+          EventImpl.create(RECEIVED_TIMESTAMP_NANOS, "RECEIVED", Attributes.Factory.empty()),
+          EventImpl.create(SENT_TIMESTAMP_NANOS, "SENT", Attributes.Factory.empty()));
 
   private static final String ENDPOINT_V1_SPANS = "/api/v1/spans";
   private static final String ENDPOINT_V2_SPANS = "/api/v2/spans";

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.exporters.zipkin;
 
-import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -140,13 +140,13 @@ class ZipkinSpanExporterTest {
     Attributes attributes =
         Attributes.Factory.newBuilder()
             .setAttribute("string", stringAttributeValue("string value"))
-            .setAttribute("boolean", AttributeValue.booleanAttributeValue(false))
-            .setAttribute("long", AttributeValue.longAttributeValue(9999L))
-            .setAttribute("double", AttributeValue.doubleAttributeValue(222.333))
-            .setAttribute("booleanArray", AttributeValue.arrayAttributeValue(true, false))
-            .setAttribute("stringArray", AttributeValue.arrayAttributeValue("Hello"))
-            .setAttribute("doubleArray", AttributeValue.arrayAttributeValue(32.33d, -98.3d))
-            .setAttribute("longArray", AttributeValue.arrayAttributeValue(33L, 999L))
+            .setAttribute("boolean", AttributeValue.Factory.booleanAttributeValue(false))
+            .setAttribute("long", AttributeValue.Factory.longAttributeValue(9999L))
+            .setAttribute("double", AttributeValue.Factory.doubleAttributeValue(222.333))
+            .setAttribute("booleanArray", AttributeValue.Factory.arrayAttributeValue(true, false))
+            .setAttribute("stringArray", AttributeValue.Factory.arrayAttributeValue("Hello"))
+            .setAttribute("doubleArray", AttributeValue.Factory.arrayAttributeValue(32.33d, -98.3d))
+            .setAttribute("longArray", AttributeValue.Factory.arrayAttributeValue(33L, 999L))
             .build();
     SpanData data = buildStandardSpan().setAttributes(attributes).setKind(Kind.CLIENT).build();
 
@@ -188,7 +188,7 @@ class ZipkinSpanExporterTest {
     Attributes attributeMap =
         Attributes.Factory.of(
             SemanticAttributes.HTTP_STATUS_CODE.key(),
-            AttributeValue.longAttributeValue(404),
+            AttributeValue.Factory.longAttributeValue(404),
             SemanticAttributes.HTTP_STATUS_TEXT.key(),
             stringAttributeValue("NOT FOUND"),
             "error",

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterTest.java
@@ -67,11 +67,11 @@ class ZipkinSpanExporterTest {
   private static final String TRACE_ID = "d239036e7d5cec116b562147388b35bf";
   private static final String SPAN_ID = "9cc1e3049173be09";
   private static final String PARENT_SPAN_ID = "8b03ab423da481c5";
-  private static final Attributes attributes = Attributes.empty();
+  private static final Attributes attributes = Attributes.Factory.empty();
   private static final List<Event> annotations =
       ImmutableList.of(
-          EventImpl.create(1505855799_433901068L, "RECEIVED", Attributes.empty()),
-          EventImpl.create(1505855799_459486280L, "SENT", Attributes.empty()));
+          EventImpl.create(1505855799_433901068L, "RECEIVED", Attributes.Factory.empty()),
+          EventImpl.create(1505855799_459486280L, "SENT", Attributes.Factory.empty()));
 
   @Test
   void generateSpan_remoteParent() {
@@ -125,7 +125,7 @@ class ZipkinSpanExporterTest {
   void generateSpan_ResourceServiceNameMapping() {
     final Resource resource =
         Resource.create(
-            Attributes.of(
+            Attributes.Factory.of(
                 ResourceConstants.SERVICE_NAME, stringAttributeValue("super-zipkin-service")));
     SpanData data = buildStandardSpan().setResource(resource).build();
 
@@ -138,7 +138,7 @@ class ZipkinSpanExporterTest {
   @Test
   void generateSpan_WithAttributes() {
     Attributes attributes =
-        Attributes.newBuilder()
+        Attributes.Factory.newBuilder()
             .setAttribute("string", stringAttributeValue("string value"))
             .setAttribute("boolean", AttributeValue.booleanAttributeValue(false))
             .setAttribute("long", AttributeValue.longAttributeValue(9999L))
@@ -186,7 +186,7 @@ class ZipkinSpanExporterTest {
   @Test
   void generateSpan_AlreadyHasHttpStatusInfo() {
     Attributes attributeMap =
-        Attributes.of(
+        Attributes.Factory.of(
             SemanticAttributes.HTTP_STATUS_CODE.key(),
             AttributeValue.longAttributeValue(404),
             SemanticAttributes.HTTP_STATUS_TEXT.key(),
@@ -214,7 +214,7 @@ class ZipkinSpanExporterTest {
   @Test
   void generateSpan_WithRpcErrorStatus() {
     Attributes attributeMap =
-        Attributes.of(
+        Attributes.Factory.of(
             SemanticAttributes.RPC_SERVICE.key(), stringAttributeValue("my service name"));
 
     String errorMessage = "timeout";

--- a/extensions/trace_utils/src/main/java/io/opentelemetry/extensions/trace/MessageEvent.java
+++ b/extensions/trace_utils/src/main/java/io/opentelemetry/extensions/trace/MessageEvent.java
@@ -61,10 +61,11 @@ public final class MessageEvent implements Event {
   }
 
   private static final AttributeValue sentAttributeValue =
-      AttributeValue.stringAttributeValue(Type.SENT.name());
+      AttributeValue.Factory.stringAttributeValue(Type.SENT.name());
   private static final AttributeValue receivedAttributeValue =
-      AttributeValue.stringAttributeValue(Type.RECEIVED.name());
-  private static final AttributeValue zeroAttributeValue = AttributeValue.longAttributeValue(0);
+      AttributeValue.Factory.stringAttributeValue(Type.RECEIVED.name());
+  private static final AttributeValue zeroAttributeValue =
+      AttributeValue.Factory.longAttributeValue(0);
 
   private final Attributes attributes;
 
@@ -87,17 +88,18 @@ public final class MessageEvent implements Event {
     attributeBuilder.setAttribute(
         TYPE, type == Type.SENT ? sentAttributeValue : receivedAttributeValue);
     attributeBuilder.setAttribute(
-        ID, messageId == 0 ? zeroAttributeValue : AttributeValue.longAttributeValue(messageId));
+        ID,
+        messageId == 0 ? zeroAttributeValue : AttributeValue.Factory.longAttributeValue(messageId));
     attributeBuilder.setAttribute(
         UNCOMPRESSED_SIZE,
         uncompressedSize == 0
             ? zeroAttributeValue
-            : AttributeValue.longAttributeValue(uncompressedSize));
+            : AttributeValue.Factory.longAttributeValue(uncompressedSize));
     attributeBuilder.setAttribute(
         COMPRESSED_SIZE,
         compressedSize == 0
             ? zeroAttributeValue
-            : AttributeValue.longAttributeValue(compressedSize));
+            : AttributeValue.Factory.longAttributeValue(compressedSize));
     return new MessageEvent(attributeBuilder.build());
   }
 

--- a/extensions/trace_utils/src/main/java/io/opentelemetry/extensions/trace/MessageEvent.java
+++ b/extensions/trace_utils/src/main/java/io/opentelemetry/extensions/trace/MessageEvent.java
@@ -83,7 +83,7 @@ public final class MessageEvent implements Event {
    */
   public static MessageEvent create(
       Type type, long messageId, long uncompressedSize, long compressedSize) {
-    Attributes.Builder attributeBuilder = Attributes.newBuilder();
+    Attributes.Builder attributeBuilder = Attributes.Factory.newBuilder();
     attributeBuilder.setAttribute(
         TYPE, type == Type.SENT ? sentAttributeValue : receivedAttributeValue);
     attributeBuilder.setAttribute(

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
@@ -119,7 +119,7 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
       error = Boolean.parseBoolean(value);
     } else {
       this.spanBuilderAttributeKeys.add(key);
-      this.spanBuilderAttributeValues.add(AttributeValue.stringAttributeValue(value));
+      this.spanBuilderAttributeValues.add(AttributeValue.Factory.stringAttributeValue(value));
     }
 
     return this;
@@ -131,7 +131,7 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
       error = value;
     } else {
       this.spanBuilderAttributeKeys.add(key);
-      this.spanBuilderAttributeValues.add(AttributeValue.booleanAttributeValue(value));
+      this.spanBuilderAttributeValues.add(AttributeValue.Factory.booleanAttributeValue(value));
     }
     return this;
   }
@@ -144,10 +144,12 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
         || value instanceof Short
         || value instanceof Byte) {
       this.spanBuilderAttributeKeys.add(key);
-      this.spanBuilderAttributeValues.add(AttributeValue.longAttributeValue(value.longValue()));
+      this.spanBuilderAttributeValues.add(
+          AttributeValue.Factory.longAttributeValue(value.longValue()));
     } else if (value instanceof Float || value instanceof Double) {
       this.spanBuilderAttributeKeys.add(key);
-      this.spanBuilderAttributeValues.add(AttributeValue.doubleAttributeValue(value.doubleValue()));
+      this.spanBuilderAttributeValues.add(
+          AttributeValue.Factory.doubleAttributeValue(value.doubleValue()));
     } else {
       throw new IllegalArgumentException("Number type not supported");
     }

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanShim.java
@@ -188,7 +188,7 @@ final class SpanShim extends BaseShimObject implements Span {
   }
 
   static Attributes convertToAttributes(Map<String, ?> fields) {
-    Attributes.Builder attributesBuilder = Attributes.newBuilder();
+    Attributes.Builder attributesBuilder = Attributes.Factory.newBuilder();
 
     for (Map.Entry<String, ?> entry : fields.entrySet()) {
       String key = entry.getKey();

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanShim.java
@@ -204,14 +204,16 @@ final class SpanShim extends BaseShimObject implements Span {
           || value instanceof Integer
           || value instanceof Long) {
         attributesBuilder.setAttribute(
-            key, AttributeValue.longAttributeValue(((Number) value).longValue()));
+            key, AttributeValue.Factory.longAttributeValue(((Number) value).longValue()));
       } else if (value instanceof Float || value instanceof Double) {
         attributesBuilder.setAttribute(
-            key, AttributeValue.doubleAttributeValue(((Number) value).doubleValue()));
+            key, AttributeValue.Factory.doubleAttributeValue(((Number) value).doubleValue()));
       } else if (value instanceof Boolean) {
-        attributesBuilder.setAttribute(key, AttributeValue.booleanAttributeValue((Boolean) value));
+        attributesBuilder.setAttribute(
+            key, AttributeValue.Factory.booleanAttributeValue((Boolean) value));
       } else {
-        attributesBuilder.setAttribute(key, AttributeValue.stringAttributeValue(value.toString()));
+        attributesBuilder.setAttribute(
+            key, AttributeValue.Factory.stringAttributeValue(value.toString()));
       }
     }
 

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
@@ -74,7 +74,7 @@ public class SpanPipelineBenchmark {
             .setAttribute("key", "value")
             .addLink(new TestLink())
             .startSpan();
-    span.addEvent("started", Attributes.of("operation", stringAttributeValue("some_work")));
+    span.addEvent("started", Attributes.Factory.of("operation", stringAttributeValue("some_work")));
     span.setAttribute("longAttribute", 33L);
     span.setAttribute("stringAttribute", "test_value");
     span.setAttribute("doubleAttribute", 4844.44d);
@@ -111,7 +111,7 @@ public class SpanPipelineBenchmark {
 
     @Override
     public Attributes getAttributes() {
-      return Attributes.of("linkAttr", stringAttributeValue("linkValue"));
+      return Attributes.Factory.of("linkAttr", stringAttributeValue("linkValue"));
     }
   }
 
@@ -123,7 +123,7 @@ public class SpanPipelineBenchmark {
 
     @Override
     public Attributes getAttributes() {
-      return Attributes.of("finalized", booleanAttributeValue(true));
+      return Attributes.Factory.of("finalized", booleanAttributeValue(true));
     }
   }
 }

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
@@ -16,8 +16,8 @@
 
 package io.opentelemetry.sdk.trace;
 
-import static io.opentelemetry.common.AttributeValue.booleanAttributeValue;
-import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.booleanAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.sdk.OpenTelemetrySdk;

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/resources/EnvAutodetectResource.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/resources/EnvAutodetectResource.java
@@ -48,9 +48,9 @@ final class EnvAutodetectResource {
   @VisibleForTesting
   static Attributes parseResourceAttributes(@Nullable String rawEnvAttributes) {
     if (rawEnvAttributes == null) {
-      return Attributes.empty();
+      return Attributes.Factory.empty();
     } else {
-      Attributes.Builder attrBuilders = Attributes.newBuilder();
+      Attributes.Builder attrBuilders = Attributes.Factory.newBuilder();
       String[] rawAttributes = rawEnvAttributes.split(ATTRIBUTE_LIST_SPLITTER, -1);
       for (String rawAttribute : rawAttributes) {
         String[] keyValuePair = rawAttribute.split(ATTRIBUTE_KEY_VALUE_SPLITTER, -1);

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/resources/Resource.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/resources/Resource.java
@@ -46,10 +46,10 @@ public abstract class Resource {
           + " characters.";
   private static final String ERROR_MESSAGE_INVALID_VALUE =
       " should be a ASCII string with a length not exceed " + MAX_LENGTH + " characters.";
-  private static final Resource EMPTY = create(Attributes.empty());
+  private static final Resource EMPTY = create(Attributes.Factory.empty());
   private static final Resource TELEMETRY_SDK =
       create(
-          Attributes.newBuilder()
+          Attributes.Factory.newBuilder()
               .setAttribute("telemetry.sdk.name", "opentelemetry")
               .setAttribute("telemetry.sdk.language", "java")
               .setAttribute("telemetry.sdk.version", readVersion())
@@ -155,7 +155,7 @@ public abstract class Resource {
       return this;
     }
 
-    Attributes.Builder attrBuilder = Attributes.newBuilder();
+    Attributes.Builder attrBuilder = Attributes.Factory.newBuilder();
     Merger merger = new Merger(attrBuilder);
     this.getAttributes().forEach(merger);
     other.getAttributes().forEach(merger);

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/resources/EnvAutodetectResourceTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/resources/EnvAutodetectResourceTest.java
@@ -44,7 +44,7 @@ class EnvAutodetectResourceTest {
   @Test
   void parseResourceAttributes_single() {
     Attributes result = EnvAutodetectResource.parseResourceAttributes("value=foo");
-    assertThat(result).isEqualTo(Attributes.of("value", stringAttributeValue("foo")));
+    assertThat(result).isEqualTo(Attributes.Factory.of("value", stringAttributeValue("foo")));
   }
 
   @Test
@@ -52,7 +52,7 @@ class EnvAutodetectResourceTest {
     Attributes result = EnvAutodetectResource.parseResourceAttributes("value=foo, other=bar");
     assertThat(result)
         .isEqualTo(
-            Attributes.of(
+            Attributes.Factory.of(
                 "value", stringAttributeValue("foo"),
                 "other", stringAttributeValue("bar")));
   }
@@ -60,13 +60,13 @@ class EnvAutodetectResourceTest {
   @Test
   void parseResourceAttributes_whitespace() {
     Attributes result = EnvAutodetectResource.parseResourceAttributes(" value = foo ");
-    assertThat(result).isEqualTo(Attributes.of("value", stringAttributeValue("foo")));
+    assertThat(result).isEqualTo(Attributes.Factory.of("value", stringAttributeValue("foo")));
   }
 
   @Test
   void parseResourceAttributes_quotes() {
     Attributes result = EnvAutodetectResource.parseResourceAttributes("value=\"foo\"");
-    assertThat(result).isEqualTo(Attributes.of("value", stringAttributeValue("foo")));
+    assertThat(result).isEqualTo(Attributes.Factory.of("value", stringAttributeValue("foo")));
   }
 
   @Test
@@ -79,7 +79,7 @@ class EnvAutodetectResourceTest {
             .readSystemProperties()
             .build();
     Attributes result = (Attributes) resource.getAttributes();
-    assertThat(result).isEqualTo(Attributes.of("value", stringAttributeValue("foo")));
+    assertThat(result).isEqualTo(Attributes.Factory.of("value", stringAttributeValue("foo")));
     System.clearProperty(key);
   }
 
@@ -94,7 +94,7 @@ class EnvAutodetectResourceTest {
               .readSystemProperties()
               .build();
       Attributes result = (Attributes) resource.getAttributes();
-      assertThat(result).isEqualTo(Attributes.of("value", stringAttributeValue("foo")));
+      assertThat(result).isEqualTo(Attributes.Factory.of("value", stringAttributeValue("foo")));
     }
   }
 }

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/resources/EnvAutodetectResourceTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/resources/EnvAutodetectResourceTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.resources;
 
-import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.common.Attributes;

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/resources/ResourceTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/resources/ResourceTest.java
@@ -27,20 +27,20 @@ import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link Resource}. */
 class ResourceTest {
-  private static final Resource DEFAULT_RESOURCE = Resource.create(Attributes.empty());
+  private static final Resource DEFAULT_RESOURCE = Resource.create(Attributes.Factory.empty());
   private Resource resource1;
   private Resource resource2;
 
   @BeforeEach
   void setUp() {
     Attributes attributes1 =
-        Attributes.of(
+        Attributes.Factory.of(
             "a",
             AttributeValue.stringAttributeValue("1"),
             "b",
             AttributeValue.stringAttributeValue("2"));
     Attributes attribute2 =
-        Attributes.of(
+        Attributes.Factory.of(
             "a",
             AttributeValue.stringAttributeValue("1"),
             "b",
@@ -54,7 +54,7 @@ class ResourceTest {
   @Test
   void create() {
     Attributes attributes =
-        Attributes.of(
+        Attributes.Factory.of(
             "a",
             AttributeValue.stringAttributeValue("1"),
             "b",
@@ -64,14 +64,14 @@ class ResourceTest {
     assertThat(resource.getAttributes().size()).isEqualTo(2);
     assertThat(resource.getAttributes()).isEqualTo(attributes);
 
-    Resource resource1 = Resource.create(Attributes.empty());
+    Resource resource1 = Resource.create(Attributes.Factory.empty());
     assertThat(resource1.getAttributes()).isNotNull();
     assertThat(resource1.getAttributes().isEmpty()).isTrue();
   }
 
   @Test
   void create_ignoreNull() {
-    Attributes.Builder attributes = Attributes.newBuilder();
+    Attributes.Builder attributes = Attributes.Factory.newBuilder();
 
     attributes.setAttribute("string", AttributeValue.stringAttributeValue(null));
     Resource resource = Resource.create(attributes.build());
@@ -112,7 +112,7 @@ class ResourceTest {
 
   @Test
   void create_NullEmptyArray() {
-    Attributes.Builder attributes = Attributes.newBuilder();
+    Attributes.Builder attributes = Attributes.Factory.newBuilder();
 
     // Empty arrays should be maintained
     attributes.setAttribute(
@@ -167,13 +167,13 @@ class ResourceTest {
   @Test
   void testResourceEquals() {
     Attributes attribute1 =
-        Attributes.of(
+        Attributes.Factory.of(
             "a",
             AttributeValue.stringAttributeValue("1"),
             "b",
             AttributeValue.stringAttributeValue("2"));
     Attributes attribute2 =
-        Attributes.of(
+        Attributes.Factory.of(
             "a",
             AttributeValue.stringAttributeValue("1"),
             "b",
@@ -189,7 +189,7 @@ class ResourceTest {
   @Test
   void testMergeResources() {
     Attributes expectedAttributes =
-        Attributes.of(
+        Attributes.Factory.of(
             "a",
             AttributeValue.stringAttributeValue("1"),
             "b",
@@ -204,7 +204,7 @@ class ResourceTest {
   @Test
   void testMergeResources_Resource1() {
     Attributes expectedAttributes =
-        Attributes.of(
+        Attributes.Factory.of(
             "a",
             AttributeValue.stringAttributeValue("1"),
             "b",
@@ -217,7 +217,7 @@ class ResourceTest {
   @Test
   void testMergeResources_Resource1_Null() {
     Attributes expectedAttributes =
-        Attributes.of(
+        Attributes.Factory.of(
             "a", AttributeValue.stringAttributeValue("1"),
             "b", AttributeValue.stringAttributeValue("3"),
             "c", AttributeValue.stringAttributeValue("4"));
@@ -229,7 +229,7 @@ class ResourceTest {
   @Test
   void testMergeResources_Resource2_Null() {
     Attributes expectedAttributes =
-        Attributes.of(
+        Attributes.Factory.of(
             "a",
             AttributeValue.stringAttributeValue("1"),
             "b",

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/resources/ResourceTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/resources/ResourceTest.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.sdk.resources;
 
+import static io.opentelemetry.common.AttributeValue.Factory.arrayAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.testing.EqualsTester;
@@ -36,17 +37,17 @@ class ResourceTest {
     Attributes attributes1 =
         Attributes.Factory.of(
             "a",
-            AttributeValue.stringAttributeValue("1"),
+            AttributeValue.Factory.stringAttributeValue("1"),
             "b",
-            AttributeValue.stringAttributeValue("2"));
+            AttributeValue.Factory.stringAttributeValue("2"));
     Attributes attribute2 =
         Attributes.Factory.of(
             "a",
-            AttributeValue.stringAttributeValue("1"),
+            AttributeValue.Factory.stringAttributeValue("1"),
             "b",
-            AttributeValue.stringAttributeValue("3"),
+            AttributeValue.Factory.stringAttributeValue("3"),
             "c",
-            AttributeValue.stringAttributeValue("4"));
+            AttributeValue.Factory.stringAttributeValue("4"));
     resource1 = Resource.create(attributes1);
     resource2 = Resource.create(attribute2);
   }
@@ -56,9 +57,9 @@ class ResourceTest {
     Attributes attributes =
         Attributes.Factory.of(
             "a",
-            AttributeValue.stringAttributeValue("1"),
+            AttributeValue.Factory.stringAttributeValue("1"),
             "b",
-            AttributeValue.stringAttributeValue("2"));
+            AttributeValue.Factory.stringAttributeValue("2"));
     Resource resource = Resource.create(attributes);
     assertThat(resource.getAttributes()).isNotNull();
     assertThat(resource.getAttributes().size()).isEqualTo(2);
@@ -73,38 +74,38 @@ class ResourceTest {
   void create_ignoreNull() {
     Attributes.Builder attributes = Attributes.Factory.newBuilder();
 
-    attributes.setAttribute("string", AttributeValue.stringAttributeValue(null));
+    attributes.setAttribute("string", AttributeValue.Factory.stringAttributeValue(null));
     Resource resource = Resource.create(attributes.build());
     assertThat(resource.getAttributes()).isNotNull();
     assertThat(resource.getAttributes().size()).isZero();
-    attributes.setAttribute("stringArray", AttributeValue.arrayAttributeValue(null, "a"));
+    attributes.setAttribute("stringArray", arrayAttributeValue(null, "a"));
     resource = Resource.create(attributes.build());
     assertThat(resource.getAttributes()).isNotNull();
     assertThat(resource.getAttributes().size()).isEqualTo(1);
 
-    attributes.setAttribute("bool", AttributeValue.booleanAttributeValue(true));
+    attributes.setAttribute("bool", AttributeValue.Factory.booleanAttributeValue(true));
     resource = Resource.create(attributes.build());
     assertThat(resource.getAttributes()).isNotNull();
     assertThat(resource.getAttributes().size()).isEqualTo(2);
-    attributes.setAttribute("boolArray", AttributeValue.arrayAttributeValue(null, true));
+    attributes.setAttribute("boolArray", arrayAttributeValue(null, true));
     resource = Resource.create(attributes.build());
     assertThat(resource.getAttributes()).isNotNull();
     assertThat(resource.getAttributes().size()).isEqualTo(3);
 
-    attributes.setAttribute("long", AttributeValue.longAttributeValue(0L));
+    attributes.setAttribute("long", AttributeValue.Factory.longAttributeValue(0L));
     resource = Resource.create(attributes.build());
     assertThat(resource.getAttributes()).isNotNull();
     assertThat(resource.getAttributes().size()).isEqualTo(4);
-    attributes.setAttribute("longArray", AttributeValue.arrayAttributeValue(1L, null));
+    attributes.setAttribute("longArray", arrayAttributeValue(1L, null));
     resource = Resource.create(attributes.build());
     assertThat(resource.getAttributes()).isNotNull();
     assertThat(resource.getAttributes().size()).isEqualTo(5);
 
-    attributes.setAttribute("double", AttributeValue.doubleAttributeValue(1.1));
+    attributes.setAttribute("double", AttributeValue.Factory.doubleAttributeValue(1.1));
     resource = Resource.create(attributes.build());
     assertThat(resource.getAttributes()).isNotNull();
     assertThat(resource.getAttributes().size()).isEqualTo(6);
-    attributes.setAttribute("doubleArray", AttributeValue.arrayAttributeValue(1.1, null));
+    attributes.setAttribute("doubleArray", arrayAttributeValue(1.1, null));
     resource = Resource.create(attributes.build());
     assertThat(resource.getAttributes()).isNotNull();
     assertThat(resource.getAttributes().size()).isEqualTo(7);
@@ -115,40 +116,30 @@ class ResourceTest {
     Attributes.Builder attributes = Attributes.Factory.newBuilder();
 
     // Empty arrays should be maintained
-    attributes.setAttribute(
-        "stringArrayAttribute", AttributeValue.arrayAttributeValue(new String[0]));
-    attributes.setAttribute(
-        "boolArrayAttribute", AttributeValue.arrayAttributeValue(new Boolean[0]));
-    attributes.setAttribute("longArrayAttribute", AttributeValue.arrayAttributeValue(new Long[0]));
-    attributes.setAttribute(
-        "doubleArrayAttribute", AttributeValue.arrayAttributeValue(new Double[0]));
+    attributes.setAttribute("stringArrayAttribute", arrayAttributeValue(new String[0]));
+    attributes.setAttribute("boolArrayAttribute", arrayAttributeValue(new Boolean[0]));
+    attributes.setAttribute("longArrayAttribute", arrayAttributeValue(new Long[0]));
+    attributes.setAttribute("doubleArrayAttribute", arrayAttributeValue(new Double[0]));
 
     Resource resource = Resource.create(attributes.build());
     assertThat(resource.getAttributes()).isNotNull();
     assertThat(resource.getAttributes().size()).isEqualTo(4);
 
     // Arrays with null values should be maintained
-    attributes.setAttribute(
-        "ArrayWithNullStringKey", AttributeValue.arrayAttributeValue(new String[] {null}));
-    attributes.setAttribute(
-        "ArrayWithNullLongKey", AttributeValue.arrayAttributeValue(new Long[] {null}));
-    attributes.setAttribute(
-        "ArrayWithNullDoubleKey", AttributeValue.arrayAttributeValue(new Double[] {null}));
-    attributes.setAttribute(
-        "ArrayWithNullBooleanKey", AttributeValue.arrayAttributeValue(new Boolean[] {null}));
+    attributes.setAttribute("ArrayWithNullStringKey", arrayAttributeValue(new String[] {null}));
+    attributes.setAttribute("ArrayWithNullLongKey", arrayAttributeValue(new Long[] {null}));
+    attributes.setAttribute("ArrayWithNullDoubleKey", arrayAttributeValue(new Double[] {null}));
+    attributes.setAttribute("ArrayWithNullBooleanKey", arrayAttributeValue(new Boolean[] {null}));
 
     resource = Resource.create(attributes.build());
     assertThat(resource.getAttributes()).isNotNull();
     assertThat(resource.getAttributes().size()).isEqualTo(8);
 
     // Null arrays should be dropped
-    attributes.setAttribute(
-        "NullArrayStringKey", AttributeValue.arrayAttributeValue((String[]) null));
-    attributes.setAttribute("NullArrayLongKey", AttributeValue.arrayAttributeValue((Long[]) null));
-    attributes.setAttribute(
-        "NullArrayDoubleKey", AttributeValue.arrayAttributeValue((Double[]) null));
-    attributes.setAttribute(
-        "NullArrayBooleanKey", AttributeValue.arrayAttributeValue((Boolean[]) null));
+    attributes.setAttribute("NullArrayStringKey", arrayAttributeValue((String[]) null));
+    attributes.setAttribute("NullArrayLongKey", arrayAttributeValue((Long[]) null));
+    attributes.setAttribute("NullArrayDoubleKey", arrayAttributeValue((Double[]) null));
+    attributes.setAttribute("NullArrayBooleanKey", arrayAttributeValue((Boolean[]) null));
 
     resource = Resource.create(attributes.build());
     assertThat(resource.getAttributes()).isNotNull();
@@ -169,17 +160,17 @@ class ResourceTest {
     Attributes attribute1 =
         Attributes.Factory.of(
             "a",
-            AttributeValue.stringAttributeValue("1"),
+            AttributeValue.Factory.stringAttributeValue("1"),
             "b",
-            AttributeValue.stringAttributeValue("2"));
+            AttributeValue.Factory.stringAttributeValue("2"));
     Attributes attribute2 =
         Attributes.Factory.of(
             "a",
-            AttributeValue.stringAttributeValue("1"),
+            AttributeValue.Factory.stringAttributeValue("1"),
             "b",
-            AttributeValue.stringAttributeValue("3"),
+            AttributeValue.Factory.stringAttributeValue("3"),
             "c",
-            AttributeValue.stringAttributeValue("4"));
+            AttributeValue.Factory.stringAttributeValue("4"));
     new EqualsTester()
         .addEqualityGroup(Resource.create(attribute1), Resource.create(attribute1), resource1)
         .addEqualityGroup(Resource.create(attribute2), resource2)
@@ -191,11 +182,11 @@ class ResourceTest {
     Attributes expectedAttributes =
         Attributes.Factory.of(
             "a",
-            AttributeValue.stringAttributeValue("1"),
+            AttributeValue.Factory.stringAttributeValue("1"),
             "b",
-            AttributeValue.stringAttributeValue("2"),
+            AttributeValue.Factory.stringAttributeValue("2"),
             "c",
-            AttributeValue.stringAttributeValue("4"));
+            AttributeValue.Factory.stringAttributeValue("4"));
 
     Resource resource = DEFAULT_RESOURCE.merge(resource1).merge(resource2);
     assertThat(resource.getAttributes()).isEqualTo(expectedAttributes);
@@ -206,9 +197,9 @@ class ResourceTest {
     Attributes expectedAttributes =
         Attributes.Factory.of(
             "a",
-            AttributeValue.stringAttributeValue("1"),
+            AttributeValue.Factory.stringAttributeValue("1"),
             "b",
-            AttributeValue.stringAttributeValue("2"));
+            AttributeValue.Factory.stringAttributeValue("2"));
 
     Resource resource = DEFAULT_RESOURCE.merge(resource1);
     assertThat(resource.getAttributes()).isEqualTo(expectedAttributes);
@@ -218,9 +209,9 @@ class ResourceTest {
   void testMergeResources_Resource1_Null() {
     Attributes expectedAttributes =
         Attributes.Factory.of(
-            "a", AttributeValue.stringAttributeValue("1"),
-            "b", AttributeValue.stringAttributeValue("3"),
-            "c", AttributeValue.stringAttributeValue("4"));
+            "a", AttributeValue.Factory.stringAttributeValue("1"),
+            "b", AttributeValue.Factory.stringAttributeValue("3"),
+            "c", AttributeValue.Factory.stringAttributeValue("4"));
 
     Resource resource = DEFAULT_RESOURCE.merge(null).merge(resource2);
     assertThat(resource.getAttributes()).isEqualTo(expectedAttributes);
@@ -231,9 +222,9 @@ class ResourceTest {
     Attributes expectedAttributes =
         Attributes.Factory.of(
             "a",
-            AttributeValue.stringAttributeValue("1"),
+            AttributeValue.Factory.stringAttributeValue("1"),
             "b",
-            AttributeValue.stringAttributeValue("2"));
+            AttributeValue.Factory.stringAttributeValue("2"));
     Resource resource = DEFAULT_RESOURCE.merge(resource1).merge(null);
     assertThat(resource.getAttributes()).isEqualTo(expectedAttributes);
   }
@@ -243,9 +234,9 @@ class ResourceTest {
     Resource resource = Resource.getTelemetrySdk();
     ReadableAttributes attributes = resource.getAttributes();
     assertThat(attributes.get("telemetry.sdk.name"))
-        .isEqualTo(AttributeValue.stringAttributeValue("opentelemetry"));
+        .isEqualTo(AttributeValue.Factory.stringAttributeValue("opentelemetry"));
     assertThat(attributes.get("telemetry.sdk.language"))
-        .isEqualTo(AttributeValue.stringAttributeValue("java"));
+        .isEqualTo(AttributeValue.Factory.stringAttributeValue("java"));
     assertThat(attributes.get("telemetry.sdk.version").getStringValue()).isNotNull();
   }
 }

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/resources/TestResourceProvider.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/resources/TestResourceProvider.java
@@ -23,6 +23,6 @@ public class TestResourceProvider extends ResourceProvider {
 
   @Override
   protected Attributes getAttributes() {
-    return Attributes.of("providerAttribute", AttributeValue.longAttributeValue(42));
+    return Attributes.Factory.of("providerAttribute", AttributeValue.longAttributeValue(42));
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/BatchRecorderSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/BatchRecorderSdkTest.java
@@ -36,7 +36,8 @@ import org.junit.jupiter.api.Test;
 class BatchRecorderSdkTest {
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.of("resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of(
+              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create("io.opentelemetry.sdk.metrics.BatchRecorderSdkTest", null);
   private final TestClock testClock = TestClock.create();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/BatchRecorderSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/BatchRecorderSdkTest.java
@@ -16,10 +16,10 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -36,8 +36,7 @@ import org.junit.jupiter.api.Test;
 class BatchRecorderSdkTest {
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.Factory.of(
-              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of("resource_key", stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create("io.opentelemetry.sdk.metrics.BatchRecorderSdkTest", null);
   private final TestClock testClock = TestClock.create();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleCounterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleCounterSdkTest.java
@@ -39,7 +39,8 @@ class DoubleCounterSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.of("resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of(
+              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create("io.opentelemetry.sdk.metrics.DoubleCounterSdkTest", null);
   private final TestClock testClock = TestClock.create();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleCounterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleCounterSdkTest.java
@@ -16,10 +16,10 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.metrics.DoubleCounter;
@@ -39,8 +39,7 @@ class DoubleCounterSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.Factory.of(
-              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of("resource_key", stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create("io.opentelemetry.sdk.metrics.DoubleCounterSdkTest", null);
   private final TestClock testClock = TestClock.create();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleSumObserverSdkTest.java
@@ -16,9 +16,9 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -35,8 +35,7 @@ class DoubleSumObserverSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.Factory.of(
-              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of("resource_key", stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(
           "io.opentelemetry.sdk.metrics.DoubleSumObserverSdkTest", null);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleSumObserverSdkTest.java
@@ -35,7 +35,8 @@ class DoubleSumObserverSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.of("resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of(
+              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(
           "io.opentelemetry.sdk.metrics.DoubleSumObserverSdkTest", null);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownCounterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownCounterSdkTest.java
@@ -16,10 +16,10 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.metrics.DoubleUpDownCounter;
@@ -39,8 +39,7 @@ class DoubleUpDownCounterSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.Factory.of(
-              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of("resource_key", stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(
           "io.opentelemetry.sdk.metrics.DoubleUpDownCounterSdkTest", null);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownCounterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownCounterSdkTest.java
@@ -39,7 +39,8 @@ class DoubleUpDownCounterSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.of("resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of(
+              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(
           "io.opentelemetry.sdk.metrics.DoubleUpDownCounterSdkTest", null);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownSumObserverSdkTest.java
@@ -16,9 +16,9 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -35,8 +35,7 @@ class DoubleUpDownSumObserverSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.Factory.of(
-              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of("resource_key", stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(
           "io.opentelemetry.sdk.metrics.DoubleUpDownSumObserverSdkTest", null);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownSumObserverSdkTest.java
@@ -35,7 +35,8 @@ class DoubleUpDownSumObserverSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.of("resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of(
+              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(
           "io.opentelemetry.sdk.metrics.DoubleUpDownSumObserverSdkTest", null);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueObserverSdkTest.java
@@ -38,7 +38,8 @@ class DoubleValueObserverSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.of("resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of(
+              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(
           "io.opentelemetry.sdk.metrics.DoubleValueObserverSdkTest", null);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueObserverSdkTest.java
@@ -16,9 +16,9 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -38,8 +38,7 @@ class DoubleValueObserverSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.Factory.of(
-              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of("resource_key", stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(
           "io.opentelemetry.sdk.metrics.DoubleValueObserverSdkTest", null);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdkTest.java
@@ -16,10 +16,10 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.metrics.DoubleValueRecorder;
@@ -42,8 +42,7 @@ class DoubleValueRecorderSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.Factory.of(
-              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of("resource_key", stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(
           "io.opentelemetry.sdk.metrics.DoubleValueRecorderSdkTest", null);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdkTest.java
@@ -42,7 +42,8 @@ class DoubleValueRecorderSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.of("resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of(
+              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(
           "io.opentelemetry.sdk.metrics.DoubleValueRecorderSdkTest", null);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongCounterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongCounterSdkTest.java
@@ -40,7 +40,8 @@ class LongCounterSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.of("resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of(
+              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create("io.opentelemetry.sdk.metrics.LongCounterSdkTest", null);
   private final TestClock testClock = TestClock.create();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongCounterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongCounterSdkTest.java
@@ -16,10 +16,10 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.metrics.LongCounter;
@@ -40,8 +40,7 @@ class LongCounterSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.Factory.of(
-              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of("resource_key", stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create("io.opentelemetry.sdk.metrics.LongCounterSdkTest", null);
   private final TestClock testClock = TestClock.create();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongSumObserverSdkTest.java
@@ -16,9 +16,9 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -35,8 +35,7 @@ class LongSumObserverSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.Factory.of(
-              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of("resource_key", stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(
           "io.opentelemetry.sdk.metrics.LongSumObserverSdkTest", null);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongSumObserverSdkTest.java
@@ -35,7 +35,8 @@ class LongSumObserverSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.of("resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of(
+              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(
           "io.opentelemetry.sdk.metrics.LongSumObserverSdkTest", null);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownCounterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownCounterSdkTest.java
@@ -39,7 +39,8 @@ class LongUpDownCounterSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.of("resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of(
+              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(
           "io.opentelemetry.sdk.metrics.LongUpDownCounterSdkTest", null);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownCounterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownCounterSdkTest.java
@@ -16,10 +16,10 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.metrics.LongUpDownCounter;
@@ -39,8 +39,7 @@ class LongUpDownCounterSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.Factory.of(
-              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of("resource_key", stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(
           "io.opentelemetry.sdk.metrics.LongUpDownCounterSdkTest", null);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownSumObserverSdkTest.java
@@ -16,9 +16,9 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -35,8 +35,7 @@ class LongUpDownSumObserverSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.Factory.of(
-              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of("resource_key", stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(
           "io.opentelemetry.sdk.metrics.LongUpDownSumObserverSdkTest", null);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownSumObserverSdkTest.java
@@ -35,7 +35,8 @@ class LongUpDownSumObserverSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.of("resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of(
+              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(
           "io.opentelemetry.sdk.metrics.LongUpDownSumObserverSdkTest", null);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongValueObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongValueObserverSdkTest.java
@@ -38,7 +38,8 @@ class LongValueObserverSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.of("resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of(
+              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(
           "io.opentelemetry.sdk.metrics.LongValueObserverSdkTest", null);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongValueObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongValueObserverSdkTest.java
@@ -16,9 +16,9 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -38,8 +38,7 @@ class LongValueObserverSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.Factory.of(
-              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of("resource_key", stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(
           "io.opentelemetry.sdk.metrics.LongValueObserverSdkTest", null);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdkTest.java
@@ -42,7 +42,8 @@ class LongValueRecorderSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.of("resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of(
+              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(
           "io.opentelemetry.sdk.metrics.LongValueRecorderSdkTest", null);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdkTest.java
@@ -16,10 +16,10 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.metrics.LongValueRecorder;
@@ -42,8 +42,7 @@ class LongValueRecorderSdkTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.Factory.of(
-              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of("resource_key", stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(
           "io.opentelemetry.sdk.metrics.LongValueRecorderSdkTest", null);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
@@ -40,7 +40,8 @@ import org.junit.jupiter.api.Test;
 class MeterSdkTest {
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.of("resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of(
+              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create("io.opentelemetry.sdk.metrics.MeterSdkTest", null);
   private final TestClock testClock = TestClock.create();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
@@ -16,10 +16,10 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.metrics.BatchRecorder;
@@ -40,8 +40,7 @@ import org.junit.jupiter.api.Test;
 class MeterSdkTest {
   private static final Resource RESOURCE =
       Resource.create(
-          Attributes.Factory.of(
-              "resource_key", AttributeValue.stringAttributeValue("resource_value")));
+          Attributes.Factory.of("resource_key", stringAttributeValue("resource_value")));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create("io.opentelemetry.sdk.metrics.MeterSdkTest", null);
   private final TestClock testClock = TestClock.create();

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -285,22 +285,22 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
 
   @Override
   public void setAttribute(String key, String value) {
-    setAttribute(key, AttributeValue.stringAttributeValue(value));
+    setAttribute(key, AttributeValue.Factory.stringAttributeValue(value));
   }
 
   @Override
   public void setAttribute(String key, long value) {
-    setAttribute(key, AttributeValue.longAttributeValue(value));
+    setAttribute(key, AttributeValue.Factory.longAttributeValue(value));
   }
 
   @Override
   public void setAttribute(String key, double value) {
-    setAttribute(key, AttributeValue.doubleAttributeValue(value));
+    setAttribute(key, AttributeValue.Factory.doubleAttributeValue(value));
   }
 
   @Override
   public void setAttribute(String key, boolean value) {
-    setAttribute(key, AttributeValue.booleanAttributeValue(value));
+    setAttribute(key, AttributeValue.Factory.booleanAttributeValue(value));
   }
 
   @Override

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -336,7 +336,7 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
     if (name == null) {
       return;
     }
-    addTimedEvent(TimedEvent.create(clock.now(), name, Attributes.empty(), 0));
+    addTimedEvent(TimedEvent.create(clock.now(), name, Attributes.Factory.empty(), 0));
   }
 
   @Override
@@ -344,7 +344,7 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
     if (name == null) {
       return;
     }
-    addTimedEvent(TimedEvent.create(timestamp, name, Attributes.empty(), 0));
+    addTimedEvent(TimedEvent.create(timestamp, name, Attributes.Factory.empty(), 0));
   }
 
   @Override
@@ -396,7 +396,7 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
       return attributes;
     }
 
-    Attributes.Builder result = Attributes.newBuilder();
+    Attributes.Builder result = Attributes.Factory.newBuilder();
     attributes.forEach(new LimitingAttributeConsumer(limit, result));
     return result.build();
   }
@@ -432,7 +432,7 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
       return;
     }
     long timestamp = clock.now();
-    Attributes.Builder attributes = Attributes.newBuilder();
+    Attributes.Builder attributes = Attributes.Factory.newBuilder();
     SemanticAttributes.EXCEPTION_TYPE.set(attributes, exception.getClass().getCanonicalName());
     if (exception.getMessage() != null) {
       SemanticAttributes.EXCEPTION_MESSAGE.set(attributes, exception.getMessage());
@@ -572,7 +572,7 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
   @GuardedBy("lock")
   private ReadableAttributes getImmutableAttributes() {
     if (attributes == null || attributes.isEmpty()) {
-      return Attributes.empty();
+      return Attributes.Factory.empty();
     }
     // if the span has ended, then the attributes are unmodifiable,
     // so we can return them directly and save copying all the data.
@@ -580,7 +580,7 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
       return attributes;
     }
     // otherwise, make a copy of the data into an immutable container.
-    Attributes.Builder builder = Attributes.newBuilder();
+    Attributes.Builder builder = Attributes.Factory.newBuilder();
     for (Map.Entry<String, AttributeValue> entry : attributes.entrySet()) {
       builder.setAttribute(entry.getKey(), entry.getValue());
     }

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -340,7 +340,8 @@ public final class Samplers {
      */
     static SamplingResult createWithProbability(Decision decision, double probability) {
       return new AutoValue_Samplers_SamplingResultImpl(
-          decision, Attributes.of(SAMPLING_PROBABILITY.key(), doubleAttributeValue(probability)));
+          decision,
+          Attributes.Factory.of(SAMPLING_PROBABILITY.key(), doubleAttributeValue(probability)));
     }
 
     /**
@@ -349,7 +350,7 @@ public final class Samplers {
      * @param decision sampling samplingResult
      */
     static SamplingResult createWithoutAttributes(Decision decision) {
-      return new AutoValue_Samplers_SamplingResultImpl(decision, Attributes.empty());
+      return new AutoValue_Samplers_SamplingResultImpl(decision, Attributes.Factory.empty());
     }
 
     /**

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.trace;
 
-import static io.opentelemetry.common.AttributeValue.doubleAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.doubleAttributeValue;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -160,22 +160,22 @@ final class SpanBuilderSdk implements Span.Builder {
 
   @Override
   public Span.Builder setAttribute(String key, String value) {
-    return setAttribute(key, AttributeValue.stringAttributeValue(value));
+    return setAttribute(key, AttributeValue.Factory.stringAttributeValue(value));
   }
 
   @Override
   public Span.Builder setAttribute(String key, long value) {
-    return setAttribute(key, AttributeValue.longAttributeValue(value));
+    return setAttribute(key, AttributeValue.Factory.longAttributeValue(value));
   }
 
   @Override
   public Span.Builder setAttribute(String key, double value) {
-    return setAttribute(key, AttributeValue.doubleAttributeValue(value));
+    return setAttribute(key, AttributeValue.Factory.doubleAttributeValue(value));
   }
 
   @Override
   public Span.Builder setAttribute(String key, boolean value) {
-    return setAttribute(key, AttributeValue.booleanAttributeValue(value));
+    return setAttribute(key, AttributeValue.Factory.booleanAttributeValue(value));
   }
 
   @Override

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -228,7 +228,8 @@ final class SpanBuilderSdk implements Span.Builder {
     // Avoid any possibility to modify the links list by adding links to the Builder after the
     // startSpan is called. If that happens all the links will be added in a new list.
     links = null;
-    ReadableAttributes immutableAttributes = attributes == null ? Attributes.empty() : attributes;
+    ReadableAttributes immutableAttributes =
+        attributes == null ? Attributes.Factory.empty() : attributes;
     SamplingResult samplingResult =
         traceConfig
             .getSampler()

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
@@ -211,7 +211,7 @@ public interface SpanData {
   @AutoValue
   abstract class Link implements io.opentelemetry.trace.Link {
 
-    private static final Attributes DEFAULT_ATTRIBUTE_COLLECTION = Attributes.empty();
+    private static final Attributes DEFAULT_ATTRIBUTE_COLLECTION = Attributes.Factory.empty();
     private static final int DEFAULT_ATTRIBUTE_COUNT = 0;
 
     /**

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -88,7 +88,7 @@ class RecordEventsReadableSpanTest {
     attributes.put("MyLongAttributeKey", AttributeValue.longAttributeValue(123L));
     attributes.put("MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(false));
     Attributes.Builder builder =
-        Attributes.newBuilder()
+        Attributes.Factory.newBuilder()
             .setAttribute(
                 "MySingleStringAttributeKey", stringAttributeValue("MySingleStringAttributeValue"));
     for (Map.Entry<String, AttributeValue> entry : attributes.entrySet()) {
@@ -108,7 +108,7 @@ class RecordEventsReadableSpanTest {
     SpanData spanData = span.toSpanData();
     verifySpanData(
         spanData,
-        Attributes.empty(),
+        Attributes.Factory.empty(),
         Collections.emptyList(),
         Collections.singletonList(link),
         SPAN_NAME,
@@ -120,7 +120,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void lazyLinksAreResolved() {
-    final Attributes attributes = Attributes.of("attr", stringAttributeValue("val"));
+    final Attributes attributes = Attributes.Factory.of("attr", stringAttributeValue("val"));
     io.opentelemetry.trace.Link link =
         new io.opentelemetry.trace.Link() {
           @Override
@@ -165,7 +165,8 @@ class RecordEventsReadableSpanTest {
       spanDoWork(span, null);
       SpanData spanData = span.toSpanData();
       Event event =
-          TimedEvent.create(START_EPOCH_NANOS + NANOS_PER_SECOND, "event2", Attributes.empty(), 0);
+          TimedEvent.create(
+              START_EPOCH_NANOS + NANOS_PER_SECOND, "event2", Attributes.Factory.empty(), 0);
       verifySpanData(
           spanData,
           expectedAttributes,
@@ -194,7 +195,8 @@ class RecordEventsReadableSpanTest {
     Mockito.verify(spanProcessor, Mockito.times(1)).onEnd(span);
     SpanData spanData = span.toSpanData();
     Event event =
-        TimedEvent.create(START_EPOCH_NANOS + NANOS_PER_SECOND, "event2", Attributes.empty(), 0);
+        TimedEvent.create(
+            START_EPOCH_NANOS + NANOS_PER_SECOND, "event2", Attributes.Factory.empty(), 0);
     verifySpanData(
         spanData,
         expectedAttributes,
@@ -224,7 +226,7 @@ class RecordEventsReadableSpanTest {
 
     assertThrows(
         UnsupportedOperationException.class,
-        () -> spanData.getEvents().add(EventImpl.create(1000, "test", Attributes.empty())));
+        () -> spanData.getEvents().add(EventImpl.create(1000, "test", Attributes.Factory.empty())));
   }
 
   @Test
@@ -536,12 +538,12 @@ class RecordEventsReadableSpanTest {
 
           @Override
           public Attributes getAttributes() {
-            return Attributes.empty();
+            return Attributes.Factory.empty();
           }
         };
     try {
       span.addEvent("event1");
-      span.addEvent("event2", Attributes.of("e1key", stringAttributeValue("e1Value")));
+      span.addEvent("event2", Attributes.Factory.of("e1key", stringAttributeValue("e1Value")));
       span.addEvent(customEvent);
     } finally {
       span.end();
@@ -629,7 +631,7 @@ class RecordEventsReadableSpanTest {
     RecordEventsReadableSpan span = createTestSpan(traceConfig);
     try {
       for (int i = 0; i < 2 * maxNumberOfEvents; i++) {
-        span.addEvent("event2", Attributes.empty());
+        span.addEvent("event2", Attributes.Factory.empty());
         testClock.advanceMillis(MILLIS_PER_SECOND);
       }
       SpanData spanData = span.toSpanData();
@@ -640,7 +642,7 @@ class RecordEventsReadableSpanTest {
             TimedEvent.create(
                 START_EPOCH_NANOS + (maxNumberOfEvents + i) * NANOS_PER_SECOND,
                 "event2",
-                Attributes.empty(),
+                Attributes.Factory.empty(),
                 0);
         assertThat(spanData.getEvents().get(i)).isEqualTo(expectedEvent);
         assertThat(spanData.getTotalRecordedEvents()).isEqualTo(2 * maxNumberOfEvents);
@@ -655,7 +657,7 @@ class RecordEventsReadableSpanTest {
           TimedEvent.create(
               START_EPOCH_NANOS + (maxNumberOfEvents + i) * NANOS_PER_SECOND,
               "event2",
-              Attributes.empty(),
+              Attributes.Factory.empty(),
               0);
       assertThat(spanData.getEvents().get(i)).isEqualTo(expectedEvent);
     }
@@ -682,7 +684,7 @@ class RecordEventsReadableSpanTest {
     assertThat(event.getEpochNanos()).isEqualTo(timestamp);
     assertThat(event.getAttributes())
         .isEqualTo(
-            Attributes.newBuilder()
+            Attributes.Factory.newBuilder()
                 .setAttribute("exception.type", "java.lang.IllegalStateException")
                 .setAttribute("exception.message", "there was an exception")
                 .setAttribute("exception.stacktrace", stacktrace)
@@ -810,7 +812,7 @@ class RecordEventsReadableSpanTest {
       span.setAttribute(attribute.getKey(), attribute.getValue());
     }
     testClock.advanceMillis(MILLIS_PER_SECOND);
-    span.addEvent("event2", Attributes.empty());
+    span.addEvent("event2", Attributes.Factory.empty());
     testClock.advanceMillis(MILLIS_PER_SECOND);
     span.updateName(SPAN_NEW_NAME);
     if (status != null) {

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -16,7 +16,8 @@
 
 package io.opentelemetry.sdk.trace;
 
-import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.arrayAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -85,8 +86,8 @@ class RecordEventsReadableSpanTest {
   void setUp() {
     MockitoAnnotations.initMocks(this);
     attributes.put("MyStringAttributeKey", stringAttributeValue("MyStringAttributeValue"));
-    attributes.put("MyLongAttributeKey", AttributeValue.longAttributeValue(123L));
-    attributes.put("MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(false));
+    attributes.put("MyLongAttributeKey", AttributeValue.Factory.longAttributeValue(123L));
+    attributes.put("MyBooleanAttributeKey", AttributeValue.Factory.booleanAttributeValue(false));
     Attributes.Builder builder =
         Attributes.Factory.newBuilder()
             .setAttribute(
@@ -279,7 +280,7 @@ class RecordEventsReadableSpanTest {
     spanData = span.toSpanData();
     assertThat(spanData.getAttributes().size()).isEqualTo(attributes.size() + 1);
     assertThat(spanData.getAttributes().get("anotherKey"))
-        .isEqualTo(AttributeValue.stringAttributeValue("anotherValue"));
+        .isEqualTo(AttributeValue.Factory.stringAttributeValue("anotherValue"));
     assertThat(spanData.getHasEnded()).isTrue();
     assertThat(spanData.getEndEpochNanos()).isGreaterThan(0);
     assertThat(spanData.getName()).isEqualTo("changedName");
@@ -380,29 +381,20 @@ class RecordEventsReadableSpanTest {
       span.setAttribute("LongKey", 1000L);
       span.setAttribute("DoubleKey", 10.0);
       span.setAttribute("BooleanKey", false);
-      span.setAttribute(
-          "ArrayStringKey",
-          AttributeValue.arrayAttributeValue("StringVal", null, "", "StringVal2"));
-      span.setAttribute("ArrayLongKey", AttributeValue.arrayAttributeValue(1L, 2L, 3L, 4L, 5L));
-      span.setAttribute(
-          "ArrayDoubleKey", AttributeValue.arrayAttributeValue(0.1, 2.3, 4.5, 6.7, 8.9));
-      span.setAttribute(
-          "ArrayBooleanKey", AttributeValue.arrayAttributeValue(true, false, false, true));
+      span.setAttribute("ArrayStringKey", arrayAttributeValue("StringVal", null, "", "StringVal2"));
+      span.setAttribute("ArrayLongKey", arrayAttributeValue(1L, 2L, 3L, 4L, 5L));
+      span.setAttribute("ArrayDoubleKey", arrayAttributeValue(0.1, 2.3, 4.5, 6.7, 8.9));
+      span.setAttribute("ArrayBooleanKey", arrayAttributeValue(true, false, false, true));
       // These should be dropped
-      span.setAttribute("NullArrayStringKey", AttributeValue.arrayAttributeValue((String[]) null));
-      span.setAttribute("NullArrayLongKey", AttributeValue.arrayAttributeValue((Long[]) null));
-      span.setAttribute("NullArrayDoubleKey", AttributeValue.arrayAttributeValue((Double[]) null));
-      span.setAttribute(
-          "NullArrayBooleanKey", AttributeValue.arrayAttributeValue((Boolean[]) null));
+      span.setAttribute("NullArrayStringKey", arrayAttributeValue((String[]) null));
+      span.setAttribute("NullArrayLongKey", arrayAttributeValue((Long[]) null));
+      span.setAttribute("NullArrayDoubleKey", arrayAttributeValue((Double[]) null));
+      span.setAttribute("NullArrayBooleanKey", arrayAttributeValue((Boolean[]) null));
       // These should be maintained
-      span.setAttribute(
-          "ArrayWithNullLongKey", AttributeValue.arrayAttributeValue(new Long[] {null}));
-      span.setAttribute(
-          "ArrayWithNullStringKey", AttributeValue.arrayAttributeValue(new String[] {null}));
-      span.setAttribute(
-          "ArrayWithNullDoubleKey", AttributeValue.arrayAttributeValue(new Double[] {null}));
-      span.setAttribute(
-          "ArrayWithNullBooleanKey", AttributeValue.arrayAttributeValue(new Boolean[] {null}));
+      span.setAttribute("ArrayWithNullLongKey", arrayAttributeValue(new Long[] {null}));
+      span.setAttribute("ArrayWithNullStringKey", arrayAttributeValue(new String[] {null}));
+      span.setAttribute("ArrayWithNullDoubleKey", arrayAttributeValue(new Double[] {null}));
+      span.setAttribute("ArrayWithNullBooleanKey", arrayAttributeValue(new Boolean[] {null}));
     } finally {
       span.end();
     }
@@ -435,49 +427,49 @@ class RecordEventsReadableSpanTest {
   @Test
   void setAttribute_emptyKeys() {
     RecordEventsReadableSpan span = createTestRootSpan();
-    span.setAttribute("", AttributeValue.stringAttributeValue(""));
+    span.setAttribute("", AttributeValue.Factory.stringAttributeValue(""));
     span.setAttribute("", 1000L);
     span.setAttribute("", 10.0);
     span.setAttribute("", false);
-    span.setAttribute("", AttributeValue.arrayAttributeValue(new String[0]));
-    span.setAttribute("", AttributeValue.arrayAttributeValue(new Boolean[0]));
-    span.setAttribute("", AttributeValue.arrayAttributeValue(new Long[0]));
-    span.setAttribute("", AttributeValue.arrayAttributeValue(new Double[0]));
+    span.setAttribute("", arrayAttributeValue(new String[0]));
+    span.setAttribute("", arrayAttributeValue(new Boolean[0]));
+    span.setAttribute("", arrayAttributeValue(new Long[0]));
+    span.setAttribute("", arrayAttributeValue(new Double[0]));
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(0);
   }
 
   @Test
   void setAttribute_nullKeys() {
     RecordEventsReadableSpan span = createTestRootSpan();
-    span.setAttribute(null, AttributeValue.stringAttributeValue(""));
+    span.setAttribute(null, AttributeValue.Factory.stringAttributeValue(""));
     span.setAttribute(null, 1000L);
     span.setAttribute(null, 10.0);
     span.setAttribute(null, false);
-    span.setAttribute(null, AttributeValue.arrayAttributeValue(new String[0]));
-    span.setAttribute(null, AttributeValue.arrayAttributeValue(new Boolean[0]));
-    span.setAttribute(null, AttributeValue.arrayAttributeValue(new Long[0]));
-    span.setAttribute(null, AttributeValue.arrayAttributeValue(new Double[0]));
+    span.setAttribute(null, arrayAttributeValue(new String[0]));
+    span.setAttribute(null, arrayAttributeValue(new Boolean[0]));
+    span.setAttribute(null, arrayAttributeValue(new Long[0]));
+    span.setAttribute(null, arrayAttributeValue(new Double[0]));
     assertThat(span.toSpanData().getAttributes().size()).isZero();
   }
 
   @Test
   void setAttribute_emptyArrayAttributeValue() {
     RecordEventsReadableSpan span = createTestRootSpan();
-    span.setAttribute("stringArrayAttribute", AttributeValue.arrayAttributeValue((String[]) null));
+    span.setAttribute("stringArrayAttribute", arrayAttributeValue((String[]) null));
     assertThat(span.toSpanData().getAttributes().size()).isZero();
-    span.setAttribute("stringArrayAttribute", AttributeValue.arrayAttributeValue(new String[0]));
+    span.setAttribute("stringArrayAttribute", arrayAttributeValue(new String[0]));
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(1);
-    span.setAttribute("boolArrayAttribute", AttributeValue.arrayAttributeValue((Boolean[]) null));
+    span.setAttribute("boolArrayAttribute", arrayAttributeValue((Boolean[]) null));
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(1);
-    span.setAttribute("boolArrayAttribute", AttributeValue.arrayAttributeValue(new Boolean[0]));
+    span.setAttribute("boolArrayAttribute", arrayAttributeValue(new Boolean[0]));
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(2);
-    span.setAttribute("longArrayAttribute", AttributeValue.arrayAttributeValue((Long[]) null));
+    span.setAttribute("longArrayAttribute", arrayAttributeValue((Long[]) null));
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(2);
-    span.setAttribute("longArrayAttribute", AttributeValue.arrayAttributeValue(new Long[0]));
+    span.setAttribute("longArrayAttribute", arrayAttributeValue(new Long[0]));
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(3);
-    span.setAttribute("doubleArrayAttribute", AttributeValue.arrayAttributeValue((Double[]) null));
+    span.setAttribute("doubleArrayAttribute", arrayAttributeValue((Double[]) null));
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(3);
-    span.setAttribute("doubleArrayAttribute", AttributeValue.arrayAttributeValue(new Double[0]));
+    span.setAttribute("doubleArrayAttribute", arrayAttributeValue(new Double[0]));
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(4);
     span.setAttribute("stringArrayAttribute", (AttributeValue) null);
     span.setAttribute("boolArrayAttribute", (AttributeValue) null);
@@ -509,10 +501,10 @@ class RecordEventsReadableSpanTest {
     span.setAttribute("longAttribute", 0L);
     span.setAttribute("boolAttribute", false);
     span.setAttribute("doubleAttribute", 0.12345f);
-    span.setAttribute("stringArrayAttribute", AttributeValue.arrayAttributeValue("", null));
-    span.setAttribute("boolArrayAttribute", AttributeValue.arrayAttributeValue(true, null));
-    span.setAttribute("longArrayAttribute", AttributeValue.arrayAttributeValue(12345L, null));
-    span.setAttribute("doubleArrayAttribute", AttributeValue.arrayAttributeValue(1.2345, null));
+    span.setAttribute("stringArrayAttribute", arrayAttributeValue("", null));
+    span.setAttribute("boolArrayAttribute", arrayAttributeValue(true, null));
+    span.setAttribute("longArrayAttribute", arrayAttributeValue(12345L, null));
+    span.setAttribute("doubleArrayAttribute", arrayAttributeValue(1.2345, null));
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(9);
     span.setAttribute("emptyString", (AttributeValue) null);
     span.setAttribute("emptyStringAttributeValue", (AttributeValue) null);
@@ -569,7 +561,7 @@ class RecordEventsReadableSpanTest {
     RecordEventsReadableSpan span = createTestSpan(traceConfig);
     try {
       for (int i = 0; i < 2 * maxNumberOfAttributes; i++) {
-        span.setAttribute("MyStringAttributeKey" + i, AttributeValue.longAttributeValue(i));
+        span.setAttribute("MyStringAttributeKey" + i, AttributeValue.Factory.longAttributeValue(i));
       }
       SpanData spanData = span.toSpanData();
       assertThat(spanData.getAttributes().size()).isEqualTo(maxNumberOfAttributes);
@@ -593,7 +585,7 @@ class RecordEventsReadableSpanTest {
     RecordEventsReadableSpan span = createTestSpan(traceConfig);
     try {
       for (int i = 0; i < 2 * maxNumberOfAttributes; i++) {
-        span.setAttribute("MyStringAttributeKey" + i, AttributeValue.longAttributeValue(i));
+        span.setAttribute("MyStringAttributeKey" + i, AttributeValue.Factory.longAttributeValue(i));
       }
       SpanData spanData = span.toSpanData();
       assertThat(spanData.getAttributes().size()).isEqualTo(maxNumberOfAttributes);
@@ -601,20 +593,21 @@ class RecordEventsReadableSpanTest {
 
       for (int i = 0; i < maxNumberOfAttributes / 2; i++) {
         int val = i + maxNumberOfAttributes * 3 / 2;
-        span.setAttribute("MyStringAttributeKey" + i, AttributeValue.longAttributeValue(val));
+        span.setAttribute(
+            "MyStringAttributeKey" + i, AttributeValue.Factory.longAttributeValue(val));
       }
       spanData = span.toSpanData();
       assertThat(spanData.getAttributes().size()).isEqualTo(maxNumberOfAttributes);
       // Test that we still have in the attributes map the latest maxNumberOfAttributes / 2 entries.
       for (int i = 0; i < maxNumberOfAttributes / 2; i++) {
         int val = i + maxNumberOfAttributes * 3 / 2;
-        AttributeValue expectedValue = AttributeValue.longAttributeValue(val);
+        AttributeValue expectedValue = AttributeValue.Factory.longAttributeValue(val);
         assertThat(spanData.getAttributes().get("MyStringAttributeKey" + i))
             .isEqualTo(expectedValue);
       }
       // Test that we have the newest re-added initial entries.
       for (int i = maxNumberOfAttributes / 2; i < maxNumberOfAttributes; i++) {
-        AttributeValue expectedValue = AttributeValue.longAttributeValue(i);
+        AttributeValue expectedValue = AttributeValue.Factory.longAttributeValue(i);
         assertThat(spanData.getAttributes().get("MyStringAttributeKey" + i))
             .isEqualTo(expectedValue);
       }

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -16,11 +16,12 @@
 
 package io.opentelemetry.sdk.trace;
 
-import static io.opentelemetry.common.AttributeValue.doubleAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.doubleAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.longAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.sdk.trace.Sampler.Decision;
 import io.opentelemetry.sdk.trace.Sampler.SamplingResult;
@@ -86,8 +87,8 @@ class SamplersTest {
   void samplingDecisionAttrs() {
     final Attributes attrs =
         Attributes.Factory.of(
-            "foo", AttributeValue.longAttributeValue(42),
-            "bar", AttributeValue.stringAttributeValue("baz"));
+            "foo", longAttributeValue(42),
+            "bar", stringAttributeValue("baz"));
     final SamplingResult sampledSamplingResult =
         Samplers.samplingResult(Sampler.Decision.RECORD_AND_SAMPLED, attrs);
     assertThat(sampledSamplingResult.getDecision()).isEqualTo(Decision.RECORD_AND_SAMPLED);

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -74,16 +74,18 @@ class SamplersTest {
 
   @Test
   void samplingDecisionEmpty() {
-    assertThat(Samplers.samplingResult(Sampler.Decision.RECORD_AND_SAMPLED, Attributes.empty()))
+    assertThat(
+            Samplers.samplingResult(
+                Sampler.Decision.RECORD_AND_SAMPLED, Attributes.Factory.empty()))
         .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLED));
-    assertThat(Samplers.samplingResult(Sampler.Decision.NOT_RECORD, Attributes.empty()))
+    assertThat(Samplers.samplingResult(Sampler.Decision.NOT_RECORD, Attributes.Factory.empty()))
         .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.NOT_RECORD));
   }
 
   @Test
   void samplingDecisionAttrs() {
     final Attributes attrs =
-        Attributes.of(
+        Attributes.Factory.of(
             "foo", AttributeValue.longAttributeValue(42),
             "bar", AttributeValue.stringAttributeValue("baz"));
     final SamplingResult sampledSamplingResult =
@@ -107,7 +109,7 @@ class SamplersTest {
                     traceId,
                     SPAN_NAME,
                     SPAN_KIND,
-                    Attributes.empty(),
+                    Attributes.Factory.empty(),
                     Collections.emptyList())
                 .getDecision())
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
@@ -120,7 +122,7 @@ class SamplersTest {
                     traceId,
                     SPAN_NAME,
                     SPAN_KIND,
-                    Attributes.empty(),
+                    Attributes.Factory.empty(),
                     Collections.emptyList())
                 .getDecision())
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
@@ -133,7 +135,7 @@ class SamplersTest {
                     traceId,
                     SPAN_NAME,
                     SPAN_KIND,
-                    Attributes.empty(),
+                    Attributes.Factory.empty(),
                     Collections.emptyList())
                 .getDecision())
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
@@ -154,7 +156,7 @@ class SamplersTest {
                     traceId,
                     SPAN_NAME,
                     SPAN_KIND,
-                    Attributes.empty(),
+                    Attributes.Factory.empty(),
                     Collections.emptyList())
                 .getDecision())
         .isEqualTo(Decision.NOT_RECORD);
@@ -167,7 +169,7 @@ class SamplersTest {
                     traceId,
                     SPAN_NAME,
                     SPAN_KIND,
-                    Attributes.empty(),
+                    Attributes.Factory.empty(),
                     Collections.emptyList())
                 .getDecision())
         .isEqualTo(Decision.NOT_RECORD);
@@ -180,7 +182,7 @@ class SamplersTest {
                     traceId,
                     SPAN_NAME,
                     SPAN_KIND,
-                    Attributes.empty(),
+                    Attributes.Factory.empty(),
                     Collections.emptyList())
                 .getDecision())
         .isEqualTo(Decision.NOT_RECORD);
@@ -201,7 +203,7 @@ class SamplersTest {
                     traceId,
                     SPAN_NAME,
                     SPAN_KIND,
-                    Attributes.empty(),
+                    Attributes.Factory.empty(),
                     Collections.emptyList())
                 .getDecision())
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
@@ -214,7 +216,7 @@ class SamplersTest {
                     traceId,
                     SPAN_NAME,
                     SPAN_KIND,
-                    Attributes.empty(),
+                    Attributes.Factory.empty(),
                     Collections.emptyList())
                 .getDecision())
         .isEqualTo(Decision.NOT_RECORD);
@@ -227,7 +229,7 @@ class SamplersTest {
                     traceId,
                     SPAN_NAME,
                     SPAN_KIND,
-                    Attributes.empty(),
+                    Attributes.Factory.empty(),
                     Collections.emptyList())
                 .getDecision())
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
@@ -243,7 +245,7 @@ class SamplersTest {
                     traceId,
                     SPAN_NAME,
                     SPAN_KIND,
-                    Attributes.empty(),
+                    Attributes.Factory.empty(),
                     Collections.emptyList())
                 .getDecision())
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
@@ -256,7 +258,7 @@ class SamplersTest {
                     traceId,
                     SPAN_NAME,
                     SPAN_KIND,
-                    Attributes.empty(),
+                    Attributes.Factory.empty(),
                     Collections.emptyList())
                 .getDecision())
         .isEqualTo(Decision.NOT_RECORD);
@@ -269,7 +271,7 @@ class SamplersTest {
                     traceId,
                     SPAN_NAME,
                     SPAN_KIND,
-                    Attributes.empty(),
+                    Attributes.Factory.empty(),
                     Collections.emptyList())
                 .getDecision())
         .isEqualTo(Decision.NOT_RECORD);
@@ -324,7 +326,7 @@ class SamplersTest {
                   idsGenerator.generateTraceId(),
                   SPAN_NAME,
                   SPAN_KIND,
-                  Attributes.empty(),
+                  Attributes.Factory.empty(),
                   parentLinks)
               .getDecision())) {
         count++;
@@ -413,12 +415,13 @@ class SamplersTest {
             notSampledtraceId,
             SPAN_NAME,
             SPAN_KIND,
-            Attributes.empty(),
+            Attributes.Factory.empty(),
             Collections.emptyList());
     assertThat(samplingResult1.getDecision()).isEqualTo(Decision.NOT_RECORD);
     assertThat(samplingResult1.getAttributes())
         .isEqualTo(
-            Attributes.of(Samplers.SAMPLING_PROBABILITY.key(), doubleAttributeValue(0.0001)));
+            Attributes.Factory.of(
+                Samplers.SAMPLING_PROBABILITY.key(), doubleAttributeValue(0.0001)));
     // This traceId will be sampled by the Probability Sampler because the last 8 bytes as long
     // is less than probability * Long.MAX_VALUE;
     TraceId sampledtraceId =
@@ -448,12 +451,13 @@ class SamplersTest {
             sampledtraceId,
             SPAN_NAME,
             SPAN_KIND,
-            Attributes.empty(),
+            Attributes.Factory.empty(),
             Collections.emptyList());
     assertThat(samplingResult2.getDecision()).isEqualTo(Decision.RECORD_AND_SAMPLED);
     assertThat(samplingResult1.getAttributes())
         .isEqualTo(
-            Attributes.of(Samplers.SAMPLING_PROBABILITY.key(), doubleAttributeValue(0.0001)));
+            Attributes.Factory.of(
+                Samplers.SAMPLING_PROBABILITY.key(), doubleAttributeValue(0.0001)));
   }
 
   @Test

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.sdk.trace;
 
+import static io.opentelemetry.common.AttributeValue.Factory.arrayAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -132,9 +133,9 @@ class SpanBuilderSdkTest {
     Span.Builder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
     Attributes attributes =
         Attributes.Factory.of(
-            "key0", AttributeValue.stringAttributeValue("str"),
-            "key1", AttributeValue.stringAttributeValue("str"),
-            "key2", AttributeValue.stringAttributeValue("str"));
+            "key0", AttributeValue.Factory.stringAttributeValue("str"),
+            "key1", AttributeValue.Factory.stringAttributeValue("str"),
+            "key2", AttributeValue.Factory.stringAttributeValue("str"));
     spanBuilder.addLink(sampledSpanContext, attributes);
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     try {
@@ -142,7 +143,7 @@ class SpanBuilderSdkTest {
           .containsExactly(
               Link.create(
                   sampledSpanContext,
-                  Attributes.Factory.of("key0", AttributeValue.stringAttributeValue("str")),
+                  Attributes.Factory.of("key0", AttributeValue.Factory.stringAttributeValue("str")),
                   3));
     } finally {
       span.end();
@@ -211,19 +212,23 @@ class SpanBuilderSdkTest {
             .setAttribute("long", 12345L)
             .setAttribute("double", .12345)
             .setAttribute("boolean", true)
-            .setAttribute("stringAttribute", AttributeValue.stringAttributeValue("attrvalue"));
+            .setAttribute(
+                "stringAttribute", AttributeValue.Factory.stringAttributeValue("attrvalue"));
 
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     try {
       SpanData spanData = span.toSpanData();
       ReadableAttributes attrs = spanData.getAttributes();
       assertThat(attrs.size()).isEqualTo(5);
-      assertThat(attrs.get("string")).isEqualTo(AttributeValue.stringAttributeValue("value"));
-      assertThat(attrs.get("long")).isEqualTo(AttributeValue.longAttributeValue(12345L));
-      assertThat(attrs.get("double")).isEqualTo(AttributeValue.doubleAttributeValue(0.12345));
-      assertThat(attrs.get("boolean")).isEqualTo(AttributeValue.booleanAttributeValue(true));
+      assertThat(attrs.get("string"))
+          .isEqualTo(AttributeValue.Factory.stringAttributeValue("value"));
+      assertThat(attrs.get("long")).isEqualTo(AttributeValue.Factory.longAttributeValue(12345L));
+      assertThat(attrs.get("double"))
+          .isEqualTo(AttributeValue.Factory.doubleAttributeValue(0.12345));
+      assertThat(attrs.get("boolean"))
+          .isEqualTo(AttributeValue.Factory.booleanAttributeValue(true));
       assertThat(attrs.get("stringAttribute"))
-          .isEqualTo(AttributeValue.stringAttributeValue("attrvalue"));
+          .isEqualTo(AttributeValue.Factory.stringAttributeValue("attrvalue"));
       assertThat(spanData.getTotalAttributeCount()).isEqualTo(5);
     } finally {
       span.end();
@@ -237,18 +242,22 @@ class SpanBuilderSdkTest {
     spanBuilder.setAttribute("long", 12345L);
     spanBuilder.setAttribute("double", .12345);
     spanBuilder.setAttribute("boolean", true);
-    spanBuilder.setAttribute("stringAttribute", AttributeValue.stringAttributeValue("attrvalue"));
+    spanBuilder.setAttribute(
+        "stringAttribute", AttributeValue.Factory.stringAttributeValue("attrvalue"));
 
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     try {
       ReadableAttributes attrs = span.toSpanData().getAttributes();
       assertThat(attrs.size()).isEqualTo(5);
-      assertThat(attrs.get("string")).isEqualTo(AttributeValue.stringAttributeValue("value"));
-      assertThat(attrs.get("long")).isEqualTo(AttributeValue.longAttributeValue(12345L));
-      assertThat(attrs.get("double")).isEqualTo(AttributeValue.doubleAttributeValue(.12345));
-      assertThat(attrs.get("boolean")).isEqualTo(AttributeValue.booleanAttributeValue(true));
+      assertThat(attrs.get("string"))
+          .isEqualTo(AttributeValue.Factory.stringAttributeValue("value"));
+      assertThat(attrs.get("long")).isEqualTo(AttributeValue.Factory.longAttributeValue(12345L));
+      assertThat(attrs.get("double"))
+          .isEqualTo(AttributeValue.Factory.doubleAttributeValue(.12345));
+      assertThat(attrs.get("boolean"))
+          .isEqualTo(AttributeValue.Factory.booleanAttributeValue(true));
       assertThat(attrs.get("stringAttribute"))
-          .isEqualTo(AttributeValue.stringAttributeValue("attrvalue"));
+          .isEqualTo(AttributeValue.Factory.stringAttributeValue("attrvalue"));
     } finally {
       span.end();
     }
@@ -257,7 +266,7 @@ class SpanBuilderSdkTest {
     span.setAttribute("long2", 12345L);
     span.setAttribute("double2", .12345);
     span.setAttribute("boolean2", true);
-    span.setAttribute("stringAttribute2", AttributeValue.stringAttributeValue("attrvalue"));
+    span.setAttribute("stringAttribute2", AttributeValue.Factory.stringAttributeValue("attrvalue"));
 
     ReadableAttributes attrs = span.toSpanData().getAttributes();
     assertThat(attrs.size()).isEqualTo(5);
@@ -271,13 +280,10 @@ class SpanBuilderSdkTest {
   @Test
   void setAttribute_emptyArrayAttributeValue() {
     Span.Builder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
-    spanBuilder.setAttribute(
-        "stringArrayAttribute", AttributeValue.arrayAttributeValue(new String[0]));
-    spanBuilder.setAttribute(
-        "boolArrayAttribute", AttributeValue.arrayAttributeValue(new Boolean[0]));
-    spanBuilder.setAttribute("longArrayAttribute", AttributeValue.arrayAttributeValue(new Long[0]));
-    spanBuilder.setAttribute(
-        "doubleArrayAttribute", AttributeValue.arrayAttributeValue(new Double[0]));
+    spanBuilder.setAttribute("stringArrayAttribute", arrayAttributeValue(new String[0]));
+    spanBuilder.setAttribute("boolArrayAttribute", arrayAttributeValue(new Boolean[0]));
+    spanBuilder.setAttribute("longArrayAttribute", arrayAttributeValue(new Long[0]));
+    spanBuilder.setAttribute("doubleArrayAttribute", arrayAttributeValue(new Double[0]));
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(4);
   }
@@ -287,8 +293,10 @@ class SpanBuilderSdkTest {
     Span.Builder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
     spanBuilder.setAttribute("emptyString", "");
     spanBuilder.setAttribute("nullString", (String) null);
-    spanBuilder.setAttribute("nullStringAttributeValue", AttributeValue.stringAttributeValue(null));
-    spanBuilder.setAttribute("emptyStringAttributeValue", AttributeValue.stringAttributeValue(""));
+    spanBuilder.setAttribute(
+        "nullStringAttributeValue", AttributeValue.Factory.stringAttributeValue(null));
+    spanBuilder.setAttribute(
+        "emptyStringAttributeValue", AttributeValue.Factory.stringAttributeValue(""));
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(2);
     span.setAttribute("emptyString", (String) null);
@@ -299,7 +307,8 @@ class SpanBuilderSdkTest {
   @Test
   void setAttribute_onlyNullStringValue() {
     Span.Builder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
-    spanBuilder.setAttribute("nullStringAttributeValue", AttributeValue.stringAttributeValue(null));
+    spanBuilder.setAttribute(
+        "nullStringAttributeValue", AttributeValue.Factory.stringAttributeValue(null));
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     assertThat(span.toSpanData().getAttributes().isEmpty()).isTrue();
   }
@@ -314,18 +323,18 @@ class SpanBuilderSdkTest {
     ReadableAttributes beforeAttributes = span.toSpanData().getAttributes();
     assertThat(beforeAttributes.size()).isEqualTo(2);
     assertThat(beforeAttributes.get("key1"))
-        .isEqualTo(AttributeValue.stringAttributeValue("value1"));
+        .isEqualTo(AttributeValue.Factory.stringAttributeValue("value1"));
     assertThat(beforeAttributes.get("key2"))
-        .isEqualTo(AttributeValue.stringAttributeValue("value2"));
+        .isEqualTo(AttributeValue.Factory.stringAttributeValue("value2"));
 
     spanBuilder.setAttribute("key3", "value3");
 
     ReadableAttributes afterAttributes = span.toSpanData().getAttributes();
     assertThat(afterAttributes.size()).isEqualTo(2);
     assertThat(afterAttributes.get("key1"))
-        .isEqualTo(AttributeValue.stringAttributeValue("value1"));
+        .isEqualTo(AttributeValue.Factory.stringAttributeValue("value1"));
     assertThat(afterAttributes.get("key2"))
-        .isEqualTo(AttributeValue.stringAttributeValue("value2"));
+        .isEqualTo(AttributeValue.Factory.stringAttributeValue("value2"));
   }
 
   @Test
@@ -333,17 +342,17 @@ class SpanBuilderSdkTest {
     Span.Builder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
     spanBuilder.setAttribute("emptyString", "");
     spanBuilder.setAttribute("nullString", (AttributeValue) null);
-    spanBuilder.setAttribute("nullStringAttributeValue", AttributeValue.stringAttributeValue(null));
-    spanBuilder.setAttribute("emptyStringAttributeValue", AttributeValue.stringAttributeValue(""));
+    spanBuilder.setAttribute(
+        "nullStringAttributeValue", AttributeValue.Factory.stringAttributeValue(null));
+    spanBuilder.setAttribute(
+        "emptyStringAttributeValue", AttributeValue.Factory.stringAttributeValue(""));
     spanBuilder.setAttribute("longAttribute", 0L);
     spanBuilder.setAttribute("boolAttribute", false);
     spanBuilder.setAttribute("doubleAttribute", 0.12345f);
-    spanBuilder.setAttribute("stringArrayAttribute", AttributeValue.arrayAttributeValue("", null));
-    spanBuilder.setAttribute("boolArrayAttribute", AttributeValue.arrayAttributeValue(true, null));
-    spanBuilder.setAttribute(
-        "longArrayAttribute", AttributeValue.arrayAttributeValue(12345L, null));
-    spanBuilder.setAttribute(
-        "doubleArrayAttribute", AttributeValue.arrayAttributeValue(1.2345, null));
+    spanBuilder.setAttribute("stringArrayAttribute", arrayAttributeValue("", null));
+    spanBuilder.setAttribute("boolArrayAttribute", arrayAttributeValue(true, null));
+    spanBuilder.setAttribute("longArrayAttribute", arrayAttributeValue(12345L, null));
+    spanBuilder.setAttribute("doubleArrayAttribute", arrayAttributeValue(1.2345, null));
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(9);
     span.setAttribute("emptyString", (AttributeValue) null);
@@ -362,16 +371,15 @@ class SpanBuilderSdkTest {
   void setAttribute_nullAttributeValue_afterEnd() {
     Span.Builder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
     spanBuilder.setAttribute("emptyString", "");
-    spanBuilder.setAttribute("emptyStringAttributeValue", AttributeValue.stringAttributeValue(""));
+    spanBuilder.setAttribute(
+        "emptyStringAttributeValue", AttributeValue.Factory.stringAttributeValue(""));
     spanBuilder.setAttribute("longAttribute", 0L);
     spanBuilder.setAttribute("boolAttribute", false);
     spanBuilder.setAttribute("doubleAttribute", 0.12345f);
-    spanBuilder.setAttribute("stringArrayAttribute", AttributeValue.arrayAttributeValue("", null));
-    spanBuilder.setAttribute("boolArrayAttribute", AttributeValue.arrayAttributeValue(true, null));
-    spanBuilder.setAttribute(
-        "longArrayAttribute", AttributeValue.arrayAttributeValue(12345L, null));
-    spanBuilder.setAttribute(
-        "doubleArrayAttribute", AttributeValue.arrayAttributeValue(1.2345, null));
+    spanBuilder.setAttribute("stringArrayAttribute", arrayAttributeValue("", null));
+    spanBuilder.setAttribute("boolArrayAttribute", arrayAttributeValue(true, null));
+    spanBuilder.setAttribute("longArrayAttribute", arrayAttributeValue(12345L, null));
+    spanBuilder.setAttribute("doubleArrayAttribute", arrayAttributeValue(1.2345, null));
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(9);
     span.end();
@@ -406,7 +414,7 @@ class SpanBuilderSdkTest {
       ReadableAttributes attrs = span.toSpanData().getAttributes();
       assertThat(attrs.size()).isEqualTo(maxNumberOfAttrs);
       for (int i = 0; i < maxNumberOfAttrs; i++) {
-        assertThat(attrs.get("key" + i)).isEqualTo(AttributeValue.longAttributeValue(i));
+        assertThat(attrs.get("key" + i)).isEqualTo(AttributeValue.Factory.longAttributeValue(i));
       }
     } finally {
       span.end();
@@ -430,10 +438,10 @@ class SpanBuilderSdkTest {
     spanBuilder.setAttribute("builderLong", 42L);
     spanBuilder.setAttribute(
         "builderStringLargeValue",
-        AttributeValue.stringAttributeValue("very large string that we have to cut"));
+        AttributeValue.Factory.stringAttributeValue("very large string that we have to cut"));
     spanBuilder.setAttribute(
         "builderStringArray",
-        AttributeValue.arrayAttributeValue("small", null, "very large string that we have to cut"));
+        arrayAttributeValue("small", null, "very large string that we have to cut"));
 
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     span.setAttribute("spanStringSmall", "small");
@@ -441,33 +449,34 @@ class SpanBuilderSdkTest {
     span.setAttribute("spanLong", 42L);
     span.setAttribute(
         "spanStringLarge",
-        AttributeValue.stringAttributeValue("very large string that we have to cut"));
+        AttributeValue.Factory.stringAttributeValue("very large string that we have to cut"));
     span.setAttribute(
         "spanStringArray",
-        AttributeValue.arrayAttributeValue("small", null, "very large string that we have to cut"));
+        arrayAttributeValue("small", null, "very large string that we have to cut"));
 
     try {
       ReadableAttributes attrs = span.toSpanData().getAttributes();
       assertThat(attrs.get("builderStringNull")).isEqualTo(null);
       assertThat(attrs.get("builderStringSmall"))
-          .isEqualTo(AttributeValue.stringAttributeValue("small"));
+          .isEqualTo(AttributeValue.Factory.stringAttributeValue("small"));
       assertThat(attrs.get("builderStringLarge"))
-          .isEqualTo(AttributeValue.stringAttributeValue("very large"));
-      assertThat(attrs.get("builderLong")).isEqualTo(AttributeValue.longAttributeValue(42L));
+          .isEqualTo(AttributeValue.Factory.stringAttributeValue("very large"));
+      assertThat(attrs.get("builderLong"))
+          .isEqualTo(AttributeValue.Factory.longAttributeValue(42L));
       assertThat(attrs.get("builderStringLargeValue"))
-          .isEqualTo(AttributeValue.stringAttributeValue("very large"));
+          .isEqualTo(AttributeValue.Factory.stringAttributeValue("very large"));
       assertThat(attrs.get("builderStringArray"))
-          .isEqualTo(AttributeValue.arrayAttributeValue("small", null, "very large"));
+          .isEqualTo(arrayAttributeValue("small", null, "very large"));
 
       assertThat(attrs.get("spanStringSmall"))
-          .isEqualTo(AttributeValue.stringAttributeValue("small"));
+          .isEqualTo(AttributeValue.Factory.stringAttributeValue("small"));
       assertThat(attrs.get("spanStringLarge"))
-          .isEqualTo(AttributeValue.stringAttributeValue("very large"));
-      assertThat(attrs.get("spanLong")).isEqualTo(AttributeValue.longAttributeValue(42L));
+          .isEqualTo(AttributeValue.Factory.stringAttributeValue("very large"));
+      assertThat(attrs.get("spanLong")).isEqualTo(AttributeValue.Factory.longAttributeValue(42L));
       assertThat(attrs.get("spanStringLarge"))
-          .isEqualTo(AttributeValue.stringAttributeValue("very large"));
+          .isEqualTo(AttributeValue.Factory.stringAttributeValue("very large"));
       assertThat(attrs.get("spanStringArray"))
-          .isEqualTo(AttributeValue.arrayAttributeValue("small", null, "very large"));
+          .isEqualTo(arrayAttributeValue("small", null, "very large"));
     } finally {
       span.end();
       tracerSdkFactory.updateActiveTraceConfig(TraceConfig.getDefault());
@@ -488,7 +497,7 @@ class SpanBuilderSdkTest {
     try {
       assertThat(span.toSpanData().getAttributes().size()).isEqualTo(1);
       assertThat(span.toSpanData().getAttributes().get(Samplers.SAMPLING_PROBABILITY.key()))
-          .isEqualTo(AttributeValue.doubleAttributeValue(1));
+          .isEqualTo(AttributeValue.Factory.doubleAttributeValue(1));
     } finally {
       span.end();
       tracerSdkFactory.updateActiveTraceConfig(TraceConfig.getDefault());
@@ -567,7 +576,8 @@ class SpanBuilderSdkTest {
                           @Override
                           public Attributes getAttributes() {
                             return Attributes.Factory.of(
-                                samplerAttributeName, AttributeValue.stringAttributeValue("bar"));
+                                samplerAttributeName,
+                                AttributeValue.Factory.stringAttributeValue("bar"));
                           }
                         };
                       }
@@ -578,7 +588,7 @@ class SpanBuilderSdkTest {
                       }
                     },
                     Collections.singletonMap(
-                        samplerAttributeName, AttributeValue.stringAttributeValue("none")))
+                        samplerAttributeName, AttributeValue.Factory.stringAttributeValue("none")))
                 .startSpan();
     try {
       assertThat(span.getContext().getTraceFlags().isSampled()).isTrue();

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -80,7 +80,7 @@ class SpanBuilderSdkTest {
     Span.Builder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
     spanBuilder.addLink(Link.create(DefaultSpan.getInvalid().getContext()));
     spanBuilder.addLink(DefaultSpan.getInvalid().getContext());
-    spanBuilder.addLink(DefaultSpan.getInvalid().getContext(), Attributes.empty());
+    spanBuilder.addLink(DefaultSpan.getInvalid().getContext(), Attributes.Factory.empty());
 
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     try {
@@ -131,7 +131,7 @@ class SpanBuilderSdkTest {
     tracerSdkFactory.updateActiveTraceConfig(traceConfig);
     Span.Builder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
     Attributes attributes =
-        Attributes.of(
+        Attributes.Factory.of(
             "key0", AttributeValue.stringAttributeValue("str"),
             "key1", AttributeValue.stringAttributeValue("str"),
             "key2", AttributeValue.stringAttributeValue("str"));
@@ -142,7 +142,7 @@ class SpanBuilderSdkTest {
           .containsExactly(
               Link.create(
                   sampledSpanContext,
-                  Attributes.of("key0", AttributeValue.stringAttributeValue("str")),
+                  Attributes.Factory.of("key0", AttributeValue.stringAttributeValue("str")),
                   3));
     } finally {
       span.end();
@@ -157,7 +157,7 @@ class SpanBuilderSdkTest {
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     try {
       assertThat(span.toSpanData().getLinks())
-          .containsExactly(Link.create(sampledSpanContext, Attributes.empty()));
+          .containsExactly(Link.create(sampledSpanContext, Attributes.Factory.empty()));
       // Use a different sampledSpanContext to ensure no logic that avoids duplicate links makes
       // this test to pass.
       spanBuilder.addLink(
@@ -167,7 +167,7 @@ class SpanBuilderSdkTest {
               TraceFlags.builder().setIsSampled(true).build(),
               TraceState.getDefault()));
       assertThat(span.toSpanData().getLinks())
-          .containsExactly(Link.create(sampledSpanContext, Attributes.empty()));
+          .containsExactly(Link.create(sampledSpanContext, Attributes.Factory.empty()));
     } finally {
       span.end();
     }
@@ -191,7 +191,7 @@ class SpanBuilderSdkTest {
   void addLinkSpanContextAttributes_nullContext() {
     assertThrows(
         NullPointerException.class,
-        () -> tracerSdk.spanBuilder(SPAN_NAME).addLink(null, Attributes.empty()));
+        () -> tracerSdk.spanBuilder(SPAN_NAME).addLink(null, Attributes.Factory.empty()));
   }
 
   @Test
@@ -566,7 +566,7 @@ class SpanBuilderSdkTest {
 
                           @Override
                           public Attributes getAttributes() {
-                            return Attributes.of(
+                            return Attributes.Factory.of(
                                 samplerAttributeName, AttributeValue.stringAttributeValue("bar"));
                           }
                         };

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
@@ -44,7 +44,7 @@ public final class TestUtils {
   static Attributes generateRandomAttributes() {
     return Attributes.Factory.of(
         UUID.randomUUID().toString(),
-        AttributeValue.stringAttributeValue(UUID.randomUUID().toString()));
+        AttributeValue.Factory.stringAttributeValue(UUID.randomUUID().toString()));
   }
 
   /**

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
@@ -42,7 +42,7 @@ public final class TestUtils {
    * @return some {@link io.opentelemetry.common.Attributes}
    */
   static Attributes generateRandomAttributes() {
-    return Attributes.of(
+    return Attributes.Factory.of(
         UUID.randomUUID().toString(),
         AttributeValue.stringAttributeValue(UUID.randomUUID().toString()));
   }

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TimedEventTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TimedEventTest.java
@@ -29,9 +29,9 @@ class TimedEventTest {
   private static final String NAME = "event";
   private static final String NAME_2 = "event2";
   private static final Attributes ATTRIBUTES =
-      Attributes.of("attribute", AttributeValue.stringAttributeValue("value"));
+      Attributes.Factory.of("attribute", AttributeValue.stringAttributeValue("value"));
   private static final Attributes ATTRIBUTES_2 =
-      Attributes.of("attribute2", AttributeValue.stringAttributeValue("value2"));
+      Attributes.Factory.of("attribute2", AttributeValue.stringAttributeValue("value2"));
   private static final Event EVENT =
       new Event() {
         @Override

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TimedEventTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TimedEventTest.java
@@ -16,9 +16,9 @@
 
 package io.opentelemetry.sdk.trace;
 
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.trace.Event;
 import org.junit.jupiter.api.Test;
@@ -29,9 +29,9 @@ class TimedEventTest {
   private static final String NAME = "event";
   private static final String NAME_2 = "event2";
   private static final Attributes ATTRIBUTES =
-      Attributes.Factory.of("attribute", AttributeValue.stringAttributeValue("value"));
+      Attributes.Factory.of("attribute", stringAttributeValue("value"));
   private static final Attributes ATTRIBUTES_2 =
-      Attributes.Factory.of("attribute2", AttributeValue.stringAttributeValue("value2"));
+      Attributes.Factory.of("attribute2", stringAttributeValue("value2"));
   private static final Event EVENT =
       new Event() {
         @Override

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -201,7 +201,8 @@ class TracerSdkTest {
     public void update() {
       Span span = tracer.spanBuilder("testSpan").startSpan();
       try (Scope ignored = tracer.withSpan(span)) {
-        span.setAttribute("testAttribute", AttributeValue.stringAttributeValue("testValue"));
+        span.setAttribute(
+            "testAttribute", AttributeValue.Factory.stringAttributeValue("testValue"));
       } finally {
         span.end();
       }

--- a/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/BeanstalkResource.java
+++ b/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/BeanstalkResource.java
@@ -61,10 +61,10 @@ public class BeanstalkResource extends ResourceProvider {
   public Attributes getAttributes() {
     File configFile = new File(configPath);
     if (!configFile.exists()) {
-      return Attributes.empty();
+      return Attributes.Factory.empty();
     }
 
-    Attributes.Builder attrBuilders = Attributes.newBuilder();
+    Attributes.Builder attrBuilders = Attributes.Factory.newBuilder();
     try (JsonParser parser = JSON_FACTORY.createParser(configFile)) {
       parser.nextToken();
 
@@ -92,7 +92,7 @@ public class BeanstalkResource extends ResourceProvider {
       }
     } catch (IOException e) {
       logger.log(Level.WARNING, "Could not parse Beanstalk config.", e);
-      return Attributes.empty();
+      return Attributes.Factory.empty();
     }
 
     return attrBuilders.build();

--- a/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/Ec2Resource.java
+++ b/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/Ec2Resource.java
@@ -154,12 +154,12 @@ public class Ec2Resource extends ResourceProvider {
     String identity = fetchIdentity(token);
     if (identity.isEmpty()) {
       // If no identity document, assume we are not actually running on EC2.
-      return Attributes.empty();
+      return Attributes.Factory.empty();
     }
 
     String hostname = fetchHostname(token);
 
-    Attributes.Builder attrBuilders = Attributes.newBuilder();
+    Attributes.Builder attrBuilders = Attributes.Factory.newBuilder();
 
     try (JsonParser parser = JSON_FACTORY.createParser(identity)) {
       parser.nextToken();
@@ -195,7 +195,7 @@ public class Ec2Resource extends ResourceProvider {
       }
     } catch (IOException e) {
       logger.log(Level.WARNING, "Could not parse identity document, resource not filled.", e);
-      return Attributes.empty();
+      return Attributes.Factory.empty();
     }
 
     attrBuilders.setAttribute(ResourceConstants.HOST_HOSTNAME, hostname);

--- a/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/EcsResource.java
+++ b/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/EcsResource.java
@@ -58,10 +58,10 @@ public class EcsResource extends ResourceProvider {
   @Override
   public Attributes getAttributes() {
     if (!isOnEcs()) {
-      return Attributes.empty();
+      return Attributes.Factory.empty();
     }
 
-    Attributes.Builder attrBuilders = Attributes.newBuilder();
+    Attributes.Builder attrBuilders = Attributes.Factory.newBuilder();
     try {
       String hostName = InetAddress.getLocalHost().getHostName();
       attrBuilders.setAttribute(ResourceConstants.CONTAINER_NAME, hostName);

--- a/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/BeanstalkResourceTest.java
+++ b/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/BeanstalkResourceTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.trace.aws.resource;
 
-import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.base.Charsets;

--- a/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/BeanstalkResourceTest.java
+++ b/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/BeanstalkResourceTest.java
@@ -43,7 +43,7 @@ class BeanstalkResourceTest {
     Attributes attributes = populator.getAttributes();
     assertThat(attributes)
         .isEqualTo(
-            Attributes.of(
+            Attributes.Factory.of(
                 ResourceConstants.SERVICE_INSTANCE, stringAttributeValue("4"),
                 ResourceConstants.SERVICE_VERSION, stringAttributeValue("2"),
                 ResourceConstants.SERVICE_NAMESPACE, stringAttributeValue("HttpSubscriber-env")));

--- a/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/Ec2ResourceTest.java
+++ b/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/Ec2ResourceTest.java
@@ -80,7 +80,7 @@ public class Ec2ResourceTest {
     stubFor(any(urlPathEqualTo("/latest/meta-data/hostname")).willReturn(ok("ec2-1-2-3-4")));
 
     Attributes attributes = populator.getAttributes();
-    Attributes.Builder expectedAttrBuilders = Attributes.newBuilder();
+    Attributes.Builder expectedAttrBuilders = Attributes.Factory.newBuilder();
     expectedAttrBuilders.setAttribute(ResourceConstants.HOST_ID, "i-1234567890abcdef0");
     expectedAttrBuilders.setAttribute(ResourceConstants.CLOUD_ZONE, "us-west-2b");
     expectedAttrBuilders.setAttribute(ResourceConstants.HOST_TYPE, "t2.micro");
@@ -111,7 +111,7 @@ public class Ec2ResourceTest {
     stubFor(any(urlPathEqualTo("/latest/meta-data/hostname")).willReturn(ok("ec2-1-2-3-4")));
 
     Attributes attributes = populator.getAttributes();
-    Attributes.Builder expectedAttrBuilders = Attributes.newBuilder();
+    Attributes.Builder expectedAttrBuilders = Attributes.Factory.newBuilder();
     expectedAttrBuilders.setAttribute(ResourceConstants.HOST_ID, "i-1234567890abcdef0");
     expectedAttrBuilders.setAttribute(ResourceConstants.CLOUD_ZONE, "us-west-2b");
     expectedAttrBuilders.setAttribute(ResourceConstants.HOST_TYPE, "t2.micro");

--- a/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/EcsResourceTest.java
+++ b/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/EcsResourceTest.java
@@ -49,7 +49,7 @@ class EcsResourceTest {
     Attributes attributes = populator.getAttributes();
     assertThat(attributes)
         .isEqualTo(
-            Attributes.of(
+            Attributes.Factory.of(
                 ResourceConstants.CONTAINER_NAME,
                 stringAttributeValue(InetAddress.getLocalHost().getHostName()),
                 ResourceConstants.CONTAINER_ID,
@@ -75,7 +75,7 @@ class EcsResourceTest {
     Attributes attributes = populator.getAttributes();
     assertThat(attributes)
         .isEqualTo(
-            Attributes.of(
+            Attributes.Factory.of(
                 ResourceConstants.CONTAINER_NAME,
                 stringAttributeValue(InetAddress.getLocalHost().getHostName())));
   }

--- a/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/EcsResourceTest.java
+++ b/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/EcsResourceTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.trace.aws.resource;
 
-import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
+import static io.opentelemetry.common.AttributeValue.Factory.stringAttributeValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 

--- a/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSampler.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSampler.java
@@ -53,7 +53,7 @@ class RateLimitingSampler implements Sampler {
     double maxBalance = maxTracesPerSecond < 1.0 ? 1.0 : maxTracesPerSecond;
     this.rateLimiter = new RateLimiter(maxTracesPerSecond, maxBalance, MillisClock.getInstance());
     Attributes attributes =
-        Attributes.of(
+        Attributes.Factory.of(
             SAMPLER_TYPE, AttributeValue.stringAttributeValue(TYPE),
             SAMPLER_PARAM, AttributeValue.doubleAttributeValue(maxTracesPerSecond));
     this.onSamplingResult = Samplers.samplingResult(Decision.RECORD_AND_SAMPLED, attributes);

--- a/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSampler.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSampler.java
@@ -54,8 +54,8 @@ class RateLimitingSampler implements Sampler {
     this.rateLimiter = new RateLimiter(maxTracesPerSecond, maxBalance, MillisClock.getInstance());
     Attributes attributes =
         Attributes.Factory.of(
-            SAMPLER_TYPE, AttributeValue.stringAttributeValue(TYPE),
-            SAMPLER_PARAM, AttributeValue.doubleAttributeValue(maxTracesPerSecond));
+            SAMPLER_TYPE, AttributeValue.Factory.stringAttributeValue(TYPE),
+            SAMPLER_PARAM, AttributeValue.Factory.doubleAttributeValue(maxTracesPerSecond));
     this.onSamplingResult = Samplers.samplingResult(Decision.RECORD_AND_SAMPLED, attributes);
     this.offSamplingResult = Samplers.samplingResult(Decision.NOT_RECORD, attributes);
   }

--- a/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSamplerTest.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSamplerTest.java
@@ -55,7 +55,7 @@ class RateLimitingSamplerTest {
                     traceId,
                     SPAN_NAME,
                     SPAN_KIND,
-                    Attributes.empty(),
+                    Attributes.Factory.empty(),
                     Collections.emptyList())
                 .getDecision())
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
@@ -66,7 +66,7 @@ class RateLimitingSamplerTest {
                     traceId,
                     SPAN_NAME,
                     SPAN_KIND,
-                    Attributes.empty(),
+                    Attributes.Factory.empty(),
                     Collections.emptyList())
                 .getDecision())
         .isEqualTo(Decision.RECORD_AND_SAMPLED);
@@ -81,7 +81,7 @@ class RateLimitingSamplerTest {
             traceId,
             SPAN_NAME,
             SPAN_KIND,
-            Attributes.empty(),
+            Attributes.Factory.empty(),
             Collections.emptyList());
     assertThat(samplingResult.getDecision()).isEqualTo(Decision.RECORD_AND_SAMPLED);
     assertThat(
@@ -91,7 +91,7 @@ class RateLimitingSamplerTest {
                     traceId,
                     SPAN_NAME,
                     SPAN_KIND,
-                    Attributes.empty(),
+                    Attributes.Factory.empty(),
                     Collections.emptyList())
                 .getDecision())
         .isEqualTo(Decision.NOT_RECORD);

--- a/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSamplerTest.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSamplerTest.java
@@ -97,10 +97,10 @@ class RateLimitingSamplerTest {
         .isEqualTo(Decision.NOT_RECORD);
     assertEquals(2, samplingResult.getAttributes().size());
     assertEquals(
-        AttributeValue.doubleAttributeValue(1),
+        AttributeValue.Factory.doubleAttributeValue(1),
         samplingResult.getAttributes().get(RateLimitingSampler.SAMPLER_PARAM));
     assertEquals(
-        AttributeValue.stringAttributeValue(RateLimitingSampler.TYPE),
+        AttributeValue.Factory.stringAttributeValue(RateLimitingSampler.TYPE),
         samplingResult.getAttributes().get(RateLimitingSampler.SAMPLER_TYPE));
   }
 

--- a/sdk_extensions/resources/src/main/java/io/opentelemetry/sdk/extensions/resources/OsResource.java
+++ b/sdk_extensions/resources/src/main/java/io/opentelemetry/sdk/extensions/resources/OsResource.java
@@ -31,14 +31,14 @@ public class OsResource extends ResourceProvider {
       os = System.getProperty("os.name");
     } catch (SecurityException t) {
       // Security manager enabled, can't provide much os information.
-      return Attributes.empty();
+      return Attributes.Factory.empty();
     }
 
     if (os == null) {
-      return Attributes.empty();
+      return Attributes.Factory.empty();
     }
 
-    Attributes.Builder attributes = Attributes.newBuilder();
+    Attributes.Builder attributes = Attributes.Factory.newBuilder();
 
     String osName = getOs(os);
     if (osName != null) {

--- a/sdk_extensions/resources/src/main/java/io/opentelemetry/sdk/extensions/resources/ProcessResource.java
+++ b/sdk_extensions/resources/src/main/java/io/opentelemetry/sdk/extensions/resources/ProcessResource.java
@@ -27,7 +27,7 @@ import java.lang.management.RuntimeMXBean;
 public class ProcessResource extends ResourceProvider {
   @Override
   protected Attributes getAttributes() {
-    Attributes.Builder attributes = Attributes.newBuilder();
+    Attributes.Builder attributes = Attributes.Factory.newBuilder();
 
     // TODO(anuraaga): Use reflection to get more stable values on Java 9+
     RuntimeMXBean runtime = ManagementFactory.getRuntimeMXBean();

--- a/testing_internal/src/main/java/io/opentelemetry/sdk/trace/TestSpanData.java
+++ b/testing_internal/src/main/java/io/opentelemetry/sdk/trace/TestSpanData.java
@@ -55,7 +55,7 @@ public abstract class TestSpanData implements SpanData {
         .setInstrumentationLibraryInfo(InstrumentationLibraryInfo.getEmpty())
         .setLinks(Collections.<Link>emptyList())
         .setTotalRecordedLinks(0)
-        .setAttributes(Attributes.empty())
+        .setAttributes(Attributes.Factory.empty())
         .setEvents(Collections.<Event>emptyList())
         .setTotalRecordedEvents(0)
         .setResource(Resource.getEmpty())

--- a/testing_internal/src/test/java/io/opentelemetry/sdk/trace/TestSpanDataTest.java
+++ b/testing_internal/src/test/java/io/opentelemetry/sdk/trace/TestSpanDataTest.java
@@ -44,7 +44,7 @@ class TestSpanDataTest {
     SpanData spanData = createBasicSpanBuilder().build();
 
     assertThat(spanData.getParentSpanId().isValid()).isFalse();
-    assertThat(spanData.getAttributes()).isEqualTo(Attributes.empty());
+    assertThat(spanData.getAttributes()).isEqualTo(Attributes.Factory.empty());
     assertThat(spanData.getEvents()).isEqualTo(emptyList());
     assertThat(spanData.getLinks()).isEqualTo(emptyList());
     assertThat(spanData.getInstrumentationLibraryInfo())
@@ -65,7 +65,7 @@ class TestSpanDataTest {
 
     assertThrows(
         UnsupportedOperationException.class,
-        () -> spanData.getEvents().add(EventImpl.create(1234, "foo", Attributes.empty())));
+        () -> spanData.getEvents().add(EventImpl.create(1234, "foo", Attributes.Factory.empty())));
   }
 
   @Test
@@ -94,13 +94,13 @@ class TestSpanDataTest {
 
   @Test
   void timedEvent_defaultTotalAttributeCountIsZero() {
-    EventImpl event = EventImpl.create(START_EPOCH_NANOS, "foo", Attributes.empty());
+    EventImpl event = EventImpl.create(START_EPOCH_NANOS, "foo", Attributes.Factory.empty());
     assertThat(event.getTotalAttributeCount()).isEqualTo(0);
   }
 
   @Test
   void timedEvent_canSetTotalAttributeCount() {
-    EventImpl event = EventImpl.create(START_EPOCH_NANOS, "foo", Attributes.empty(), 123);
+    EventImpl event = EventImpl.create(START_EPOCH_NANOS, "foo", Attributes.Factory.empty(), 123);
     assertThat(event.getTotalAttributeCount()).isEqualTo(123);
   }
 


### PR DESCRIPTION
The creational methods are now in inner classes, which is definitely an API breaking change.

Note: had to pull out the other inner classes up a level, otherwise they would inherit the interfaces `public` access modifier.

The rationale for this is to make life easier for the instrumentation agent code, where it is more desirable to deal with interfaces than abstract classes.

Relevant Issues:
* https://github.com/open-telemetry/opentelemetry-java/issues/1580
* https://github.com/open-telemetry/opentelemetry-java/issues/1314
* https://github.com/open-telemetry/opentelemetry-java/issues/1191
* https://github.com/open-telemetry/opentelemetry-java/issues/1081

Other PRs that strive to achieve the same goal in different ways:
* https://github.com/open-telemetry/opentelemetry-java/pull/1500
* https://github.com/open-telemetry/opentelemetry-java/pull/1097
