### PR TITLE
Expose a new TracerSdkManagement interface on the OpenTelemetrySdk class.

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -388,9 +388,9 @@ a particular backend. OpenTelemetry offers four exporters out of the box:
 Other exporters can be found in the [OpenTelemetry Registry].
 
 ```java
-tracerProvider.addSpanProcessor(
+tracerSdkManagement.addSpanProcessor(
     SimpleSpanProcessor.newBuilder(InMemorySpanExporter.create()).build());
-tracerProvider.addSpanProcessor(
+tracerSdkManagement.addSpanProcessor(
     SimpleSpanProcessor.newBuilder(new LoggingSpanExporter()).build());
 
 ManagedChannel jaegerChannel =
@@ -398,19 +398,19 @@ ManagedChannel jaegerChannel =
 JaegerGrpcSpanExporter jaegerExporter = JaegerGrpcSpanExporter.newBuilder()
     .setServiceName("example").setChannel(jaegerChannel).setDeadline(30000)
     .build();
-tracerProvider.addSpanProcessor(BatchSpanProcessor.newBuilder(
+tracerSdkManagement.addSpanProcessor(BatchSpanProcessor.newBuilder(
     jaegerExporter
 ).build());
 ```
 
 ### TraceConfig
 
-The `TraceConfig` associated with a `TracerSdkProvider` can be updated via system properties, 
+The `TraceConfig` associated with a Tracer SDK can be updated via system properties, 
 environment variables and builder `set*` methods.  
 
 ```java
-// Get TraceConfig associated with TracerSdkProvider 
-TraceConfig traceConfig = OpenTelemetrySdk.getTracerProvider().getActiveTraceConfig();
+// Get TraceConfig associated with TracerSdk 
+TracerConfig traceConfig = OpenTelemetrySdk.getTracerSdkManagement().getActiveTraceConfig();
 
 // Get TraceConfig Builder
 Builder builder = traceConfig.toBuilder();
@@ -425,7 +425,7 @@ builder.readEnvironmentVariables()
 builder.setMaxNumberOfLinks(10);
 
 // Update the resulting TraceConfig instance
-OpenTelemetrySdk.getTracerProvider().updateActiveTraceConfig(builder.build());
+OpenTelemetrySdk.getTracerSdkManagement().updateActiveTraceConfig(builder.build());
 ```
 
 Supported system properties and environment variables:

--- a/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryTracing.java
+++ b/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryTracing.java
@@ -36,7 +36,7 @@ import javax.annotation.concurrent.Immutable;
  *   public void testCondition() {
  *     TracerSdkProvider tracerSdkProvider = TracerSdkProvider.builder().build()
  *     InMemoryTracing tracing =
- *         InMemoryTracing.builder().setTracerSdkProvider(tracerSdkProvider).build();
+ *         InMemoryTracing.builder().setTracerSdkManagement(tracerSdkProvider).build();
  *     Tracer tracer = tracerSdkProvider.getTracer("MyTestClass");
  *     tracer.spanBuilder("span").startSpan().end();
  *

--- a/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryTracing.java
+++ b/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryTracing.java
@@ -20,15 +20,14 @@ import com.google.auto.value.AutoValue;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.propagation.DefaultContextPropagators;
 import io.opentelemetry.sdk.trace.TracerSdkManagement;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.trace.propagation.HttpTraceContext;
 import javax.annotation.concurrent.Immutable;
 
 /**
  * InMemoryTracing is an utility class that helps installing the {@link SimpleSpanProcessor} and an
- * instance of the {@link InMemorySpanExporter} to a given {@link TracerSdkProvider}. Can be used to
- * test OpenTelemetry integration.
+ * instance of the {@link InMemorySpanExporter} to a given {@link TracerSdkManagement}. Can be used
+ * to test OpenTelemetry integration.
  *
  * <p>Example usage:
  *
@@ -53,12 +52,12 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public abstract class InMemoryTracing {
   /**
-   * Returns the {@code TracerSdkProvider} passed during construction.
+   * Returns the {@code TracerSdkManagement} passed during construction.
    *
-   * @return the {@code TracerSdkProvider} passed during construction.
+   * @return the {@code TracerSdkManagement} passed during construction.
    * @since 0.1.0
    */
-  abstract TracerSdkManagement getTracerProvider();
+  abstract TracerSdkManagement getTracerSdkManagement();
 
   /**
    * Returns the installed {@link InMemorySpanExporter}.
@@ -84,11 +83,11 @@ public abstract class InMemoryTracing {
    */
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder setTracerProvider(TracerSdkManagement tracerProvider);
+    public abstract Builder setTracerSdkManagement(TracerSdkManagement tracerSdkManagement);
 
     abstract Builder setSpanExporter(InMemorySpanExporter exporter);
 
-    abstract TracerSdkManagement getTracerProvider();
+    abstract TracerSdkManagement getTracerSdkManagement();
 
     abstract InMemoryTracing autoBuild();
 
@@ -105,7 +104,7 @@ public abstract class InMemoryTracing {
               .addTextMapPropagator(HttpTraceContext.getInstance())
               .build());
       InMemorySpanExporter exporter = InMemorySpanExporter.create();
-      getTracerProvider().addSpanProcessor(SimpleSpanProcessor.newBuilder(exporter).build());
+      getTracerSdkManagement().addSpanProcessor(SimpleSpanProcessor.newBuilder(exporter).build());
       return setSpanExporter(exporter).autoBuild();
     }
   }

--- a/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryTracing.java
+++ b/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryTracing.java
@@ -19,6 +19,7 @@ package io.opentelemetry.exporters.inmemory;
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.propagation.DefaultContextPropagators;
+import io.opentelemetry.sdk.trace.TracerSdkManagement;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.trace.propagation.HttpTraceContext;
@@ -57,7 +58,7 @@ public abstract class InMemoryTracing {
    * @return the {@code TracerSdkProvider} passed during construction.
    * @since 0.1.0
    */
-  abstract TracerSdkProvider getTracerProvider();
+  abstract TracerSdkManagement getTracerProvider();
 
   /**
    * Returns the installed {@link InMemorySpanExporter}.
@@ -83,11 +84,11 @@ public abstract class InMemoryTracing {
    */
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder setTracerProvider(TracerSdkProvider tracerProvider);
+    public abstract Builder setTracerProvider(TracerSdkManagement tracerProvider);
 
     abstract Builder setSpanExporter(InMemorySpanExporter exporter);
 
-    abstract TracerSdkProvider getTracerProvider();
+    abstract TracerSdkManagement getTracerProvider();
 
     abstract InMemoryTracing autoBuild();
 

--- a/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemoryTracingTest.java
+++ b/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemoryTracingTest.java
@@ -31,12 +31,12 @@ import org.junit.jupiter.api.Test;
 class InMemoryTracingTest {
   private final TracerSdkProvider tracerSdkProvider = TracerSdkProvider.builder().build();
   private final InMemoryTracing tracing =
-      InMemoryTracing.builder().setTracerProvider(tracerSdkProvider).build();
+      InMemoryTracing.builder().setTracerSdkManagement(tracerSdkProvider).build();
   private final Tracer tracer = tracerSdkProvider.get("InMemoryTracing");
 
   @Test
   void defaultInstance() {
-    assertThat(tracing.getTracerProvider()).isSameAs(tracerSdkProvider);
+    assertThat(tracing.getTracerSdkManagement()).isSameAs(tracerSdkProvider);
     assertThat(tracing.getSpanExporter().getFinishedSpanItems()).hasSize(0);
   }
 
@@ -44,7 +44,7 @@ class InMemoryTracingTest {
   void ctor_nullTracer() {
     assertThrows(
         NullPointerException.class,
-        () -> InMemoryTracing.builder().setTracerProvider(null).build(),
+        () -> InMemoryTracing.builder().setTracerSdkManagement(null).build(),
         "tracerProvider");
   }
 

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerIntegrationTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerIntegrationTest.java
@@ -75,7 +75,7 @@ class JaegerIntegrationTest {
             .setChannel(jaegerChannel)
             .setDeadlineMs(30000)
             .build();
-    OpenTelemetrySdk.getTracerProvider()
+    OpenTelemetrySdk.getTracerManagement()
         .addSpanProcessor(SimpleSpanProcessor.newBuilder(jaegerExporter).build());
   }
 

--- a/integration_tests/src/main/java/io/opentelemetry/SendTraceToJaeger.java
+++ b/integration_tests/src/main/java/io/opentelemetry/SendTraceToJaeger.java
@@ -50,7 +50,7 @@ public class SendTraceToJaeger {
             .build();
 
     // Set to process the spans by the Jaeger Exporter
-    OpenTelemetrySdk.getTracerProvider()
+    OpenTelemetrySdk.getTracerManagement()
         .addSpanProcessor(SimpleSpanProcessor.newBuilder(jaegerExporter).build());
   }
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
@@ -19,10 +19,11 @@ package io.opentelemetry.opentracingshim.testbed;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.baggage.DefaultBaggageManager;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
 import io.opentelemetry.opentracingshim.TraceShim;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentracing.Scope;
@@ -33,12 +34,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class OpenTelemetryInteroperabilityTest {
-  private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
-  private final io.opentelemetry.trace.Tracer tracer = sdk.get("opentracingshim");
+  private final io.opentelemetry.trace.Tracer tracer = OpenTelemetry.getTracer("opentracingshim");
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder()
+          .setTracerSdkManagement(OpenTelemetrySdk.getTracerManagement())
+          .build();
   private final Tracer otTracer =
-      TraceShim.createTracerShim(sdk, DefaultBaggageManager.getInstance());
+      TraceShim.createTracerShim(
+          OpenTelemetry.getTracerProvider(), DefaultBaggageManager.getInstance());
 
   @BeforeEach
   void before() {

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/activespanreplacement/ActiveSpanReplacementTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/activespanreplacement/ActiveSpanReplacementTest.java
@@ -45,7 +45,7 @@ class ActiveSpanReplacementTest {
 
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = TraceShim.createTracerShim(sdk, new BaggageManagerSdk());
   private final ExecutorService executor = Executors.newCachedThreadPool();
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/actorpropagation/ActorPropagationTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/actorpropagation/ActorPropagationTest.java
@@ -50,7 +50,7 @@ import org.junit.jupiter.api.Test;
 class ActorPropagationTest {
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = TraceShim.createTracerShim(sdk, new BaggageManagerSdk());
   private Phaser phaser;
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/baggagehandling/BaggageHandlingTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/baggagehandling/BaggageHandlingTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 public final class BaggageHandlingTest {
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = TraceShim.createTracerShim(sdk, new BaggageManagerSdk());
   private final ExecutorService executor = Executors.newCachedThreadPool();
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/clientserver/TestClientServerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/clientserver/TestClientServerTest.java
@@ -41,7 +41,7 @@ class TestClientServerTest {
 
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = TraceShim.createTracerShim(sdk, new BaggageManagerSdk());
   private final ArrayBlockingQueue<Message> queue = new ArrayBlockingQueue<>(10);
   private Server server;

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/concurrentcommonrequesthandler/HandlerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/concurrentcommonrequesthandler/HandlerTest.java
@@ -49,7 +49,7 @@ class HandlerTest {
 
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = TraceShim.createTracerShim(sdk, new BaggageManagerSdk());
   private final Client client = new Client(new RequestHandler(tracer));
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/errorreporting/ErrorReportingTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/errorreporting/ErrorReportingTest.java
@@ -47,7 +47,7 @@ public final class ErrorReportingTest {
 
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = TraceShim.createTracerShim(sdk, new BaggageManagerSdk());
   private final ExecutorService executor = Executors.newCachedThreadPool();
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/latespanfinish/LateSpanFinishTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/latespanfinish/LateSpanFinishTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
 public final class LateSpanFinishTest {
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = TraceShim.createTracerShim(sdk, new BaggageManagerSdk());
   private final ExecutorService executor = Executors.newCachedThreadPool();
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/listenerperrequest/ListenerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/listenerperrequest/ListenerTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 class ListenerTest {
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = TraceShim.createTracerShim(sdk, new BaggageManagerSdk());
 
   @Test

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/multiplecallbacks/MultipleCallbacksTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/multiplecallbacks/MultipleCallbacksTest.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.Test;
 class MultipleCallbacksTest {
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = TraceShim.createTracerShim(sdk, new BaggageManagerSdk());
 
   @Test

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/nestedcallbacks/NestedCallbacksTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/nestedcallbacks/NestedCallbacksTest.java
@@ -43,7 +43,7 @@ public final class NestedCallbacksTest {
 
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = TraceShim.createTracerShim(sdk, new BaggageManagerSdk());
   private final ExecutorService executor = Executors.newCachedThreadPool();
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/promisepropagation/PromisePropagationTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/promisepropagation/PromisePropagationTest.java
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.Test;
 class PromisePropagationTest {
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = TraceShim.createTracerShim(sdk, new BaggageManagerSdk());
   private Phaser phaser;
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/statelesscommonrequesthandler/HandlerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/statelesscommonrequesthandler/HandlerTest.java
@@ -38,7 +38,7 @@ public final class HandlerTest {
 
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = TraceShim.createTracerShim(sdk, new BaggageManagerSdk());
   private final Client client = new Client(new RequestHandler(tracer));
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/suspendresumepropagation/SuspendResumePropagationTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/suspendresumepropagation/SuspendResumePropagationTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 class SuspendResumePropagationTest {
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = TraceShim.createTracerShim(sdk, new BaggageManagerSdk());
 
   @BeforeEach

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanAttributeTruncateBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanAttributeTruncateBenchmark.java
@@ -16,9 +16,11 @@
 
 package io.opentelemetry.sdk.trace;
 
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.trace.Span.Kind;
+import io.opentelemetry.trace.Tracer;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
@@ -35,8 +37,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @State(Scope.Benchmark)
 public class SpanAttributeTruncateBenchmark {
 
-  private final TracerSdk tracerSdk =
-      (TracerSdk) OpenTelemetrySdk.getTracerProvider().get("benchmarkTracer");
+  private final Tracer tracerSdk = OpenTelemetry.getTracer("benchmarkTracer");
   private SpanBuilderSdk spanBuilderSdk;
 
   public String shortValue = "short";
@@ -49,12 +50,12 @@ public class SpanAttributeTruncateBenchmark {
   @Setup(Level.Trial)
   public final void setup() {
     TraceConfig config =
-        OpenTelemetrySdk.getTracerProvider()
+        OpenTelemetrySdk.getTracerManagement()
             .getActiveTraceConfig()
             .toBuilder()
             .setMaxLengthOfAttributeValues(maxLength)
             .build();
-    OpenTelemetrySdk.getTracerProvider().updateActiveTraceConfig(config);
+    OpenTelemetrySdk.getTracerManagement().updateActiveTraceConfig(config);
     spanBuilderSdk =
         (SpanBuilderSdk)
             tracerSdk

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanAttributeTruncateBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanAttributeTruncateBenchmark.java
@@ -35,7 +35,8 @@ import org.openjdk.jmh.annotations.Warmup;
 @State(Scope.Benchmark)
 public class SpanAttributeTruncateBenchmark {
 
-  private final TracerSdk tracerSdk = OpenTelemetrySdk.getTracerProvider().get("benchmarkTracer");
+  private final TracerSdk tracerSdk =
+      (TracerSdk) OpenTelemetrySdk.getTracerProvider().get("benchmarkTracer");
   private SpanBuilderSdk spanBuilderSdk;
 
   public String shortValue = "short";

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanBenchmark.java
@@ -34,7 +34,8 @@ import org.openjdk.jmh.annotations.Warmup;
 @State(Scope.Benchmark)
 public class SpanBenchmark {
 
-  private final TracerSdk tracerSdk = OpenTelemetrySdk.getTracerProvider().get("benchmarkTracer");
+  private final TracerSdk tracerSdk =
+      (TracerSdk) OpenTelemetrySdk.getTracerProvider().get("benchmarkTracer");
   private RecordEventsReadableSpan span;
 
   @Setup(Level.Trial)

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanBenchmark.java
@@ -16,9 +16,10 @@
 
 package io.opentelemetry.sdk.trace;
 
-import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.Status;
+import io.opentelemetry.trace.Tracer;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
@@ -34,8 +35,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @State(Scope.Benchmark)
 public class SpanBenchmark {
 
-  private final TracerSdk tracerSdk =
-      (TracerSdk) OpenTelemetrySdk.getTracerProvider().get("benchmarkTracer");
+  private final Tracer tracerSdk = OpenTelemetry.getTracer("benchmarkTracer");
   private RecordEventsReadableSpan span;
 
   @Setup(Level.Trial)

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
@@ -21,6 +21,7 @@ import static io.opentelemetry.common.AttributesKeys.doubleKey;
 import static io.opentelemetry.common.AttributesKeys.longKey;
 import static io.opentelemetry.common.AttributesKeys.stringKey;
 
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.common.AttributeKey;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -34,6 +35,7 @@ import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.Status;
+import io.opentelemetry.trace.Tracer;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -57,7 +59,7 @@ public class SpanPipelineBenchmark {
   private static final AttributeKey<String> STRING_ATTRIBUTE_KEY = stringKey("stringAttribute");
   private static final AttributeKey<Double> DOUBLE_ATTRIBUTE_KEY = doubleKey("doubleAttribute");
   private static final AttributeKey<Boolean> BOOLEAN_ATTRIBUTE_KEY = booleanKey("booleanAttribute");
-  private final TracerSdk tracerSdk = OpenTelemetrySdk.getTracerProvider().get("benchmarkTracer");
+  private final Tracer tracer = OpenTelemetry.getTracerProvider().get("benchmarkTracer");
 
   @Setup(Level.Trial)
   public final void setup() {
@@ -78,7 +80,7 @@ public class SpanPipelineBenchmark {
 
   private void doWork() {
     Span span =
-        tracerSdk
+        tracer
             .spanBuilder("benchmarkSpan")
             .setSpanKind(Kind.CLIENT)
             .setAttribute("key", "value")

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
@@ -64,7 +64,7 @@ public class SpanPipelineBenchmark {
   @Setup(Level.Trial)
   public final void setup() {
     SpanExporter exporter = new NoOpSpanExporter();
-    OpenTelemetrySdk.getTracerProvider()
+    OpenTelemetrySdk.getTracerManagement()
         .addSpanProcessor(SimpleSpanProcessor.newBuilder(exporter).build());
   }
 

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -20,12 +20,13 @@ import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.internal.Obfuscated;
 import io.opentelemetry.sdk.baggage.BaggageManagerSdk;
 import io.opentelemetry.sdk.metrics.MeterSdkProvider;
+import io.opentelemetry.sdk.trace.TracerSdkManagement;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * This class provides a static global accessor for SDK telemetry objects {@link TracerSdkProvider},
- * {@link MeterSdkProvider} and {@link BaggageManagerSdk}.
+ * This class provides a static global accessor for SDK telemetry objects {@link
+ * TracerSdkManagement}, {@link MeterSdkProvider} and {@link BaggageManagerSdk}.
  *
  * <p>This is a convenience class getting and casting the telemetry objects from {@link
  * OpenTelemetry}.
@@ -35,12 +36,12 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class OpenTelemetrySdk {
   /**
-   * Returns a {@link TracerSdkProvider}.
+   * Returns a {@link TracerSdkManagement}.
    *
-   * @return TracerProvider returned by {@link OpenTelemetry#getTracerProvider()}.
+   * @return TracerSdkManagement for managing your Tracing SDK.
    */
-  public static TracerSdkProvider getTracerProvider() {
-    return (TracerSdkProvider) ((Obfuscated<?>) OpenTelemetry.getTracerProvider()).unobfuscate();
+  public static TracerSdkManagement getTracerManagement() {
+    return (TracerSdkManagement) ((Obfuscated<?>) OpenTelemetry.getTracerProvider()).unobfuscate();
   }
 
   /**

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -21,7 +21,6 @@ import io.opentelemetry.internal.Obfuscated;
 import io.opentelemetry.sdk.baggage.BaggageManagerSdk;
 import io.opentelemetry.sdk.metrics.MeterSdkProvider;
 import io.opentelemetry.sdk.trace.TracerSdkManagement;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -19,13 +19,14 @@ package io.opentelemetry.sdk;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.OpenTelemetry;
+import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import org.junit.jupiter.api.Test;
 
 class OpenTelemetrySdkTest {
 
   @Test
   void testDefault() {
-    assertThat(OpenTelemetrySdk.getTracerProvider().get(""))
+    assertThat(((TracerSdkProvider) OpenTelemetrySdk.getTracerManagement()).get(""))
         .isSameAs(OpenTelemetry.getTracerProvider().get(""));
     assertThat(OpenTelemetrySdk.getBaggageManager()).isSameAs(OpenTelemetry.getBaggageManager());
     assertThat(OpenTelemetrySdk.getMeterProvider()).isSameAs(OpenTelemetry.getMeterProvider());

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
@@ -59,8 +59,7 @@ final class TracerSdk implements Tracer {
   }
 
   /**
-   * Returns the instrumentation library specified when creating the tracer using {@link
-   * TracerSdkProvider}.
+   * Returns the instrumentation library specified when creating the tracer.
    *
    * @return an instance of {@link InstrumentationLibraryInfo}
    */

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/TracerSdkManagement.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/TracerSdkManagement.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.trace;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.config.TraceConfig;
+import io.opentelemetry.trace.Tracer;
+
+/**
+ * "Management" interface for the Tracing SDK. This interface exposes methods for configuring the
+ * Tracing SDK, as well as several lifecycle methods.
+ */
+public interface TracerSdkManagement {
+
+  /**
+   * Returns the active {@code TraceConfig}.
+   *
+   * @return the active {@code TraceConfig}.
+   */
+  TraceConfig getActiveTraceConfig();
+
+  /**
+   * Updates the active {@link TraceConfig}.
+   *
+   * <p>Note: To update the {@link TraceConfig} associated with this instance you should use the
+   * {@link TraceConfig#toBuilder()} method on the {@link TraceConfig} returned from {@link
+   * #getActiveTraceConfig()}, make the changes desired to the {@link TraceConfig.Builder} instance,
+   * then use this method with the resulting {@link TraceConfig} instance.
+   *
+   * @param traceConfig the new active {@code TraceConfig}.
+   * @see TraceConfig
+   */
+  void updateActiveTraceConfig(TraceConfig traceConfig);
+
+  /**
+   * Adds a new {@code SpanProcessor} to this {@code Tracer}.
+   *
+   * <p>Any registered processor cause overhead, consider to use an async/batch processor especially
+   * for span exporting, and export to multiple backends using the {@link
+   * io.opentelemetry.sdk.trace.export.MultiSpanExporter}.
+   *
+   * @param spanProcessor the new {@code SpanProcessor} to be added.
+   */
+  void addSpanProcessor(SpanProcessor spanProcessor);
+
+  /**
+   * Attempts to stop all the activity for this {@link Tracer}. Calls {@link
+   * SpanProcessor#shutdown()} for all registered {@link SpanProcessor}s.
+   *
+   * <p>This operation may block until all the Spans are processed. Must be called before turning
+   * off the main application to ensure all data are processed and exported.
+   *
+   * <p>After this is called all the newly created {@code Span}s will be no-op.
+   */
+  void shutdown();
+
+  /**
+   * Requests the active span processor to process all span events that have not yet been processed
+   * and returns a {@link CompletableResultCode} which is completed when the flush is finished.
+   *
+   * @see SpanProcessor#forceFlush()
+   */
+  CompletableResultCode forceFlush();
+}

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/TracerSdkProvider.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/TracerSdkProvider.java
@@ -56,12 +56,12 @@ public class TracerSdkProvider implements TracerProvider {
   }
 
   @Override
-  public TracerSdk get(String instrumentationName) {
+  public Tracer get(String instrumentationName) {
     return tracerSdkComponentRegistry.get(instrumentationName);
   }
 
   @Override
-  public TracerSdk get(String instrumentationName, String instrumentationVersion) {
+  public Tracer get(String instrumentationName, String instrumentationVersion) {
     return tracerSdkComponentRegistry.get(instrumentationName, instrumentationVersion);
   }
 

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/TracerSdkProvider.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/TracerSdkProvider.java
@@ -36,7 +36,7 @@ import java.util.logging.Logger;
  * io.opentelemetry.OpenTelemetry}. However, if you need a custom implementation of the factory, you
  * can create one as needed.
  */
-public class TracerSdkProvider implements TracerProvider {
+public class TracerSdkProvider implements TracerProvider, TracerSdkManagement {
   private static final Logger logger = Logger.getLogger(TracerProvider.class.getName());
   private final TracerSharedState sharedState;
   private final TracerSdkComponentRegistry tracerSdkComponentRegistry;
@@ -65,52 +65,22 @@ public class TracerSdkProvider implements TracerProvider {
     return tracerSdkComponentRegistry.get(instrumentationName, instrumentationVersion);
   }
 
-  /**
-   * Returns the active {@code TraceConfig}.
-   *
-   * @return the active {@code TraceConfig}.
-   */
+  @Override
   public TraceConfig getActiveTraceConfig() {
     return sharedState.getActiveTraceConfig();
   }
 
-  /**
-   * Updates the active {@link TraceConfig}.
-   *
-   * <p>Note: To update the {@link TraceConfig} associated with this instance you should use the
-   * {@link TraceConfig#toBuilder()} method on the {@link TraceConfig} returned from {@link
-   * #getActiveTraceConfig()}, make the changes desired to the {@link TraceConfig.Builder} instance,
-   * then use this method with the resulting {@link TraceConfig} instance.
-   *
-   * @param traceConfig the new active {@code TraceConfig}.
-   * @see TraceConfig
-   */
+  @Override
   public void updateActiveTraceConfig(TraceConfig traceConfig) {
     sharedState.updateActiveTraceConfig(traceConfig);
   }
 
-  /**
-   * Adds a new {@code SpanProcessor} to this {@code Tracer}.
-   *
-   * <p>Any registered processor cause overhead, consider to use an async/batch processor especially
-   * for span exporting, and export to multiple backends using the {@link
-   * io.opentelemetry.sdk.trace.export.MultiSpanExporter}.
-   *
-   * @param spanProcessor the new {@code SpanProcessor} to be added.
-   */
+  @Override
   public void addSpanProcessor(SpanProcessor spanProcessor) {
     sharedState.addSpanProcessor(spanProcessor);
   }
 
-  /**
-   * Attempts to stop all the activity for this {@link Tracer}. Calls {@link
-   * SpanProcessor#shutdown()} for all registered {@link SpanProcessor}s.
-   *
-   * <p>This operation may block until all the Spans are processed. Must be called before turning
-   * off the main application to ensure all data are processed and exported.
-   *
-   * <p>After this is called all the newly created {@code Span}s will be no-op.
-   */
+  @Override
   public void shutdown() {
     if (sharedState.isStopped()) {
       logger.log(Level.WARNING, "Calling shutdown() multiple times.");
@@ -119,12 +89,7 @@ public class TracerSdkProvider implements TracerProvider {
     sharedState.stop();
   }
 
-  /**
-   * Requests the active span processor to process all span events that have not yet been processed
-   * and returns a {@link CompletableResultCode} which is completed when the flush is finished.
-   *
-   * @see SpanProcessor#forceFlush()
-   */
+  @Override
   public CompletableResultCode forceFlush() {
     return sharedState.getActiveSpanProcessor().forceFlush();
   }

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
@@ -34,10 +34,10 @@ import javax.annotation.concurrent.Immutable;
  * Class that holds global trace parameters.
  *
  * <p>Note: To update the TraceConfig associated with a {@link
- * io.opentelemetry.sdk.trace.TracerSdkProvider}, you should use the {@link #toBuilder()} method on
- * the TraceConfig currently assigned to the provider, make the changes desired to the {@link
+ * io.opentelemetry.sdk.trace.TracerSdkManagement}, you should use the {@link #toBuilder()} method
+ * on the TraceConfig currently assigned to the provider, make the changes desired to the {@link
  * Builder} instance, then use the {@link
- * io.opentelemetry.sdk.trace.TracerSdkProvider#updateActiveTraceConfig(TraceConfig)} with the
+ * io.opentelemetry.sdk.trace.TracerSdkManagement#updateActiveTraceConfig(TraceConfig)} with the
  * resulting TraceConfig instance.
  *
  * <p>Configuration options for {@link TraceConfig} can be read from system properties, environment

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/SpanExporter.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/SpanExporter.java
@@ -17,7 +17,7 @@
 package io.opentelemetry.sdk.trace.export;
 
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.sdk.trace.TracerSdkManagement;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.Collection;
 
@@ -51,7 +51,7 @@ public interface SpanExporter {
   CompletableResultCode flush();
 
   /**
-   * Called when {@link TracerSdkProvider#shutdown()} is called, if this {@code SpanExporter} is
+   * Called when {@link TracerSdkManagement#shutdown()} is called, if this {@code SpanExporter} is
    * register to a {@code TracerSdkProvider} object.
    *
    * @return a {@link CompletableResultCode} which is completed when shutdown completes.

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/SpanExporter.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/SpanExporter.java
@@ -52,7 +52,7 @@ public interface SpanExporter {
 
   /**
    * Called when {@link TracerSdkManagement#shutdown()} is called, if this {@code SpanExporter} is
-   * register to a {@code TracerSdkProvider} object.
+   * registered to a {@code TracerSdkManagement} object.
    *
    * @return a {@link CompletableResultCode} which is completed when shutdown completes.
    */

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -63,7 +63,7 @@ class SpanBuilderSdkTest {
           TraceState.getDefault());
 
   private final TracerSdkProvider tracerSdkFactory = TracerSdkProvider.builder().build();
-  private final TracerSdk tracerSdk = tracerSdkFactory.get("SpanBuilderSdkTest");
+  private final TracerSdk tracerSdk = (TracerSdk) tracerSdkFactory.get("SpanBuilderSdkTest");
 
   @Test
   void setSpanKind_null() {

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
@@ -74,9 +74,9 @@ public final class TestUtils {
    * @return A SpanData instance.
    */
   public static Span.Builder startSpanWithSampler(
-      TracerSdkManagement tracerSdkFactory, Tracer tracer, String spanName, Sampler sampler) {
+      TracerSdkManagement tracerSdkManagement, Tracer tracer, String spanName, Sampler sampler) {
     return startSpanWithSampler(
-        tracerSdkFactory, tracer, spanName, sampler, Collections.emptyMap());
+        tracerSdkManagement, tracer, spanName, sampler, Collections.emptyMap());
   }
 
   /**
@@ -86,13 +86,13 @@ public final class TestUtils {
    * @return A SpanData instance.
    */
   public static Span.Builder startSpanWithSampler(
-      TracerSdkManagement tracerSdkFactory,
+      TracerSdkManagement tracerSdkManagement,
       Tracer tracer,
       String spanName,
       Sampler sampler,
       Map<String, String> attributes) {
-    TraceConfig originalConfig = tracerSdkFactory.getActiveTraceConfig();
-    tracerSdkFactory.updateActiveTraceConfig(
+    TraceConfig originalConfig = tracerSdkManagement.getActiveTraceConfig();
+    tracerSdkManagement.updateActiveTraceConfig(
         originalConfig.toBuilder().setSampler(sampler).build());
     try {
       Span.Builder builder = tracer.spanBuilder(spanName);
@@ -100,7 +100,7 @@ public final class TestUtils {
 
       return builder;
     } finally {
-      tracerSdkFactory.updateActiveTraceConfig(originalConfig);
+      tracerSdkManagement.updateActiveTraceConfig(originalConfig);
     }
   }
 }

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
@@ -74,7 +74,7 @@ public final class TestUtils {
    * @return A SpanData instance.
    */
   public static Span.Builder startSpanWithSampler(
-      TracerSdkProvider tracerSdkFactory, Tracer tracer, String spanName, Sampler sampler) {
+      TracerSdkManagement tracerSdkFactory, Tracer tracer, String spanName, Sampler sampler) {
     return startSpanWithSampler(
         tracerSdkFactory, tracer, spanName, sampler, Collections.emptyMap());
   }
@@ -86,7 +86,7 @@ public final class TestUtils {
    * @return A SpanData instance.
    */
   public static Span.Builder startSpanWithSampler(
-      TracerSdkProvider tracerSdkFactory,
+      TracerSdkManagement tracerSdkFactory,
       Tracer tracer,
       String spanName,
       Sampler sampler,

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkProviderTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkProviderTest.java
@@ -28,6 +28,7 @@ import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.Tracer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -104,8 +105,8 @@ class TracerSdkProviderTest {
   void propagatesInstrumentationLibraryInfoToTracer() {
     InstrumentationLibraryInfo expected =
         InstrumentationLibraryInfo.create("theName", "theVersion");
-    TracerSdk tracer = tracerFactory.get(expected.getName(), expected.getVersion());
-    assertThat(tracer.getInstrumentationLibraryInfo()).isEqualTo(expected);
+    Tracer tracer = tracerFactory.get(expected.getName(), expected.getVersion());
+    assertThat(((TracerSdk) tracer).getInstrumentationLibraryInfo()).isEqualTo(expected);
   }
 
   @Test

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -51,9 +51,10 @@ class TracerSdkTest {
           INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION);
   @Mock private Span span;
   private final TracerSdk tracer =
-      TracerSdkProvider.builder()
-          .build()
-          .get(INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION);
+      (TracerSdk)
+          TracerSdkProvider.builder()
+              .build()
+              .get(INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION);
 
   @BeforeEach
   void setUp() {
@@ -118,7 +119,8 @@ class TracerSdkTest {
     TracerSdkProvider tracerSdkProvider = TracerSdkProvider.builder().build();
     tracerSdkProvider.addSpanProcessor(spanProcessor);
     TracerSdk tracer =
-        tracerSdkProvider.get(INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION);
+        (TracerSdk)
+            tracerSdkProvider.get(INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION);
 
     StressTestRunner.Builder stressTestBuilder =
         StressTestRunner.builder().setTracer(tracer).setSpanProcessor(spanProcessor);
@@ -140,7 +142,8 @@ class TracerSdkTest {
     TracerSdkProvider tracerSdkProvider = TracerSdkProvider.builder().build();
     tracerSdkProvider.addSpanProcessor(spanProcessor);
     TracerSdk tracer =
-        tracerSdkProvider.get(INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION);
+        (TracerSdk)
+            tracerSdkProvider.get(INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION);
 
     StressTestRunner.Builder stressTestBuilder =
         StressTestRunner.builder().setTracer(tracer).setSpanProcessor(spanProcessor);

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/activespanreplacement/ActiveSpanReplacementTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/activespanreplacement/ActiveSpanReplacementTest.java
@@ -41,7 +41,7 @@ class ActiveSpanReplacementTest {
 
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = sdk.get(ActiveSpanReplacementTest.class.getName());
   private final ExecutorService executor = Executors.newCachedThreadPool();
 

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/actorpropagation/ActorPropagationTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/actorpropagation/ActorPropagationTest.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.Test;
 class ActorPropagationTest {
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = sdk.get(ActorPropagationTest.class.getName());
   private Phaser phaser;
 

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/clientserver/TestClientServerTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/clientserver/TestClientServerTest.java
@@ -39,7 +39,7 @@ class TestClientServerTest {
 
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = sdk.get(TestClientServerTest.class.getName());
   private final ArrayBlockingQueue<Message> queue = new ArrayBlockingQueue<>(10);
   private Server server;

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/concurrentcommonrequesthandler/HandlerTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/concurrentcommonrequesthandler/HandlerTest.java
@@ -44,7 +44,7 @@ class HandlerTest {
 
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = sdk.get(HandlerTest.class.getName());
   private final Client client = new Client(new RequestHandler(tracer));
 

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/errorreporting/ErrorReportingTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/errorreporting/ErrorReportingTest.java
@@ -42,7 +42,7 @@ public final class ErrorReportingTest {
 
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = sdk.get(ErrorReportingTest.class.getName());
   private final ExecutorService executor = Executors.newCachedThreadPool();
 

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/latespanfinish/LateSpanFinishTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/latespanfinish/LateSpanFinishTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 public final class LateSpanFinishTest {
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = sdk.get(LateSpanFinishTest.class.getName());
   private final ExecutorService executor = Executors.newCachedThreadPool();
 

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/listenerperrequest/ListenerTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/listenerperrequest/ListenerTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 class ListenerTest {
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = sdk.get(ListenerTest.class.getName());
 
   @Test

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/multiplecallbacks/MultipleCallbacksTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/multiplecallbacks/MultipleCallbacksTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
 class MultipleCallbacksTest {
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = sdk.get(MultipleCallbacksTest.class.getName());
 
   @Test

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/nestedcallbacks/NestedCallbacksTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/nestedcallbacks/NestedCallbacksTest.java
@@ -41,7 +41,7 @@ public final class NestedCallbacksTest {
 
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = sdk.get(NestedCallbacksTest.class.getName());
   private final ExecutorService executor = Executors.newCachedThreadPool();
 

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/promisepropagation/PromisePropagationTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/promisepropagation/PromisePropagationTest.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.Test;
 class PromisePropagationTest {
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = sdk.get(PromisePropagationTest.class.getName());
   private Phaser phaser;
 

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/statelesscommonrequesthandler/HandlerTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/statelesscommonrequesthandler/HandlerTest.java
@@ -36,7 +36,7 @@ public final class HandlerTest {
 
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = sdk.get(HandlerTest.class.getName());
   private final Client client = new Client(new RequestHandler(tracer));
 

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/suspendresumepropagation/SuspendResumePropagationTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/suspendresumepropagation/SuspendResumePropagationTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 class SuspendResumePropagationTest {
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
   private final InMemoryTracing inMemoryTracing =
-      InMemoryTracing.builder().setTracerProvider(sdk).build();
+      InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
   private final Tracer tracer = sdk.get(SuspendResumePropagationTest.class.getName());
 
   @BeforeEach

--- a/sdk_extensions/zpages/src/jmh/java/io/opentelemetry/sdk/extensions/zpages/TracezDataAggregatorBenchmark.java
+++ b/sdk_extensions/zpages/src/jmh/java/io/opentelemetry/sdk/extensions/zpages/TracezDataAggregatorBenchmark.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.zpages;
 
-import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.Tracer;
@@ -41,8 +41,7 @@ public class TracezDataAggregatorBenchmark {
   private static final String runningSpan = "RUNNING_SPAN";
   private static final String latencySpan = "LATENCY_SPAN";
   private static final String errorSpan = "ERROR_SPAN";
-  private final Tracer tracer =
-      OpenTelemetrySdk.getTracerProvider().get("TracezDataAggregatorBenchmark");
+  private final Tracer tracer = OpenTelemetry.getTracer("TracezDataAggregatorBenchmark");
   private final TracezSpanProcessor spanProcessor = TracezSpanProcessor.newBuilder().build();
   private final TracezDataAggregator dataAggregator = new TracezDataAggregator(spanProcessor);
 

--- a/sdk_extensions/zpages/src/jmh/java/io/opentelemetry/sdk/extensions/zpages/TracezSpanBucketsBenchmark.java
+++ b/sdk_extensions/zpages/src/jmh/java/io/opentelemetry/sdk/extensions/zpages/TracezSpanBucketsBenchmark.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.sdk.extensions.zpages;
 
-import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -43,7 +43,7 @@ public class TracezSpanBucketsBenchmark {
   @Setup(Level.Trial)
   public final void setup() {
     bucket = new TracezSpanBuckets();
-    Tracer tracer = OpenTelemetrySdk.getTracerProvider().get("TracezZPageBenchmark");
+    Tracer tracer = OpenTelemetry.getTracer("TracezZPageBenchmark");
     Span span = tracer.spanBuilder(spanName).startSpan();
     span.end();
     readableSpan = (ReadableSpan) span;

--- a/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/TraceConfigzZPageHandler.java
+++ b/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/TraceConfigzZPageHandler.java
@@ -45,10 +45,10 @@ final class TraceConfigzZPageHandler extends ZPageHandler {
   // Background color used for zebra striping rows in table
   private static final String ZEBRA_STRIPE_COLOR = "#e6e6e6";
   private static final Logger logger = Logger.getLogger(TraceConfigzZPageHandler.class.getName());
-  private final TracerSdkManagement tracerProvider;
+  private final TracerSdkManagement tracerSdkManagement;
 
-  TraceConfigzZPageHandler(TracerSdkManagement tracerProvider) {
-    this.tracerProvider = tracerProvider;
+  TraceConfigzZPageHandler(TracerSdkManagement tracerSdkManagement) {
+    this.tracerSdkManagement = tracerSdkManagement;
   }
 
   @Override
@@ -221,42 +221,45 @@ final class TraceConfigzZPageHandler extends ZPageHandler {
     emitActiveTableRow(
         /* out= */ out,
         /* paramName= */ "Sampler",
-        /* paramValue=*/ this.tracerProvider.getActiveTraceConfig().getSampler().getDescription(),
+        /* paramValue=*/ this.tracerSdkManagement
+            .getActiveTraceConfig()
+            .getSampler()
+            .getDescription(),
         /* zebraStripeColor= */ ZEBRA_STRIPE_COLOR,
         /* zebraStripe= */ false);
     emitActiveTableRow(
         /* out= */ out,
         /* paramName= */ "MaxNumOfAttributes",
         /* paramValue=*/ Integer.toString(
-            this.tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributes()),
+            this.tracerSdkManagement.getActiveTraceConfig().getMaxNumberOfAttributes()),
         /* zebraStripeColor= */ ZEBRA_STRIPE_COLOR,
         /* zebraStripe= */ true);
     emitActiveTableRow(
         /* out= */ out,
         /* paramName= */ "MaxNumOfEvents",
         /* paramValue=*/ Integer.toString(
-            this.tracerProvider.getActiveTraceConfig().getMaxNumberOfEvents()),
+            this.tracerSdkManagement.getActiveTraceConfig().getMaxNumberOfEvents()),
         /* zebraStripeColor= */ ZEBRA_STRIPE_COLOR,
         /* zebraStripe= */ false);
     emitActiveTableRow(
         /* out= */ out,
         /* paramName= */ "MaxNumOfLinks",
         /* paramValue=*/ Integer.toString(
-            this.tracerProvider.getActiveTraceConfig().getMaxNumberOfLinks()),
+            this.tracerSdkManagement.getActiveTraceConfig().getMaxNumberOfLinks()),
         /* zebraStripeColor= */ ZEBRA_STRIPE_COLOR,
         /* zebraStripe= */ true);
     emitActiveTableRow(
         /* out= */ out,
         /* paramName= */ "MaxNumOfAttributesPerEvent",
         /* paramValue=*/ Integer.toString(
-            this.tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributesPerEvent()),
+            this.tracerSdkManagement.getActiveTraceConfig().getMaxNumberOfAttributesPerEvent()),
         /* zebraStripeColor= */ ZEBRA_STRIPE_COLOR,
         /* zebraStripe= */ false);
     emitActiveTableRow(
         /* out= */ out,
         /* paramName= */ "MaxNumOfAttributesPerLink",
         /* paramValue=*/ Integer.toString(
-            this.tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributesPerLink()),
+            this.tracerSdkManagement.getActiveTraceConfig().getMaxNumberOfAttributesPerLink()),
         /* zebraStripeColor= */ ZEBRA_STRIPE_COLOR,
         /* zebraStripe=*/ true);
     out.print("</table>");
@@ -376,7 +379,8 @@ final class TraceConfigzZPageHandler extends ZPageHandler {
       return;
     }
     if (action.equals(QUERY_STRING_ACTION_CHANGE)) {
-      TraceConfig.Builder newConfigBuilder = this.tracerProvider.getActiveTraceConfig().toBuilder();
+      TraceConfig.Builder newConfigBuilder =
+          this.tracerSdkManagement.getActiveTraceConfig().toBuilder();
       String samplingProbabilityStr = queryMap.get(QUERY_STRING_SAMPLING_PROBABILITY);
       if (samplingProbabilityStr != null) {
         try {
@@ -441,10 +445,10 @@ final class TraceConfigzZPageHandler extends ZPageHandler {
               "MaxNumOfAttributesPerLink must be of the type integer", e);
         }
       }
-      this.tracerProvider.updateActiveTraceConfig(newConfigBuilder.build());
+      this.tracerSdkManagement.updateActiveTraceConfig(newConfigBuilder.build());
     } else if (action.equals(QUERY_STRING_ACTION_DEFAULT)) {
       TraceConfig defaultConfig = TraceConfig.getDefault().toBuilder().build();
-      this.tracerProvider.updateActiveTraceConfig(defaultConfig);
+      this.tracerSdkManagement.updateActiveTraceConfig(defaultConfig);
     }
   }
 }

--- a/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/TraceConfigzZPageHandler.java
+++ b/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/TraceConfigzZPageHandler.java
@@ -17,7 +17,7 @@
 package io.opentelemetry.sdk.extensions.zpages;
 
 import io.opentelemetry.sdk.trace.Samplers;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.sdk.trace.TracerSdkManagement;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -45,9 +45,9 @@ final class TraceConfigzZPageHandler extends ZPageHandler {
   // Background color used for zebra striping rows in table
   private static final String ZEBRA_STRIPE_COLOR = "#e6e6e6";
   private static final Logger logger = Logger.getLogger(TraceConfigzZPageHandler.class.getName());
-  private final TracerSdkProvider tracerProvider;
+  private final TracerSdkManagement tracerProvider;
 
-  TraceConfigzZPageHandler(TracerSdkProvider tracerProvider) {
+  TraceConfigzZPageHandler(TracerSdkManagement tracerProvider) {
     this.tracerProvider = tracerProvider;
   }
 

--- a/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/ZPageServer.java
+++ b/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/ZPageServer.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.sun.net.httpserver.HttpServer;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.trace.TracerSdkManagement;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -69,7 +70,7 @@ public final class ZPageServer {
       TracezSpanProcessor.newBuilder().build();
   private static final TracezDataAggregator tracezDataAggregator =
       new TracezDataAggregator(tracezSpanProcessor);
-  private static final TracerSdkProvider tracerProvider = OpenTelemetrySdk.getTracerProvider();
+  private static final TracerSdkManagement tracerProvider = OpenTelemetrySdk.getTracerManagement();
   // Handler for /tracez page
   private static final ZPageHandler tracezZPageHandler =
       new TracezZPageHandler(tracezDataAggregator);

--- a/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/ZPageServer.java
+++ b/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/ZPageServer.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableList;
 import com.sun.net.httpserver.HttpServer;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.TracerSdkManagement;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -70,13 +69,14 @@ public final class ZPageServer {
       TracezSpanProcessor.newBuilder().build();
   private static final TracezDataAggregator tracezDataAggregator =
       new TracezDataAggregator(tracezSpanProcessor);
-  private static final TracerSdkManagement tracerProvider = OpenTelemetrySdk.getTracerManagement();
+  private static final TracerSdkManagement TRACER_SDK_MANAGEMENT =
+      OpenTelemetrySdk.getTracerManagement();
   // Handler for /tracez page
   private static final ZPageHandler tracezZPageHandler =
       new TracezZPageHandler(tracezDataAggregator);
   // Handler for /traceconfigz page
   private static final ZPageHandler traceConfigzZPageHandler =
-      new TraceConfigzZPageHandler(tracerProvider);
+      new TraceConfigzZPageHandler(TRACER_SDK_MANAGEMENT);
   // Handler for index page, **please include all available ZPageHandlers in the constructor**
   private static final ZPageHandler indexZPageHandler =
       new IndexZPageHandler(ImmutableList.of(tracezZPageHandler, traceConfigzZPageHandler));
@@ -88,10 +88,10 @@ public final class ZPageServer {
   @Nullable
   private static HttpServer server;
 
-  /** Function that adds the {@link TracezSpanProcessor} to the {@link TracerSdkProvider}. */
+  /** Function that adds the {@link TracezSpanProcessor} to the {@link TracerSdkManagement}. */
   private static void addTracezSpanProcessor() {
     if (isTracezSpanProcesserAdded.compareAndSet(/* expectedValue=*/ false, /* newValue=*/ true)) {
-      tracerProvider.addSpanProcessor(tracezSpanProcessor);
+      TRACER_SDK_MANAGEMENT.addSpanProcessor(tracezSpanProcessor);
     }
   }
 

--- a/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TraceConfigzZPageHandlerTest.java
+++ b/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TraceConfigzZPageHandlerTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.Samplers;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.sdk.trace.TracerSdkManagement;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link TraceConfigzZPageHandler}. */
 public final class TraceConfigzZPageHandlerTest {
-  private static final TracerSdkProvider tracerProvider = OpenTelemetrySdk.getTracerProvider();
+  private static final TracerSdkManagement tracerProvider = OpenTelemetrySdk.getTracerManagement();
   private static final Map<String, String> emptyQueryMap = ImmutableMap.of();
 
   @BeforeEach

--- a/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TraceConfigzZPageHandlerTest.java
+++ b/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TraceConfigzZPageHandlerTest.java
@@ -31,7 +31,8 @@ import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link TraceConfigzZPageHandler}. */
 public final class TraceConfigzZPageHandlerTest {
-  private static final TracerSdkManagement tracerProvider = OpenTelemetrySdk.getTracerManagement();
+  private static final TracerSdkManagement TRACER_SDK_MANAGEMENT =
+      OpenTelemetrySdk.getTracerManagement();
   private static final Map<String, String> emptyQueryMap = ImmutableMap.of();
 
   @BeforeEach
@@ -41,21 +42,21 @@ public final class TraceConfigzZPageHandlerTest {
     Map<String, String> queryMap = ImmutableMap.of("action", "default");
 
     TraceConfigzZPageHandler traceConfigzZPageHandler =
-        new TraceConfigzZPageHandler(tracerProvider);
+        new TraceConfigzZPageHandler(TRACER_SDK_MANAGEMENT);
     traceConfigzZPageHandler.processRequest("POST", queryMap, output);
     traceConfigzZPageHandler.emitHtml(queryMap, output);
 
-    assertThat(tracerProvider.getActiveTraceConfig().getSampler().getDescription())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getSampler().getDescription())
         .isEqualTo(TraceConfig.getDefault().getSampler().getDescription());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributes())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributes())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfAttributes());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfEvents())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfEvents())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfEvents());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfLinks())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfLinks())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfLinks());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributesPerEvent())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributesPerEvent())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfAttributesPerEvent());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributesPerLink())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributesPerLink())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfAttributesPerLink());
   }
 
@@ -70,7 +71,7 @@ public final class TraceConfigzZPageHandlerTest {
     String queryMaxNumOfAttributesPerLink = "maxnumofattributesperlink";
 
     TraceConfigzZPageHandler traceConfigzZPageHandler =
-        new TraceConfigzZPageHandler(tracerProvider);
+        new TraceConfigzZPageHandler(TRACER_SDK_MANAGEMENT);
     traceConfigzZPageHandler.emitHtml(emptyQueryMap, output);
 
     assertThat(output.toString()).contains("SamplingProbability to");
@@ -111,43 +112,47 @@ public final class TraceConfigzZPageHandlerTest {
     OutputStream output = new ByteArrayOutputStream();
 
     TraceConfigzZPageHandler traceConfigzZPageHandler =
-        new TraceConfigzZPageHandler(tracerProvider);
+        new TraceConfigzZPageHandler(TRACER_SDK_MANAGEMENT);
     traceConfigzZPageHandler.emitHtml(emptyQueryMap, output);
 
     assertThat(output.toString()).contains("Sampler");
     assertThat(output.toString())
-        .contains(">" + tracerProvider.getActiveTraceConfig().getSampler().getDescription() + "<");
+        .contains(
+            ">" + TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getSampler().getDescription() + "<");
     assertThat(output.toString()).contains("MaxNumberOfAttributes");
     assertThat(output.toString())
         .contains(
             ">"
-                + Integer.toString(tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributes())
+                + Integer.toString(
+                    TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributes())
                 + "<");
     assertThat(output.toString()).contains("MaxNumberOfEvents");
     assertThat(output.toString())
         .contains(
             ">"
-                + Integer.toString(tracerProvider.getActiveTraceConfig().getMaxNumberOfEvents())
+                + Integer.toString(
+                    TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfEvents())
                 + "<");
     assertThat(output.toString()).contains("MaxNumberOfLinks");
     assertThat(output.toString())
         .contains(
             ">"
-                + Integer.toString(tracerProvider.getActiveTraceConfig().getMaxNumberOfLinks())
+                + Integer.toString(
+                    TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfLinks())
                 + "<");
     assertThat(output.toString()).contains("MaxNumberOfAttributesPerEvent");
     assertThat(output.toString())
         .contains(
             ">"
                 + Integer.toString(
-                    tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributesPerEvent())
+                    TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributesPerEvent())
                 + "<");
     assertThat(output.toString()).contains("MaxNumberOfAttributesPerLink");
     assertThat(output.toString())
         .contains(
             ">"
                 + Integer.toString(
-                    tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributesPerLink())
+                    TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributesPerLink())
                 + "<");
   }
 
@@ -179,23 +184,23 @@ public final class TraceConfigzZPageHandlerTest {
             .build();
 
     TraceConfigzZPageHandler traceConfigzZPageHandler =
-        new TraceConfigzZPageHandler(tracerProvider);
+        new TraceConfigzZPageHandler(TRACER_SDK_MANAGEMENT);
     traceConfigzZPageHandler.processRequest("POST", queryMap, output);
     traceConfigzZPageHandler.emitHtml(queryMap, output);
 
-    assertThat(tracerProvider.getActiveTraceConfig().getSampler().getDescription())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getSampler().getDescription())
         .isEqualTo(
             Samplers.traceIdRatioBased(Double.parseDouble(newSamplingProbability))
                 .getDescription());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributes())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributes())
         .isEqualTo(Integer.parseInt(newMaxNumOfAttributes));
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfEvents())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfEvents())
         .isEqualTo(Integer.parseInt(newMaxNumOfEvents));
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfLinks())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfLinks())
         .isEqualTo(Integer.parseInt(newMaxNumOfLinks));
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributesPerEvent())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributesPerEvent())
         .isEqualTo(Integer.parseInt(newMaxNumOfAttributesPerEvent));
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributesPerLink())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributesPerLink())
         .isEqualTo(Integer.parseInt(newMaxNumOfAttributesPerLink));
   }
 
@@ -206,21 +211,21 @@ public final class TraceConfigzZPageHandlerTest {
     Map<String, String> queryMap = ImmutableMap.of("action", "default");
 
     TraceConfigzZPageHandler traceConfigzZPageHandler =
-        new TraceConfigzZPageHandler(tracerProvider);
+        new TraceConfigzZPageHandler(TRACER_SDK_MANAGEMENT);
     traceConfigzZPageHandler.processRequest("POST", queryMap, output);
     traceConfigzZPageHandler.emitHtml(queryMap, output);
 
-    assertThat(tracerProvider.getActiveTraceConfig().getSampler().getDescription())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getSampler().getDescription())
         .isEqualTo(TraceConfig.getDefault().getSampler().getDescription());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributes())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributes())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfAttributes());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfEvents())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfEvents())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfEvents());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfLinks())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfLinks())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfLinks());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributesPerEvent())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributesPerEvent())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfAttributesPerEvent());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributesPerLink())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributesPerLink())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfAttributesPerLink());
   }
 
@@ -231,21 +236,21 @@ public final class TraceConfigzZPageHandlerTest {
     Map<String, String> queryMap = ImmutableMap.of("action", "change");
 
     TraceConfigzZPageHandler traceConfigzZPageHandler =
-        new TraceConfigzZPageHandler(tracerProvider);
+        new TraceConfigzZPageHandler(TRACER_SDK_MANAGEMENT);
     traceConfigzZPageHandler.processRequest("POST", queryMap, output);
     traceConfigzZPageHandler.emitHtml(queryMap, output);
 
-    assertThat(tracerProvider.getActiveTraceConfig().getSampler().getDescription())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getSampler().getDescription())
         .isEqualTo(TraceConfig.getDefault().getSampler().getDescription());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributes())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributes())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfAttributes());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfEvents())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfEvents())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfEvents());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfLinks())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfLinks())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfLinks());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributesPerEvent())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributesPerEvent())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfAttributesPerEvent());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributesPerLink())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributesPerLink())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfAttributesPerLink());
   }
 
@@ -254,7 +259,7 @@ public final class TraceConfigzZPageHandlerTest {
     // Invalid samplingProbability (not type of double)
     OutputStream output = new ByteArrayOutputStream();
     TraceConfigzZPageHandler traceConfigzZPageHandler =
-        new TraceConfigzZPageHandler(tracerProvider);
+        new TraceConfigzZPageHandler(TRACER_SDK_MANAGEMENT);
     Map<String, String> queryMap =
         ImmutableMap.of("action", "change", "samplingprobability", "invalid");
 
@@ -265,7 +270,7 @@ public final class TraceConfigzZPageHandlerTest {
 
     // Invalid samplingProbability (< 0)
     output = new ByteArrayOutputStream();
-    traceConfigzZPageHandler = new TraceConfigzZPageHandler(tracerProvider);
+    traceConfigzZPageHandler = new TraceConfigzZPageHandler(TRACER_SDK_MANAGEMENT);
     queryMap = ImmutableMap.of("action", "change", "samplingprobability", "-1");
 
     traceConfigzZPageHandler.processRequest("POST", queryMap, output);
@@ -275,7 +280,7 @@ public final class TraceConfigzZPageHandlerTest {
 
     // Invalid samplingProbability (> 1)
     output = new ByteArrayOutputStream();
-    traceConfigzZPageHandler = new TraceConfigzZPageHandler(tracerProvider);
+    traceConfigzZPageHandler = new TraceConfigzZPageHandler(TRACER_SDK_MANAGEMENT);
     queryMap = ImmutableMap.of("action", "change", "samplingprobability", "1.1");
 
     traceConfigzZPageHandler.processRequest("POST", queryMap, output);
@@ -285,7 +290,7 @@ public final class TraceConfigzZPageHandlerTest {
 
     // Invalid maxNumOfAttributes
     output = new ByteArrayOutputStream();
-    traceConfigzZPageHandler = new TraceConfigzZPageHandler(tracerProvider);
+    traceConfigzZPageHandler = new TraceConfigzZPageHandler(TRACER_SDK_MANAGEMENT);
     queryMap = ImmutableMap.of("action", "change", "maxnumofattributes", "invalid");
 
     traceConfigzZPageHandler.processRequest("POST", queryMap, output);
@@ -295,7 +300,7 @@ public final class TraceConfigzZPageHandlerTest {
 
     // Invalid maxNumOfEvents
     output = new ByteArrayOutputStream();
-    traceConfigzZPageHandler = new TraceConfigzZPageHandler(tracerProvider);
+    traceConfigzZPageHandler = new TraceConfigzZPageHandler(TRACER_SDK_MANAGEMENT);
     queryMap = ImmutableMap.of("action", "change", "maxnumofevents", "invalid");
 
     traceConfigzZPageHandler.processRequest("POST", queryMap, output);
@@ -305,7 +310,7 @@ public final class TraceConfigzZPageHandlerTest {
 
     // Invalid maxNumLinks
     output = new ByteArrayOutputStream();
-    traceConfigzZPageHandler = new TraceConfigzZPageHandler(tracerProvider);
+    traceConfigzZPageHandler = new TraceConfigzZPageHandler(TRACER_SDK_MANAGEMENT);
     queryMap = ImmutableMap.of("action", "change", "maxnumoflinks", "invalid");
 
     traceConfigzZPageHandler.processRequest("POST", queryMap, output);
@@ -315,7 +320,7 @@ public final class TraceConfigzZPageHandlerTest {
 
     // Invalid maxNumOfAttributesPerEvent
     output = new ByteArrayOutputStream();
-    traceConfigzZPageHandler = new TraceConfigzZPageHandler(tracerProvider);
+    traceConfigzZPageHandler = new TraceConfigzZPageHandler(TRACER_SDK_MANAGEMENT);
     queryMap = ImmutableMap.of("action", "change", "maxnumofattributesperevent", "invalid");
 
     traceConfigzZPageHandler.processRequest("POST", queryMap, output);
@@ -326,7 +331,7 @@ public final class TraceConfigzZPageHandlerTest {
 
     // Invalid maxNumOfAttributesPerLink
     output = new ByteArrayOutputStream();
-    traceConfigzZPageHandler = new TraceConfigzZPageHandler(tracerProvider);
+    traceConfigzZPageHandler = new TraceConfigzZPageHandler(TRACER_SDK_MANAGEMENT);
     queryMap = ImmutableMap.of("action", "change", "maxnumofattributesperlink", "invalid");
 
     traceConfigzZPageHandler.processRequest("POST", queryMap, output);
@@ -364,41 +369,41 @@ public final class TraceConfigzZPageHandlerTest {
             .build();
 
     TraceConfigzZPageHandler traceConfigzZPageHandler =
-        new TraceConfigzZPageHandler(tracerProvider);
+        new TraceConfigzZPageHandler(TRACER_SDK_MANAGEMENT);
 
     // GET request, Should not apply changes
     traceConfigzZPageHandler.emitHtml(queryMap, output);
 
-    assertThat(tracerProvider.getActiveTraceConfig().getSampler().getDescription())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getSampler().getDescription())
         .isEqualTo(TraceConfig.getDefault().getSampler().getDescription());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributes())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributes())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfAttributes());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfEvents())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfEvents())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfEvents());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfLinks())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfLinks())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfLinks());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributesPerEvent())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributesPerEvent())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfAttributesPerEvent());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributesPerLink())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributesPerLink())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfAttributesPerLink());
 
     // POST request, Should apply changes
     traceConfigzZPageHandler.processRequest("POST", queryMap, output);
     traceConfigzZPageHandler.emitHtml(queryMap, output);
 
-    assertThat(tracerProvider.getActiveTraceConfig().getSampler().getDescription())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getSampler().getDescription())
         .isEqualTo(
             Samplers.traceIdRatioBased(Double.parseDouble(newSamplingProbability))
                 .getDescription());
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributes())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributes())
         .isEqualTo(Integer.parseInt(newMaxNumOfAttributes));
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfEvents())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfEvents())
         .isEqualTo(Integer.parseInt(newMaxNumOfEvents));
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfLinks())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfLinks())
         .isEqualTo(Integer.parseInt(newMaxNumOfLinks));
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributesPerEvent())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributesPerEvent())
         .isEqualTo(Integer.parseInt(newMaxNumOfAttributesPerEvent));
-    assertThat(tracerProvider.getActiveTraceConfig().getMaxNumberOfAttributesPerLink())
+    assertThat(TRACER_SDK_MANAGEMENT.getActiveTraceConfig().getMaxNumberOfAttributesPerLink())
         .isEqualTo(Integer.parseInt(newMaxNumOfAttributesPerLink));
   }
 }


### PR DESCRIPTION
Rather than expose the TracerSdkProvider directly, this introduces a new interface for managing the Tracing SDK. This will make it more obvious that the OpenTelemetrySdk access methods are not to be used for instrumentation purposes, but for operating the SDK itself.

This is a draft of how to resolve #1635 . 

Note: this only covers the Tracing side of the house. Metrics and Baggage probably want the same treatment, but I wanted to keep this relatively limited to make sure we're ok with moving in this direction.