### PR TITLE
Preserve the ParentOrElse behavior when changing sampling probability via configuration

### DIFF
--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -245,6 +245,32 @@ public final class Samplers {
     public String getDescription() {
       return String.format("ParentOrElse{%s}", this.delegateSampler.getDescription());
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof ParentOrElse)) {
+        return false;
+      }
+
+      ParentOrElse that = (ParentOrElse) o;
+
+      return delegateSampler != null
+          ? delegateSampler.equals(that.delegateSampler)
+          : that.delegateSampler == null;
+    }
+
+    @Override
+    public int hashCode() {
+      return delegateSampler != null ? delegateSampler.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+      return "ParentOrElse{" + "delegateSampler=" + delegateSampler + '}';
+    }
   }
 
   /**

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
@@ -296,11 +296,11 @@ public abstract class TraceConfig {
       Utils.checkArgument(
           samplerProbability <= 1, "samplerProbability must be lesser than or equal to 1.");
       if (samplerProbability == 1) {
-        setSampler(Samplers.alwaysOn());
+        setSampler(Samplers.parentOrElse(Samplers.alwaysOn()));
       } else if (samplerProbability == 0) {
         setSampler(Samplers.alwaysOff());
       } else {
-        setSampler(Samplers.probability(samplerProbability));
+        setSampler(Samplers.parentOrElse(Samplers.probability(samplerProbability)));
       }
       return this;
     }

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigSystemPropertiesTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigSystemPropertiesTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.trace.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.opentelemetry.sdk.trace.Samplers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class TraceConfigSystemPropertiesTest {
+
+  @AfterEach
+  void tearDown() {
+    System.clearProperty("otel.config.sampler.probability");
+    System.clearProperty("otel.config.max.attrs");
+    System.clearProperty("otel.config.max.events");
+    System.clearProperty("otel.config.max.links");
+    System.clearProperty("otel.config.max.event.attrs");
+    System.clearProperty("otel.config.max.link.attrs");
+  }
+
+  @Test
+  void updateTraceConfig_SystemProperties() {
+    System.setProperty("otel.config.sampler.probability", "0.3");
+    System.setProperty("otel.config.max.attrs", "5");
+    System.setProperty("otel.config.max.events", "6");
+    System.setProperty("otel.config.max.links", "9");
+    System.setProperty("otel.config.max.event.attrs", "7");
+    System.setProperty("otel.config.max.link.attrs", "11");
+    TraceConfig traceConfig =
+        TraceConfig.getDefault()
+            .toBuilder()
+            .readEnvironmentVariables()
+            .readSystemProperties()
+            .build();
+    // this is not a useful assertion. How can we do better?
+    assertThat(traceConfig.getSampler())
+        .isEqualTo(Samplers.parentOrElse(Samplers.probability(0.3)));
+    assertThat(traceConfig.getMaxNumberOfAttributes()).isEqualTo(5);
+    assertThat(traceConfig.getMaxNumberOfEvents()).isEqualTo(6);
+    assertThat(traceConfig.getMaxNumberOfLinks()).isEqualTo(9);
+    assertThat(traceConfig.getMaxNumberOfAttributesPerEvent()).isEqualTo(7);
+    assertThat(traceConfig.getMaxNumberOfAttributesPerLink()).isEqualTo(11);
+  }
+
+  @Test
+  void updateTraceConfig_InvalidSamplerProbability() {
+    System.setProperty("otel.config.sampler.probability", "-1");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> TraceConfig.getDefault().toBuilder().readSystemProperties().build());
+  }
+
+  @Test
+  void updateTraceConfig_NonPositiveMaxNumberOfAttributes() {
+    System.setProperty("otel.config.max.attrs", "-5");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> TraceConfig.getDefault().toBuilder().readSystemProperties().build());
+  }
+
+  @Test
+  void updateTraceConfig_NonPositiveMaxNumberOfEvents() {
+    System.setProperty("otel.config.max.events", "-6");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> TraceConfig.getDefault().toBuilder().readSystemProperties().build());
+  }
+
+  @Test
+  void updateTraceConfig_NonPositiveMaxNumberOfLinks() {
+    System.setProperty("otel.config.max.links", "-9");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> TraceConfig.getDefault().toBuilder().readSystemProperties().build());
+  }
+
+  @Test
+  void updateTraceConfig_NonPositiveMaxNumberOfAttributesPerEvent() {
+    System.setProperty("otel.config.max.event.attrs", "-7");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> TraceConfig.getDefault().toBuilder().readSystemProperties().build());
+  }
+
+  @Test
+  void updateTraceConfig_NonPositiveMaxNumberOfAttributesPerLink() {
+    System.setProperty("otel.config.max.link.attrs", "-10");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> TraceConfig.getDefault().toBuilder().readSystemProperties().build());
+  }
+}

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
@@ -19,8 +19,8 @@ package io.opentelemetry.sdk.trace.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.opentelemetry.sdk.trace.Sampler;
 import io.opentelemetry.sdk.trace.Samplers;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class TraceConfigTest {
@@ -95,13 +95,15 @@ class TraceConfigTest {
   @Test
   void updateTraceConfig_OffSamplerProbability() {
     TraceConfig traceConfig = TraceConfig.getDefault().toBuilder().setSamplerProbability(0).build();
-    assertThat(traceConfig.getSampler()).isEqualTo(Samplers.alwaysOff());
+    assertThat(traceConfig.getSampler()).isSameAs(Samplers.alwaysOff());
   }
 
   @Test
   void updateTraceConfig_OnSamplerProbability() {
     TraceConfig traceConfig = TraceConfig.getDefault().toBuilder().setSamplerProbability(1).build();
-    assertThat(traceConfig.getSampler()).isEqualTo(Samplers.alwaysOn());
+
+    Sampler sampler = traceConfig.getSampler();
+    assertThat(sampler).isEqualTo(Samplers.parentOrElse(Samplers.alwaysOn()));
   }
 
   @Test
@@ -122,88 +124,5 @@ class TraceConfigTest {
     assertThat(traceConfig.getMaxNumberOfLinks()).isEqualTo(11);
     assertThat(traceConfig.getMaxNumberOfAttributesPerEvent()).isEqualTo(1);
     assertThat(traceConfig.getMaxNumberOfAttributesPerLink()).isEqualTo(2);
-  }
-
-  public static class SystemPropertiesTest {
-
-    @AfterEach
-    public void tearDown() {
-      System.clearProperty("otel.config.sampler.probability");
-      System.clearProperty("otel.config.max.attrs");
-      System.clearProperty("otel.config.max.events");
-      System.clearProperty("otel.config.max.links");
-      System.clearProperty("otel.config.max.event.attrs");
-      System.clearProperty("otel.config.max.link.attrs");
-    }
-
-    @Test
-    void updateTraceConfig_SystemProperties() {
-      System.setProperty("otel.config.sampler.probability", "0.3");
-      System.setProperty("otel.config.max.attrs", "5");
-      System.setProperty("otel.config.max.events", "6");
-      System.setProperty("otel.config.max.links", "9");
-      System.setProperty("otel.config.max.event.attrs", "7");
-      System.setProperty("otel.config.max.link.attrs", "11");
-      TraceConfig traceConfig =
-          TraceConfig.getDefault()
-              .toBuilder()
-              .readEnvironmentVariables()
-              .readSystemProperties()
-              .build();
-      assertThat(traceConfig.getSampler()).isEqualTo(Samplers.probability(0.3));
-      assertThat(traceConfig.getMaxNumberOfAttributes()).isEqualTo(5);
-      assertThat(traceConfig.getMaxNumberOfEvents()).isEqualTo(6);
-      assertThat(traceConfig.getMaxNumberOfLinks()).isEqualTo(9);
-      assertThat(traceConfig.getMaxNumberOfAttributesPerEvent()).isEqualTo(7);
-      assertThat(traceConfig.getMaxNumberOfAttributesPerLink()).isEqualTo(11);
-    }
-
-    @Test
-    void updateTraceConfig_InvalidSamplerProbability() {
-      System.setProperty("otel.config.sampler.probability", "-1");
-      assertThrows(
-          IllegalArgumentException.class,
-          () -> TraceConfig.getDefault().toBuilder().readSystemProperties().build());
-    }
-
-    @Test
-    void updateTraceConfig_NonPositiveMaxNumberOfAttributes() {
-      System.setProperty("otel.config.max.attrs", "-5");
-      assertThrows(
-          IllegalArgumentException.class,
-          () -> TraceConfig.getDefault().toBuilder().readSystemProperties().build());
-    }
-
-    @Test
-    void updateTraceConfig_NonPositiveMaxNumberOfEvents() {
-      System.setProperty("otel.config.max.events", "-6");
-      assertThrows(
-          IllegalArgumentException.class,
-          () -> TraceConfig.getDefault().toBuilder().readSystemProperties().build());
-    }
-
-    @Test
-    void updateTraceConfig_NonPositiveMaxNumberOfLinks() {
-      System.setProperty("otel.config.max.links", "-9");
-      assertThrows(
-          IllegalArgumentException.class,
-          () -> TraceConfig.getDefault().toBuilder().readSystemProperties().build());
-    }
-
-    @Test
-    void updateTraceConfig_NonPositiveMaxNumberOfAttributesPerEvent() {
-      System.setProperty("otel.config.max.event.attrs", "-7");
-      assertThrows(
-          IllegalArgumentException.class,
-          () -> TraceConfig.getDefault().toBuilder().readSystemProperties().build());
-    }
-
-    @Test
-    void updateTraceConfig_NonPositiveMaxNumberOfAttributesPerLink() {
-      System.setProperty("otel.config.max.link.attrs", "-10");
-      assertThrows(
-          IllegalArgumentException.class,
-          () -> TraceConfig.getDefault().toBuilder().readSystemProperties().build());
-    }
   }
 }


### PR DESCRIPTION
This seems like the bare minimum to get #1557 unblocked and preserve at least the parenting logic when a user configures a probability sampler. 

Resolves #1526 

Note: we definitely need to figure out a more robust configuration story for samplers, but that's out of scope for this PR.