### PR TITLE
Fixes for BOM publishing

### DIFF
--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "maven-publish"
 }
 
+description = 'OpenTelemetry Bill of Materials'
 group = "io.opentelemetry"
 
 dependencies {
@@ -14,14 +15,5 @@ dependencies {
                     api project
                     println project
                 }
-    }
-}
-
-publishing {
-    publications {
-        mavenBom(MavenPublication) {
-            artifactId = 'opentelemetry-bom'
-            from components.javaPlatform
-        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,6 @@ subprojects {
 
                     pom {
                         name = 'OpenTelemetry Java'
-                        packaging = 'jar'
                         url = 'https://github.com/open-telemetry/opentelemetry-java'
 
                         licenses {


### PR DESCRIPTION
Don't set packaging type explicitly since Gradle determines it automatically, set description for BOM project, and remove outdated bom publication configuration