### PR TITLE
Add an overload to the recordException method to support additional attributes

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
@@ -100,6 +100,9 @@ public final class DefaultSpan implements Span {
   public void recordException(Throwable exception) {}
 
   @Override
+  public void recordException(Throwable exception, Attributes additionalAttributes) {}
+
+  @Override
   public void updateName(String name) {}
 
   @Override

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -230,6 +230,15 @@ public interface Span {
   void recordException(Throwable exception);
 
   /**
+   * Records information about the {@link Throwable} to the {@link Span}.
+   *
+   * @param exception the {@link Throwable} to record.
+   * @param additionalAttributes the additional {@link Attributes} to record.
+   * @since 0.8.0
+   */
+  void recordException(Throwable exception, Attributes additionalAttributes);
+
+  /**
    * Updates the {@code Span} name.
    *
    * <p>If used, this will override the name provided via {@code Span.Builder}.

--- a/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
@@ -60,6 +60,7 @@ class DefaultSpanTest {
     span.addEvent((Event) null);
     span.setStatus(Status.OK);
     span.recordException(new IllegalStateException());
+    span.recordException(new IllegalStateException(), Attributes.empty());
     span.end();
     span.end(EndSpanOptions.getDefault());
     span.end(null);

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -428,11 +428,25 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
 
   @Override
   public void recordException(Throwable exception) {
+    recordException(exception, null);
+  }
+
+  @Override
+  public void recordException(Throwable exception, Attributes additionalAttributes) {
     if (exception == null) {
       return;
     }
     long timestamp = clock.now();
-    Attributes.Builder attributes = Attributes.newBuilder();
+    final Attributes.Builder attributes = Attributes.newBuilder();
+    if (additionalAttributes != null) {
+      additionalAttributes.forEach(
+          new KeyValueConsumer<AttributeValue>() {
+            @Override
+            public void consume(String key, AttributeValue value) {
+              attributes.setAttribute(key, value);
+            }
+          });
+    }
     SemanticAttributes.EXCEPTION_TYPE.set(attributes, exception.getClass().getCanonicalName());
     if (exception.getMessage() != null) {
       SemanticAttributes.EXCEPTION_MESSAGE.set(attributes, exception.getMessage());

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -437,16 +437,10 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
       return;
     }
     long timestamp = clock.now();
-    final Attributes.Builder attributes = Attributes.newBuilder();
-    if (additionalAttributes != null) {
-      additionalAttributes.forEach(
-          new KeyValueConsumer<AttributeValue>() {
-            @Override
-            public void consume(String key, AttributeValue value) {
-              attributes.setAttribute(key, value);
-            }
-          });
-    }
+    Attributes.Builder attributes =
+        additionalAttributes != null
+            ? Attributes.newBuilder(additionalAttributes)
+            : Attributes.newBuilder();
     SemanticAttributes.EXCEPTION_TYPE.set(attributes, exception.getClass().getCanonicalName());
     if (exception.getMessage() != null) {
       SemanticAttributes.EXCEPTION_MESSAGE.set(attributes, exception.getMessage());

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -438,9 +438,7 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
     }
     long timestamp = clock.now();
     Attributes.Builder attributes =
-        additionalAttributes != null
-            ? Attributes.newBuilder(additionalAttributes)
-            : Attributes.newBuilder();
+        additionalAttributes != null ? additionalAttributes.toBuilder() : Attributes.newBuilder();
     SemanticAttributes.EXCEPTION_TYPE.set(attributes, exception.getClass().getCanonicalName());
     if (exception.getMessage() != null) {
       SemanticAttributes.EXCEPTION_MESSAGE.set(attributes, exception.getMessage());

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -733,7 +733,12 @@ class RecordEventsReadableSpanTest {
     long timestamp = testClock.now();
 
     span.recordException(
-        exception, Attributes.of("key1", stringAttributeValue("this is an additional attribute")));
+        exception,
+        Attributes.of(
+            "key1",
+            stringAttributeValue("this is an additional attribute"),
+            "exception.message",
+            stringAttributeValue("this is a precedence attribute")));
 
     List<Event> events = span.toSpanData().getEvents();
     assertThat(events).hasSize(1);
@@ -745,7 +750,7 @@ class RecordEventsReadableSpanTest {
             Attributes.newBuilder()
                 .setAttribute("key1", "this is an additional attribute")
                 .setAttribute("exception.type", "java.lang.IllegalStateException")
-                .setAttribute("exception.message", "there was an exception")
+                .setAttribute("exception.message", "this is a precedence attribute")
                 .setAttribute("exception.stacktrace", stacktrace)
                 .build());
   }


### PR DESCRIPTION
closes [https://github.com/open-telemetry/opentelemetry-java/issues/1597](https://github.com/open-telemetry/opentelemetry-java/issues/1597)