### PR TITLE
Make the getKey method on AttributeKey non-nullable

### DIFF
--- a/api/src/main/java/io/opentelemetry/common/AttributeKey.java
+++ b/api/src/main/java/io/opentelemetry/common/AttributeKey.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.common;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -32,7 +31,6 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public interface AttributeKey<T> extends Comparable<AttributeKey> {
   /** Returns the underlying String representation of the key. */
-  @Nullable
   String getKey();
 
   /** Returns the type of attribute for this key. Useful for building switch statements. */

--- a/api/src/main/java/io/opentelemetry/common/AttributeKeyImpl.java
+++ b/api/src/main/java/io/opentelemetry/common/AttributeKeyImpl.java
@@ -17,14 +17,23 @@
 package io.opentelemetry.common;
 
 import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
 
 @SuppressWarnings("rawtypes")
 @AutoValue
 abstract class AttributeKeyImpl<T> implements AttributeKey<T> {
 
   static <T> AttributeKeyImpl<T> create(String key, AttributeType type) {
-    return new AutoValue_AttributeKeyImpl<>(key, type);
+    return new AutoValue_AttributeKeyImpl<>(type, key);
   }
+
+  @Override
+  public String getKey() {
+    return key();
+  }
+
+  @Nullable
+  abstract String key();
 
   //////////////////////////////////
   // IMPORTANT: the equals/hashcode/compareTo *only* include the key, and not the type,


### PR DESCRIPTION
This was done by tricking AutoValue with a separate field for the storage.

resolves #1678 