### PR TITLE
Log EC2Resource messages at FINE.

### DIFF
--- a/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/Ec2Resource.java
+++ b/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/Ec2Resource.java
@@ -83,14 +83,14 @@ public class Ec2Resource extends ResourceProvider {
     try {
       connection = (HttpURLConnection) url.openConnection();
     } catch (Exception e) {
-      logger.log(Level.WARNING, "Error connecting to IMDS.", e);
+      logger.log(Level.FINE, "Error connecting to IMDS.", e);
       return "";
     }
 
     try {
       connection.setRequestMethod(httpMethod);
     } catch (ProtocolException e) {
-      logger.log(Level.WARNING, "Unknown HTTP method, this is a programming bug.", e);
+      logger.log(Level.FINE, "Unknown HTTP method, this is a programming bug.", e);
       return "";
     }
 
@@ -108,13 +108,13 @@ public class Ec2Resource extends ResourceProvider {
     try {
       responseCode = connection.getResponseCode();
     } catch (Exception e) {
-      logger.log(Level.WARNING, "Error connecting to IMDS: ", e);
+      logger.log(Level.FINE, "Error connecting to IMDS: ", e);
       return "";
     }
 
     if (responseCode != 200) {
       logger.log(
-          Level.WARNING,
+          Level.FINE,
           "Error reponse from IMDS: code ("
               + responseCode
               + ") text "


### PR DESCRIPTION
At least the first warning definitely should be flipped or it always logs when off EC2. The other ones also don't seem helpful to warn over since it's not critical resource information.