### PR TITLE
Update wrapper declaration in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -438,5 +438,5 @@ configure(opentelemetryProjects) {
 
 wrapper {
     distributionType = Wrapper.DistributionType.ALL
-    gradleVersion = '6.5.1'
+    gradleVersion = '6.6'
 }


### PR DESCRIPTION
Follow-up for #1529.

Since we also have a "Validate Gradlew Wrapper" task, I was somehow expecting this to be checked already. Since it was outdated for quite some time, maybe we can just remove the `wrapper{}` block from build.gradle? No idea what the implications would be.