### PR TITLE
Remove the method to parent via Baggage. 

### DIFF
--- a/api/src/main/java/io/opentelemetry/baggage/Baggage.java
+++ b/api/src/main/java/io/opentelemetry/baggage/Baggage.java
@@ -47,24 +47,6 @@ public interface Baggage {
    */
   interface Builder {
     /**
-     * Sets the parent {@link Baggage} to use. If no parent is provided, the value of {@link
-     * BaggageManager#getCurrentBaggage()} at {@link #build()} time will be used as parent, unless
-     * {@link #setNoParent()} was called.
-     *
-     * <p>This <b>must</b> be used to create a {@link Baggage} when manual Context propagation is
-     * used.
-     *
-     * <p>If called multiple times, only the last specified value will be used.
-     *
-     * @param parent the {@link Baggage} used as parent, not null.
-     * @return this.
-     * @throws NullPointerException if {@code parent} is {@code null}.
-     * @see #setNoParent()
-     * @since 0.9.0
-     */
-    Builder setParent(Baggage parent);
-
-    /**
      * Sets the parent {@link Baggage} to use from the specified {@code Context}. If no parent
      * {@link Baggage} is provided, the value of {@link BaggageManager#getCurrentBaggage()} at
      * {@link #build()} time will be used as parent, unless {@link #setNoParent()} was called.
@@ -87,7 +69,7 @@ public interface Baggage {
 
     /**
      * Sets the option to become a root {@link Baggage} with no parent. If <b>not</b> called, the
-     * value provided using {@link #setParent(Baggage)} or otherwise {@link
+     * value provided using {@link #setParent(Context)} or otherwise {@link
      * BaggageManager#getCurrentBaggage()} at {@link #build()} time will be used as parent.
      *
      * @return this.

--- a/api/src/main/java/io/opentelemetry/baggage/BaggageManager.java
+++ b/api/src/main/java/io/opentelemetry/baggage/BaggageManager.java
@@ -16,7 +16,7 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <p>Implementations may have different constraints and are free to convert entry contexts to their
  * own subtypes. This means callers cannot assume the {@link #getCurrentBaggage() current context}
- * is the same instance as the one {@link #withContext(Baggage) placed into scope}.
+ * is the same instance as the one {@link #withBaggage(Baggage) placed into scope}.
  *
  * @since 0.9.0
  */
@@ -44,10 +44,10 @@ public interface BaggageManager {
    * the previous {@code Baggage}) and returns an object that represents that scope. The scope is
    * exited when the returned object is closed.
    *
-   * @param distContext the {@code Baggage} to be set as the current context.
+   * @param baggage the {@code Baggage} to be set as the current context.
    * @return an object that defines a scope where the given {@code Baggage} is set as the current
    *     context.
    * @since 0.9.0
    */
-  Scope withContext(Baggage distContext);
+  Scope withBaggage(Baggage baggage);
 }

--- a/api/src/main/java/io/opentelemetry/baggage/BaggageManager.java
+++ b/api/src/main/java/io/opentelemetry/baggage/BaggageManager.java
@@ -16,7 +16,7 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <p>Implementations may have different constraints and are free to convert entry contexts to their
  * own subtypes. This means callers cannot assume the {@link #getCurrentBaggage() current context}
- * is the same instance as the one {@link #withBaggage(Baggage) placed into scope}.
+ * is the same instance as the one {@linkplain #withBaggage(Baggage) placed into scope}.
  *
  * @since 0.9.0
  */

--- a/api/src/main/java/io/opentelemetry/baggage/DefaultBaggageManager.java
+++ b/api/src/main/java/io/opentelemetry/baggage/DefaultBaggageManager.java
@@ -42,18 +42,12 @@ public final class DefaultBaggageManager implements BaggageManager {
   }
 
   @Override
-  public Scope withContext(Baggage distContext) {
-    return BaggageUtils.currentContextWith(distContext);
+  public Scope withBaggage(Baggage baggage) {
+    return BaggageUtils.currentContextWith(baggage);
   }
 
   @Immutable
   private static final class NoopBaggageBuilder implements Baggage.Builder {
-    @Override
-    public Baggage.Builder setParent(Baggage parent) {
-      Objects.requireNonNull(parent, "parent");
-      return this;
-    }
-
     @Override
     public Baggage.Builder setParent(Context context) {
       Objects.requireNonNull(context, "context");

--- a/api/src/main/java/io/opentelemetry/baggage/Entry.java
+++ b/api/src/main/java/io/opentelemetry/baggage/Entry.java
@@ -8,7 +8,6 @@ package io.opentelemetry.baggage;
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.internal.Utils;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -71,7 +70,6 @@ public abstract class Entry {
    * @return the {@code EntryMetadata}.
    * @since 0.9.0
    */
-  @Nullable
   public abstract EntryMetadata getEntryMetadata();
 
   /**

--- a/api/src/main/java/io/opentelemetry/baggage/Entry.java
+++ b/api/src/main/java/io/opentelemetry/baggage/Entry.java
@@ -8,6 +8,7 @@ package io.opentelemetry.baggage;
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.internal.Utils;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -24,8 +25,8 @@ public abstract class Entry {
   /**
    * Creates an {@code Entry} from the given key, value and metadata.
    *
-   * @param key the entry key.
-   * @param value the entry value.
+   * @param key           the entry key.
+   * @param value         the entry value.
    * @param entryMetadata the entry metadata.
    * @return a {@code Entry}.
    * @since 0.9.0
@@ -70,6 +71,7 @@ public abstract class Entry {
    * @return the {@code EntryMetadata}.
    * @since 0.9.0
    */
+  @Nullable
   public abstract EntryMetadata getEntryMetadata();
 
   /**

--- a/api/src/main/java/io/opentelemetry/baggage/Entry.java
+++ b/api/src/main/java/io/opentelemetry/baggage/Entry.java
@@ -25,8 +25,8 @@ public abstract class Entry {
   /**
    * Creates an {@code Entry} from the given key, value and metadata.
    *
-   * @param key           the entry key.
-   * @param value         the entry value.
+   * @param key the entry key.
+   * @param value the entry value.
    * @param entryMetadata the entry metadata.
    * @return a {@code Entry}.
    * @since 0.9.0

--- a/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
+++ b/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
@@ -410,7 +410,7 @@ class OpenTelemetryTest {
 
     @Nullable
     @Override
-    public Scope withContext(Baggage distContext) {
+    public Scope withBaggage(Baggage baggage) {
       return null;
     }
   }

--- a/api/src/test/java/io/opentelemetry/baggage/DefaultBaggageManagerTest.java
+++ b/api/src/test/java/io/opentelemetry/baggage/DefaultBaggageManagerTest.java
@@ -47,16 +47,16 @@ class DefaultBaggageManagerTest {
   @Test
   void getCurrentContext_ContextSetToNull() {
     try (Scope ignored = BaggageUtils.withBaggage(null, Context.current()).makeCurrent()) {
-      Baggage distContext = DEFAULT_BAGGAGE_MANAGER.getCurrentBaggage();
-      assertThat(distContext).isNotNull();
-      assertThat(distContext.getEntries()).isEmpty();
+      Baggage baggage = DEFAULT_BAGGAGE_MANAGER.getCurrentBaggage();
+      assertThat(baggage).isNotNull();
+      assertThat(baggage.getEntries()).isEmpty();
     }
   }
 
   @Test
   void withContext() {
     assertThat(DEFAULT_BAGGAGE_MANAGER.getCurrentBaggage()).isSameAs(EmptyBaggage.getInstance());
-    try (Scope wtm = DEFAULT_BAGGAGE_MANAGER.withContext(DIST_CONTEXT)) {
+    try (Scope wtm = DEFAULT_BAGGAGE_MANAGER.withBaggage(DIST_CONTEXT)) {
       assertThat(DEFAULT_BAGGAGE_MANAGER.getCurrentBaggage()).isSameAs(DIST_CONTEXT);
     }
     assertThat(DEFAULT_BAGGAGE_MANAGER.getCurrentBaggage()).isSameAs(EmptyBaggage.getInstance());
@@ -65,7 +65,7 @@ class DefaultBaggageManagerTest {
   @Test
   void withContext_nullContext() {
     assertThat(DEFAULT_BAGGAGE_MANAGER.getCurrentBaggage()).isSameAs(EmptyBaggage.getInstance());
-    try (Scope wtm = DEFAULT_BAGGAGE_MANAGER.withContext(null)) {
+    try (Scope wtm = DEFAULT_BAGGAGE_MANAGER.withBaggage(null)) {
       assertThat(DEFAULT_BAGGAGE_MANAGER.getCurrentBaggage()).isSameAs(EmptyBaggage.getInstance());
     }
     assertThat(DEFAULT_BAGGAGE_MANAGER.getCurrentBaggage()).isSameAs(EmptyBaggage.getInstance());
@@ -74,7 +74,7 @@ class DefaultBaggageManagerTest {
   @Test
   void withContextUsingWrap() {
     Runnable runnable;
-    try (Scope wtm = DEFAULT_BAGGAGE_MANAGER.withContext(DIST_CONTEXT)) {
+    try (Scope wtm = DEFAULT_BAGGAGE_MANAGER.withBaggage(DIST_CONTEXT)) {
       assertThat(DEFAULT_BAGGAGE_MANAGER.getCurrentBaggage()).isSameAs(DIST_CONTEXT);
       runnable =
           Context.current()
@@ -86,12 +86,6 @@ class DefaultBaggageManagerTest {
     assertThat(DEFAULT_BAGGAGE_MANAGER.getCurrentBaggage()).isSameAs(EmptyBaggage.getInstance());
     // When we run the runnable we will have the Baggage in the current Context.
     runnable.run();
-  }
-
-  @Test
-  void noopContextBuilder_SetParent_DisallowsNullParent() {
-    Baggage.Builder noopBuilder = DEFAULT_BAGGAGE_MANAGER.baggageBuilder();
-    assertThrows(NullPointerException.class, () -> noopBuilder.setParent((Baggage) null));
   }
 
   @Test

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
@@ -178,7 +178,7 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
   @SuppressWarnings({"rawtypes", "unchecked"})
   @Override
   public Span start() {
-    Baggage distContext = null;
+    Baggage baggage = null;
     io.opentelemetry.trace.Span.Builder builder = tracer().spanBuilder(spanName);
 
     if (ignoreActiveSpan && parentSpan == null && parentSpanContext == null) {
@@ -186,12 +186,12 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
     } else if (parentSpan != null) {
       builder.setParent(TracingContextUtils.withSpan(parentSpan.getSpan(), Context.root()));
       SpanContextShim contextShim = spanContextTable().get(parentSpan);
-      distContext = contextShim == null ? null : contextShim.getBaggage();
+      baggage = contextShim == null ? null : contextShim.getBaggage();
     } else if (parentSpanContext != null) {
       builder.setParent(
           TracingContextUtils.withSpan(
               DefaultSpan.create(parentSpanContext.getSpanContext()), Context.root()));
-      distContext = parentSpanContext.getBaggage();
+      baggage = parentSpanContext.getBaggage();
     }
 
     for (io.opentelemetry.trace.SpanContext link : parentLinks) {
@@ -215,8 +215,8 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
 
     SpanShim spanShim = new SpanShim(telemetryInfo(), span);
 
-    if (distContext != null && distContext != telemetryInfo().emptyBaggage()) {
-      spanContextTable().create(spanShim, distContext);
+    if (baggage != null && baggage != telemetryInfo().emptyBaggage()) {
+      spanContextTable().create(spanShim, baggage);
     }
 
     return spanShim;

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
@@ -5,11 +5,11 @@
 
 package io.opentelemetry.opentracingshim;
 
-import io.grpc.Context;
 import io.opentelemetry.baggage.Baggage;
 import io.opentelemetry.baggage.BaggageUtils;
 import io.opentelemetry.baggage.Entry;
 import io.opentelemetry.baggage.EntryMetadata;
+import io.opentelemetry.context.Context;
 import io.opentracing.SpanContext;
 import java.util.Iterator;
 import java.util.Map;
@@ -61,7 +61,7 @@ final class SpanContextShim extends BaseShimObject implements SpanContext {
 
   @Override
   public String toSpanId() {
-    return context.getSpanIdAsHexString().toString();
+    return context.getSpanIdAsHexString();
   }
 
   @Override

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
@@ -5,7 +5,9 @@
 
 package io.opentelemetry.opentracingshim;
 
+import io.grpc.Context;
 import io.opentelemetry.baggage.Baggage;
+import io.opentelemetry.baggage.BaggageUtils;
 import io.opentelemetry.baggage.Entry;
 import io.opentelemetry.baggage.EntryMetadata;
 import io.opentracing.SpanContext;
@@ -15,7 +17,7 @@ import java.util.Map;
 final class SpanContextShim extends BaseShimObject implements SpanContext {
 
   private final io.opentelemetry.trace.SpanContext context;
-  private final Baggage distContext;
+  private final Baggage baggage;
 
   public SpanContextShim(SpanShim spanShim) {
     this(
@@ -29,16 +31,16 @@ final class SpanContextShim extends BaseShimObject implements SpanContext {
   }
 
   public SpanContextShim(
-      TelemetryInfo telemetryInfo,
-      io.opentelemetry.trace.SpanContext context,
-      Baggage distContext) {
+      TelemetryInfo telemetryInfo, io.opentelemetry.trace.SpanContext context, Baggage baggage) {
     super(telemetryInfo);
     this.context = context;
-    this.distContext = distContext;
+    this.baggage = baggage;
   }
 
   SpanContextShim newWithKeyValue(String key, String value) {
-    Baggage.Builder builder = contextManager().baggageBuilder().setParent(distContext);
+    Context parentContext = BaggageUtils.withBaggage(baggage, Context.current());
+
+    Baggage.Builder builder = contextManager().baggageBuilder().setParent(parentContext);
     builder.put(key, value, EntryMetadata.EMPTY);
 
     return new SpanContextShim(telemetryInfo(), context, builder.build());
@@ -49,7 +51,7 @@ final class SpanContextShim extends BaseShimObject implements SpanContext {
   }
 
   Baggage getBaggage() {
-    return distContext;
+    return baggage;
   }
 
   @Override
@@ -64,13 +66,13 @@ final class SpanContextShim extends BaseShimObject implements SpanContext {
 
   @Override
   public Iterable<Map.Entry<String, String>> baggageItems() {
-    final Iterator<Entry> iterator = distContext.getEntries().iterator();
+    final Iterator<Entry> iterator = baggage.getEntries().iterator();
     return new BaggageIterable(iterator);
   }
 
   @SuppressWarnings("ReturnMissingNullable")
   String getBaggageItem(String key) {
-    return distContext.getEntryValue(key);
+    return baggage.getEntryValue(key);
   }
 
   static class BaggageIterable implements Iterable<Map.Entry<String, String>> {

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShimTable.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShimTable.java
@@ -77,7 +77,7 @@ final class SpanContextShimTable {
     return create(spanShim, spanShim.telemetryInfo().emptyBaggage());
   }
 
-  public SpanContextShim create(SpanShim spanShim, Baggage distContext) {
+  public SpanContextShim create(SpanShim spanShim, Baggage baggage) {
     lock.writeLock().lock();
     try {
       SpanContextShim contextShim = shimsMap.get(spanShim.getSpan());
@@ -86,8 +86,7 @@ final class SpanContextShimTable {
       }
 
       contextShim =
-          new SpanContextShim(
-              spanShim.telemetryInfo(), spanShim.getSpan().getContext(), distContext);
+          new SpanContextShim(spanShim.telemetryInfo(), spanShim.getSpan().getContext(), baggage);
       shimsMap.put(spanShim.getSpan(), contextShim);
       return contextShim;
 

--- a/sdk/baggage/src/main/java/io/opentelemetry/sdk/baggage/BaggageManagerSdk.java
+++ b/sdk/baggage/src/main/java/io/opentelemetry/sdk/baggage/BaggageManagerSdk.java
@@ -24,7 +24,7 @@ public class BaggageManagerSdk implements BaggageManager {
   }
 
   @Override
-  public Scope withContext(Baggage distContext) {
-    return BaggageUtils.currentContextWith(distContext);
+  public Scope withBaggage(Baggage baggage) {
+    return BaggageUtils.currentContextWith(baggage);
   }
 }

--- a/sdk/baggage/src/main/java/io/opentelemetry/sdk/baggage/BaggageSdk.java
+++ b/sdk/baggage/src/main/java/io/opentelemetry/sdk/baggage/BaggageSdk.java
@@ -14,7 +14,6 @@ import io.opentelemetry.context.Context;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -52,11 +51,7 @@ class BaggageSdk implements Baggage {
       }
     }
     // Clean out any null values that may have been added by Builder.remove.
-    for (Iterator<Entry> it = combined.values().iterator(); it.hasNext(); ) {
-      if (it.next() == null) {
-        it.remove();
-      }
-    }
+    combined.values().removeIf(Objects::isNull);
 
     return Collections.unmodifiableCollection(combined.values());
   }
@@ -77,16 +72,16 @@ class BaggageSdk implements Baggage {
     if (this == o) {
       return true;
     }
-    if (o == null || !(o instanceof BaggageSdk)) {
+    if (!(o instanceof BaggageSdk)) {
       return false;
     }
 
-    BaggageSdk distContextSdk = (BaggageSdk) o;
+    BaggageSdk baggageSdk = (BaggageSdk) o;
 
-    if (!entries.equals(distContextSdk.entries)) {
+    if (!entries.equals(baggageSdk.entries)) {
       return false;
     }
-    return parent != null ? parent.equals(distContextSdk.parent) : distContextSdk.parent == null;
+    return parent != null ? parent.equals(baggageSdk.parent) : baggageSdk.parent == null;
   }
 
   @Override
@@ -109,15 +104,9 @@ class BaggageSdk implements Baggage {
     }
 
     @Override
-    public Baggage.Builder setParent(Baggage parent) {
-      this.parent = Objects.requireNonNull(parent, "parent");
-      return this;
-    }
-
-    @Override
     public Baggage.Builder setParent(Context context) {
       Objects.requireNonNull(context, "context");
-      setParent(BaggageUtils.getBaggage(context));
+      parent = BaggageUtils.getBaggage(context);
       return this;
     }
 

--- a/sdk/baggage/src/test/java/io/opentelemetry/sdk/baggage/BaggageManagerSdkTest.java
+++ b/sdk/baggage/src/test/java/io/opentelemetry/sdk/baggage/BaggageManagerSdkTest.java
@@ -22,7 +22,7 @@ import org.mockito.MockitoAnnotations;
 // try-with-resources.
 @SuppressWarnings("MustBeClosedChecker")
 class BaggageManagerSdkTest {
-  @Mock private Baggage distContext;
+  @Mock private Baggage baggage;
   private final BaggageManagerSdk contextManager = new BaggageManagerSdk();
 
   @BeforeEach
@@ -38,17 +38,17 @@ class BaggageManagerSdkTest {
   @Test
   void testGetCurrentContext_ContextSetToNull() {
     try (Scope ignored = BaggageUtils.withBaggage(null, Context.current()).makeCurrent()) {
-      Baggage distContext = contextManager.getCurrentBaggage();
-      assertThat(distContext).isNotNull();
-      assertThat(distContext.getEntries()).isEmpty();
+      Baggage baggage = contextManager.getCurrentBaggage();
+      assertThat(baggage).isNotNull();
+      assertThat(baggage.getEntries()).isEmpty();
     }
   }
 
   @Test
   void testWithBaggage() {
     assertThat(contextManager.getCurrentBaggage()).isSameAs(EmptyBaggage.getInstance());
-    try (Scope wtm = contextManager.withContext(distContext)) {
-      assertThat(contextManager.getCurrentBaggage()).isSameAs(distContext);
+    try (Scope wtm = contextManager.withBaggage(baggage)) {
+      assertThat(contextManager.getCurrentBaggage()).isSameAs(baggage);
     }
     assertThat(contextManager.getCurrentBaggage()).isSameAs(EmptyBaggage.getInstance());
   }
@@ -56,13 +56,13 @@ class BaggageManagerSdkTest {
   @Test
   void testWithBaggageUsingWrap() {
     Runnable runnable;
-    try (Scope wtm = contextManager.withContext(distContext)) {
-      assertThat(contextManager.getCurrentBaggage()).isSameAs(distContext);
+    try (Scope wtm = contextManager.withBaggage(baggage)) {
+      assertThat(contextManager.getCurrentBaggage()).isSameAs(baggage);
       runnable =
           Context.current()
               .wrap(
                   () -> {
-                    assertThat(contextManager.getCurrentBaggage()).isSameAs(distContext);
+                    assertThat(contextManager.getCurrentBaggage()).isSameAs(baggage);
                   });
     }
     assertThat(contextManager.getCurrentBaggage()).isSameAs(EmptyBaggage.getInstance());

--- a/sdk/baggage/src/test/java/io/opentelemetry/sdk/baggage/BaggageSdkTest.java
+++ b/sdk/baggage/src/test/java/io/opentelemetry/sdk/baggage/BaggageSdkTest.java
@@ -55,7 +55,7 @@ class BaggageSdkTest {
   void getEntries_chain() {
     Entry t1alt = Entry.create(K1, V2, TMD);
     Baggage parent = listToBaggage(T1, T2);
-    Context parentContext = BaggageUtils.withBaggage(parent, Context.ROOT);
+    Context parentContext = BaggageUtils.withBaggage(parent, Context.root());
     Baggage baggage =
         contextManager
             .baggageBuilder()
@@ -68,7 +68,7 @@ class BaggageSdkTest {
   @Test
   void put_newKey() {
     Baggage parent = listToBaggage(T1);
-    Context parentContext = BaggageUtils.withBaggage(parent, Context.ROOT);
+    Context parentContext = BaggageUtils.withBaggage(parent, Context.root());
     assertThat(
             contextManager
                 .baggageBuilder()
@@ -82,7 +82,7 @@ class BaggageSdkTest {
   @Test
   void put_existingKey() {
     BaggageSdk parent = listToBaggage(T1);
-    Context parentContext = BaggageUtils.withBaggage(parent, Context.ROOT);
+    Context parentContext = BaggageUtils.withBaggage(parent, Context.root());
     assertThat(
             contextManager
                 .baggageBuilder()
@@ -96,7 +96,7 @@ class BaggageSdkTest {
   @Test
   void put_nullKey() {
     Baggage parent = listToBaggage(T1);
-    Context parentContext = BaggageUtils.withBaggage(parent, Context.ROOT);
+    Context parentContext = BaggageUtils.withBaggage(parent, Context.root());
     Baggage.Builder builder = contextManager.baggageBuilder().setParent(parentContext);
     assertThrows(NullPointerException.class, () -> builder.put(null, V2, TMD), "key");
   }
@@ -104,7 +104,7 @@ class BaggageSdkTest {
   @Test
   void put_nullValue() {
     BaggageSdk parent = listToBaggage(T1);
-    Context parentContext = BaggageUtils.withBaggage(parent, Context.ROOT);
+    Context parentContext = BaggageUtils.withBaggage(parent, Context.root());
     Baggage.Builder builder = contextManager.baggageBuilder().setParent(parentContext);
     assertThrows(NullPointerException.class, () -> builder.put(K2, null, TMD), "value");
   }
@@ -136,7 +136,7 @@ class BaggageSdkTest {
   @Test
   void setParent_setNoParent() {
     BaggageSdk parent = listToBaggage(T1);
-    Context parentContext = BaggageUtils.withBaggage(parent, Context.ROOT);
+    Context parentContext = BaggageUtils.withBaggage(parent, Context.root());
     Baggage baggage =
         contextManager.baggageBuilder().setParent(parentContext).setNoParent().build();
     assertThat(baggage.getEntries()).isEmpty();
@@ -163,7 +163,7 @@ class BaggageSdkTest {
   @Test
   void remove_keyFromParent() {
     BaggageSdk parent = listToBaggage(T1, T2);
-    Context parentContext = BaggageUtils.withBaggage(parent, Context.ROOT);
+    Context parentContext = BaggageUtils.withBaggage(parent, Context.root());
     assertThat(
             contextManager
                 .baggageBuilder()

--- a/sdk/baggage/src/test/java/io/opentelemetry/sdk/baggage/BaggageSdkTest.java
+++ b/sdk/baggage/src/test/java/io/opentelemetry/sdk/baggage/BaggageSdkTest.java
@@ -41,36 +41,38 @@ class BaggageSdkTest {
 
   @Test
   void getEntries_empty() {
-    BaggageSdk distContext = new BaggageSdk.Builder().build();
-    assertThat(distContext.getEntries()).isEmpty();
+    BaggageSdk baggage = new BaggageSdk.Builder().build();
+    assertThat(baggage.getEntries()).isEmpty();
   }
 
   @Test
   void getEntries_nonEmpty() {
-    BaggageSdk distContext = listToBaggage(T1, T2);
-    assertThat(distContext.getEntries()).containsExactly(T1, T2);
+    BaggageSdk baggage = listToBaggage(T1, T2);
+    assertThat(baggage.getEntries()).containsExactly(T1, T2);
   }
 
   @Test
   void getEntries_chain() {
     Entry t1alt = Entry.create(K1, V2, TMD);
-    BaggageSdk parent = listToBaggage(T1, T2);
-    Baggage distContext =
+    Baggage parent = listToBaggage(T1, T2);
+    Context parentContext = BaggageUtils.withBaggage(parent, Context.ROOT);
+    Baggage baggage =
         contextManager
             .baggageBuilder()
-            .setParent(parent)
+            .setParent(parentContext)
             .put(t1alt.getKey(), t1alt.getValue(), t1alt.getEntryMetadata())
             .build();
-    assertThat(distContext.getEntries()).containsExactly(t1alt, T2);
+    assertThat(baggage.getEntries()).containsExactly(t1alt, T2);
   }
 
   @Test
   void put_newKey() {
-    BaggageSdk distContext = listToBaggage(T1);
+    Baggage parent = listToBaggage(T1);
+    Context parentContext = BaggageUtils.withBaggage(parent, Context.ROOT);
     assertThat(
             contextManager
                 .baggageBuilder()
-                .setParent(distContext)
+                .setParent(parentContext)
                 .put(K2, V2, TMD)
                 .build()
                 .getEntries())
@@ -79,11 +81,12 @@ class BaggageSdkTest {
 
   @Test
   void put_existingKey() {
-    BaggageSdk distContext = listToBaggage(T1);
+    BaggageSdk parent = listToBaggage(T1);
+    Context parentContext = BaggageUtils.withBaggage(parent, Context.ROOT);
     assertThat(
             contextManager
                 .baggageBuilder()
-                .setParent(distContext)
+                .setParent(parentContext)
                 .put(K1, V2, TMD)
                 .build()
                 .getEntries())
@@ -92,24 +95,18 @@ class BaggageSdkTest {
 
   @Test
   void put_nullKey() {
-    BaggageSdk distContext = listToBaggage(T1);
-    Baggage.Builder builder = contextManager.baggageBuilder().setParent(distContext);
+    Baggage parent = listToBaggage(T1);
+    Context parentContext = BaggageUtils.withBaggage(parent, Context.ROOT);
+    Baggage.Builder builder = contextManager.baggageBuilder().setParent(parentContext);
     assertThrows(NullPointerException.class, () -> builder.put(null, V2, TMD), "key");
   }
 
   @Test
   void put_nullValue() {
-    BaggageSdk distContext = listToBaggage(T1);
-    Baggage.Builder builder = contextManager.baggageBuilder().setParent(distContext);
-    assertThrows(NullPointerException.class, () -> builder.put(K2, null, TMD), "value");
-  }
-
-  @Test
-  void setParent_nullValue() {
     BaggageSdk parent = listToBaggage(T1);
-    assertThrows(
-        NullPointerException.class,
-        () -> contextManager.baggageBuilder().setParent(parent).setParent((Baggage) null).build());
+    Context parentContext = BaggageUtils.withBaggage(parent, Context.ROOT);
+    Baggage.Builder builder = contextManager.baggageBuilder().setParent(parentContext);
+    assertThrows(NullPointerException.class, () -> builder.put(K2, null, TMD), "value");
   }
 
   @Test
@@ -121,9 +118,8 @@ class BaggageSdkTest {
 
   @Test
   void setParent_fromContext() {
-    BaggageSdk parent = listToBaggage(T1);
     Context context = BaggageUtils.withBaggage(listToBaggage(T2), Context.current());
-    Baggage baggage = contextManager.baggageBuilder().setParent(parent).setParent(context).build();
+    Baggage baggage = contextManager.baggageBuilder().setParent(context).build();
     assertThat(baggage.getEntries()).containsExactly(T2);
   }
 
@@ -140,8 +136,10 @@ class BaggageSdkTest {
   @Test
   void setParent_setNoParent() {
     BaggageSdk parent = listToBaggage(T1);
-    Baggage distContext = contextManager.baggageBuilder().setParent(parent).setNoParent().build();
-    assertThat(distContext.getEntries()).isEmpty();
+    Context parentContext = BaggageUtils.withBaggage(parent, Context.ROOT);
+    Baggage baggage =
+        contextManager.baggageBuilder().setParent(parentContext).setNoParent().build();
+    assertThat(baggage.getEntries()).isEmpty();
   }
 
   @Test
@@ -164,9 +162,15 @@ class BaggageSdkTest {
 
   @Test
   void remove_keyFromParent() {
-    BaggageSdk distContext = listToBaggage(T1, T2);
+    BaggageSdk parent = listToBaggage(T1, T2);
+    Context parentContext = BaggageUtils.withBaggage(parent, Context.ROOT);
     assertThat(
-            contextManager.baggageBuilder().setParent(distContext).remove(K1).build().getEntries())
+            contextManager
+                .baggageBuilder()
+                .setParent(parentContext)
+                .remove(K1)
+                .build()
+                .getEntries())
         .containsExactly(T2);
   }
 

--- a/sdk/baggage/src/test/java/io/opentelemetry/sdk/baggage/ScopedBaggageTest.java
+++ b/sdk/baggage/src/test/java/io/opentelemetry/sdk/baggage/ScopedBaggageTest.java
@@ -48,7 +48,7 @@ class ScopedBaggageTest {
     assertThat(contextManager.getCurrentBaggage().getEntries()).isEmpty();
     Baggage scopedEntries =
         contextManager.baggageBuilder().put(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION).build();
-    try (Scope scope = contextManager.withContext(scopedEntries)) {
+    try (Scope scope = contextManager.withBaggage(scopedEntries)) {
       assertThat(contextManager.getCurrentBaggage()).isSameAs(scopedEntries);
     }
     assertThat(contextManager.getCurrentBaggage().getEntries()).isEmpty();
@@ -56,9 +56,9 @@ class ScopedBaggageTest {
 
   @Test
   void createBuilderFromCurrentEntries() {
-    Baggage scopedDistContext =
+    Baggage scopedBaggage =
         contextManager.baggageBuilder().put(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION).build();
-    try (Scope scope = contextManager.withContext(scopedDistContext)) {
+    try (Scope scope = contextManager.withBaggage(scopedBaggage)) {
       Baggage newEntries =
           contextManager
               .baggageBuilder()
@@ -68,84 +68,84 @@ class ScopedBaggageTest {
           .containsExactlyInAnyOrder(
               Entry.create(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION),
               Entry.create(KEY_2, VALUE_2, METADATA_UNLIMITED_PROPAGATION));
-      assertThat(contextManager.getCurrentBaggage()).isSameAs(scopedDistContext);
+      assertThat(contextManager.getCurrentBaggage()).isSameAs(scopedBaggage);
     }
   }
 
   @Test
   void setCurrentEntriesWithBuilder() {
     assertThat(contextManager.getCurrentBaggage().getEntries()).isEmpty();
-    Baggage scopedDistContext =
+    Baggage scopedBaggage =
         contextManager.baggageBuilder().put(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION).build();
-    try (Scope scope = contextManager.withContext(scopedDistContext)) {
+    try (Scope scope = contextManager.withBaggage(scopedBaggage)) {
       assertThat(contextManager.getCurrentBaggage().getEntries())
           .containsExactly(Entry.create(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION));
-      assertThat(contextManager.getCurrentBaggage()).isSameAs(scopedDistContext);
+      assertThat(contextManager.getCurrentBaggage()).isSameAs(scopedBaggage);
     }
     assertThat(contextManager.getCurrentBaggage().getEntries()).isEmpty();
   }
 
   @Test
   void addToCurrentEntriesWithBuilder() {
-    Baggage scopedDistContext =
+    Baggage scopedBaggage =
         contextManager.baggageBuilder().put(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION).build();
-    try (Scope scope1 = contextManager.withContext(scopedDistContext)) {
-      Baggage innerDistContext =
+    try (Scope scope1 = contextManager.withBaggage(scopedBaggage)) {
+      Baggage innerBaggage =
           contextManager
               .baggageBuilder()
               .put(KEY_2, VALUE_2, METADATA_UNLIMITED_PROPAGATION)
               .build();
-      try (Scope scope2 = contextManager.withContext(innerDistContext)) {
+      try (Scope scope2 = contextManager.withBaggage(innerBaggage)) {
         assertThat(contextManager.getCurrentBaggage().getEntries())
             .containsExactlyInAnyOrder(
                 Entry.create(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION),
                 Entry.create(KEY_2, VALUE_2, METADATA_UNLIMITED_PROPAGATION));
-        assertThat(contextManager.getCurrentBaggage()).isSameAs(innerDistContext);
+        assertThat(contextManager.getCurrentBaggage()).isSameAs(innerBaggage);
       }
-      assertThat(contextManager.getCurrentBaggage()).isSameAs(scopedDistContext);
+      assertThat(contextManager.getCurrentBaggage()).isSameAs(scopedBaggage);
     }
   }
 
   @Test
   void multiScopeBaggageWithMetadata() {
-    Baggage scopedDistContext =
+    Baggage scopedBaggage =
         contextManager
             .baggageBuilder()
             .put(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION)
             .put(KEY_2, VALUE_2, METADATA_UNLIMITED_PROPAGATION)
             .build();
-    try (Scope scope1 = contextManager.withContext(scopedDistContext)) {
-      Baggage innerDistContext =
+    try (Scope scope1 = contextManager.withBaggage(scopedBaggage)) {
+      Baggage innerBaggage =
           contextManager
               .baggageBuilder()
               .put(KEY_3, VALUE_3, METADATA_NO_PROPAGATION)
               .put(KEY_2, VALUE_4, METADATA_NO_PROPAGATION)
               .build();
-      try (Scope scope2 = contextManager.withContext(innerDistContext)) {
+      try (Scope scope2 = contextManager.withBaggage(innerBaggage)) {
         assertThat(contextManager.getCurrentBaggage().getEntries())
             .containsExactlyInAnyOrder(
                 Entry.create(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION),
                 Entry.create(KEY_2, VALUE_4, METADATA_NO_PROPAGATION),
                 Entry.create(KEY_3, VALUE_3, METADATA_NO_PROPAGATION));
-        assertThat(contextManager.getCurrentBaggage()).isSameAs(innerDistContext);
+        assertThat(contextManager.getCurrentBaggage()).isSameAs(innerBaggage);
       }
-      assertThat(contextManager.getCurrentBaggage()).isSameAs(scopedDistContext);
+      assertThat(contextManager.getCurrentBaggage()).isSameAs(scopedBaggage);
     }
   }
 
   @Test
   void setNoParent_doesNotInheritContext() {
     assertThat(contextManager.getCurrentBaggage().getEntries()).isEmpty();
-    Baggage scopedDistContext =
+    Baggage scopedBaggage =
         contextManager.baggageBuilder().put(KEY_1, VALUE_1, METADATA_UNLIMITED_PROPAGATION).build();
-    try (Scope scope = contextManager.withContext(scopedDistContext)) {
-      Baggage innerDistContext =
+    try (Scope scope = contextManager.withBaggage(scopedBaggage)) {
+      Baggage innerBaggage =
           contextManager
               .baggageBuilder()
               .setNoParent()
               .put(KEY_2, VALUE_2, METADATA_UNLIMITED_PROPAGATION)
               .build();
-      assertThat(innerDistContext.getEntries())
+      assertThat(innerBaggage.getEntries())
           .containsExactly(Entry.create(KEY_2, VALUE_2, METADATA_UNLIMITED_PROPAGATION));
     }
     assertThat(contextManager.getCurrentBaggage().getEntries()).isEmpty();


### PR DESCRIPTION
Parenting is still allowed via the Context.
Also, renamed many old variables and method to use the new baggage name.

Builds on changes in #1764

Amends #1530 