### PR TITLE
Add GitHub workflows to automate releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,11 +114,3 @@ workflows:
     jobs:
       - build
       - java11
-  build_and_release:
-    jobs:
-      - release_job:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -1,3 +1,5 @@
+# Releases a patch by cherrypicking commits into a release branch based on the previous
+# release tag.
 name: Patch Release Build
 on:
   workflow_dispatch:
@@ -76,9 +78,8 @@ jobs:
           remote-build-cache-proxy-enabled: false
           arguments: final --stacktrace -Prelease.version=${{ github.event.inputs.version }}
           properties: |
-            enable.docker.tests=trued
+            enable.docker.tests=true
         env:
-          CI: true
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
           GRGIT_USER: ${{ github.actor }}

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -1,0 +1,99 @@
+name: Patch Release Build
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The version to tag the release with, e.g., 1.2.1, 1.2.2
+        required: true
+      commits:
+        description: Comma separated list of commit shas to cherrypick
+        required: true
+
+jobs:
+  prepare-release-branch:
+    runs-on: ubuntu-latest
+    outputs:
+      release-branch-name: ${{ steps.parse-release-branch.outputs.release-branch-name }}
+    steps:
+      - id: parse-release-branch
+        name: Parse release branch name
+        run: |
+          # Sets the release-branch-name output to the version number with the last non-period element replaced with an 'x' and preprended with v.
+          echo "::set-output name=release-branch-name::$(echo '${{ github.event.inputs.version }}' | sed -E 's/([^.]+)\.([^.]+)\.([^.]+)/v\1.\2.x/')"
+          # Sets the release-tag-name output to the version number with the last non-period element replace with a '0' and prepended with v
+          echo "::set-output name=release-tag-name::$(echo '${{ github.event.inputs.version }}' | sed -E 's/([^.]+)\.([^.]+)\.([^.]+)/v\1.\2.0/')"
+      - id: checkout-release-branch
+        name: Check out release branch
+        continue-on-error: true
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.parse-release-branch.outputs.release-branch-name }}
+      - id: checkout-release-tag
+        name: Check out release tag
+        if: ${{ steps.checkout-release-branch.outcome == 'failure' }}
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.parse-release-branch.outputs.release-tag-name }}
+      - name: Create release branch
+        if: ${{ steps.checkout-release-tag.outcome == 'success' }}
+        run: |
+          git checkout -b ${{ steps.parse-release-branch.outputs.release-branch-name }}
+          git push --set-upstream origin ${{ steps.parse-release-branch.outputs.release-branch-name }}
+  build:
+    runs-on: ubuntu-latest
+    needs: prepare-release-branch
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.prepare-release-branch.outputs.release-branch-name }}
+          submodules: true
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Setup git name
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - name: Cherrypicks
+        run: |
+          git fetch origin master
+          echo ${{ github.event.inputs.commits }} | sed -n 1'p' | tr ',' '\n' | while read word; do
+              # Trim whitespaces and cherrypick
+              echo $word | sed 's/ *$//g' | sed 's/^ *//g' | git cherry-pick --stdin
+          done
+      - uses: burrunan/gradle-cache-action@v1.5
+        with:
+          job-id: jdk11
+          remote-build-cache-proxy-enabled: false
+          arguments: build --stacktrace -Prelease.version=${{ github.event.inputs.version }}
+          properties: |
+            enable.docker.tests=true
+      - name: Publish artifacts
+        uses: burrunan/gradle-cache-action@v1.5
+        with:
+          job-id: jdk11
+          remote-build-cache-proxy-enabled: false
+          arguments: final --stacktrace -Prelease.version=${{ github.event.inputs.version }}
+          properties: |
+            enable.docker.tests=trued
+        env:
+          CI: true
+          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+          BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
+          GRGIT_USER: ${{ github.actor }}
+          GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}
+      - run: git push
+      - name: Checkout master
+        uses: actions/checkout@v2
+        with:
+           submodules: true
+      - uses: burrunan/gradle-cache-action@v1.5
+        with:
+          job-id: jdk11
+          remote-build-cache-proxy-enabled: false
+          arguments: prepareRelease --stacktrace -Prelease.version=${{ github.event.inputs.version }}
+      - name: Commit README changes
+        run: |
+          git commit -am "README update for patch release ${{ github.event.inputs.version }}"
+          git push

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -58,6 +58,7 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
       - name: Cherrypicks
+        if: ${{ github.event.inputs.commits != '' }}
         run: |
           git fetch origin master
           echo ${{ github.event.inputs.commits }} | sed -n 1'p' | tr ',' '\n' | while read word; do
@@ -93,7 +94,7 @@ jobs:
         with:
           job-id: jdk11
           remote-build-cache-proxy-enabled: false
-          arguments: prepareRelease --stacktrace -Prelease.version=${{ github.event.inputs.version }}
+          arguments: updateVersionInDocs --stacktrace -Prelease.version=${{ github.event.inputs.version }}
       - name: Commit README changes
         run: |
           git commit -am "README update for patch release ${{ github.event.inputs.version }}"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,42 @@
+name: Release Build
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The version to tag the release with, e.g., 1.2.0, 1.2.1-alpha.1
+        required: true
+
+jobs:
+  build:
+    name: Build and release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: burrunan/gradle-cache-action@v1.5
+        with:
+          job-id: jdk8
+          remote-build-cache-proxy-enabled: false
+          arguments: prepareRelease build --stacktrace -Prelease.version=${{ github.event.inputs.version }}
+          properties: |
+            enable.docker.tests=true
+      - name: Setup git name
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - name: Commit README updates
+        run: git commit -am "Releasing ${{ github.event.inputs.version }}"
+      - name: Publish artifacts
+        run: ./gradlew final --stacktrace -Prelease.version=${{ github.event.inputs.version }}
+        env:
+          CI: true
+          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+          BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
+          GRGIT_USER: ${{ github.actor }}
+          GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push README updates
+        run: git push

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,3 +1,4 @@
+# Releases a new minor / major version from the HEAD of the main branch
 name: Release Build
 on:
   workflow_dispatch:
@@ -19,7 +20,7 @@ jobs:
           java-version: 11
       - uses: burrunan/gradle-cache-action@v1.5
         with:
-          job-id: jdk8
+          job-id: jdk11
           remote-build-cache-proxy-enabled: false
           arguments: prepareRelease build --stacktrace -Prelease.version=${{ github.event.inputs.version }}
           properties: |
@@ -33,7 +34,6 @@ jobs:
       - name: Publish artifacts
         run: ./gradlew final --stacktrace -Prelease.version=${{ github.event.inputs.version }}
         env:
-          CI: true
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
           GRGIT_USER: ${{ github.actor }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           job-id: jdk11
           remote-build-cache-proxy-enabled: false
-          arguments: prepareRelease build --stacktrace -Prelease.version=${{ github.event.inputs.version }}
+          arguments: updateVersionInDocs build --stacktrace -Prelease.version=${{ github.event.inputs.version }}
           properties: |
             enable.docker.tests=true
       - name: Setup git name

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ verify-format:
 .PHONY: publish-snapshots
 publish-snapshots:
 ifeq ($(CIRCLE_BRANCH),master)
-	./gradlew artifactoryPublish
+  # TODO(anuraaga): Remove version specificer after next release creates a tag on master.
+	./gradlew artifactoryPublish -Prelease.version=0.10.0-SNAPSHOT
 endif
 
 .PHONY: publish-release-artifacts

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ verify-format:
 .PHONY: publish-snapshots
 publish-snapshots:
 ifeq ($(CIRCLE_BRANCH),master)
-  # TODO(anuraaga): Remove version specificer after next release creates a tag on master.
+	# TODO(anuraaga): Remove version specificer after next release creates a tag on master.
 	./gradlew artifactoryPublish -Prelease.version=0.10.0-SNAPSHOT
 endif
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ repositories {
 }
 
 dependencies {
-	implementation('io.opentelemetry:opentelemetry-api:0.9.0-SNAPSHOT')
+	implementation('io.opentelemetry:opentelemetry-api:0.10.0-SNAPSHOT')
 }
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -46,6 +46,44 @@ You will see a button that says "Run workflow". Press the button, enter the vers
 to release in the input field for version that pops up and the commits you want to cherrypick for the
 patch as a comma-separated list. Then, press "Run workflow".
 
+If the commits cannot be cleanly applied to the release branch, for example because it has diverged
+too much from main, then the workflow will fail before building. In this case, you will need to
+prepare the release branch manually.
+
+This example will assume patching into release branch `v1.2.x` from a git repository with remotes
+named `origin` and `upstream`.
+
+```
+$ git remote -v
+origin	git@github.com:username/opentelemetry-java.git (fetch)
+origin	git@github.com:username/opentelemetry-java.git (push)
+upstream	git@github.com:open-telemetry/opentelemetry-java.git (fetch)
+upstream	git@github.com:open-telemetry/opentelemetry-java.git (push)
+```
+
+First, checkout the release branch
+
+```
+git fetch upstream v1.2.x
+git checkout upstream/v1.2.x
+```
+
+Apply cherrypicks manually and commit. It is ok to apply multiple cherrypicks in a single commit.
+Use a commit message such as "Manual cherrypick for commits commithash1, commithash2".
+
+After commiting the change, push to your fork's branch.
+
+```
+git push origin v1.2.x
+```
+
+Create a PR to have code review and merge this into upstream's release branch. As this was not
+applied automatically, we need to do code review to make sure the manual cherrypick is correct.
+
+After it is merged, Run the patch release workflow again, but leave the commits input field blank.
+The release will be made with the current state of the release branch, which is what you prepared
+above.
+
 ## Release candidates
 
 Release candidate artifacts are released using the same process described above. The version schema for release candidates

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,94 +1,22 @@
 # OpenTelemetry Release Process
 
-## Tagging the Release
+## Starting the Release
 
-The first step in the release process is to create a release branch, bump versions, and create a tag
-for the release. Our release branches follow the naming convention of v<major>.<minor>.x, while the
-tags include the patch version v<major>.<minor>.<patch>. For example, the same branch v0.3.x would
-be used to create all v0.3.* tags (e.g. v0.3.0, v0.3.1).
+Open the release build workflow in your browser [here](https://github.com/open-telemetry/opentelemetry-java/actions?query=workflow%3A%22Release+Build%22).
 
-In this section upstream repository refers to the main opentelemetry-java github repository.
+You will see a button that says "Run workflow". Press the button, enter the version number you want
+to release in the input field that pops up, and then press "Run workflow".
 
-Before any push to the upstream repository you need to create a
-[personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line).
-
-Note: The scripts referenced in here may or may not work as-is, depending on your operating system
-and command-line shell of choice. In all cases, a description of what needs to be done is also
-provided, for clarity.
-
-1.  Create the new version series (eg. `v0.10.x`) branch and push it to GitHub:
-
-    ```bash
-    $ MAJOR=0 MINOR=3 PATCH=0 # Set appropriately for new release
-    $ VERSION_FILES=(
-      build.gradle
-      )
-    $ git checkout -b v$MAJOR.$MINOR.x master
-    $ git push upstream v$MAJOR.$MINOR.x
-    ```
-    The branch will be automatically protected by the GitHub branch protection rule for release
-    branches.
-
-2.  Back on the `master` branch:
-
-    -   Change the version in the root `build.gradle` to the next minor snapshot (e.g.
-        `0.11.0-SNAPSHOT`).
-
-    ```bash
-    $ git checkout -b bump-version master
-    # Change version to next minor (but keep the `-SNAPSHOT` suffix)
-    $ sed -i "" 's/[0-9]\+\.[0-9]\+\.[0-9]\+\(.*CURRENT_OPEN_TELEMETRY_VERSION\)/'$MAJOR.$((MINOR+1)).0'\1/' \
-      "${VERSION_FILES[@]}"
-    $ ./gradlew build
-    $ git commit -a -m "Start $MAJOR.$((MINOR+1)).0 development cycle"
-    ```
-
-    -   Go through the normal PR review against master, and merge to the master branch on GitHub.
-       
-3.  From the `vMajor.Minor.x` branch:
-
-    -   Create a new branch called 'release'; change the version in the root build.gradle to remove "-SNAPSHOT" for the next release
-        version (eg. `0.10.0`). Commit the result and tag it with the version being released (eg. "v0.10.0"):
-
-    ```bash
-    $ git checkout -b release v$MAJOR.$MINOR.x
-    # Change the version to remove -SNAPSHOT
-    $ sed -i "" 's/-SNAPSHOT\(.*CURRENT_OPEN_TELEMETRY_VERSION\)/\1/' "${VERSION_FILES[@]}"
-    $ ./gradlew build
-    $ git commit -a -m "Bump version to $MAJOR.$MINOR.$PATCH"
-    $ git tag -a v$MAJOR.$MINOR.$PATCH -m "Version $MAJOR.$MINOR.$PATCH"
-    ```
-
-    -   Change the version in the root `build.gradle` to the next patch level snapshot version (e.g.
-        `0.10.1-SNAPSHOT`). Commit the result:
-
-    ```bash
-    # Change version to the next patch level and add -SNAPSHOT
-    $ sed -i "" 's/[0-9]\+\.[0-9]\+\.[0-9]\+\(.*CURRENT_OPEN_TELEMETRY_VERSION\)/'$MAJOR.$MINOR.$((PATCH+1))-SNAPSHOT'\1/' \
-     "${VERSION_FILES[@]}"
-    $ ./gradlew build
-    $ git commit -a -m "Bump version to $MAJOR.$MINOR.$((PATCH+1))-SNAPSHOT"
-    ```
-
-    -   Create a PR with the current state of your 'release' branch against the `v.M.m.x` branch.
-        *Do not merge this PR to the master branch!*
-        Go through PR review and after approval, manually push the release tag and updated `v.M.m.x` branch
-        to GitHub (note: do not squash the commits when you merge otherwise you
-        will lose the release tag!):
-
-    ```bash
-    $ git checkout v$MAJOR.$MINOR.x
-    $ git merge --ff-only release
-    $ git push upstream v$MAJOR.$MINOR.x
-    ### this next step, pushing the tag, is what triggers the build that publishes the release:
-    $ git push upstream v$MAJOR.$MINOR.$PATCH
-    ```
+This triggers the release process, which builds the artifacts, updates the README with the new
+version numbers, commits the change to the README, publishes the artifacts, and creates and pushes
+a git tag with the version number.
 
 ## Announcement
    
-Once deployment is done by Circle CI (controlled by the Bintray plugin) , go to Github [release
+Once the GitHub workflow completes, go to Github [release
 page](https://github.com/open-telemetry/opentelemetry-java/releases), press
-`Draft a new release` to write release notes about the new release.
+`Draft a new release` to write release notes about the new release. If there is already a draft
+release notes, just point it at the created tag.
 
 You can use `git log upstream/v$MAJOR.$((MINOR-1)).x..upstream/v$MAJOR.$MINOR.x --graph --first-parent`
 or the Github [compare tool](https://github.com/open-telemetry/opentelemetry-java/compare/)
@@ -101,7 +29,6 @@ for a list of major changes since last release.
 ## Update release versions in documentations and CHANGELOG files
 
 After releasing is done, you need to update
-[README.md](https://github.com/open-telemetry/opentelemetry-java/blob/master/README.md) and
 [CHANGELOG.md](https://github.com/open-telemetry/opentelemetry-java/blob/master/CHANGELOG.md).
 
 Create a PR to mark the new release in
@@ -111,21 +38,13 @@ on master branch.
 ## Patch Release
 
 All patch releases should include only bug-fixes, and must avoid
-adding/modifying the public APIs. To cherry-pick one commit use the following
-instructions:
+adding/modifying the public APIs. 
 
-- Create and push a tag:
+Open the patch release build workflow in your browser [here](https://github.com/open-telemetry/opentelemetry-java/actions?query=workflow%3A%22Patch+Release+Build%22).
 
-```bash
-COMMIT=1224f0a # Set the right commit hash.
-git checkout -b cherrypick v$MAJOR.$MINOR.x
-git cherry-pick -x $COMMIT
-git commit -a -m "Cherry-pick commit $COMMIT"
-```
-
-- Go through PR review and merge it to GitHub v$MAJOR.$MINOR.x branch.
-
-- Tag a new patch release when all commits are merged.
+You will see a button that says "Run workflow". Press the button, enter the version number you want
+to release in the input field for version that pops up and the commits you want to cherrypick for the
+patch as a comma-separated list. Then, press "Run workflow".
 
 ## Release candidates
 
@@ -151,5 +70,6 @@ export BINTRAY_USER=my_bintray_user
 export BINTRAY_KEY=my_user_api_key
 export SONATYPE_USER=my_maven_user
 export SONATYPE_KEY=my_maven_password
-make publish-release-artifacts
+export RELEASE_VERSION=2.4.5 # Set version you want to release
+./gradlew final -Prelease.version=${RELEASE_VERSION}
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -465,7 +465,7 @@ wrapper {
     gradleVersion = '6.6'
 }
 
-tasks.register("prepareRelease") {
+tasks.register("updateVersionInDocs") {
     doLast {
         def versionParts = version.toString().split('\\.')
         def minorVersionNumber = Integer.parseInt(versionParts[1])

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,10 @@
+import nebula.plugin.release.git.opinion.Strategies
+
 plugins {
     id "com.diffplug.spotless" version "5.6.1"
     id "com.jfrog.artifactory" apply false
     id "com.jfrog.bintray" version "1.8.4" apply false // Need *specific* version.
+    id "nebula.release"
     id "net.ltgt.errorprone" apply false
     id "ru.vyarus.animalsniffer" apply false
     id "io.morethan.jmhreport" apply false
@@ -11,14 +14,34 @@ ext {
     opentelemetryProjects = subprojects - project(":opentelemetry-bom")
 }
 
+release {
+    defaultVersionStrategy = Strategies.getSNAPSHOT()
+}
+
+nebulaRelease {
+    addReleaseBranchPattern(/v\d+\.\d+\.x/)
+}
+
+def releaseTask = tasks.named("release")
+releaseTask.configure {
+    mustRunAfter("snapshotSetup", "finalSetup")
+}
+
 subprojects {
     group = "io.opentelemetry"
-    version = "0.10.0-SNAPSHOT" // CURRENT_OPEN_TELEMETRY_VERSION
 
     plugins.withId("maven-publish") {
         // Always include the artifactory/bintray plugins to do the deployment.
         pluginManager.apply "com.jfrog.artifactory"
         pluginManager.apply "com.jfrog.bintray"
+
+        releaseTask.configure {
+            if (version.toString().endsWith('-SNAPSHOT')) {
+                finalizedBy(tasks.named('artifactoryPublish'))
+            } else {
+                finalizedBy(tasks.named('bintrayUpload'))
+            }
+        }
 
         publishing {
             publications {
@@ -72,6 +95,7 @@ subprojects {
                 }
             }
         }
+
 
         // Snapshot publishing.
         artifactory {
@@ -445,7 +469,7 @@ tasks.register("prepareRelease") {
     doLast {
         def versionParts = version.toString().split('\\.')
         def minorVersionNumber = Integer.parseInt(versionParts[1])
-        def nextSnapshot = "${versionParts[0]}.${minorVersionNumber + 1}.${versionParts[2]}-SNAPSHOT"
+        def nextSnapshot = "${versionParts[0]}.${minorVersionNumber + 1}.0-SNAPSHOT"
 
         def readmeText = file("README.md").text
         def updatedText = readmeText

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,7 @@ pluginManagement {
         id "com.jfrog.artifactory" version "4.13.0"
         id "io.morethan.jmhreport" version "0.9.0"
         id "me.champeau.gradle.jmh" version "0.5.0"
+        id "nebula.release" version "15.1.0"
         id "net.ltgt.errorprone" version "1.2.0"
         id "org.unbroken-dome.test-sets" version "3.0.1"
         id "ru.vyarus.animalsniffer" version "1.5.1"


### PR DESCRIPTION
This makes three major changes

- Use nebula-release-plugin for determining version number of project. Mainly to allow SNAPSHOT version to automatically be set to the minor version after the previous release tag on master. This is same pattern as instrumentation repo.
- Add a release workflow which builds artifacts for a version specified by the releaser, updates README, tags master with the released version
- Add a patch release workflow that first creates a release branch if none exists yet, cherrypicks provided commits, and builds artifacts for provided version, tags release branch, updates README in master

Because SNAPSHOT versions are based on the previous tag on master, there is a chicken/egg problem where our current tag is on a release branch and not picked up. So until the next release, I explicitly set the snapshot version as well.

@iNikem will remember noticing it's hard to "skip a patch version" in the instrumentation repo release process. Here I have the releaser specify a version manually, I think this control is good and can allow RC releases, etc flexibility and is not really any harder than picking between "minor" and "patch" scope.

Hope this makes future releases easier :)

Sample runs

- Normal release - https://github.com/anuraaga/opentelemetry-java/actions/runs/301530974
- First patch release, creates release branch too - https://github.com/anuraaga/opentelemetry-java/actions/runs/301554274
- Second patch release, uses existing release branch - https://github.com/anuraaga/opentelemetry-java/actions/runs/301579635