### PR TITLE
[Prototype] Move Context interaction to Tracer

### DIFF
--- a/api/src/jmh/java/io/opentelemetry/trace/propagation/HttpTraceContextInjectBenchmark.java
+++ b/api/src/jmh/java/io/opentelemetry/trace/propagation/HttpTraceContextInjectBenchmark.java
@@ -76,7 +76,7 @@ public class HttpTraceContextInjectBenchmark {
     List<Context> contexts = new ArrayList<>();
     for (SpanContext context : spanContexts) {
       contexts.add(
-          OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(context), Context.ROOT));
+          OpenTelemetry.getTracer().contextWithSpan(DefaultSpan.create(context), Context.ROOT));
     }
     return contexts;
   }

--- a/api/src/jmh/java/io/opentelemetry/trace/propagation/HttpTraceContextInjectBenchmark.java
+++ b/api/src/jmh/java/io/opentelemetry/trace/propagation/HttpTraceContextInjectBenchmark.java
@@ -6,12 +6,12 @@
 package io.opentelemetry.trace.propagation;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator.Setter;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceState;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -75,7 +75,8 @@ public class HttpTraceContextInjectBenchmark {
   private static List<Context> createContexts(List<SpanContext> spanContexts) {
     List<Context> contexts = new ArrayList<>();
     for (SpanContext context : spanContexts) {
-      contexts.add(TracingContextUtils.withSpan(DefaultSpan.create(context), Context.ROOT));
+      contexts.add(
+          OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(context), Context.ROOT));
     }
     return contexts;
   }

--- a/api/src/main/java/io/opentelemetry/OpenTelemetry.java
+++ b/api/src/main/java/io/opentelemetry/OpenTelemetry.java
@@ -60,6 +60,16 @@ public final class OpenTelemetry {
   }
 
   /**
+   * Gets or creates a default-named tracer instance.
+   *
+   * @return a tracer instance.
+   * @since 0.8.0
+   */
+  public static Tracer getTracer() {
+    return getTracerProvider().get("default");
+  }
+
+  /**
    * Gets or creates a named tracer instance.
    *
    * <p>This is a shortcut method for <code>getTracerProvider().get(instrumentationName)</code>.

--- a/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
@@ -8,7 +8,6 @@ package io.opentelemetry.trace;
 import io.grpc.Context;
 import io.opentelemetry.common.AttributeKey;
 import io.opentelemetry.common.Attributes;
-import io.opentelemetry.context.Scope;
 import io.opentelemetry.internal.Utils;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -30,16 +29,6 @@ public final class DefaultTracer implements Tracer {
    */
   public static Tracer getInstance() {
     return INSTANCE;
-  }
-
-  @Override
-  public Span getCurrentSpan() {
-    return TracingContextUtils.getCurrentSpan();
-  }
-
-  @Override
-  public Scope withSpan(Span span) {
-    return TracingContextUtils.currentContextWith(span);
   }
 
   @Override

--- a/api/src/main/java/io/opentelemetry/trace/Tracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/Tracer.java
@@ -97,7 +97,7 @@ public interface Tracer {
   }
 
   /** Sets the Span for the specified Context. */
-  default Context setCurrentSpan(Span span, Context context) {
+  default Context contextWithSpan(Span span, Context context) {
     return TracingContextUtils.withSpan(span, context);
   }
 

--- a/api/src/main/java/io/opentelemetry/trace/TracingContextUtils.java
+++ b/api/src/main/java/io/opentelemetry/trace/TracingContextUtils.java
@@ -17,7 +17,7 @@ import javax.annotation.concurrent.Immutable;
  * @since 0.1.0
  */
 @Immutable
-public final class TracingContextUtils {
+final class TracingContextUtils {
   private static final Context.Key<Span> CONTEXT_SPAN_KEY =
       Context.key("opentelemetry-trace-span-key");
 

--- a/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
@@ -149,7 +149,7 @@ public class HttpTraceContext implements TextMapPropagator {
       return context;
     }
 
-    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().contextWithSpan(DefaultSpan.create(spanContext), context);
   }
 
   private static <C> SpanContext extractImpl(C carrier, Getter<C> getter) {

--- a/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.internal.Utils.checkArgument;
 import static io.opentelemetry.internal.Utils.checkNotNull;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.internal.TemporaryBuffers;
 import io.opentelemetry.trace.DefaultSpan;
@@ -17,7 +18,6 @@ import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -94,7 +94,7 @@ public class HttpTraceContext implements TextMapPropagator {
     checkNotNull(context, "context");
     checkNotNull(setter, "setter");
 
-    SpanContext spanContext = TracingContextUtils.getSpan(context).getContext();
+    SpanContext spanContext = OpenTelemetry.getTracer().getCurrentSpan(context).getContext();
     if (!spanContext.isValid()) {
       return;
     }
@@ -149,7 +149,7 @@ public class HttpTraceContext implements TextMapPropagator {
       return context;
     }
 
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
   }
 
   private static <C> SpanContext extractImpl(C carrier, Getter<C> getter) {

--- a/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
+++ b/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.grpc.Context;
 import io.opentelemetry.baggage.Baggage;
 import io.opentelemetry.baggage.BaggageManager;
 import io.opentelemetry.baggage.DefaultBaggageManager;
@@ -254,7 +255,19 @@ class OpenTelemetryTest {
 
     @Nullable
     @Override
+    public Span getCurrentSpan(Context context) {
+      return null;
+    }
+
+    @Nullable
+    @Override
     public Scope withSpan(Span span) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Scope withSpan(Span span, Context context) {
       return null;
     }
 

--- a/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
@@ -52,7 +52,7 @@ class HttpTraceContextTest {
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
-    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().contextWithSpan(DefaultSpan.create(spanContext), context);
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator.Getter;
 import io.opentelemetry.context.propagation.TextMapPropagator.Setter;
 import io.opentelemetry.trace.DefaultSpan;
@@ -19,7 +20,6 @@ import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -48,11 +48,11 @@ class HttpTraceContextTest {
   private final HttpTraceContext httpTraceContext = HttpTraceContext.getInstance();
 
   private static SpanContext getSpanContext(Context context) {
-    return TracingContextUtils.getSpan(context).getContext();
+    return OpenTelemetry.getTracer().getCurrentSpan(context).getContext();
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
   }
 
   @Test

--- a/extensions/trace_propagators/src/jmh/java/io/opentelemetry/extensions/trace/propagation/PropagatorContextExtractBenchmark.java
+++ b/extensions/trace_propagators/src/jmh/java/io/opentelemetry/extensions/trace/propagation/PropagatorContextExtractBenchmark.java
@@ -6,9 +6,9 @@
 package io.opentelemetry.extensions.trace.propagation;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.trace.Span;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -55,7 +55,7 @@ public class PropagatorContextExtractBenchmark {
     @BenchmarkMode(Mode.AverageTime)
     @Fork(1)
     public Span measureExtract() {
-      return TracingContextUtils.getSpan(doExtract());
+      return OpenTelemetry.getTracer().getCurrentSpan(doExtract());
     }
 
     protected abstract Context doExtract();

--- a/extensions/trace_propagators/src/jmh/java/io/opentelemetry/extensions/trace/propagation/PropagatorContextInjectBenchmark.java
+++ b/extensions/trace_propagators/src/jmh/java/io/opentelemetry/extensions/trace/propagation/PropagatorContextInjectBenchmark.java
@@ -6,12 +6,12 @@
 package io.opentelemetry.extensions.trace.propagation;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceState;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -63,7 +63,8 @@ public class PropagatorContextInjectBenchmark {
     @Fork(1)
     public Map<String, String> measureInject() {
       Context context =
-          TracingContextUtils.withSpan(DefaultSpan.create(contextToTest), Context.current());
+          OpenTelemetry.getTracer()
+              .setCurrentSpan(DefaultSpan.create(contextToTest), Context.current());
       doInject(context, carrier);
       return carrier;
     }

--- a/extensions/trace_propagators/src/jmh/java/io/opentelemetry/extensions/trace/propagation/PropagatorContextInjectBenchmark.java
+++ b/extensions/trace_propagators/src/jmh/java/io/opentelemetry/extensions/trace/propagation/PropagatorContextInjectBenchmark.java
@@ -64,7 +64,7 @@ public class PropagatorContextInjectBenchmark {
     public Map<String, String> measureInject() {
       Context context =
           OpenTelemetry.getTracer()
-              .setCurrentSpan(DefaultSpan.create(contextToTest), Context.current());
+              .contextWithSpan(DefaultSpan.create(contextToTest), Context.current());
       doInject(context, carrier);
       return carrier;
     }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
@@ -128,7 +128,7 @@ public class AwsXRayPropagator implements TextMapPropagator {
       return context;
     }
 
-    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().contextWithSpan(DefaultSpan.create(spanContext), context);
   }
 
   private static <C> SpanContext getSpanContextFromHeader(C carrier, Getter<C> getter) {

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.extensions.trace.propagation;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
@@ -14,7 +15,6 @@ import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -85,7 +85,7 @@ public class AwsXRayPropagator implements TextMapPropagator {
     Objects.requireNonNull(context, "context");
     Objects.requireNonNull(setter, "setter");
 
-    Span span = TracingContextUtils.getSpan(context);
+    Span span = OpenTelemetry.getTracer().getCurrentSpan(context);
     if (!span.getContext().isValid()) {
       return;
     }
@@ -128,7 +128,7 @@ public class AwsXRayPropagator implements TextMapPropagator {
       return context;
     }
 
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
   }
 
   private static <C> SpanContext getSpanContextFromHeader(C carrier, Getter<C> getter) {

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
@@ -32,7 +32,7 @@ final class B3PropagatorExtractorMultipleHeaders implements B3PropagatorExtracto
       return context;
     }
 
-    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().contextWithSpan(DefaultSpan.create(spanContext), context);
   }
 
   private static <C> SpanContext getSpanContextFromMultipleHeaders(

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
@@ -10,10 +10,10 @@ import static io.opentelemetry.extensions.trace.propagation.B3Propagator.SPAN_ID
 import static io.opentelemetry.extensions.trace.propagation.B3Propagator.TRACE_ID_HEADER;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.SpanContext;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Objects;
 import java.util.logging.Logger;
 import javax.annotation.concurrent.Immutable;
@@ -32,7 +32,7 @@ final class B3PropagatorExtractorMultipleHeaders implements B3PropagatorExtracto
       return context;
     }
 
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
   }
 
   private static <C> SpanContext getSpanContextFromMultipleHeaders(

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorSingleHeader.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorSingleHeader.java
@@ -31,7 +31,7 @@ final class B3PropagatorExtractorSingleHeader implements B3PropagatorExtractor {
       return context;
     }
 
-    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().contextWithSpan(DefaultSpan.create(spanContext), context);
   }
 
   @SuppressWarnings("StringSplitter")

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorSingleHeader.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorSingleHeader.java
@@ -9,10 +9,10 @@ import static io.opentelemetry.extensions.trace.propagation.B3Propagator.COMBINE
 import static io.opentelemetry.extensions.trace.propagation.B3Propagator.COMBINED_HEADER_DELIMITER;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.SpanContext;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Objects;
 import java.util.logging.Logger;
 import javax.annotation.concurrent.Immutable;
@@ -31,7 +31,7 @@ final class B3PropagatorExtractorSingleHeader implements B3PropagatorExtractor {
       return context;
     }
 
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
   }
 
   @SuppressWarnings("StringSplitter")

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
@@ -6,9 +6,9 @@
 package io.opentelemetry.extensions.trace.propagation;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.trace.SpanContext;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
 
@@ -19,7 +19,7 @@ final class B3PropagatorInjectorMultipleHeaders implements B3PropagatorInjector 
     Objects.requireNonNull(context, "context");
     Objects.requireNonNull(setter, "setter");
 
-    SpanContext spanContext = TracingContextUtils.getSpan(context).getContext();
+    SpanContext spanContext = OpenTelemetry.getTracer().getCurrentSpan(context).getContext();
     if (!spanContext.isValid()) {
       return;
     }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorSingleHeader.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorSingleHeader.java
@@ -6,11 +6,11 @@
 package io.opentelemetry.extensions.trace.propagation;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceId;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
 
@@ -30,7 +30,7 @@ final class B3PropagatorInjectorSingleHeader implements B3PropagatorInjector {
     Objects.requireNonNull(context, "context");
     Objects.requireNonNull(setter, "setter");
 
-    SpanContext spanContext = TracingContextUtils.getSpan(context).getContext();
+    SpanContext spanContext = OpenTelemetry.getTracer().getCurrentSpan(context).getContext();
     if (!spanContext.isValid()) {
       return;
     }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.extensions.trace.propagation;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.SpanContext;
@@ -13,7 +14,6 @@ import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.Collections;
@@ -83,7 +83,7 @@ public class JaegerPropagator implements TextMapPropagator {
     Objects.requireNonNull(context, "context");
     Objects.requireNonNull(setter, "setter");
 
-    SpanContext spanContext = TracingContextUtils.getSpan(context).getContext();
+    SpanContext spanContext = OpenTelemetry.getTracer().getCurrentSpan(context).getContext();
     if (!spanContext.isValid()) {
       return;
     }
@@ -118,7 +118,7 @@ public class JaegerPropagator implements TextMapPropagator {
       return context;
     }
 
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
   }
 
   @SuppressWarnings("StringSplitter")

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
@@ -118,7 +118,7 @@ public class JaegerPropagator implements TextMapPropagator {
       return context;
     }
 
-    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().contextWithSpan(DefaultSpan.create(spanContext), context);
   }
 
   @SuppressWarnings("StringSplitter")

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagator.java
@@ -8,11 +8,11 @@ package io.opentelemetry.extensions.trace.propagation;
 import static io.opentelemetry.extensions.trace.propagation.Common.MAX_TRACE_ID_LENGTH;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.TraceId;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -54,7 +54,7 @@ public class OtTracerPropagator implements TextMapPropagator {
     if (context == null || setter == null) {
       return;
     }
-    final SpanContext spanContext = TracingContextUtils.getSpan(context).getContext();
+    final SpanContext spanContext = OpenTelemetry.getTracer().getCurrentSpan(context).getContext();
     if (!spanContext.isValid()) {
       return;
     }
@@ -79,7 +79,7 @@ public class OtTracerPropagator implements TextMapPropagator {
     if (!spanContext.isValid()) {
       return context;
     }
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
   }
 
   static SpanContext buildSpanContext(String traceId, String spanId, String sampled) {

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagator.java
@@ -79,7 +79,7 @@ public class OtTracerPropagator implements TextMapPropagator {
     if (!spanContext.isValid()) {
       return context;
     }
-    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().contextWithSpan(DefaultSpan.create(spanContext), context);
   }
 
   static SpanContext buildSpanContext(String traceId, String spanId, String sampled) {

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagator.java
@@ -6,8 +6,8 @@
 package io.opentelemetry.extensions.trace.propagation;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -131,7 +131,9 @@ public class TraceMultiPropagator implements TextMapPropagator {
   }
 
   private static boolean isSpanContextExtracted(Context context) {
-    return TracingContextUtils.getSpanWithoutDefault(context) != null;
+    // TODO: Wonder: if the user extracts an invalid Span, is that something we want
+    // to keep?
+    return OpenTelemetry.getTracer().getCurrentSpan(context).getContext().isValid();
   }
 
   /**

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagatorTest.java
@@ -244,7 +244,7 @@ class AwsXRayPropagatorTest {
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
-    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().contextWithSpan(DefaultSpan.create(spanContext), context);
   }
 
   private static SpanContext getSpanContext(Context context) {

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagatorTest.java
@@ -9,12 +9,12 @@ import static io.opentelemetry.extensions.trace.propagation.AwsXRayPropagator.TR
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceState;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -244,10 +244,10 @@ class AwsXRayPropagatorTest {
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
   }
 
   private static SpanContext getSpanContext(Context context) {
-    return TracingContextUtils.getSpan(context).getContext();
+    return OpenTelemetry.getTracer().getCurrentSpan(context).getContext();
   }
 }

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.extensions.trace.propagation;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator.Getter;
 import io.opentelemetry.context.propagation.TextMapPropagator.Setter;
 import io.opentelemetry.trace.DefaultSpan;
@@ -16,7 +17,6 @@ import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -48,11 +48,11 @@ class B3PropagatorTest {
   private final B3Propagator b3PropagatorSingleHeader = B3Propagator.getSingleHeaderPropagator();
 
   private static SpanContext getSpanContext(Context context) {
-    return TracingContextUtils.getSpan(context).getContext();
+    return OpenTelemetry.getTracer().getCurrentSpan(context).getContext();
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
   }
 
   @Test

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
@@ -52,7 +52,7 @@ class B3PropagatorTest {
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
-    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().contextWithSpan(DefaultSpan.create(spanContext), context);
   }
 
   @Test

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagatorTest.java
@@ -64,7 +64,7 @@ class JaegerPropagatorTest {
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
-    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().contextWithSpan(DefaultSpan.create(spanContext), context);
   }
 
   @Test

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagatorTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.grpc.Context;
 import io.jaegertracing.internal.JaegerSpanContext;
 import io.jaegertracing.internal.propagation.TextMapCodec;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.context.propagation.TextMapPropagator.Setter;
 import io.opentelemetry.trace.DefaultSpan;
@@ -21,7 +22,6 @@ import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Collections;
@@ -60,11 +60,11 @@ class JaegerPropagatorTest {
   private final JaegerPropagator jaegerPropagator = JaegerPropagator.getInstance();
 
   private static SpanContext getSpanContext(Context context) {
-    return TracingContextUtils.getSpan(context).getContext();
+    return OpenTelemetry.getTracer().getCurrentSpan(context).getContext();
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
   }
 
   @Test

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagatorTest.java
@@ -40,7 +40,7 @@ class OtTracerPropagatorTest {
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
-    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().contextWithSpan(DefaultSpan.create(spanContext), context);
   }
 
   @Test

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagatorTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.extensions.trace.propagation;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator.Getter;
 import io.opentelemetry.context.propagation.TextMapPropagator.Setter;
 import io.opentelemetry.trace.DefaultSpan;
@@ -16,7 +17,6 @@ import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -36,11 +36,11 @@ class OtTracerPropagatorTest {
   private final OtTracerPropagator propagator = OtTracerPropagator.getInstance();
 
   private static SpanContext getSpanContext(Context context) {
-    return TracingContextUtils.getSpan(context).getContext();
+    return OpenTelemetry.getTracer().getCurrentSpan(context).getContext();
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return OpenTelemetry.getTracer().setCurrentSpan(DefaultSpan.create(spanContext), context);
   }
 
   @Test

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagatorTest.java
@@ -48,7 +48,7 @@ class TraceMultiPropagatorTest {
   }
 
   private static Context withSpan(Span span, Context context) {
-    return OpenTelemetry.getTracer().setCurrentSpan(span, context);
+    return OpenTelemetry.getTracer().contextWithSpan(span, context);
   }
 
   @BeforeEach

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagatorTest.java
@@ -5,14 +5,13 @@
 
 package io.opentelemetry.extensions.trace.propagation;
 
-import static io.opentelemetry.trace.TracingContextUtils.getSpan;
-import static io.opentelemetry.trace.TracingContextUtils.withSpan;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
@@ -43,6 +42,14 @@ class TraceMultiPropagatorTest {
               SpanId.fromLong(12345),
               TraceFlags.getDefault(),
               TraceState.getDefault()));
+
+  private static Span getSpan(Context context) {
+    return OpenTelemetry.getTracer().getCurrentSpan(context);
+  }
+
+  private static Context withSpan(Span span, Context context) {
+    return OpenTelemetry.getTracer().setCurrentSpan(span, context);
+  }
 
   @BeforeEach
   void init() {

--- a/extensions/trace_utils/src/main/java/io/opentelemetry/extensions/trace/CurrentSpanUtils.java
+++ b/extensions/trace_utils/src/main/java/io/opentelemetry/extensions/trace/CurrentSpanUtils.java
@@ -55,7 +55,7 @@ public final class CurrentSpanUtils {
     @Override
     public void run() {
       Context origContext =
-          OpenTelemetry.getTracer().setCurrentSpan(span, Context.current()).attach();
+          OpenTelemetry.getTracer().contextWithSpan(span, Context.current()).attach();
       try {
         runnable.run();
       } catch (Throwable t) {
@@ -89,7 +89,7 @@ public final class CurrentSpanUtils {
     @Override
     public V call() throws Exception {
       Context origContext =
-          OpenTelemetry.getTracer().setCurrentSpan(span, Context.current()).attach();
+          OpenTelemetry.getTracer().contextWithSpan(span, Context.current()).attach();
       try {
         return callable.call();
       } catch (Exception e) {

--- a/extensions/trace_utils/src/main/java/io/opentelemetry/extensions/trace/CurrentSpanUtils.java
+++ b/extensions/trace_utils/src/main/java/io/opentelemetry/extensions/trace/CurrentSpanUtils.java
@@ -6,9 +6,9 @@
 package io.opentelemetry.extensions.trace;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Status;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.concurrent.Callable;
 
 /** Util methods/functionality to interact with the {@link Span} in the {@link io.grpc.Context}. */
@@ -54,7 +54,8 @@ public final class CurrentSpanUtils {
 
     @Override
     public void run() {
-      Context origContext = TracingContextUtils.withSpan(span, Context.current()).attach();
+      Context origContext =
+          OpenTelemetry.getTracer().setCurrentSpan(span, Context.current()).attach();
       try {
         runnable.run();
       } catch (Throwable t) {
@@ -87,7 +88,8 @@ public final class CurrentSpanUtils {
 
     @Override
     public V call() throws Exception {
-      Context origContext = TracingContextUtils.withSpan(span, Context.current()).attach();
+      Context origContext =
+          OpenTelemetry.getTracer().setCurrentSpan(span, Context.current()).attach();
       try {
         return callable.call();
       } catch (Exception e) {

--- a/extensions/trace_utils/src/test/java/io/opentelemetry/extensions/trace/CurrentSpanUtilsTest.java
+++ b/extensions/trace_utils/src/test/java/io/opentelemetry/extensions/trace/CurrentSpanUtilsTest.java
@@ -9,10 +9,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Status;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.concurrent.Callable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -205,6 +205,6 @@ class CurrentSpanUtilsTest {
   }
 
   private static Span getCurrentSpan() {
-    return TracingContextUtils.getCurrentSpan();
+    return OpenTelemetry.getTracer().getCurrentSpan();
   }
 }

--- a/integration_tests/tracecontext/src/main/java/io/opentelemetry/Application.java
+++ b/integration_tests/tracecontext/src/main/java/io/opentelemetry/Application.java
@@ -91,7 +91,7 @@ public class Application {
                       .setParent(context)
                       .startSpan();
 
-              Context withSpanContext = OpenTelemetry.getTracer().setCurrentSpan(span, context);
+              Context withSpanContext = OpenTelemetry.getTracer().contextWithSpan(span, context);
 
               // Make a new request using the builder
               okhttp3.Request.Builder reqBuilder = new okhttp3.Request.Builder();

--- a/integration_tests/tracecontext/src/main/java/io/opentelemetry/Application.java
+++ b/integration_tests/tracecontext/src/main/java/io/opentelemetry/Application.java
@@ -11,7 +11,6 @@ import io.opentelemetry.context.propagation.DefaultContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator.Getter;
 import io.opentelemetry.context.propagation.TextMapPropagator.Setter;
 import io.opentelemetry.trace.Span;
-import io.opentelemetry.trace.TracingContextUtils;
 import io.opentelemetry.trace.propagation.HttpTraceContext;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -92,7 +91,7 @@ public class Application {
                       .setParent(context)
                       .startSpan();
 
-              Context withSpanContext = TracingContextUtils.withSpan(span, context);
+              Context withSpanContext = OpenTelemetry.getTracer().setCurrentSpan(span, context);
 
               // Make a new request using the builder
               okhttp3.Request.Builder reqBuilder = new okhttp3.Request.Builder();

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/Propagation.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/Propagation.java
@@ -25,7 +25,7 @@ final class Propagation extends BaseShimObject {
   public void injectTextMap(SpanContextShim contextShim, TextMapInject carrier) {
     Context context =
         OpenTelemetry.getTracer()
-            .setCurrentSpan(DefaultSpan.create(contextShim.getSpanContext()), Context.current());
+            .contextWithSpan(DefaultSpan.create(contextShim.getSpanContext()), Context.current());
     context = BaggageUtils.withBaggage(contextShim.getBaggage(), context);
 
     propagators().getTextMapPropagator().inject(context, carrier, TextMapSetter.INSTANCE);

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
@@ -185,13 +185,13 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
       builder.setNoParent();
     } else if (parentSpan != null) {
       builder.setParent(
-          OpenTelemetry.getTracer().setCurrentSpan(parentSpan.getSpan(), Context.ROOT));
+          OpenTelemetry.getTracer().contextWithSpan(parentSpan.getSpan(), Context.ROOT));
       SpanContextShim contextShim = spanContextTable().get(parentSpan);
       distContext = contextShim == null ? null : contextShim.getBaggage();
     } else if (parentSpanContext != null) {
       builder.setParent(
           OpenTelemetry.getTracer()
-              .setCurrentSpan(
+              .contextWithSpan(
                   DefaultSpan.create(parentSpanContext.getSpanContext()), Context.ROOT));
       distContext = parentSpanContext.getBaggage();
     }

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.common.AttributesKeys.longKey;
 import static io.opentelemetry.common.AttributesKeys.stringKey;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.common.AttributeConsumer;
 import io.opentelemetry.common.AttributeKey;
 import io.opentelemetry.common.Attributes;
@@ -30,7 +31,6 @@ import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceState;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -175,7 +175,7 @@ final class SpanBuilderSdk implements Span.Builder {
   public Span startSpan() {
     final Context parentContext =
         isRootSpan ? Context.ROOT : parent == null ? Context.current() : parent;
-    final Span parentSpan = TracingContextUtils.getSpan(parentContext);
+    final Span parentSpan = OpenTelemetry.getTracer().getCurrentSpan(parentContext);
     final SpanContext parentSpanContext = parentSpan.getContext();
     String traceId;
     String spanId = idsGenerator.generateSpanId();

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
@@ -5,12 +5,10 @@
 
 package io.opentelemetry.sdk.trace;
 
-import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.trace.DefaultTracer;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
-import io.opentelemetry.trace.TracingContextUtils;
 
 /** {@link TracerSdk} is SDK implementation of {@link Tracer}. */
 final class TracerSdk implements Tracer {
@@ -20,16 +18,6 @@ final class TracerSdk implements Tracer {
   TracerSdk(TracerSharedState sharedState, InstrumentationLibraryInfo instrumentationLibraryInfo) {
     this.sharedState = sharedState;
     this.instrumentationLibraryInfo = instrumentationLibraryInfo;
-  }
-
-  @Override
-  public Span getCurrentSpan() {
-    return TracingContextUtils.getCurrentSpan();
-  }
-
-  @Override
-  public Scope withSpan(Span span) {
-    return TracingContextUtils.currentContextWith(span);
   }
 
   @Override

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.common.AttributeKey;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.common.ReadableAttributes;
@@ -34,7 +35,6 @@ import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TraceState;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -585,7 +585,7 @@ class SpanBuilderSdkTest {
               tracerSdk
                   .spanBuilder(SPAN_NAME)
                   .setNoParent()
-                  .setParent(TracingContextUtils.withSpan(parent, Context.current()))
+                  .setParent(OpenTelemetry.getTracer().setCurrentSpan(parent, Context.current()))
                   .startSpan();
       try {
         assertThat(span.getContext().getTraceIdAsHexString())
@@ -598,7 +598,7 @@ class SpanBuilderSdkTest {
                 tracerSdk
                     .spanBuilder(SPAN_NAME)
                     .setNoParent()
-                    .setParent(TracingContextUtils.withSpan(parent, Context.current()))
+                    .setParent(OpenTelemetry.getTracer().setCurrentSpan(parent, Context.current()))
                     .startSpan();
         try {
           assertThat(span2.getContext().getTraceIdAsHexString())
@@ -624,7 +624,7 @@ class SpanBuilderSdkTest {
               tracerSdk
                   .spanBuilder(SPAN_NAME)
                   .setNoParent()
-                  .setParent(TracingContextUtils.withSpan(parent, Context.current()))
+                  .setParent(OpenTelemetry.getTracer().setCurrentSpan(parent, Context.current()))
                   .startSpan();
       try {
         assertThat(span.getContext().getTraceIdAsHexString())
@@ -642,7 +642,7 @@ class SpanBuilderSdkTest {
   @Test
   void parent_fromContext() {
     Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
-    Context context = TracingContextUtils.withSpan(parent, Context.current());
+    Context context = OpenTelemetry.getTracer().setCurrentSpan(parent, Context.current());
     try {
       RecordEventsReadableSpan span =
           (RecordEventsReadableSpan)
@@ -666,7 +666,7 @@ class SpanBuilderSdkTest {
     Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
     try {
       RecordEventsReadableSpan span;
-      try (Scope scope = TracingContextUtils.currentContextWith(parent)) {
+      try (Scope scope = OpenTelemetry.getTracer().withSpan(parent)) {
         span =
             (RecordEventsReadableSpan)
                 tracerSdk.spanBuilder(SPAN_NAME).setParent(emptyContext).startSpan();
@@ -712,7 +712,7 @@ class SpanBuilderSdkTest {
         (RecordEventsReadableSpan)
             tracerSdk
                 .spanBuilder(SPAN_NAME)
-                .setParent(TracingContextUtils.withSpan(parent, Context.current()))
+                .setParent(OpenTelemetry.getTracer().setCurrentSpan(parent, Context.current()))
                 .startSpan();
     try {
       assertThat(span.getContext().getTraceIdAsHexString())

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -585,7 +585,7 @@ class SpanBuilderSdkTest {
               tracerSdk
                   .spanBuilder(SPAN_NAME)
                   .setNoParent()
-                  .setParent(OpenTelemetry.getTracer().setCurrentSpan(parent, Context.current()))
+                  .setParent(OpenTelemetry.getTracer().contextWithSpan(parent, Context.current()))
                   .startSpan();
       try {
         assertThat(span.getContext().getTraceIdAsHexString())
@@ -598,7 +598,7 @@ class SpanBuilderSdkTest {
                 tracerSdk
                     .spanBuilder(SPAN_NAME)
                     .setNoParent()
-                    .setParent(OpenTelemetry.getTracer().setCurrentSpan(parent, Context.current()))
+                    .setParent(OpenTelemetry.getTracer().contextWithSpan(parent, Context.current()))
                     .startSpan();
         try {
           assertThat(span2.getContext().getTraceIdAsHexString())
@@ -624,7 +624,7 @@ class SpanBuilderSdkTest {
               tracerSdk
                   .spanBuilder(SPAN_NAME)
                   .setNoParent()
-                  .setParent(OpenTelemetry.getTracer().setCurrentSpan(parent, Context.current()))
+                  .setParent(OpenTelemetry.getTracer().contextWithSpan(parent, Context.current()))
                   .startSpan();
       try {
         assertThat(span.getContext().getTraceIdAsHexString())
@@ -642,7 +642,7 @@ class SpanBuilderSdkTest {
   @Test
   void parent_fromContext() {
     Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
-    Context context = OpenTelemetry.getTracer().setCurrentSpan(parent, Context.current());
+    Context context = OpenTelemetry.getTracer().contextWithSpan(parent, Context.current());
     try {
       RecordEventsReadableSpan span =
           (RecordEventsReadableSpan)
@@ -712,7 +712,7 @@ class SpanBuilderSdkTest {
         (RecordEventsReadableSpan)
             tracerSdk
                 .spanBuilder(SPAN_NAME)
-                .setParent(OpenTelemetry.getTracer().setCurrentSpan(parent, Context.current()))
+                .setParent(OpenTelemetry.getTracer().contextWithSpan(parent, Context.current()))
                 .startSpan();
     try {
       assertThat(span.getContext().getTraceIdAsHexString())

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.trace;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -17,7 +18,6 @@ import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,7 +63,8 @@ class TracerSdkTest {
   @Test
   void getCurrentSpan() {
     assertThat(tracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
-    Context origContext = TracingContextUtils.withSpan(span, Context.current()).attach();
+    Context origContext =
+        OpenTelemetry.getTracer().setCurrentSpan(span, Context.current()).attach();
     // Make sure context is detached even if test fails.
     try {
       assertThat(tracer.getCurrentSpan()).isSameAs(span);

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -64,7 +64,7 @@ class TracerSdkTest {
   void getCurrentSpan() {
     assertThat(tracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
     Context origContext =
-        OpenTelemetry.getTracer().setCurrentSpan(span, Context.current()).attach();
+        OpenTelemetry.getTracer().contextWithSpan(span, Context.current()).attach();
     // Make sure context is detached even if test fails.
     try {
       assertThat(tracer.getCurrentSpan()).isSameAs(span);

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/concurrentcommonrequesthandler/HandlerTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/concurrentcommonrequesthandler/HandlerTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.extensions.trace.testbed.concurrentcommonrequesthan
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
 import io.opentelemetry.sdk.extensions.trace.testbed.TestUtils;
@@ -17,7 +18,6 @@ import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Tracer;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -102,7 +102,7 @@ class HandlerTest {
       client =
           new Client(
               new RequestHandler(
-                  tracer, TracingContextUtils.withSpan(parentSpan, Context.current())));
+                  tracer, OpenTelemetry.getTracer().setCurrentSpan(parentSpan, Context.current())));
       String response = client.send("correct_parent").get(15, TimeUnit.SECONDS);
       assertThat(response).isEqualTo("correct_parent:response");
     } finally {

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/concurrentcommonrequesthandler/HandlerTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/concurrentcommonrequesthandler/HandlerTest.java
@@ -102,7 +102,8 @@ class HandlerTest {
       client =
           new Client(
               new RequestHandler(
-                  tracer, OpenTelemetry.getTracer().setCurrentSpan(parentSpan, Context.current())));
+                  tracer,
+                  OpenTelemetry.getTracer().contextWithSpan(parentSpan, Context.current())));
       String response = client.send("correct_parent").get(15, TimeUnit.SECONDS);
       assertThat(response).isEqualTo("correct_parent:response");
     } finally {


### PR DESCRIPTION
Prototype PR for https://github.com/open-telemetry/opentelemetry-specification/issues/1019,  specifically inspired by @mwear's [proposal](https://github.com/open-telemetry/opentelemetry-specification/issues/1019#issuecomment-700144249) - mostly as an alternative presented by @bogdandrutu.

Changes are:

* `TracingContextUtils` is hidden, and remains as an implementation specific detail.
* All the interaction happens through the `Tracer` (and it would happen through `BaggageManager` for the `baggage` part). This means we end up with the following **default** methods in `Tracer`:
  - `Span Tracer.getCurrentSpan()`
  - `Span Tracer.getCurrentSpan(Context context)`
  - `Scope Tracer.withSpan(Span span)`
  - `Context Tracer.contextWithSpan(Span span)`
* A notion of a 'default' tracer is added (not to confuse with the current `DefaultTracer` class) - that is, `OpenTelemetry.getTracer()` which gets a `Tracer` with a default name.

Under this case, most of the interaction would happen through such default tracer:

```java
Span span = OpenTelemetry.getTracer().getCurrentSpan(ctx);
```

Which is *slightly* odd, as any code that calls this will automatically force the loading of tracer/meter/baggage, even if they didn't intend to (for example, a `Propagator` having its inject/extract facilities could run into this). Not sure that's an actual problem, but wanted to mention it anyway.

For your consideration ;) 