### PR TITLE
Updated Sampling Result names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,15 +66,7 @@ It does not support all required rules, so you still have to run `googleJavaForm
   Javadoc, though the style of documentation is up to the author.
 * Try to do the least amount of change when modifying existing documentation.
   Don't change the style unless you have a good reason.
-
-``` sh
-$ git checkout -b docs
-$ ./gradlew javadoc
-$ rm -fr docs/*
-$ cp -R api/build/docs/javadoc/* docs
-$ git add -A .
-$ git commit -m "Update javadoc for API."
-```
+* Our javadoc is available via [javadoc.io}(https://javadoc.io/doc/io.opentelemetry/opentelemetry-api)
 
 ### AutoValue
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This project contains the following top level components:
 * [sdk](sdk/): The reference implementation complying to the OpenTelemetry API.
 * [sdk_extensions](sdk_extensions/): Additional extensions to SDK.
 * [OpenTracing shim](opentracing_shim/): A bridge layer from OpenTelemetry to the OpenTracing API.
+* [Examples](examples/): Various examples on how to use the APIs, SDK, and standard exporters.
 
 We would love to hear from the larger community: please provide feedback proactively.
 

--- a/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureTraceExample.java
+++ b/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureTraceExample.java
@@ -119,7 +119,7 @@ class ConfigureTraceExample {
           List<Link> parentLinks) {
         // We sample only if the Span name contains "SAMPLE"
         return Samplers.emptySamplingResult(
-            name.contains("SAMPLE") ? Decision.RECORD_AND_SAMPLED : Decision.NOT_RECORD);
+            name.contains("SAMPLE") ? Decision.RECORD_AND_SAMPLE : Decision.DROP);
       }
 
       @Override

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -38,7 +38,6 @@ public final class OpenTelemetrySdk {
    * Returns a {@link TracerSdkProvider}.
    *
    * @return TracerProvider returned by {@link OpenTelemetry#getTracerProvider()}.
-   * @since 0.1.0
    */
   public static TracerSdkProvider getTracerProvider() {
     return (TracerSdkProvider) ((Obfuscated<?>) OpenTelemetry.getTracerProvider()).unobfuscate();
@@ -48,7 +47,6 @@ public final class OpenTelemetrySdk {
    * Returns a {@link MeterSdkProvider}.
    *
    * @return MeterProvider returned by {@link OpenTelemetry#getMeterProvider()}.
-   * @since 0.1.0
    */
   public static MeterSdkProvider getMeterProvider() {
     return (MeterSdkProvider) OpenTelemetry.getMeterProvider();
@@ -58,7 +56,6 @@ public final class OpenTelemetrySdk {
    * Returns a {@link CorrelationContextManagerSdk}.
    *
    * @return context manager returned by {@link OpenTelemetry#getCorrelationContextManager()}.
-   * @since 0.1.0
    */
   public static CorrelationContextManagerSdk getCorrelationContextManager() {
     return (CorrelationContextManagerSdk) OpenTelemetry.getCorrelationContextManager();

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/Clock.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/Clock.java
@@ -16,17 +16,12 @@
 
 package io.opentelemetry.sdk.common;
 
-/**
- * Interface for getting the current time.
- *
- * @since 0.1.0
- */
+/** Interface for getting the current time. */
 public interface Clock {
   /**
    * Obtains the current epoch timestamp in nanos from this clock.
    *
    * @return the current epoch timestamp in nanos.
-   * @since 0.1.0
    */
   long now();
 
@@ -36,7 +31,6 @@ public interface Clock {
    *
    * @return a time measurement with nanosecond precision that can only be used to calculate elapsed
    *     time.
-   * @since 0.1.0
    */
   long nanoTime();
 }

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/TestClock.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/TestClock.java
@@ -21,11 +21,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
-/**
- * A mutable {@link Clock} that allows the time to be set for testing.
- *
- * @since 0.1.0
- */
+/** A mutable {@link Clock} that allows the time to be set for testing. */
 @ThreadSafe
 public class TestClock implements Clock {
 
@@ -40,7 +36,6 @@ public class TestClock implements Clock {
    * Creates a clock initialized to a constant non-zero time.
    *
    * @return a clock initialized to a constant non-zero time.
-   * @since 0.1.0
    */
   public static TestClock create() {
     // Set Time to Tuesday, May 7, 2019 12:00:00 AM GMT-07:00 DST
@@ -52,7 +47,6 @@ public class TestClock implements Clock {
    *
    * @param epochNanos the initial time in nanos since epoch.
    * @return a new {@code TestClock} with the given time.
-   * @since 0.1.0
    */
   public static TestClock create(long epochNanos) {
     return new TestClock(epochNanos);
@@ -62,7 +56,6 @@ public class TestClock implements Clock {
    * Sets the time.
    *
    * @param epochNanos the new time.
-   * @since 0.1.0
    */
   public synchronized void setTime(long epochNanos) {
     currentEpochNanos = epochNanos;
@@ -72,7 +65,6 @@ public class TestClock implements Clock {
    * Advances the time by millis and mutates this instance.
    *
    * @param millis the increase in time.
-   * @since 0.1.0
    */
   public synchronized void advanceMillis(long millis) {
     long nanos = TimeUnit.MILLISECONDS.toNanos(millis);
@@ -83,7 +75,6 @@ public class TestClock implements Clock {
    * Advances the time by nanos and mutates this instance.
    *
    * @param nanos the increase in time.
-   * @since 0.1.0
    */
   public synchronized void advanceNanos(long nanos) {
     currentEpochNanos += nanos;

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/resources/EnvAutodetectResource.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/resources/EnvAutodetectResource.java
@@ -26,8 +26,6 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * Provides a framework for detection of resource information from the environment variable
  * "OTEL_RESOURCE_ATTRIBUTES" and system properties "otel.resource.attributes".
- *
- * @since 0.1.0
  */
 @ThreadSafe
 final class EnvAutodetectResource {

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/resources/Resource.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/resources/Resource.java
@@ -33,8 +33,6 @@ import javax.annotation.concurrent.Immutable;
 /**
  * {@link Resource} represents a resource, which capture identifying information about the entities
  * for which signals (stats or traces) are reported.
- *
- * @since 0.1.0
  */
 @Immutable
 @AutoValue
@@ -96,7 +94,6 @@ public abstract class Resource {
    * Returns an empty {@link Resource}.
    *
    * @return an empty {@code Resource}.
-   * @since 0.1.0
    */
   public static Resource getEmpty() {
     return EMPTY;
@@ -106,7 +103,6 @@ public abstract class Resource {
    * Returns the telemetry sdk {@link Resource}.
    *
    * @return a {@code Resource} with telemetry sdk attributes.
-   * @since 0.6.0
    */
   public static Resource getTelemetrySdk() {
     return TELEMETRY_SDK;
@@ -116,7 +112,6 @@ public abstract class Resource {
    * Returns a map of attributes that describe the resource.
    *
    * @return a map of attributes.
-   * @since 0.1.0
    */
   public abstract ReadableAttributes getAttributes();
 
@@ -132,7 +127,6 @@ public abstract class Resource {
    * @throws NullPointerException if {@code attributes} is null.
    * @throws IllegalArgumentException if attribute key or attribute value is not a valid printable
    *     ASCII string or exceed {@link #MAX_LENGTH} characters.
-   * @since 0.1.0
    */
   public static Resource create(Attributes attributes) {
     checkAttributes(Objects.requireNonNull(attributes, "attributes"));
@@ -155,7 +149,6 @@ public abstract class Resource {
    *
    * @param other the {@code Resource} that will be merged with {@code this}.
    * @return the newly merged {@code Resource}.
-   * @since 0.1.0
    */
   public Resource merge(@Nullable Resource other) {
     if (other == null) {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/InstrumentRegistry.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/InstrumentRegistry.java
@@ -22,12 +22,13 @@ import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-// Basic registry class for metrics instruments. The current implementation allows instruments to be
-// registered only once for a given name.
-//
-// TODO: Discuss what is the right behavior when an already registered Instrument with the same name
-//  is present.
-// TODO: Decide what is the identifier for an Instrument? Only name?
+/**
+ * Basic registry class for metrics instruments. The current implementation allows instruments to be
+ * registered only once for a given name.
+ *
+ * <p>TODO: Discuss what is the right behavior when an already registered Instrument with the same
+ * name is present. TODO: Decide what is the identifier for an Instrument? Only name?
+ */
 final class InstrumentRegistry {
   private final ConcurrentMap<String, AbstractInstrument> registry = new ConcurrentHashMap<>();
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/MeterSdkProvider.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/MeterSdkProvider.java
@@ -87,8 +87,6 @@ public final class MeterSdkProvider implements MeterProvider {
   /**
    * Builder class for the {@link MeterSdkProvider}. Has fully functional default implementations of
    * all three required interfaces.
-   *
-   * @since 0.4.0
    */
   public static final class Builder {
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/MetricData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/MetricData.java
@@ -26,8 +26,6 @@ import javax.annotation.concurrent.Immutable;
 
 /**
  * A {@link MetricData} represents the data exported as part of aggregating one {@code Instrument}.
- *
- * @since 0.1.0
  */
 @Immutable
 @AutoValue
@@ -38,7 +36,6 @@ public abstract class MetricData {
    * Returns the {@link Descriptor} of this metric.
    *
    * @return the {@code Descriptor} of this metric.
-   * @since 0.1.0
    */
   public abstract Descriptor getDescriptor();
 
@@ -46,7 +43,6 @@ public abstract class MetricData {
    * Returns the resource of this {@code MetricData}.
    *
    * @return the resource of this {@code MetricData}.
-   * @since 0.1.0
    */
   public abstract Resource getResource();
 
@@ -65,7 +61,6 @@ public abstract class MetricData {
    * is determined by the {@link Descriptor.Type}.
    *
    * @return the data {@link Point}s for this metric, or empty {@code Collection} if no points.
-   * @since 0.3.0
    */
   public abstract Collection<Point> getPoints();
 
@@ -86,7 +81,6 @@ public abstract class MetricData {
      * the metric was created or an aggregation was enabled.
      *
      * @return the start epoch timestamp in nanos.
-     * @since 0.3.0
      */
     public abstract long getStartEpochNanos();
 
@@ -95,7 +89,6 @@ public abstract class MetricData {
      * moment when {@code Instrument.getData()} was called.
      *
      * @return the epoch timestamp in nanos.
-     * @since 0.3.0
      */
     public abstract long getEpochNanos();
 
@@ -221,50 +214,26 @@ public abstract class MetricData {
     }
   }
 
-  /**
-   * {@link Descriptor} defines metadata about the {@code MetricData} type and its schema.
-   *
-   * @since 0.1.0
-   */
+  /** {@link Descriptor} defines metadata about the {@code MetricData} type and its schema. */
   @Immutable
   @AutoValue
   public abstract static class Descriptor {
 
     Descriptor() {}
 
-    /**
-     * The kind of metric. It describes how the data is reported.
-     *
-     * @since 0.1.0
-     */
+    /** The kind of metric. It describes how the data is reported. */
     public enum Type {
 
-      /**
-       * An instantaneous measurement of a long (int64) value. Reports {@link LongPoint} points.
-       *
-       * @since 0.1.0
-       */
+      /** An instantaneous measurement of a long (int64) value. Reports {@link LongPoint} points. */
       NON_MONOTONIC_LONG,
 
-      /**
-       * An instantaneous measurement of a double value. Reports {@link DoublePoint} points.
-       *
-       * @since 0.1.0
-       */
+      /** An instantaneous measurement of a double value. Reports {@link DoublePoint} points. */
       NON_MONOTONIC_DOUBLE,
 
-      /**
-       * An cumulative measurement of an long (int64) value. Reports {@link LongPoint} points.
-       *
-       * @since 0.1.0
-       */
+      /** An cumulative measurement of an long (int64) value. Reports {@link LongPoint} points. */
       MONOTONIC_LONG,
 
-      /**
-       * An cumulative measurement of a double value. Reports {@link DoublePoint} points.
-       *
-       * @since 0.1.0
-       */
+      /** An cumulative measurement of a double value. Reports {@link DoublePoint} points. */
       MONOTONIC_DOUBLE,
 
       /**
@@ -279,7 +248,6 @@ public abstract class MetricData {
      * Returns the metric descriptor name.
      *
      * @return the metric descriptor name.
-     * @since 0.1.0
      */
     public abstract String getName();
 
@@ -287,7 +255,6 @@ public abstract class MetricData {
      * Returns the description of this metric descriptor.
      *
      * @return the description of this metric descriptor.
-     * @since 0.1.0
      */
     public abstract String getDescription();
 
@@ -295,7 +262,6 @@ public abstract class MetricData {
      * Returns the unit of this metric descriptor.
      *
      * @return the unit of this metric descriptor.
-     * @since 0.1.0
      */
     public abstract String getUnit();
 
@@ -303,7 +269,6 @@ public abstract class MetricData {
      * Returns the type of this metric descriptor.
      *
      * @return the type of this metric descriptor.
-     * @since 0.1.0
      */
     public abstract Type getType();
 
@@ -311,7 +276,6 @@ public abstract class MetricData {
      * Returns the constant labels associated with this metric descriptor.
      *
      * @return the constant labels associated with this metric descriptor.
-     * @since 0.1.0
      */
     public abstract Labels getConstantLabels();
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
@@ -55,8 +55,6 @@ import javax.annotation.concurrent.Immutable;
  * <ul>
  *   <li>{@code OTEL_IMR_EXPORT_INTERVAL}: sets the export interval between pushes to the exporter.
  * </ul>
- *
- * @since 0.3.0
  */
 public final class IntervalMetricReader {
   private static final Logger logger = Logger.getLogger(IntervalMetricReader.class.getName());
@@ -64,11 +62,7 @@ public final class IntervalMetricReader {
   private final Exporter exporter;
   private final ScheduledExecutorService scheduler;
 
-  /**
-   * Stops the scheduled task and calls export one more time.
-   *
-   * @since 0.3.0
-   */
+  /** Stops the scheduled task and calls export one more time. */
   public void shutdown() {
     scheduler.shutdown();
     try {
@@ -105,11 +99,7 @@ public final class IntervalMetricReader {
     return builder().readEnvironmentVariables().readSystemProperties();
   }
 
-  /**
-   * Builder for {@link IntervalMetricReader}.
-   *
-   * @since 0.3.0
-   */
+  /** Builder for {@link IntervalMetricReader}. */
   public static final class Builder extends ConfigBuilder<Builder> {
     private final InternalState.Builder optionsBuilder;
     private static final String KEY_EXPORT_INTERVAL = "otel.imr.export.interval";
@@ -123,7 +113,6 @@ public final class IntervalMetricReader {
      *
      * @param exportIntervalMillis the export interval between pushes to the exporter.
      * @return this.
-     * @since 0.3.0
      */
     public Builder setExportIntervalMillis(long exportIntervalMillis) {
       optionsBuilder.setExportIntervalMillis(exportIntervalMillis);
@@ -135,7 +124,6 @@ public final class IntervalMetricReader {
      *
      * @param metricExporter the {@link MetricExporter} to be called when export metrics.
      * @return this.
-     * @since 0.3.0
      */
     public Builder setMetricExporter(MetricExporter metricExporter) {
       optionsBuilder.setMetricExporter(metricExporter);
@@ -148,7 +136,6 @@ public final class IntervalMetricReader {
      * @param metricProducers a collection of {@link MetricProducer} from where the metrics should
      *     be read.
      * @return this.
-     * @since 0.3.0
      */
     public Builder setMetricProducers(Collection<MetricProducer> metricProducers) {
       optionsBuilder.setMetricProducers(metricProducers);
@@ -159,7 +146,6 @@ public final class IntervalMetricReader {
      * Builds a new {@link IntervalMetricReader} with current settings.
      *
      * @return a {@code IntervalMetricReader}.
-     * @since 0.3.0
      */
     public IntervalMetricReader build() {
       InternalState internalState = optionsBuilder.build();

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/MetricExporter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/MetricExporter.java
@@ -25,8 +25,6 @@ import java.util.Collection;
  * export metrics to the OpenTelemetry exporters.
  *
  * <p>All OpenTelemetry exporters should allow access to a {@code MetricExporter} instance.
- *
- * @since 0.1.0
  */
 public interface MetricExporter {
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/MetricProducer.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/MetricProducer.java
@@ -26,8 +26,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * #collectAllMetrics()} will return any metric generated since the last call was made.
  *
  * <p>Implementations must be thread-safe.
- *
- * @since 0.3.0
  */
 @ThreadSafe
 public interface MetricProducer {
@@ -36,7 +34,6 @@ public interface MetricProducer {
    * metrics that have been produced since the last time this method was called.
    *
    * @return a collection of produced {@link MetricData}s to be exported.
-   * @since 0.17
    */
   Collection<MetricData> collectAllMetrics();
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/Aggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/Aggregation.java
@@ -25,8 +25,6 @@ import javax.annotation.concurrent.Immutable;
 /**
  * {@link Aggregation} is the process of combining a certain set of recorded measurements for a
  * given {@code Instrument} into the equivalent {@code MetricData}.
- *
- * @since 0.1.0
  */
 @Immutable
 public interface Aggregation {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/Aggregations.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/Aggregations.java
@@ -35,7 +35,6 @@ public class Aggregations {
    * Returns an {@code Aggregation} that calculates sum of recorded measurements.
    *
    * @return an {@code Aggregation} that calculates sum of recorded measurements.
-   * @since 0.1.0
    */
   public static Aggregation sum() {
     return Sum.INSTANCE;
@@ -47,7 +46,6 @@ public class Aggregations {
    *
    * @return an {@code Aggregation} that calculates count of recorded measurements (the number of
    *     recorded * measurements).
-   * @since 0.1.0
    */
   public static Aggregation count() {
     return Count.INSTANCE;
@@ -61,7 +59,6 @@ public class Aggregations {
    *
    * @param bucketBoundaries bucket boundaries to use for distribution.
    * @return an {@code Aggregation} that calculates distribution stats on recorded measurements.
-   * @since 0.1.0
    */
   public static Aggregation distributionWithExplicitBounds(Double... bucketBoundaries) {
     return new Distribution(bucketBoundaries);
@@ -71,7 +68,6 @@ public class Aggregations {
    * Returns an {@code Aggregation} that calculates the last value of all recorded measurements.
    *
    * @return an {@code Aggregation} that calculates the last value of all recorded measurements.
-   * @since 0.1.0
    */
   public static Aggregation lastValue() {
     return LastValue.INSTANCE;
@@ -83,7 +79,6 @@ public class Aggregations {
    * value recorded and the minimum value recorded.
    *
    * @return an {@code Aggregation} that calculates a simple summary of all recorded measurements.
-   * @since 0.3.0
    */
   public static Aggregation minMaxSumCount() {
     return MinMaxSumCount.INSTANCE;

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
@@ -30,7 +30,6 @@ public interface ReadableSpan {
    * <p>Equivalent with {@link Span#getContext()}.
    *
    * @return the {@link SpanContext} of the {@code Span}.
-   * @since 0.1.0
    */
   SpanContext getSpanContext();
 
@@ -41,7 +40,6 @@ public interface ReadableSpan {
    * Span#updateName(String)} so this value cannot be cached.
    *
    * @return the name of the {@code Span}.
-   * @since 0.1.0
    */
   String getName();
 
@@ -49,7 +47,6 @@ public interface ReadableSpan {
    * This converts this instance into an immutable SpanData instance, for use in export.
    *
    * @return an immutable {@link SpanData} instance.
-   * @since 0.1.0
    */
   SpanData toSpanData();
 
@@ -66,7 +63,6 @@ public interface ReadableSpan {
    * Returns whether this Span has already been ended.
    *
    * @return {@code true} if the span has already been ended, {@code false} if not.
-   * @since 0.4.0
    */
   boolean hasEnded();
 
@@ -75,7 +71,6 @@ public interface ReadableSpan {
    * time.
    *
    * @return the latency of the {@code Span} in nanos.
-   * @since 0.4.0
    */
   long getLatencyNanos();
 }

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Sampler.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Sampler.java
@@ -63,9 +63,9 @@ public interface Sampler {
 
   /** A decision on whether a span should be recorded, recorded and sampled or not recorded. */
   enum Decision {
-    NOT_RECORD,
-    RECORD,
-    RECORD_AND_SAMPLED,
+    DROP,
+    RECORD_ONLY,
+    RECORD_AND_SAMPLE,
   }
 
   /**

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Sampler.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Sampler.java
@@ -27,11 +27,7 @@ import io.opentelemetry.trace.TraceId;
 import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
 
-/**
- * Sampler is used to make decisions on {@link Span} sampling.
- *
- * @since 0.1.0
- */
+/** Sampler is used to make decisions on {@link Span} sampling. */
 @ThreadSafe
 public interface Sampler {
   /**
@@ -46,7 +42,6 @@ public interface Sampler {
    * @param attributes list of {@link AttributeValue} with their keys.
    * @param parentLinks the parentLinks associated with the new {@code Span}.
    * @return sampling samplingResult whether span should be sampled or not.
-   * @since 0.1.0
    */
   SamplingResult shouldSample(
       SpanContext parentContext,
@@ -63,7 +58,6 @@ public interface Sampler {
    * <p>Example: "ProbabilitySampler{0.000100}"
    *
    * @return the description of this {@code Sampler}.
-   * @since 0.1.0
    */
   String getDescription();
 
@@ -77,8 +71,6 @@ public interface Sampler {
   /**
    * Sampling result returned by {@link Sampler#shouldSample(SpanContext, String, String, Kind,
    * ReadableAttributes, List)}.
-   *
-   * @since 0.1.0
    */
   interface SamplingResult {
 
@@ -86,7 +78,6 @@ public interface Sampler {
      * Return decision on whether a span should be recorded, recorded and sampled or not recorded.
      *
      * @return sampling result.
-     * @since 0.7.0
      */
     Decision getDecision();
 
@@ -96,7 +87,6 @@ public interface Sampler {
      * @return attributes added to span. These attributes should be added to the span only when
      *     {@linkplain #getDecision() the sampling decision} is {@link Decision#RECORD} or {@link
      *     Decision#RECORD_AND_SAMPLED}.
-     * @since 0.1.0
      */
     Attributes getAttributes();
   }

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Sampler.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Sampler.java
@@ -85,8 +85,8 @@ public interface Sampler {
      * Return tags which will be attached to the span.
      *
      * @return attributes added to span. These attributes should be added to the span only when
-     *     {@linkplain #getDecision() the sampling decision} is {@link Decision#RECORD} or {@link
-     *     Decision#RECORD_AND_SAMPLED}.
+     *     {@linkplain #getDecision() the sampling decision} is {@link Decision#RECORD_ONLY} or
+     *     {@link Decision#RECORD_AND_SAMPLE}.
      */
     Attributes getAttributes();
   }

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -35,11 +35,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
-/**
- * Static class to access a set of pre-defined {@link Sampler Samplers}.
- *
- * @since 0.1.0
- */
+/** Static class to access a set of pre-defined {@link Sampler Samplers}. */
 @Immutable
 public final class Samplers {
 
@@ -124,7 +120,6 @@ public final class Samplers {
    *
    * @return a {@code Sampler} that always makes a "yes" {@link SamplingResult} for {@code Span}
    *     sampling.
-   * @since 0.1.0
    */
   public static Sampler alwaysOn() {
     return AlwaysOnSampler.INSTANCE;
@@ -136,7 +131,6 @@ public final class Samplers {
    *
    * @return a {@code Sampler} that always makes a "no" {@link SamplingResult} for {@code Span}
    *     sampling.
-   * @since 0.1.0
    */
   public static Sampler alwaysOff() {
     return AlwaysOffSampler.INSTANCE;
@@ -151,7 +145,6 @@ public final class Samplers {
    *     not exist.
    * @return a {@code Sampler} that follows the parent's sampling decision if one exists, otherwise
    *     following the root sampler's decision.
-   * @since 0.7.0
    */
   public static Sampler parentBased(Sampler root) {
     return parentBasedBuilder(root).build();
@@ -164,7 +157,6 @@ public final class Samplers {
    * @param root the required {@code Sampler} which is used to make the sampling decisions if the
    *     parent does not exist.
    * @return a {@code ParentBased.Builder}
-   * @since 0.8.0
    */
   public static ParentBased.Builder parentBasedBuilder(Sampler root) {
     return new ParentBased.Builder(root);

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -52,21 +52,21 @@ public final class Samplers {
       DoubleAttributeSetter.create("sampling.probability");
 
   private static final SamplingResult EMPTY_RECORDED_AND_SAMPLED_SAMPLING_RESULT =
-      SamplingResultImpl.createWithoutAttributes(Decision.RECORD_AND_SAMPLED);
+      SamplingResultImpl.createWithoutAttributes(Decision.RECORD_AND_SAMPLE);
   private static final SamplingResult EMPTY_NOT_SAMPLED_OR_RECORDED_SAMPLING_RESULT =
-      SamplingResultImpl.createWithoutAttributes(Decision.NOT_RECORD);
+      SamplingResultImpl.createWithoutAttributes(Decision.DROP);
   private static final SamplingResult EMPTY_RECORDED_SAMPLING_RESULT =
-      SamplingResultImpl.createWithoutAttributes(Decision.RECORD);
+      SamplingResultImpl.createWithoutAttributes(Decision.RECORD_ONLY);
 
   // No instance of this class.
   private Samplers() {}
 
   static boolean isRecording(Decision decision) {
-    return Decision.RECORD.equals(decision) || Decision.RECORD_AND_SAMPLED.equals(decision);
+    return Decision.RECORD_ONLY.equals(decision) || Decision.RECORD_AND_SAMPLE.equals(decision);
   }
 
   static boolean isSampled(Decision decision) {
-    return Decision.RECORD_AND_SAMPLED.equals(decision);
+    return Decision.RECORD_AND_SAMPLE.equals(decision);
   }
 
   /**
@@ -104,11 +104,11 @@ public final class Samplers {
    */
   public static SamplingResult emptySamplingResult(Decision decision) {
     switch (decision) {
-      case RECORD_AND_SAMPLED:
+      case RECORD_AND_SAMPLE:
         return EMPTY_RECORDED_AND_SAMPLED_SAMPLING_RESULT;
-      case RECORD:
+      case RECORD_ONLY:
         return EMPTY_RECORDED_SAMPLING_RESULT;
-      case NOT_RECORD:
+      case DROP:
         return EMPTY_NOT_SAMPLED_OR_RECORDED_SAMPLING_RESULT;
     }
     throw new AssertionError("unrecognised samplingResult");
@@ -445,8 +445,8 @@ public final class Samplers {
       return new AutoValue_Samplers_Probability(
           probability,
           idUpperBound,
-          SamplingResultImpl.createWithProbability(Decision.RECORD_AND_SAMPLED, probability),
-          SamplingResultImpl.createWithProbability(Decision.NOT_RECORD, probability));
+          SamplingResultImpl.createWithProbability(Decision.RECORD_AND_SAMPLE, probability),
+          SamplingResultImpl.createWithProbability(Decision.DROP, probability));
     }
 
     abstract double getProbability();

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/TracerSdkProvider.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/TracerSdkProvider.java
@@ -132,8 +132,6 @@ public class TracerSdkProvider implements TracerProvider {
   /**
    * Builder class for the TracerSdkFactory. Has fully functional default implementations of all
    * three required interfaces.
-   *
-   * @since 0.4.0
    */
   public static class Builder {
 

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
@@ -101,7 +101,6 @@ public abstract class TraceConfig {
    * Returns the default {@code TraceConfig}.
    *
    * @return the default {@code TraceConfig}.
-   * @since 0.1.0
    */
   public static TraceConfig getDefault() {
     return DEFAULT;

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/data/EventImpl.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/data/EventImpl.java
@@ -23,8 +23,6 @@ import javax.annotation.concurrent.Immutable;
 /**
  * An immutable timed event representation. Enhances the core {@link io.opentelemetry.trace.Event}
  * by adding the time at which the event occurred.
- *
- * @since 0.1.0
  */
 @Immutable
 @AutoValue
@@ -37,7 +35,6 @@ public abstract class EventImpl implements SpanData.Event {
    * @param name the name of the {@code Event}.
    * @param attributes the attributes of the {@code Event}.
    * @return a new immutable {@code Event<T>}
-   * @since 0.1.0
    */
   public static EventImpl create(long epochNanos, String name, Attributes attributes) {
     return new AutoValue_EventImpl(name, attributes, epochNanos, attributes.size());
@@ -51,7 +48,6 @@ public abstract class EventImpl implements SpanData.Event {
    * @param attributes the attributes of the {@code Event}.
    * @param totalAttributeCount the total number of attributes for this {@code} Event.
    * @return a new immutable {@code Event<T>}
-   * @since 0.1.0
    */
   public static EventImpl create(
       long epochNanos, String name, Attributes attributes, int totalAttributeCount) {

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
@@ -31,8 +31,6 @@ import javax.annotation.concurrent.Immutable;
 
 /**
  * Immutable representation of all data collected by the {@link io.opentelemetry.trace.Span} class.
- *
- * @since 0.1.0
  */
 @Immutable
 public interface SpanData {
@@ -66,7 +64,6 @@ public interface SpanData {
    * returned will be invalid..
    *
    * @return the parent {@code SpanId} or an invalid SpanId if this is a root {@code Span}.
-   * @since 0.1.0
    */
   String getParentSpanId();
 
@@ -74,7 +71,6 @@ public interface SpanData {
    * Returns the resource of this {@code Span}.
    *
    * @return the resource of this {@code Span}.
-   * @since 0.1.0
    */
   Resource getResource();
 
@@ -90,7 +86,6 @@ public interface SpanData {
    * Returns the name of this {@code Span}.
    *
    * @return the name of this {@code Span}.
-   * @since 0.1.0
    */
   String getName();
 
@@ -98,7 +93,6 @@ public interface SpanData {
    * Returns the kind of this {@code Span}.
    *
    * @return the kind of this {@code Span}.
-   * @since 0.1.0
    */
   Kind getKind();
 
@@ -106,7 +100,6 @@ public interface SpanData {
    * Returns the start epoch timestamp in nanos of this {@code Span}.
    *
    * @return the start epoch timestamp in nanos of this {@code Span}.
-   * @since 0.1.0
    */
   long getStartEpochNanos();
 
@@ -114,7 +107,6 @@ public interface SpanData {
    * Returns the attributes recorded for this {@code Span}.
    *
    * @return the attributes recorded for this {@code Span}.
-   * @since 0.1.0
    */
   ReadableAttributes getAttributes();
 
@@ -122,7 +114,6 @@ public interface SpanData {
    * Returns the timed events recorded for this {@code Span}.
    *
    * @return the timed events recorded for this {@code Span}.
-   * @since 0.1.0
    */
   List<Event> getEvents();
 
@@ -130,7 +121,6 @@ public interface SpanData {
    * Returns links recorded for this {@code Span}.
    *
    * @return links recorded for this {@code Span}.
-   * @since 0.1.0
    */
   List<Link> getLinks();
 
@@ -138,7 +128,6 @@ public interface SpanData {
    * Returns the {@code Status}.
    *
    * @return the {@code Status}.
-   * @since 0.1.0
    */
   Status getStatus();
 
@@ -146,7 +135,6 @@ public interface SpanData {
    * Returns the end epoch timestamp in nanos of this {@code Span}.
    *
    * @return the end epoch timestamp in nanos of this {@code Span}.
-   * @since 0.1.0
    */
   long getEndEpochNanos();
 
@@ -156,7 +144,6 @@ public interface SpanData {
    *
    * @return {@code true} if the parent is on a different process. {@code false} if this is a root
    *     span.
-   * @since 0.3.0
    */
   boolean getHasRemoteParent();
 
@@ -164,7 +151,6 @@ public interface SpanData {
    * Returns whether this Span has already been ended.
    *
    * @return {@code true} if the span has already been ended, {@code false} if not.
-   * @since 0.4.0
    */
   boolean getHasEnded();
 
@@ -195,11 +181,7 @@ public interface SpanData {
    */
   int getTotalAttributeCount();
 
-  /**
-   * An immutable implementation of {@link io.opentelemetry.trace.Link}.
-   *
-   * @since 0.1.0
-   */
+  /** An immutable implementation of {@link io.opentelemetry.trace.Link}. */
   @Immutable
   @AutoValue
   abstract class Link implements io.opentelemetry.trace.Link {
@@ -212,7 +194,6 @@ public interface SpanData {
      *
      * @param spanContext the {@code SpanContext} of this {@code Link}.
      * @return a new immutable {@code Event<T>}
-     * @since 0.1.0
      */
     public static Link create(SpanContext spanContext) {
       return new AutoValue_SpanData_Link(
@@ -225,7 +206,6 @@ public interface SpanData {
      * @param spanContext the {@code SpanContext} of this {@code Link}.
      * @param attributes the attributes of this {@code Link}.
      * @return a new immutable {@code Event<T>}
-     * @since 0.1.0
      */
     public static Link create(SpanContext spanContext, Attributes attributes) {
       return new AutoValue_SpanData_Link(spanContext, attributes, attributes.size());
@@ -238,7 +218,6 @@ public interface SpanData {
      * @param attributes the attributes of this {@code Link}.
      * @param totalAttributeCount the total number of attributed for this {@code Link}.
      * @return a new immutable {@code Event<T>}
-     * @since 0.1.0
      */
     public static Link create(
         SpanContext spanContext, Attributes attributes, int totalAttributeCount) {
@@ -263,7 +242,6 @@ public interface SpanData {
      * Returns the epoch time in nanos of this event.
      *
      * @return the epoch time in nanos of this event.
-     * @since 0.1.0
      */
     long getEpochNanos();
 

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/spi/TracerProviderFactorySdk.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/spi/TracerProviderFactorySdk.java
@@ -22,6 +22,7 @@ import io.opentelemetry.trace.spi.TracerProviderFactory;
 
 /** SDK implementation of the TracerProviderFactory for SPI. */
 public final class TracerProviderFactorySdk implements TracerProviderFactory {
+
   @Override
   public TracerProvider create() {
     return TracerSdkProvider.builder().build();

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -58,30 +58,30 @@ class SamplersTest {
 
   @Test
   void emptySamplingDecision() {
-    assertThat(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLED))
-        .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLED));
-    assertThat(Samplers.emptySamplingResult(Sampler.Decision.NOT_RECORD))
-        .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.NOT_RECORD));
+    assertThat(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLE))
+        .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLE));
+    assertThat(Samplers.emptySamplingResult(Sampler.Decision.DROP))
+        .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.DROP));
 
-    assertThat(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLED).getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+    assertThat(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLE).getDecision())
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
     assertThat(
-            Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLED)
+            Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLE)
                 .getAttributes()
                 .isEmpty())
         .isTrue();
-    assertThat(Samplers.emptySamplingResult(Sampler.Decision.NOT_RECORD).getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
-    assertThat(Samplers.emptySamplingResult(Sampler.Decision.NOT_RECORD).getAttributes().isEmpty())
+    assertThat(Samplers.emptySamplingResult(Sampler.Decision.DROP).getDecision())
+        .isEqualTo(Decision.DROP);
+    assertThat(Samplers.emptySamplingResult(Sampler.Decision.DROP).getAttributes().isEmpty())
         .isTrue();
   }
 
   @Test
   void samplingDecisionEmpty() {
-    assertThat(Samplers.samplingResult(Sampler.Decision.RECORD_AND_SAMPLED, Attributes.empty()))
-        .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLED));
-    assertThat(Samplers.samplingResult(Sampler.Decision.NOT_RECORD, Attributes.empty()))
-        .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.NOT_RECORD));
+    assertThat(Samplers.samplingResult(Sampler.Decision.RECORD_AND_SAMPLE, Attributes.empty()))
+        .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLE));
+    assertThat(Samplers.samplingResult(Sampler.Decision.DROP, Attributes.empty()))
+        .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.DROP));
   }
 
   @Test
@@ -91,13 +91,13 @@ class SamplersTest {
             "foo", AttributeValue.longAttributeValue(42),
             "bar", AttributeValue.stringAttributeValue("baz"));
     final SamplingResult sampledSamplingResult =
-        Samplers.samplingResult(Sampler.Decision.RECORD_AND_SAMPLED, attrs);
-    assertThat(sampledSamplingResult.getDecision()).isEqualTo(Decision.RECORD_AND_SAMPLED);
+        Samplers.samplingResult(Sampler.Decision.RECORD_AND_SAMPLE, attrs);
+    assertThat(sampledSamplingResult.getDecision()).isEqualTo(Decision.RECORD_AND_SAMPLE);
     assertThat(sampledSamplingResult.getAttributes()).isEqualTo(attrs);
 
     final SamplingResult notSampledSamplingResult =
-        Samplers.samplingResult(Sampler.Decision.NOT_RECORD, attrs);
-    assertThat(notSampledSamplingResult.getDecision()).isEqualTo(Decision.NOT_RECORD);
+        Samplers.samplingResult(Sampler.Decision.DROP, attrs);
+    assertThat(notSampledSamplingResult.getDecision()).isEqualTo(Decision.DROP);
     assertThat(notSampledSamplingResult.getAttributes()).isEqualTo(attrs);
   }
 
@@ -114,7 +114,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
 
     // Not sampled parent.
     assertThat(
@@ -127,7 +127,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
 
     // Null parent.
     assertThat(
@@ -140,7 +140,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
   }
 
   @Test
@@ -161,7 +161,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     // Not sampled parent.
     assertThat(
@@ -174,7 +174,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     // Null parent.
     assertThat(
@@ -187,7 +187,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
   }
 
   @Test
@@ -208,7 +208,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
 
     // Not sampled parent.
     assertThat(
@@ -221,7 +221,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
   }
 
   @Test
@@ -237,7 +237,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
 
     // Not sampled parent.
     assertThat(
@@ -250,7 +250,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
   }
 
   @Test
@@ -267,7 +267,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOff())
@@ -281,7 +281,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOn())
@@ -295,7 +295,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOn())
@@ -309,7 +309,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
   }
 
   @Test
@@ -327,7 +327,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOff())
@@ -341,7 +341,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOn())
@@ -355,7 +355,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOn())
@@ -369,7 +369,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
   }
 
   @Test
@@ -386,7 +386,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOff())
@@ -400,7 +400,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOn())
@@ -414,7 +414,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOn())
@@ -428,7 +428,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
   }
 
   @Test
@@ -445,7 +445,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOff())
@@ -459,7 +459,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOn())
@@ -473,7 +473,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOn())
@@ -487,7 +487,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
   }
 
   @Test
@@ -502,7 +502,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     assertThat(
             Samplers.parentBased(Samplers.alwaysOff())
@@ -514,7 +514,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOff())
@@ -531,7 +531,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     assertThat(
             Samplers.parentBased(Samplers.alwaysOn())
@@ -543,7 +543,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
   }
 
   @Test
@@ -718,7 +718,7 @@ class SamplersTest {
             SPAN_KIND,
             Attributes.empty(),
             Collections.emptyList());
-    assertThat(samplingResult1.getDecision()).isEqualTo(Decision.NOT_RECORD);
+    assertThat(samplingResult1.getDecision()).isEqualTo(Decision.DROP);
     assertThat(samplingResult1.getAttributes())
         .isEqualTo(
             Attributes.of(Samplers.SAMPLING_PROBABILITY.key(), doubleAttributeValue(0.0001)));
@@ -752,7 +752,7 @@ class SamplersTest {
             SPAN_KIND,
             Attributes.empty(),
             Collections.emptyList());
-    assertThat(samplingResult2.getDecision()).isEqualTo(Decision.RECORD_AND_SAMPLED);
+    assertThat(samplingResult2.getDecision()).isEqualTo(Decision.RECORD_AND_SAMPLE);
     assertThat(samplingResult1.getAttributes())
         .isEqualTo(
             Attributes.of(Samplers.SAMPLING_PROBABILITY.key(), doubleAttributeValue(0.0001)));
@@ -760,15 +760,15 @@ class SamplersTest {
 
   @Test
   void isSampled() {
-    assertThat(Samplers.isSampled(Decision.NOT_RECORD)).isFalse();
-    assertThat(Samplers.isSampled(Decision.RECORD)).isFalse();
-    assertThat(Samplers.isSampled(Decision.RECORD_AND_SAMPLED)).isTrue();
+    assertThat(Samplers.isSampled(Decision.DROP)).isFalse();
+    assertThat(Samplers.isSampled(Decision.RECORD_ONLY)).isFalse();
+    assertThat(Samplers.isSampled(Decision.RECORD_AND_SAMPLE)).isTrue();
   }
 
   @Test
   void isRecording() {
-    assertThat(Samplers.isRecording(Decision.NOT_RECORD)).isFalse();
-    assertThat(Samplers.isRecording(Decision.RECORD)).isTrue();
-    assertThat(Samplers.isRecording(Decision.RECORD_AND_SAMPLED)).isTrue();
+    assertThat(Samplers.isRecording(Decision.DROP)).isFalse();
+    assertThat(Samplers.isRecording(Decision.RECORD_ONLY)).isTrue();
+    assertThat(Samplers.isRecording(Decision.RECORD_AND_SAMPLE)).isTrue();
   }
 }

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -561,7 +561,7 @@ class SpanBuilderSdkTest {
                         return new SamplingResult() {
                           @Override
                           public Decision getDecision() {
-                            return Decision.RECORD_AND_SAMPLED;
+                            return Decision.RECORD_AND_SAMPLE;
                           }
 
                           @Override

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -71,7 +71,7 @@ class BatchSpanProcessorTest {
     tracerSdkFactory.shutdown();
   }
 
-  // TODO(bdrutu): Fix this when Sampler return RECORD option.
+  // TODO(bdrutu): Fix this when Sampler return RECORD_ONLY option.
   /*
   private ReadableSpan createNotSampledRecordingEventsEndedSpan(String spanName) {
     io.opentelemetry.trace.Span span =
@@ -400,7 +400,7 @@ class BatchSpanProcessorTest {
 
   @Test
   void exportNotSampledSpans_recordingEvents() {
-    // TODO(bdrutu): Fix this when Sampler return RECORD option.
+    // TODO(bdrutu): Fix this when Sampler return RECORD_ONLY option.
     /*
     tracerSdkFactory.addSpanProcessor(
         BatchSpanProcessor.newBuilder(waitingSpanExporter)
@@ -416,7 +416,7 @@ class BatchSpanProcessorTest {
 
   @Test
   void exportNotSampledSpans_reportOnlySampled() {
-    // TODO(bdrutu): Fix this when Sampler return RECORD option.
+    // TODO(bdrutu): Fix this when Sampler return RECORD_ONLY option.
     /*
     tracerSdkFactory.addSpanProcessor(
         BatchSpanProcessor.newBuilder(waitingSpanExporter)

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
@@ -172,7 +172,7 @@ class SimpleSpanProcessorTest {
 
   @Test
   void tracerSdk_NotSampled_RecordingEventsSpan() {
-    // TODO(bdrutu): Fix this when Sampler return RECORD option.
+    // TODO(bdrutu): Fix this when Sampler return RECORD_ONLY option.
     /*
     tracer.addSpanProcessor(
         BatchSpanProcessor.newBuilder(waitingSpanExporter)

--- a/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSampler.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSampler.java
@@ -55,8 +55,8 @@ class RateLimitingSampler implements Sampler {
         Attributes.of(
             SAMPLER_TYPE, AttributeValue.stringAttributeValue(TYPE),
             SAMPLER_PARAM, AttributeValue.doubleAttributeValue(maxTracesPerSecond));
-    this.onSamplingResult = Samplers.samplingResult(Decision.RECORD_AND_SAMPLED, attributes);
-    this.offSamplingResult = Samplers.samplingResult(Decision.NOT_RECORD, attributes);
+    this.onSamplingResult = Samplers.samplingResult(Decision.RECORD_AND_SAMPLE, attributes);
+    this.offSamplingResult = Samplers.samplingResult(Decision.DROP, attributes);
   }
 
   @Override

--- a/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSamplerTest.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSamplerTest.java
@@ -56,7 +56,7 @@ class RateLimitingSamplerTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
     assertThat(
             sampler
                 .shouldSample(
@@ -67,7 +67,7 @@ class RateLimitingSamplerTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
   }
 
   @Test
@@ -81,7 +81,7 @@ class RateLimitingSamplerTest {
             SPAN_KIND,
             Attributes.empty(),
             Collections.emptyList());
-    assertThat(samplingResult.getDecision()).isEqualTo(Decision.RECORD_AND_SAMPLED);
+    assertThat(samplingResult.getDecision()).isEqualTo(Decision.RECORD_AND_SAMPLE);
     assertThat(
             sampler
                 .shouldSample(
@@ -92,7 +92,7 @@ class RateLimitingSamplerTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
     assertEquals(2, samplingResult.getAttributes().size());
     assertEquals(
         AttributeValue.doubleAttributeValue(1),


### PR DESCRIPTION
This PR updates the names of Sampling result for consistency, closing [#1648](https://github.com/open-telemetry/opentelemetry-java/issues/1648)

The changes have been made following these specifications:  
[open-telemetry/opentelemetry-specification#938](https://github.com/open-telemetry/opentelemetry-specification/pull/938)
[open-telemetry/opentelemetry-specification#956 ](https://github.com/open-telemetry/opentelemetry-specification/pull/956)


Changed from:

- `NOT_RECORD`

- `RECORD`

- `RECORD_AND_SAMPLED`

Changed to: 

- `DROP`

- `RECORD_ONLY`

- `RECORD_AND_SAMPLE`