### PR TITLE
Remove assertion on interrupted which is not reliable.

### DIFF
--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/CompletableResultCodeTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/CompletableResultCodeTest.java
@@ -251,7 +251,6 @@ class CompletableResultCodeTest {
             });
     thread.start();
     thread.interrupt();
-    await().untilAsserted(() -> assertThat(thread.isInterrupted()).isTrue());
     // Different thread so wait a bit for result to be propagated.
     await().untilAsserted(() -> assertThat(result.isDone()).isTrue());
     assertThat(result.isSuccess()).isFalse();

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/CompletableResultCodeTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/CompletableResultCodeTest.java
@@ -251,7 +251,7 @@ class CompletableResultCodeTest {
             });
     thread.start();
     thread.interrupt();
-    assertThat(thread.isInterrupted()).isTrue();
+    await().untilAsserted(() -> assertThat(thread.isInterrupted()).isTrue());
     // Different thread so wait a bit for result to be propagated.
     await().untilAsserted(() -> assertThat(result.isDone()).isTrue());
     assertThat(result.isSuccess()).isFalse();


### PR DESCRIPTION
Not totally sure but seems reasonable to require some time to propagate interruption to another thread and can get unflipped by the time of assertion.