### PR TITLE
Make setting null-valued attributes a no-op, and document that their behavior is undefined.

### DIFF
--- a/api/src/main/java/io/opentelemetry/common/Attributes.java
+++ b/api/src/main/java/io/opentelemetry/common/Attributes.java
@@ -232,7 +232,7 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey, Ob
 
     /** Sets a {@link AttributeKey} with associated value into this. */
     public <T> Builder setAttribute(AttributeKey<T> key, T value) {
-      if (value == null || key == null || key.getKey() == null || key.getKey().length() == 0) {
+      if (key == null || key.getKey() == null || key.getKey().length() == 0 || value == null ) {
         return this;
       }
       data.add(key);

--- a/api/src/main/java/io/opentelemetry/common/Attributes.java
+++ b/api/src/main/java/io/opentelemetry/common/Attributes.java
@@ -29,7 +29,6 @@ import com.google.auto.value.AutoValue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -83,7 +82,7 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey, Ob
   }
 
   /** Returns a {@link Attributes} instance with a single key-value pair. */
-  public static <T> Attributes of(AttributeKey<T> key, @Nonnull T value) {
+  public static <T> Attributes of(AttributeKey<T> key, T value) {
     return sortAndFilterToAttributes(key, value);
   }
 
@@ -92,7 +91,7 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey, Ob
    * preserved. Duplicate keys will be removed.
    */
   public static <T, U> Attributes of(
-      AttributeKey<T> key1, @Nonnull T value1, AttributeKey<U> key2, @Nonnull U value2) {
+      AttributeKey<T> key1, T value1, AttributeKey<U> key2, U value2) {
     return sortAndFilterToAttributes(key1, value1, key2, value2);
   }
 
@@ -102,11 +101,11 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey, Ob
    */
   public static <T, U, V> Attributes of(
       AttributeKey<T> key1,
-      @Nonnull T value1,
+      T value1,
       AttributeKey<U> key2,
-      @Nonnull U value2,
+      U value2,
       AttributeKey<V> key3,
-      @Nonnull V value3) {
+      V value3) {
     return sortAndFilterToAttributes(key1, value1, key2, value2, key3, value3);
   }
 
@@ -116,13 +115,13 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey, Ob
    */
   public static <T, U, V, W> Attributes of(
       AttributeKey<T> key1,
-      @Nonnull T value1,
+      T value1,
       AttributeKey<U> key2,
-      @Nonnull U value2,
+      U value2,
       AttributeKey<V> key3,
-      @Nonnull V value3,
+      V value3,
       AttributeKey<W> key4,
-      @Nonnull W value4) {
+      W value4) {
     return sortAndFilterToAttributes(key1, value1, key2, value2, key3, value3, key4, value4);
   }
 
@@ -132,15 +131,15 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey, Ob
    */
   public static <T, U, V, W, X> Attributes of(
       AttributeKey<T> key1,
-      @Nonnull T value1,
+      T value1,
       AttributeKey<U> key2,
-      @Nonnull U value2,
+      U value2,
       AttributeKey<V> key3,
-      @Nonnull V value3,
+      V value3,
       AttributeKey<W> key4,
-      @Nonnull W value4,
+      W value4,
       AttributeKey<X> key5,
-      @Nonnull X value5) {
+      X value5) {
     return sortAndFilterToAttributes(
         key1, value1,
         key2, value2,
@@ -232,7 +231,7 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey, Ob
 
     /** Sets a {@link AttributeKey} with associated value into this. */
     public <T> Builder setAttribute(AttributeKey<T> key, T value) {
-      if (key == null || key.getKey() == null || key.getKey().length() == 0 || value == null ) {
+      if (key == null || key.getKey() == null || key.getKey().length() == 0 || value == null) {
         return this;
       }
       data.add(key);
@@ -248,7 +247,7 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey, Ob
      *
      * @return this Builder
      */
-    public Builder setAttribute(String key, @Nonnull String value) {
+    public Builder setAttribute(String key, String value) {
       return setAttribute(stringKey(key), value);
     }
 

--- a/api/src/main/java/io/opentelemetry/common/Attributes.java
+++ b/api/src/main/java/io/opentelemetry/common/Attributes.java
@@ -28,8 +28,8 @@ import static io.opentelemetry.common.AttributesKeys.stringKey;
 import com.google.auto.value.AutoValue;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -37,6 +37,10 @@ import javax.annotation.concurrent.Immutable;
  *
  * <p>The keys are {@link AttributeKey}s and the values are Object instances that match the type of
  * the provided key.
+ *
+ * <p>Null keys will be silently dropped.
+ *
+ * <p>Note: The behavior of null-valued attributes is undefined, and hence strongly discouraged.
  */
 @SuppressWarnings("rawtypes")
 @Immutable
@@ -79,7 +83,7 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey, Ob
   }
 
   /** Returns a {@link Attributes} instance with a single key-value pair. */
-  public static <T> Attributes of(AttributeKey<T> key, T value) {
+  public static <T> Attributes of(AttributeKey<T> key, @Nonnull T value) {
     return sortAndFilterToAttributes(key, value);
   }
 
@@ -88,7 +92,7 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey, Ob
    * preserved. Duplicate keys will be removed.
    */
   public static <T, U> Attributes of(
-      AttributeKey<T> key1, T value1, AttributeKey<U> key2, U value2) {
+      AttributeKey<T> key1, @Nonnull T value1, AttributeKey<U> key2, @Nonnull U value2) {
     return sortAndFilterToAttributes(key1, value1, key2, value2);
   }
 
@@ -98,11 +102,11 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey, Ob
    */
   public static <T, U, V> Attributes of(
       AttributeKey<T> key1,
-      T value1,
+      @Nonnull T value1,
       AttributeKey<U> key2,
-      U value2,
+      @Nonnull U value2,
       AttributeKey<V> key3,
-      V value3) {
+      @Nonnull V value3) {
     return sortAndFilterToAttributes(key1, value1, key2, value2, key3, value3);
   }
 
@@ -112,13 +116,13 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey, Ob
    */
   public static <T, U, V, W> Attributes of(
       AttributeKey<T> key1,
-      T value1,
+      @Nonnull T value1,
       AttributeKey<U> key2,
-      U value2,
+      @Nonnull U value2,
       AttributeKey<V> key3,
-      V value3,
+      @Nonnull V value3,
       AttributeKey<W> key4,
-      W value4) {
+      @Nonnull W value4) {
     return sortAndFilterToAttributes(key1, value1, key2, value2, key3, value3, key4, value4);
   }
 
@@ -128,15 +132,15 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey, Ob
    */
   public static <T, U, V, W, X> Attributes of(
       AttributeKey<T> key1,
-      T value1,
+      @Nonnull T value1,
       AttributeKey<U> key2,
-      U value2,
+      @Nonnull U value2,
       AttributeKey<V> key3,
-      V value3,
+      @Nonnull V value3,
       AttributeKey<W> key4,
-      W value4,
+      @Nonnull W value4,
       AttributeKey<X> key5,
-      X value5) {
+      @Nonnull X value5) {
     return sortAndFilterToAttributes(
         key1, value1,
         key2, value2,
@@ -172,10 +176,14 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey, Ob
   }
 
   private static Attributes sortAndFilterToAttributes(Object... data) {
-    // null out any empty keys
+    // null out any empty keys or keys with null values
+    // so they will then be removed by the sortAndFilter method.
     for (int i = 0; i < data.length; i += 2) {
       AttributeKey<?> key = (AttributeKey<?>) data[i];
       if (key != null && (key.getKey() == null || "".equals(key.getKey()))) {
+        data[i] = null;
+      }
+      if (data[i + 1] == null) {
         data[i] = null;
       }
     }
@@ -190,13 +198,7 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey, Ob
   /** Returns a new {@link Builder} instance from ReadableAttributes. */
   public static Builder newBuilder(ReadableAttributes attributes) {
     final Builder builder = new Builder();
-    attributes.forEach(
-        new AttributeConsumer() {
-          @Override
-          public <T> void consume(AttributeKey<T> key, T value) {
-            builder.setAttribute(key, value);
-          }
-        });
+    attributes.forEach(builder::setAttribute);
     return builder;
   }
 
@@ -230,24 +232,7 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey, Ob
 
     /** Sets a {@link AttributeKey} with associated value into this. */
     public <T> Builder setAttribute(AttributeKey<T> key, T value) {
-      if (key == null || key.getKey() == null || key.getKey().length() == 0) {
-        return this;
-      }
-      if (value == null) {
-        // Remove key/value pairs
-        Iterator<Object> itr = data.iterator();
-        while (itr.hasNext()) {
-          AttributeKey k = (AttributeKey) itr.next();
-          if (key.equals(k)) {
-            // delete key and value
-            itr.remove();
-            itr.next();
-            itr.remove();
-          } else {
-            // skip the value part
-            itr.next();
-          }
-        }
+      if (value == null || key == null || key.getKey() == null || key.getKey().length() == 0) {
         return this;
       }
       data.add(key);
@@ -263,7 +248,7 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey, Ob
      *
      * @return this Builder
      */
-    public Builder setAttribute(String key, String value) {
+    public Builder setAttribute(String key, @Nonnull String value) {
       return setAttribute(stringKey(key), value);
     }
 

--- a/api/src/main/java/io/opentelemetry/common/package-info.java
+++ b/api/src/main/java/io/opentelemetry/common/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains code common across the OpenTelemetry APIs, including {@link
+ * io.opentelemetry.common.Attributes} and classes/utilities for interacting with them.
+ */
+@ParametersAreNonnullByDefault
+package io.opentelemetry.common;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -19,7 +19,7 @@ package io.opentelemetry.trace;
 import io.grpc.Context;
 import io.opentelemetry.common.AttributeKey;
 import io.opentelemetry.common.Attributes;
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -85,8 +85,8 @@ public interface Span {
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
    * the key, the old value is replaced by the specified value.
    *
-   * <p>If a null or empty String {@code value} is passed in, the attribute will be silently
-   * dropped. Note: this behavior could change in the future.
+   * <p>If a null or empty String {@code value} is passed in, the behavior is undefined, and hence
+   * strongly discouraged.
    *
    * <p>Note: It is strongly recommended to use {@link #setAttribute(AttributeKey, Object)}, and
    * pre-allocate your keys, if possible.
@@ -95,7 +95,7 @@ public interface Span {
    * @param value the value for this attribute.
    * @since 0.1.0
    */
-  void setAttribute(String key, @Nullable String value);
+  void setAttribute(String key, @Nonnull String value);
 
   /**
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
@@ -140,11 +140,13 @@ public interface Span {
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
    * the key, the old value is replaced by the specified value.
    *
+   * <p>Note: the behavior of null values is undefined, and hence strongly discouraged.
+   *
    * @param key the key for this attribute.
    * @param value the value for this attribute.
    * @since 0.1.0
    */
-  <T> void setAttribute(AttributeKey<T> key, T value);
+  <T> void setAttribute(AttributeKey<T> key, @Nonnull T value);
 
   /**
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
@@ -481,8 +483,8 @@ public interface Span {
      * Sets an attribute to the newly created {@code Span}. If {@code Span.Builder} previously
      * contained a mapping for the key, the old value is replaced by the specified value.
      *
-     * <p>If a null or empty String {@code value} is passed in, the attribute will be silently
-     * dropped. Note: this behavior could change in the future.
+     * <p>If a null or empty String {@code value} is passed in, the behavior is undefined, and hence
+     * strongly discouraged.
      *
      * <p>Note: It is strongly recommended to use {@link #setAttribute(AttributeKey, Object)}, and
      * pre-allocate your keys, if possible.
@@ -493,7 +495,7 @@ public interface Span {
      * @throws NullPointerException if {@code key} is {@code null}.
      * @since 0.3.0
      */
-    Builder setAttribute(String key, @Nullable String value);
+    Builder setAttribute(String key, @Nonnull String value);
 
     /**
      * Sets an attribute to the newly created {@code Span}. If {@code Span.Builder} previously
@@ -544,6 +546,8 @@ public interface Span {
      * Sets an attribute to the newly created {@code Span}. If {@code Span.Builder} previously
      * contained a mapping for the key, the old value is replaced by the specified value.
      *
+     * <p>Note: the behavior of null values is undefined, and hence strongly discouraged.
+     *
      * @param key the key for this attribute.
      * @param value the value for this attribute.
      * @return this.
@@ -551,7 +555,7 @@ public interface Span {
      * @throws NullPointerException if {@code value} is {@code null}.
      * @since 0.3.0
      */
-    <T> Builder setAttribute(AttributeKey<T> key, T value);
+    <T> Builder setAttribute(AttributeKey<T> key, @Nonnull T value);
 
     /**
      * Sets the {@link Span.Kind} for the newly created {@code Span}. If not called, the

--- a/api/src/test/java/io/opentelemetry/common/AttributesTest.java
+++ b/api/src/test/java/io/opentelemetry/common/AttributesTest.java
@@ -258,26 +258,4 @@ class AttributesTest {
     // Original not mutated.
     assertThat(partial).isEqualTo(Attributes.newBuilder().setAttribute("cat", "meow").build());
   }
-
-  @Test
-  void deleteByNull() {
-    Attributes.Builder attributes = Attributes.newBuilder();
-    attributes.setAttribute(stringKey("attrValue"), "attrValue");
-    attributes.setAttribute("string", "string");
-    attributes.setAttribute("long", 10);
-    attributes.setAttribute("double", 1.0);
-    attributes.setAttribute("bool", true);
-    attributes.setAttribute("arrayString", new String[] {"string"});
-    attributes.setAttribute("arrayLong", new Long[] {10L});
-    attributes.setAttribute("arrayDouble", new Double[] {1.0});
-    attributes.setAttribute("arrayBool", new Boolean[] {true});
-    assertThat(attributes.build().size()).isEqualTo(9);
-    attributes.setAttribute(stringKey("attrValue"), null);
-    attributes.setAttribute("string", (String) null);
-    attributes.setAttribute("arrayString", (String[]) null);
-    attributes.setAttribute("arrayLong", (Long[]) null);
-    attributes.setAttribute("arrayDouble", (Double[]) null);
-    attributes.setAttribute("arrayBool", (Boolean[]) null);
-    assertThat(attributes.build().size()).isEqualTo(3);
-  }
 }

--- a/api/src/test/java/io/opentelemetry/common/AttributesTest.java
+++ b/api/src/test/java/io/opentelemetry/common/AttributesTest.java
@@ -24,6 +24,7 @@ import static io.opentelemetry.common.AttributesKeys.longArrayKey;
 import static io.opentelemetry.common.AttributesKeys.longKey;
 import static io.opentelemetry.common.AttributesKeys.stringArrayKey;
 import static io.opentelemetry.common.AttributesKeys.stringKey;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
@@ -257,5 +258,37 @@ class AttributesTest {
     assertThat(fromPartial).isEqualTo(filled);
     // Original not mutated.
     assertThat(partial).isEqualTo(Attributes.newBuilder().setAttribute("cat", "meow").build());
+  }
+
+  @Test
+  void nullsAreNoOps() {
+    Attributes.Builder builder = Attributes.newBuilder();
+    builder.setAttribute(stringKey("attrValue"), "attrValue");
+    builder.setAttribute("string", "string");
+    builder.setAttribute("long", 10);
+    builder.setAttribute("double", 1.0);
+    builder.setAttribute("bool", true);
+    builder.setAttribute("arrayString", new String[] {"string"});
+    builder.setAttribute("arrayLong", new Long[] {10L});
+    builder.setAttribute("arrayDouble", new Double[] {1.0});
+    builder.setAttribute("arrayBool", new Boolean[] {true});
+    assertThat(builder.build().size()).isEqualTo(9);
+
+    // note: currently these are no-op calls; that behavior is not required, so if it needs to
+    // change, that is fine.
+    builder.setAttribute(stringKey("attrValue"), null);
+    builder.setAttribute("string", (String) null);
+    builder.setAttribute("arrayString", (String[]) null);
+    builder.setAttribute("arrayLong", (Long[]) null);
+    builder.setAttribute("arrayDouble", (Double[]) null);
+    builder.setAttribute("arrayBool", (Boolean[]) null);
+
+    Attributes attributes = builder.build();
+    assertThat(attributes.size()).isEqualTo(9);
+    assertThat(attributes.get(stringKey("string"))).isEqualTo("string");
+    assertThat(attributes.get(stringArrayKey("arrayString"))).isEqualTo(singletonList("string"));
+    assertThat(attributes.get(longArrayKey("arrayLong"))).isEqualTo(singletonList(10L));
+    assertThat(attributes.get(doubleArrayKey("arrayDouble"))).isEqualTo(singletonList(1.0d));
+    assertThat(attributes.get(booleanArrayKey("arrayBool"))).isEqualTo(singletonList(true));
   }
 }

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/AttributesMap.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/AttributesMap.java
@@ -40,6 +40,9 @@ final class AttributesMap implements ReadableAttributes {
   }
 
   public <T> void put(AttributeKey<T> key, T value) {
+    if (key == null || key.getKey() == null || value == null) {
+      return;
+    }
     totalAddedValues++;
     if (data.size() >= capacity && !data.containsKey(key)) {
       return;

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -308,18 +308,12 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
 
   @Override
   public <T> void setAttribute(AttributeKey<T> key, T value) {
-    if (key == null || key.getKey() == null || key.getKey().length() == 0) {
+    if (key == null || key.getKey() == null || key.getKey().length() == 0 || value == null) {
       return;
     }
     synchronized (lock) {
       if (hasEnded) {
         logger.log(Level.FINE, "Calling setAttribute() on an ended Span.");
-        return;
-      }
-      if (value == null) {
-        if (attributes != null) {
-          attributes.remove(key);
-        }
         return;
       }
       if (attributes == null) {

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -163,9 +163,6 @@ final class SpanBuilderSdk implements Span.Builder {
   public <T> Span.Builder setAttribute(AttributeKey<T> key, T value) {
     Objects.requireNonNull(key, "key");
     if (value == null) {
-      if (attributes != null) {
-        attributes.remove(key);
-      }
       return this;
     }
     if (attributes == null) {

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -482,11 +482,6 @@ class RecordEventsReadableSpanTest {
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(3);
     span.setAttribute(doubleArrayKey("doubleArrayAttribute"), Collections.emptyList());
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(4);
-    span.setAttribute(stringArrayKey("stringArrayAttribute"), null);
-    span.setAttribute(booleanArrayKey("boolArrayAttribute"), null);
-    span.setAttribute(longArrayKey("longArrayAttribute"), null);
-    span.setAttribute(doubleArrayKey("doubleArrayAttribute"), null);
-    assertThat(span.toSpanData().getAttributes().size()).isZero();
   }
 
   @Test
@@ -497,9 +492,6 @@ class RecordEventsReadableSpanTest {
     span.setAttribute(stringKey("nullStringAttributeValue"), null);
     span.setAttribute(stringKey("emptyStringAttributeValue"), "");
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(2);
-    span.setAttribute("emptyString", null);
-    span.setAttribute("emptyStringAttributeValue", null);
-    assertThat(span.toSpanData().getAttributes().isEmpty()).isTrue();
   }
 
   @Test
@@ -517,16 +509,6 @@ class RecordEventsReadableSpanTest {
     span.setAttribute(longArrayKey("longArrayAttribute"), Arrays.asList(12345L, null));
     span.setAttribute(doubleArrayKey("doubleArrayAttribute"), Arrays.asList(1.2345, null));
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(9);
-    span.setAttribute(stringKey("emptyString"), null);
-    span.setAttribute(stringKey("emptyStringAttributeValue"), null);
-    span.setAttribute(longKey("longAttribute"), null);
-    span.setAttribute(booleanKey("boolAttribute"), null);
-    span.setAttribute(doubleKey("doubleAttribute"), null);
-    span.setAttribute(stringArrayKey("stringArrayAttribute"), null);
-    span.setAttribute(booleanArrayKey("boolArrayAttribute"), null);
-    span.setAttribute(longArrayKey("longArrayAttribute"), null);
-    span.setAttribute(doubleArrayKey("doubleArrayAttribute"), null);
-    assertThat(span.toSpanData().getAttributes().isEmpty()).isTrue();
   }
 
   @Test

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -286,9 +286,6 @@ class SpanBuilderSdkTest {
     spanBuilder.setAttribute(stringKey("emptyStringAttributeValue"), "");
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(2);
-    span.setAttribute("emptyString", null);
-    span.setAttribute("emptyStringAttributeValue", null);
-    assertThat(span.toSpanData().getAttributes().isEmpty()).isTrue();
   }
 
   @Test
@@ -335,16 +332,6 @@ class SpanBuilderSdkTest {
     spanBuilder.setAttribute(doubleArrayKey("doubleArrayAttribute"), Arrays.asList(1.2345, null));
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(9);
-    span.setAttribute("emptyString", null);
-    span.setAttribute(stringKey("emptyStringAttributeValue"), null);
-    span.setAttribute(longKey("longAttribute"), null);
-    span.setAttribute(booleanKey("boolAttribute"), null);
-    span.setAttribute(doubleKey("doubleAttribute"), null);
-    span.setAttribute(stringArrayKey("stringArrayAttribute"), null);
-    span.setAttribute(booleanArrayKey("boolArrayAttribute"), null);
-    span.setAttribute(longArrayKey("longArrayAttribute"), null);
-    span.setAttribute(doubleArrayKey("doubleArrayAttribute"), null);
-    assertThat(span.toSpanData().getAttributes().isEmpty()).isTrue();
   }
 
   @Test


### PR DESCRIPTION

resolves #1703 