### PR TITLE
Rename dangling references to MeterRegistry

### DIFF
--- a/api/src/main/java/io/opentelemetry/metrics/DoubleCounter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleCounter.java
@@ -29,7 +29,7 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <pre>{@code
  * class YourClass {
- *   private static final Meter meter = OpenTelemetry.getMeterRegistry().get("my_library_name");
+ *   private static final Meter meter = OpenTelemetry.getMeterProvider().get("my_library_name");
  *   private static final DoubleCounter counter =
  *       meter.
  *           .doubleCounterBuilder("allocated_resources")

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleSumObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleSumObserver.java
@@ -18,6 +18,7 @@ package io.opentelemetry.metrics;
 
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.metrics.AsynchronousInstrument.DoubleResult;
+
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -36,7 +37,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * <pre>{@code
  * class YourClass {
  *
- *   private static final Meter meter = OpenTelemetry.getMeterRegistry().get("my_library_name");
+ *   private static final Meter meter = OpenTelemetry.getMeterProvider().get("my_library_name");
  *   private static final DoubleSumObserver cpuObserver =
  *       meter.
  *           .doubleSumObserverBuilder("cpu_time")

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleSumObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleSumObserver.java
@@ -18,7 +18,6 @@ package io.opentelemetry.metrics;
 
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.metrics.AsynchronousInstrument.DoubleResult;
-
 import javax.annotation.concurrent.ThreadSafe;
 
 /**

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleUpDownCounter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleUpDownCounter.java
@@ -18,6 +18,7 @@ package io.opentelemetry.metrics;
 
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.metrics.DoubleUpDownCounter.BoundDoubleUpDownCounter;
+
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -31,7 +32,7 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <pre>{@code
  * class YourClass {
- *   private static final Meter meter = OpenTelemetry.getMeterRegistry().get("my_library_name");
+ *   private static final Meter meter = OpenTelemetry.getMeterProvider().get("my_library_name");
  *   private static final DoubleUpDownCounter upDownCounter =
  *       meter.
  *           .doubleUpDownCounterBuilder("resource_usage")

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleUpDownCounter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleUpDownCounter.java
@@ -18,7 +18,6 @@ package io.opentelemetry.metrics;
 
 import io.opentelemetry.common.Labels;
 import io.opentelemetry.metrics.DoubleUpDownCounter.BoundDoubleUpDownCounter;
-
 import javax.annotation.concurrent.ThreadSafe;
 
 /**

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleUpDownSumObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleUpDownSumObserver.java
@@ -36,7 +36,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * <pre>{@code
  * class YourClass {
  *
- *   private static final Meter meter = OpenTelemetry.getMeterRegistry().get("my_library_name");
+ *   private static final Meter meter = OpenTelemetry.getMeterProvider().get("my_library_name");
  *   private static final DoubleUpDownSumObserver memoryObserver =
  *       meter.
  *           .doubleUpDownSumObserverBuilder("memory_usage")

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleValueObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleValueObserver.java
@@ -33,7 +33,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * <pre>{@code
  * class YourClass {
  *
- *   private static final Meter meter = OpenTelemetry.getMeterRegistry().get("my_library_name");
+ *   private static final Meter meter = OpenTelemetry.getMeterProvider().get("my_library_name");
  *   private static final DoubleValueObserver cpuObserver =
  *       meter.
  *           .doubleValueObserverBuilder("cpu_temperature")

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleValueRecorder.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleValueRecorder.java
@@ -40,7 +40,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * <pre>{@code
  * class YourClass {
  *
- *   private static final Meter meter = OpenTelemetry.getMeterRegistry().get("my_library_name");
+ *   private static final Meter meter = OpenTelemetry.getMeterProvider().get("my_library_name");
  *   private static final DoubleValueRecorder valueRecorder =
  *       meter.
  *           .doubleValueRecorderBuilder("doWork_latency")

--- a/api/src/main/java/io/opentelemetry/metrics/LongCounter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongCounter.java
@@ -29,7 +29,7 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <pre>{@code
  * class YourClass {
- *   private static final Meter meter = OpenTelemetry.getMeterRegistry().get("my_library_name");
+ *   private static final Meter meter = OpenTelemetry.getMeterProvider().get("my_library_name");
  *   private static final LongCounter counter =
  *       meter.
  *           .longCounterBuilder("processed_jobs")

--- a/api/src/main/java/io/opentelemetry/metrics/LongSumObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongSumObserver.java
@@ -36,7 +36,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * <pre>{@code
  * class YourClass {
  *
- *   private static final Meter meter = OpenTelemetry.getMeterRegistry().get("my_library_name");
+ *   private static final Meter meter = OpenTelemetry.getMeterProvider().get("my_library_name");
  *   private static final LongSumObserver cpuObserver =
  *       meter.
  *           .longSumObserverBuilder("cpu_time")

--- a/api/src/main/java/io/opentelemetry/metrics/LongUpDownCounter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongUpDownCounter.java
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <pre>{@code
  * class YourClass {
- *   private static final Meter meter = OpenTelemetry.getMeterRegistry().get("my_library_name");
+ *   private static final Meter meter = OpenTelemetry.getMeterProvider().get("my_library_name");
  *   private static final LongUpDownCounter upDownCounter =
  *       meter.
  *           .longUpDownCounterBuilder("active_tasks")

--- a/api/src/main/java/io/opentelemetry/metrics/LongUpDownSumObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongUpDownSumObserver.java
@@ -36,7 +36,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * <pre>{@code
  * class YourClass {
  *
- *   private static final Meter meter = OpenTelemetry.getMeterRegistry().get("my_library_name");
+ *   private static final Meter meter = OpenTelemetry.getMeterProvider().get("my_library_name");
  *   private static final LongUpDownSumObserver memoryObserver =
  *       meter.
  *           .longUpDownSumObserverBuilder("memory_usage")

--- a/api/src/main/java/io/opentelemetry/metrics/LongValueObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongValueObserver.java
@@ -33,7 +33,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * <pre>{@code
  * class YourClass {
  *
- *   private static final Meter meter = OpenTelemetry.getMeterRegistry().get("my_library_name");
+ *   private static final Meter meter = OpenTelemetry.getMeterProvider().get("my_library_name");
  *   private static final LongValueObserver cpuObserver =
  *       meter.
  *           .longValueObserverBuilder("cpu_fan_speed")

--- a/api/src/main/java/io/opentelemetry/metrics/LongValueRecorder.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongValueRecorder.java
@@ -40,7 +40,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * <pre>{@code
  * class YourClass {
  *
- *   private static final Meter meter = OpenTelemetry.getMeterRegistry().get("my_library_name");
+ *   private static final Meter meter = OpenTelemetry.getMeterProvider().get("my_library_name");
  *   private static final LongValueRecorder valueRecorder =
  *       meter.
  *           .longValueRecorderBuilder("doWork_latency")

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkRegistryTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 /** Unit tests for {@link MeterSdkProvider}. */
 class MeterSdkRegistryTest {
   private final TestClock testClock = TestClock.create();
-  private final MeterSdkProvider meterRegistry =
+  private final MeterSdkProvider meterProvider =
       MeterSdkProvider.builder().setClock(testClock).setResource(Resource.getEmpty()).build();
 
   @Test
@@ -61,38 +61,38 @@ class MeterSdkRegistryTest {
 
   @Test
   void defaultGet() {
-    assertThat(meterRegistry.get("test")).isInstanceOf(MeterSdk.class);
+    assertThat(meterProvider.get("test")).isInstanceOf(MeterSdk.class);
   }
 
   @Test
   void getSameInstanceForSameName_WithoutVersion() {
-    assertThat(meterRegistry.get("test")).isSameAs(meterRegistry.get("test"));
-    assertThat(meterRegistry.get("test")).isSameAs(meterRegistry.get("test", null));
+    assertThat(meterProvider.get("test")).isSameAs(meterProvider.get("test"));
+    assertThat(meterProvider.get("test")).isSameAs(meterProvider.get("test", null));
   }
 
   @Test
   void getSameInstanceForSameName_WithVersion() {
-    assertThat(meterRegistry.get("test", "version")).isSameAs(meterRegistry.get("test", "version"));
+    assertThat(meterProvider.get("test", "version")).isSameAs(meterProvider.get("test", "version"));
   }
 
   @Test
   void propagatesInstrumentationLibraryInfoToMeter() {
     InstrumentationLibraryInfo expected =
         InstrumentationLibraryInfo.create("theName", "theVersion");
-    MeterSdk meter = meterRegistry.get(expected.getName(), expected.getVersion());
+    MeterSdk meter = meterProvider.get(expected.getName(), expected.getVersion());
     assertThat(meter.getInstrumentationLibraryInfo()).isEqualTo(expected);
   }
 
   @Test
   void metricProducer_GetAllMetrics() {
-    MeterSdk meterSdk1 = meterRegistry.get("io.opentelemetry.sdk.metrics.MeterSdkRegistryTest_1");
+    MeterSdk meterSdk1 = meterProvider.get("io.opentelemetry.sdk.metrics.MeterSdkRegistryTest_1");
     LongCounterSdk longCounter1 = meterSdk1.longCounterBuilder("testLongCounter").build();
     longCounter1.add(10, Labels.empty());
-    MeterSdk meterSdk2 = meterRegistry.get("io.opentelemetry.sdk.metrics.MeterSdkRegistryTest_2");
+    MeterSdk meterSdk2 = meterProvider.get("io.opentelemetry.sdk.metrics.MeterSdkRegistryTest_2");
     LongCounterSdk longCounter2 = meterSdk2.longCounterBuilder("testLongCounter").build();
     longCounter2.add(10, Labels.empty());
 
-    assertThat(meterRegistry.getMetricProducer().collectAllMetrics())
+    assertThat(meterProvider.getMetricProducer().collectAllMetrics())
         .containsExactlyInAnyOrder(
             MetricData.create(
                 Descriptor.create(


### PR DESCRIPTION
This is a follow-up from #870 

After `MeterRegistry` was renamed to `MeterProvider`, some of the javadoc examples still pointed to the old name, which could be misleading/confusing for new users.

There was also one remaining variable reference.
