### PR TITLE
Remove baggage parent from the API

### DIFF
--- a/api/src/main/java/io/opentelemetry/baggage/Baggage.java
+++ b/api/src/main/java/io/opentelemetry/baggage/Baggage.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.baggage;
 
-import io.grpc.Context;
 import java.util.Collection;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -46,55 +45,6 @@ public interface Baggage {
    * @since 0.9.0
    */
   interface Builder {
-    /**
-     * Sets the parent {@link Baggage} to use. If no parent is provided, the value of {@link
-     * BaggageManager#getCurrentBaggage()} at {@link #build()} time will be used as parent, unless
-     * {@link #setNoParent()} was called.
-     *
-     * <p>This <b>must</b> be used to create a {@link Baggage} when manual Context propagation is
-     * used.
-     *
-     * <p>If called multiple times, only the last specified value will be used.
-     *
-     * @param parent the {@link Baggage} used as parent, not null.
-     * @return this.
-     * @throws NullPointerException if {@code parent} is {@code null}.
-     * @see #setNoParent()
-     * @since 0.9.0
-     */
-    Builder setParent(Baggage parent);
-
-    /**
-     * Sets the parent {@link Baggage} to use from the specified {@code Context}. If no parent
-     * {@link Baggage} is provided, the value of {@link BaggageManager#getCurrentBaggage()} at
-     * {@link #build()} time will be used as parent, unless {@link #setNoParent()} was called.
-     *
-     * <p>If no parent {@link Baggage} is available in the specified {@code Context}, the resulting
-     * {@link Baggage} will become a root instance, as if {@link #setNoParent()} had been called.
-     *
-     * <p>This <b>must</b> be used to create a {@link Baggage} when manual Context propagation is
-     * used.
-     *
-     * <p>If called multiple times, only the last specified value will be used.
-     *
-     * @param context the {@code Context}.
-     * @return this.
-     * @throws NullPointerException if {@code context} is {@code null}.
-     * @see #setNoParent()
-     * @since 0.9.0
-     */
-    Builder setParent(Context context);
-
-    /**
-     * Sets the option to become a root {@link Baggage} with no parent. If <b>not</b> called, the
-     * value provided using {@link #setParent(Baggage)} or otherwise {@link
-     * BaggageManager#getCurrentBaggage()} at {@link #build()} time will be used as parent.
-     *
-     * @return this.
-     * @since 0.9.0
-     */
-    Builder setNoParent();
-
     /**
      * Adds the key/value pair and metadata regardless of whether the key is present.
      *

--- a/api/src/main/java/io/opentelemetry/baggage/BaggageManager.java
+++ b/api/src/main/java/io/opentelemetry/baggage/BaggageManager.java
@@ -16,7 +16,7 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <p>Implementations may have different constraints and are free to convert entry contexts to their
  * own subtypes. This means callers cannot assume the {@link #getCurrentBaggage() current context}
- * is the same instance as the one {@link #withContext(Baggage) placed into scope}.
+ * is the same instance as the one {@link #withBaggage(Baggage) placed into scope}.
  *
  * @since 0.9.0
  */
@@ -44,10 +44,10 @@ public interface BaggageManager {
    * the previous {@code Baggage}) and returns an object that represents that scope. The scope is
    * exited when the returned object is closed.
    *
-   * @param distContext the {@code Baggage} to be set as the current context.
+   * @param baggage the {@code Baggage} to be set as the current context.
    * @return an object that defines a scope where the given {@code Baggage} is set as the current
    *     context.
    * @since 0.9.0
    */
-  Scope withContext(Baggage distContext);
+  Scope withBaggage(Baggage baggage);
 }

--- a/api/src/main/java/io/opentelemetry/baggage/DefaultBaggageManager.java
+++ b/api/src/main/java/io/opentelemetry/baggage/DefaultBaggageManager.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.baggage;
 
-import io.grpc.Context;
 import io.opentelemetry.context.Scope;
 import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
@@ -42,29 +41,12 @@ public final class DefaultBaggageManager implements BaggageManager {
   }
 
   @Override
-  public Scope withContext(Baggage distContext) {
-    return BaggageUtils.currentContextWith(distContext);
+  public Scope withBaggage(Baggage baggage) {
+    return BaggageUtils.currentContextWith(baggage);
   }
 
   @Immutable
   private static final class NoopBaggageBuilder implements Baggage.Builder {
-    @Override
-    public Baggage.Builder setParent(Baggage parent) {
-      Objects.requireNonNull(parent, "parent");
-      return this;
-    }
-
-    @Override
-    public Baggage.Builder setParent(Context context) {
-      Objects.requireNonNull(context, "context");
-      return this;
-    }
-
-    @Override
-    public Baggage.Builder setNoParent() {
-      return this;
-    }
-
     @Override
     public Baggage.Builder put(String key, String value, EntryMetadata entryMetadata) {
       Objects.requireNonNull(key, "key");

--- a/api/src/main/java/io/opentelemetry/baggage/Entry.java
+++ b/api/src/main/java/io/opentelemetry/baggage/Entry.java
@@ -6,9 +6,9 @@
 package io.opentelemetry.baggage;
 
 import com.google.auto.value.AutoValue;
-import io.opentelemetry.baggage.EntryMetadata.EntryTtl;
 import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.internal.Utils;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -19,31 +19,14 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 @AutoValue
 public abstract class Entry {
-  /**
-   * The maximum length for an entry key name. The value is {@value #MAX_KEY_LENGTH}.
-   *
-   * @since 0.9.0
-   */
-  public static final int MAX_KEY_LENGTH = 255;
-
-  /**
-   * The maximum length for a entry value. The value is {@value #MAX_VALUE_LENGTH}.
-   *
-   * @since 0.9.0
-   */
-  public static final int MAX_VALUE_LENGTH = 255;
-
-  /** Default propagation metadata - unlimited propagation. */
-  public static final EntryMetadata METADATA_UNLIMITED_PROPAGATION =
-      EntryMetadata.create(EntryTtl.UNLIMITED_PROPAGATION);
 
   Entry() {}
 
   /**
    * Creates an {@code Entry} from the given key, value and metadata.
    *
-   * @param key the entry key.
-   * @param value the entry value.
+   * @param key           the entry key.
+   * @param value         the entry value.
    * @param entryMetadata the entry metadata.
    * @return a {@code Entry}.
    * @since 0.9.0
@@ -52,6 +35,18 @@ public abstract class Entry {
     Utils.checkArgument(keyIsValid(key), "Invalid entry key name: %s", key);
     Utils.checkArgument(isValueValid(value), "Invalid entry value: %s", value);
     return new AutoValue_Entry(key, value, entryMetadata);
+  }
+
+  /**
+   * Creates an {@code Entry} from the given key, value, with no metadata.
+   *
+   * @param key           the entry key.
+   * @param value         the entry value.
+   * @return a {@code Entry}.
+   * @since 0.9.0
+   */
+  public static Entry create(String key, String value) {
+    return create(key, value, EntryMetadata.EMPTY);
   }
 
   /**
@@ -71,11 +66,12 @@ public abstract class Entry {
   public abstract String getValue();
 
   /**
-   * Returns the {@link EntryMetadata} associated with this {@link Entry}.
+   * Returns the (optional) {@link EntryMetadata} associated with this {@link Entry}.
    *
    * @return the {@code EntryMetadata}.
    * @since 0.9.0
    */
+  @Nullable
   public abstract EntryMetadata getEntryMetadata();
 
   /**
@@ -85,9 +81,7 @@ public abstract class Entry {
    * @return whether the name is valid.
    */
   private static boolean keyIsValid(String name) {
-    return !name.isEmpty()
-        && name.length() <= MAX_KEY_LENGTH
-        && StringUtils.isPrintableString(name);
+    return !name.isEmpty() && StringUtils.isPrintableString(name);
   }
 
   /**
@@ -97,6 +91,6 @@ public abstract class Entry {
    * @return whether the value is valid.
    */
   private static boolean isValueValid(String value) {
-    return value.length() <= MAX_VALUE_LENGTH && StringUtils.isPrintableString(value);
+    return StringUtils.isPrintableString(value);
   }
 }

--- a/api/src/main/java/io/opentelemetry/baggage/Entry.java
+++ b/api/src/main/java/io/opentelemetry/baggage/Entry.java
@@ -25,8 +25,8 @@ public abstract class Entry {
   /**
    * Creates an {@code Entry} from the given key, value and metadata.
    *
-   * @param key           the entry key.
-   * @param value         the entry value.
+   * @param key the entry key.
+   * @param value the entry value.
    * @param entryMetadata the entry metadata.
    * @return a {@code Entry}.
    * @since 0.9.0
@@ -40,8 +40,8 @@ public abstract class Entry {
   /**
    * Creates an {@code Entry} from the given key, value, with no metadata.
    *
-   * @param key           the entry key.
-   * @param value         the entry value.
+   * @param key the entry key.
+   * @param value the entry value.
    * @return a {@code Entry}.
    * @since 0.9.0
    */

--- a/api/src/main/java/io/opentelemetry/baggage/EntryMetadata.java
+++ b/api/src/main/java/io/opentelemetry/baggage/EntryMetadata.java
@@ -9,28 +9,27 @@ import com.google.auto.value.AutoValue;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * {@link EntryMetadata} contains properties associated with an {@link Entry}.
- *
- * <p>For now only the property {@link EntryTtl} is defined. In future, additional properties may be
- * added to address specific situations.
+ * {@link EntryMetadata} contains properties associated with an {@link Entry}. This is an opaque
+ * wrapper for a String metadata value.
  *
  * @since 0.9.0
  */
 @Immutable
 @AutoValue
 public abstract class EntryMetadata {
+  public static EntryMetadata EMPTY = create("");
 
   EntryMetadata() {}
 
   /**
-   * Creates an {@link EntryMetadata} with the given {@link EntryTtl}.
+   * Creates an {@link EntryMetadata} with the given value.
    *
-   * @param entryTtl TTL of an {@code Entry}.
+   * @param metadata TTL of an {@code Entry}.
    * @return an {@code EntryMetadata}.
    * @since 0.9.0
    */
-  public static EntryMetadata create(EntryTtl entryTtl) {
-    return new AutoValue_EntryMetadata(entryTtl);
+  public static EntryMetadata create(String metadata) {
+    return new AutoValue_EntryMetadata(metadata);
   }
 
   /**
@@ -39,51 +38,5 @@ public abstract class EntryMetadata {
    * @return the {@code EntryTtl}.
    * @since 0.9.0
    */
-  public abstract EntryTtl getEntryTtl();
-
-  /**
-   * {@link EntryTtl} is an integer that represents number of hops an entry can propagate.
-   *
-   * <p>Anytime a sender serializes a entry, sends it over the wire and receiver deserializes the
-   * entry then the entry is considered to have travelled one hop.
-   *
-   * <p>There could be one or more proxy(ies) between sender and receiver. Proxies are treated as
-   * transparent entities and they are not counted as hops.
-   *
-   * <p>For now, only special values of {@link EntryTtl} are supported.
-   *
-   * @since 0.9.0
-   */
-  public enum EntryTtl {
-
-    /**
-     * An {@link Entry} with {@link EntryTtl#NO_PROPAGATION} is considered to have local scope and
-     * is used within the process where it's created.
-     *
-     * @since 0.9.0
-     */
-    NO_PROPAGATION(0),
-
-    /**
-     * An {@link Entry} with {@link EntryTtl#UNLIMITED_PROPAGATION} can propagate unlimited hops.
-     *
-     * <p>However, it is still subject to outgoing and incoming (on remote side) filter criteria.
-     *
-     * <p>{@link EntryTtl#UNLIMITED_PROPAGATION} is typical used to track a request, which may be
-     * processed across multiple entities.
-     *
-     * @since 0.9.0
-     */
-    UNLIMITED_PROPAGATION(-1);
-
-    private final int hops;
-
-    EntryTtl(int hops) {
-      this.hops = hops;
-    }
-
-    int getHops() {
-      return hops;
-    }
-  }
+  public abstract String getValue();
 }

--- a/api/src/main/java/io/opentelemetry/baggage/EntryMetadata.java
+++ b/api/src/main/java/io/opentelemetry/baggage/EntryMetadata.java
@@ -33,9 +33,9 @@ public abstract class EntryMetadata {
   }
 
   /**
-   * Returns the {@link EntryTtl} of this {@link EntryMetadata}.
+   * Returns the String value of this {@link EntryMetadata}.
    *
-   * @return the {@code EntryTtl}.
+   * @return the raw metadata value.
    * @since 0.9.0
    */
   public abstract String getValue();

--- a/api/src/main/java/io/opentelemetry/baggage/EntryMetadata.java
+++ b/api/src/main/java/io/opentelemetry/baggage/EntryMetadata.java
@@ -17,7 +17,7 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 @AutoValue
 public abstract class EntryMetadata {
-  public static EntryMetadata EMPTY = create("");
+  public static final EntryMetadata EMPTY = create("");
 
   EntryMetadata() {}
 

--- a/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
+++ b/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
@@ -410,7 +410,7 @@ class OpenTelemetryTest {
 
     @Nullable
     @Override
-    public Scope withContext(Baggage distContext) {
+    public Scope withBaggage(Baggage baggage) {
       return null;
     }
   }

--- a/api/src/test/java/io/opentelemetry/baggage/DefaultBaggageManagerTest.java
+++ b/api/src/test/java/io/opentelemetry/baggage/DefaultBaggageManagerTest.java
@@ -18,14 +18,14 @@ class DefaultBaggageManagerTest {
   private static final BaggageManager DEFAULT_BAGGAGE_MANAGER = DefaultBaggageManager.getInstance();
   private static final String KEY = "key";
   private static final String VALUE = "value";
+  private static final EntryMetadata SAMPLE_METADATA = EntryMetadata.create("sample");
 
   private static final Baggage DIST_CONTEXT =
       new Baggage() {
 
         @Override
         public Collection<Entry> getEntries() {
-          return Collections.singletonList(
-              Entry.create(KEY, VALUE, Entry.METADATA_UNLIMITED_PROPAGATION));
+          return Collections.singletonList(Entry.create(KEY, VALUE, SAMPLE_METADATA));
         }
 
         @Override
@@ -113,17 +113,13 @@ class DefaultBaggageManagerTest {
   @Test
   void noopContextBuilder_Put_DisallowsNullKey() {
     Baggage.Builder noopBuilder = DEFAULT_BAGGAGE_MANAGER.baggageBuilder();
-    assertThrows(
-        NullPointerException.class,
-        () -> noopBuilder.put(null, VALUE, Entry.METADATA_UNLIMITED_PROPAGATION));
+    assertThrows(NullPointerException.class, () -> noopBuilder.put(null, VALUE, SAMPLE_METADATA));
   }
 
   @Test
   void noopContextBuilder_Put_DisallowsNullValue() {
     Baggage.Builder noopBuilder = DEFAULT_BAGGAGE_MANAGER.baggageBuilder();
-    assertThrows(
-        NullPointerException.class,
-        () -> noopBuilder.put(KEY, null, Entry.METADATA_UNLIMITED_PROPAGATION));
+    assertThrows(NullPointerException.class, () -> noopBuilder.put(KEY, null, SAMPLE_METADATA));
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/baggage/DefaultBaggageManagerTest.java
+++ b/api/src/test/java/io/opentelemetry/baggage/DefaultBaggageManagerTest.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class DefaultBaggageManagerTest {
+
   private static final BaggageManager DEFAULT_BAGGAGE_MANAGER = DefaultBaggageManager.getInstance();
   private static final String KEY = "key";
   private static final String VALUE = "value";
@@ -59,7 +60,7 @@ class DefaultBaggageManagerTest {
   @Test
   void withContext() {
     assertThat(DEFAULT_BAGGAGE_MANAGER.getCurrentBaggage()).isSameAs(EmptyBaggage.getInstance());
-    try (Scope wtm = DEFAULT_BAGGAGE_MANAGER.withContext(DIST_CONTEXT)) {
+    try (Scope wtm = DEFAULT_BAGGAGE_MANAGER.withBaggage(DIST_CONTEXT)) {
       assertThat(DEFAULT_BAGGAGE_MANAGER.getCurrentBaggage()).isSameAs(DIST_CONTEXT);
     }
     assertThat(DEFAULT_BAGGAGE_MANAGER.getCurrentBaggage()).isSameAs(EmptyBaggage.getInstance());
@@ -68,7 +69,7 @@ class DefaultBaggageManagerTest {
   @Test
   void withContext_nullContext() {
     assertThat(DEFAULT_BAGGAGE_MANAGER.getCurrentBaggage()).isSameAs(EmptyBaggage.getInstance());
-    try (Scope wtm = DEFAULT_BAGGAGE_MANAGER.withContext(null)) {
+    try (Scope wtm = DEFAULT_BAGGAGE_MANAGER.withBaggage(null)) {
       assertThat(DEFAULT_BAGGAGE_MANAGER.getCurrentBaggage()).isSameAs(EmptyBaggage.getInstance());
     }
     assertThat(DEFAULT_BAGGAGE_MANAGER.getCurrentBaggage()).isSameAs(EmptyBaggage.getInstance());
@@ -77,7 +78,7 @@ class DefaultBaggageManagerTest {
   @Test
   void withContextUsingWrap() {
     Runnable runnable;
-    try (Scope wtm = DEFAULT_BAGGAGE_MANAGER.withContext(DIST_CONTEXT)) {
+    try (Scope wtm = DEFAULT_BAGGAGE_MANAGER.withBaggage(DIST_CONTEXT)) {
       assertThat(DEFAULT_BAGGAGE_MANAGER.getCurrentBaggage()).isSameAs(DIST_CONTEXT);
       runnable =
           Context.current()
@@ -89,25 +90,6 @@ class DefaultBaggageManagerTest {
     assertThat(DEFAULT_BAGGAGE_MANAGER.getCurrentBaggage()).isSameAs(EmptyBaggage.getInstance());
     // When we run the runnable we will have the Baggage in the current Context.
     runnable.run();
-  }
-
-  @Test
-  void noopContextBuilder_SetParent_DisallowsNullParent() {
-    Baggage.Builder noopBuilder = DEFAULT_BAGGAGE_MANAGER.baggageBuilder();
-    assertThrows(NullPointerException.class, () -> noopBuilder.setParent((Baggage) null));
-  }
-
-  @Test
-  void noopContextBuilder_SetParent_DisallowsNullContext() {
-    Baggage.Builder noopBuilder = DEFAULT_BAGGAGE_MANAGER.baggageBuilder();
-    assertThrows(NullPointerException.class, () -> noopBuilder.setParent((Context) null));
-    ;
-  }
-
-  @Test
-  void noopContextBuilder_SetParent_fromContext() {
-    Baggage.Builder noopBuilder = DEFAULT_BAGGAGE_MANAGER.baggageBuilder();
-    noopBuilder.setParent(Context.current()); // No error.
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/baggage/EntryMetadataTest.java
+++ b/api/src/test/java/io/opentelemetry/baggage/EntryMetadataTest.java
@@ -8,24 +8,21 @@ package io.opentelemetry.baggage;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import io.opentelemetry.baggage.EntryMetadata.EntryTtl;
 import org.junit.jupiter.api.Test;
 
 class EntryMetadataTest {
 
   @Test
-  void testGetEntryTtl() {
-    EntryMetadata entryMetadata = EntryMetadata.create(EntryTtl.NO_PROPAGATION);
-    assertThat(entryMetadata.getEntryTtl()).isEqualTo(EntryTtl.NO_PROPAGATION);
+  void getValue() {
+    EntryMetadata entryMetadata = EntryMetadata.create("metadata;value=foo");
+    assertThat(entryMetadata.getValue()).isEqualTo("metadata;value=foo");
   }
 
   @Test
   void testEquals() {
     new EqualsTester()
-        .addEqualityGroup(
-            EntryMetadata.create(EntryTtl.NO_PROPAGATION),
-            EntryMetadata.create(EntryTtl.NO_PROPAGATION))
-        .addEqualityGroup(EntryMetadata.create(EntryTtl.UNLIMITED_PROPAGATION))
+        .addEqualityGroup(EntryMetadata.create("value"), EntryMetadata.create("value"))
+        .addEqualityGroup(EntryMetadata.create("other value"))
         .testEquals();
   }
 }

--- a/api/src/test/java/io/opentelemetry/baggage/EntryTest.java
+++ b/api/src/test/java/io/opentelemetry/baggage/EntryTest.java
@@ -9,8 +9,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.testing.EqualsTester;
-import io.opentelemetry.baggage.EntryMetadata.EntryTtl;
-import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 class EntryTest {
@@ -19,100 +17,45 @@ class EntryTest {
   private static final String KEY_2 = "KEY2";
   private static final String VALUE = "VALUE";
   private static final String VALUE_2 = "VALUE2";
-  private static final EntryMetadata METADATA_UNLIMITED_PROPAGATION =
-      EntryMetadata.create(EntryTtl.UNLIMITED_PROPAGATION);
-  private static final EntryMetadata METADATA_NO_PROPAGATION =
-      EntryMetadata.create(EntryTtl.NO_PROPAGATION);
+  private static final EntryMetadata SAMPLE_METADATA =
+      EntryMetadata.create("propagation=unlimited");
 
   @Test
   void testGetKey() {
-    assertThat(Entry.create(KEY, VALUE, METADATA_UNLIMITED_PROPAGATION).getKey()).isEqualTo(KEY);
+    assertThat(Entry.create(KEY, VALUE, SAMPLE_METADATA).getKey()).isEqualTo(KEY);
   }
 
   @Test
   void testGetEntryMetadata() {
-    assertThat(Entry.create(KEY, VALUE, METADATA_NO_PROPAGATION).getEntryMetadata())
-        .isEqualTo(METADATA_NO_PROPAGATION);
+    assertThat(Entry.create(KEY, VALUE, SAMPLE_METADATA).getEntryMetadata())
+        .isEqualTo(SAMPLE_METADATA);
   }
 
   @Test
   void testEntryEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            Entry.create(KEY, VALUE, METADATA_UNLIMITED_PROPAGATION),
-            Entry.create(KEY, VALUE, METADATA_UNLIMITED_PROPAGATION))
-        .addEqualityGroup(Entry.create(KEY, VALUE_2, METADATA_UNLIMITED_PROPAGATION))
-        .addEqualityGroup(Entry.create(KEY_2, VALUE, METADATA_UNLIMITED_PROPAGATION))
-        .addEqualityGroup(Entry.create(KEY, VALUE, METADATA_NO_PROPAGATION))
+            Entry.create(KEY, VALUE, SAMPLE_METADATA), Entry.create(KEY, VALUE, SAMPLE_METADATA))
+        .addEqualityGroup(Entry.create(KEY, VALUE_2, SAMPLE_METADATA))
+        .addEqualityGroup(Entry.create(KEY_2, VALUE, SAMPLE_METADATA))
+        .addEqualityGroup(Entry.create(KEY, VALUE, EntryMetadata.create("other")))
         .testEquals();
-  }
-
-  @Test
-  void testKeyMaxLength() {
-    assertThat(Entry.MAX_KEY_LENGTH).isEqualTo(255);
-  }
-
-  @Test
-  void create_AllowEntryKeyNameWithMaxLength() {
-    char[] chars = new char[Entry.MAX_KEY_LENGTH];
-    Arrays.fill(chars, 'k');
-    String key = new String(chars);
-    assertThat(Entry.create(key, "value", Entry.METADATA_UNLIMITED_PROPAGATION)).isNotNull();
-  }
-
-  @Test
-  void create_DisallowEntryKeyNameOverMaxLength() {
-    char[] chars = new char[Entry.MAX_KEY_LENGTH + 1];
-    Arrays.fill(chars, 'k');
-    String key = new String(chars);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> Entry.create(key, "value", Entry.METADATA_UNLIMITED_PROPAGATION));
   }
 
   @Test
   void create_DisallowKeyUnprintableChars() {
     assertThrows(
-        IllegalArgumentException.class,
-        () -> Entry.create("\2ab\3cd", "value", Entry.METADATA_UNLIMITED_PROPAGATION));
+        IllegalArgumentException.class, () -> Entry.create("\2ab\3cd", "value", SAMPLE_METADATA));
   }
 
   @Test
   void createString_DisallowKeyEmpty() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> Entry.create("", "value", Entry.METADATA_UNLIMITED_PROPAGATION));
-  }
-
-  @Test
-  void testValueMaxLength() {
-    assertThat(Entry.MAX_VALUE_LENGTH).isEqualTo(255);
-  }
-
-  @Test
-  void create_AllowEntryValueWithMaxLength() {
-    char[] chars = new char[Entry.MAX_VALUE_LENGTH];
-    Arrays.fill(chars, 'v');
-    String value = new String(chars);
-    assertThat(Entry.create("key", value, Entry.METADATA_UNLIMITED_PROPAGATION).getValue())
-        .isEqualTo(value);
-  }
-
-  @Test
-  void create_DisallowEntryValueOverMaxLength() {
-    char[] chars = new char[Entry.MAX_VALUE_LENGTH + 1];
-    Arrays.fill(chars, 'v');
-    String value = new String(chars);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> Entry.create("key", value, Entry.METADATA_UNLIMITED_PROPAGATION));
+    assertThrows(IllegalArgumentException.class, () -> Entry.create("", "value", SAMPLE_METADATA));
   }
 
   @Test
   void disallowEntryValueWithUnprintableChars() {
     String value = "\2ab\3cd";
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> Entry.create("key", value, Entry.METADATA_UNLIMITED_PROPAGATION));
+    assertThrows(IllegalArgumentException.class, () -> Entry.create("key", value, SAMPLE_METADATA));
   }
 }

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
@@ -13,8 +13,8 @@ import java.util.Iterator;
 import java.util.Map;
 
 final class SpanContextShim extends BaseShimObject implements SpanContext {
-  static final EntryMetadata DEFAULT_ENTRY_METADATA =
-      EntryMetadata.create(EntryMetadata.EntryTtl.UNLIMITED_PROPAGATION);
+
+  static final EntryMetadata DEFAULT_ENTRY_METADATA = EntryMetadata.create("testmetadata");
 
   private final io.opentelemetry.trace.SpanContext context;
   private final Baggage distContext;
@@ -76,6 +76,7 @@ final class SpanContextShim extends BaseShimObject implements SpanContext {
   }
 
   static class BaggageIterable implements Iterable<Map.Entry<String, String>> {
+
     final Iterator<Entry> iterator;
 
     BaggageIterable(Iterator<Entry> iterator) {
@@ -102,6 +103,7 @@ final class SpanContextShim extends BaseShimObject implements SpanContext {
   }
 
   static class BaggageEntry implements Map.Entry<String, String> {
+
     final Entry entry;
 
     BaggageEntry(Entry entry) {

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
@@ -14,8 +14,6 @@ import java.util.Map;
 
 final class SpanContextShim extends BaseShimObject implements SpanContext {
 
-  static final EntryMetadata DEFAULT_ENTRY_METADATA = EntryMetadata.create("testmetadata");
-
   private final io.opentelemetry.trace.SpanContext context;
   private final Baggage distContext;
 
@@ -41,7 +39,7 @@ final class SpanContextShim extends BaseShimObject implements SpanContext {
 
   SpanContextShim newWithKeyValue(String key, String value) {
     Baggage.Builder builder = contextManager().baggageBuilder().setParent(distContext);
-    builder.put(key, value, DEFAULT_ENTRY_METADATA);
+    builder.put(key, value, EntryMetadata.EMPTY);
 
     return new SpanContextShim(telemetryInfo(), context, builder.build());
   }

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
@@ -38,7 +38,10 @@ final class SpanContextShim extends BaseShimObject implements SpanContext {
   }
 
   SpanContextShim newWithKeyValue(String key, String value) {
-    Baggage.Builder builder = contextManager().baggageBuilder().setParent(distContext);
+    Baggage.Builder builder = contextManager().baggageBuilder();
+    distContext
+        .getEntries()
+        .forEach(entry -> builder.put(entry.getKey(), entry.getValue(), entry.getEntryMetadata()));
     builder.put(key, value, EntryMetadata.EMPTY);
 
     return new SpanContextShim(telemetryInfo(), context, builder.build());

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.opentracingshim;
 
 import static io.opentelemetry.opentracingshim.TestUtils.getBaggageMap;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -48,8 +49,8 @@ class SpanShimTest {
     SpanContextShim contextShim = (SpanContextShim) spanShim.context();
     assertNotNull(contextShim);
     assertEquals(contextShim.getSpanContext(), span.getContext());
-    assertEquals(contextShim.toTraceId(), span.getContext().getTraceIdAsHexString().toString());
-    assertEquals(contextShim.toSpanId(), span.getContext().getSpanIdAsHexString().toString());
+    assertEquals(contextShim.toTraceId(), span.getContext().getTraceIdAsHexString());
+    assertEquals(contextShim.toSpanId(), span.getContext().getSpanIdAsHexString());
     assertFalse(contextShim.baggageItems().iterator().hasNext());
   }
 
@@ -59,15 +60,15 @@ class SpanShimTest {
 
     spanShim.setBaggageItem("key1", "value1");
     spanShim.setBaggageItem("key2", "value2");
-    assertEquals(spanShim.getBaggageItem("key1"), "value1");
-    assertEquals(spanShim.getBaggageItem("key2"), "value2");
+    assertThat(spanShim.getBaggageItem("key1")).isEqualTo("value1");
+    assertThat(spanShim.getBaggageItem("key2")).isEqualTo("value2");
 
     SpanContextShim contextShim = (SpanContextShim) spanShim.context();
     assertNotNull(contextShim);
     Map<String, String> baggageMap = getBaggageMap(contextShim.baggageItems());
-    assertEquals(2, baggageMap.size());
-    assertEquals(baggageMap.get("key1"), "value1");
-    assertEquals(baggageMap.get("key2"), "value2");
+    assertThat(baggageMap.size()).isEqualTo(2);
+    assertThat(baggageMap.get("key1")).isEqualTo("value1");
+    assertThat(baggageMap.get("key2")).isEqualTo("value2");
   }
 
   @Test

--- a/sdk/baggage/src/main/java/io/opentelemetry/sdk/baggage/BaggageManagerSdk.java
+++ b/sdk/baggage/src/main/java/io/opentelemetry/sdk/baggage/BaggageManagerSdk.java
@@ -24,7 +24,7 @@ public class BaggageManagerSdk implements BaggageManager {
   }
 
   @Override
-  public Scope withContext(Baggage distContext) {
-    return BaggageUtils.currentContextWith(distContext);
+  public Scope withBaggage(Baggage baggage) {
+    return BaggageUtils.currentContextWith(baggage);
   }
 }

--- a/sdk/baggage/src/test/java/io/opentelemetry/sdk/baggage/BaggageManagerSdkTest.java
+++ b/sdk/baggage/src/test/java/io/opentelemetry/sdk/baggage/BaggageManagerSdkTest.java
@@ -50,7 +50,7 @@ class BaggageManagerSdkTest {
   @Test
   void testWithBaggage() {
     assertThat(contextManager.getCurrentBaggage()).isSameAs(EmptyBaggage.getInstance());
-    try (Scope wtm = contextManager.withContext(distContext)) {
+    try (Scope wtm = contextManager.withBaggage(distContext)) {
       assertThat(contextManager.getCurrentBaggage()).isSameAs(distContext);
     }
     assertThat(contextManager.getCurrentBaggage()).isSameAs(EmptyBaggage.getInstance());
@@ -59,7 +59,7 @@ class BaggageManagerSdkTest {
   @Test
   void testWithBaggageUsingWrap() {
     Runnable runnable;
-    try (Scope wtm = contextManager.withContext(distContext)) {
+    try (Scope wtm = contextManager.withBaggage(distContext)) {
       assertThat(contextManager.getCurrentBaggage()).isSameAs(distContext);
       runnable =
           Context.current()

--- a/sdk/baggage/src/test/java/io/opentelemetry/sdk/baggage/BaggageSdkTest.java
+++ b/sdk/baggage/src/test/java/io/opentelemetry/sdk/baggage/BaggageSdkTest.java
@@ -25,10 +25,10 @@ import org.junit.jupiter.api.Test;
  * <p>Tests for scope management with {@link BaggageManagerSdk} are in {@link ScopedBaggageTest}.
  */
 class BaggageSdkTest {
+
   private final BaggageManager contextManager = new BaggageManagerSdk();
 
-  private static final EntryMetadata TMD =
-      EntryMetadata.create(EntryMetadata.EntryTtl.UNLIMITED_PROPAGATION);
+  private static final EntryMetadata TMD = EntryMetadata.create("tmd");
 
   private static final String K1 = "k1";
   private static final String K2 = "k2";

--- a/sdk/baggage/src/test/java/io/opentelemetry/sdk/baggage/ScopedBaggageTest.java
+++ b/sdk/baggage/src/test/java/io/opentelemetry/sdk/baggage/ScopedBaggageTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
  * interact with the current {@link BaggageSdk}.
  */
 class ScopedBaggageTest {
+
   private static final String KEY_1 = "key 1";
   private static final String KEY_2 = "key 2";
   private static final String KEY_3 = "key 3";
@@ -30,9 +31,8 @@ class ScopedBaggageTest {
   private static final String VALUE_4 = "value 4";
 
   private static final EntryMetadata METADATA_UNLIMITED_PROPAGATION =
-      EntryMetadata.create(EntryMetadata.EntryTtl.UNLIMITED_PROPAGATION);
-  private static final EntryMetadata METADATA_NO_PROPAGATION =
-      EntryMetadata.create(EntryMetadata.EntryTtl.NO_PROPAGATION);
+      EntryMetadata.create("unlimited");
+  private static final EntryMetadata METADATA_NO_PROPAGATION = EntryMetadata.create("noprop");
 
   private final BaggageManager contextManager = new BaggageManagerSdk();
 

--- a/sdk/baggage/src/test/java/io/opentelemetry/sdk/baggage/ScopedBaggageTest.java
+++ b/sdk/baggage/src/test/java/io/opentelemetry/sdk/baggage/ScopedBaggageTest.java
@@ -48,7 +48,7 @@ class ScopedBaggageTest {
     assertThat(contextManager.getCurrentBaggage().getEntries()).isEmpty();
     Baggage scopedEntries =
         contextManager.baggageBuilder().put(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION).build();
-    try (Scope scope = contextManager.withContext(scopedEntries)) {
+    try (Scope scope = contextManager.withBaggage(scopedEntries)) {
       assertThat(contextManager.getCurrentBaggage()).isSameAs(scopedEntries);
     }
     assertThat(contextManager.getCurrentBaggage().getEntries()).isEmpty();
@@ -56,9 +56,9 @@ class ScopedBaggageTest {
 
   @Test
   void createBuilderFromCurrentEntries() {
-    Baggage scopedDistContext =
+    Baggage scopedBaggage =
         contextManager.baggageBuilder().put(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION).build();
-    try (Scope scope = contextManager.withContext(scopedDistContext)) {
+    try (Scope scope = contextManager.withBaggage(scopedBaggage)) {
       Baggage newEntries =
           contextManager
               .baggageBuilder()
@@ -68,7 +68,7 @@ class ScopedBaggageTest {
           .containsExactlyInAnyOrder(
               Entry.create(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION),
               Entry.create(KEY_2, VALUE_2, METADATA_UNLIMITED_PROPAGATION));
-      assertThat(contextManager.getCurrentBaggage()).isSameAs(scopedDistContext);
+      assertThat(contextManager.getCurrentBaggage()).isSameAs(scopedBaggage);
     }
   }
 
@@ -77,7 +77,7 @@ class ScopedBaggageTest {
     assertThat(contextManager.getCurrentBaggage().getEntries()).isEmpty();
     Baggage scopedDistContext =
         contextManager.baggageBuilder().put(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION).build();
-    try (Scope scope = contextManager.withContext(scopedDistContext)) {
+    try (Scope scope = contextManager.withBaggage(scopedDistContext)) {
       assertThat(contextManager.getCurrentBaggage().getEntries())
           .containsExactly(Entry.create(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION));
       assertThat(contextManager.getCurrentBaggage()).isSameAs(scopedDistContext);
@@ -89,13 +89,13 @@ class ScopedBaggageTest {
   void addToCurrentEntriesWithBuilder() {
     Baggage scopedDistContext =
         contextManager.baggageBuilder().put(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION).build();
-    try (Scope scope1 = contextManager.withContext(scopedDistContext)) {
+    try (Scope scope1 = contextManager.withBaggage(scopedDistContext)) {
       Baggage innerDistContext =
           contextManager
               .baggageBuilder()
               .put(KEY_2, VALUE_2, METADATA_UNLIMITED_PROPAGATION)
               .build();
-      try (Scope scope2 = contextManager.withContext(innerDistContext)) {
+      try (Scope scope2 = contextManager.withBaggage(innerDistContext)) {
         assertThat(contextManager.getCurrentBaggage().getEntries())
             .containsExactlyInAnyOrder(
                 Entry.create(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION),
@@ -114,14 +114,14 @@ class ScopedBaggageTest {
             .put(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION)
             .put(KEY_2, VALUE_2, METADATA_UNLIMITED_PROPAGATION)
             .build();
-    try (Scope scope1 = contextManager.withContext(scopedDistContext)) {
+    try (Scope scope1 = contextManager.withBaggage(scopedDistContext)) {
       Baggage innerDistContext =
           contextManager
               .baggageBuilder()
               .put(KEY_3, VALUE_3, METADATA_NO_PROPAGATION)
               .put(KEY_2, VALUE_4, METADATA_NO_PROPAGATION)
               .build();
-      try (Scope scope2 = contextManager.withContext(innerDistContext)) {
+      try (Scope scope2 = contextManager.withBaggage(innerDistContext)) {
         assertThat(contextManager.getCurrentBaggage().getEntries())
             .containsExactlyInAnyOrder(
                 Entry.create(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION),
@@ -131,23 +131,5 @@ class ScopedBaggageTest {
       }
       assertThat(contextManager.getCurrentBaggage()).isSameAs(scopedDistContext);
     }
-  }
-
-  @Test
-  void setNoParent_doesNotInheritContext() {
-    assertThat(contextManager.getCurrentBaggage().getEntries()).isEmpty();
-    Baggage scopedDistContext =
-        contextManager.baggageBuilder().put(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION).build();
-    try (Scope scope = contextManager.withContext(scopedDistContext)) {
-      Baggage innerDistContext =
-          contextManager
-              .baggageBuilder()
-              .setNoParent()
-              .put(KEY_2, VALUE_2, METADATA_UNLIMITED_PROPAGATION)
-              .build();
-      assertThat(innerDistContext.getEntries())
-          .containsExactly(Entry.create(KEY_2, VALUE_2, METADATA_UNLIMITED_PROPAGATION));
-    }
-    assertThat(contextManager.getCurrentBaggage().getEntries()).isEmpty();
   }
 }


### PR DESCRIPTION
The spec mentions nothing about Baggage having an explicit parent attribute, so this removes it. This PR retains the implicit parent that gets amended if the Context contains Baggage when new Baggage is created.

This is a follow-on to #1764 and continues work toward having the Baggage implementation match the specification.

Amends #1530 

The next step after this will be to move the Baggage implementation up to the API, removing the no-op baggage implementation.