### PR TITLE
Allow forward slash in metric name

### DIFF
--- a/api/src/main/java/io/opentelemetry/internal/StringUtils.java
+++ b/api/src/main/java/io/opentelemetry/internal/StringUtils.java
@@ -56,7 +56,7 @@ public final class StringUtils {
     if (metricName.isEmpty() || metricName.length() > NAME_MAX_LENGTH) {
       return false;
     }
-    String pattern = "[aA-zZ][aA-zZ0-9_\\-.]*";
+    String pattern = "[aA-zZ][aA-zZ0-9_\\-\\/.]*";
     return metricName.matches(pattern);
   }
 

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
@@ -69,6 +69,8 @@ class AbstractInstrumentBuilderTest {
     new TestInstrumentBuilder("METRIC_name", METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE);
     new TestInstrumentBuilder("metric.name_01", METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE);
     new TestInstrumentBuilder("metric_name.01", METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE);
+    new TestInstrumentBuilder("metric/name.01", METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE);
+    new TestInstrumentBuilder("metric/name_01", METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE);
     assertThrows(
         IllegalArgumentException.class,
         () ->


### PR DESCRIPTION
Allow metric names to have a forward slash in them.

I couldn't find consistent and explicit naming conventions, but it appears that other languages (like otel-go) are not as strict, and thus this poses problems when defining a single metrics pipeline with different language agents since you have to define metrics to the least common denominator.