### PR TITLE
Add an override for Span.setStatus without description.

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -202,19 +202,35 @@ public interface Span {
   void addEvent(String name, Attributes attributes, long timestamp);
 
   /**
-   * Sets the status to the {@code Span}.
+   * Sets the status for this {@link Span} without a description.
    *
-   * <p>If used, this will override the default {@code Span} status. Default status code is {@link
-   * StatusCanonicalCode#UNSET}.
+   * <p>If used, this will override the default span {@linkplain StatusCanonicalCode status code} of
+   * {@link StatusCanonicalCode#UNSET}.
    *
    * <p>Only the value of the last call will be recorded, and implementations are free to ignore
    * previous calls.
    *
    * @param canonicalCode the {@link StatusCanonicalCode} to set.
-   * @param description the description of the {@code Status}.
    * @since 0.1.0
    */
-  // TODO: Add a setStatus overload without description.
+  default void setStatus(StatusCanonicalCode canonicalCode) {
+    setStatus(canonicalCode, null);
+  }
+
+  /**
+   * Sets the status for this {@link Span} with the provided description.
+   *
+   * <p>If used, this will override the default span {@linkplain StatusCanonicalCode status code} of
+   * {@link StatusCanonicalCode#UNSET}.
+   *
+   * <p>Only the value of the last call will be recorded, and implementations are free to ignore
+   * previous calls.
+   *
+   * @param canonicalCode the {@link StatusCanonicalCode} to set.
+   * @param description the description of the {@code Status}. If {@code null}, no description is
+   *     set.
+   * @since 0.1.0
+   */
   void setStatus(StatusCanonicalCode canonicalCode, @Nullable String description);
 
   /**

--- a/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultSpanTest.java
@@ -45,6 +45,7 @@ class DefaultSpanTest {
     span.addEvent("event", 0);
     span.addEvent("event", Attributes.of(booleanKey("MyBooleanAttributeKey"), true));
     span.addEvent("event", Attributes.of(booleanKey("MyBooleanAttributeKey"), true), 0);
+    span.setStatus(StatusCanonicalCode.OK);
     span.setStatus(StatusCanonicalCode.OK, null);
     span.recordException(new IllegalStateException());
     span.recordException(new IllegalStateException(), Attributes.empty());

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -260,6 +260,20 @@ class RecordEventsReadableSpanTest {
     try {
       testClock.advanceMillis(MILLIS_PER_SECOND);
       assertThat(span.toSpanData().getStatus()).isEqualTo(ImmutableStatus.UNSET);
+      span.setStatus(StatusCanonicalCode.ERROR);
+      assertThat(span.toSpanData().getStatus()).isEqualTo(ImmutableStatus.ERROR);
+    } finally {
+      span.end();
+    }
+    assertThat(span.toSpanData().getStatus()).isEqualTo(ImmutableStatus.ERROR);
+  }
+
+  @Test
+  void setStatusWithDescription() {
+    RecordEventsReadableSpan span = createTestSpan(Kind.CONSUMER);
+    try {
+      testClock.advanceMillis(MILLIS_PER_SECOND);
+      assertThat(span.toSpanData().getStatus()).isEqualTo(ImmutableStatus.UNSET);
       span.setStatus(StatusCanonicalCode.ERROR, "CANCELLED");
       assertThat(span.toSpanData().getStatus())
           .isEqualTo(ImmutableStatus.ERROR.withDescription("CANCELLED"));


### PR DESCRIPTION
@bogdandrutu I know you mentioned you would do this in a subsequent PR but I went ahead and did it now. As the Java SDK PRs have gotten faster, we need to keep up the snapshot dependency in the java-instrumentation repo more frequently, so I was trying to update. I realized that losing the ability to set a code without a description in a one-arg method is a significant regression so want to get it fixed separately / sooner.