### PR TITLE
Proof of concept: ContextChangeListener

### DIFF
--- a/api/src/main/java/io/opentelemetry/OpenTelemetry.java
+++ b/api/src/main/java/io/opentelemetry/OpenTelemetry.java
@@ -16,6 +16,8 @@
 
 package io.opentelemetry;
 
+import io.opentelemetry.context.ContextManager;
+import io.opentelemetry.context.interceptor.ContextChangeInterceptors;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.DefaultContextPropagators;
 import io.opentelemetry.correlationcontext.CorrelationContextManager;
@@ -186,6 +188,10 @@ public final class OpenTelemetry {
   public static void setPropagators(ContextPropagators propagators) {
     Utils.checkNotNull(propagators, "propagators");
     getInstance().propagators = propagators;
+  }
+
+  public static ContextChangeInterceptors getContextChangeInterceptors() {
+    return ContextManager.getInstance().getContextChangeInterceptors();
   }
 
   /** Lazy loads an instance. */

--- a/api/src/main/java/io/opentelemetry/correlationcontext/CorrelationsContextUtils.java
+++ b/api/src/main/java/io/opentelemetry/correlationcontext/CorrelationsContextUtils.java
@@ -91,8 +91,7 @@ public final class CorrelationsContextUtils {
    * @since 0.1.0
    */
   public static Scope currentContextWith(CorrelationContext corrContext) {
-    Context context = withCorrelationContext(corrContext, Context.current());
-    return ContextUtils.withScopedContext(context);
+    return ContextUtils.withScopedContext(withCorrelationContext(corrContext, Context.current()));
   }
 
   private CorrelationsContextUtils() {}

--- a/context_prop/src/main/java/io/opentelemetry/context/ContextManager.java
+++ b/context_prop/src/main/java/io/opentelemetry/context/ContextManager.java
@@ -1,0 +1,53 @@
+package io.opentelemetry.context;
+
+import io.grpc.Context;
+import io.opentelemetry.context.interceptor.ContextChangeInterceptors;
+import io.opentelemetry.context.interceptor.DefaultContextChangeInterceptors;
+
+// TODO: better name
+public final class ContextManager {
+  private static final ContextManager INSTANCE = new ContextManager();
+
+  private final ContextChangeInterceptors contextChangeInterceptors =
+      new DefaultContextChangeInterceptors();
+
+  public static ContextManager getInstance() {
+    return INSTANCE;
+  }
+
+  public ContextChangeInterceptors getContextChangeInterceptors() {
+    return contextChangeInterceptors;
+  }
+
+  public Scope withScopedContext(Context context) {
+    return new ContextInScope(context);
+  }
+
+  private final class ContextInScope implements Scope {
+    private final Context context;
+    private final Context previous;
+
+    private ContextInScope(Context newContext) {
+      Context currentContext = Context.current();
+      Context interceptedNewContext =
+          contextChangeInterceptors
+              .getActiveContextChangeInterceptor()
+              .interceptUpdate(currentContext, newContext);
+
+      this.context = interceptedNewContext;
+      this.previous = interceptedNewContext.attach();
+    }
+
+    @Override
+    public void close() {
+      Context interceptedPreviousContext =
+          contextChangeInterceptors
+              .getActiveContextChangeInterceptor()
+              .interceptUpdate(context, previous);
+
+      context.detach(interceptedPreviousContext);
+    }
+  }
+
+  private ContextManager() {}
+}

--- a/context_prop/src/main/java/io/opentelemetry/context/ContextUtils.java
+++ b/context_prop/src/main/java/io/opentelemetry/context/ContextUtils.java
@@ -35,26 +35,7 @@ public final class ContextUtils {
    * @since 0.1.0
    */
   public static Scope withScopedContext(Context context) {
-    if (context == null) {
-      throw new NullPointerException("context");
-    }
-
-    return new ContextInScope(context);
-  }
-
-  private static final class ContextInScope implements Scope {
-    private final Context context;
-    private final Context previous;
-
-    public ContextInScope(Context context) {
-      this.context = context;
-      this.previous = context.attach();
-    }
-
-    @Override
-    public void close() {
-      context.detach(previous);
-    }
+    return ContextManager.getInstance().withScopedContext(context);
   }
 
   private ContextUtils() {}

--- a/context_prop/src/main/java/io/opentelemetry/context/interceptor/ContextChangeInterceptor.java
+++ b/context_prop/src/main/java/io/opentelemetry/context/interceptor/ContextChangeInterceptor.java
@@ -1,0 +1,7 @@
+package io.opentelemetry.context.interceptor;
+
+import io.grpc.Context;
+
+public interface ContextChangeInterceptor {
+  Context interceptUpdate(Context currentContext, Context newContext);
+}

--- a/context_prop/src/main/java/io/opentelemetry/context/interceptor/ContextChangeInterceptors.java
+++ b/context_prop/src/main/java/io/opentelemetry/context/interceptor/ContextChangeInterceptors.java
@@ -1,0 +1,7 @@
+package io.opentelemetry.context.interceptor;
+
+public interface ContextChangeInterceptors {
+  void addContextChangeInterceptor(ContextChangeInterceptor contextChangeInterceptor);
+
+  ContextChangeInterceptor getActiveContextChangeInterceptor();
+}

--- a/context_prop/src/main/java/io/opentelemetry/context/interceptor/DefaultContextChangeInterceptors.java
+++ b/context_prop/src/main/java/io/opentelemetry/context/interceptor/DefaultContextChangeInterceptors.java
@@ -1,0 +1,36 @@
+package io.opentelemetry.context.interceptor;
+
+import io.grpc.Context;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public final class DefaultContextChangeInterceptors
+    implements ContextChangeInterceptors, ContextChangeInterceptor {
+  private final List<ContextChangeInterceptor> interceptors = new CopyOnWriteArrayList<>();
+
+  @Override
+  public void addContextChangeInterceptor(ContextChangeInterceptor contextChangeInterceptor) {
+    interceptors.add(contextChangeInterceptor);
+  }
+
+  @Override
+  public ContextChangeInterceptor getActiveContextChangeInterceptor() {
+    return this;
+  }
+
+  @Override
+  public Context interceptUpdate(Context currentContext, Context newContext) {
+    try {
+      Context updated = newContext;
+      for (ContextChangeInterceptor interceptor : interceptors) {
+        updated = interceptor.interceptUpdate(currentContext, updated);
+      }
+      return updated;
+    } catch (Error e) {
+      throw e;
+    } catch (Throwable ignored) {
+      // in case any interceptor throws just ignore the interception process
+      return newContext;
+    }
+  }
+}

--- a/extensions/trace_utils/src/main/java/io/opentelemetry/extensions/trace/CurrentSpanUtils.java
+++ b/extensions/trace_utils/src/main/java/io/opentelemetry/extensions/trace/CurrentSpanUtils.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.extensions.trace;
 
-import io.grpc.Context;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.TracingContextUtils;
@@ -65,8 +65,7 @@ public final class CurrentSpanUtils {
 
     @Override
     public void run() {
-      Context origContext = TracingContextUtils.withSpan(span, Context.current()).attach();
-      try {
+      try (Scope ignored = TracingContextUtils.currentContextWith(span)) {
         runnable.run();
       } catch (Throwable t) {
         setErrorStatus(span, t);
@@ -77,7 +76,6 @@ public final class CurrentSpanUtils {
         }
         throw new IllegalStateException("unexpected", t);
       } finally {
-        Context.current().detach(origContext);
         if (endSpan) {
           span.end();
         }
@@ -98,8 +96,7 @@ public final class CurrentSpanUtils {
 
     @Override
     public V call() throws Exception {
-      Context origContext = TracingContextUtils.withSpan(span, Context.current()).attach();
-      try {
+      try (Scope ignored = TracingContextUtils.currentContextWith(span)) {
         return callable.call();
       } catch (Exception e) {
         setErrorStatus(span, e);
@@ -111,7 +108,6 @@ public final class CurrentSpanUtils {
         }
         throw new IllegalStateException("unexpected", t);
       } finally {
-        Context.current().detach(origContext);
         if (endSpan) {
           span.end();
         }


### PR DESCRIPTION
Alternative idea to https://github.com/open-telemetry/opentelemetry-java/issues/922 & https://github.com/open-telemetry/opentelemetry-java/pull/923. This is only an idea, please forgive me lack of unit tests & JavaDocs.

I've decided to treat `ContextChangeListener` similarly to `ContextPropagators` so that it can be used both in traces and correlation contexts (and so that it's accessible from the API, where `Scope` implementation is defined).

There are 2 significant downsides to this solution:
* calling `Context#attach()` and `Context#detach()` manually will not run the listener;
* `ContextUtils#withScopedContext(Context)` needs to be deprecated  -- and it's being used in a lot of places in the java agent.

It would be quite easy to implement MDC support using the new listener:
```java
Class<?> threadContextClass = Class.forName("org.slf4j.MDC");
MethodHandles.Lookup lookup = MethodHandles.publicLookup();
MethodHandle putMethod =
    lookup.findStatic(
        threadContextClass,
        "put",
        MethodType.methodType(void.class, String.class, String.class));
MethodHandle removeMethod =
    lookup.findStatic(
        threadContextClass, "remove", MethodType.methodType(void.class, String.class));

OpenTelemetry.getContextChangeListeners()
    .addContextChangeListener(new LoggingSpanContextSetter(putMethod, removeMethod));

class LoggingSpanContextSetter implements ContextChangeListener {
  private final MethodHandle putMethod;
  private final MethodHandle removeMethod;

  LoggingSpanContextSetter(MethodHandle putMethod, MethodHandle removeMethod) {
    this.putMethod = putMethod;
    this.removeMethod = removeMethod;
  }

  @Override
  public void updated(Context oldContext, Context newContext) {
    try {
      SpanContext newSpanContext = TracingContextUtils.getSpan(newContext).getContext();
      if (newSpanContext.isValid()) {
        putMethod.invoke("otel.trace_id", newSpanContext.getTraceIdAsHexString());
        putMethod.invoke("otel.span_id", newSpanContext.getSpanIdAsHexString());
      } else {
        removeMethod.invoke("otel.trace_id");
        removeMethod.invoke("otel.span_id");
      }
    } catch (Error e) {
      throw e;
    } catch (Throwable ignored) {
    }
  }
}
```