### PR TITLE
Update opentelemetry-proto to latest version.

### DIFF
--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/SpanAdapter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/SpanAdapter.java
@@ -16,6 +16,12 @@
 
 package io.opentelemetry.exporters.otlp;
 
+import static io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT;
+import static io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CONSUMER;
+import static io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_INTERNAL;
+import static io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_PRODUCER;
+import static io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER;
+
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.common.ReadableKeyValuePairs.KeyValueConsumer;
@@ -124,15 +130,15 @@ final class SpanAdapter {
   static Span.SpanKind toProtoSpanKind(Kind kind) {
     switch (kind) {
       case INTERNAL:
-        return SpanKind.INTERNAL;
+        return SPAN_KIND_INTERNAL;
       case SERVER:
-        return SpanKind.SERVER;
+        return SPAN_KIND_SERVER;
       case CLIENT:
-        return SpanKind.CLIENT;
+        return SPAN_KIND_CLIENT;
       case PRODUCER:
-        return SpanKind.PRODUCER;
+        return SPAN_KIND_PRODUCER;
       case CONSUMER:
-        return SpanKind.CONSUMER;
+        return SPAN_KIND_CONSUMER;
     }
     return SpanKind.UNRECOGNIZED;
   }

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
@@ -16,6 +16,28 @@
 
 package io.opentelemetry.exporters.otlp;
 
+import static io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT;
+import static io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CONSUMER;
+import static io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_INTERNAL;
+import static io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_PRODUCER;
+import static io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER;
+import static io.opentelemetry.proto.trace.v1.Status.StatusCode.STATUS_CODE_ABORTED;
+import static io.opentelemetry.proto.trace.v1.Status.StatusCode.STATUS_CODE_ALREADY_EXISTS;
+import static io.opentelemetry.proto.trace.v1.Status.StatusCode.STATUS_CODE_CANCELLED;
+import static io.opentelemetry.proto.trace.v1.Status.StatusCode.STATUS_CODE_DATA_LOSS;
+import static io.opentelemetry.proto.trace.v1.Status.StatusCode.STATUS_CODE_DEADLINE_EXCEEDED;
+import static io.opentelemetry.proto.trace.v1.Status.StatusCode.STATUS_CODE_FAILED_PRECONDITION;
+import static io.opentelemetry.proto.trace.v1.Status.StatusCode.STATUS_CODE_INTERNAL_ERROR;
+import static io.opentelemetry.proto.trace.v1.Status.StatusCode.STATUS_CODE_INVALID_ARGUMENT;
+import static io.opentelemetry.proto.trace.v1.Status.StatusCode.STATUS_CODE_NOT_FOUND;
+import static io.opentelemetry.proto.trace.v1.Status.StatusCode.STATUS_CODE_OK;
+import static io.opentelemetry.proto.trace.v1.Status.StatusCode.STATUS_CODE_OUT_OF_RANGE;
+import static io.opentelemetry.proto.trace.v1.Status.StatusCode.STATUS_CODE_PERMISSION_DENIED;
+import static io.opentelemetry.proto.trace.v1.Status.StatusCode.STATUS_CODE_RESOURCE_EXHAUSTED;
+import static io.opentelemetry.proto.trace.v1.Status.StatusCode.STATUS_CODE_UNAUTHENTICATED;
+import static io.opentelemetry.proto.trace.v1.Status.StatusCode.STATUS_CODE_UNAVAILABLE;
+import static io.opentelemetry.proto.trace.v1.Status.StatusCode.STATUS_CODE_UNIMPLEMENTED;
+import static io.opentelemetry.proto.trace.v1.Status.StatusCode.STATUS_CODE_UNKNOWN_ERROR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.ByteString;
@@ -24,9 +46,7 @@ import io.opentelemetry.common.Attributes;
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.proto.trace.v1.Span;
-import io.opentelemetry.proto.trace.v1.Span.SpanKind;
 import io.opentelemetry.proto.trace.v1.Status;
-import io.opentelemetry.proto.trace.v1.Status.StatusCode;
 import io.opentelemetry.sdk.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.EventImpl;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
@@ -79,7 +99,7 @@ class SpanAdapterTest {
     assertThat(span.getSpanId().toByteArray()).isEqualTo(SPAN_ID_BYTES);
     assertThat(span.getParentSpanId().toByteArray()).isEqualTo(new byte[] {});
     assertThat(span.getName()).isEqualTo("GET /api/endpoint");
-    assertThat(span.getKind()).isEqualTo(SpanKind.SERVER);
+    assertThat(span.getKind()).isEqualTo(SPAN_KIND_SERVER);
     assertThat(span.getStartTimeUnixNano()).isEqualTo(12345);
     assertThat(span.getEndTimeUnixNano()).isEqualTo(12349);
     assertThat(span.getAttributesList())
@@ -100,38 +120,38 @@ class SpanAdapterTest {
                 .setSpanId(ByteString.copyFrom(SPAN_ID_BYTES))
                 .build());
     assertThat(span.getDroppedLinksCount()).isEqualTo(1); // 2 - 1
-    assertThat(span.getStatus()).isEqualTo(Status.newBuilder().setCode(StatusCode.Ok).build());
+    assertThat(span.getStatus()).isEqualTo(Status.newBuilder().setCode(STATUS_CODE_OK).build());
   }
 
   @Test
   void toProtoSpanKind() {
-    assertThat(SpanAdapter.toProtoSpanKind(Kind.INTERNAL)).isEqualTo(SpanKind.INTERNAL);
-    assertThat(SpanAdapter.toProtoSpanKind(Kind.CLIENT)).isEqualTo(SpanKind.CLIENT);
-    assertThat(SpanAdapter.toProtoSpanKind(Kind.SERVER)).isEqualTo(SpanKind.SERVER);
-    assertThat(SpanAdapter.toProtoSpanKind(Kind.PRODUCER)).isEqualTo(SpanKind.PRODUCER);
-    assertThat(SpanAdapter.toProtoSpanKind(Kind.CONSUMER)).isEqualTo(SpanKind.CONSUMER);
+    assertThat(SpanAdapter.toProtoSpanKind(Kind.INTERNAL)).isEqualTo(SPAN_KIND_INTERNAL);
+    assertThat(SpanAdapter.toProtoSpanKind(Kind.CLIENT)).isEqualTo(SPAN_KIND_CLIENT);
+    assertThat(SpanAdapter.toProtoSpanKind(Kind.SERVER)).isEqualTo(SPAN_KIND_SERVER);
+    assertThat(SpanAdapter.toProtoSpanKind(Kind.PRODUCER)).isEqualTo(SPAN_KIND_PRODUCER);
+    assertThat(SpanAdapter.toProtoSpanKind(Kind.CONSUMER)).isEqualTo(SPAN_KIND_CONSUMER);
   }
 
   @Test
   void toProtoStatus() {
     assertThat(SpanAdapter.toStatusProto(io.opentelemetry.trace.Status.OK))
-        .isEqualTo(Status.newBuilder().setCode(StatusCode.Ok).build());
+        .isEqualTo(Status.newBuilder().setCode(STATUS_CODE_OK).build());
     assertThat(
             SpanAdapter.toStatusProto(
                 io.opentelemetry.trace.Status.CANCELLED.withDescription("CANCELLED")))
         .isEqualTo(
-            Status.newBuilder().setCode(StatusCode.Cancelled).setMessage("CANCELLED").build());
+            Status.newBuilder().setCode(STATUS_CODE_CANCELLED).setMessage("CANCELLED").build());
     assertThat(
             SpanAdapter.toStatusProto(
                 io.opentelemetry.trace.Status.UNKNOWN.withDescription("UNKNOWN")))
         .isEqualTo(
-            Status.newBuilder().setCode(StatusCode.UnknownError).setMessage("UNKNOWN").build());
+            Status.newBuilder().setCode(STATUS_CODE_UNKNOWN_ERROR).setMessage("UNKNOWN").build());
     assertThat(
             SpanAdapter.toStatusProto(
                 io.opentelemetry.trace.Status.INVALID_ARGUMENT.withDescription("INVALID_ARGUMENT")))
         .isEqualTo(
             Status.newBuilder()
-                .setCode(StatusCode.InvalidArgument)
+                .setCode(STATUS_CODE_INVALID_ARGUMENT)
                 .setMessage("INVALID_ARGUMENT")
                 .build());
     assertThat(
@@ -140,20 +160,20 @@ class SpanAdapterTest {
                     "DEADLINE_EXCEEDED")))
         .isEqualTo(
             Status.newBuilder()
-                .setCode(StatusCode.DeadlineExceeded)
+                .setCode(STATUS_CODE_DEADLINE_EXCEEDED)
                 .setMessage("DEADLINE_EXCEEDED")
                 .build());
     assertThat(
             SpanAdapter.toStatusProto(
                 io.opentelemetry.trace.Status.NOT_FOUND.withDescription("NOT_FOUND")))
         .isEqualTo(
-            Status.newBuilder().setCode(StatusCode.NotFound).setMessage("NOT_FOUND").build());
+            Status.newBuilder().setCode(STATUS_CODE_NOT_FOUND).setMessage("NOT_FOUND").build());
     assertThat(
             SpanAdapter.toStatusProto(
                 io.opentelemetry.trace.Status.ALREADY_EXISTS.withDescription("ALREADY_EXISTS")))
         .isEqualTo(
             Status.newBuilder()
-                .setCode(StatusCode.AlreadyExists)
+                .setCode(STATUS_CODE_ALREADY_EXISTS)
                 .setMessage("ALREADY_EXISTS")
                 .build());
     assertThat(
@@ -162,7 +182,7 @@ class SpanAdapterTest {
                     "PERMISSION_DENIED")))
         .isEqualTo(
             Status.newBuilder()
-                .setCode(StatusCode.PermissionDenied)
+                .setCode(STATUS_CODE_PERMISSION_DENIED)
                 .setMessage("PERMISSION_DENIED")
                 .build());
     assertThat(
@@ -171,7 +191,7 @@ class SpanAdapterTest {
                     "RESOURCE_EXHAUSTED")))
         .isEqualTo(
             Status.newBuilder()
-                .setCode(StatusCode.ResourceExhausted)
+                .setCode(STATUS_CODE_RESOURCE_EXHAUSTED)
                 .setMessage("RESOURCE_EXHAUSTED")
                 .build());
     assertThat(
@@ -180,47 +200,50 @@ class SpanAdapterTest {
                     "FAILED_PRECONDITION")))
         .isEqualTo(
             Status.newBuilder()
-                .setCode(StatusCode.FailedPrecondition)
+                .setCode(STATUS_CODE_FAILED_PRECONDITION)
                 .setMessage("FAILED_PRECONDITION")
                 .build());
     assertThat(
             SpanAdapter.toStatusProto(
                 io.opentelemetry.trace.Status.ABORTED.withDescription("ABORTED")))
-        .isEqualTo(Status.newBuilder().setCode(StatusCode.Aborted).setMessage("ABORTED").build());
+        .isEqualTo(Status.newBuilder().setCode(STATUS_CODE_ABORTED).setMessage("ABORTED").build());
     assertThat(
             SpanAdapter.toStatusProto(
                 io.opentelemetry.trace.Status.OUT_OF_RANGE.withDescription("OUT_OF_RANGE")))
         .isEqualTo(
-            Status.newBuilder().setCode(StatusCode.OutOfRange).setMessage("OUT_OF_RANGE").build());
+            Status.newBuilder()
+                .setCode(STATUS_CODE_OUT_OF_RANGE)
+                .setMessage("OUT_OF_RANGE")
+                .build());
     assertThat(
             SpanAdapter.toStatusProto(
                 io.opentelemetry.trace.Status.UNIMPLEMENTED.withDescription("UNIMPLEMENTED")))
         .isEqualTo(
             Status.newBuilder()
-                .setCode(StatusCode.Unimplemented)
+                .setCode(STATUS_CODE_UNIMPLEMENTED)
                 .setMessage("UNIMPLEMENTED")
                 .build());
     assertThat(
             SpanAdapter.toStatusProto(
                 io.opentelemetry.trace.Status.INTERNAL.withDescription("INTERNAL")))
         .isEqualTo(
-            Status.newBuilder().setCode(StatusCode.InternalError).setMessage("INTERNAL").build());
+            Status.newBuilder().setCode(STATUS_CODE_INTERNAL_ERROR).setMessage("INTERNAL").build());
     assertThat(
             SpanAdapter.toStatusProto(
                 io.opentelemetry.trace.Status.UNAVAILABLE.withDescription("UNAVAILABLE")))
         .isEqualTo(
-            Status.newBuilder().setCode(StatusCode.Unavailable).setMessage("UNAVAILABLE").build());
+            Status.newBuilder().setCode(STATUS_CODE_UNAVAILABLE).setMessage("UNAVAILABLE").build());
     assertThat(
             SpanAdapter.toStatusProto(
                 io.opentelemetry.trace.Status.DATA_LOSS.withDescription("DATA_LOSS")))
         .isEqualTo(
-            Status.newBuilder().setCode(StatusCode.DataLoss).setMessage("DATA_LOSS").build());
+            Status.newBuilder().setCode(STATUS_CODE_DATA_LOSS).setMessage("DATA_LOSS").build());
     assertThat(
             SpanAdapter.toStatusProto(
                 io.opentelemetry.trace.Status.UNAUTHENTICATED.withDescription("UNAUTHENTICATED")))
         .isEqualTo(
             Status.newBuilder()
-                .setCode(StatusCode.Unauthenticated)
+                .setCode(STATUS_CODE_UNAUTHENTICATED)
                 .setMessage("UNAUTHENTICATED")
                 .build());
   }


### PR DESCRIPTION
Currently, java instrumentation smoke tests fail because we use JSON. collector `file` exporter writes as JSON and the tests read the JSON. But currently the JSON is not compatible between collector and Java because of renamed enums. Updating the proto will allow us to continue to develop against new versions of the collector.

I'm guessing the intent of the metrics protocol change is for the SDK to also adopt similar data structures. I'm not doing that in this PR since I only want to make the SDK JSON-compatible with the latest collectors - at the same time I've probably made them somewhat compatible for metrics too. The conversion of summary to histogram is clearly not ideal, converting double values into long counts, but I think semantically it may capture something reasonable. Anyways given before the change, the SDK isn't compatible at all for metrics with the latest collector, this is probably an improvement until rewriting the SDK.