### PR TITLE
Disable cache action remote proxy

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: burrunan/gradle-cache-action@v1.5
         with:
           job-id: jdk${{ matrix.java }}
+          remote-build-cache-proxy-enabled: false
           arguments: check --stacktrace ${{ matrix.coverage && ':opentelemetry-all:jacocoTestReport' || '' }}
           properties: |
             enable.docker.tests=${{ matrix.os == 'ubuntu-latest' }}


### PR DESCRIPTION
I was hoping since this is a simple build it'd be ok but I see the throttling happening quite a bit here too. I hope it's not permanent but let me try disabling it to see the effect on the build @iNikem @vlsi