### PR TITLE
Exclude jaeger proto classes from coverage.

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -63,6 +63,9 @@ jacocoTestReport {
     sourceDirectories.from = files(subprojects.sourceSets.main.allSource.srcDirs)
     classDirectories.from = files(subprojects.sourceSets.main.output)
     classDirectories.from = files(classDirectories.files.collect {
-        fileTree(dir: it)
+        fileTree(dir: it, excludes: [
+                // Ignore generated code
+                "io/opentelemetry/exporters/jaeger/proto/**"
+        ])
     })
 }


### PR DESCRIPTION
I noticed reports with low coverage had these protos included, which have almost no coverage. I'm not sure why sometimes they're included in the report and sometimes not, but I could reliably see reports locally have lots of red for this folder before the change and it's gone after.