### PR TITLE
Remove instructions on generating javadoc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,15 +66,7 @@ It does not support all required rules, so you still have to run `googleJavaForm
   Javadoc, though the style of documentation is up to the author.
 * Try to do the least amount of change when modifying existing documentation.
   Don't change the style unless you have a good reason.
-
-``` sh
-$ git checkout -b docs
-$ ./gradlew javadoc
-$ rm -fr docs/*
-$ cp -R api/build/docs/javadoc/* docs
-$ git add -A .
-$ git commit -m "Update javadoc for API."
-```
+* Our javadoc is available via [javadoc.io}(https://javadoc.io/doc/io.opentelemetry/opentelemetry-api)
 
 ### AutoValue
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This project contains the following top level components:
 * [sdk](sdk/): The reference implementation complying to the OpenTelemetry API.
 * [sdk_extensions](sdk_extensions/): Additional extensions to SDK.
 * [OpenTracing shim](opentracing_shim/): A bridge layer from OpenTelemetry to the OpenTracing API.
+* [Examples](examples/): Various examples on how to use the APIs, SDK, and standard exporters.
 
 We would love to hear from the larger community: please provide feedback proactively.
 


### PR DESCRIPTION
And, add a link in the README to the examples