### PR TITLE
Use awaitility / higher timeout to reduce flakiness.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -331,6 +331,7 @@ configure(opentelemetryProjects) {
                 libraries.mockito,
                 libraries.mockito_junit_jupiter,
                 libraries.assertj,
+                libraries.awaitility,
                 libraries.guava_testlib
 
         testRuntimeOnly libraries.junit_jupiter_engine,

--- a/exporters/jaeger/build.gradle
+++ b/exporters/jaeger/build.gradle
@@ -22,7 +22,6 @@ dependencies {
 
     testImplementation "io.grpc:grpc-testing:${grpcVersion}",
             libraries.testcontainers,
-            libraries.awaitility,
             libraries.rest_assured
 
     testImplementation project(':opentelemetry-testing-internal')

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
@@ -17,6 +17,7 @@
 package io.opentelemetry.exporters.otlp;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import com.google.common.io.Closer;
 import io.grpc.ManagedChannel;
@@ -30,6 +31,7 @@ import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.Span.Kind;
@@ -138,12 +140,14 @@ class OtlpGrpcSpanExporterTest {
 
     try {
       TimeUnit.MILLISECONDS.sleep(2 * deadlineMs);
-      assertThat(exporter.export(Collections.singletonList(generateFakeSpan())).isSuccess())
-          .isTrue();
+      CompletableResultCode result1 =
+          exporter.export(Collections.singletonList(generateFakeSpan()));
+      await().untilAsserted(() -> assertThat(result1.isSuccess()).isTrue());
 
       TimeUnit.MILLISECONDS.sleep(2 * deadlineMs);
-      assertThat(exporter.export(Collections.singletonList(generateFakeSpan())).isSuccess())
-          .isTrue();
+      CompletableResultCode result2 =
+          exporter.export(Collections.singletonList(generateFakeSpan()));
+      await().untilAsserted(() -> assertThat(result2.isSuccess()).isTrue());
     } finally {
       exporter.shutdown();
     }

--- a/integration_tests/build.gradle
+++ b/integration_tests/build.gradle
@@ -28,7 +28,6 @@ dependencies {
         "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
     testImplementation libraries.testcontainers,
-        libraries.awaitility,
         libraries.rest_assured
 
     signature "org.codehaus.mojo.signature:java18:1.0@signature"

--- a/opentracing_shim/build.gradle
+++ b/opentracing_shim/build.gradle
@@ -14,8 +14,7 @@ dependencies {
             project(':opentelemetry-exporters-inmemory'),
             libraries.junit,
             libraries.assertj,
-            libraries.slf4jsimple,
-            libraries.awaitility
+            libraries.slf4jsimple
 }
 test {
     testLogging.showStandardStreams = true

--- a/sdk/common/build.gradle
+++ b/sdk/common/build.gradle
@@ -20,8 +20,7 @@ dependencies {
     testCompileOnly libraries.auto_value_annotation
 
     testImplementation project(':opentelemetry-testing-internal')
-    testImplementation libraries.junit_pioneer,
-            libraries.awaitility
+    testImplementation libraries.junit_pioneer
 
     signature "org.codehaus.mojo.signature:java18:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/CompletableResultCodeTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/CompletableResultCodeTest.java
@@ -240,7 +240,7 @@ class CompletableResultCodeTest {
               result.succeed();
             })
         .start();
-    assertThat(result.join(500, TimeUnit.MILLISECONDS).isSuccess()).isTrue();
+    assertThat(result.join(10, TimeUnit.SECONDS).isSuccess()).isTrue();
     // Already completed, synchronous call.
     assertThat(result.join(0, TimeUnit.NANOSECONDS).isSuccess()).isTrue();
   }

--- a/sdk/tracing/build.gradle
+++ b/sdk/tracing/build.gradle
@@ -24,8 +24,7 @@ dependencies {
     testCompile project(path: ':opentelemetry-sdk-common', configuration: 'testClasses')
 
     testImplementation project(':opentelemetry-testing-internal')
-    testImplementation libraries.junit_pioneer,
-            libraries.awaitility
+    testImplementation libraries.junit_pioneer
 
     signature "org.codehaus.mojo.signature:java18:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"

--- a/sdk_extensions/jaeger_remote_sampler/build.gradle
+++ b/sdk_extensions/jaeger_remote_sampler/build.gradle
@@ -21,8 +21,7 @@ dependencies {
             libraries.protobuf_util
 
     testImplementation "io.grpc:grpc-testing:${grpcVersion}",
-            libraries.testcontainers,
-            libraries.awaitility
+            libraries.testcontainers
 
     testRuntime "io.grpc:grpc-netty-shaded:${grpcVersion}"
 

--- a/sdk_extensions/testbed/build.gradle
+++ b/sdk_extensions/testbed/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     implementation project(':opentelemetry-api'),
             project(':opentelemetry-sdk'),
             project(':opentelemetry-exporters-inmemory'),
-            libraries.awaitility,
             libraries.guava
 
     signature "org.codehaus.mojo.signature:java18:1.0@signature"


### PR DESCRIPTION
Noticed these sometimes fail randomly. Also went ahead and made awaitility automatic test dependency since it's otherwise harmless yet often useful since we have many async tests.