### PR TITLE
changed B3Propagator to default to inject/extra single header

### DIFF
--- a/extensions/trace_propagators/src/jmh/java/io/opentelemetry/extensions/trace/propagation/PropagatorContextExtractBenchmark.java
+++ b/extensions/trace_propagators/src/jmh/java/io/opentelemetry/extensions/trace/propagation/PropagatorContextExtractBenchmark.java
@@ -187,7 +187,7 @@ public class PropagatorContextExtractBenchmark {
           }
         };
 
-    private final B3Propagator b3Propagator = B3Propagator.getSingleHeaderPropagator();
+    private final B3Propagator b3Propagator = B3Propagator.getInstance();
 
     @Override
     protected Context doExtract() {
@@ -233,7 +233,7 @@ public class PropagatorContextExtractBenchmark {
           }
         };
 
-    private final B3Propagator b3Propagator = B3Propagator.getMultipleHeaderPropagator();
+    private final B3Propagator b3Propagator = B3Propagator.getInstance();
 
     @Override
     protected Context doExtract() {

--- a/extensions/trace_propagators/src/jmh/java/io/opentelemetry/extensions/trace/propagation/PropagatorContextInjectBenchmark.java
+++ b/extensions/trace_propagators/src/jmh/java/io/opentelemetry/extensions/trace/propagation/PropagatorContextInjectBenchmark.java
@@ -122,7 +122,7 @@ public class PropagatorContextInjectBenchmark {
       extends AbstractContextInjectBenchmark {
 
     private final B3Propagator b3Propagator =
-        B3Propagator.builder().injectFromMultipleHeaders().build();
+        B3Propagator.builder().injectMultipleHeaders().build();
     private final TextMapPropagator.Setter<Map<String, String>> setter =
         new TextMapPropagator.Setter<Map<String, String>>() {
           @Override

--- a/extensions/trace_propagators/src/jmh/java/io/opentelemetry/extensions/trace/propagation/PropagatorContextInjectBenchmark.java
+++ b/extensions/trace_propagators/src/jmh/java/io/opentelemetry/extensions/trace/propagation/PropagatorContextInjectBenchmark.java
@@ -102,7 +102,7 @@ public class PropagatorContextInjectBenchmark {
   /** Benchmark for injecting trace context into a single B3 header. */
   public static class B3SingleHeaderContextInjectBenchmark extends AbstractContextInjectBenchmark {
 
-    private final B3Propagator b3Propagator = B3Propagator.getSingleHeaderPropagator();
+    private final B3Propagator b3Propagator = B3Propagator.getInstance();
     private final TextMapPropagator.Setter<Map<String, String>> setter =
         new TextMapPropagator.Setter<Map<String, String>>() {
           @Override
@@ -121,7 +121,8 @@ public class PropagatorContextInjectBenchmark {
   public static class B3MultipleHeaderContextInjectBenchmark
       extends AbstractContextInjectBenchmark {
 
-    private final B3Propagator b3Propagator = B3Propagator.getMultipleHeaderPropagator();
+    private final B3Propagator b3Propagator =
+        B3Propagator.builder().injectFromMultipleHeaders().build();
     private final TextMapPropagator.Setter<Map<String, String>> setter =
         new TextMapPropagator.Setter<Map<String, String>>() {
           @Override

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3Propagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3Propagator.java
@@ -39,7 +39,7 @@ import javax.annotation.concurrent.Immutable;
  * OpenTelemetry.setPropagators(
  *   DefaultContextPropagators
  *     .builder()
- *     .addTextMapPropagator(B3Propagator.builder().injectFromMultipleHeaders().build())
+ *     .addTextMapPropagator(B3Propagator.builder().injectMultipleHeaders().build())
  *     .build());
  * }</pre>
  */
@@ -89,7 +89,7 @@ public class B3Propagator implements TextMapPropagator {
       injectSingleHeader = true;
     }
 
-    public Builder injectFromMultipleHeaders() {
+    public Builder injectMultipleHeaders() {
       this.injectSingleHeader = false;
       return this;
     }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3Propagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3Propagator.java
@@ -15,6 +15,30 @@ import javax.annotation.concurrent.Immutable;
 /**
  * Implementation of the B3 propagation protocol. See <a
  * href=https://github.com/openzipkin/b3-propagation>openzipkin/b3-propagation</a>.
+ *
+ * <p>Also see <a
+ * href=https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/api-propagators.md#b3-requirements>B3
+ * Requirements</a>
+ *
+ * <p>To register the default B3 propagator, which injects a single header, use the default instance
+ *
+ * <pre>{@code
+ * OpenTelemetry.setPropagators(
+ *   DefaultContextPropagators
+ *     .builder()
+ *     .addTextMapPropagator(B3Propagator.getInstance())
+ *     .build());
+ * }</pre>
+ *
+ * <p>To register a B3 propagator that injects multiple headers, use the builder
+ *
+ * <pre>{@code
+ * OpenTelemetry.setPropagators(
+ *   DefaultContextPropagators
+ *     .builder()
+ *     .addTextMapPropagator(B3Propagator.builder().injectFromMultipleHeaders().build())
+ *     .build());
+ * }</pre>
  */
 @Immutable
 public class B3Propagator implements TextMapPropagator {
@@ -31,44 +55,54 @@ public class B3Propagator implements TextMapPropagator {
   private static final List<String> FIELDS =
       Collections.unmodifiableList(Arrays.asList(TRACE_ID_HEADER, SPAN_ID_HEADER, SAMPLED_HEADER));
 
+  private static final B3Propagator INSTANCE = B3Propagator.builder().build();
+
+  private final B3PropagatorExtractor singleHeaderExtractor =
+      new B3PropagatorExtractorSingleHeader();
+  private final B3PropagatorExtractor multipleHeadersExtractor =
+      new B3PropagatorExtractorMultipleHeaders();
   private final B3PropagatorInjector b3PropagatorInjector;
-  private final B3PropagatorExtractor b3PropagatorExtractor;
 
-  private static final B3Propagator SINGLE_HEADER =
-      new B3Propagator(
-          new B3PropagatorInjectorSingleHeader(), new B3PropagatorExtractorSingleHeader());
-  private static final B3Propagator MULTI_HEADER =
-      new B3Propagator(
-          new B3PropagatorInjectorMultipleHeaders(), new B3PropagatorExtractorMultipleHeaders());
-
-  /**
-   * Returns an instance of {@link B3Propagator} with Single Header Implementation of B3 propagation
-   * protocol. See <a
-   * href=https://github.com/openzipkin/b3-propagation#single-header>openzipkin/b3-propagation#single-header</a>.
-   *
-   * @return Returns an instance of {@link B3Propagator} with Single Header implementation of B3
-   *     propagation protocol.
-   */
-  public static B3Propagator getSingleHeaderPropagator() {
-    return SINGLE_HEADER;
-  }
-
-  /**
-   * Returns an instance of {@link B3Propagator} with Multiple Header Implementation of B3
-   * propagation protocol. See <a
-   * href=https://github.com/openzipkin/b3-propagation#multiple-headers>openzipkin/b3-propagation#multiple-headers</a>.
-   *
-   * @return Returns an instance of {@link B3Propagator} with Multiple Header implementation of B3
-   *     propagation protocol.
-   */
-  public static B3Propagator getMultipleHeaderPropagator() {
-    return MULTI_HEADER;
-  }
-
-  private B3Propagator(
-      B3PropagatorInjector b3PropagatorInjector, B3PropagatorExtractor b3PropagatorExtractor) {
+  private B3Propagator(B3PropagatorInjector b3PropagatorInjector) {
     this.b3PropagatorInjector = b3PropagatorInjector;
-    this.b3PropagatorExtractor = b3PropagatorExtractor;
+  }
+
+  /**
+   * Returns a new {@link B3Propagator.Builder} instance for configuring injection option for {@link
+   * B3Propagator}.
+   */
+  public static B3Propagator.Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Enables the creation of an {@link B3Propagator} instance with the ability to switch injector
+   * from single header (default) to multiple headers.
+   */
+  public static class Builder {
+    private boolean injectSingleHeader;
+
+    private Builder() {
+      injectSingleHeader = true;
+    }
+
+    public Builder injectFromMultipleHeaders() {
+      this.injectSingleHeader = false;
+      return this;
+    }
+
+    /** Create the {@link B3Propagator} with selected injector type. */
+    public B3Propagator build() {
+      if (injectSingleHeader) {
+        return new B3Propagator(new B3PropagatorInjectorSingleHeader());
+      } else {
+        return new B3Propagator(new B3PropagatorInjectorMultipleHeaders());
+      }
+    }
+  }
+
+  public static B3Propagator getInstance() {
+    return INSTANCE;
   }
 
   @Override
@@ -83,6 +117,15 @@ public class B3Propagator implements TextMapPropagator {
 
   @Override
   public <C> Context extract(Context context, C carrier, Getter<C> getter) {
-    return b3PropagatorExtractor.extract(context, carrier, getter);
+
+    Context contextFromSingleHeader = singleHeaderExtractor.extract(context, carrier, getter);
+    if (contextFromSingleHeader != null) {
+      return contextFromSingleHeader;
+    }
+    Context contextFromMultipleHeaders = multipleHeadersExtractor.extract(context, carrier, getter);
+    if (contextFromMultipleHeaders != null) {
+      return contextFromMultipleHeaders;
+    }
+    return context;
   }
 }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractor.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractor.java
@@ -7,12 +7,11 @@ package io.opentelemetry.extensions.trace.propagation;
 
 import io.grpc.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import javax.annotation.Nullable;
+import java.util.Optional;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
 interface B3PropagatorExtractor {
 
-  @Nullable
-  <C> Context extract(Context context, C carrier, TextMapPropagator.Getter<C> getter);
+  <C> Optional<Context> extract(Context context, C carrier, TextMapPropagator.Getter<C> getter);
 }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractor.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractor.java
@@ -7,10 +7,12 @@ package io.opentelemetry.extensions.trace.propagation;
 
 import io.grpc.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
 interface B3PropagatorExtractor {
 
+  @Nullable
   <C> Context extract(Context context, C carrier, TextMapPropagator.Getter<C> getter);
 }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
@@ -15,6 +15,7 @@ import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.logging.Logger;
 import javax.annotation.concurrent.Immutable;
 
@@ -24,15 +25,16 @@ final class B3PropagatorExtractorMultipleHeaders implements B3PropagatorExtracto
       Logger.getLogger(B3PropagatorExtractorMultipleHeaders.class.getName());
 
   @Override
-  public <C> Context extract(Context context, C carrier, TextMapPropagator.Getter<C> getter) {
+  public <C> Optional<Context> extract(
+      Context context, C carrier, TextMapPropagator.Getter<C> getter) {
     Objects.requireNonNull(carrier, "carrier");
     Objects.requireNonNull(getter, "getter");
     SpanContext spanContext = getSpanContextFromMultipleHeaders(carrier, getter);
     if (!spanContext.isValid()) {
-      return null;
+      return Optional.empty();
     }
 
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return Optional.of(TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context));
   }
 
   private static <C> SpanContext getSpanContextFromMultipleHeaders(

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
@@ -29,7 +29,7 @@ final class B3PropagatorExtractorMultipleHeaders implements B3PropagatorExtracto
     Objects.requireNonNull(getter, "getter");
     SpanContext spanContext = getSpanContextFromMultipleHeaders(carrier, getter);
     if (!spanContext.isValid()) {
-      return context;
+      return null;
     }
 
     return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorSingleHeader.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorSingleHeader.java
@@ -14,6 +14,7 @@ import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.logging.Logger;
 import javax.annotation.concurrent.Immutable;
 
@@ -23,15 +24,16 @@ final class B3PropagatorExtractorSingleHeader implements B3PropagatorExtractor {
       Logger.getLogger(B3PropagatorExtractorSingleHeader.class.getName());
 
   @Override
-  public <C> Context extract(Context context, C carrier, TextMapPropagator.Getter<C> getter) {
+  public <C> Optional<Context> extract(
+      Context context, C carrier, TextMapPropagator.Getter<C> getter) {
     Objects.requireNonNull(carrier, "carrier");
     Objects.requireNonNull(getter, "getter");
     SpanContext spanContext = getSpanContextFromSingleHeader(carrier, getter);
     if (!spanContext.isValid()) {
-      return null;
+      return Optional.empty();
     }
 
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return Optional.of(TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context));
   }
 
   @SuppressWarnings("StringSplitter")

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorSingleHeader.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorSingleHeader.java
@@ -28,7 +28,7 @@ final class B3PropagatorExtractorSingleHeader implements B3PropagatorExtractor {
     Objects.requireNonNull(getter, "getter");
     SpanContext spanContext = getSpanContextFromSingleHeader(carrier, getter);
     if (!spanContext.isValid()) {
-      return context;
+      return null;
     }
 
     return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
@@ -46,8 +46,7 @@ class B3PropagatorTest {
           return carrier.get(key);
         }
       };
-  private final B3Propagator b3Propagator =
-      B3Propagator.builder().injectFromMultipleHeaders().build();
+  private final B3Propagator b3Propagator = B3Propagator.builder().injectMultipleHeaders().build();
   private final B3Propagator b3PropagatorSingleHeader = B3Propagator.getInstance();
 
   private static SpanContext getSpanContext(Context context) {

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagatorTest.java
@@ -32,8 +32,9 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 class TraceMultiPropagatorTest {
-  private static final TextMapPropagator PROPAGATOR1 = B3Propagator.getSingleHeaderPropagator();
-  private static final TextMapPropagator PROPAGATOR2 = B3Propagator.getMultipleHeaderPropagator();
+  private static final TextMapPropagator PROPAGATOR1 = B3Propagator.getInstance();
+  private static final TextMapPropagator PROPAGATOR2 =
+      B3Propagator.builder().injectFromMultipleHeaders().build();
   private static final TextMapPropagator PROPAGATOR3 = HttpTraceContext.getInstance();
 
   private static final Span SPAN =

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagatorTest.java
@@ -34,7 +34,7 @@ import org.mockito.MockitoAnnotations;
 class TraceMultiPropagatorTest {
   private static final TextMapPropagator PROPAGATOR1 = B3Propagator.getInstance();
   private static final TextMapPropagator PROPAGATOR2 =
-      B3Propagator.builder().injectFromMultipleHeaders().build();
+      B3Propagator.builder().injectMultipleHeaders().build();
   private static final TextMapPropagator PROPAGATOR3 = HttpTraceContext.getInstance();
 
   private static final Span SPAN =


### PR DESCRIPTION
resolves #1684 

Wasn't sure what you had in mind for making the ```B3Propagator``` configurable so I added a builder that can configure creation of it.

Default (inject single header)
```
B3Propagator.getInstance();
```

Using builder
```
    B3Propagator.builder()
      .injectFromMultipleHeaders()
      .build();
```
