### PR TITLE
Add w3c context propagation tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
       - restore_cache:
           keys:
             - gradle-w3c-{{ checksum "build.gradle" }}
-      - run: sudo apt-get update && sudo apt-get install python3 && sudo apt-get install python3-pip
+      - run: sudo apt-get update && sudo apt-get install python3.6 && sudo apt-get install python3-pip
       - run:
           name: Integration Tests
           command: cd integration_tests/tracecontext && ./tracecontext-integration-test.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,8 +121,8 @@ jobs:
           keys:
             - gradle-it-{{ checksum "build.gradle" }}
       - run:
-          name: Upgrade pip
-          command: pip install --upgrade pip
+          name: Install pip3
+          command: sudo apt-get install python3-pip
       - run:
           name: Integration Tests
           command: cd integration_tests/tracecontext && ./tracecontext-integration-test.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,28 +107,6 @@ jobs:
           paths:
             - ~/.gradle
           key: gradle-{{ checksum "build.gradle" }}
-# Integration tests
-  integration-tests:
-    environment:
-      # Configure the JVM and Gradle to avoid OOM errors
-      _JAVA_OPTIONS: "-Xmx1g"
-      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
-    docker:
-      - image: openkbs/jdk-mvn-py3
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - gradle-w3c-{{ checksum "build.gradle" }}
-      - run:
-          name: Integration Tests
-          command: cd integration_tests/tracecontext && ./tracecontext-integration-test.sh
-      - run:
-          <<: *publish_snapshots_task
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: gradle-w3c-{{ checksum "build.gradle" }}
 
 workflows:
   version: 2
@@ -136,7 +114,6 @@ workflows:
     jobs:
       - build
       - java11
-      - integration-tests
   build_and_release:
     jobs:
       - release_job:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
       - restore_cache:
           keys:
             - gradle-it-{{ checksum "build.gradle" }}
-      - run
+      - run:
           name: Upgrade pip
           command: pip install --upgrade pip
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,10 +119,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - gradle-it-{{ checksum "build.gradle" }}
-      - run:
-          name: Install pip3
-          command: sudo apt-get install python3-pip
+            - gradle-w3c-{{ checksum "build.gradle" }}
       - run:
           name: Integration Tests
           command: cd integration_tests/tracecontext && ./tracecontext-integration-test.sh
@@ -131,7 +128,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle
-          key: gradle-it-{{ checksum "build.gradle" }}
+          key: gradle-w3c-{{ checksum "build.gradle" }}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,13 +114,12 @@ jobs:
       _JAVA_OPTIONS: "-Xmx1g"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: openkbs/jdk-mvn-py3
     steps:
       - checkout
       - restore_cache:
           keys:
             - gradle-w3c-{{ checksum "build.gradle" }}
-      - run: sudo add-apt-repository ppa:deadsnakes/ppa && sudo apt-get update && sudo apt-get install python3.6 && sudo apt-get install python3-pip && /usr/bin/pip3 --version
       - run:
           name: Integration Tests
           command: cd integration_tests/tracecontext && ./tracecontext-integration-test.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
       _JAVA_OPTIONS: "-Xmx1g"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
       docker:
-        - image: elancapital/docker-java-python3
+        - image: openkbs/jdk-mvn-py3
       steps:
         - checkout
         - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,9 @@ jobs:
       - restore_cache:
           keys:
             - gradle-it-{{ checksum "build.gradle" }}
+      - run
+          name: Upgrade pip
+          command: pip install --upgrade pip
       - run:
           name: Integration Tests
           command: cd integration_tests/tracecontext && ./tracecontext-integration-test.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,22 +113,22 @@ jobs:
       # Configure the JVM and Gradle to avoid OOM errors
       _JAVA_OPTIONS: "-Xmx1g"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
-      docker:
-        - image: openkbs/jdk-mvn-py3
-      steps:
-        - checkout
-        - restore_cache:
-            keys:
-              - gradle-it-{{ checksum "build.gradle" }}
-        - run:
-            name: Integration Tests
-            command: cd integration_tests/tracecontext && ./tracecontext-integration-test.sh
-        - run:
-            <<: *publish_snapshots_task
-        - save_cache:
-            paths:
-              - ~/.gradle
-            key: gradle-it-{{ checksum "build.gradle" }}
+    docker:
+      - image: openkbs/jdk-mvn-py3
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - gradle-it-{{ checksum "build.gradle" }}
+      - run:
+          name: Integration Tests
+          command: cd integration_tests/tracecontext && ./tracecontext-integration-test.sh
+      - run:
+          <<: *publish_snapshots_task
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: gradle-it-{{ checksum "build.gradle" }}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,12 +114,13 @@ jobs:
       _JAVA_OPTIONS: "-Xmx1g"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
     docker:
-      - image: openkbs/jdk-mvn-py3
+      - image: circleci/openjdk:8-jdk
     steps:
       - checkout
       - restore_cache:
           keys:
             - gradle-w3c-{{ checksum "build.gradle" }}
+      - run: sudo apt-get update && sudo apt-get install python3 && sudo apt-get install python3-pip
       - run:
           name: Integration Tests
           command: cd integration_tests/tracecontext && ./tracecontext-integration-test.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
       - restore_cache:
           keys:
             - gradle-w3c-{{ checksum "build.gradle" }}
-      - run: sudo add-apt-repository ppa:jonathonf/python-3.6 && sudo apt-get update && sudo apt-get install python3.6 && sudo apt-get install python3-pip
+      - run: sudo add-apt-repository ppa:deadsnakes/ppa && sudo apt-get update && sudo apt-get install python3.6 && sudo apt-get install python3-pip
       - run:
           name: Integration Tests
           command: cd integration_tests/tracecontext && ./tracecontext-integration-test.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,28 @@ jobs:
           paths:
             - ~/.gradle
           key: gradle-{{ checksum "build.gradle" }}
+# Integration tests
+  integration-tests:
+    environment:
+      # Configure the JVM and Gradle to avoid OOM errors
+      _JAVA_OPTIONS: "-Xmx1g"
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
+      docker:
+        - image: elancapital/docker-java-python3
+      steps:
+        - checkout
+        - restore_cache:
+            keys:
+              - gradle-it-{{ checksum "build.gradle" }}
+        - run:
+            name: Integration Tests
+            command: cd integration_tests/tracecontext && ./tracecontext-integration-test.sh
+        - run:
+            <<: *publish_snapshots_task
+        - save_cache:
+            paths:
+              - ~/.gradle
+            key: gradle-it-{{ checksum "build.gradle" }}
 
 workflows:
   version: 2
@@ -114,6 +136,7 @@ workflows:
     jobs:
       - build
       - java11
+      - integration-tests
   build_and_release:
     jobs:
       - release_job:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
       - restore_cache:
           keys:
             - gradle-w3c-{{ checksum "build.gradle" }}
-      - run: sudo apt-get update && sudo apt-get install python3.6 && sudo apt-get install python3-pip
+      - run: sudo add-apt-repository ppa:jonathonf/python-3.6 && sudo apt-get update && sudo apt-get install python3.6 && sudo apt-get install python3-pip
       - run:
           name: Integration Tests
           command: cd integration_tests/tracecontext && ./tracecontext-integration-test.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
       - restore_cache:
           keys:
             - gradle-w3c-{{ checksum "build.gradle" }}
-      - run: sudo add-apt-repository ppa:deadsnakes/ppa && sudo apt-get update && sudo apt-get install python3.6 && sudo apt-get install python3-pip
+      - run: sudo add-apt-repository ppa:deadsnakes/ppa && sudo apt-get update && sudo apt-get install python3.6 && sudo apt-get install python3-pip && /usr/bin/pip3 --version
       - run:
           name: Integration Tests
           command: cd integration_tests/tracecontext && ./tracecontext-integration-test.sh

--- a/all/build.gradle
+++ b/all/build.gradle
@@ -19,6 +19,7 @@ def subprojects = [
         project(':opentelemetry-exporters-prometheus'),
         project(':opentelemetry-exporters-zipkin'),
         project(':opentelemetry-integration-tests'),
+        project(':opentelemetry-integration-tests-tracecontext'),
         project(':opentelemetry-opentracing-shim'),
         project(':opentelemetry-sdk-common'),
         project(':opentelemetry-sdk-correlation-context'),

--- a/integration_tests/tracecontext/README.md
+++ b/integration_tests/tracecontext/README.md
@@ -2,6 +2,10 @@
 
 Based on https://github.com/w3c/trace-context/tree/master/test
 
+Environmental requirements:
+- System with bourne shell e.g. linux, macOS
+- Python version >= 3.6.0
+
 ```shell script
 ./tracecontext-integration-test.sh
 ```

--- a/integration_tests/tracecontext/README.md
+++ b/integration_tests/tracecontext/README.md
@@ -1,0 +1,7 @@
+# OpenTelemetry W3C Context Propagation tests
+
+Based on https://github.com/w3c/trace-context/tree/master/test
+
+```shell script
+./tracecontext-integration-test.sh
+```

--- a/integration_tests/tracecontext/README.md
+++ b/integration_tests/tracecontext/README.md
@@ -5,6 +5,7 @@ Based on https://github.com/w3c/trace-context/tree/master/test
 Environmental requirements:
 - System with bourne shell e.g. linux, macOS
 - Python version >= 3.6.0
+- pip3
 
 ```shell script
 ./tracecontext-integration-test.sh

--- a/integration_tests/tracecontext/build.gradle
+++ b/integration_tests/tracecontext/build.gradle
@@ -1,11 +1,20 @@
 plugins {
     id 'java'
-    id "application"
 }
 
 description = 'OpenTelemetry W3C Context Propagation Integration Tests'
 ext.moduleName = "io.opentelemetry.tracecontext.integration.tests"
 
+
+// create a single Jar with all dependencies
+task fatJar(type: Jar) {
+    manifest {
+        attributes 'Main-Class': 'io.opentelemetry.Application'
+    }
+    archiveName = 'tracecontext-tests.jar'
+    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
+    with jar
+}
 
 dependencies {
     api project(':opentelemetry-api')
@@ -17,10 +26,3 @@ dependencies {
         "com.google.code.gson:gson:2.8.6"
 }
 
-ext {
-    javaMainClass = "io.opentelemetry.Application"
-}
-
-application {
-    mainClassName = javaMainClass
-}

--- a/integration_tests/tracecontext/build.gradle
+++ b/integration_tests/tracecontext/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'java'
+    id "application"
+}
+
+description = 'OpenTelemetry W3C Context Propagation Integration Tests'
+ext.moduleName = "io.opentelemetry.tracecontext.integration.tests"
+
+
+dependencies {
+    api project(':opentelemetry-api')
+
+    implementation project(':opentelemetry-sdk'),
+        project(':opentelemetry-extension-trace-propagators'),
+        "com.sparkjava:spark-core:2.9.2",
+        "com.squareup.okhttp3:okhttp:3.14.9",
+        "com.google.code.gson:gson:2.8.6"
+}
+
+ext {
+    javaMainClass = "io.opentelemetry.Application"
+}
+
+application {
+    mainClassName = javaMainClass
+}

--- a/integration_tests/tracecontext/src/main/java/io/opentelemetry/Application.java
+++ b/integration_tests/tracecontext/src/main/java/io/opentelemetry/Application.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry;
+
+import com.google.gson.Gson;
+import io.grpc.Context;
+import io.opentelemetry.context.propagation.TextMapPropagator.Getter;
+import io.opentelemetry.context.propagation.TextMapPropagator.Setter;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.TracingContextUtils;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.RequestBody;
+import spark.Request;
+import spark.Response;
+import spark.Route;
+import spark.Spark;
+
+public class Application {
+  private static final Logger logger = Logger.getLogger(Application.class.getName());
+
+  private Application() {}
+
+  /** Entry point. */
+  public static void main(String[] args) {
+    Spark.port(5000);
+    Spark.post(
+        "verify-tracecontext",
+        new Route() {
+          @Override
+          public Object handle(Request request, Response response) {
+            final Gson gson = new Gson();
+
+            final io.opentelemetry.Request[] requests =
+                gson.fromJson(request.body(), io.opentelemetry.Request[].class);
+
+            Context context =
+                OpenTelemetry.getPropagators()
+                    .getTextMapPropagator()
+                    .extract(
+                        Context.current(),
+                        request,
+                        new Getter<Request>() {
+                          @Override
+                          public String get(Request carrier, String key) {
+                            return carrier.headers(key);
+                          }
+                        });
+
+            for (io.opentelemetry.Request req : requests) {
+              final Span.Builder builder =
+                  OpenTelemetry.getTracer("validation-server")
+                      .spanBuilder("Entering Validation Server");
+
+              Span parent = TracingContextUtils.getSpanWithoutDefault(context);
+              if (parent != null) {
+                builder.setParent(parent);
+              }
+              Span span = builder.startSpan();
+
+              Context withSpanContext = TracingContextUtils.withSpan(span, context);
+
+              // Make a new request using the builder
+              okhttp3.Request.Builder reqBuilder = new okhttp3.Request.Builder();
+
+              // Inject the current context into the new request.
+              OpenTelemetry.getPropagators()
+                  .getTextMapPropagator()
+                  .inject(
+                      withSpanContext,
+                      reqBuilder,
+                      new Setter<okhttp3.Request.Builder>() {
+                        @Override
+                        public void set(okhttp3.Request.Builder carrier, String key, String value) {
+                          carrier.addHeader(key, value);
+                        }
+                      });
+
+              // Add the post body and build the request
+              String argumentsJson = gson.toJson(req.getArguments());
+              RequestBody argumentsBody =
+                  RequestBody.create(
+                      MediaType.parse("application/json; charset=utf-8"), argumentsJson);
+              okhttp3.Request newRequest = reqBuilder.url(req.getUrl()).post(argumentsBody).build();
+
+              // Execute the request
+              OkHttpClient client = new OkHttpClient();
+              try (okhttp3.Response res = client.newCall(newRequest).execute()) {
+                logger.info("response: " + res.code());
+              } catch (Exception e) {
+                logger.log(Level.SEVERE, "failed to send", e);
+              }
+              span.end();
+            }
+
+            return "Done";
+          }
+        });
+
+    Spark.awaitInitialization();
+  }
+}

--- a/integration_tests/tracecontext/src/main/java/io/opentelemetry/Request.java
+++ b/integration_tests/tracecontext/src/main/java/io/opentelemetry/Request.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry;
+
+import java.util.Arrays;
+
+public class Request {
+  private String url;
+  private Request[] arguments;
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  public Request[] getArguments() {
+    return arguments;
+  }
+
+  public void setArguments(Request[] arguments) {
+    this.arguments = arguments;
+  }
+
+  @Override
+  public String toString() {
+    return "Request{" + "url='" + url + '\'' + ", arguments=" + Arrays.toString(arguments) + '}';
+  }
+}

--- a/integration_tests/tracecontext/tracecontext-integration-test.sh
+++ b/integration_tests/tracecontext/tracecontext-integration-test.sh
@@ -7,8 +7,8 @@ mkdir -p target
 rm -rf ./target/trace-context
 git clone https://github.com/w3c/trace-context ./target/trace-context
 cd ./target/trace-context && git checkout $TRACECONTEXT_GIT_TAG && cd -
-pip3 install setuptools;
-pip3 install aiohttp;
+pip install setuptools;
+pip install aiohttp;
 ../../gradlew fatJar
 java -jar build/libs/tracecontext-tests.jar 1>&2 &
 EXAMPLE_SERVER_PID=$!

--- a/integration_tests/tracecontext/tracecontext-integration-test.sh
+++ b/integration_tests/tracecontext/tracecontext-integration-test.sh
@@ -7,8 +7,8 @@ mkdir -p target
 rm -rf ./target/trace-context
 git clone https://github.com/w3c/trace-context ./target/trace-context
 cd ./target/trace-context && git checkout $TRACECONTEXT_GIT_TAG && cd -
-pip install setuptools;
-pip install aiohttp;
+pip3 install setuptools;
+pip3 install aiohttp;
 ../../gradlew fatJar
 java -jar build/libs/tracecontext-tests.jar 1>&2 &
 EXAMPLE_SERVER_PID=$!

--- a/integration_tests/tracecontext/tracecontext-integration-test.sh
+++ b/integration_tests/tracecontext/tracecontext-integration-test.sh
@@ -7,8 +7,8 @@ mkdir -p target
 rm -rf ./target/trace-context
 git clone https://github.com/w3c/trace-context ./target/trace-context
 cd ./target/trace-context && git checkout $TRACECONTEXT_GIT_TAG && cd -
-/usr/local/bin/pip3 install setuptools;
-/usr/local/bin/pip3 install aiohttp;
+pip3 install setuptools;
+pip3 install aiohttp;
 ../../gradlew fatJar
 java -jar build/libs/tracecontext-tests.jar 1>&2 &
 EXAMPLE_SERVER_PID=$!

--- a/integration_tests/tracecontext/tracecontext-integration-test.sh
+++ b/integration_tests/tracecontext/tracecontext-integration-test.sh
@@ -7,6 +7,7 @@ mkdir -p target
 rm -rf ./target/trace-context
 git clone https://github.com/w3c/trace-context ./target/trace-context
 cd ./target/trace-context && git checkout $TRACECONTEXT_GIT_TAG && cd -
+export PATH=/usr/local/bin:$PATH
 pip3 install setuptools;
 pip3 install aiohttp;
 ../../gradlew fatJar

--- a/integration_tests/tracecontext/tracecontext-integration-test.sh
+++ b/integration_tests/tracecontext/tracecontext-integration-test.sh
@@ -9,8 +9,8 @@ git clone https://github.com/w3c/trace-context ./target/trace-context
 cd ./target/trace-context && git checkout $TRACECONTEXT_GIT_TAG && cd -
 pip3 install setuptools;
 pip3 install aiohttp;
-../../gradlew build
-../../gradlew run 1>&2 &
+../../gradlew fatJar
+java -jar build/libs/tracecontext-tests.jar 1>&2 &
 EXAMPLE_SERVER_PID=$!
 # give the app server a little time to start up. Not adding some sort
 # of delay would cause many of the tracecontext tests to fail being

--- a/integration_tests/tracecontext/tracecontext-integration-test.sh
+++ b/integration_tests/tracecontext/tracecontext-integration-test.sh
@@ -18,6 +18,8 @@ EXAMPLE_SERVER_PID=$!
 sleep 5
 onshutdown()
 {
+    # sleep for printing test results
+    sleep 2
     kill $EXAMPLE_SERVER_PID
 }
 trap onshutdown EXIT

--- a/integration_tests/tracecontext/tracecontext-integration-test.sh
+++ b/integration_tests/tracecontext/tracecontext-integration-test.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+# hard-coding the git tag to ensure stable builds.
+TRACECONTEXT_GIT_TAG="98f210efd89c63593dce90e2bae0a1bdcb986f51"
+# clone w3c tracecontext tests
+mkdir -p target
+rm -rf ./target/trace-context
+git clone https://github.com/w3c/trace-context ./target/trace-context
+cd ./target/trace-context && git checkout $TRACECONTEXT_GIT_TAG && cd -
+pip3 install setuptools;
+pip3 install aiohttp;
+../../gradlew build
+../../gradlew run 1>&2 &
+EXAMPLE_SERVER_PID=$!
+# give the app server a little time to start up. Not adding some sort
+# of delay would cause many of the tracecontext tests to fail being
+# unable to connect.
+sleep 5
+onshutdown()
+{
+    kill $EXAMPLE_SERVER_PID
+}
+trap onshutdown EXIT
+export STRICT_LEVEL=1
+cd ./target/trace-context/test
+python3 test.py http://127.0.0.1:5000/verify-tracecontext

--- a/integration_tests/tracecontext/tracecontext-integration-test.sh
+++ b/integration_tests/tracecontext/tracecontext-integration-test.sh
@@ -7,9 +7,8 @@ mkdir -p target
 rm -rf ./target/trace-context
 git clone https://github.com/w3c/trace-context ./target/trace-context
 cd ./target/trace-context && git checkout $TRACECONTEXT_GIT_TAG && cd -
-export PATH=/usr/local/bin:$PATH
-pip3 install setuptools;
-pip3 install aiohttp;
+/usr/local/bin/pip3 install setuptools;
+/usr/local/bin/pip3 install aiohttp;
 ../../gradlew fatJar
 java -jar build/libs/tracecontext-tests.jar 1>&2 &
 EXAMPLE_SERVER_PID=$!

--- a/settings.gradle
+++ b/settings.gradle
@@ -32,6 +32,7 @@ include ":opentelemetry-all",
         ":opentelemetry-exporters-prometheus",
         ":opentelemetry-exporters-zipkin",
         ":opentelemetry-integration-tests",
+        ":opentelemetry-integration-tests-tracecontext",
         ":opentelemetry-opentracing-shim",
         ":opentelemetry-proto",
         ":opentelemetry-sdk-common",
@@ -51,6 +52,7 @@ include ":opentelemetry-all",
 
 rootProject.children.each {
     it.projectDir = "$rootDir/" + it.name
+        .replace("opentelemetry-integration-tests-", "integration_tests/")
         .replace("opentelemetry-exporters-", "exporters/")
         .replace("opentelemetry-extension-", "extensions/")
         .replace("opentelemetry-sdk-extension-", "sdk_extensions/")


### PR DESCRIPTION
It's already done for Python and JS.
Although most of the tests pass there are some which fail.
Because execution of the tests is not part of the circleci workflow it doesn't affect build.
```
----------------------------------------------------------------------
Ran 40 tests in 1.220s

FAILED (failures=3, skipped=6)
```
