### PR TITLE
Increase deadline for deadline test.

### DIFF
--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
@@ -131,7 +131,7 @@ class OtlpGrpcSpanExporterTest {
 
   @Test
   void testExport_DeadlineSetPerExport() throws InterruptedException {
-    int deadlineMs = 500;
+    int deadlineMs = 1500;
     OtlpGrpcSpanExporter exporter =
         OtlpGrpcSpanExporter.newBuilder()
             .setChannel(inProcessChannel)
@@ -139,15 +139,10 @@ class OtlpGrpcSpanExporterTest {
             .build();
 
     try {
-      TimeUnit.MILLISECONDS.sleep(2 * deadlineMs);
-      CompletableResultCode result1 =
+      TimeUnit.MILLISECONDS.sleep(2000);
+      CompletableResultCode result =
           exporter.export(Collections.singletonList(generateFakeSpan()));
-      await().untilAsserted(() -> assertThat(result1.isSuccess()).isTrue());
-
-      TimeUnit.MILLISECONDS.sleep(2 * deadlineMs);
-      CompletableResultCode result2 =
-          exporter.export(Collections.singletonList(generateFakeSpan()));
-      await().untilAsserted(() -> assertThat(result2.isSuccess()).isTrue());
+      await().untilAsserted(() -> assertThat(result.isSuccess()).isTrue());
     } finally {
       exporter.shutdown();
     }

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
@@ -140,8 +140,7 @@ class OtlpGrpcSpanExporterTest {
 
     try {
       TimeUnit.MILLISECONDS.sleep(2000);
-      CompletableResultCode result =
-          exporter.export(Collections.singletonList(generateFakeSpan()));
+      CompletableResultCode result = exporter.export(Collections.singletonList(generateFakeSpan()));
       await().untilAsserted(() -> assertThat(result.isSuccess()).isTrue());
     } finally {
       exporter.shutdown();


### PR DESCRIPTION
If the thread sleeps for 500ms or so between the calls of `withDeadlineAfter` and `export`, the test will fail. A full GC or similar, during CI, can get to that range and we see this happen more often on GitHub Actions which might have more thread contention that CircleCI. Increasing the deadline should reduce the chance of this, and I think for the original intent of the regression test, we can get seconds of runtime back by only exporting once and sleeping for a small amount more than the deadline, which guarantees triggering the previously broken behavior.