### PR TITLE
Add GitHub Actions continuous build to replace CircleCI.

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -1,0 +1,44 @@
+name: "Continuous Build"
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        java:
+          # Test all OS's with Java 11
+          - 11
+        include:
+          - os: ubuntu-latest
+            java: 11
+            coverage: true
+          - os: ubuntu-latest
+            java: 8
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - uses: burrunan/gradle-cache-action@v1.5
+        with:
+          job-id: jdk${{ matrix.java }}
+          arguments: check --stacktrace ${{ matrix.coverage && ':opentelemetry-all:jacocoTestReport' || '' }}
+          properties: |
+            enable.docker.tests=${{ matrix.os == 'ubuntu-latest' }}
+      - uses: codecov/codecov-action@v1
+        if: ${{ matrix.coverage }}


### PR DESCRIPTION
For #1381

We've made a lot of good progress on migrating instrumentation repo to actions. This repo is much easier, so we may as well do it. It let's us easily test multiple OS's, to avoid an e.g. Windows contributor have the build fail for them. Supports testcontainers well without having to fallback to a machine executor. And I think we can use a similar config for release builds later, which would allow starting a release from a button on the UI without any local, manual steps at all.

I haven't added snapshot publishing to this yet since presumably that should go together with removing the CircleCI master build. I do upload to codecov since I think uploading twice is harmless. And I just run `:check` - the circleci config separates out several tasks, but from what I can tell `:check` runs all of them anyways.