### PR TITLE
Rename newBuilder to builder for consistency.

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -316,7 +316,7 @@ TracerSdkManagement tracerSdkManagement = OpenTelemetrySdk.getTracerManagement()
 
 // Set to export the traces to a logging stream
 tracerSdkManagement.addSpanProcessor(
-    SimpleSpanProcessor.newBuilder(
+    SimpleSpanProcessor.builder(
         new LoggingSpanExporter()
     ).build());
 ```
@@ -360,14 +360,14 @@ in bulk. Multiple Span processors can be configured to be active at the same tim
 
 ```java
 tracerSdkManagement.addSpanProcessor(
-    SimpleSpanProcessor.newBuilder(new LoggingSpanExporter()).build()
+    SimpleSpanProcessor.builder(new LoggingSpanExporter()).build()
 );
 tracerSdkManagement.addSpanProcessor(
-    BatchSpanProcessor.newBuilder(new LoggingSpanExporter()).build()
+    BatchSpanProcessor.builder(new LoggingSpanExporter()).build()
 );
 tracerSdkManagement.addSpanProcessor(MultiSpanProcessor.create(Arrays.asList(
-            SimpleSpanProcessor.newBuilder(new LoggingSpanExporter()).build(),
-            BatchSpanProcessor.newBuilder(new LoggingSpanExporter()).build()
+            SimpleSpanProcessor.builder(new LoggingSpanExporter()).build(),
+            BatchSpanProcessor.builder(new LoggingSpanExporter()).build()
 )));
 ```
 
@@ -385,16 +385,16 @@ Other exporters can be found in the [OpenTelemetry Registry].
 
 ```java
 tracerSdkManagement.addSpanProcessor(
-    SimpleSpanProcessor.newBuilder(InMemorySpanExporter.create()).build());
+    SimpleSpanProcessor.builder(InMemorySpanExporter.create()).build());
 tracerSdkManagement.addSpanProcessor(
-    SimpleSpanProcessor.newBuilder(new LoggingSpanExporter()).build());
+    SimpleSpanProcessor.builder(new LoggingSpanExporter()).build());
 
 ManagedChannel jaegerChannel =
     ManagedChannelBuilder.forAddress([ip:String], [port:int]).usePlaintext().build();
-JaegerGrpcSpanExporter jaegerExporter = JaegerGrpcSpanExporter.newBuilder()
+JaegerGrpcSpanExporter jaegerExporter = JaegerGrpcSpanExporter.builder()
     .setServiceName("example").setChannel(jaegerChannel).setDeadline(30000)
     .build();
-tracerSdkManagement.addSpanProcessor(BatchSpanProcessor.newBuilder(
+tracerSdkManagement.addSpanProcessor(BatchSpanProcessor.builder(
     jaegerExporter
 ).build());
 ```

--- a/api/src/main/java/io/opentelemetry/common/Attributes.java
+++ b/api/src/main/java/io/opentelemetry/common/Attributes.java
@@ -34,7 +34,7 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey, Object>
     implements ReadableAttributes {
-  private static final Attributes EMPTY = Attributes.newBuilder().build();
+  private static final Attributes EMPTY = Attributes.builder().build();
 
   @AutoValue
   @Immutable
@@ -179,12 +179,12 @@ public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey, Ob
   }
 
   /** Returns a new {@link Builder} instance for creating arbitrary {@link Attributes}. */
-  public static Builder newBuilder() {
+  public static Builder builder() {
     return new Builder();
   }
 
   /** Returns a new {@link Builder} instance from ReadableAttributes. */
-  public static Builder newBuilder(ReadableAttributes attributes) {
+  public static Builder builder(ReadableAttributes attributes) {
     final Builder builder = new Builder();
     attributes.forEach(builder::setAttribute);
     return builder;

--- a/api/src/main/java/io/opentelemetry/common/Labels.java
+++ b/api/src/main/java/io/opentelemetry/common/Labels.java
@@ -14,7 +14,7 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public abstract class Labels extends ImmutableKeyValuePairs<String, String> {
 
-  private static final Labels EMPTY = Labels.newBuilder().build();
+  private static final Labels EMPTY = Labels.builder().build();
 
   public abstract void forEach(LabelConsumer consumer);
 
@@ -117,7 +117,7 @@ public abstract class Labels extends ImmutableKeyValuePairs<String, String> {
   }
 
   /** Creates a new {@link Builder} instance for creating arbitrary {@link Labels}. */
-  public static Builder newBuilder() {
+  public static Builder builder() {
     return new Builder();
   }
 

--- a/api/src/test/java/io/opentelemetry/common/AttributesTest.java
+++ b/api/src/test/java/io/opentelemetry/common/AttributesTest.java
@@ -50,7 +50,7 @@ class AttributesTest {
 
   @Test
   void builder_nullKey() {
-    Attributes attributes = Attributes.newBuilder().setAttribute(stringKey(null), "value").build();
+    Attributes attributes = Attributes.builder().setAttribute(stringKey(null), "value").build();
     assertThat(attributes).isEqualTo(Attributes.empty());
   }
 
@@ -125,7 +125,7 @@ class AttributesTest {
   @Test
   void builder() {
     Attributes attributes =
-        Attributes.newBuilder()
+        Attributes.builder()
             .setAttribute("string", "value1")
             .setAttribute("long", 100)
             .setAttribute(longKey("long2"), 10)
@@ -148,7 +148,7 @@ class AttributesTest {
             false);
     assertThat(attributes).isEqualTo(wantAttributes);
 
-    Attributes.Builder newAttributes = Attributes.newBuilder(attributes);
+    Attributes.Builder newAttributes = Attributes.builder(attributes);
     newAttributes.setAttribute("newKey", "newValue");
     assertThat(newAttributes.build())
         .isEqualTo(
@@ -172,7 +172,7 @@ class AttributesTest {
   @Test
   void builder_arrayTypes() {
     Attributes attributes =
-        Attributes.newBuilder()
+        Attributes.builder()
             .setAttribute("string", "value1", "value2")
             .setAttribute("long", 100L, 200L)
             .setAttribute("double", 33.44, -44.33)
@@ -230,7 +230,7 @@ class AttributesTest {
   @Test
   void toBuilder() {
     Attributes filled =
-        Attributes.newBuilder().setAttribute("cat", "meow").setAttribute("dog", "bark").build();
+        Attributes.builder().setAttribute("cat", "meow").setAttribute("dog", "bark").build();
 
     Attributes fromEmpty =
         Attributes.empty()
@@ -242,16 +242,16 @@ class AttributesTest {
     // Original not mutated.
     assertThat(Attributes.empty().isEmpty()).isTrue();
 
-    Attributes partial = Attributes.newBuilder().setAttribute("cat", "meow").build();
+    Attributes partial = Attributes.builder().setAttribute("cat", "meow").build();
     Attributes fromPartial = partial.toBuilder().setAttribute("dog", "bark").build();
     assertThat(fromPartial).isEqualTo(filled);
     // Original not mutated.
-    assertThat(partial).isEqualTo(Attributes.newBuilder().setAttribute("cat", "meow").build());
+    assertThat(partial).isEqualTo(Attributes.builder().setAttribute("cat", "meow").build());
   }
 
   @Test
   void nullsAreNoOps() {
-    Attributes.Builder builder = Attributes.newBuilder();
+    Attributes.Builder builder = Attributes.builder();
     builder.setAttribute(stringKey("attrValue"), "attrValue");
     builder.setAttribute("string", "string");
     builder.setAttribute("long", 10);

--- a/api/src/test/java/io/opentelemetry/common/LabelsTest.java
+++ b/api/src/test/java/io/opentelemetry/common/LabelsTest.java
@@ -98,7 +98,7 @@ class LabelsTest {
   @Test
   void builder() {
     Labels labels =
-        Labels.newBuilder()
+        Labels.builder()
             .setLabel("key1", "duplicateShouldBeIgnored")
             .setLabel("key1", "value1")
             .setLabel("key2", "value2")

--- a/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporter.java
+++ b/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporter.java
@@ -25,7 +25,7 @@ import java.util.List;
  *
  *   {@literal @}Before
  *   public void setup() {
- *     tracer.addSpanProcessor(SimpleSampledSpansProcessor.newBuilder(testExporter).build());
+ *     tracer.addSpanProcessor(SimpleSampledSpansProcessor.builder(testExporter).build());
  *   }
  *
  *   {@literal @}Test

--- a/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryTracing.java
+++ b/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryTracing.java
@@ -93,7 +93,7 @@ public abstract class InMemoryTracing {
               .addTextMapPropagator(HttpTraceContext.getInstance())
               .build());
       InMemorySpanExporter exporter = InMemorySpanExporter.create();
-      getTracerSdkManagement().addSpanProcessor(SimpleSpanProcessor.newBuilder(exporter).build());
+      getTracerSdkManagement().addSpanProcessor(SimpleSpanProcessor.builder(exporter).build());
       return setSpanExporter(exporter).autoBuild();
     }
   }

--- a/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
+++ b/exporters/inmemory/src/test/java/io/opentelemetry/exporters/inmemory/InMemorySpanExporterTest.java
@@ -29,7 +29,7 @@ class InMemorySpanExporterTest {
 
   @BeforeEach
   void setup() {
-    tracerSdkProvider.addSpanProcessor(SimpleSpanProcessor.newBuilder(exporter).build());
+    tracerSdkProvider.addSpanProcessor(SimpleSpanProcessor.builder(exporter).build());
   }
 
   @Test
@@ -87,7 +87,7 @@ class InMemorySpanExporterTest {
   }
 
   static SpanData makeBasicSpan() {
-    return TestSpanData.newBuilder()
+    return TestSpanData.builder()
         .setHasEnded(true)
         .setTraceId(TraceId.getInvalid())
         .setSpanId(SpanId.getInvalid())

--- a/exporters/jaeger/README.md
+++ b/exporters/jaeger/README.md
@@ -13,7 +13,7 @@ spans will be sent to a Jaeger gRPC endpoint running on `localhost`:
 
 ```java
 JaegerGrpcSpanExporter exporter =
-        JaegerGrpcSpanExporter.newBuilder()
+        JaegerGrpcSpanExporter.builder()
             .setEndpoint("localhost:14250")
             .setServiceName("my-service")
             .build();
@@ -24,7 +24,7 @@ Service name and Endpoint can be also configured via environment variables or sy
 ```java
 // Using environment variables
 JaegerGrpcSpanExporter exporter = 
-        JaegerGrpcSpanExporter.newBuilder()
+        JaegerGrpcSpanExporter.builder()
             .readEnvironmentVariables()
             .build()
 ```
@@ -32,7 +32,7 @@ JaegerGrpcSpanExporter exporter =
 ```java
 // Using system properties
 JaegerGrpcSpanExporter exporter = 
-        JaegerGrpcSpanExporter.newBuilder()
+        JaegerGrpcSpanExporter.builder()
             .readSystemProperties()
             .build()
 ```

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporter.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporter.java
@@ -152,7 +152,7 @@ public final class JaegerGrpcSpanExporter implements SpanExporter {
    *
    * @return a new builder instance for this exporter.
    */
-  public static Builder newBuilder() {
+  public static Builder builder() {
     return new Builder();
   }
 

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/AdapterTest.java
@@ -210,7 +210,7 @@ class AdapterTest {
     long startMs = System.currentTimeMillis();
     long endMs = startMs + 900;
     SpanData span =
-        TestSpanData.newBuilder()
+        TestSpanData.builder()
             .setHasEnded(true)
             .setTraceId(TRACE_ID)
             .setSpanId(SPAN_ID)
@@ -237,7 +237,7 @@ class AdapterTest {
     long startMs = System.currentTimeMillis();
     long endMs = startMs + 900;
     SpanData span =
-        TestSpanData.newBuilder()
+        TestSpanData.builder()
             .setHasEnded(true)
             .setTraceId(TRACE_ID)
             .setSpanId(SPAN_ID)
@@ -271,7 +271,7 @@ class AdapterTest {
 
     Link link = Link.create(createSpanContext(LINK_TRACE_ID, LINK_SPAN_ID), attributes);
 
-    return TestSpanData.newBuilder()
+    return TestSpanData.builder()
         .setHasEnded(true)
         .setTraceId(TRACE_ID)
         .setSpanId(SPAN_ID)

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporterTest.java
@@ -79,7 +79,7 @@ class JaegerGrpcSpanExporterTest {
     long startMs = System.currentTimeMillis();
     long endMs = startMs + duration;
     SpanData span =
-        TestSpanData.newBuilder()
+        TestSpanData.builder()
             .setHasEnded(true)
             .setTraceId(TRACE_ID)
             .setSpanId(SPAN_ID)
@@ -97,7 +97,7 @@ class JaegerGrpcSpanExporterTest {
 
     // test
     JaegerGrpcSpanExporter exporter =
-        JaegerGrpcSpanExporter.newBuilder().setServiceName("test").setChannel(channel).build();
+        JaegerGrpcSpanExporter.builder().setServiceName("test").setChannel(channel).build();
     exporter.export(Collections.singletonList(span));
 
     // verify
@@ -158,7 +158,7 @@ class JaegerGrpcSpanExporterTest {
     String endpoint = "127.0.0.1:9090";
     options.put("otel.exporter.jaeger.service.name", serviceName);
     options.put("otel.exporter.jaeger.endpoint", endpoint);
-    JaegerGrpcSpanExporter.Builder config = JaegerGrpcSpanExporter.newBuilder();
+    JaegerGrpcSpanExporter.Builder config = JaegerGrpcSpanExporter.builder();
     JaegerGrpcSpanExporter.Builder spy = Mockito.spy(config);
     spy.fromConfigMap(options, ConfigBuilderTest.getNaming()).build();
     Mockito.verify(spy).setServiceName(serviceName);

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerIntegrationTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerIntegrationTest.java
@@ -59,13 +59,13 @@ class JaegerIntegrationTest {
             .usePlaintext()
             .build();
     SpanExporter jaegerExporter =
-        JaegerGrpcSpanExporter.newBuilder()
+        JaegerGrpcSpanExporter.builder()
             .setServiceName(SERVICE_NAME)
             .setChannel(jaegerChannel)
             .setDeadlineMs(30000)
             .build();
     OpenTelemetrySdk.getTracerManagement()
-        .addSpanProcessor(SimpleSpanProcessor.newBuilder(jaegerExporter).build());
+        .addSpanProcessor(SimpleSpanProcessor.builder(jaegerExporter).build());
   }
 
   private void imitateWork() {

--- a/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingSpanExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporters/logging/LoggingSpanExporterTest.java
@@ -47,7 +47,7 @@ class LoggingSpanExporterTest {
   void returnCode() {
     long epochNanos = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
     SpanData spanData =
-        TestSpanData.newBuilder()
+        TestSpanData.builder()
             .setHasEnded(true)
             .setTraceId(TraceId.fromLongs(1234L, 6789L))
             .setSpanId(SpanId.fromLong(9876L))

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcMetricExporter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcMetricExporter.java
@@ -142,7 +142,7 @@ public final class OtlpGrpcMetricExporter implements MetricExporter {
    *
    * @return a new builder instance for this exporter.
    */
-  public static Builder newBuilder() {
+  public static Builder builder() {
     return new Builder();
   }
 
@@ -155,7 +155,7 @@ public final class OtlpGrpcMetricExporter implements MetricExporter {
    * @since 0.5.0
    */
   public static OtlpGrpcMetricExporter getDefault() {
-    return newBuilder().readEnvironmentVariables().readSystemProperties().build();
+    return builder().readEnvironmentVariables().readSystemProperties().build();
   }
 
   /**

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
@@ -144,7 +144,7 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
    *
    * @return a new builder instance for this exporter.
    */
-  public static Builder newBuilder() {
+  public static Builder builder() {
     return new Builder();
   }
 
@@ -157,7 +157,7 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
    * @since 0.5.0
    */
   public static OtlpGrpcSpanExporter getDefault() {
-    return newBuilder().readEnvironmentVariables().readSystemProperties().build();
+    return builder().readEnvironmentVariables().readSystemProperties().build();
   }
 
   /**

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcMetricExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcMetricExporterTest.java
@@ -75,7 +75,7 @@ class OtlpGrpcMetricExporterTest {
     Map<String, String> options = new HashMap<>();
     options.put("otel.exporter.otlp.metric.timeout", "12");
     options.put("otel.exporter.otlp.insecure", "true");
-    OtlpGrpcMetricExporter.Builder config = OtlpGrpcMetricExporter.newBuilder();
+    OtlpGrpcMetricExporter.Builder config = OtlpGrpcMetricExporter.builder();
     OtlpGrpcMetricExporter.Builder spy = Mockito.spy(config);
     spy.fromConfigMap(options, ConfigBuilderTest.getNaming());
     verify(spy).setDeadlineMs(12);
@@ -86,7 +86,7 @@ class OtlpGrpcMetricExporterTest {
   void testExport() {
     MetricData span = generateFakeMetric();
     OtlpGrpcMetricExporter exporter =
-        OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcMetricExporter.builder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(span)).isSuccess()).isTrue();
       assertThat(fakeCollector.getReceivedMetrics())
@@ -103,7 +103,7 @@ class OtlpGrpcMetricExporterTest {
       spans.add(generateFakeMetric());
     }
     OtlpGrpcMetricExporter exporter =
-        OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcMetricExporter.builder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(spans).isSuccess()).isTrue();
       assertThat(fakeCollector.getReceivedMetrics())
@@ -117,7 +117,7 @@ class OtlpGrpcMetricExporterTest {
   void testExport_DeadlineSetPerExport() {
     int deadlineMs = 1000;
     OtlpGrpcMetricExporter exporter =
-        OtlpGrpcMetricExporter.newBuilder()
+        OtlpGrpcMetricExporter.builder()
             .setChannel(inProcessChannel)
             .setDeadlineMs(deadlineMs)
             .build();
@@ -139,7 +139,7 @@ class OtlpGrpcMetricExporterTest {
   void testExport_AfterShutdown() {
     MetricData span = generateFakeMetric();
     OtlpGrpcMetricExporter exporter =
-        OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcMetricExporter.builder().setChannel(inProcessChannel).build();
     exporter.shutdown();
     assertThat(exporter.export(Collections.singletonList(span)).isSuccess()).isFalse();
   }
@@ -148,7 +148,7 @@ class OtlpGrpcMetricExporterTest {
   void testExport_Cancelled() {
     fakeCollector.setReturnedStatus(Status.CANCELLED);
     OtlpGrpcMetricExporter exporter =
-        OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcMetricExporter.builder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeMetric())).isSuccess())
           .isFalse();
@@ -161,7 +161,7 @@ class OtlpGrpcMetricExporterTest {
   void testExport_DeadlineExceeded() {
     fakeCollector.setReturnedStatus(Status.DEADLINE_EXCEEDED);
     OtlpGrpcMetricExporter exporter =
-        OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcMetricExporter.builder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeMetric())).isSuccess())
           .isFalse();
@@ -174,7 +174,7 @@ class OtlpGrpcMetricExporterTest {
   void testExport_ResourceExhausted() {
     fakeCollector.setReturnedStatus(Status.RESOURCE_EXHAUSTED);
     OtlpGrpcMetricExporter exporter =
-        OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcMetricExporter.builder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeMetric())).isSuccess())
           .isFalse();
@@ -187,7 +187,7 @@ class OtlpGrpcMetricExporterTest {
   void testExport_OutOfRange() {
     fakeCollector.setReturnedStatus(Status.OUT_OF_RANGE);
     OtlpGrpcMetricExporter exporter =
-        OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcMetricExporter.builder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeMetric())).isSuccess())
           .isFalse();
@@ -200,7 +200,7 @@ class OtlpGrpcMetricExporterTest {
   void testExport_Unavailable() {
     fakeCollector.setReturnedStatus(Status.UNAVAILABLE);
     OtlpGrpcMetricExporter exporter =
-        OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcMetricExporter.builder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeMetric())).isSuccess())
           .isFalse();
@@ -213,7 +213,7 @@ class OtlpGrpcMetricExporterTest {
   void testExport_DataLoss() {
     fakeCollector.setReturnedStatus(Status.DATA_LOSS);
     OtlpGrpcMetricExporter exporter =
-        OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcMetricExporter.builder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeMetric())).isSuccess())
           .isFalse();
@@ -226,7 +226,7 @@ class OtlpGrpcMetricExporterTest {
   void testExport_PermissionDenied() {
     fakeCollector.setReturnedStatus(Status.PERMISSION_DENIED);
     OtlpGrpcMetricExporter exporter =
-        OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcMetricExporter.builder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeMetric())).isSuccess())
           .isFalse();
@@ -238,7 +238,7 @@ class OtlpGrpcMetricExporterTest {
   @Test
   void testExport_flush() {
     OtlpGrpcMetricExporter exporter =
-        OtlpGrpcMetricExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcMetricExporter.builder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.flush().isSuccess()).isTrue();
     } finally {

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
@@ -57,7 +57,7 @@ class OtlpGrpcSpanExporterTest {
     options.put(
         "otel.exporter.otlp.span.headers",
         "key=value;key2=value2=;key3=val=ue3; key4 = value4 ;key5= ");
-    OtlpGrpcSpanExporter.Builder config = OtlpGrpcSpanExporter.newBuilder();
+    OtlpGrpcSpanExporter.Builder config = OtlpGrpcSpanExporter.builder();
     OtlpGrpcSpanExporter.Builder spy = Mockito.spy(config);
     spy.fromConfigMap(options, ConfigBuilderTest.getNaming());
     Mockito.verify(spy).setDeadlineMs(12);
@@ -91,7 +91,7 @@ class OtlpGrpcSpanExporterTest {
   void testExport() {
     SpanData span = generateFakeSpan();
     OtlpGrpcSpanExporter exporter =
-        OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcSpanExporter.builder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(span)).isSuccess()).isTrue();
       assertThat(fakeCollector.getReceivedSpans())
@@ -108,7 +108,7 @@ class OtlpGrpcSpanExporterTest {
       spans.add(generateFakeSpan());
     }
     OtlpGrpcSpanExporter exporter =
-        OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcSpanExporter.builder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(spans).isSuccess()).isTrue();
       assertThat(fakeCollector.getReceivedSpans())
@@ -122,7 +122,7 @@ class OtlpGrpcSpanExporterTest {
   void testExport_DeadlineSetPerExport() throws InterruptedException {
     int deadlineMs = 1500;
     OtlpGrpcSpanExporter exporter =
-        OtlpGrpcSpanExporter.newBuilder()
+        OtlpGrpcSpanExporter.builder()
             .setChannel(inProcessChannel)
             .setDeadlineMs(deadlineMs)
             .build();
@@ -140,7 +140,7 @@ class OtlpGrpcSpanExporterTest {
   void testExport_AfterShutdown() {
     SpanData span = generateFakeSpan();
     OtlpGrpcSpanExporter exporter =
-        OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcSpanExporter.builder().setChannel(inProcessChannel).build();
     exporter.shutdown();
     // TODO: This probably should not be retryable because we never restart the channel.
     assertThat(exporter.export(Collections.singletonList(span)).isSuccess()).isFalse();
@@ -150,7 +150,7 @@ class OtlpGrpcSpanExporterTest {
   void testExport_Cancelled() {
     fakeCollector.setReturnedStatus(Status.CANCELLED);
     OtlpGrpcSpanExporter exporter =
-        OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcSpanExporter.builder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeSpan())).isSuccess())
           .isFalse();
@@ -163,7 +163,7 @@ class OtlpGrpcSpanExporterTest {
   void testExport_DeadlineExceeded() {
     fakeCollector.setReturnedStatus(Status.DEADLINE_EXCEEDED);
     OtlpGrpcSpanExporter exporter =
-        OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcSpanExporter.builder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeSpan())).isSuccess())
           .isFalse();
@@ -176,7 +176,7 @@ class OtlpGrpcSpanExporterTest {
   void testExport_ResourceExhausted() {
     fakeCollector.setReturnedStatus(Status.RESOURCE_EXHAUSTED);
     OtlpGrpcSpanExporter exporter =
-        OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcSpanExporter.builder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeSpan())).isSuccess())
           .isFalse();
@@ -189,7 +189,7 @@ class OtlpGrpcSpanExporterTest {
   void testExport_OutOfRange() {
     fakeCollector.setReturnedStatus(Status.OUT_OF_RANGE);
     OtlpGrpcSpanExporter exporter =
-        OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcSpanExporter.builder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeSpan())).isSuccess())
           .isFalse();
@@ -202,7 +202,7 @@ class OtlpGrpcSpanExporterTest {
   void testExport_Unavailable() {
     fakeCollector.setReturnedStatus(Status.UNAVAILABLE);
     OtlpGrpcSpanExporter exporter =
-        OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcSpanExporter.builder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeSpan())).isSuccess())
           .isFalse();
@@ -215,7 +215,7 @@ class OtlpGrpcSpanExporterTest {
   void testExport_DataLoss() {
     fakeCollector.setReturnedStatus(Status.DATA_LOSS);
     OtlpGrpcSpanExporter exporter =
-        OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcSpanExporter.builder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeSpan())).isSuccess())
           .isFalse();
@@ -228,7 +228,7 @@ class OtlpGrpcSpanExporterTest {
   void testExport_PermissionDenied() {
     fakeCollector.setReturnedStatus(Status.PERMISSION_DENIED);
     OtlpGrpcSpanExporter exporter =
-        OtlpGrpcSpanExporter.newBuilder().setChannel(inProcessChannel).build();
+        OtlpGrpcSpanExporter.builder().setChannel(inProcessChannel).build();
     try {
       assertThat(exporter.export(Collections.singletonList(generateFakeSpan())).isSuccess())
           .isFalse();
@@ -241,7 +241,7 @@ class OtlpGrpcSpanExporterTest {
     long duration = TimeUnit.MILLISECONDS.toNanos(900);
     long startNs = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
     long endNs = startNs + duration;
-    return TestSpanData.newBuilder()
+    return TestSpanData.builder()
         .setHasEnded(true)
         .setTraceId(TRACE_ID)
         .setSpanId(SPAN_ID)

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/SpanAdapterTest.java
@@ -52,7 +52,7 @@ class SpanAdapterTest {
   void toProtoSpan() {
     Span span =
         SpanAdapter.toProtoSpan(
-            TestSpanData.newBuilder()
+            TestSpanData.builder()
                 .setHasEnded(true)
                 .setTraceId(TRACE_ID)
                 .setSpanId(SPAN_ID)

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporters/prometheus/PrometheusCollector.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporters/prometheus/PrometheusCollector.java
@@ -35,7 +35,7 @@ public final class PrometheusCollector extends Collector {
    *
    * @return a new builder instance for this exporter.
    */
-  public static Builder newBuilder() {
+  public static Builder builder() {
     return new Builder();
   }
 

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporters/prometheus/PrometheusCollectorTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporters/prometheus/PrometheusCollectorTest.java
@@ -34,7 +34,7 @@ class PrometheusCollectorTest {
   void setUp() {
     MockitoAnnotations.initMocks(this);
     prometheusCollector =
-        PrometheusCollector.newBuilder().setMetricProducer(metricProducer).buildAndRegister();
+        PrometheusCollector.builder().setMetricProducer(metricProducer).buildAndRegister();
   }
 
   @Test

--- a/exporters/zipkin/README.md
+++ b/exporters/zipkin/README.md
@@ -19,7 +19,7 @@ spans will be sent to a Zipkin endpoint running on `localhost`:
 
 ```java
 ZipkinSpanExporter exporter =
-        ZipkinSpanExporter.newBuilder()
+        ZipkinSpanExporter.builder()
             .setEndpoint("http://localhost/api/v2/spans")
             .setServiceName("my-service")
             .build();
@@ -30,7 +30,7 @@ Service name and Endpoint can be also configured via environment variables or sy
 ```java
 // Using environment variables
 ZipkinSpanExporter exporter = 
-        ZipkinSpanExporter.newBuilder()
+        ZipkinSpanExporter.builder()
             .readEnvironmentVariables()
             .build()
 ```
@@ -38,7 +38,7 @@ ZipkinSpanExporter exporter =
 ```java
 // Using system properties
 ZipkinSpanExporter exporter = 
-        ZipkinSpanExporter.newBuilder()
+        ZipkinSpanExporter.builder()
             .readSystemProperties()
             .build()
 ```

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporter.java
@@ -283,7 +283,7 @@ public final class ZipkinSpanExporter implements SpanExporter {
    *
    * @return a new {@link ZipkinSpanExporter}.
    */
-  public static Builder newBuilder() {
+  public static Builder builder() {
     return new Builder();
   }
 

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
@@ -58,7 +58,7 @@ public class ZipkinSpanExporterEndToEndHttpTest {
   public void testExportWithDefaultEncoding() {
 
     ZipkinSpanExporter exporter =
-        ZipkinSpanExporter.newBuilder()
+        ZipkinSpanExporter.builder()
             .setEndpoint(zipkin.httpUrl() + ENDPOINT_V2_SPANS)
             .setServiceName(SERVICE_NAME)
             .build();
@@ -110,7 +110,7 @@ public class ZipkinSpanExporterEndToEndHttpTest {
 
   private static ZipkinSpanExporter buildZipkinExporter(
       String endpoint, Encoding encoding, SpanBytesEncoder encoder) {
-    return ZipkinSpanExporter.newBuilder()
+    return ZipkinSpanExporter.builder()
         .setSender(OkHttpSender.newBuilder().endpoint(endpoint).encoding(encoding).build())
         .setServiceName(SERVICE_NAME)
         .setEncoder(encoder)
@@ -136,7 +136,7 @@ public class ZipkinSpanExporterEndToEndHttpTest {
   }
 
   private static TestSpanData.Builder buildStandardSpan() {
-    return TestSpanData.newBuilder()
+    return TestSpanData.builder()
         .setTraceId(TRACE_ID)
         .setSpanId(SPAN_ID)
         .setParentSpanId(PARENT_SPAN_ID)

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporterTest.java
@@ -143,7 +143,7 @@ class ZipkinSpanExporterTest {
   @Test
   void generateSpan_WithAttributes() {
     Attributes attributes =
-        Attributes.newBuilder()
+        Attributes.builder()
             .setAttribute(stringKey("string"), "string value")
             .setAttribute(booleanKey("boolean"), false)
             .setAttribute(longKey("long"), 9999L)
@@ -282,10 +282,7 @@ class ZipkinSpanExporterTest {
   @Test
   void testCreate() {
     ZipkinSpanExporter exporter =
-        ZipkinSpanExporter.newBuilder()
-            .setSender(mockSender)
-            .setServiceName("myGreatService")
-            .build();
+        ZipkinSpanExporter.builder().setSender(mockSender).setServiceName("myGreatService").build();
 
     assertThat(exporter).isNotNull();
   }
@@ -293,17 +290,14 @@ class ZipkinSpanExporterTest {
   @Test
   void testShutdown() throws IOException {
     ZipkinSpanExporter exporter =
-        ZipkinSpanExporter.newBuilder()
-            .setServiceName("myGreatService")
-            .setSender(mockSender)
-            .build();
+        ZipkinSpanExporter.builder().setServiceName("myGreatService").setSender(mockSender).build();
 
     exporter.shutdown();
     verify(mockSender).close();
   }
 
   private static TestSpanData.Builder buildStandardSpan() {
-    return TestSpanData.newBuilder()
+    return TestSpanData.builder()
         .setTraceId(TRACE_ID)
         .setSpanId(SPAN_ID)
         .setParentSpanId(PARENT_SPAN_ID)
@@ -352,7 +346,7 @@ class ZipkinSpanExporterTest {
     String endpoint = "http://127.0.0.1:9090";
     options.put("otel.exporter.zipkin.service.name", serviceName);
     options.put("otel.exporter.zipkin.endpoint", endpoint);
-    ZipkinSpanExporter.Builder config = ZipkinSpanExporter.newBuilder();
+    ZipkinSpanExporter.Builder config = ZipkinSpanExporter.builder();
     ZipkinSpanExporter.Builder spy = Mockito.spy(config);
     spy.fromConfigMap(options, ConfigBuilderTest.getNaming()).build();
     Mockito.verify(spy).setServiceName(serviceName);

--- a/extensions/trace_utils/src/main/java/io/opentelemetry/extensions/trace/MessageEvent.java
+++ b/extensions/trace_utils/src/main/java/io/opentelemetry/extensions/trace/MessageEvent.java
@@ -66,7 +66,7 @@ public final class MessageEvent {
    */
   public static void record(
       Span span, Type type, long messageId, long uncompressedSize, long compressedSize) {
-    Attributes.Builder attributeBuilder = Attributes.newBuilder();
+    Attributes.Builder attributeBuilder = Attributes.builder();
     attributeBuilder.setAttribute(
         TYPE, type == Type.SENT ? Type.SENT.name() : Type.RECEIVED.name());
     attributeBuilder.setAttribute(ID, messageId);

--- a/integration_tests/src/main/java/io/opentelemetry/SendTraceToJaeger.java
+++ b/integration_tests/src/main/java/io/opentelemetry/SendTraceToJaeger.java
@@ -32,7 +32,7 @@ public class SendTraceToJaeger {
         ManagedChannelBuilder.forAddress(ip, port).usePlaintext().build();
     // Export traces to Jaeger
     JaegerGrpcSpanExporter jaegerExporter =
-        JaegerGrpcSpanExporter.newBuilder()
+        JaegerGrpcSpanExporter.builder()
             .setServiceName("integration test")
             .setChannel(jaegerChannel)
             .setDeadlineMs(30000)
@@ -40,7 +40,7 @@ public class SendTraceToJaeger {
 
     // Set to process the spans by the Jaeger Exporter
     OpenTelemetrySdk.getTracerManagement()
-        .addSpanProcessor(SimpleSpanProcessor.newBuilder(jaegerExporter).build());
+        .addSpanProcessor(SimpleSpanProcessor.builder(jaegerExporter).build());
   }
 
   private void myWonderfulUseCase() {

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanShim.java
@@ -183,7 +183,7 @@ final class SpanShim extends BaseShimObject implements Span {
   }
 
   static Attributes convertToAttributes(Map<String, ?> fields) {
-    Attributes.Builder attributesBuilder = Attributes.newBuilder();
+    Attributes.Builder attributesBuilder = Attributes.builder();
 
     for (Map.Entry<String, ?> entry : fields.entrySet()) {
       String key = entry.getKey();

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
@@ -49,7 +49,7 @@ public class SpanPipelineBenchmark {
   public final void setup() {
     SpanExporter exporter = new NoOpSpanExporter();
     OpenTelemetrySdk.getTracerManagement()
-        .addSpanProcessor(SimpleSpanProcessor.newBuilder(exporter).build());
+        .addSpanProcessor(SimpleSpanProcessor.builder(exporter).build());
   }
 
   @Benchmark

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBenchmark.java
@@ -75,7 +75,7 @@ public class BatchSpanProcessorBenchmark {
   @Setup(Level.Trial)
   public final void setup() {
     SpanExporter exporter = new DelayingSpanExporter(delayMs);
-    processor = BatchSpanProcessor.newBuilder(exporter).build();
+    processor = BatchSpanProcessor.builder(exporter).build();
 
     ImmutableList.Builder<Span> spans = ImmutableList.builderWithExpectedSize(spanCount);
     Tracer tracer = OpenTelemetry.getTracerProvider().get("benchmarkTracer");

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorDroppedSpansBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorDroppedSpansBenchmark.java
@@ -63,7 +63,7 @@ public class BatchSpanProcessorDroppedSpansBenchmark {
     @Setup(Level.Trial)
     public final void setup() {
       SpanExporter exporter = new DelayingSpanExporter();
-      processor = BatchSpanProcessor.newBuilder(exporter).build();
+      processor = BatchSpanProcessor.builder(exporter).build();
 
       tracer = OpenTelemetry.getTracerProvider().get("benchmarkTracer");
     }

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorFlushBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorFlushBenchmark.java
@@ -75,7 +75,7 @@ public class BatchSpanProcessorFlushBenchmark {
   @Setup(Level.Trial)
   public final void setup() {
     SpanExporter exporter = new DelayingSpanExporter(delayMs);
-    processor = BatchSpanProcessor.newBuilder(exporter).build();
+    processor = BatchSpanProcessor.builder(exporter).build();
 
     ImmutableList.Builder<Span> spans = ImmutableList.builderWithExpectedSize(spanCount);
     Tracer tracer = OpenTelemetry.getTracerProvider().get("benchmarkTracer");

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/MultiSpanExporterBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/MultiSpanExporterBenchmark.java
@@ -66,7 +66,7 @@ public class MultiSpanExporterBenchmark {
     TestSpanData[] spans = new TestSpanData[spanCount];
     for (int i = 0; i < spans.length; i++) {
       spans[i] =
-          TestSpanData.newBuilder()
+          TestSpanData.builder()
               .setTraceId(TraceId.fromLongs(1, 1))
               .setSpanId(SpanId.fromLong(1))
               .setName("noop")

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/resources/EnvAutodetectResource.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/resources/EnvAutodetectResource.java
@@ -37,7 +37,7 @@ final class EnvAutodetectResource {
     if (rawEnvAttributes == null) {
       return Attributes.empty();
     } else {
-      Attributes.Builder attrBuilders = Attributes.newBuilder();
+      Attributes.Builder attrBuilders = Attributes.builder();
       String[] rawAttributes = rawEnvAttributes.split(ATTRIBUTE_LIST_SPLITTER, -1);
       for (String rawAttribute : rawAttributes) {
         String[] keyValuePair = rawAttribute.split(ATTRIBUTE_KEY_VALUE_SPLITTER, -1);

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/resources/Resource.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/resources/Resource.java
@@ -47,7 +47,7 @@ public abstract class Resource {
   static {
     TELEMETRY_SDK =
         create(
-            Attributes.newBuilder()
+            Attributes.builder()
                 .setAttribute(SDK_NAME, "opentelemetry")
                 .setAttribute(SDK_LANGUAGE, "java")
                 .setAttribute(SDK_VERSION, readVersion())
@@ -77,7 +77,7 @@ public abstract class Resource {
 
   private static Resource readResourceFromProviders() {
     ResourcesConfig resourcesConfig =
-        ResourcesConfig.newBuilder().readEnvironmentVariables().readSystemProperties().build();
+        ResourcesConfig.builder().readEnvironmentVariables().readSystemProperties().build();
     Resource result = Resource.EMPTY;
     for (ResourceProvider resourceProvider : ServiceLoader.load(ResourceProvider.class)) {
       if (resourcesConfig
@@ -157,7 +157,7 @@ public abstract class Resource {
       return this;
     }
 
-    Attributes.Builder attrBuilder = Attributes.newBuilder();
+    Attributes.Builder attrBuilder = Attributes.builder();
     Merger merger = new Merger(attrBuilder);
     other.getAttributes().forEach(merger);
     this.getAttributes().forEach(merger);

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/resources/ResourcesConfig.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/resources/ResourcesConfig.java
@@ -53,7 +53,7 @@ public abstract class ResourcesConfig {
     return DEFAULT;
   }
 
-  private static final ResourcesConfig DEFAULT = ResourcesConfig.newBuilder().build();
+  private static final ResourcesConfig DEFAULT = ResourcesConfig.builder().build();
 
   /**
    * Returns the fully qualified class names of {@link ResourceProvider} implementations that are
@@ -69,7 +69,7 @@ public abstract class ResourcesConfig {
    *
    * @return a new {@link Builder}.
    */
-  public static Builder newBuilder() {
+  public static Builder builder() {
     return new AutoValue_ResourcesConfig.Builder().setDisabledResourceProviders(ImmutableSet.of());
   }
 

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/resources/ResourceTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/resources/ResourceTest.java
@@ -54,7 +54,7 @@ class ResourceTest {
 
   @Test
   void create_ignoreNull() {
-    Attributes.Builder attributes = Attributes.newBuilder();
+    Attributes.Builder attributes = Attributes.builder();
 
     attributes.setAttribute(stringKey("string"), null);
     Resource resource = Resource.create(attributes.build());
@@ -95,7 +95,7 @@ class ResourceTest {
 
   @Test
   void create_NullEmptyArray() {
-    Attributes.Builder attributes = Attributes.newBuilder();
+    Attributes.Builder attributes = Attributes.builder();
 
     // Empty arrays should be maintained
     attributes.setAttribute(stringArrayKey("stringArrayAttribute"), Collections.emptyList());

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/resources/ResourcesConfigTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/resources/ResourcesConfigTest.java
@@ -32,7 +32,7 @@ class ResourcesConfigTest {
         "otel.java.disabled.resource_providers",
         "com.package.provider.ToDisable1, com.package.provider.ToDisable2");
     ResourcesConfig resourcesConfig =
-        ResourcesConfig.newBuilder().readSystemProperties().readEnvironmentVariables().build();
+        ResourcesConfig.builder().readSystemProperties().readEnvironmentVariables().build();
     assertThat(resourcesConfig.getDisabledResourceProviders())
         .isEqualTo(
             ImmutableSet.of("com.package.provider.ToDisable1", "com.package.provider.ToDisable2"));
@@ -42,14 +42,14 @@ class ResourcesConfigTest {
   void updateResourcesConfig_EmptyDisabledResourceProviders() {
     System.setProperty("otel.java.disabled.resource_providers", "");
     ResourcesConfig resourcesConfig =
-        ResourcesConfig.newBuilder().readSystemProperties().readEnvironmentVariables().build();
+        ResourcesConfig.builder().readSystemProperties().readEnvironmentVariables().build();
     assertThat(resourcesConfig.getDisabledResourceProviders()).isEqualTo(ImmutableSet.of());
   }
 
   @Test
   void updateResourcesConfig_All() {
     ResourcesConfig resourcesConfig =
-        ResourcesConfig.newBuilder()
+        ResourcesConfig.builder()
             .setDisabledResourceProviders(ImmutableSet.of("com.package.provider.ToDisable"))
             .build();
     assertThat(resourcesConfig.getDisabledResourceProviders())

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/AttributesMap.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/AttributesMap.java
@@ -83,7 +83,7 @@ final class AttributesMap implements ReadableAttributes {
 
   @SuppressWarnings("rawtypes")
   ReadableAttributes immutableCopy() {
-    Attributes.Builder builder = Attributes.newBuilder();
+    Attributes.Builder builder = Attributes.builder();
     for (Map.Entry<AttributeKey, Object> entry : data.entrySet()) {
       builder.setAttribute(entry.getKey(), entry.getValue());
     }

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -350,7 +350,7 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
       return attributes;
     }
 
-    Attributes.Builder result = Attributes.newBuilder();
+    Attributes.Builder result = Attributes.builder();
     attributes.forEach(new LimitingAttributeConsumer(limit, result));
     return result.build();
   }
@@ -397,7 +397,7 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
     }
     long timestamp = clock.now();
 
-    Attributes.Builder attributes = Attributes.newBuilder();
+    Attributes.Builder attributes = Attributes.builder();
     attributes.setAttribute(
         SemanticAttributes.EXCEPTION_TYPE, exception.getClass().getCanonicalName());
     if (exception.getMessage() != null) {

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
@@ -93,7 +93,7 @@ public abstract class TraceConfig {
     return DEFAULT;
   }
 
-  private static final TraceConfig DEFAULT = TraceConfig.newBuilder().build();
+  private static final TraceConfig DEFAULT = TraceConfig.builder().build();
 
   /**
    * Returns the global default {@code Sampler} which is used when constructing a new {@code Span}.
@@ -154,7 +154,7 @@ public abstract class TraceConfig {
    *
    * @return a new {@link Builder}.
    */
-  private static Builder newBuilder() {
+  private static Builder builder() {
     return new AutoValue_TraceConfig.Builder()
         .setSampler(DEFAULT_SAMPLER)
         .setMaxNumberOfAttributes(DEFAULT_SPAN_MAX_NUM_ATTRIBUTES)

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -295,7 +295,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
    * @return a new {@link BatchSpanProcessor}.
    * @throws NullPointerException if the {@code spanExporter} is {@code null}.
    */
-  public static Builder newBuilder(SpanExporter spanExporter) {
+  public static Builder builder(SpanExporter spanExporter) {
     return new Builder(spanExporter);
   }
 

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
@@ -110,7 +110,7 @@ public final class SimpleSpanProcessor implements SpanProcessor {
    * @return a new {@link SimpleSpanProcessor}.
    * @throws NullPointerException if the {@code spanExporter} is {@code null}.
    */
-  public static Builder newBuilder(SpanExporter spanExporter) {
+  public static Builder builder(SpanExporter spanExporter) {
     return new Builder(spanExporter);
   }
 

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -86,7 +86,7 @@ class RecordEventsReadableSpanTest {
     attributes.put(longKey("MyLongAttributeKey"), 123L);
     attributes.put(booleanKey("MyBooleanAttributeKey"), false);
     Attributes.Builder builder =
-        Attributes.newBuilder()
+        Attributes.builder()
             .setAttribute("MySingleStringAttributeKey", "MySingleStringAttributeValue");
     for (Map.Entry<AttributeKey, Object> entry : attributes.entrySet()) {
       builder.setAttribute(entry.getKey(), entry.getValue());
@@ -611,7 +611,7 @@ class RecordEventsReadableSpanTest {
     assertThat(event.getEpochNanos()).isEqualTo(timestamp);
     assertThat(event.getAttributes())
         .isEqualTo(
-            Attributes.newBuilder()
+            Attributes.builder()
                 .setAttribute(SemanticAttributes.EXCEPTION_TYPE, "java.lang.IllegalStateException")
                 .setAttribute(SemanticAttributes.EXCEPTION_MESSAGE, "there was an exception")
                 .setAttribute(SemanticAttributes.EXCEPTION_STACKTRACE, stacktrace)
@@ -674,7 +674,7 @@ class RecordEventsReadableSpanTest {
     assertThat(event.getEpochNanos()).isEqualTo(timestamp);
     assertThat(event.getAttributes())
         .isEqualTo(
-            Attributes.newBuilder()
+            Attributes.builder()
                 .setAttribute("key1", "this is an additional attribute")
                 .setAttribute("exception.type", "java.lang.IllegalStateException")
                 .setAttribute("exception.message", "this is a precedence attribute")

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
@@ -42,7 +42,7 @@ public final class TestUtils {
    * @return A SpanData instance.
    */
   public static SpanData makeBasicSpan() {
-    return TestSpanData.newBuilder()
+    return TestSpanData.builder()
         .setHasEnded(true)
         .setTraceId(TraceId.getInvalid())
         .setSpanId(SpanId.getInvalid())

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -124,7 +124,7 @@ class TracerSdkTest {
   @Test
   void stressTest_withBatchSpanProcessor() {
     CountingSpanExporter countingSpanExporter = new CountingSpanExporter();
-    SpanProcessor spanProcessor = BatchSpanProcessor.newBuilder(countingSpanExporter).build();
+    SpanProcessor spanProcessor = BatchSpanProcessor.builder(countingSpanExporter).build();
     TracerSdkProvider tracerSdkProvider = TracerSdkProvider.builder().build();
     tracerSdkProvider.addSpanProcessor(spanProcessor);
     TracerSdk tracer =

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -93,7 +93,7 @@ class BatchSpanProcessorTest {
     options.put("otel.bsp.export.timeout.millis", "78");
     options.put("otel.bsp.export.sampled", "false");
     BatchSpanProcessor.Builder config =
-        BatchSpanProcessor.newBuilder(new WaitingSpanExporter(0, CompletableResultCode.ofSuccess()))
+        BatchSpanProcessor.builder(new WaitingSpanExporter(0, CompletableResultCode.ofSuccess()))
             .fromConfigMap(options, ConfigTester.getNamingDot());
     assertThat(config.getScheduleDelayMillis()).isEqualTo(12);
     assertThat(config.getMaxQueueSize()).isEqualTo(34);
@@ -105,7 +105,7 @@ class BatchSpanProcessorTest {
   @Test
   void configTest_EmptyOptions() {
     BatchSpanProcessor.Builder config =
-        BatchSpanProcessor.newBuilder(new WaitingSpanExporter(0, CompletableResultCode.ofSuccess()))
+        BatchSpanProcessor.builder(new WaitingSpanExporter(0, CompletableResultCode.ofSuccess()))
             .fromConfigMap(Collections.emptyMap(), ConfigTester.getNamingDot());
     assertThat(config.getScheduleDelayMillis())
         .isEqualTo(BatchSpanProcessor.Builder.DEFAULT_SCHEDULE_DELAY_MILLIS);
@@ -122,7 +122,7 @@ class BatchSpanProcessorTest {
   @Test
   void startEndRequirements() {
     BatchSpanProcessor spansProcessor =
-        BatchSpanProcessor.newBuilder(new WaitingSpanExporter(0, CompletableResultCode.ofSuccess()))
+        BatchSpanProcessor.builder(new WaitingSpanExporter(0, CompletableResultCode.ofSuccess()))
             .build();
     assertThat(spansProcessor.isStartRequired()).isFalse();
     assertThat(spansProcessor.isEndRequired()).isTrue();
@@ -133,7 +133,7 @@ class BatchSpanProcessorTest {
     WaitingSpanExporter waitingSpanExporter =
         new WaitingSpanExporter(2, CompletableResultCode.ofSuccess());
     tracerSdkFactory.addSpanProcessor(
-        BatchSpanProcessor.newBuilder(waitingSpanExporter)
+        BatchSpanProcessor.builder(waitingSpanExporter)
             .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
             .build());
 
@@ -147,7 +147,7 @@ class BatchSpanProcessorTest {
   void exportMoreSpansThanTheBufferSize() {
     CompletableSpanExporter spanExporter = new CompletableSpanExporter();
     BatchSpanProcessor batchSpanProcessor =
-        BatchSpanProcessor.newBuilder(spanExporter)
+        BatchSpanProcessor.builder(spanExporter)
             .setMaxQueueSize(6)
             .setMaxExportBatchSize(2)
             .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
@@ -182,7 +182,7 @@ class BatchSpanProcessorTest {
     WaitingSpanExporter waitingSpanExporter =
         new WaitingSpanExporter(100, CompletableResultCode.ofSuccess(), 1);
     BatchSpanProcessor batchSpanProcessor =
-        BatchSpanProcessor.newBuilder(waitingSpanExporter)
+        BatchSpanProcessor.builder(waitingSpanExporter)
             .setMaxQueueSize(10_000)
             // Force flush should send all spans, make sure the number of spans we check here is
             // not divisible by the batch size.
@@ -211,7 +211,7 @@ class BatchSpanProcessorTest {
     WaitingSpanExporter waitingSpanExporter2 =
         new WaitingSpanExporter(2, CompletableResultCode.ofSuccess());
     tracerSdkFactory.addSpanProcessor(
-        BatchSpanProcessor.newBuilder(
+        BatchSpanProcessor.builder(
                 MultiSpanExporter.create(Arrays.asList(waitingSpanExporter, waitingSpanExporter2)))
             .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
             .build());
@@ -230,7 +230,7 @@ class BatchSpanProcessorTest {
     WaitingSpanExporter waitingSpanExporter =
         new WaitingSpanExporter(maxQueuedSpans, CompletableResultCode.ofSuccess());
     BatchSpanProcessor batchSpanProcessor =
-        BatchSpanProcessor.newBuilder(
+        BatchSpanProcessor.builder(
                 MultiSpanExporter.create(Arrays.asList(blockingSpanExporter, waitingSpanExporter)))
             .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
             .setMaxQueueSize(maxQueuedSpans)
@@ -295,7 +295,7 @@ class BatchSpanProcessorTest {
         .when(mockServiceHandler)
         .export(ArgumentMatchers.anyList());
     tracerSdkFactory.addSpanProcessor(
-        BatchSpanProcessor.newBuilder(
+        BatchSpanProcessor.builder(
                 MultiSpanExporter.create(Arrays.asList(mockServiceHandler, waitingSpanExporter)))
             .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
             .build());
@@ -341,7 +341,7 @@ class BatchSpanProcessorTest {
 
     int exporterTimeoutMillis = 100;
     BatchSpanProcessor batchSpanProcessor =
-        BatchSpanProcessor.newBuilder(waitingSpanExporter)
+        BatchSpanProcessor.builder(waitingSpanExporter)
             .setExporterTimeoutMillis(exporterTimeoutMillis)
             .setScheduleDelayMillis(1)
             .setMaxQueueSize(1)
@@ -363,7 +363,7 @@ class BatchSpanProcessorTest {
     WaitingSpanExporter waitingSpanExporter =
         new WaitingSpanExporter(1, CompletableResultCode.ofSuccess());
     BatchSpanProcessor batchSpanProcessor =
-        BatchSpanProcessor.newBuilder(waitingSpanExporter)
+        BatchSpanProcessor.builder(waitingSpanExporter)
             .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
             .build();
     tracerSdkFactory.addSpanProcessor(batchSpanProcessor);
@@ -386,7 +386,7 @@ class BatchSpanProcessorTest {
     // TODO(bdrutu): Fix this when Sampler return RECORD_ONLY option.
     /*
     tracerSdkFactory.addSpanProcessor(
-        BatchSpanProcessor.newBuilder(waitingSpanExporter)
+        BatchSpanProcessor.builder(waitingSpanExporter)
             .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
             .reportOnlySampled(false)
             .build());
@@ -402,7 +402,7 @@ class BatchSpanProcessorTest {
     // TODO(bdrutu): Fix this when Sampler return RECORD_ONLY option.
     /*
     tracerSdkFactory.addSpanProcessor(
-        BatchSpanProcessor.newBuilder(waitingSpanExporter)
+        BatchSpanProcessor.builder(waitingSpanExporter)
             .reportOnlySampled(true)
             .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
             .build());
@@ -422,7 +422,7 @@ class BatchSpanProcessorTest {
     // Set the export delay to large value, in order to confirm the #flush() below works
 
     tracerSdkFactory.addSpanProcessor(
-        BatchSpanProcessor.newBuilder(waitingSpanExporter).setScheduleDelayMillis(10_000).build());
+        BatchSpanProcessor.builder(waitingSpanExporter).setScheduleDelayMillis(10_000).build());
 
     ReadableSpan span2 = createSampledEndedSpan(SPAN_NAME_2);
 
@@ -437,7 +437,7 @@ class BatchSpanProcessorTest {
   @Test
   void shutdownPropagatesSuccess() {
     when(mockServiceHandler.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
-    BatchSpanProcessor processor = BatchSpanProcessor.newBuilder(mockServiceHandler).build();
+    BatchSpanProcessor processor = BatchSpanProcessor.builder(mockServiceHandler).build();
     CompletableResultCode result = processor.shutdown();
     result.join(1, TimeUnit.SECONDS);
     assertThat(result.isSuccess()).isTrue();
@@ -446,7 +446,7 @@ class BatchSpanProcessorTest {
   @Test
   void shutdownPropagatesFailure() {
     when(mockServiceHandler.shutdown()).thenReturn(CompletableResultCode.ofFailure());
-    BatchSpanProcessor processor = BatchSpanProcessor.newBuilder(mockServiceHandler).build();
+    BatchSpanProcessor processor = BatchSpanProcessor.builder(mockServiceHandler).build();
     CompletableResultCode result = processor.shutdown();
     result.join(1, TimeUnit.SECONDS);
     assertThat(result.isSuccess()).isFalse();

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
@@ -63,7 +63,7 @@ class SimpleSpanProcessorTest {
 
   @BeforeEach
   void setUp() {
-    simpleSampledSpansProcessor = SimpleSpanProcessor.newBuilder(spanExporter).build();
+    simpleSampledSpansProcessor = SimpleSpanProcessor.builder(spanExporter).build();
   }
 
   @Test
@@ -71,7 +71,7 @@ class SimpleSpanProcessorTest {
     Map<String, String> options = new HashMap<>();
     options.put("otel.ssp.export.sampled", "false");
     SimpleSpanProcessor.Builder config =
-        SimpleSpanProcessor.newBuilder(spanExporter)
+        SimpleSpanProcessor.builder(spanExporter)
             .fromConfigMap(options, ConfigTester.getNamingDot());
     assertThat(config.getExportOnlySampled()).isEqualTo(false);
   }
@@ -79,7 +79,7 @@ class SimpleSpanProcessorTest {
   @Test
   void configTest_EmptyOptions() {
     SimpleSpanProcessor.Builder config =
-        SimpleSpanProcessor.newBuilder(spanExporter)
+        SimpleSpanProcessor.builder(spanExporter)
             .fromConfigMap(Collections.emptyMap(), ConfigTester.getNamingDot());
     assertThat(config.getExportOnlySampled())
         .isEqualTo(SimpleSpanProcessor.Builder.DEFAULT_EXPORT_ONLY_SAMPLED);
@@ -113,7 +113,7 @@ class SimpleSpanProcessorTest {
     when(readableSpan.toSpanData())
         .thenReturn(TestUtils.makeBasicSpan())
         .thenThrow(new RuntimeException());
-    SimpleSpanProcessor simpleSpanProcessor = SimpleSpanProcessor.newBuilder(spanExporter).build();
+    SimpleSpanProcessor simpleSpanProcessor = SimpleSpanProcessor.builder(spanExporter).build();
     simpleSpanProcessor.onEnd(readableSpan);
     verifyNoInteractions(spanExporter);
   }
@@ -124,7 +124,7 @@ class SimpleSpanProcessorTest {
     when(readableSpan.toSpanData())
         .thenReturn(TestUtils.makeBasicSpan())
         .thenThrow(new RuntimeException());
-    SimpleSpanProcessor simpleSpanProcessor = SimpleSpanProcessor.newBuilder(spanExporter).build();
+    SimpleSpanProcessor simpleSpanProcessor = SimpleSpanProcessor.builder(spanExporter).build();
     simpleSpanProcessor.onEnd(readableSpan);
     verify(spanExporter).export(Collections.singletonList(TestUtils.makeBasicSpan()));
   }
@@ -135,7 +135,7 @@ class SimpleSpanProcessorTest {
         new WaitingSpanExporter(1, CompletableResultCode.ofSuccess());
 
     tracerSdkFactory.addSpanProcessor(
-        BatchSpanProcessor.newBuilder(waitingSpanExporter)
+        BatchSpanProcessor.builder(waitingSpanExporter)
             .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
             .build());
 
@@ -164,7 +164,7 @@ class SimpleSpanProcessorTest {
     // TODO(bdrutu): Fix this when Sampler return RECORD_ONLY option.
     /*
     tracer.addSpanProcessor(
-        BatchSpanProcessor.newBuilder(waitingSpanExporter)
+        BatchSpanProcessor.builder(waitingSpanExporter)
             .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
             .reportOnlySampled(false)
             .build());
@@ -202,7 +202,7 @@ class SimpleSpanProcessorTest {
   void buildFromProperties_defaultSampledFlag() {
     Properties properties = new Properties();
     SimpleSpanProcessor spanProcessor =
-        SimpleSpanProcessor.newBuilder(spanExporter).readProperties(properties).build();
+        SimpleSpanProcessor.builder(spanExporter).readProperties(properties).build();
 
     when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
     spanProcessor.onEnd(readableSpan);
@@ -214,7 +214,7 @@ class SimpleSpanProcessorTest {
     Properties properties = new Properties();
     properties.setProperty("otel.ssp.export.sampled", "true");
     SimpleSpanProcessor spanProcessor =
-        SimpleSpanProcessor.newBuilder(spanExporter).readProperties(properties).build();
+        SimpleSpanProcessor.builder(spanExporter).readProperties(properties).build();
 
     when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
     spanProcessor.onEnd(readableSpan);
@@ -226,7 +226,7 @@ class SimpleSpanProcessorTest {
     Properties properties = new Properties();
     properties.setProperty("otel.ssp.export.sampled", "false");
     SimpleSpanProcessor spanProcessor =
-        SimpleSpanProcessor.newBuilder(spanExporter).readProperties(properties).build();
+        SimpleSpanProcessor.builder(spanExporter).readProperties(properties).build();
     SpanData spanData = TestUtils.makeBasicSpan();
 
     when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);

--- a/sdk_extensions/async_processor/src/main/java/io/opentelemetry/sdk/extensions/trace/export/DisruptorAsyncSpanProcessor.java
+++ b/sdk_extensions/async_processor/src/main/java/io/opentelemetry/sdk/extensions/trace/export/DisruptorAsyncSpanProcessor.java
@@ -98,7 +98,7 @@ public final class DisruptorAsyncSpanProcessor implements SpanProcessor {
    * @return a new {@link DisruptorAsyncSpanProcessor}.
    * @throws NullPointerException if the {@code spanProcessor} is {@code null}.
    */
-  public static Builder newBuilder(SpanProcessor spanProcessor) {
+  public static Builder builder(SpanProcessor spanProcessor) {
     return new Builder(Objects.requireNonNull(spanProcessor));
   }
 

--- a/sdk_extensions/async_processor/src/test/java/io/opentelemetry/sdk/extensions/trace/export/DisruptorAsyncSpanProcessorTest.java
+++ b/sdk_extensions/async_processor/src/test/java/io/opentelemetry/sdk/extensions/trace/export/DisruptorAsyncSpanProcessorTest.java
@@ -114,7 +114,7 @@ class DisruptorAsyncSpanProcessorTest {
   void incrementOnce() {
     IncrementSpanProcessor incrementSpanProcessor = new IncrementSpanProcessor(REQUIRED, REQUIRED);
     DisruptorAsyncSpanProcessor disruptorAsyncSpanProcessor =
-        DisruptorAsyncSpanProcessor.newBuilder(incrementSpanProcessor).build();
+        DisruptorAsyncSpanProcessor.builder(incrementSpanProcessor).build();
     assertThat(disruptorAsyncSpanProcessor.isStartRequired()).isTrue();
     assertThat(disruptorAsyncSpanProcessor.isEndRequired()).isTrue();
     assertThat(incrementSpanProcessor.getCounterOnStart()).isEqualTo(0);
@@ -134,7 +134,7 @@ class DisruptorAsyncSpanProcessorTest {
     IncrementSpanProcessor incrementSpanProcessor =
         new IncrementSpanProcessor(NOT_REQUIRED, REQUIRED);
     DisruptorAsyncSpanProcessor disruptorAsyncSpanProcessor =
-        DisruptorAsyncSpanProcessor.newBuilder(incrementSpanProcessor).build();
+        DisruptorAsyncSpanProcessor.builder(incrementSpanProcessor).build();
     assertThat(disruptorAsyncSpanProcessor.isStartRequired()).isFalse();
     assertThat(disruptorAsyncSpanProcessor.isEndRequired()).isTrue();
     assertThat(incrementSpanProcessor.getCounterOnStart()).isEqualTo(0);
@@ -154,7 +154,7 @@ class DisruptorAsyncSpanProcessorTest {
     IncrementSpanProcessor incrementSpanProcessor =
         new IncrementSpanProcessor(REQUIRED, NOT_REQUIRED);
     DisruptorAsyncSpanProcessor disruptorAsyncSpanProcessor =
-        DisruptorAsyncSpanProcessor.newBuilder(incrementSpanProcessor).build();
+        DisruptorAsyncSpanProcessor.builder(incrementSpanProcessor).build();
     assertThat(disruptorAsyncSpanProcessor.isStartRequired()).isTrue();
     assertThat(disruptorAsyncSpanProcessor.isEndRequired()).isFalse();
     assertThat(incrementSpanProcessor.getCounterOnStart()).isEqualTo(0);
@@ -173,7 +173,7 @@ class DisruptorAsyncSpanProcessorTest {
   void shutdownIsCalledOnlyOnce() {
     IncrementSpanProcessor incrementSpanProcessor = new IncrementSpanProcessor(REQUIRED, REQUIRED);
     DisruptorAsyncSpanProcessor disruptorAsyncSpanProcessor =
-        DisruptorAsyncSpanProcessor.newBuilder(incrementSpanProcessor).build();
+        DisruptorAsyncSpanProcessor.builder(incrementSpanProcessor).build();
     disruptorAsyncSpanProcessor.shutdown().join(10, TimeUnit.SECONDS);
     disruptorAsyncSpanProcessor.shutdown().join(10, TimeUnit.SECONDS);
     disruptorAsyncSpanProcessor.shutdown().join(10, TimeUnit.SECONDS);
@@ -186,7 +186,7 @@ class DisruptorAsyncSpanProcessorTest {
   void incrementAfterShutdown() {
     IncrementSpanProcessor incrementSpanProcessor = new IncrementSpanProcessor(REQUIRED, REQUIRED);
     DisruptorAsyncSpanProcessor disruptorAsyncSpanProcessor =
-        DisruptorAsyncSpanProcessor.newBuilder(incrementSpanProcessor).build();
+        DisruptorAsyncSpanProcessor.builder(incrementSpanProcessor).build();
     disruptorAsyncSpanProcessor.shutdown().join(10, TimeUnit.SECONDS);
     disruptorAsyncSpanProcessor.onStart(readWriteSpan);
     disruptorAsyncSpanProcessor.onEnd(readableSpan);
@@ -203,7 +203,7 @@ class DisruptorAsyncSpanProcessorTest {
     final int tenK = 10000;
     IncrementSpanProcessor incrementSpanProcessor = new IncrementSpanProcessor(REQUIRED, REQUIRED);
     DisruptorAsyncSpanProcessor disruptorAsyncSpanProcessor =
-        DisruptorAsyncSpanProcessor.newBuilder(incrementSpanProcessor).build();
+        DisruptorAsyncSpanProcessor.builder(incrementSpanProcessor).build();
     for (int i = 1; i <= tenK; i++) {
       disruptorAsyncSpanProcessor.onStart(readWriteSpan);
       disruptorAsyncSpanProcessor.onEnd(readableSpan);
@@ -223,7 +223,7 @@ class DisruptorAsyncSpanProcessorTest {
     IncrementSpanProcessor incrementSpanProcessor1 = new IncrementSpanProcessor(REQUIRED, REQUIRED);
     IncrementSpanProcessor incrementSpanProcessor2 = new IncrementSpanProcessor(REQUIRED, REQUIRED);
     DisruptorAsyncSpanProcessor disruptorAsyncSpanProcessor =
-        DisruptorAsyncSpanProcessor.newBuilder(
+        DisruptorAsyncSpanProcessor.builder(
                 MultiSpanProcessor.create(
                     Arrays.asList(incrementSpanProcessor1, incrementSpanProcessor2)))
             .build();
@@ -245,7 +245,7 @@ class DisruptorAsyncSpanProcessorTest {
     final int tenK = 10000;
     IncrementSpanProcessor incrementSpanProcessor = new IncrementSpanProcessor(REQUIRED, REQUIRED);
     DisruptorAsyncSpanProcessor disruptorAsyncSpanProcessor =
-        DisruptorAsyncSpanProcessor.newBuilder(incrementSpanProcessor).build();
+        DisruptorAsyncSpanProcessor.builder(incrementSpanProcessor).build();
     for (int i = 1; i <= tenK; i++) {
       disruptorAsyncSpanProcessor.onStart(readWriteSpan);
       disruptorAsyncSpanProcessor.onEnd(readableSpan);
@@ -276,7 +276,7 @@ class DisruptorAsyncSpanProcessorTest {
     options.put("otel.disruptor.sleeping.time", "78");
     IncrementSpanProcessor incrementSpanProcessor = new IncrementSpanProcessor(REQUIRED, REQUIRED);
     DisruptorAsyncSpanProcessor.Builder config =
-        DisruptorAsyncSpanProcessor.newBuilder(incrementSpanProcessor);
+        DisruptorAsyncSpanProcessor.builder(incrementSpanProcessor);
     DisruptorAsyncSpanProcessor.Builder spy = Mockito.spy(config);
     spy.fromConfigMap(options, ConfigBuilderTest.getNaming());
     Mockito.verify(spy).setBlocking(false);

--- a/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/BeanstalkResource.java
+++ b/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/BeanstalkResource.java
@@ -53,7 +53,7 @@ public class BeanstalkResource extends ResourceProvider {
       return Attributes.empty();
     }
 
-    Attributes.Builder attrBuilders = Attributes.newBuilder();
+    Attributes.Builder attrBuilders = Attributes.builder();
     try (JsonParser parser = JSON_FACTORY.createParser(configFile)) {
       parser.nextToken();
 

--- a/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/Ec2Resource.java
+++ b/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/Ec2Resource.java
@@ -148,7 +148,7 @@ public class Ec2Resource extends ResourceProvider {
 
     String hostname = fetchHostname(token);
 
-    Attributes.Builder attrBuilders = Attributes.newBuilder();
+    Attributes.Builder attrBuilders = Attributes.builder();
     attrBuilders.setAttribute(
         ResourceAttributes.CLOUD_PROVIDER, AwsResourceConstants.cloudProvider());
 

--- a/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/EcsResource.java
+++ b/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/EcsResource.java
@@ -50,7 +50,7 @@ public class EcsResource extends ResourceProvider {
       return Attributes.empty();
     }
 
-    Attributes.Builder attrBuilders = Attributes.newBuilder();
+    Attributes.Builder attrBuilders = Attributes.builder();
     attrBuilders.setAttribute(
         ResourceAttributes.CLOUD_PROVIDER, AwsResourceConstants.cloudProvider());
     try {

--- a/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/EksResource.java
+++ b/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/resource/EksResource.java
@@ -60,7 +60,7 @@ public class EksResource extends ResourceProvider {
       return Attributes.empty();
     }
 
-    Attributes.Builder attrBuilders = Attributes.newBuilder();
+    Attributes.Builder attrBuilders = Attributes.builder();
 
     String clusterName = getClusterName();
     if (!Strings.isNullOrEmpty(clusterName)) {

--- a/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/Ec2ResourceTest.java
+++ b/sdk_extensions/aws_v1_support/src/test/java/io/opentelemetry/sdk/extensions/trace/aws/resource/Ec2ResourceTest.java
@@ -69,7 +69,7 @@ public class Ec2ResourceTest {
     stubFor(any(urlPathEqualTo("/latest/meta-data/hostname")).willReturn(ok("ec2-1-2-3-4")));
 
     Attributes attributes = populator.getAttributes();
-    Attributes.Builder expectedAttrBuilders = Attributes.newBuilder();
+    Attributes.Builder expectedAttrBuilders = Attributes.builder();
 
     expectedAttrBuilders.setAttribute(ResourceAttributes.CLOUD_PROVIDER, "aws");
     expectedAttrBuilders.setAttribute(ResourceAttributes.HOST_ID, "i-1234567890abcdef0");
@@ -104,7 +104,7 @@ public class Ec2ResourceTest {
     Attributes attributes = populator.getAttributes();
 
     Attributes.Builder expectedAttrBuilders =
-        Attributes.newBuilder()
+        Attributes.builder()
             .setAttribute(ResourceAttributes.CLOUD_PROVIDER, "aws")
             .setAttribute(ResourceAttributes.HOST_ID, "i-1234567890abcdef0")
             .setAttribute(ResourceAttributes.CLOUD_ZONE, "us-west-2b")

--- a/sdk_extensions/jaeger_remote_sampler/README.md
+++ b/sdk_extensions/jaeger_remote_sampler/README.md
@@ -8,7 +8,7 @@ The sampler configuration is received from collector's gRPC endpoint.
 The following example shows initialization and installation of the sampler:
 
 ```java
-Builder remoteSamplerBuilder = JaegerRemoteSampler.newBuilder()
+Builder remoteSamplerBuilder = JaegerRemoteSampler.builder()
     .setChannel(grpcChannel)
     .setServiceName("my-service");
 TraceConfig traceConfig = provider.getActiveTraceConfig()

--- a/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/JaegerRemoteSampler.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/JaegerRemoteSampler.java
@@ -116,7 +116,7 @@ public class JaegerRemoteSampler implements Sampler {
     return this.sampler;
   }
 
-  public static Builder newBuilder() {
+  public static Builder builder() {
     return new Builder();
   }
 

--- a/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/JaegerRemoteSamplerIntegrationTest.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/JaegerRemoteSamplerIntegrationTest.java
@@ -43,7 +43,7 @@ class JaegerRemoteSamplerIntegrationTest {
     String jaegerHost =
         String.format("127.0.0.1:%d", jaegerContainer.getMappedPort(COLLECTOR_PORT));
     final JaegerRemoteSampler remoteSampler =
-        JaegerRemoteSampler.newBuilder()
+        JaegerRemoteSampler.builder()
             .setChannel(ManagedChannelBuilder.forTarget(jaegerHost).usePlaintext().build())
             .setServiceName(SERVICE_NAME)
             .build();
@@ -60,7 +60,7 @@ class JaegerRemoteSamplerIntegrationTest {
     String jaegerHost =
         String.format("127.0.0.1:%d", jaegerContainer.getMappedPort(COLLECTOR_PORT));
     final JaegerRemoteSampler remoteSampler =
-        JaegerRemoteSampler.newBuilder()
+        JaegerRemoteSampler.builder()
             .setChannel(ManagedChannelBuilder.forTarget(jaegerHost).usePlaintext().build())
             .setServiceName(SERVICE_NAME_RATE_LIMITING)
             .build();

--- a/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/JaegerRemoteSamplerTest.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/JaegerRemoteSamplerTest.java
@@ -90,7 +90,7 @@ class JaegerRemoteSamplerTest {
         ArgumentCaptor.forClass(Sampling.SamplingStrategyParameters.class);
 
     JaegerRemoteSampler sampler =
-        JaegerRemoteSampler.newBuilder()
+        JaegerRemoteSampler.builder()
             .setChannel(inProcessChannel)
             .setServiceName(SERVICE_NAME)
             .build();
@@ -108,7 +108,7 @@ class JaegerRemoteSamplerTest {
   @Test
   void description() {
     JaegerRemoteSampler sampler =
-        JaegerRemoteSampler.newBuilder()
+        JaegerRemoteSampler.builder()
             .setChannel(inProcessChannel)
             .setServiceName(SERVICE_NAME)
             .build();

--- a/sdk_extensions/logging/src/main/java/io/opentelemetry/sdk/logging/data/LogRecord.java
+++ b/sdk_extensions/logging/src/main/java/io/opentelemetry/sdk/logging/data/LogRecord.java
@@ -90,7 +90,7 @@ public abstract class LogRecord {
     private String severityText;
     private String name;
     private AnyValue body = AnyValue.stringAnyValue("");
-    private final Attributes.Builder attributeBuilder = Attributes.newBuilder();
+    private final Attributes.Builder attributeBuilder = Attributes.builder();
 
     public Builder setUnixTimeNano(long timestamp) {
       this.timeUnixNano = timestamp;

--- a/sdk_extensions/logging/src/main/java/io/opentelemetry/sdk/logging/export/BatchLogProcessor.java
+++ b/sdk_extensions/logging/src/main/java/io/opentelemetry/sdk/logging/export/BatchLogProcessor.java
@@ -240,7 +240,7 @@ public class BatchLogProcessor implements LogProcessor {
       this.logExporter = Objects.requireNonNull(logExporter, "Exporter argument can not be null");
     }
 
-    public Builder newBuilder(LogExporter logExporter) {
+    public Builder builder(LogExporter logExporter) {
       return new Builder(logExporter);
     }
 

--- a/sdk_extensions/resources/src/main/java/io/opentelemetry/sdk/extensions/resources/OsResource.java
+++ b/sdk_extensions/resources/src/main/java/io/opentelemetry/sdk/extensions/resources/OsResource.java
@@ -27,7 +27,7 @@ public class OsResource extends ResourceProvider {
       return Attributes.empty();
     }
 
-    Attributes.Builder attributes = Attributes.newBuilder();
+    Attributes.Builder attributes = Attributes.builder();
 
     String osName = getOs(os);
     if (osName != null) {

--- a/sdk_extensions/resources/src/main/java/io/opentelemetry/sdk/extensions/resources/ProcessResource.java
+++ b/sdk_extensions/resources/src/main/java/io/opentelemetry/sdk/extensions/resources/ProcessResource.java
@@ -16,7 +16,7 @@ import java.lang.management.RuntimeMXBean;
 public class ProcessResource extends ResourceProvider {
   @Override
   protected Attributes getAttributes() {
-    Attributes.Builder attributes = Attributes.newBuilder();
+    Attributes.Builder attributes = Attributes.builder();
 
     // TODO(anuraaga): Use reflection to get more stable values on Java 9+
     RuntimeMXBean runtime = ManagementFactory.getRuntimeMXBean();

--- a/sdk_extensions/tracing_incubator/src/main/java/io/opentelemetry/sdk/extensions/incubator/trace/data/DelegatingSpanData.java
+++ b/sdk_extensions/tracing_incubator/src/main/java/io/opentelemetry/sdk/extensions/incubator/trace/data/DelegatingSpanData.java
@@ -30,7 +30,7 @@ import java.util.List;
  *     super(delegate);
  *     String clientType = ClientConfig.parseUserAgent(
  *       delegate.getAttributes().get(SemanticAttributes.HTTP_USER_AGENT).getStringValue());
- *     Attributes.Builder newAttributes = Attributes.newBuilder(delegate.getAttributes());
+ *     Attributes.Builder newAttributes = Attributes.builder(delegate.getAttributes());
  *     newAttributes.setAttribute("client_type", clientType);
  *     attributes = newAttributes.build();
  *   }

--- a/sdk_extensions/tracing_incubator/src/main/java/io/opentelemetry/sdk/extensions/incubator/trace/data/SpanDataBuilder.java
+++ b/sdk_extensions/tracing_incubator/src/main/java/io/opentelemetry/sdk/extensions/incubator/trace/data/SpanDataBuilder.java
@@ -22,10 +22,10 @@ import javax.annotation.concurrent.Immutable;
  * <pre>{@code
  * String clientType = ClientConfig.parseUserAgent(
  *   data.getAttributes().get(SemanticAttributes.HTTP_USER_AGENT).getStringValue());
- * Attributes newAttributes = Attributes.newBuilder(data.getAttributes())
+ * Attributes newAttributes = Attributes.builder(data.getAttributes())
  *   .setAttribute("client_type", clientType)
  *   .build();
- * data = io.opentelemetry.sdk.extensions.incubator.trace.data.SpanData.newBuilder(data)
+ * data = io.opentelemetry.sdk.extensions.incubator.trace.data.SpanData.builder(data)
  *   .setAttributes(newAttributes)
  *   .build();
  * exporter.export(data);
@@ -42,7 +42,7 @@ public abstract class SpanDataBuilder implements SpanData {
    * Returns a {@link SpanDataBuilder.Builder} populated with the information in the provided {@link
    * SpanData}.
    */
-  public static SpanDataBuilder.Builder newBuilder(SpanData spanData) {
+  public static SpanDataBuilder.Builder builder(SpanData spanData) {
     return new AutoValue_SpanDataBuilder.Builder()
         .setTraceId(spanData.getTraceId())
         .setSpanId(spanData.getSpanId())

--- a/sdk_extensions/tracing_incubator/src/test/java/io/opentelemetry/sdk/extensions/incubator/trace/data/DelegatingSpanDataTest.java
+++ b/sdk_extensions/tracing_incubator/src/test/java/io/opentelemetry/sdk/extensions/incubator/trace/data/DelegatingSpanDataTest.java
@@ -44,7 +44,7 @@ class DelegatingSpanDataTest {
       } else {
         clientType = "unknown";
       }
-      Attributes.Builder newAttributes = Attributes.newBuilder();
+      Attributes.Builder newAttributes = Attributes.builder();
       delegate.getAttributes().forEach(newAttributes::setAttribute);
       newAttributes.setAttribute("client_type", clientType);
       attributes = newAttributes.build();
@@ -101,7 +101,7 @@ class DelegatingSpanDataTest {
   }
 
   private static TestSpanData.Builder createBasicSpanBuilder() {
-    return TestSpanData.newBuilder()
+    return TestSpanData.builder()
         .setHasEnded(true)
         .setSpanId(SpanId.getInvalid())
         .setTraceId(TraceId.getInvalid())

--- a/sdk_extensions/tracing_incubator/src/test/java/io/opentelemetry/sdk/extensions/incubator/trace/data/SpanDataBuilderTest.java
+++ b/sdk_extensions/tracing_incubator/src/test/java/io/opentelemetry/sdk/extensions/incubator/trace/data/SpanDataBuilderTest.java
@@ -22,7 +22,7 @@ class SpanDataBuilderTest {
   private static final String SPAN_ID = "0000000000def456";
 
   private static final TestSpanData TEST_SPAN_DATA =
-      TestSpanData.newBuilder()
+      TestSpanData.builder()
           .setHasEnded(true)
           .setTraceId(TRACE_ID)
           .setSpanId(SPAN_ID)
@@ -32,17 +32,14 @@ class SpanDataBuilderTest {
           .setKind(Span.Kind.SERVER)
           .setStatus(Status.error())
           .setAttributes(
-              Attributes.newBuilder()
-                  .setAttribute("cat", "meow")
-                  .setAttribute("dog", "bark")
-                  .build())
+              Attributes.builder().setAttribute("cat", "meow").setAttribute("dog", "bark").build())
           .setTotalRecordedEvents(1000)
           .setTotalRecordedLinks(2300)
           .build();
 
   @Test
   void noOp() {
-    assertThat(SpanDataBuilder.newBuilder(TEST_SPAN_DATA).build())
+    assertThat(SpanDataBuilder.builder(TEST_SPAN_DATA).build())
         .isEqualToComparingFieldByField(TEST_SPAN_DATA);
   }
 
@@ -50,7 +47,7 @@ class SpanDataBuilderTest {
   void modifySpanData() {
     assertThat(TEST_SPAN_DATA.getStatus()).isEqualTo(Status.error());
     SpanData modified =
-        SpanDataBuilder.newBuilder(TEST_SPAN_DATA)
+        SpanDataBuilder.builder(TEST_SPAN_DATA)
             .setStatus(Status.create(StatusCanonicalCode.ERROR, "ABORTED"))
             .build();
     assertThat(modified.getStatus()).isEqualTo(Status.create(StatusCanonicalCode.ERROR, "ABORTED"));
@@ -58,14 +55,14 @@ class SpanDataBuilderTest {
 
   @Test
   void equalsHashCode() {
-    assertThat(SpanDataBuilder.newBuilder(TEST_SPAN_DATA).build()).isEqualTo(TEST_SPAN_DATA);
+    assertThat(SpanDataBuilder.builder(TEST_SPAN_DATA).build()).isEqualTo(TEST_SPAN_DATA);
     EqualsTester tester = new EqualsTester();
     tester
         .addEqualityGroup(
-            SpanDataBuilder.newBuilder(TEST_SPAN_DATA).build(),
-            SpanDataBuilder.newBuilder(TEST_SPAN_DATA).build())
+            SpanDataBuilder.builder(TEST_SPAN_DATA).build(),
+            SpanDataBuilder.builder(TEST_SPAN_DATA).build())
         .addEqualityGroup(
-            SpanDataBuilder.newBuilder(TEST_SPAN_DATA)
+            SpanDataBuilder.builder(TEST_SPAN_DATA)
                 .setStatus(Status.create(StatusCanonicalCode.ERROR, "ABORTED"))
                 .build());
     tester.testEquals();

--- a/sdk_extensions/zpages/src/jmh/java/io/opentelemetry/sdk/extensions/zpages/TracezDataAggregatorBenchmark.java
+++ b/sdk_extensions/zpages/src/jmh/java/io/opentelemetry/sdk/extensions/zpages/TracezDataAggregatorBenchmark.java
@@ -31,7 +31,7 @@ public class TracezDataAggregatorBenchmark {
   private static final String latencySpan = "LATENCY_SPAN";
   private static final String errorSpan = "ERROR_SPAN";
   private final Tracer tracer = OpenTelemetry.getTracer("TracezDataAggregatorBenchmark");
-  private final TracezSpanProcessor spanProcessor = TracezSpanProcessor.newBuilder().build();
+  private final TracezSpanProcessor spanProcessor = TracezSpanProcessor.builder().build();
   private final TracezDataAggregator dataAggregator = new TracezDataAggregator(spanProcessor);
 
   @Param({"1", "10", "1000", "1000000"})

--- a/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/TracezSpanProcessor.java
+++ b/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/TracezSpanProcessor.java
@@ -125,7 +125,7 @@ final class TracezSpanProcessor implements SpanProcessor {
    *
    * @return a new {@link TracezSpanProcessor}.
    */
-  public static Builder newBuilder() {
+  public static Builder builder() {
     return new Builder();
   }
 

--- a/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/ZPageServer.java
+++ b/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/ZPageServer.java
@@ -55,7 +55,7 @@ public final class ZPageServer {
   private static final int HTTPSERVER_STOP_DELAY = 1;
   // Tracez SpanProcessor and DataAggregator for constructing TracezZPageHandler
   private static final TracezSpanProcessor tracezSpanProcessor =
-      TracezSpanProcessor.newBuilder().build();
+      TracezSpanProcessor.builder().build();
   private static final TracezDataAggregator tracezDataAggregator =
       new TracezDataAggregator(tracezSpanProcessor);
   private static final TracerSdkManagement TRACER_SDK_MANAGEMENT =

--- a/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TracezDataAggregatorTest.java
+++ b/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TracezDataAggregatorTest.java
@@ -28,7 +28,7 @@ public final class TracezDataAggregatorTest {
   private final TracerSdkProvider tracerSdkProvider =
       TracerSdkProvider.builder().setClock(testClock).build();
   private final Tracer tracer = tracerSdkProvider.get("TracezDataAggregatorTest");
-  private final TracezSpanProcessor spanProcessor = TracezSpanProcessor.newBuilder().build();
+  private final TracezSpanProcessor spanProcessor = TracezSpanProcessor.builder().build();
   private final TracezDataAggregator dataAggregator = new TracezDataAggregator(spanProcessor);
 
   @BeforeEach

--- a/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TracezSpanProcessorTest.java
+++ b/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TracezSpanProcessorTest.java
@@ -54,7 +54,7 @@ class TracezSpanProcessorTest {
 
   @Test
   void onStart_sampledSpan_inCache() {
-    TracezSpanProcessor spanProcessor = TracezSpanProcessor.newBuilder().build();
+    TracezSpanProcessor spanProcessor = TracezSpanProcessor.builder().build();
     /* Return a sampled span, which should be added to the running cache by default */
     when(readWriteSpan.getSpanContext()).thenReturn(SAMPLED_SPAN_CONTEXT);
     spanProcessor.onStart(readWriteSpan);
@@ -63,7 +63,7 @@ class TracezSpanProcessorTest {
 
   @Test
   void onEnd_sampledSpan_inCache() {
-    TracezSpanProcessor spanProcessor = TracezSpanProcessor.newBuilder().build();
+    TracezSpanProcessor spanProcessor = TracezSpanProcessor.builder().build();
     /* Return a sampled span, which should be added to the completed cache upon ending */
     when(readWriteSpan.getSpanContext()).thenReturn(SAMPLED_SPAN_CONTEXT);
     when(readWriteSpan.getName()).thenReturn(SPAN_NAME);
@@ -79,7 +79,7 @@ class TracezSpanProcessorTest {
 
   @Test
   void onStart_notSampledSpan_inCache() {
-    TracezSpanProcessor spanProcessor = TracezSpanProcessor.newBuilder().build();
+    TracezSpanProcessor spanProcessor = TracezSpanProcessor.builder().build();
     /* Return a non-sampled span, which should not be added to the running cache by default */
     when(readWriteSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
     spanProcessor.onStart(readWriteSpan);
@@ -88,7 +88,7 @@ class TracezSpanProcessorTest {
 
   @Test
   void onEnd_notSampledSpan_notInCache() {
-    TracezSpanProcessor spanProcessor = TracezSpanProcessor.newBuilder().build();
+    TracezSpanProcessor spanProcessor = TracezSpanProcessor.builder().build();
     /* Return a non-sampled span, which should not be added to the running cache by default */
     when(readWriteSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
     when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
@@ -103,7 +103,7 @@ class TracezSpanProcessorTest {
     Properties properties = new Properties();
     properties.setProperty("otel.zpages.export.sampled", "true");
     TracezSpanProcessor spanProcessor =
-        TracezSpanProcessor.newBuilder().readProperties(properties).build();
+        TracezSpanProcessor.builder().readProperties(properties).build();
 
     /* Return a non-sampled span, which should not be added to the completed cache */
     when(readWriteSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
@@ -120,7 +120,7 @@ class TracezSpanProcessorTest {
     Properties properties = new Properties();
     properties.setProperty("otel.zpages.export.sampled", "false");
     TracezSpanProcessor spanProcessor =
-        TracezSpanProcessor.newBuilder().readProperties(properties).build();
+        TracezSpanProcessor.builder().readProperties(properties).build();
 
     /* Return a non-sampled span, which should be added to the caches */
     when(readWriteSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);

--- a/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TracezZPageHandlerTest.java
+++ b/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TracezZPageHandlerTest.java
@@ -41,7 +41,7 @@ class TracezZPageHandlerTest {
   private final TracerSdkProvider tracerSdkProvider =
       TracerSdkProvider.builder().setClock(testClock).build();
   private final Tracer tracer = tracerSdkProvider.get("TracezZPageHandlerTest");
-  private final TracezSpanProcessor spanProcessor = TracezSpanProcessor.newBuilder().build();
+  private final TracezSpanProcessor spanProcessor = TracezSpanProcessor.builder().build();
   private final TracezDataAggregator dataAggregator = new TracezDataAggregator(spanProcessor);
   private final Map<String, String> emptyQueryMap = ImmutableMap.of();
 

--- a/testing_internal/src/main/java/io/opentelemetry/sdk/trace/TestSpanData.java
+++ b/testing_internal/src/main/java/io/opentelemetry/sdk/trace/TestSpanData.java
@@ -34,7 +34,7 @@ public abstract class TestSpanData implements SpanData {
    * @return a new Builder.
    * @since 0.1.0
    */
-  public static Builder newBuilder() {
+  public static Builder builder() {
     return new AutoValue_TestSpanData.Builder()
         .setParentSpanId(SpanId.getInvalid())
         .setInstrumentationLibraryInfo(InstrumentationLibraryInfo.getEmpty())

--- a/testing_internal/src/test/java/io/opentelemetry/sdk/trace/TestSpanDataTest.java
+++ b/testing_internal/src/test/java/io/opentelemetry/sdk/trace/TestSpanDataTest.java
@@ -105,7 +105,7 @@ class TestSpanDataTest {
   }
 
   private static TestSpanData.Builder createBasicSpanBuilder() {
-    return TestSpanData.newBuilder()
+    return TestSpanData.builder()
         .setHasEnded(true)
         .setSpanId(SpanId.getInvalid())
         .setTraceId(TraceId.getInvalid())


### PR DESCRIPTION
We currently are not consistent with whether we use `newBuilder` or `builder` for a builder factory. This consolidates on `builder`, similar to Guava and slightly recommended by AutoValue.