### PR TITLE
Remove DefaultSpan from public API.

### DIFF
--- a/api/src/jmh/java/io/opentelemetry/trace/propagation/HttpTraceContextInjectBenchmark.java
+++ b/api/src/jmh/java/io/opentelemetry/trace/propagation/HttpTraceContextInjectBenchmark.java
@@ -75,7 +75,7 @@ public class HttpTraceContextInjectBenchmark {
   private static List<Context> createContexts(List<SpanContext> spanContexts) {
     List<Context> contexts = new ArrayList<>();
     for (SpanContext context : spanContexts) {
-      contexts.add(TracingContextUtils.withSpan(Span.getPropagated(context), Context.root()));
+      contexts.add(TracingContextUtils.withSpan(Span.wrap(context), Context.root()));
     }
     return contexts;
   }

--- a/api/src/jmh/java/io/opentelemetry/trace/propagation/HttpTraceContextInjectBenchmark.java
+++ b/api/src/jmh/java/io/opentelemetry/trace/propagation/HttpTraceContextInjectBenchmark.java
@@ -7,7 +7,7 @@ package io.opentelemetry.trace.propagation;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator.Setter;
-import io.opentelemetry.trace.DefaultSpan;
+import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceState;
@@ -75,7 +75,7 @@ public class HttpTraceContextInjectBenchmark {
   private static List<Context> createContexts(List<SpanContext> spanContexts) {
     List<Context> contexts = new ArrayList<>();
     for (SpanContext context : spanContexts) {
-      contexts.add(TracingContextUtils.withSpan(DefaultSpan.create(context), Context.root()));
+      contexts.add(TracingContextUtils.withSpan(Span.getPropagated(context), Context.root()));
     }
     return contexts;
   }

--- a/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
@@ -64,9 +64,7 @@ public final class DefaultTracer implements Tracer {
         spanContext = TracingContextUtils.getCurrentSpan().getContext();
       }
 
-      return spanContext != null && !SpanContext.getInvalid().equals(spanContext)
-          ? new DefaultSpan(spanContext)
-          : DefaultSpan.getInvalid();
+      return Span.getPropagated(spanContext);
     }
 
     @Override

--- a/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
@@ -59,7 +59,7 @@ public final class DefaultTracer implements Tracer {
         spanContext = TracingContextUtils.getCurrentSpan().getContext();
       }
 
-      return Span.getPropagated(spanContext);
+      return Span.wrap(spanContext);
     }
 
     @Override

--- a/api/src/main/java/io/opentelemetry/trace/PropagatedSpan.java
+++ b/api/src/main/java/io/opentelemetry/trace/PropagatedSpan.java
@@ -13,39 +13,16 @@ import javax.annotation.concurrent.Immutable;
  * The {@code DefaultSpan} is the default {@link Span} that is used when no {@code Span}
  * implementation is available. All operations are no-op except context propagation.
  *
- * <p>Used also to stop tracing, see {@link Tracer#withSpan}.
- *
  * @since 0.1.0
  */
 @Immutable
-public final class DefaultSpan implements Span {
+final class PropagatedSpan implements Span {
 
-  private static final DefaultSpan INVALID = new DefaultSpan(SpanContext.getInvalid());
-
-  /**
-   * Returns a {@link DefaultSpan} with an invalid {@link SpanContext}.
-   *
-   * @return a {@code DefaultSpan} with an invalid {@code SpanContext}.
-   * @since 0.1.0
-   */
-  public static Span getInvalid() {
-    return INVALID;
-  }
-
-  /**
-   * Creates an instance of this class with the {@link SpanContext}.
-   *
-   * @param spanContext the {@code SpanContext}.
-   * @return a {@link DefaultSpan}.
-   * @since 0.1.0
-   */
-  public static Span create(SpanContext spanContext) {
-    return new DefaultSpan(spanContext);
-  }
+  static final PropagatedSpan INVALID = new PropagatedSpan(SpanContext.getInvalid());
 
   private final SpanContext spanContext;
 
-  DefaultSpan(SpanContext spanContext) {
+  PropagatedSpan(SpanContext spanContext) {
     this.spanContext = spanContext;
   }
 

--- a/api/src/main/java/io/opentelemetry/trace/PropagatedSpan.java
+++ b/api/src/main/java/io/opentelemetry/trace/PropagatedSpan.java
@@ -12,7 +12,6 @@ import javax.annotation.concurrent.Immutable;
 /**
  * The {@code DefaultSpan} is the default {@link Span} that is used when no {@code Span}
  * implementation is available. All operations are no-op except context propagation.
- *
  */
 @Immutable
 final class PropagatedSpan implements Span {

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -24,6 +24,26 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface Span {
 
   /**
+   * Returns an invalid {@link Span}. An invalid {@link Span} is used when tracing is disabled,
+   * usually because there is no OpenTelemetry SDK installed.
+   */
+  static Span getInvalid() {
+    return PropagatedSpan.INVALID;
+  }
+
+  /**
+   * Returns a non-recording {@link Span} that holds the provided {@link SpanContext} but has no
+   * functionality. It will not be exported and all tracing operations are no-op, but it can be used
+   * to propagate a valid {@link SpanContext} downstream.
+   */
+  static Span getPropagated(SpanContext spanContext) {
+    if (spanContext == null || !spanContext.isValid()) {
+      return getInvalid();
+    }
+    return new PropagatedSpan(spanContext);
+  }
+
+  /**
    * Type of span. Can be used to specify additional relationships between spans in addition to a
    * parent/child relationship.
    *
@@ -303,6 +323,15 @@ public interface Span {
    * @since 0.1.0
    */
   boolean isRecording();
+
+  /**
+   * Returns whether this {@link Span} is valid.
+   *
+   * @see Span#getInvalid()
+   */
+  default boolean isValid() {
+    return getContext().isValid();
+  }
 
   /**
    * {@link Builder} is used to construct {@link Span} instances which define arbitrary scopes of

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -34,7 +34,7 @@ public interface Span {
    * functionality. It will not be exported and all tracing operations are no-op, but it can be used
    * to propagate a valid {@link SpanContext} downstream.
    */
-  static Span getPropagated(SpanContext spanContext) {
+  static Span wrap(SpanContext spanContext) {
     if (spanContext == null || !spanContext.isValid()) {
       return getInvalid();
     }
@@ -285,15 +285,6 @@ public interface Span {
    * @return {@code true} if this {@code Span} records tracing events.
    */
   boolean isRecording();
-
-  /**
-   * Returns whether this {@link Span} is valid.
-   *
-   * @see Span#getInvalid()
-   */
-  default boolean isValid() {
-    return getContext().isValid();
-  }
 
   /**
    * {@link Builder} is used to construct {@link Span} instances which define arbitrary scopes of

--- a/api/src/main/java/io/opentelemetry/trace/Tracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/Tracer.java
@@ -81,7 +81,8 @@ public interface Tracer {
    *
    * <p>Supports try-with-resource idiom.
    *
-   * <p>Can be called with {@link DefaultSpan} to enter a scope of code where tracing is stopped.
+   * <p>Can be called with {@code Span.wrapWithNoOp(span.getContext())} to enter a scope of code
+   * where tracing is stopped.
    *
    * <p>Example of usage:
    *

--- a/api/src/main/java/io/opentelemetry/trace/Tracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/Tracer.java
@@ -81,7 +81,7 @@ public interface Tracer {
    *
    * <p>Supports try-with-resource idiom.
    *
-   * <p>Can be called with {@code Span.wrapWithNoOp(span.getContext())} to enter a scope of code
+   * <p>Can be called with {@code Span.getPropagated(span.getContext())} to enter a scope of code
    * where tracing is stopped.
    *
    * <p>Example of usage:

--- a/api/src/main/java/io/opentelemetry/trace/TracingContextUtils.java
+++ b/api/src/main/java/io/opentelemetry/trace/TracingContextUtils.java
@@ -54,7 +54,7 @@ public final class TracingContextUtils {
    */
   public static Span getSpan(Context context) {
     Span span = context.getValue(CONTEXT_SPAN_KEY);
-    return span == null ? DefaultSpan.getInvalid() : span;
+    return span == null ? Span.getInvalid() : span;
   }
 
   /**

--- a/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
@@ -149,7 +149,7 @@ public class HttpTraceContext implements TextMapPropagator {
       return context;
     }
 
-    return TracingContextUtils.withSpan(Span.getPropagated(spanContext), context);
+    return TracingContextUtils.withSpan(Span.wrap(spanContext), context);
   }
 
   private static <C> SpanContext extractImpl(C carrier, Getter<C> getter) {

--- a/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
@@ -10,7 +10,7 @@ import static io.opentelemetry.internal.Utils.checkArgument;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.internal.TemporaryBuffers;
-import io.opentelemetry.trace.DefaultSpan;
+import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
@@ -149,7 +149,7 @@ public class HttpTraceContext implements TextMapPropagator {
       return context;
     }
 
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return TracingContextUtils.withSpan(Span.getPropagated(spanContext), context);
   }
 
   private static <C> SpanContext extractImpl(C carrier, Getter<C> getter) {

--- a/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
@@ -31,16 +31,16 @@ class DefaultTracerTest {
 
   @Test
   void defaultGetCurrentSpan() {
-    assertThat(defaultTracer.getCurrentSpan().isValid()).isFalse();
+    assertThat(defaultTracer.getCurrentSpan().getContext().isValid()).isFalse();
   }
 
   @Test
   void getCurrentSpan_WithSpan() {
-    assertThat(defaultTracer.getCurrentSpan().isValid()).isFalse();
+    assertThat(defaultTracer.getCurrentSpan().getContext().isValid()).isFalse();
     try (Scope ws = defaultTracer.withSpan(Span.getInvalid())) {
-      assertThat(defaultTracer.getCurrentSpan().isValid()).isFalse();
+      assertThat(defaultTracer.getCurrentSpan().getContext().isValid()).isFalse();
     }
-    assertThat(defaultTracer.getCurrentSpan().isValid()).isFalse();
+    assertThat(defaultTracer.getCurrentSpan().getContext().isValid()).isFalse();
   }
 
   @Test
@@ -50,7 +50,7 @@ class DefaultTracerTest {
 
   @Test
   void defaultSpanBuilderWithName() {
-    assertThat(defaultTracer.spanBuilder(SPAN_NAME).startSpan().isValid()).isFalse();
+    assertThat(defaultTracer.spanBuilder(SPAN_NAME).startSpan().getContext().isValid()).isFalse();
   }
 
   @Test
@@ -65,7 +65,7 @@ class DefaultTracerTest {
         assertThat(defaultTracer.getCurrentSpan()).isEqualTo(span);
       }
     }
-    assertThat(defaultTracer.getCurrentSpan().isValid()).isFalse();
+    assertThat(defaultTracer.getCurrentSpan().getContext().isValid()).isFalse();
   }
 
   @Test
@@ -73,15 +73,14 @@ class DefaultTracerTest {
     Span span =
         defaultTracer
             .spanBuilder(SPAN_NAME)
-            .setParent(
-                TracingContextUtils.withSpan(Span.getPropagated(spanContext), Context.root()))
+            .setParent(TracingContextUtils.withSpan(Span.wrap(spanContext), Context.root()))
             .startSpan();
     assertThat(span.getContext()).isSameAs(spanContext);
   }
 
   @Test
   void testSpanContextPropagation() {
-    Span parent = Span.getPropagated(spanContext);
+    Span parent = Span.wrap(spanContext);
 
     Span span =
         defaultTracer
@@ -106,8 +105,7 @@ class DefaultTracerTest {
 
   @Test
   void testSpanContextPropagation_fromContext() {
-    Context context =
-        TracingContextUtils.withSpan(Span.getPropagated(spanContext), Context.current());
+    Context context = TracingContextUtils.withSpan(Span.wrap(spanContext), Context.current());
 
     Span span = defaultTracer.spanBuilder(SPAN_NAME).setParent(context).startSpan();
     assertThat(span.getContext()).isSameAs(spanContext);
@@ -115,8 +113,7 @@ class DefaultTracerTest {
 
   @Test
   void testSpanContextPropagation_fromContextAfterNoParent() {
-    Context context =
-        TracingContextUtils.withSpan(Span.getPropagated(spanContext), Context.current());
+    Context context = TracingContextUtils.withSpan(Span.wrap(spanContext), Context.current());
 
     Span span = defaultTracer.spanBuilder(SPAN_NAME).setNoParent().setParent(context).startSpan();
     assertThat(span.getContext()).isSameAs(spanContext);
@@ -124,8 +121,7 @@ class DefaultTracerTest {
 
   @Test
   void testSpanContextPropagation_fromContextThenNoParent() {
-    Context context =
-        TracingContextUtils.withSpan(Span.getPropagated(spanContext), Context.current());
+    Context context = TracingContextUtils.withSpan(Span.wrap(spanContext), Context.current());
 
     Span span = defaultTracer.spanBuilder(SPAN_NAME).setParent(context).setNoParent().startSpan();
     assertThat(span.getContext()).isEqualTo(SpanContext.getInvalid());
@@ -133,7 +129,7 @@ class DefaultTracerTest {
 
   @Test
   void testSpanContextPropagationCurrentSpan() {
-    Span parent = Span.getPropagated(spanContext);
+    Span parent = Span.wrap(spanContext);
     try (Scope scope = defaultTracer.withSpan(parent)) {
       Span span = defaultTracer.spanBuilder(SPAN_NAME).startSpan();
       assertThat(span.getContext()).isSameAs(spanContext);
@@ -142,8 +138,7 @@ class DefaultTracerTest {
 
   @Test
   void testSpanContextPropagationCurrentSpanContext() {
-    Context context =
-        TracingContextUtils.withSpan(Span.getPropagated(spanContext), Context.current());
+    Context context = TracingContextUtils.withSpan(Span.wrap(spanContext), Context.current());
     try (Scope scope = context.makeCurrent()) {
       Span span = defaultTracer.spanBuilder(SPAN_NAME).startSpan();
       assertThat(span.getContext()).isSameAs(spanContext);

--- a/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
@@ -31,16 +31,16 @@ class DefaultTracerTest {
 
   @Test
   void defaultGetCurrentSpan() {
-    assertThat(defaultTracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(defaultTracer.getCurrentSpan().isValid()).isFalse();
   }
 
   @Test
   void getCurrentSpan_WithSpan() {
-    assertThat(defaultTracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
-    try (Scope ws = defaultTracer.withSpan(DefaultSpan.getInvalid())) {
-      assertThat(defaultTracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(defaultTracer.getCurrentSpan().isValid()).isFalse();
+    try (Scope ws = defaultTracer.withSpan(Span.getInvalid())) {
+      assertThat(defaultTracer.getCurrentSpan().isValid()).isFalse();
     }
-    assertThat(defaultTracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(defaultTracer.getCurrentSpan().isValid()).isFalse();
   }
 
   @Test
@@ -50,7 +50,7 @@ class DefaultTracerTest {
 
   @Test
   void defaultSpanBuilderWithName() {
-    assertThat(defaultTracer.spanBuilder(SPAN_NAME).startSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(defaultTracer.spanBuilder(SPAN_NAME).startSpan().isValid()).isFalse();
   }
 
   @Test
@@ -65,7 +65,7 @@ class DefaultTracerTest {
         assertThat(defaultTracer.getCurrentSpan()).isEqualTo(span);
       }
     }
-    assertThat(defaultTracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(defaultTracer.getCurrentSpan().isValid()).isFalse();
   }
 
   @Test
@@ -74,14 +74,14 @@ class DefaultTracerTest {
         defaultTracer
             .spanBuilder(SPAN_NAME)
             .setParent(
-                TracingContextUtils.withSpan(DefaultSpan.create(spanContext), Context.root()))
+                TracingContextUtils.withSpan(Span.getPropagated(spanContext), Context.root()))
             .startSpan();
     assertThat(span.getContext()).isSameAs(spanContext);
   }
 
   @Test
   void testSpanContextPropagation() {
-    DefaultSpan parent = new DefaultSpan(spanContext);
+    Span parent = Span.getPropagated(spanContext);
 
     Span span =
         defaultTracer
@@ -106,7 +106,8 @@ class DefaultTracerTest {
 
   @Test
   void testSpanContextPropagation_fromContext() {
-    Context context = TracingContextUtils.withSpan(new DefaultSpan(spanContext), Context.current());
+    Context context =
+        TracingContextUtils.withSpan(Span.getPropagated(spanContext), Context.current());
 
     Span span = defaultTracer.spanBuilder(SPAN_NAME).setParent(context).startSpan();
     assertThat(span.getContext()).isSameAs(spanContext);
@@ -114,7 +115,8 @@ class DefaultTracerTest {
 
   @Test
   void testSpanContextPropagation_fromContextAfterNoParent() {
-    Context context = TracingContextUtils.withSpan(new DefaultSpan(spanContext), Context.current());
+    Context context =
+        TracingContextUtils.withSpan(Span.getPropagated(spanContext), Context.current());
 
     Span span = defaultTracer.spanBuilder(SPAN_NAME).setNoParent().setParent(context).startSpan();
     assertThat(span.getContext()).isSameAs(spanContext);
@@ -122,7 +124,8 @@ class DefaultTracerTest {
 
   @Test
   void testSpanContextPropagation_fromContextThenNoParent() {
-    Context context = TracingContextUtils.withSpan(new DefaultSpan(spanContext), Context.current());
+    Context context =
+        TracingContextUtils.withSpan(Span.getPropagated(spanContext), Context.current());
 
     Span span = defaultTracer.spanBuilder(SPAN_NAME).setParent(context).setNoParent().startSpan();
     assertThat(span.getContext()).isEqualTo(SpanContext.getInvalid());
@@ -130,7 +133,7 @@ class DefaultTracerTest {
 
   @Test
   void testSpanContextPropagationCurrentSpan() {
-    DefaultSpan parent = new DefaultSpan(spanContext);
+    Span parent = Span.getPropagated(spanContext);
     try (Scope scope = defaultTracer.withSpan(parent)) {
       Span span = defaultTracer.spanBuilder(SPAN_NAME).startSpan();
       assertThat(span.getContext()).isSameAs(spanContext);
@@ -140,7 +143,7 @@ class DefaultTracerTest {
   @Test
   void testSpanContextPropagationCurrentSpanContext() {
     Context context =
-        TracingContextUtils.withSpan(DefaultSpan.create(spanContext), Context.current());
+        TracingContextUtils.withSpan(Span.getPropagated(spanContext), Context.current());
     try (Scope scope = context.makeCurrent()) {
       Span span = defaultTracer.spanBuilder(SPAN_NAME).startSpan();
       assertThat(span.getContext()).isSameAs(spanContext);

--- a/api/src/test/java/io/opentelemetry/trace/PropagatedSpanTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/PropagatedSpanTest.java
@@ -17,19 +17,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.common.Attributes;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link DefaultSpan}. */
-class DefaultSpanTest {
+class PropagatedSpanTest {
 
   @Test
   void hasInvalidContextAndDefaultSpanOptions() {
-    SpanContext context = DefaultSpan.getInvalid().getContext();
+    SpanContext context = Span.getInvalid().getContext();
     assertThat(context.getTraceFlags()).isEqualTo(TraceFlags.getDefault());
     assertThat(context.getTraceState()).isEqualTo(TraceState.getDefault());
   }
 
   @Test
   void doNotCrash() {
-    Span span = DefaultSpan.getInvalid();
+    Span span = Span.getInvalid();
     span.setAttribute(stringKey("MyStringAttributeKey"), "MyStringAttributeValue");
     span.setAttribute(booleanKey("MyBooleanAttributeKey"), true);
     span.setAttribute(longKey("MyLongAttributeKey"), 123L);
@@ -56,7 +55,7 @@ class DefaultSpanTest {
 
   @Test
   void defaultSpan_ToString() {
-    Span span = DefaultSpan.getInvalid();
+    Span span = Span.getInvalid();
     assertThat(span.toString()).isEqualTo("DefaultSpan");
   }
 }

--- a/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
@@ -22,18 +22,18 @@ class SpanBuilderTest {
   void doNotCrash_NoopImplementation() {
     Span.Builder spanBuilder = tracer.spanBuilder("MySpanName");
     spanBuilder.setSpanKind(Kind.SERVER);
-    spanBuilder.setParent(TracingContextUtils.withSpan(DefaultSpan.create(null), Context.root()));
+    spanBuilder.setParent(TracingContextUtils.withSpan(Span.getPropagated(null), Context.root()));
     spanBuilder.setParent(Context.root());
     spanBuilder.setNoParent();
-    spanBuilder.addLink(DefaultSpan.getInvalid().getContext());
-    spanBuilder.addLink(DefaultSpan.getInvalid().getContext(), Attributes.empty());
+    spanBuilder.addLink(Span.getInvalid().getContext());
+    spanBuilder.addLink(Span.getInvalid().getContext(), Attributes.empty());
     spanBuilder.setAttribute("key", "value");
     spanBuilder.setAttribute("key", 12345L);
     spanBuilder.setAttribute("key", .12345);
     spanBuilder.setAttribute("key", true);
     spanBuilder.setAttribute(stringKey("key"), "value");
     spanBuilder.setStartTimestamp(12345L);
-    assertThat(spanBuilder.startSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(spanBuilder.startSpan().isValid()).isFalse();
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
@@ -22,7 +22,7 @@ class SpanBuilderTest {
   void doNotCrash_NoopImplementation() {
     Span.Builder spanBuilder = tracer.spanBuilder("MySpanName");
     spanBuilder.setSpanKind(Kind.SERVER);
-    spanBuilder.setParent(TracingContextUtils.withSpan(Span.getPropagated(null), Context.root()));
+    spanBuilder.setParent(TracingContextUtils.withSpan(Span.wrap(null), Context.root()));
     spanBuilder.setParent(Context.root());
     spanBuilder.setNoParent();
     spanBuilder.addLink(Span.getInvalid().getContext());
@@ -33,7 +33,7 @@ class SpanBuilderTest {
     spanBuilder.setAttribute("key", true);
     spanBuilder.setAttribute(stringKey("key"), "value");
     spanBuilder.setStartTimestamp(12345L);
-    assertThat(spanBuilder.startSpan().isValid()).isFalse();
+    assertThat(spanBuilder.startSpan().getContext().isValid()).isFalse();
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/trace/TracingContextUtilsTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TracingContextUtilsTest.java
@@ -16,12 +16,12 @@ class TracingContextUtilsTest {
   @Test
   void testGetCurrentSpan_Default() {
     Span span = TracingContextUtils.getCurrentSpan();
-    assertThat(span).isSameAs(DefaultSpan.getInvalid());
+    assertThat(span).isSameAs(Span.getInvalid());
   }
 
   @Test
   void testGetCurrentSpan_SetSpan() {
-    Span span = DefaultSpan.create(SpanContext.getInvalid());
+    Span span = Span.getPropagated(SpanContext.getInvalid());
     try (Scope ignored = TracingContextUtils.withSpan(span, Context.current()).makeCurrent()) {
       assertThat(TracingContextUtils.getCurrentSpan()).isSameAs(span);
     }
@@ -30,12 +30,12 @@ class TracingContextUtilsTest {
   @Test
   void testGetSpan_DefaultContext() {
     Span span = TracingContextUtils.getSpan(Context.current());
-    assertThat(span).isSameAs(DefaultSpan.getInvalid());
+    assertThat(span).isSameAs(Span.getInvalid());
   }
 
   @Test
   void testGetSpan_ExplicitContext() {
-    Span span = DefaultSpan.create(SpanContext.getInvalid());
+    Span span = Span.getPropagated(SpanContext.getInvalid());
     Context context = TracingContextUtils.withSpan(span, Context.current());
     assertThat(TracingContextUtils.getSpan(context)).isSameAs(span);
   }
@@ -48,7 +48,7 @@ class TracingContextUtilsTest {
 
   @Test
   void testGetSpanWithoutDefault_ExplicitContext() {
-    Span span = DefaultSpan.create(SpanContext.getInvalid());
+    Span span = Span.getPropagated(SpanContext.getInvalid());
     Context context = TracingContextUtils.withSpan(span, Context.current());
     assertThat(TracingContextUtils.getSpanWithoutDefault(context)).isSameAs(span);
   }

--- a/api/src/test/java/io/opentelemetry/trace/TracingContextUtilsTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TracingContextUtilsTest.java
@@ -21,7 +21,7 @@ class TracingContextUtilsTest {
 
   @Test
   void testGetCurrentSpan_SetSpan() {
-    Span span = Span.getPropagated(SpanContext.getInvalid());
+    Span span = Span.wrap(SpanContext.getInvalid());
     try (Scope ignored = TracingContextUtils.withSpan(span, Context.current()).makeCurrent()) {
       assertThat(TracingContextUtils.getCurrentSpan()).isSameAs(span);
     }
@@ -35,7 +35,7 @@ class TracingContextUtilsTest {
 
   @Test
   void testGetSpan_ExplicitContext() {
-    Span span = Span.getPropagated(SpanContext.getInvalid());
+    Span span = Span.wrap(SpanContext.getInvalid());
     Context context = TracingContextUtils.withSpan(span, Context.current());
     assertThat(TracingContextUtils.getSpan(context)).isSameAs(span);
   }
@@ -48,7 +48,7 @@ class TracingContextUtilsTest {
 
   @Test
   void testGetSpanWithoutDefault_ExplicitContext() {
-    Span span = Span.getPropagated(SpanContext.getInvalid());
+    Span span = Span.wrap(SpanContext.getInvalid());
     Context context = TracingContextUtils.withSpan(span, Context.current());
     assertThat(TracingContextUtils.getSpanWithoutDefault(context)).isSameAs(span);
   }

--- a/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.entry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator.Getter;
 import io.opentelemetry.context.propagation.TextMapPropagator.Setter;
-import io.opentelemetry.trace.DefaultSpan;
+import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
@@ -52,7 +52,7 @@ class HttpTraceContextTest {
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return TracingContextUtils.withSpan(Span.getPropagated(spanContext), context);
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
@@ -52,7 +52,7 @@ class HttpTraceContextTest {
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
-    return TracingContextUtils.withSpan(Span.getPropagated(spanContext), context);
+    return TracingContextUtils.withSpan(Span.wrap(spanContext), context);
   }
 
   @Test

--- a/extensions/trace_propagators/src/jmh/java/io/opentelemetry/extensions/trace/propagation/PropagatorContextInjectBenchmark.java
+++ b/extensions/trace_propagators/src/jmh/java/io/opentelemetry/extensions/trace/propagation/PropagatorContextInjectBenchmark.java
@@ -62,8 +62,7 @@ public class PropagatorContextInjectBenchmark {
     @BenchmarkMode(Mode.AverageTime)
     @Fork(1)
     public Map<String, String> measureInject() {
-      Context context =
-          TracingContextUtils.withSpan(Span.getPropagated(contextToTest), Context.current());
+      Context context = TracingContextUtils.withSpan(Span.wrap(contextToTest), Context.current());
       doInject(context, carrier);
       return carrier;
     }

--- a/extensions/trace_propagators/src/jmh/java/io/opentelemetry/extensions/trace/propagation/PropagatorContextInjectBenchmark.java
+++ b/extensions/trace_propagators/src/jmh/java/io/opentelemetry/extensions/trace/propagation/PropagatorContextInjectBenchmark.java
@@ -7,7 +7,7 @@ package io.opentelemetry.extensions.trace.propagation;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.trace.DefaultSpan;
+import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceState;
@@ -63,7 +63,7 @@ public class PropagatorContextInjectBenchmark {
     @Fork(1)
     public Map<String, String> measureInject() {
       Context context =
-          TracingContextUtils.withSpan(DefaultSpan.create(contextToTest), Context.current());
+          TracingContextUtils.withSpan(Span.getPropagated(contextToTest), Context.current());
       doInject(context, carrier);
       return carrier;
     }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
@@ -127,7 +127,7 @@ public class AwsXRayPropagator implements TextMapPropagator {
       return context;
     }
 
-    return TracingContextUtils.withSpan(Span.getPropagated(spanContext), context);
+    return TracingContextUtils.withSpan(Span.wrap(spanContext), context);
   }
 
   private static <C> SpanContext getSpanContextFromHeader(C carrier, Getter<C> getter) {

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
@@ -7,7 +7,6 @@ package io.opentelemetry.extensions.trace.propagation;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
@@ -128,7 +127,7 @@ public class AwsXRayPropagator implements TextMapPropagator {
       return context;
     }
 
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return TracingContextUtils.withSpan(Span.getPropagated(spanContext), context);
   }
 
   private static <C> SpanContext getSpanContextFromHeader(C carrier, Getter<C> getter) {

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
@@ -34,7 +34,7 @@ final class B3PropagatorExtractorMultipleHeaders implements B3PropagatorExtracto
       return Optional.empty();
     }
 
-    return Optional.of(TracingContextUtils.withSpan(Span.getPropagated(spanContext), context));
+    return Optional.of(TracingContextUtils.withSpan(Span.wrap(spanContext), context));
   }
 
   private static <C> SpanContext getSpanContextFromMultipleHeaders(

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
@@ -11,7 +11,7 @@ import static io.opentelemetry.extensions.trace.propagation.B3Propagator.TRACE_I
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.trace.DefaultSpan;
+import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Objects;
@@ -34,7 +34,7 @@ final class B3PropagatorExtractorMultipleHeaders implements B3PropagatorExtracto
       return Optional.empty();
     }
 
-    return Optional.of(TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context));
+    return Optional.of(TracingContextUtils.withSpan(Span.getPropagated(spanContext), context));
   }
 
   private static <C> SpanContext getSpanContextFromMultipleHeaders(

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorSingleHeader.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorSingleHeader.java
@@ -10,7 +10,7 @@ import static io.opentelemetry.extensions.trace.propagation.B3Propagator.COMBINE
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.trace.DefaultSpan;
+import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Objects;
@@ -33,7 +33,7 @@ final class B3PropagatorExtractorSingleHeader implements B3PropagatorExtractor {
       return Optional.empty();
     }
 
-    return Optional.of(TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context));
+    return Optional.of(TracingContextUtils.withSpan(Span.getPropagated(spanContext), context));
   }
 
   @SuppressWarnings("StringSplitter")

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorSingleHeader.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorExtractorSingleHeader.java
@@ -33,7 +33,7 @@ final class B3PropagatorExtractorSingleHeader implements B3PropagatorExtractor {
       return Optional.empty();
     }
 
-    return Optional.of(TracingContextUtils.withSpan(Span.getPropagated(spanContext), context));
+    return Optional.of(TracingContextUtils.withSpan(Span.wrap(spanContext), context));
   }
 
   @SuppressWarnings("StringSplitter")

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
@@ -7,7 +7,7 @@ package io.opentelemetry.extensions.trace.propagation;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.trace.DefaultSpan;
+import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
@@ -118,7 +118,7 @@ public class JaegerPropagator implements TextMapPropagator {
       return context;
     }
 
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return TracingContextUtils.withSpan(Span.getPropagated(spanContext), context);
   }
 
   @SuppressWarnings("StringSplitter")

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
@@ -118,7 +118,7 @@ public class JaegerPropagator implements TextMapPropagator {
       return context;
     }
 
-    return TracingContextUtils.withSpan(Span.getPropagated(spanContext), context);
+    return TracingContextUtils.withSpan(Span.wrap(spanContext), context);
   }
 
   @SuppressWarnings("StringSplitter")

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagator.java
@@ -79,7 +79,7 @@ public class OtTracerPropagator implements TextMapPropagator {
     if (!spanContext.isValid()) {
       return context;
     }
-    return TracingContextUtils.withSpan(Span.getPropagated(spanContext), context);
+    return TracingContextUtils.withSpan(Span.wrap(spanContext), context);
   }
 
   static SpanContext buildSpanContext(String traceId, String spanId, String sampled) {

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagator.java
@@ -9,7 +9,7 @@ import static io.opentelemetry.extensions.trace.propagation.Common.MAX_TRACE_ID_
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.trace.DefaultSpan;
+import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.TracingContextUtils;
@@ -79,7 +79,7 @@ public class OtTracerPropagator implements TextMapPropagator {
     if (!spanContext.isValid()) {
       return context;
     }
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return TracingContextUtils.withSpan(Span.getPropagated(spanContext), context);
   }
 
   static SpanContext buildSpanContext(String traceId, String spanId, String sampled) {

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagatorTest.java
@@ -244,7 +244,7 @@ class AwsXRayPropagatorTest {
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
-    return TracingContextUtils.withSpan(Span.getPropagated(spanContext), context);
+    return TracingContextUtils.withSpan(Span.wrap(spanContext), context);
   }
 
   private static SpanContext getSpanContext(Context context) {

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagatorTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.trace.DefaultSpan;
+import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.TraceFlags;
 import io.opentelemetry.trace.TraceState;
@@ -244,7 +244,7 @@ class AwsXRayPropagatorTest {
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return TracingContextUtils.withSpan(Span.getPropagated(spanContext), context);
   }
 
   private static SpanContext getSpanContext(Context context) {

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator.Getter;
 import io.opentelemetry.context.propagation.TextMapPropagator.Setter;
-import io.opentelemetry.trace.DefaultSpan;
+import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
@@ -54,7 +54,7 @@ class B3PropagatorTest {
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return TracingContextUtils.withSpan(Span.getPropagated(spanContext), context);
   }
 
   @Test

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
@@ -54,7 +54,7 @@ class B3PropagatorTest {
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
-    return TracingContextUtils.withSpan(Span.getPropagated(spanContext), context);
+    return TracingContextUtils.withSpan(Span.wrap(spanContext), context);
   }
 
   @Test

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagatorTest.java
@@ -64,7 +64,7 @@ class JaegerPropagatorTest {
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
-    return TracingContextUtils.withSpan(Span.getPropagated(spanContext), context);
+    return TracingContextUtils.withSpan(Span.wrap(spanContext), context);
   }
 
   @Test

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagatorTest.java
@@ -15,7 +15,7 @@ import io.jaegertracing.internal.propagation.TextMapCodec;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.context.propagation.TextMapPropagator.Setter;
-import io.opentelemetry.trace.DefaultSpan;
+import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
@@ -64,7 +64,7 @@ class JaegerPropagatorTest {
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return TracingContextUtils.withSpan(Span.getPropagated(spanContext), context);
   }
 
   @Test

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagatorTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator.Getter;
 import io.opentelemetry.context.propagation.TextMapPropagator.Setter;
-import io.opentelemetry.trace.DefaultSpan;
+import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.TraceFlags;
@@ -40,7 +40,7 @@ class OtTracerPropagatorTest {
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
-    return TracingContextUtils.withSpan(DefaultSpan.create(spanContext), context);
+    return TracingContextUtils.withSpan(Span.getPropagated(spanContext), context);
   }
 
   @Test

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagatorTest.java
@@ -40,7 +40,7 @@ class OtTracerPropagatorTest {
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
-    return TracingContextUtils.withSpan(Span.getPropagated(spanContext), context);
+    return TracingContextUtils.withSpan(Span.wrap(spanContext), context);
   }
 
   @Test

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagatorTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.SpanId;
@@ -38,7 +37,7 @@ class TraceMultiPropagatorTest {
   private static final TextMapPropagator PROPAGATOR3 = HttpTraceContext.getInstance();
 
   private static final Span SPAN =
-      DefaultSpan.create(
+      Span.getPropagated(
           SpanContext.createFromRemoteParent(
               TraceId.fromLongs(1245, 67890),
               SpanId.fromLong(12345),

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagatorTest.java
@@ -37,7 +37,7 @@ class TraceMultiPropagatorTest {
   private static final TextMapPropagator PROPAGATOR3 = HttpTraceContext.getInstance();
 
   private static final Span SPAN =
-      Span.getPropagated(
+      Span.wrap(
           SpanContext.createFromRemoteParent(
               TraceId.fromLongs(1245, 67890),
               SpanId.fromLong(12345),

--- a/extensions/trace_utils/src/test/java/io/opentelemetry/extensions/trace/CurrentSpanUtilsTest.java
+++ b/extensions/trace_utils/src/test/java/io/opentelemetry/extensions/trace/CurrentSpanUtilsTest.java
@@ -53,7 +53,7 @@ class CurrentSpanUtilsTest {
 
   @Test
   void withSpanRunnable() {
-    assertThat(getCurrentSpan().isValid()).isFalse();
+    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
     Runnable runnable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -61,12 +61,12 @@ class CurrentSpanUtilsTest {
         };
     CurrentSpanUtils.withSpan(span, false, runnable).run();
     verifyNoInteractions(span);
-    assertThat(getCurrentSpan().isValid()).isFalse();
+    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
   }
 
   @Test
   void withSpanRunnable_EndSpan() {
-    assertThat(getCurrentSpan().isValid()).isFalse();
+    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
     Runnable runnable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -74,13 +74,13 @@ class CurrentSpanUtilsTest {
         };
     CurrentSpanUtils.withSpan(span, true, runnable).run();
     verify(span).end();
-    assertThat(getCurrentSpan().isValid()).isFalse();
+    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
   }
 
   @Test
   void withSpanRunnable_WithError() {
     final AssertionError error = new AssertionError("MyError");
-    assertThat(getCurrentSpan().isValid()).isFalse();
+    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
     Runnable runnable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -90,13 +90,13 @@ class CurrentSpanUtilsTest {
     executeRunnableAndExpectError(runnable, error);
     verify(span).setStatus(StatusCanonicalCode.ERROR, "MyError");
     verify(span).end();
-    assertThat(getCurrentSpan().isValid()).isFalse();
+    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
   }
 
   @Test
   void withSpanRunnable_WithErrorNoMessage() {
     final AssertionError error = new AssertionError();
-    assertThat(getCurrentSpan().isValid()).isFalse();
+    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
     Runnable runnable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -106,13 +106,13 @@ class CurrentSpanUtilsTest {
     executeRunnableAndExpectError(runnable, error);
     verify(span).setStatus(StatusCanonicalCode.ERROR, "AssertionError");
     verify(span).end();
-    assertThat(getCurrentSpan().isValid()).isFalse();
+    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
   }
 
   @Test
   void withSpanCallable() throws Exception {
     final Object ret = new Object();
-    assertThat(getCurrentSpan().isValid()).isFalse();
+    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -121,13 +121,13 @@ class CurrentSpanUtilsTest {
         };
     assertThat(CurrentSpanUtils.withSpan(span, false, callable).call()).isEqualTo(ret);
     verifyNoInteractions(span);
-    assertThat(getCurrentSpan().isValid()).isFalse();
+    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
   }
 
   @Test
   void withSpanCallable_EndSpan() throws Exception {
     final Object ret = new Object();
-    assertThat(getCurrentSpan().isValid()).isFalse();
+    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -136,13 +136,13 @@ class CurrentSpanUtilsTest {
         };
     assertThat(CurrentSpanUtils.withSpan(span, true, callable).call()).isEqualTo(ret);
     verify(span).end();
-    assertThat(getCurrentSpan().isValid()).isFalse();
+    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
   }
 
   @Test
   void withSpanCallable_WithException() {
     final Exception exception = new Exception("MyException");
-    assertThat(getCurrentSpan().isValid()).isFalse();
+    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -152,13 +152,13 @@ class CurrentSpanUtilsTest {
     executeCallableAndExpectError(callable, exception);
     verify(span).setStatus(StatusCanonicalCode.ERROR, "MyException");
     verify(span).end();
-    assertThat(getCurrentSpan().isValid()).isFalse();
+    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
   }
 
   @Test
   void withSpanCallable_WithExceptionNoMessage() {
     final Exception exception = new Exception();
-    assertThat(getCurrentSpan().isValid()).isFalse();
+    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -168,13 +168,13 @@ class CurrentSpanUtilsTest {
     executeCallableAndExpectError(callable, exception);
     verify(span).setStatus(StatusCanonicalCode.ERROR, "Exception");
     verify(span).end();
-    assertThat(getCurrentSpan().isValid()).isFalse();
+    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
   }
 
   @Test
   void withSpanCallable_WithError() {
     final AssertionError error = new AssertionError("MyError");
-    assertThat(getCurrentSpan().isValid()).isFalse();
+    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -184,13 +184,13 @@ class CurrentSpanUtilsTest {
     executeCallableAndExpectError(callable, error);
     verify(span).setStatus(StatusCanonicalCode.ERROR, "MyError");
     verify(span).end();
-    assertThat(getCurrentSpan().isValid()).isFalse();
+    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
   }
 
   @Test
   void withSpanCallable_WithErrorNoMessage() {
     final AssertionError error = new AssertionError();
-    assertThat(getCurrentSpan().isValid()).isFalse();
+    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -200,7 +200,7 @@ class CurrentSpanUtilsTest {
     executeCallableAndExpectError(callable, error);
     verify(span).setStatus(StatusCanonicalCode.ERROR, "AssertionError");
     verify(span).end();
-    assertThat(getCurrentSpan().isValid()).isFalse();
+    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
   }
 
   private static Span getCurrentSpan() {

--- a/extensions/trace_utils/src/test/java/io/opentelemetry/extensions/trace/CurrentSpanUtilsTest.java
+++ b/extensions/trace_utils/src/test/java/io/opentelemetry/extensions/trace/CurrentSpanUtilsTest.java
@@ -9,7 +9,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.StatusCanonicalCode;
 import io.opentelemetry.trace.TracingContextUtils;
@@ -54,7 +53,7 @@ class CurrentSpanUtilsTest {
 
   @Test
   void withSpanRunnable() {
-    assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(getCurrentSpan().isValid()).isFalse();
     Runnable runnable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -62,12 +61,12 @@ class CurrentSpanUtilsTest {
         };
     CurrentSpanUtils.withSpan(span, false, runnable).run();
     verifyNoInteractions(span);
-    assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(getCurrentSpan().isValid()).isFalse();
   }
 
   @Test
   void withSpanRunnable_EndSpan() {
-    assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(getCurrentSpan().isValid()).isFalse();
     Runnable runnable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -75,13 +74,13 @@ class CurrentSpanUtilsTest {
         };
     CurrentSpanUtils.withSpan(span, true, runnable).run();
     verify(span).end();
-    assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(getCurrentSpan().isValid()).isFalse();
   }
 
   @Test
   void withSpanRunnable_WithError() {
     final AssertionError error = new AssertionError("MyError");
-    assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(getCurrentSpan().isValid()).isFalse();
     Runnable runnable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -91,13 +90,13 @@ class CurrentSpanUtilsTest {
     executeRunnableAndExpectError(runnable, error);
     verify(span).setStatus(StatusCanonicalCode.ERROR, "MyError");
     verify(span).end();
-    assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(getCurrentSpan().isValid()).isFalse();
   }
 
   @Test
   void withSpanRunnable_WithErrorNoMessage() {
     final AssertionError error = new AssertionError();
-    assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(getCurrentSpan().isValid()).isFalse();
     Runnable runnable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -107,13 +106,13 @@ class CurrentSpanUtilsTest {
     executeRunnableAndExpectError(runnable, error);
     verify(span).setStatus(StatusCanonicalCode.ERROR, "AssertionError");
     verify(span).end();
-    assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(getCurrentSpan().isValid()).isFalse();
   }
 
   @Test
   void withSpanCallable() throws Exception {
     final Object ret = new Object();
-    assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(getCurrentSpan().isValid()).isFalse();
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -122,13 +121,13 @@ class CurrentSpanUtilsTest {
         };
     assertThat(CurrentSpanUtils.withSpan(span, false, callable).call()).isEqualTo(ret);
     verifyNoInteractions(span);
-    assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(getCurrentSpan().isValid()).isFalse();
   }
 
   @Test
   void withSpanCallable_EndSpan() throws Exception {
     final Object ret = new Object();
-    assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(getCurrentSpan().isValid()).isFalse();
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -137,13 +136,13 @@ class CurrentSpanUtilsTest {
         };
     assertThat(CurrentSpanUtils.withSpan(span, true, callable).call()).isEqualTo(ret);
     verify(span).end();
-    assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(getCurrentSpan().isValid()).isFalse();
   }
 
   @Test
   void withSpanCallable_WithException() {
     final Exception exception = new Exception("MyException");
-    assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(getCurrentSpan().isValid()).isFalse();
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -153,13 +152,13 @@ class CurrentSpanUtilsTest {
     executeCallableAndExpectError(callable, exception);
     verify(span).setStatus(StatusCanonicalCode.ERROR, "MyException");
     verify(span).end();
-    assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(getCurrentSpan().isValid()).isFalse();
   }
 
   @Test
   void withSpanCallable_WithExceptionNoMessage() {
     final Exception exception = new Exception();
-    assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(getCurrentSpan().isValid()).isFalse();
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -169,13 +168,13 @@ class CurrentSpanUtilsTest {
     executeCallableAndExpectError(callable, exception);
     verify(span).setStatus(StatusCanonicalCode.ERROR, "Exception");
     verify(span).end();
-    assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(getCurrentSpan().isValid()).isFalse();
   }
 
   @Test
   void withSpanCallable_WithError() {
     final AssertionError error = new AssertionError("MyError");
-    assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(getCurrentSpan().isValid()).isFalse();
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -185,13 +184,13 @@ class CurrentSpanUtilsTest {
     executeCallableAndExpectError(callable, error);
     verify(span).setStatus(StatusCanonicalCode.ERROR, "MyError");
     verify(span).end();
-    assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(getCurrentSpan().isValid()).isFalse();
   }
 
   @Test
   void withSpanCallable_WithErrorNoMessage() {
     final AssertionError error = new AssertionError();
-    assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(getCurrentSpan().isValid()).isFalse();
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -201,7 +200,7 @@ class CurrentSpanUtilsTest {
     executeCallableAndExpectError(callable, error);
     verify(span).setStatus(StatusCanonicalCode.ERROR, "AssertionError");
     verify(span).end();
-    assertThat(getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(getCurrentSpan().isValid()).isFalse();
   }
 
   private static Span getCurrentSpan() {

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/Propagation.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/Propagation.java
@@ -23,8 +23,7 @@ final class Propagation extends BaseShimObject {
 
   public void injectTextMap(SpanContextShim contextShim, TextMapInject carrier) {
     Context context =
-        TracingContextUtils.withSpan(
-            Span.getPropagated(contextShim.getSpanContext()), Context.current());
+        TracingContextUtils.withSpan(Span.wrap(contextShim.getSpanContext()), Context.current());
     context = BaggageUtils.withBaggage(contextShim.getBaggage(), context);
 
     propagators().getTextMapPropagator().inject(context, carrier, TextMapSetter.INSTANCE);

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/Propagation.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/Propagation.java
@@ -8,7 +8,6 @@ package io.opentelemetry.opentracingshim;
 import io.opentelemetry.baggage.BaggageUtils;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.TracingContextUtils;
 import io.opentracing.propagation.TextMapExtract;
@@ -25,7 +24,7 @@ final class Propagation extends BaseShimObject {
   public void injectTextMap(SpanContextShim contextShim, TextMapInject carrier) {
     Context context =
         TracingContextUtils.withSpan(
-            DefaultSpan.create(contextShim.getSpanContext()), Context.current());
+            Span.getPropagated(contextShim.getSpanContext()), Context.current());
     context = BaggageUtils.withBaggage(contextShim.getBaggage(), context);
 
     propagators().getTextMapPropagator().inject(context, carrier, TextMapSetter.INSTANCE);

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/ScopeManagerShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/ScopeManagerShim.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.opentracingshim;
 
-import io.opentelemetry.trace.DefaultSpan;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
@@ -20,10 +19,9 @@ final class ScopeManagerShim extends BaseShimObject implements ScopeManager {
   @SuppressWarnings("ReturnMissingNullable")
   public Span activeSpan() {
     // As OpenTracing simply returns null when no active instance is available,
-    // we need to do an explicit check against DefaultSpan,
-    // which is used in OpenTelemetry for this very case.
+    // we need to do map an invalid OpenTelemetry span to null here.
     io.opentelemetry.trace.Span span = tracer().getCurrentSpan();
-    if (DefaultSpan.getInvalid().equals(span)) {
+    if (!span.isValid()) {
       return null;
     }
 

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/ScopeManagerShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/ScopeManagerShim.java
@@ -21,7 +21,7 @@ final class ScopeManagerShim extends BaseShimObject implements ScopeManager {
     // As OpenTracing simply returns null when no active instance is available,
     // we need to do map an invalid OpenTelemetry span to null here.
     io.opentelemetry.trace.Span span = tracer().getCurrentSpan();
-    if (!span.isValid()) {
+    if (!span.getContext().isValid()) {
       return null;
     }
 

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
@@ -13,7 +13,6 @@ import static io.opentelemetry.common.AttributeKey.stringKey;
 import io.opentelemetry.baggage.Baggage;
 import io.opentelemetry.common.AttributeKey;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.StatusCanonicalCode;
 import io.opentelemetry.trace.TracingContextUtils;
@@ -190,7 +189,8 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
     } else if (parentSpanContext != null) {
       builder.setParent(
           TracingContextUtils.withSpan(
-              DefaultSpan.create(parentSpanContext.getSpanContext()), Context.root()));
+              io.opentelemetry.trace.Span.getPropagated(parentSpanContext.getSpanContext()),
+              Context.root()));
       baggage = parentSpanContext.getBaggage();
     }
 

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
@@ -189,7 +189,7 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
     } else if (parentSpanContext != null) {
       builder.setParent(
           TracingContextUtils.withSpan(
-              io.opentelemetry.trace.Span.getPropagated(parentSpanContext.getSpanContext()),
+              io.opentelemetry.trace.Span.wrap(parentSpanContext.getSpanContext()),
               Context.root()));
       baggage = parentSpanContext.getBaggage();
     }

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/TracerShimTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/TracerShimTest.java
@@ -5,13 +5,12 @@
 
 package io.opentelemetry.opentracingshim;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.trace.DefaultSpan;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
@@ -82,6 +81,6 @@ class TracerShimTest {
     tracerShim.close();
     Span otSpan = tracerShim.buildSpan(null).start();
     io.opentelemetry.trace.Span span = ((SpanShim) otSpan).getSpan();
-    assertTrue(span instanceof DefaultSpan);
+    assertThat(span.isValid()).isFalse();
   }
 }

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/TracerShimTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/TracerShimTest.java
@@ -81,6 +81,6 @@ class TracerShimTest {
     tracerShim.close();
     Span otSpan = tracerShim.buildSpan(null).start();
     io.opentelemetry.trace.Span span = ((SpanShim) otSpan).getSpan();
-    assertThat(span.isValid()).isFalse();
+    assertThat(span.getContext().isValid()).isFalse();
   }
 }

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.opentracingshim.testbed;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -14,7 +15,6 @@ import io.opentelemetry.exporters.inmemory.InMemoryTracing;
 import io.opentelemetry.opentracingshim.TraceShim;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.trace.DefaultSpan;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
@@ -45,7 +45,7 @@ class OpenTelemetryInteroperabilityTest {
     } finally {
       otSpan.finish();
     }
-    assertEquals(tracer.getCurrentSpan().getClass(), DefaultSpan.class);
+    assertThat(tracer.getCurrentSpan().isValid()).isFalse();
     assertNull(otTracer.activeSpan());
 
     List<SpanData> finishedSpans = inMemoryTracing.getSpanExporter().getFinishedSpanItems();
@@ -62,7 +62,7 @@ class OpenTelemetryInteroperabilityTest {
       otelSpan.end();
     }
 
-    assertEquals(tracer.getCurrentSpan().getClass(), DefaultSpan.class);
+    assertThat(tracer.getCurrentSpan().isValid()).isFalse();
     assertNull(otTracer.activeSpan());
 
     List<SpanData> finishedSpans = inMemoryTracing.getSpanExporter().getFinishedSpanItems();

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
@@ -45,7 +45,7 @@ class OpenTelemetryInteroperabilityTest {
     } finally {
       otSpan.finish();
     }
-    assertThat(tracer.getCurrentSpan().isValid()).isFalse();
+    assertThat(tracer.getCurrentSpan().getContext().isValid()).isFalse();
     assertNull(otTracer.activeSpan());
 
     List<SpanData> finishedSpans = inMemoryTracing.getSpanExporter().getFinishedSpanItems();
@@ -62,7 +62,7 @@ class OpenTelemetryInteroperabilityTest {
       otelSpan.end();
     }
 
-    assertThat(tracer.getCurrentSpan().isValid()).isFalse();
+    assertThat(tracer.getCurrentSpan().getContext().isValid()).isFalse();
     assertNull(otTracer.activeSpan());
 
     List<SpanData> finishedSpans = inMemoryTracing.getSpanExporter().getFinishedSpanItems();

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -24,7 +24,6 @@ import io.opentelemetry.sdk.trace.Sampler.SamplingResult;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
-import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanContext;
@@ -212,7 +211,7 @@ final class SpanBuilderSdk implements Span.Builder {
             traceId, spanId, samplingResultTraceState, Samplers.isSampled(samplingDecision));
 
     if (!Samplers.isRecording(samplingDecision)) {
-      return DefaultSpan.create(spanContext);
+      return Span.getPropagated(spanContext);
     }
     ReadableAttributes samplingAttributes = samplingResult.getAttributes();
     if (!samplingAttributes.isEmpty()) {

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -211,7 +211,7 @@ final class SpanBuilderSdk implements Span.Builder {
             traceId, spanId, samplingResultTraceState, Samplers.isSampled(samplingDecision));
 
     if (!Samplers.isRecording(samplingDecision)) {
-      return Span.getPropagated(spanContext);
+      return Span.wrap(spanContext);
     }
     ReadableAttributes samplingAttributes = samplingResult.getAttributes();
     if (!samplingAttributes.isEmpty()) {

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -26,7 +26,6 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Link;
-import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanContext;
@@ -71,8 +70,8 @@ class SpanBuilderSdkTest {
   void addLink() {
     // Verify methods do not crash.
     Span.Builder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
-    spanBuilder.addLink(DefaultSpan.getInvalid().getContext());
-    spanBuilder.addLink(DefaultSpan.getInvalid().getContext(), Attributes.empty());
+    spanBuilder.addLink(Span.getInvalid().getContext());
+    spanBuilder.addLink(Span.getInvalid().getContext(), Attributes.empty());
 
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     try {
@@ -178,8 +177,7 @@ class SpanBuilderSdkTest {
   void addLinkSpanContextAttributes_nullAttributes() {
     assertThrows(
         NullPointerException.class,
-        () ->
-            tracerSdk.spanBuilder(SPAN_NAME).addLink(DefaultSpan.getInvalid().getContext(), null));
+        () -> tracerSdk.spanBuilder(SPAN_NAME).addLink(Span.getInvalid().getContext(), null));
   }
 
   @Test
@@ -762,7 +760,7 @@ class SpanBuilderSdkTest {
 
   @Test
   void parent_invalidContext() {
-    Span parent = DefaultSpan.getInvalid();
+    Span parent = Span.getInvalid();
 
     RecordEventsReadableSpan span =
         (RecordEventsReadableSpan)

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkProviderTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkProviderTest.java
@@ -15,7 +15,6 @@ import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
-import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
 import org.junit.jupiter.api.BeforeEach;
@@ -131,7 +130,7 @@ class TracerSdkProviderTest {
   void returnNoopSpanAfterShutdown() {
     tracerFactory.shutdown();
     Span span = tracerFactory.get("noop").spanBuilder("span").startSpan();
-    assertThat(span).isInstanceOf(DefaultSpan.class);
+    assertThat(span.isValid()).isFalse();
     span.end();
   }
 }

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkProviderTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkProviderTest.java
@@ -130,7 +130,7 @@ class TracerSdkProviderTest {
   void returnNoopSpanAfterShutdown() {
     tracerFactory.shutdown();
     Span span = tracerFactory.get("noop").spanBuilder("span").startSpan();
-    assertThat(span.isValid()).isFalse();
+    assertThat(span.getContext().isValid()).isFalse();
     span.end();
   }
 }

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -51,7 +51,7 @@ class TracerSdkTest {
 
   @Test
   void defaultGetCurrentSpan() {
-    assertThat(tracer.getCurrentSpan().isValid()).isFalse();
+    assertThat(tracer.getCurrentSpan().getContext().isValid()).isFalse();
   }
 
   @Test
@@ -61,30 +61,30 @@ class TracerSdkTest {
 
   @Test
   void getCurrentSpan() {
-    assertThat(tracer.getCurrentSpan().isValid()).isFalse();
+    assertThat(tracer.getCurrentSpan().getContext().isValid()).isFalse();
     // Make sure context is detached even if test fails.
     try (Scope ignored = TracingContextUtils.withSpan(span, Context.current()).makeCurrent()) {
       assertThat(tracer.getCurrentSpan()).isSameAs(span);
     }
-    assertThat(tracer.getCurrentSpan().isValid()).isFalse();
+    assertThat(tracer.getCurrentSpan().getContext().isValid()).isFalse();
   }
 
   @Test
   void withSpan_NullSpan() {
-    assertThat(tracer.getCurrentSpan().isValid()).isFalse();
+    assertThat(tracer.getCurrentSpan().getContext().isValid()).isFalse();
     try (Scope ignored = tracer.withSpan(null)) {
-      assertThat(tracer.getCurrentSpan().isValid()).isFalse();
+      assertThat(tracer.getCurrentSpan().getContext().isValid()).isFalse();
     }
-    assertThat(tracer.getCurrentSpan().isValid()).isFalse();
+    assertThat(tracer.getCurrentSpan().getContext().isValid()).isFalse();
   }
 
   @Test
   void getCurrentSpan_WithSpan() {
-    assertThat(tracer.getCurrentSpan().isValid()).isFalse();
+    assertThat(tracer.getCurrentSpan().getContext().isValid()).isFalse();
     try (Scope ignored = tracer.withSpan(span)) {
       assertThat(tracer.getCurrentSpan()).isSameAs(span);
     }
-    assertThat(tracer.getCurrentSpan().isValid()).isFalse();
+    assertThat(tracer.getCurrentSpan().getContext().isValid()).isFalse();
   }
 
   @Test

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -15,7 +15,6 @@ import io.opentelemetry.sdk.trace.StressTestRunner.OperationUpdater;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
-import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Collection;
@@ -52,7 +51,7 @@ class TracerSdkTest {
 
   @Test
   void defaultGetCurrentSpan() {
-    assertThat(tracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(tracer.getCurrentSpan().isValid()).isFalse();
   }
 
   @Test
@@ -62,30 +61,30 @@ class TracerSdkTest {
 
   @Test
   void getCurrentSpan() {
-    assertThat(tracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(tracer.getCurrentSpan().isValid()).isFalse();
     // Make sure context is detached even if test fails.
     try (Scope ignored = TracingContextUtils.withSpan(span, Context.current()).makeCurrent()) {
       assertThat(tracer.getCurrentSpan()).isSameAs(span);
     }
-    assertThat(tracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(tracer.getCurrentSpan().isValid()).isFalse();
   }
 
   @Test
   void withSpan_NullSpan() {
-    assertThat(tracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(tracer.getCurrentSpan().isValid()).isFalse();
     try (Scope ignored = tracer.withSpan(null)) {
-      assertThat(tracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+      assertThat(tracer.getCurrentSpan().isValid()).isFalse();
     }
-    assertThat(tracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(tracer.getCurrentSpan().isValid()).isFalse();
   }
 
   @Test
   void getCurrentSpan_WithSpan() {
-    assertThat(tracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(tracer.getCurrentSpan().isValid()).isFalse();
     try (Scope ignored = tracer.withSpan(span)) {
       assertThat(tracer.getCurrentSpan()).isSameAs(span);
     }
-    assertThat(tracer.getCurrentSpan()).isInstanceOf(DefaultSpan.class);
+    assertThat(tracer.getCurrentSpan().isValid()).isFalse();
   }
 
   @Test

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/activespanreplacement/ActiveSpanReplacementTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/activespanreplacement/ActiveSpanReplacementTest.java
@@ -15,7 +15,6 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Tracer;
@@ -61,7 +60,7 @@ class ActiveSpanReplacementTest {
     assertThat(spans.get(0).getTraceId()).isNotEqualTo(spans.get(1).getTraceId());
     assertThat(spans.get(0).getParentSpanId()).isEqualTo(SpanId.getInvalid());
 
-    assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(Span.getInvalid());
   }
 
   private void submitAnotherTask(final Span initialSpan) {

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/actorpropagation/ActorPropagationTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/actorpropagation/ActorPropagationTest.java
@@ -12,7 +12,6 @@ import io.opentelemetry.exporters.inmemory.InMemoryTracing;
 import io.opentelemetry.sdk.extensions.trace.testbed.TestUtils;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.Tracer;
@@ -73,7 +72,7 @@ class ActorPropagationTest {
       assertThat(TestUtils.getByKind(finished, Span.Kind.CONSUMER)).hasSize(2);
       assertThat(TestUtils.getOneByKind(finished, Span.Kind.PRODUCER)).isNotNull();
 
-      assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
+      assertThat(tracer.getCurrentSpan()).isSameAs(Span.getInvalid());
     }
   }
 
@@ -114,7 +113,7 @@ class ActorPropagationTest {
       assertThat(TestUtils.getByKind(finished, Span.Kind.CONSUMER)).hasSize(2);
       assertThat(TestUtils.getOneByKind(finished, Span.Kind.PRODUCER)).isNotNull();
 
-      assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
+      assertThat(tracer.getCurrentSpan()).isSameAs(Span.getInvalid());
     }
   }
 }

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/clientserver/TestClientServerTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/clientserver/TestClientServerTest.java
@@ -14,7 +14,7 @@ import io.opentelemetry.exporters.inmemory.InMemoryTracing;
 import io.opentelemetry.sdk.extensions.trace.testbed.TestUtils;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.trace.DefaultSpan;
+import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.Tracer;
 import java.util.List;
@@ -62,6 +62,6 @@ class TestClientServerTest {
     assertThat(finished.get(0).getKind()).isEqualTo(Kind.CLIENT);
     assertThat(finished.get(1).getKind()).isEqualTo(Kind.SERVER);
 
-    assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(Span.getInvalid());
   }
 }

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/concurrentcommonrequesthandler/HandlerTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/concurrentcommonrequesthandler/HandlerTest.java
@@ -13,7 +13,6 @@ import io.opentelemetry.exporters.inmemory.InMemoryTracing;
 import io.opentelemetry.sdk.extensions.trace.testbed.TestUtils;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Tracer;
@@ -61,7 +60,7 @@ class HandlerTest {
     assertThat(finished.get(0).getParentSpanId()).isEqualTo(SpanId.getInvalid());
     assertThat(finished.get(1).getParentSpanId()).isEqualTo(SpanId.getInvalid());
 
-    assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(Span.getInvalid());
   }
 
   /** Active parent is not picked up by child. */

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/errorreporting/ErrorReportingTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/errorreporting/ErrorReportingTest.java
@@ -16,7 +16,6 @@ import io.opentelemetry.sdk.extensions.trace.testbed.TestUtils;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
-import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.StatusCanonicalCode;
 import io.opentelemetry.trace.Tracer;
@@ -47,7 +46,7 @@ public final class ErrorReportingTest {
       span.end();
     }
 
-    assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(Span.getInvalid());
 
     List<SpanData> spans = inMemoryTracing.getSpanExporter().getFinishedSpanItems();
     assertThat(spans).hasSize(1);
@@ -98,7 +97,7 @@ public final class ErrorReportingTest {
     span.setStatus(StatusCanonicalCode.ERROR); // Could not fetch anything.
     span.end();
 
-    assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(Span.getInvalid());
 
     List<SpanData> spans = inMemoryTracing.getSpanExporter().getFinishedSpanItems();
     assertThat(spans).hasSize(1);

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/latespanfinish/LateSpanFinishTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/latespanfinish/LateSpanFinishTest.java
@@ -12,7 +12,6 @@ import io.opentelemetry.exporters.inmemory.InMemoryTracing;
 import io.opentelemetry.sdk.extensions.trace.testbed.TestUtils;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
 import java.util.List;
@@ -51,7 +50,7 @@ public final class LateSpanFinishTest {
 
     TestUtils.assertSameTrace(spans);
 
-    assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(Span.getInvalid());
   }
 
   /*

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/listenerperrequest/ListenerTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/listenerperrequest/ListenerTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.trace.DefaultSpan;
+import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.Tracer;
 import java.util.List;
@@ -33,6 +33,6 @@ class ListenerTest {
     assertThat(finished).hasSize(1);
     assertThat(finished.get(0).getKind()).isEqualTo(Kind.CLIENT);
 
-    assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(Span.getInvalid());
   }
 }

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/multiplecallbacks/MultipleCallbacksTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/multiplecallbacks/MultipleCallbacksTest.java
@@ -14,7 +14,6 @@ import io.opentelemetry.exporters.inmemory.InMemoryTracing;
 import io.opentelemetry.sdk.extensions.trace.testbed.TestUtils;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
 import java.util.List;
@@ -64,6 +63,6 @@ class MultipleCallbacksTest {
       assertThat(spans.get(i).getParentSpanId()).isEqualTo(parentSpan.getSpanId());
     }
 
-    assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(Span.getInvalid());
   }
 }

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/nestedcallbacks/NestedCallbacksTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/nestedcallbacks/NestedCallbacksTest.java
@@ -16,7 +16,6 @@ import io.opentelemetry.exporters.inmemory.InMemoryTracing;
 import io.opentelemetry.sdk.extensions.trace.testbed.TestUtils;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
 import java.util.List;
@@ -54,7 +53,7 @@ public final class NestedCallbacksTest {
       assertThat(attrs.get(stringKey("key" + i))).isEqualTo(Integer.toString(i));
     }
 
-    assertThat(tracer.getCurrentSpan()).isSameAs(DefaultSpan.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(Span.getInvalid());
   }
 
   private void submitCallbacks(final Span span) {


### PR DESCRIPTION
We use `DefaultSpan`, a no-op wrapper of a spancontext, for three use cases

- propagated span
- unsampled span
- disabling implicit tracing in a scope

So it actually didn't make sense to use the propagated span terminology to replace it. I used a `wrapAsNoop` factory instead since that's literally what we're doing. ~~To give the propagated term some love, I renamed the relevant `SpanContext` factory to use the word.~~ Realized I was confusing propagated span with remote span but they are different.

Would be much easier to reason about without the `SpanContext` I guess 😋 

Fixes #1704