### PR TITLE
Move static access of current span to Span.

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
@@ -35,7 +35,7 @@ public final class DefaultTracer implements Tracer {
 
   @Override
   public Span getCurrentSpan() {
-    return TracingContextUtils.getCurrentSpan();
+    return Span.current();
   }
 
   @Override
@@ -61,7 +61,7 @@ public final class DefaultTracer implements Tracer {
     @Override
     public Span startSpan() {
       if (spanContext == null) {
-        spanContext = TracingContextUtils.getCurrentSpan().getContext();
+        spanContext = Span.current().getContext();
       }
 
       return spanContext != null && !SpanContext.getInvalid().equals(spanContext)

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -24,6 +24,17 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface Span {
 
   /**
+   * Returns the {@link Span} from the current {@code Context}, falling back to a default, no-op
+   * {@link Span} if there is no current span in the context. This is generally used to access a
+   * {@link Span} that you did not create, for example one created by instrumentation of a request
+   * handler. There is some overhead in accessing the current span statically, so if you have
+   * created the {@link Span} yourself it is recommended to maintain a reference to it instead.
+   */
+  static Span current() {
+    return TracingContextUtils.getCurrentSpan();
+  }
+
+  /**
    * Type of span. Can be used to specify additional relationships between spans in addition to a
    * parent/child relationship.
    *

--- a/api/src/main/java/io/opentelemetry/trace/TracingContextUtils.java
+++ b/api/src/main/java/io/opentelemetry/trace/TracingContextUtils.java
@@ -33,14 +33,7 @@ public final class TracingContextUtils {
     return context.withValues(CONTEXT_SPAN_KEY, span);
   }
 
-  /**
-   * Returns the {@link Span} from the current {@code Context}, falling back to a default, no-op
-   * {@link Span}.
-   *
-   * @return the {@link Span} from the current {@code Context}.
-   * @since 0.3.0
-   */
-  public static Span getCurrentSpan() {
+  static Span getCurrentSpan() {
     return getSpan(io.opentelemetry.context.Context.current());
   }
 

--- a/api/src/test/java/io/opentelemetry/trace/TracingContextUtilsTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TracingContextUtilsTest.java
@@ -15,7 +15,7 @@ class TracingContextUtilsTest {
 
   @Test
   void testGetCurrentSpan_Default() {
-    Span span = TracingContextUtils.getCurrentSpan();
+    Span span = Span.current();
     assertThat(span).isSameAs(DefaultSpan.getInvalid());
   }
 
@@ -23,7 +23,7 @@ class TracingContextUtilsTest {
   void testGetCurrentSpan_SetSpan() {
     Span span = DefaultSpan.create(SpanContext.getInvalid());
     try (Scope ignored = TracingContextUtils.withSpan(span, Context.current()).makeCurrent()) {
-      assertThat(TracingContextUtils.getCurrentSpan()).isSameAs(span);
+      assertThat(Span.current()).isSameAs(span);
     }
   }
 

--- a/extensions/trace_utils/src/test/java/io/opentelemetry/extensions/trace/CurrentSpanUtilsTest.java
+++ b/extensions/trace_utils/src/test/java/io/opentelemetry/extensions/trace/CurrentSpanUtilsTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import io.opentelemetry.trace.DefaultSpan;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.StatusCanonicalCode;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.concurrent.Callable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -205,6 +204,6 @@ class CurrentSpanUtilsTest {
   }
 
   private static Span getCurrentSpan() {
-    return TracingContextUtils.getCurrentSpan();
+    return Span.current();
   }
 }

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
@@ -24,7 +24,7 @@ final class TracerSdk implements Tracer {
 
   @Override
   public Span getCurrentSpan() {
-    return TracingContextUtils.getCurrentSpan();
+    return Span.current();
   }
 
   @Override


### PR DESCRIPTION
I was thinking of talking about this after changes like #1753 and #1737 (after which I'm thinking of moving context interaction to `OpenTelemetry`) but figured it doesn't hurt to split this out as an idea.

I think getting the current span is a very common operation, especially for javaagent users. They will rarely create spans, or deal with tracers. But adding attributes to a span is very common for anyone.

```java
Response myRequestHandler(Request request) {
  Span.current().setAttribute("userid", request.getUserId());
}
```

We are also toying with the idea of having static methods on `Tracer`
```java
Response myRequestHandler(Request request) {
  Tracer.currentSpan().setAttribute("userid", request.getUserId());
}
```

For simple usage, which is common for accessing the current span since when you have a tracer, you usually also will have created a span from it to track yourself, the former feels more intuitive and looks like better code from a user perspective to me. Tracer is a very important concept for instrumentation authors, but not so important for end users.