### PR TITLE
Case-insensitive names for metric instruments

### DIFF
--- a/api/src/main/java/io/opentelemetry/internal/StringUtils.java
+++ b/api/src/main/java/io/opentelemetry/internal/StringUtils.java
@@ -25,7 +25,7 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public final class StringUtils {
 
-  public static final int NAME_MAX_LENGTH = 255;
+  public static final int METRIC_NAME_MAX_LENGTH = 255;
 
   /**
    * Determines whether the {@code String} contains only printable characters.
@@ -53,7 +53,7 @@ public final class StringUtils {
    * @return whether the metricName contains a valid name.
    */
   public static boolean isValidMetricName(String metricName) {
-    if (metricName.isEmpty() || metricName.length() > NAME_MAX_LENGTH) {
+    if (metricName.isEmpty() || metricName.length() > METRIC_NAME_MAX_LENGTH) {
       return false;
     }
     String pattern = "[aA-zZ][aA-zZ0-9_\\-.]*";

--- a/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
@@ -35,7 +35,7 @@ public final class DefaultMeter implements Meter {
 
   /* VisibleForTesting */ static final String ERROR_MESSAGE_INVALID_NAME =
       "Name should be a ASCII string with a length no greater than "
-          + StringUtils.NAME_MAX_LENGTH
+          + StringUtils.METRIC_NAME_MAX_LENGTH
           + " characters.";
 
   /**

--- a/api/src/test/java/io/opentelemetry/metrics/DoubleCounterTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/DoubleCounterTest.java
@@ -57,7 +57,7 @@ class DoubleCounterTest {
 
   @Test
   void preventTooLongName() {
-    char[] chars = new char[StringUtils.NAME_MAX_LENGTH + 1];
+    char[] chars = new char[StringUtils.METRIC_NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
     assertThrows(

--- a/api/src/test/java/io/opentelemetry/metrics/DoubleSumObserverTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/DoubleSumObserverTest.java
@@ -53,7 +53,7 @@ class DoubleSumObserverTest {
 
   @Test
   void preventTooLongName() {
-    char[] chars = new char[StringUtils.NAME_MAX_LENGTH + 1];
+    char[] chars = new char[StringUtils.METRIC_NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
     assertThrows(

--- a/api/src/test/java/io/opentelemetry/metrics/DoubleUpDownCounterTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/DoubleUpDownCounterTest.java
@@ -57,7 +57,7 @@ class DoubleUpDownCounterTest {
 
   @Test
   void preventTooLongName() {
-    char[] chars = new char[StringUtils.NAME_MAX_LENGTH + 1];
+    char[] chars = new char[StringUtils.METRIC_NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
     assertThrows(

--- a/api/src/test/java/io/opentelemetry/metrics/DoubleUpDownSumObserverTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/DoubleUpDownSumObserverTest.java
@@ -55,7 +55,7 @@ class DoubleUpDownSumObserverTest {
 
   @Test
   void preventTooLongName() {
-    char[] chars = new char[StringUtils.NAME_MAX_LENGTH + 1];
+    char[] chars = new char[StringUtils.METRIC_NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
     assertThrows(

--- a/api/src/test/java/io/opentelemetry/metrics/DoubleValueObserverTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/DoubleValueObserverTest.java
@@ -54,7 +54,7 @@ class DoubleValueObserverTest {
 
   @Test
   void preventTooLongName() {
-    char[] chars = new char[StringUtils.NAME_MAX_LENGTH + 1];
+    char[] chars = new char[StringUtils.METRIC_NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
     assertThrows(

--- a/api/src/test/java/io/opentelemetry/metrics/LongCounterTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/LongCounterTest.java
@@ -57,7 +57,7 @@ class LongCounterTest {
 
   @Test
   void preventTooLongName() {
-    char[] chars = new char[StringUtils.NAME_MAX_LENGTH + 1];
+    char[] chars = new char[StringUtils.METRIC_NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
     assertThrows(

--- a/api/src/test/java/io/opentelemetry/metrics/LongSumObserverTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/LongSumObserverTest.java
@@ -56,7 +56,7 @@ class LongSumObserverTest {
 
   @Test
   void preventTooLongName() {
-    char[] chars = new char[StringUtils.NAME_MAX_LENGTH + 1];
+    char[] chars = new char[StringUtils.METRIC_NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
     assertThrows(

--- a/api/src/test/java/io/opentelemetry/metrics/LongUpDownCounterTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/LongUpDownCounterTest.java
@@ -57,7 +57,7 @@ class LongUpDownCounterTest {
 
   @Test
   void preventTooLongName() {
-    char[] chars = new char[StringUtils.NAME_MAX_LENGTH + 1];
+    char[] chars = new char[StringUtils.METRIC_NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
     assertThrows(

--- a/api/src/test/java/io/opentelemetry/metrics/LongUpDownSumObserverTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/LongUpDownSumObserverTest.java
@@ -57,7 +57,7 @@ class LongUpDownSumObserverTest {
 
   @Test
   void preventTooLongName() {
-    char[] chars = new char[StringUtils.NAME_MAX_LENGTH + 1];
+    char[] chars = new char[StringUtils.METRIC_NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
     assertThrows(

--- a/api/src/test/java/io/opentelemetry/metrics/LongValueObserverTest.java
+++ b/api/src/test/java/io/opentelemetry/metrics/LongValueObserverTest.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.metrics;
 
-import static io.opentelemetry.internal.StringUtils.NAME_MAX_LENGTH;
+import static io.opentelemetry.internal.StringUtils.METRIC_NAME_MAX_LENGTH;
 import static io.opentelemetry.metrics.DefaultMeter.ERROR_MESSAGE_INVALID_NAME;
 import static java.util.Arrays.fill;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -58,7 +58,7 @@ class LongValueObserverTest {
 
   @Test
   void preventTooLongName() {
-    char[] chars = new char[NAME_MAX_LENGTH + 1];
+    char[] chars = new char[METRIC_NAME_MAX_LENGTH + 1];
     fill(chars, 'a');
     String longName = String.valueOf(chars);
     assertThrows(

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
@@ -90,7 +90,7 @@ abstract class AbstractInstrument implements Instrument {
       implements Instrument.Builder {
     /* VisibleForTesting */ static final String ERROR_MESSAGE_INVALID_NAME =
         "Name should be a ASCII string with a length no greater than "
-            + StringUtils.NAME_MAX_LENGTH
+            + StringUtils.METRIC_NAME_MAX_LENGTH
             + " characters.";
 
     private final String name;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
@@ -88,10 +88,9 @@ abstract class AbstractInstrument implements Instrument {
 
   abstract static class Builder<B extends AbstractInstrument.Builder<?>>
       implements Instrument.Builder {
-    /* VisibleForTesting */ static final int NAME_MAX_LENGTH = 255;
     /* VisibleForTesting */ static final String ERROR_MESSAGE_INVALID_NAME =
         "Name should be a ASCII string with a length no greater than "
-            + NAME_MAX_LENGTH
+            + StringUtils.NAME_MAX_LENGTH
             + " characters.";
 
     private final String name;
@@ -109,9 +108,7 @@ abstract class AbstractInstrument implements Instrument {
         MeterSdk meterSdk) {
       this.meterSdk = meterSdk;
       Objects.requireNonNull(name, "name");
-      Utils.checkArgument(
-          StringUtils.isValidMetricName(name) && name.length() <= NAME_MAX_LENGTH,
-          ERROR_MESSAGE_INVALID_NAME);
+      Utils.checkArgument(StringUtils.isValidMetricName(name), ERROR_MESSAGE_INVALID_NAME);
       this.name = name;
       this.meterProviderSharedState = meterProviderSharedState;
       this.meterSharedState = meterSharedState;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/InstrumentRegistry.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/InstrumentRegistry.java
@@ -44,7 +44,7 @@ final class InstrumentRegistry {
   @SuppressWarnings("unchecked")
   <I extends AbstractInstrument> I register(I instrument) {
     AbstractInstrument oldInstrument =
-        registry.putIfAbsent(instrument.getDescriptor().getName(), instrument);
+        registry.putIfAbsent(instrument.getDescriptor().getName().toLowerCase(), instrument);
     if (oldInstrument != null) {
       if (!instrument.getClass().isInstance(oldInstrument) || !instrument.equals(oldInstrument)) {
         throw new IllegalArgumentException(

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
@@ -88,7 +88,7 @@ class AbstractInstrumentBuilderTest {
 
   @Test
   void preventTooLongName() {
-    char[] chars = new char[StringUtils.NAME_MAX_LENGTH + 1];
+    char[] chars = new char[StringUtils.METRIC_NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
     assertThrows(

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
@@ -17,11 +17,11 @@
 package io.opentelemetry.sdk.metrics;
 
 import static io.opentelemetry.sdk.metrics.AbstractInstrument.Builder.ERROR_MESSAGE_INVALID_NAME;
-import static io.opentelemetry.sdk.metrics.AbstractInstrument.Builder.NAME_MAX_LENGTH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.common.Labels;
+import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
@@ -88,7 +88,7 @@ class AbstractInstrumentBuilderTest {
 
   @Test
   void preventTooLongName() {
-    char[] chars = new char[NAME_MAX_LENGTH + 1];
+    char[] chars = new char[StringUtils.NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
     assertThrows(

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
@@ -23,6 +23,8 @@ import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.metrics.BatchRecorder;
+import io.opentelemetry.metrics.DoubleValueObserver;
+import io.opentelemetry.metrics.LongValueObserver;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.metrics.data.MetricData;
@@ -73,6 +75,10 @@ class MeterSdkTest {
         IllegalArgumentException.class,
         () -> testSdk.longCounterBuilder("testLongCounter").build(),
         "Instrument with same name and different descriptor already created.");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> testSdk.longCounterBuilder("testLongCounter".toUpperCase()).build(),
+        "Instrument with same name and different descriptor already created.");
   }
 
   @Test
@@ -98,6 +104,10 @@ class MeterSdkTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> testSdk.longUpDownCounterBuilder("testLongUpDownCounter").build(),
+        "Instrument with same name and different descriptor already created.");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> testSdk.longUpDownCounterBuilder("testLongUpDownCounter".toUpperCase()).build(),
         "Instrument with same name and different descriptor already created.");
   }
 
@@ -125,6 +135,40 @@ class MeterSdkTest {
         IllegalArgumentException.class,
         () -> testSdk.longValueRecorderBuilder("testLongValueRecorder").build(),
         "Instrument with same name and different descriptor already created.");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> testSdk.longValueRecorderBuilder("testLongValueRecorder".toUpperCase()).build(),
+        "Instrument with same name and different descriptor already created.");
+  }
+
+  @Test
+  void testLongValueObserver() {
+    LongValueObserver longValueObserver =
+        testSdk
+            .longValueObserverBuilder("longValueObserver")
+            .setConstantLabels(Labels.of("sk1", "sv1"))
+            .setDescription("My very own counter")
+            .setUnit("metric tonnes")
+            .build();
+    assertThat(longValueObserver).isNotNull();
+
+    assertThat(
+            testSdk
+                .longValueObserverBuilder("longValueObserver")
+                .setConstantLabels(Labels.of("sk1", "sv1"))
+                .setDescription("My very own counter")
+                .setUnit("metric tonnes")
+                .build())
+        .isSameAs(longValueObserver);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> testSdk.longValueObserverBuilder("longValueObserver").build(),
+        "Instrument with same name and different descriptor already created.");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> testSdk.longValueObserverBuilder("longValueObserver".toUpperCase()).build(),
+        "Instrument with same name and different descriptor already created.");
   }
 
   @Test
@@ -150,6 +194,11 @@ class MeterSdkTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> testSdk.longSumObserverBuilder("testLongSumObserver").build(),
+        "Instrument with same name and different descriptor already created.");
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> testSdk.longSumObserverBuilder("testLongSumObserver".toUpperCase()).build(),
         "Instrument with same name and different descriptor already created.");
   }
 
@@ -177,6 +226,12 @@ class MeterSdkTest {
         IllegalArgumentException.class,
         () -> testSdk.longUpDownSumObserverBuilder("testLongUpDownSumObserver").build(),
         "Instrument with same name and different descriptor already created.");
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            testSdk.longUpDownSumObserverBuilder("testLongUpDownSumObserver".toUpperCase()).build(),
+        "Instrument with same name and different descriptor already created.");
   }
 
   @Test
@@ -202,6 +257,10 @@ class MeterSdkTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> testSdk.doubleCounterBuilder("testDoubleCounter").build(),
+        "Instrument with same name and different descriptor already created.");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> testSdk.doubleCounterBuilder("testDoubleCounter".toUpperCase()).build(),
         "Instrument with same name and different descriptor already created.");
   }
 
@@ -229,6 +288,10 @@ class MeterSdkTest {
         IllegalArgumentException.class,
         () -> testSdk.doubleUpDownCounterBuilder("testDoubleUpDownCounter").build(),
         "Instrument with same name and different descriptor already created.");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> testSdk.doubleUpDownCounterBuilder("testDoubleUpDownCounter".toUpperCase()).build(),
+        "Instrument with same name and different descriptor already created.");
   }
 
   @Test
@@ -254,6 +317,10 @@ class MeterSdkTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> testSdk.doubleValueRecorderBuilder("testDoubleValueRecorder").build(),
+        "Instrument with same name and different descriptor already created.");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> testSdk.doubleValueRecorderBuilder("testDoubleValueRecorder".toUpperCase()).build(),
         "Instrument with same name and different descriptor already created.");
   }
 
@@ -281,6 +348,10 @@ class MeterSdkTest {
         IllegalArgumentException.class,
         () -> testSdk.doubleSumObserverBuilder("testDoubleSumObserver").build(),
         "Instrument with same name and different descriptor already created.");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> testSdk.doubleSumObserverBuilder("testDoubleSumObserver".toUpperCase()).build(),
+        "Instrument with same name and different descriptor already created.");
   }
 
   @Test
@@ -306,6 +377,43 @@ class MeterSdkTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> testSdk.doubleUpDownSumObserverBuilder("testDoubleUpDownSumObserver").build(),
+        "Instrument with same name and different descriptor already created.");
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            testSdk
+                .doubleUpDownSumObserverBuilder("testDoubleUpDownSumObserver".toUpperCase())
+                .build(),
+        "Instrument with same name and different descriptor already created.");
+  }
+
+  @Test
+  void testDoubleValueObserver() {
+    DoubleValueObserver doubleValueObserver =
+        testSdk
+            .doubleValueObserverBuilder("doubleValueObserver")
+            .setConstantLabels(Labels.of("sk1", "sv1"))
+            .setDescription("My very own counter")
+            .setUnit("metric tonnes")
+            .build();
+    assertThat(doubleValueObserver).isNotNull();
+
+    assertThat(
+            testSdk
+                .doubleValueObserverBuilder("doubleValueObserver")
+                .setConstantLabels(Labels.of("sk1", "sv1"))
+                .setDescription("My very own counter")
+                .setUnit("metric tonnes")
+                .build())
+        .isSameAs(doubleValueObserver);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> testSdk.doubleValueObserverBuilder("doubleValueObserver").build(),
+        "Instrument with same name and different descriptor already created.");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> testSdk.doubleValueObserverBuilder("doubleValueObserver".toUpperCase()).build(),
         "Instrument with same name and different descriptor already created.");
   }
 


### PR DESCRIPTION
This PR properly addresses the requirements for metric instrument names.
[Spec link](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/metrics/api.md#instrument-naming-requirements)