### PR TITLE
Fix warnings found by idea IDE in the SDK dir.

### DIFF
--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/metrics/MetricsTestOperationBuilder.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/metrics/MetricsTestOperationBuilder.java
@@ -23,102 +23,90 @@ import io.opentelemetry.metrics.Meter;
  */
 public enum MetricsTestOperationBuilder {
   LongCounterAdd(
-      new OperationBuilder() {
-        @Override
-        public Operation build(final Meter meter) {
-          return new Operation() {
-            LongCounter metric = meter.longCounterBuilder("long_counter").build();
-            LongCounter.BoundLongCounter boundMetric =
-                meter
-                    .longCounterBuilder("bound_long_counter")
-                    .build()
-                    .bind(Labels.of("KEY", "VALUE"));
+      meter -> {
+        return new Operation() {
+          final LongCounter metric = meter.longCounterBuilder("long_counter").build();
+          final LongCounter.BoundLongCounter boundMetric =
+              meter
+                  .longCounterBuilder("bound_long_counter")
+                  .build()
+                  .bind(Labels.of("KEY", "VALUE"));
 
-            @Override
-            public void perform(Labels labels) {
-              metric.add(5L, labels);
-            }
+          @Override
+          public void perform(Labels labels) {
+            metric.add(5L, labels);
+          }
 
-            @Override
-            public void performBound() {
-              boundMetric.add(5L);
-            }
-          };
-        }
+          @Override
+          public void performBound() {
+            boundMetric.add(5L);
+          }
+        };
       }),
   DoubleCounterAdd(
-      new OperationBuilder() {
-        @Override
-        public Operation build(final Meter meter) {
-          return new Operation() {
-            DoubleCounter metric = meter.doubleCounterBuilder("double_counter").build();
-            DoubleCounter.BoundDoubleCounter boundMetric =
-                meter
-                    .doubleCounterBuilder("bound_double_counter")
-                    .build()
-                    .bind(Labels.of("KEY", "VALUE"));
+      meter -> {
+        return new Operation() {
+          final DoubleCounter metric = meter.doubleCounterBuilder("double_counter").build();
+          final DoubleCounter.BoundDoubleCounter boundMetric =
+              meter
+                  .doubleCounterBuilder("bound_double_counter")
+                  .build()
+                  .bind(Labels.of("KEY", "VALUE"));
 
-            @Override
-            public void perform(Labels labels) {
-              metric.add(5.0d, labels);
-            }
+          @Override
+          public void perform(Labels labels) {
+            metric.add(5.0d, labels);
+          }
 
-            @Override
-            public void performBound() {
-              boundMetric.add(5.0d);
-            }
-          };
-        }
+          @Override
+          public void performBound() {
+            boundMetric.add(5.0d);
+          }
+        };
       }),
   DoubleValueRecorderRecord(
-      new OperationBuilder() {
-        @Override
-        public Operation build(final Meter meter) {
-          return new Operation() {
-            DoubleValueRecorder metric =
-                meter.doubleValueRecorderBuilder("double_value_recorder").build();
-            BoundDoubleValueRecorder boundMetric =
-                meter
-                    .doubleValueRecorderBuilder("bound_double_value_recorder")
-                    .build()
-                    .bind(Labels.of("KEY", "VALUE"));
+      meter -> {
+        return new Operation() {
+          final DoubleValueRecorder metric =
+              meter.doubleValueRecorderBuilder("double_value_recorder").build();
+          final BoundDoubleValueRecorder boundMetric =
+              meter
+                  .doubleValueRecorderBuilder("bound_double_value_recorder")
+                  .build()
+                  .bind(Labels.of("KEY", "VALUE"));
 
-            @Override
-            public void perform(Labels labels) {
-              metric.record(5.0d, labels);
-            }
+          @Override
+          public void perform(Labels labels) {
+            metric.record(5.0d, labels);
+          }
 
-            @Override
-            public void performBound() {
-              boundMetric.record(5.0d);
-            }
-          };
-        }
+          @Override
+          public void performBound() {
+            boundMetric.record(5.0d);
+          }
+        };
       }),
   LongValueRecorderRecord(
-      new OperationBuilder() {
-        @Override
-        public Operation build(final Meter meter) {
-          return new Operation() {
-            LongValueRecorder metric =
-                meter.longValueRecorderBuilder("long_value_recorder").build();
-            BoundLongValueRecorder boundMetric =
-                meter
-                    .longValueRecorderBuilder("bound_long_value_recorder")
-                    .build()
-                    .bind(Labels.of("KEY", "VALUE"));
+      meter -> {
+        return new Operation() {
+          final LongValueRecorder metric =
+              meter.longValueRecorderBuilder("long_value_recorder").build();
+          final BoundLongValueRecorder boundMetric =
+              meter
+                  .longValueRecorderBuilder("bound_long_value_recorder")
+                  .build()
+                  .bind(Labels.of("KEY", "VALUE"));
 
-            @Override
-            public void perform(Labels labels) {
-              metric.record(5L, labels);
-            }
+          @Override
+          public void perform(Labels labels) {
+            metric.record(5L, labels);
+          }
 
-            @Override
-            public void performBound() {
-              boundMetric.record(5L);
-            }
-          };
-        }
+          @Override
+          public void performBound() {
+            boundMetric.record(5L);
+          }
+        };
       });
 
   private final OperationBuilder builder;
@@ -137,8 +125,8 @@ public enum MetricsTestOperationBuilder {
   }
 
   interface Operation {
-    abstract void perform(Labels labels);
+    void perform(Labels labels);
 
-    abstract void performBound();
+    void performBound();
   }
 }

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanAttributeTruncateBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanAttributeTruncateBenchmark.java
@@ -39,7 +39,9 @@ public class SpanAttributeTruncateBenchmark {
   @Setup(Level.Trial)
   public final void setup() {
     TraceConfig config =
-        OpenTelemetrySdk.getTracerManagement().getActiveTraceConfig().toBuilder()
+        OpenTelemetrySdk.getTracerManagement()
+            .getActiveTraceConfig()
+            .toBuilder()
             .setMaxLengthOfAttributeValues(maxLength)
             .build();
     OpenTelemetrySdk.getTracerManagement().updateActiveTraceConfig(config);

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanAttributeTruncateBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanAttributeTruncateBenchmark.java
@@ -29,8 +29,8 @@ public class SpanAttributeTruncateBenchmark {
   private final Tracer tracerSdk = OpenTelemetry.getTracer("benchmarkTracer");
   private SpanBuilderSdk spanBuilderSdk;
 
-  public String shortValue = "short";
-  public String longValue = "very_long_attribute_and_then_some_more";
+  public final String shortValue = "short";
+  public final String longValue = "very_long_attribute_and_then_some_more";
   public String veryLongValue;
 
   @Param({"10", "1000000"})
@@ -39,9 +39,7 @@ public class SpanAttributeTruncateBenchmark {
   @Setup(Level.Trial)
   public final void setup() {
     TraceConfig config =
-        OpenTelemetrySdk.getTracerManagement()
-            .getActiveTraceConfig()
-            .toBuilder()
+        OpenTelemetrySdk.getTracerManagement().getActiveTraceConfig().toBuilder()
             .setMaxLengthOfAttributeValues(maxLength)
             .build();
     OpenTelemetrySdk.getTracerManagement().updateActiveTraceConfig(config);

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBenchmark.java
@@ -47,15 +47,7 @@ public class BatchSpanProcessorBenchmark {
     @Override
     public CompletableResultCode export(Collection<SpanData> spans) {
       final CompletableResultCode result = new CompletableResultCode();
-      executor.schedule(
-          new Runnable() {
-            @Override
-            public void run() {
-              result.succeed();
-            }
-          },
-          delayMs,
-          TimeUnit.MILLISECONDS);
+      executor.schedule((Runnable) result::succeed, delayMs, TimeUnit.MILLISECONDS);
       return result;
     }
 

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorFlushBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorFlushBenchmark.java
@@ -47,15 +47,7 @@ public class BatchSpanProcessorFlushBenchmark {
     @Override
     public CompletableResultCode export(Collection<SpanData> spans) {
       final CompletableResultCode result = new CompletableResultCode();
-      executor.schedule(
-          new Runnable() {
-            @Override
-            public void run() {
-              result.succeed();
-            }
-          },
-          delayMs,
-          TimeUnit.MILLISECONDS);
+      executor.schedule((Runnable) result::succeed, delayMs, TimeUnit.MILLISECONDS);
       return result;
     }
 

--- a/sdk/baggage/src/main/java/io/opentelemetry/sdk/baggage/BaggageSdk.java
+++ b/sdk/baggage/src/main/java/io/opentelemetry/sdk/baggage/BaggageSdk.java
@@ -14,7 +14,6 @@ import io.opentelemetry.context.Context;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -52,11 +51,7 @@ class BaggageSdk implements Baggage {
       }
     }
     // Clean out any null values that may have been added by Builder.remove.
-    for (Iterator<Entry> it = combined.values().iterator(); it.hasNext(); ) {
-      if (it.next() == null) {
-        it.remove();
-      }
-    }
+    combined.values().removeIf(Objects::isNull);
 
     return Collections.unmodifiableCollection(combined.values());
   }
@@ -77,7 +72,7 @@ class BaggageSdk implements Baggage {
     if (this == o) {
       return true;
     }
-    if (o == null || !(o instanceof BaggageSdk)) {
+    if (!(o instanceof BaggageSdk)) {
       return false;
     }
 
@@ -86,7 +81,7 @@ class BaggageSdk implements Baggage {
     if (!entries.equals(distContextSdk.entries)) {
       return false;
     }
-    return parent != null ? parent.equals(distContextSdk.parent) : distContextSdk.parent == null;
+    return Objects.equals(parent, distContextSdk.parent);
   }
 
   @Override

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/CompletableResultCode.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/CompletableResultCode.java
@@ -43,18 +43,15 @@ public class CompletableResultCode {
     final AtomicBoolean failed = new AtomicBoolean();
     for (final CompletableResultCode code : codes) {
       code.whenComplete(
-          new Runnable() {
-            @Override
-            public void run() {
-              if (!code.isSuccess()) {
-                failed.set(true);
-              }
-              if (pending.decrementAndGet() == 0) {
-                if (failed.get()) {
-                  result.fail();
-                } else {
-                  result.succeed();
-                }
+          () -> {
+            if (!code.isSuccess()) {
+              failed.set(true);
+            }
+            if (pending.decrementAndGet() == 0) {
+              if (failed.get()) {
+                result.fail();
+              } else {
+                result.succeed();
               }
             }
           });
@@ -149,13 +146,7 @@ public class CompletableResultCode {
       return this;
     }
     final CountDownLatch latch = new CountDownLatch(1);
-    whenComplete(
-        new Runnable() {
-          @Override
-          public void run() {
-            latch.countDown();
-          }
-        });
+    whenComplete(latch::countDown);
     try {
       if (!latch.await(timeout, unit)) {
         fail();

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/CompletableResultCodeTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/CompletableResultCodeTest.java
@@ -32,22 +32,9 @@ class CompletableResultCodeTest {
 
     CountDownLatch completions = new CountDownLatch(1);
 
-    new Thread(
-            new Runnable() {
-              @Override
-              public void run() {
-                resultCode.succeed();
-              }
-            })
-        .start();
+    new Thread(resultCode::succeed).start();
 
-    resultCode.whenComplete(
-        new Runnable() {
-          @Override
-          public void run() {
-            completions.countDown();
-          }
-        });
+    resultCode.whenComplete(completions::countDown);
 
     completions.await(3, TimeUnit.SECONDS);
 
@@ -60,22 +47,9 @@ class CompletableResultCodeTest {
 
     CountDownLatch completions = new CountDownLatch(1);
 
-    new Thread(
-            new Runnable() {
-              @Override
-              public void run() {
-                resultCode.fail();
-              }
-            })
-        .start();
+    new Thread(resultCode::fail).start();
 
-    resultCode.whenComplete(
-        new Runnable() {
-          @Override
-          public void run() {
-            completions.countDown();
-          }
-        });
+    resultCode.whenComplete(completions::countDown);
 
     completions.await(3, TimeUnit.SECONDS);
 
@@ -88,30 +62,9 @@ class CompletableResultCodeTest {
 
     CountDownLatch completions = new CountDownLatch(2);
 
-    new Thread(
-            new Runnable() {
-              @Override
-              public void run() {
-                resultCode.succeed();
-              }
-            })
-        .start();
+    new Thread(resultCode::succeed).start();
 
-    resultCode
-        .whenComplete(
-            new Runnable() {
-              @Override
-              public void run() {
-                completions.countDown();
-              }
-            })
-        .whenComplete(
-            new Runnable() {
-              @Override
-              public void run() {
-                completions.countDown();
-              }
-            });
+    resultCode.whenComplete(completions::countDown).whenComplete(completions::countDown);
 
     completions.await(3, TimeUnit.SECONDS);
 
@@ -124,29 +77,13 @@ class CompletableResultCodeTest {
 
     CountDownLatch completions = new CountDownLatch(2);
 
-    new Thread(
-            new Runnable() {
-              @Override
-              public void run() {
-                resultCode.succeed();
-              }
-            })
-        .start();
+    new Thread(resultCode::succeed).start();
 
     resultCode.whenComplete(
-        new Runnable() {
-          @Override
-          public void run() {
-            completions.countDown();
+        () -> {
+          completions.countDown();
 
-            resultCode.whenComplete(
-                new Runnable() {
-                  @Override
-                  public void run() {
-                    completions.countDown();
-                  }
-                });
-          }
+          resultCode.whenComplete(completions::countDown);
         });
 
     completions.await(3, TimeUnit.SECONDS);
@@ -160,22 +97,9 @@ class CompletableResultCodeTest {
 
     CountDownLatch completions = new CountDownLatch(1);
 
-    new Thread(
-            new Runnable() {
-              @Override
-              public void run() {
-                resultCode.succeed().fail();
-              }
-            })
-        .start();
+    new Thread(() -> resultCode.succeed().fail()).start();
 
-    resultCode.whenComplete(
-        new Runnable() {
-          @Override
-          public void run() {
-            completions.countDown();
-          }
-        });
+    resultCode.whenComplete(completions::countDown);
 
     completions.await(3, TimeUnit.SECONDS);
 
@@ -244,11 +168,7 @@ class CompletableResultCodeTest {
   @Test
   void joinInterrupted() {
     CompletableResultCode result = new CompletableResultCode();
-    Thread thread =
-        new Thread(
-            () -> {
-              result.join(10, TimeUnit.SECONDS);
-            });
+    Thread thread = new Thread(() -> result.join(10, TimeUnit.SECONDS));
     thread.start();
     thread.interrupt();
     // Different thread so wait a bit for result to be propagated.

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
@@ -50,8 +50,7 @@ abstract class AbstractInstrument implements Instrument {
   }
 
   /**
-   * Collects records from all the entries (labelSet, Bound) that changed since the last {@link
-   * AbstractInstrument#collectAll()} call.
+   * Collects records from all the entries (labelSet, Bound) that changed since the previous call.
    */
   abstract List<MetricData> collectAll();
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/BatchRecorderSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/BatchRecorderSdk.java
@@ -29,37 +29,37 @@ final class BatchRecorderSdk implements BatchRecorder {
 
   @Override
   public BatchRecorder put(LongValueRecorder valueRecorder, long value) {
-    ((LongValueRecorderSdk) valueRecorder).record(value, labelSet);
+    valueRecorder.record(value, labelSet);
     return this;
   }
 
   @Override
   public BatchRecorder put(DoubleValueRecorder valueRecorder, double value) {
-    ((DoubleValueRecorderSdk) valueRecorder).record(value, labelSet);
+    valueRecorder.record(value, labelSet);
     return this;
   }
 
   @Override
   public BatchRecorder put(LongCounter counter, long value) {
-    ((LongCounterSdk) counter).add(value, labelSet);
+    counter.add(value, labelSet);
     return this;
   }
 
   @Override
   public BatchRecorder put(DoubleCounter counter, double value) {
-    ((DoubleCounterSdk) counter).add(value, labelSet);
+    counter.add(value, labelSet);
     return this;
   }
 
   @Override
   public BatchRecorder put(LongUpDownCounter upDownCounter, long value) {
-    ((LongUpDownCounterSdk) upDownCounter).add(value, labelSet);
+    upDownCounter.add(value, labelSet);
     return this;
   }
 
   @Override
   public BatchRecorder put(DoubleUpDownCounter upDownCounter, double value) {
-    ((DoubleUpDownCounterSdk) upDownCounter).add(value, labelSet);
+    upDownCounter.add(value, labelSet);
     return this;
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
@@ -101,10 +101,7 @@ final class MeterSdk implements Meter {
     return new BatchRecorderSdk(keyValuePairs);
   }
 
-  /**
-   * Collects all the metric recordings that changed since the last {@link MeterSdk#collectAll()}
-   * call.
-   */
+  /** Collects all the metric recordings that changed since the previous call. */
   Collection<MetricData> collectAll() {
     InstrumentRegistry instrumentRegistry = meterSharedState.getInstrumentRegistry();
     Collection<AbstractInstrument> instruments = instrumentRegistry.getInstruments();

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCount.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCount.java
@@ -18,13 +18,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class DoubleMinMaxSumCount extends AbstractAggregator {
 
-  private static final AggregatorFactory AGGREGATOR_FACTORY =
-      new AggregatorFactory() {
-        @Override
-        public Aggregator getAggregator() {
-          return new DoubleMinMaxSumCount();
-        }
-      };
+  private static final AggregatorFactory AGGREGATOR_FACTORY = DoubleMinMaxSumCount::new;
 
   // The current value. This controls its own internal thread-safety via method access. Don't
   // try to use its fields directly.

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleSumAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleSumAggregator.java
@@ -13,13 +13,7 @@ import io.opentelemetry.sdk.metrics.data.MetricData.Point;
 public final class DoubleSumAggregator extends AbstractAggregator {
 
   private static final double DEFAULT_VALUE = 0.0;
-  private static final AggregatorFactory AGGREGATOR_FACTORY =
-      new AggregatorFactory() {
-        @Override
-        public Aggregator getAggregator() {
-          return new DoubleSumAggregator();
-        }
-      };
+  private static final AggregatorFactory AGGREGATOR_FACTORY = DoubleSumAggregator::new;
 
   // TODO: Change to use DoubleAdder when changed to java8.
   private final AtomicDouble current = new AtomicDouble(DEFAULT_VALUE);

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongLastValueAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongLastValueAggregator.java
@@ -22,13 +22,7 @@ import javax.annotation.Nullable;
 public final class LongLastValueAggregator extends AbstractAggregator {
 
   @Nullable private static final Long DEFAULT_VALUE = null;
-  private static final AggregatorFactory AGGREGATOR_FACTORY =
-      new AggregatorFactory() {
-        @Override
-        public Aggregator getAggregator() {
-          return new LongLastValueAggregator();
-        }
-      };
+  private static final AggregatorFactory AGGREGATOR_FACTORY = LongLastValueAggregator::new;
 
   private final AtomicReference<Long> current = new AtomicReference<>(DEFAULT_VALUE);
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCount.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCount.java
@@ -18,13 +18,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class LongMinMaxSumCount extends AbstractAggregator {
 
-  private static final AggregatorFactory AGGREGATOR_FACTORY =
-      new AggregatorFactory() {
-        @Override
-        public Aggregator getAggregator() {
-          return new LongMinMaxSumCount();
-        }
-      };
+  private static final AggregatorFactory AGGREGATOR_FACTORY = LongMinMaxSumCount::new;
 
   // The current value. This controls its own internal thread-safety via method access. Don't
   // try to use its fields directly.

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongSumAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongSumAggregator.java
@@ -13,13 +13,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public final class LongSumAggregator extends AbstractAggregator {
 
   private static final long DEFAULT_VALUE = 0L;
-  private static final AggregatorFactory AGGREGATOR_FACTORY =
-      new AggregatorFactory() {
-        @Override
-        public Aggregator getAggregator() {
-          return new LongSumAggregator();
-        }
-      };
+  private static final AggregatorFactory AGGREGATOR_FACTORY = LongSumAggregator::new;
 
   // TODO: Change to use LongAdder when changed to java8.
   private final AtomicLong current = new AtomicLong(DEFAULT_VALUE);

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/NoopAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/NoopAggregator.java
@@ -11,13 +11,7 @@ import javax.annotation.Nullable;
 
 public final class NoopAggregator implements Aggregator {
   private static final Aggregator NOOP_AGGREGATOR = new NoopAggregator();
-  private static final AggregatorFactory AGGREGATOR_FACTORY =
-      new AggregatorFactory() {
-        @Override
-        public Aggregator getAggregator() {
-          return NOOP_AGGREGATOR;
-        }
-      };
+  private static final AggregatorFactory AGGREGATOR_FACTORY = () -> NOOP_AGGREGATOR;
 
   public static AggregatorFactory getFactory() {
     return AGGREGATOR_FACTORY;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
@@ -195,14 +195,11 @@ public final class IntervalMetricReader {
           final CompletableResultCode result =
               internalState.getMetricExporter().export(Collections.unmodifiableList(metricsList));
           result.whenComplete(
-              new Runnable() {
-                @Override
-                public void run() {
-                  if (!result.isSuccess()) {
-                    logger.log(Level.FINE, "Exporter failed");
-                  }
-                  exportAvailable.set(true);
+              () -> {
+                if (!result.isSuccess()) {
+                  logger.log(Level.FINE, "Exporter failed");
                 }
+                exportAvailable.set(true);
               });
         } catch (Exception e) {
           logger.log(Level.WARNING, "Exporter threw an Exception", e);

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/README.md
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/README.md
@@ -93,7 +93,7 @@ public final class PullExporter {
 
   public PushExporter(Collection<MetricProducer> producers) {
     metricExporter = new PullMetricExporter();
-    producers = Collections.unmodifiableCollection(new ArrayList<MetricProducer>(producers));
+    producers = Collections.unmodifiableCollection(new ArrayList<>(producers));
   }
 
   // Can be accessed by any "push based" library to export metrics.

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/AbstractAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/AbstractAggregatorTest.java
@@ -44,8 +44,8 @@ public class AbstractAggregatorTest {
   }
 
   private static class TestAggregator extends AbstractAggregator {
-    AtomicLong recordedLong = new AtomicLong();
-    AtomicDouble recordedDouble = new AtomicDouble();
+    final AtomicLong recordedLong = new AtomicLong();
+    final AtomicDouble recordedDouble = new AtomicDouble();
 
     @Override
     public MetricData.Point toPoint(long startEpochNanos, long epochNanos, Labels labels) {

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/AttributesMap.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/AttributesMap.java
@@ -39,10 +39,6 @@ final class AttributesMap implements ReadableAttributes {
     data.put(key, value);
   }
 
-  void remove(AttributeKey key) {
-    data.remove(key);
-  }
-
   int getTotalAddedValues() {
     return totalAddedValues;
   }

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -59,12 +59,6 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
   private final List<SpanData.Link> links;
   // Number of links recorded.
   private final int totalRecordedLinks;
-
-  // Lock used to internally guard the mutable state of this instance
-  private final Object lock = new Object();
-
-  @GuardedBy("lock")
-  private String name;
   // The kind of the span.
   private final Kind kind;
   // The clock used to get the time.
@@ -75,6 +69,11 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
   private final InstrumentationLibraryInfo instrumentationLibraryInfo;
   // The start time of the span.
   private final long startEpochNanos;
+  // Lock used to internally guard the mutable state of this instance
+  private final Object lock = new Object();
+
+  @GuardedBy("lock")
+  private String name;
   // Set of recorded attributes. DO NOT CALL any other method that changes the ordering of events.
   @GuardedBy("lock")
   @Nullable
@@ -236,18 +235,6 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
   @Override
   public InstrumentationLibraryInfo getInstrumentationLibraryInfo() {
     return instrumentationLibraryInfo;
-  }
-
-  /**
-   * Returns the end nano time (see {@link System#nanoTime()}) or zero if the current {@code Span}
-   * is not ended.
-   *
-   * @return the end nano time.
-   */
-  long getEndEpochNanos() {
-    synchronized (lock) {
-      return endEpochNanos;
-    }
   }
 
   /**

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -350,27 +350,19 @@ public final class Samplers {
 
       ParentBased that = (ParentBased) o;
 
-      if (root != null ? !root.equals(that.root) : that.root != null) {
+      if (!Objects.equals(root, that.root)) {
         return false;
       }
-      if (remoteParentSampled != null
-          ? !remoteParentSampled.equals(that.remoteParentSampled)
-          : that.remoteParentSampled != null) {
+      if (!Objects.equals(remoteParentSampled, that.remoteParentSampled)) {
         return false;
       }
-      if (remoteParentNotSampled != null
-          ? !remoteParentNotSampled.equals(that.remoteParentNotSampled)
-          : that.remoteParentNotSampled != null) {
+      if (!Objects.equals(remoteParentNotSampled, that.remoteParentNotSampled)) {
         return false;
       }
-      if (localParentSampled != null
-          ? !localParentSampled.equals(that.localParentSampled)
-          : that.localParentSampled != null) {
+      if (!Objects.equals(localParentSampled, that.localParentSampled)) {
         return false;
       }
-      return localParentNotSampled != null
-          ? localParentNotSampled.equals(that.localParentNotSampled)
-          : that.localParentNotSampled == null;
+      return Objects.equals(localParentNotSampled, that.localParentNotSampled);
     }
 
     @Override

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
@@ -74,12 +74,9 @@ public final class SimpleSpanProcessor implements SpanProcessor {
       List<SpanData> spans = Collections.singletonList(span.toSpanData());
       final CompletableResultCode result = spanExporter.export(spans);
       result.whenComplete(
-          new Runnable() {
-            @Override
-            public void run() {
-              if (!result.isSuccess()) {
-                logger.log(Level.FINE, "Exporter failed");
-              }
+          () -> {
+            if (!result.isSuccess()) {
+              logger.log(Level.FINE, "Exporter failed");
             }
           });
     } catch (Exception e) {

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -85,7 +85,9 @@ class SpanBuilderSdkTest {
   void truncateLink() {
     final int maxNumberOfLinks = 8;
     TraceConfig traceConfig =
-        tracerSdkFactory.getActiveTraceConfig().toBuilder()
+        tracerSdkFactory
+            .getActiveTraceConfig()
+            .toBuilder()
             .setMaxNumberOfLinks(maxNumberOfLinks)
             .build();
     tracerSdkFactory.updateActiveTraceConfig(traceConfig);
@@ -112,7 +114,9 @@ class SpanBuilderSdkTest {
   @Test
   void truncateLinkAttributes() {
     TraceConfig traceConfig =
-        tracerSdkFactory.getActiveTraceConfig().toBuilder()
+        tracerSdkFactory
+            .getActiveTraceConfig()
+            .toBuilder()
             .setMaxNumberOfAttributesPerLink(1)
             .build();
     tracerSdkFactory.updateActiveTraceConfig(traceConfig);
@@ -340,7 +344,9 @@ class SpanBuilderSdkTest {
   void droppingAttributes() {
     final int maxNumberOfAttrs = 8;
     TraceConfig traceConfig =
-        tracerSdkFactory.getActiveTraceConfig().toBuilder()
+        tracerSdkFactory
+            .getActiveTraceConfig()
+            .toBuilder()
             .setMaxNumberOfAttributes(maxNumberOfAttrs)
             .build();
     tracerSdkFactory.updateActiveTraceConfig(traceConfig);
@@ -364,7 +370,9 @@ class SpanBuilderSdkTest {
   @Test
   public void tooLargeAttributeValuesAreTruncated() {
     TraceConfig traceConfig =
-        tracerSdkFactory.getActiveTraceConfig().toBuilder()
+        tracerSdkFactory
+            .getActiveTraceConfig()
+            .toBuilder()
             .setMaxLengthOfAttributeValues(10)
             .build();
     tracerSdkFactory.updateActiveTraceConfig(traceConfig);
@@ -413,7 +421,9 @@ class SpanBuilderSdkTest {
   @Test
   void addAttributes_OnlyViaSampler() {
     TraceConfig traceConfig =
-        tracerSdkFactory.getActiveTraceConfig().toBuilder()
+        tracerSdkFactory
+            .getActiveTraceConfig()
+            .toBuilder()
             .setSampler(Samplers.traceIdRatioBased(1))
             .build();
     tracerSdkFactory.updateActiveTraceConfig(traceConfig);

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -85,9 +85,7 @@ class SpanBuilderSdkTest {
   void truncateLink() {
     final int maxNumberOfLinks = 8;
     TraceConfig traceConfig =
-        tracerSdkFactory
-            .getActiveTraceConfig()
-            .toBuilder()
+        tracerSdkFactory.getActiveTraceConfig().toBuilder()
             .setMaxNumberOfLinks(maxNumberOfLinks)
             .build();
     tracerSdkFactory.updateActiveTraceConfig(traceConfig);
@@ -114,9 +112,7 @@ class SpanBuilderSdkTest {
   @Test
   void truncateLinkAttributes() {
     TraceConfig traceConfig =
-        tracerSdkFactory
-            .getActiveTraceConfig()
-            .toBuilder()
+        tracerSdkFactory.getActiveTraceConfig().toBuilder()
             .setMaxNumberOfAttributesPerLink(1)
             .build();
     tracerSdkFactory.updateActiveTraceConfig(traceConfig);
@@ -344,9 +340,7 @@ class SpanBuilderSdkTest {
   void droppingAttributes() {
     final int maxNumberOfAttrs = 8;
     TraceConfig traceConfig =
-        tracerSdkFactory
-            .getActiveTraceConfig()
-            .toBuilder()
+        tracerSdkFactory.getActiveTraceConfig().toBuilder()
             .setMaxNumberOfAttributes(maxNumberOfAttrs)
             .build();
     tracerSdkFactory.updateActiveTraceConfig(traceConfig);
@@ -370,14 +364,12 @@ class SpanBuilderSdkTest {
   @Test
   public void tooLargeAttributeValuesAreTruncated() {
     TraceConfig traceConfig =
-        tracerSdkFactory
-            .getActiveTraceConfig()
-            .toBuilder()
+        tracerSdkFactory.getActiveTraceConfig().toBuilder()
             .setMaxLengthOfAttributeValues(10)
             .build();
     tracerSdkFactory.updateActiveTraceConfig(traceConfig);
     Span.Builder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
-    spanBuilder.setAttribute("builderStringNull", (String) null);
+    spanBuilder.setAttribute("builderStringNull", null);
     spanBuilder.setAttribute("builderStringSmall", "small");
     spanBuilder.setAttribute("builderStringLarge", "very large string that we have to cut");
     spanBuilder.setAttribute("builderLong", 42L);
@@ -421,9 +413,7 @@ class SpanBuilderSdkTest {
   @Test
   void addAttributes_OnlyViaSampler() {
     TraceConfig traceConfig =
-        tracerSdkFactory
-            .getActiveTraceConfig()
-            .toBuilder()
+        tracerSdkFactory.getActiveTraceConfig().toBuilder()
             .setSampler(Samplers.traceIdRatioBased(1))
             .build();
     tracerSdkFactory.updateActiveTraceConfig(traceConfig);

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -205,7 +205,7 @@ class TracerSdkTest {
 
   private static class CountingSpanExporter implements SpanExporter {
 
-    public AtomicLong numberOfSpansExported = new AtomicLong();
+    public final AtomicLong numberOfSpansExported = new AtomicLong();
 
     @Override
     public CompletableResultCode export(Collection<SpanData> spans) {

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -320,25 +320,19 @@ class BatchSpanProcessorTest {
             CompletableResultCode result = super.export(spans);
             Thread exporterThread =
                 new Thread(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        try {
-                          // sleep longer than the configured timeout of 100ms
-                          Thread.sleep(1000);
-                        } catch (InterruptedException e) {
-                          interruptMarker.countDown();
-                        }
+                    () -> {
+                      try {
+                        // sleep longer than the configured timeout of 100ms
+                        Thread.sleep(1000);
+                      } catch (InterruptedException e) {
+                        interruptMarker.countDown();
                       }
                     });
             exporterThread.start();
             result.whenComplete(
-                new Runnable() {
-                  @Override
-                  public void run() {
-                    if (!result.isSuccess()) {
-                      exporterThread.interrupt();
-                    }
+                () -> {
+                  if (!result.isSuccess()) {
+                    exporterThread.interrupt();
                   }
                 });
             return result;


### PR DESCRIPTION
* Use lambdas or method references where possible
* Remove dead code
* Make members final where possible
* Use Objects.equals instead of manually implementing the same functionality

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>