### PR TITLE
Turn the Baggage metadata into a simple wrapper for a String.

### DIFF
--- a/api/src/main/java/io/opentelemetry/baggage/Entry.java
+++ b/api/src/main/java/io/opentelemetry/baggage/Entry.java
@@ -6,9 +6,9 @@
 package io.opentelemetry.baggage;
 
 import com.google.auto.value.AutoValue;
-import io.opentelemetry.baggage.EntryMetadata.EntryTtl;
 import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.internal.Utils;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -19,31 +19,14 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 @AutoValue
 public abstract class Entry {
-  /**
-   * The maximum length for an entry key name. The value is {@value #MAX_KEY_LENGTH}.
-   *
-   * @since 0.9.0
-   */
-  public static final int MAX_KEY_LENGTH = 255;
-
-  /**
-   * The maximum length for a entry value. The value is {@value #MAX_VALUE_LENGTH}.
-   *
-   * @since 0.9.0
-   */
-  public static final int MAX_VALUE_LENGTH = 255;
-
-  /** Default propagation metadata - unlimited propagation. */
-  public static final EntryMetadata METADATA_UNLIMITED_PROPAGATION =
-      EntryMetadata.create(EntryTtl.UNLIMITED_PROPAGATION);
 
   Entry() {}
 
   /**
    * Creates an {@code Entry} from the given key, value and metadata.
    *
-   * @param key the entry key.
-   * @param value the entry value.
+   * @param key           the entry key.
+   * @param value         the entry value.
    * @param entryMetadata the entry metadata.
    * @return a {@code Entry}.
    * @since 0.9.0
@@ -52,6 +35,18 @@ public abstract class Entry {
     Utils.checkArgument(keyIsValid(key), "Invalid entry key name: %s", key);
     Utils.checkArgument(isValueValid(value), "Invalid entry value: %s", value);
     return new AutoValue_Entry(key, value, entryMetadata);
+  }
+
+  /**
+   * Creates an {@code Entry} from the given key, value, with no metadata.
+   *
+   * @param key           the entry key.
+   * @param value         the entry value.
+   * @return a {@code Entry}.
+   * @since 0.9.0
+   */
+  public static Entry create(String key, String value) {
+    return create(key, value, EntryMetadata.EMPTY);
   }
 
   /**
@@ -71,11 +66,12 @@ public abstract class Entry {
   public abstract String getValue();
 
   /**
-   * Returns the {@link EntryMetadata} associated with this {@link Entry}.
+   * Returns the (optional) {@link EntryMetadata} associated with this {@link Entry}.
    *
    * @return the {@code EntryMetadata}.
    * @since 0.9.0
    */
+  @Nullable
   public abstract EntryMetadata getEntryMetadata();
 
   /**
@@ -85,9 +81,7 @@ public abstract class Entry {
    * @return whether the name is valid.
    */
   private static boolean keyIsValid(String name) {
-    return !name.isEmpty()
-        && name.length() <= MAX_KEY_LENGTH
-        && StringUtils.isPrintableString(name);
+    return !name.isEmpty() && StringUtils.isPrintableString(name);
   }
 
   /**
@@ -97,6 +91,6 @@ public abstract class Entry {
    * @return whether the value is valid.
    */
   private static boolean isValueValid(String value) {
-    return value.length() <= MAX_VALUE_LENGTH && StringUtils.isPrintableString(value);
+    return StringUtils.isPrintableString(value);
   }
 }

--- a/api/src/main/java/io/opentelemetry/baggage/Entry.java
+++ b/api/src/main/java/io/opentelemetry/baggage/Entry.java
@@ -8,7 +8,6 @@ package io.opentelemetry.baggage;
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.internal.Utils;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -71,7 +70,6 @@ public abstract class Entry {
    * @return the {@code EntryMetadata}.
    * @since 0.9.0
    */
-  @Nullable
   public abstract EntryMetadata getEntryMetadata();
 
   /**

--- a/api/src/main/java/io/opentelemetry/baggage/Entry.java
+++ b/api/src/main/java/io/opentelemetry/baggage/Entry.java
@@ -25,8 +25,8 @@ public abstract class Entry {
   /**
    * Creates an {@code Entry} from the given key, value and metadata.
    *
-   * @param key           the entry key.
-   * @param value         the entry value.
+   * @param key the entry key.
+   * @param value the entry value.
    * @param entryMetadata the entry metadata.
    * @return a {@code Entry}.
    * @since 0.9.0
@@ -40,8 +40,8 @@ public abstract class Entry {
   /**
    * Creates an {@code Entry} from the given key, value, with no metadata.
    *
-   * @param key           the entry key.
-   * @param value         the entry value.
+   * @param key the entry key.
+   * @param value the entry value.
    * @return a {@code Entry}.
    * @since 0.9.0
    */

--- a/api/src/main/java/io/opentelemetry/baggage/EntryMetadata.java
+++ b/api/src/main/java/io/opentelemetry/baggage/EntryMetadata.java
@@ -9,28 +9,27 @@ import com.google.auto.value.AutoValue;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * {@link EntryMetadata} contains properties associated with an {@link Entry}.
- *
- * <p>For now only the property {@link EntryTtl} is defined. In future, additional properties may be
- * added to address specific situations.
+ * {@link EntryMetadata} contains properties associated with an {@link Entry}. This is an opaque
+ * wrapper for a String metadata value.
  *
  * @since 0.9.0
  */
 @Immutable
 @AutoValue
 public abstract class EntryMetadata {
+  public static EntryMetadata EMPTY = create("");
 
   EntryMetadata() {}
 
   /**
-   * Creates an {@link EntryMetadata} with the given {@link EntryTtl}.
+   * Creates an {@link EntryMetadata} with the given value.
    *
-   * @param entryTtl TTL of an {@code Entry}.
+   * @param metadata TTL of an {@code Entry}.
    * @return an {@code EntryMetadata}.
    * @since 0.9.0
    */
-  public static EntryMetadata create(EntryTtl entryTtl) {
-    return new AutoValue_EntryMetadata(entryTtl);
+  public static EntryMetadata create(String metadata) {
+    return new AutoValue_EntryMetadata(metadata);
   }
 
   /**
@@ -39,51 +38,5 @@ public abstract class EntryMetadata {
    * @return the {@code EntryTtl}.
    * @since 0.9.0
    */
-  public abstract EntryTtl getEntryTtl();
-
-  /**
-   * {@link EntryTtl} is an integer that represents number of hops an entry can propagate.
-   *
-   * <p>Anytime a sender serializes a entry, sends it over the wire and receiver deserializes the
-   * entry then the entry is considered to have travelled one hop.
-   *
-   * <p>There could be one or more proxy(ies) between sender and receiver. Proxies are treated as
-   * transparent entities and they are not counted as hops.
-   *
-   * <p>For now, only special values of {@link EntryTtl} are supported.
-   *
-   * @since 0.9.0
-   */
-  public enum EntryTtl {
-
-    /**
-     * An {@link Entry} with {@link EntryTtl#NO_PROPAGATION} is considered to have local scope and
-     * is used within the process where it's created.
-     *
-     * @since 0.9.0
-     */
-    NO_PROPAGATION(0),
-
-    /**
-     * An {@link Entry} with {@link EntryTtl#UNLIMITED_PROPAGATION} can propagate unlimited hops.
-     *
-     * <p>However, it is still subject to outgoing and incoming (on remote side) filter criteria.
-     *
-     * <p>{@link EntryTtl#UNLIMITED_PROPAGATION} is typical used to track a request, which may be
-     * processed across multiple entities.
-     *
-     * @since 0.9.0
-     */
-    UNLIMITED_PROPAGATION(-1);
-
-    private final int hops;
-
-    EntryTtl(int hops) {
-      this.hops = hops;
-    }
-
-    int getHops() {
-      return hops;
-    }
-  }
+  public abstract String getValue();
 }

--- a/api/src/main/java/io/opentelemetry/baggage/EntryMetadata.java
+++ b/api/src/main/java/io/opentelemetry/baggage/EntryMetadata.java
@@ -33,9 +33,9 @@ public abstract class EntryMetadata {
   }
 
   /**
-   * Returns the {@link EntryTtl} of this {@link EntryMetadata}.
+   * Returns the String value of this {@link EntryMetadata}.
    *
-   * @return the {@code EntryTtl}.
+   * @return the raw metadata value.
    * @since 0.9.0
    */
   public abstract String getValue();

--- a/api/src/main/java/io/opentelemetry/baggage/EntryMetadata.java
+++ b/api/src/main/java/io/opentelemetry/baggage/EntryMetadata.java
@@ -17,7 +17,7 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 @AutoValue
 public abstract class EntryMetadata {
-  public static EntryMetadata EMPTY = create("");
+  public static final EntryMetadata EMPTY = create("");
 
   EntryMetadata() {}
 

--- a/api/src/test/java/io/opentelemetry/baggage/DefaultBaggageManagerTest.java
+++ b/api/src/test/java/io/opentelemetry/baggage/DefaultBaggageManagerTest.java
@@ -18,14 +18,14 @@ class DefaultBaggageManagerTest {
   private static final BaggageManager DEFAULT_BAGGAGE_MANAGER = DefaultBaggageManager.getInstance();
   private static final String KEY = "key";
   private static final String VALUE = "value";
+  private static final EntryMetadata SAMPLE_METADATA = EntryMetadata.create("sample");
 
   private static final Baggage DIST_CONTEXT =
       new Baggage() {
 
         @Override
         public Collection<Entry> getEntries() {
-          return Collections.singletonList(
-              Entry.create(KEY, VALUE, Entry.METADATA_UNLIMITED_PROPAGATION));
+          return Collections.singletonList(Entry.create(KEY, VALUE, SAMPLE_METADATA));
         }
 
         @Override
@@ -110,17 +110,13 @@ class DefaultBaggageManagerTest {
   @Test
   void noopContextBuilder_Put_DisallowsNullKey() {
     Baggage.Builder noopBuilder = DEFAULT_BAGGAGE_MANAGER.baggageBuilder();
-    assertThrows(
-        NullPointerException.class,
-        () -> noopBuilder.put(null, VALUE, Entry.METADATA_UNLIMITED_PROPAGATION));
+    assertThrows(NullPointerException.class, () -> noopBuilder.put(null, VALUE, SAMPLE_METADATA));
   }
 
   @Test
   void noopContextBuilder_Put_DisallowsNullValue() {
     Baggage.Builder noopBuilder = DEFAULT_BAGGAGE_MANAGER.baggageBuilder();
-    assertThrows(
-        NullPointerException.class,
-        () -> noopBuilder.put(KEY, null, Entry.METADATA_UNLIMITED_PROPAGATION));
+    assertThrows(NullPointerException.class, () -> noopBuilder.put(KEY, null, SAMPLE_METADATA));
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/baggage/EntryMetadataTest.java
+++ b/api/src/test/java/io/opentelemetry/baggage/EntryMetadataTest.java
@@ -8,24 +8,21 @@ package io.opentelemetry.baggage;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import io.opentelemetry.baggage.EntryMetadata.EntryTtl;
 import org.junit.jupiter.api.Test;
 
 class EntryMetadataTest {
 
   @Test
-  void testGetEntryTtl() {
-    EntryMetadata entryMetadata = EntryMetadata.create(EntryTtl.NO_PROPAGATION);
-    assertThat(entryMetadata.getEntryTtl()).isEqualTo(EntryTtl.NO_PROPAGATION);
+  void getValue() {
+    EntryMetadata entryMetadata = EntryMetadata.create("metadata;value=foo");
+    assertThat(entryMetadata.getValue()).isEqualTo("metadata;value=foo");
   }
 
   @Test
   void testEquals() {
     new EqualsTester()
-        .addEqualityGroup(
-            EntryMetadata.create(EntryTtl.NO_PROPAGATION),
-            EntryMetadata.create(EntryTtl.NO_PROPAGATION))
-        .addEqualityGroup(EntryMetadata.create(EntryTtl.UNLIMITED_PROPAGATION))
+        .addEqualityGroup(EntryMetadata.create("value"), EntryMetadata.create("value"))
+        .addEqualityGroup(EntryMetadata.create("other value"))
         .testEquals();
   }
 }

--- a/api/src/test/java/io/opentelemetry/baggage/EntryTest.java
+++ b/api/src/test/java/io/opentelemetry/baggage/EntryTest.java
@@ -9,8 +9,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.testing.EqualsTester;
-import io.opentelemetry.baggage.EntryMetadata.EntryTtl;
-import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 class EntryTest {
@@ -19,100 +17,45 @@ class EntryTest {
   private static final String KEY_2 = "KEY2";
   private static final String VALUE = "VALUE";
   private static final String VALUE_2 = "VALUE2";
-  private static final EntryMetadata METADATA_UNLIMITED_PROPAGATION =
-      EntryMetadata.create(EntryTtl.UNLIMITED_PROPAGATION);
-  private static final EntryMetadata METADATA_NO_PROPAGATION =
-      EntryMetadata.create(EntryTtl.NO_PROPAGATION);
+  private static final EntryMetadata SAMPLE_METADATA =
+      EntryMetadata.create("propagation=unlimited");
 
   @Test
   void testGetKey() {
-    assertThat(Entry.create(KEY, VALUE, METADATA_UNLIMITED_PROPAGATION).getKey()).isEqualTo(KEY);
+    assertThat(Entry.create(KEY, VALUE, SAMPLE_METADATA).getKey()).isEqualTo(KEY);
   }
 
   @Test
   void testGetEntryMetadata() {
-    assertThat(Entry.create(KEY, VALUE, METADATA_NO_PROPAGATION).getEntryMetadata())
-        .isEqualTo(METADATA_NO_PROPAGATION);
+    assertThat(Entry.create(KEY, VALUE, SAMPLE_METADATA).getEntryMetadata())
+        .isEqualTo(SAMPLE_METADATA);
   }
 
   @Test
   void testEntryEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            Entry.create(KEY, VALUE, METADATA_UNLIMITED_PROPAGATION),
-            Entry.create(KEY, VALUE, METADATA_UNLIMITED_PROPAGATION))
-        .addEqualityGroup(Entry.create(KEY, VALUE_2, METADATA_UNLIMITED_PROPAGATION))
-        .addEqualityGroup(Entry.create(KEY_2, VALUE, METADATA_UNLIMITED_PROPAGATION))
-        .addEqualityGroup(Entry.create(KEY, VALUE, METADATA_NO_PROPAGATION))
+            Entry.create(KEY, VALUE, SAMPLE_METADATA), Entry.create(KEY, VALUE, SAMPLE_METADATA))
+        .addEqualityGroup(Entry.create(KEY, VALUE_2, SAMPLE_METADATA))
+        .addEqualityGroup(Entry.create(KEY_2, VALUE, SAMPLE_METADATA))
+        .addEqualityGroup(Entry.create(KEY, VALUE, EntryMetadata.create("other")))
         .testEquals();
-  }
-
-  @Test
-  void testKeyMaxLength() {
-    assertThat(Entry.MAX_KEY_LENGTH).isEqualTo(255);
-  }
-
-  @Test
-  void create_AllowEntryKeyNameWithMaxLength() {
-    char[] chars = new char[Entry.MAX_KEY_LENGTH];
-    Arrays.fill(chars, 'k');
-    String key = new String(chars);
-    assertThat(Entry.create(key, "value", Entry.METADATA_UNLIMITED_PROPAGATION)).isNotNull();
-  }
-
-  @Test
-  void create_DisallowEntryKeyNameOverMaxLength() {
-    char[] chars = new char[Entry.MAX_KEY_LENGTH + 1];
-    Arrays.fill(chars, 'k');
-    String key = new String(chars);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> Entry.create(key, "value", Entry.METADATA_UNLIMITED_PROPAGATION));
   }
 
   @Test
   void create_DisallowKeyUnprintableChars() {
     assertThrows(
-        IllegalArgumentException.class,
-        () -> Entry.create("\2ab\3cd", "value", Entry.METADATA_UNLIMITED_PROPAGATION));
+        IllegalArgumentException.class, () -> Entry.create("\2ab\3cd", "value", SAMPLE_METADATA));
   }
 
   @Test
   void createString_DisallowKeyEmpty() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> Entry.create("", "value", Entry.METADATA_UNLIMITED_PROPAGATION));
-  }
-
-  @Test
-  void testValueMaxLength() {
-    assertThat(Entry.MAX_VALUE_LENGTH).isEqualTo(255);
-  }
-
-  @Test
-  void create_AllowEntryValueWithMaxLength() {
-    char[] chars = new char[Entry.MAX_VALUE_LENGTH];
-    Arrays.fill(chars, 'v');
-    String value = new String(chars);
-    assertThat(Entry.create("key", value, Entry.METADATA_UNLIMITED_PROPAGATION).getValue())
-        .isEqualTo(value);
-  }
-
-  @Test
-  void create_DisallowEntryValueOverMaxLength() {
-    char[] chars = new char[Entry.MAX_VALUE_LENGTH + 1];
-    Arrays.fill(chars, 'v');
-    String value = new String(chars);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> Entry.create("key", value, Entry.METADATA_UNLIMITED_PROPAGATION));
+    assertThrows(IllegalArgumentException.class, () -> Entry.create("", "value", SAMPLE_METADATA));
   }
 
   @Test
   void disallowEntryValueWithUnprintableChars() {
     String value = "\2ab\3cd";
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> Entry.create("key", value, Entry.METADATA_UNLIMITED_PROPAGATION));
+    assertThrows(IllegalArgumentException.class, () -> Entry.create("key", value, SAMPLE_METADATA));
   }
 }

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
@@ -13,8 +13,8 @@ import java.util.Iterator;
 import java.util.Map;
 
 final class SpanContextShim extends BaseShimObject implements SpanContext {
-  static final EntryMetadata DEFAULT_ENTRY_METADATA =
-      EntryMetadata.create(EntryMetadata.EntryTtl.UNLIMITED_PROPAGATION);
+
+  static final EntryMetadata DEFAULT_ENTRY_METADATA = EntryMetadata.create("testmetadata");
 
   private final io.opentelemetry.trace.SpanContext context;
   private final Baggage distContext;
@@ -76,6 +76,7 @@ final class SpanContextShim extends BaseShimObject implements SpanContext {
   }
 
   static class BaggageIterable implements Iterable<Map.Entry<String, String>> {
+
     final Iterator<Entry> iterator;
 
     BaggageIterable(Iterator<Entry> iterator) {
@@ -102,6 +103,7 @@ final class SpanContextShim extends BaseShimObject implements SpanContext {
   }
 
   static class BaggageEntry implements Map.Entry<String, String> {
+
     final Entry entry;
 
     BaggageEntry(Entry entry) {

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
@@ -14,8 +14,6 @@ import java.util.Map;
 
 final class SpanContextShim extends BaseShimObject implements SpanContext {
 
-  static final EntryMetadata DEFAULT_ENTRY_METADATA = EntryMetadata.create("testmetadata");
-
   private final io.opentelemetry.trace.SpanContext context;
   private final Baggage distContext;
 
@@ -41,7 +39,7 @@ final class SpanContextShim extends BaseShimObject implements SpanContext {
 
   SpanContextShim newWithKeyValue(String key, String value) {
     Baggage.Builder builder = contextManager().baggageBuilder().setParent(distContext);
-    builder.put(key, value, DEFAULT_ENTRY_METADATA);
+    builder.put(key, value, EntryMetadata.EMPTY);
 
     return new SpanContextShim(telemetryInfo(), context, builder.build());
   }

--- a/sdk/baggage/src/test/java/io/opentelemetry/sdk/baggage/BaggageSdkTest.java
+++ b/sdk/baggage/src/test/java/io/opentelemetry/sdk/baggage/BaggageSdkTest.java
@@ -25,10 +25,10 @@ import org.junit.jupiter.api.Test;
  * <p>Tests for scope management with {@link BaggageManagerSdk} are in {@link ScopedBaggageTest}.
  */
 class BaggageSdkTest {
+
   private final BaggageManager contextManager = new BaggageManagerSdk();
 
-  private static final EntryMetadata TMD =
-      EntryMetadata.create(EntryMetadata.EntryTtl.UNLIMITED_PROPAGATION);
+  private static final EntryMetadata TMD = EntryMetadata.create("tmd");
 
   private static final String K1 = "k1";
   private static final String K2 = "k2";

--- a/sdk/baggage/src/test/java/io/opentelemetry/sdk/baggage/ScopedBaggageTest.java
+++ b/sdk/baggage/src/test/java/io/opentelemetry/sdk/baggage/ScopedBaggageTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
  * interact with the current {@link BaggageSdk}.
  */
 class ScopedBaggageTest {
+
   private static final String KEY_1 = "key 1";
   private static final String KEY_2 = "key 2";
   private static final String KEY_3 = "key 3";
@@ -30,9 +31,8 @@ class ScopedBaggageTest {
   private static final String VALUE_4 = "value 4";
 
   private static final EntryMetadata METADATA_UNLIMITED_PROPAGATION =
-      EntryMetadata.create(EntryMetadata.EntryTtl.UNLIMITED_PROPAGATION);
-  private static final EntryMetadata METADATA_NO_PROPAGATION =
-      EntryMetadata.create(EntryMetadata.EntryTtl.NO_PROPAGATION);
+      EntryMetadata.create("unlimited");
+  private static final EntryMetadata METADATA_NO_PROPAGATION = EntryMetadata.create("noprop");
 
   private final BaggageManager contextManager = new BaggageManagerSdk();
 


### PR DESCRIPTION
This is the first step toward a W3C Baggage Propagator implementation.

Amends #1530 