### PR TITLE
Remove since tags until 1.0.0

### DIFF
--- a/api/src/main/java/io/opentelemetry/OpenTelemetry.java
+++ b/api/src/main/java/io/opentelemetry/OpenTelemetry.java
@@ -53,7 +53,6 @@ public final class OpenTelemetry {
    * @return registered TracerProvider or default via {@link DefaultTracerProvider#getInstance()}.
    * @throws IllegalStateException if a specified TracerProvider (via system properties) could not
    *     be found.
-   * @since 0.1.0
    */
   public static TracerProvider getTracerProvider() {
     return getInstance().tracerProvider;
@@ -67,7 +66,6 @@ public final class OpenTelemetry {
    * @param instrumentationName The name of the instrumentation library, not the name of the
    *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.
    * @return a tracer instance.
-   * @since 0.5.0
    */
   public static Tracer getTracer(String instrumentationName) {
     return getTracerProvider().get(instrumentationName);
@@ -84,7 +82,6 @@ public final class OpenTelemetry {
    * @param instrumentationVersion The version of the instrumentation library (e.g.,
    *     "semver:1.0.0").
    * @return a tracer instance.
-   * @since 0.5.0
    */
   public static Tracer getTracer(String instrumentationName, String instrumentationVersion) {
     return getTracerProvider().get(instrumentationName, instrumentationVersion);
@@ -96,7 +93,6 @@ public final class OpenTelemetry {
    * @return registered MeterProvider or default via {@link DefaultMeterProvider#getInstance()}.
    * @throws IllegalStateException if a specified MeterProvider (via system properties) could not be
    *     found.
-   * @since 0.1.0
    */
   public static MeterProvider getMeterProvider() {
     return getInstance().meterProvider;
@@ -110,7 +106,6 @@ public final class OpenTelemetry {
    * @param instrumentationName The name of the instrumentation library, not the name of the
    *     instrument*ed* library.
    * @return a tracer instance.
-   * @since 0.5.0
    */
   public static Meter getMeter(String instrumentationName) {
     return getMeterProvider().get(instrumentationName);
@@ -126,7 +121,6 @@ public final class OpenTelemetry {
    *     instrument*ed* library.
    * @param instrumentationVersion The version of the instrumentation library.
    * @return a tracer instance.
-   * @since 0.5.0
    */
   public static Meter getMeter(String instrumentationName, String instrumentationVersion) {
     return getMeterProvider().get(instrumentationName, instrumentationVersion);
@@ -138,7 +132,6 @@ public final class OpenTelemetry {
    * @return registered manager or default via {@link DefaultBaggageManager#getInstance()}.
    * @throws IllegalStateException if a specified manager (via system properties) could not be
    *     found.
-   * @since 0.1.0
    */
   public static BaggageManager getBaggageManager() {
     return getInstance().contextManager;
@@ -152,7 +145,6 @@ public final class OpenTelemetry {
    *     with {@link HttpTraceContext} registered.
    * @throws IllegalStateException if a specified manager (via system properties) could not be
    *     found.
-   * @since 0.3.0
    */
   public static ContextPropagators getPropagators() {
     return getInstance().propagators;
@@ -166,7 +158,6 @@ public final class OpenTelemetry {
    * @throws IllegalStateException if a specified manager (via system properties) could not be
    *     found.
    * @throws NullPointerException if {@code propagators} is {@code null}.
-   * @since 0.3.0
    */
   public static void setPropagators(ContextPropagators propagators) {
     Objects.requireNonNull(propagators, "propagators");

--- a/api/src/main/java/io/opentelemetry/baggage/Baggage.java
+++ b/api/src/main/java/io/opentelemetry/baggage/Baggage.java
@@ -17,7 +17,6 @@ import javax.annotation.concurrent.Immutable;
  * <p>For example, {@code Baggage}s can be used to label stats, log messages, or debugging
  * information.
  *
- * @since 0.9.0
  */
 @Immutable
 public interface Baggage {
@@ -26,7 +25,6 @@ public interface Baggage {
    * guaranteed.
    *
    * @return an immutable collection of the entries in this {@code Baggage}.
-   * @since 0.9.0
    */
   Collection<Entry> getEntries();
 
@@ -43,7 +41,6 @@ public interface Baggage {
   /**
    * Builder for the {@link Baggage} class.
    *
-   * @since 0.9.0
    */
   interface Builder {
     /**
@@ -63,7 +60,6 @@ public interface Baggage {
      * @return this.
      * @throws NullPointerException if {@code context} is {@code null}.
      * @see #setNoParent()
-     * @since 0.9.0
      */
     Builder setParent(Context context);
 
@@ -73,7 +69,6 @@ public interface Baggage {
      * BaggageManager#getCurrentBaggage()} at {@link #build()} time will be used as parent.
      *
      * @return this.
-     * @since 0.9.0
      */
     Builder setNoParent();
 
@@ -84,7 +79,6 @@ public interface Baggage {
      * @param value the {@code String} value to set for the given key.
      * @param entryMetadata the {@code EntryMetadata} associated with this {@link Entry}.
      * @return this
-     * @since 0.9.0
      */
     Builder put(String key, String value, EntryMetadata entryMetadata);
 
@@ -93,7 +87,6 @@ public interface Baggage {
      *
      * @param key the {@code String} key which will be removed.
      * @return this
-     * @since 0.9.0
      */
     Builder remove(String key);
 
@@ -101,7 +94,6 @@ public interface Baggage {
      * Creates a {@code Baggage} from this builder.
      *
      * @return a {@code Baggage} with the same entries as this builder.
-     * @since 0.9.0
      */
     Baggage build();
   }

--- a/api/src/main/java/io/opentelemetry/baggage/Baggage.java
+++ b/api/src/main/java/io/opentelemetry/baggage/Baggage.java
@@ -16,7 +16,6 @@ import javax.annotation.concurrent.Immutable;
  *
  * <p>For example, {@code Baggage}s can be used to label stats, log messages, or debugging
  * information.
- *
  */
 @Immutable
 public interface Baggage {
@@ -38,10 +37,7 @@ public interface Baggage {
   @Nullable
   String getEntryValue(String entryKey);
 
-  /**
-   * Builder for the {@link Baggage} class.
-   *
-   */
+  /** Builder for the {@link Baggage} class. */
   interface Builder {
     /**
      * Sets the parent {@link Baggage} to use from the specified {@code Context}. If no parent

--- a/api/src/main/java/io/opentelemetry/baggage/BaggageManager.java
+++ b/api/src/main/java/io/opentelemetry/baggage/BaggageManager.java
@@ -17,7 +17,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * <p>Implementations may have different constraints and are free to convert entry contexts to their
  * own subtypes. This means callers cannot assume the {@link #getCurrentBaggage() current context}
  * is the same instance as the one {@linkplain #withBaggage(Baggage) placed into scope}.
- *
  */
 @ThreadSafe
 public interface BaggageManager {

--- a/api/src/main/java/io/opentelemetry/baggage/BaggageManager.java
+++ b/api/src/main/java/io/opentelemetry/baggage/BaggageManager.java
@@ -18,7 +18,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * own subtypes. This means callers cannot assume the {@link #getCurrentBaggage() current context}
  * is the same instance as the one {@linkplain #withBaggage(Baggage) placed into scope}.
  *
- * @since 0.9.0
  */
 @ThreadSafe
 public interface BaggageManager {
@@ -27,7 +26,6 @@ public interface BaggageManager {
    * Returns the current {@code Baggage}.
    *
    * @return the current {@code Baggage}.
-   * @since 0.9.0
    */
   Baggage getCurrentBaggage();
 
@@ -35,7 +33,6 @@ public interface BaggageManager {
    * Returns a new {@link Baggage.Builder}.
    *
    * @return a new {@code Baggage.Builder}.
-   * @since 0.9.0
    */
   Baggage.Builder baggageBuilder();
 
@@ -47,7 +44,6 @@ public interface BaggageManager {
    * @param baggage the {@code Baggage} to be set as the current context.
    * @return an object that defines a scope where the given {@code Baggage} is set as the current
    *     context.
-   * @since 0.9.0
    */
   Scope withBaggage(Baggage baggage);
 }

--- a/api/src/main/java/io/opentelemetry/baggage/BaggageUtils.java
+++ b/api/src/main/java/io/opentelemetry/baggage/BaggageUtils.java
@@ -14,7 +14,6 @@ import javax.annotation.concurrent.Immutable;
 /**
  * Utility methods for accessing the {@link Baggage} contained in the {@link Context}.
  *
- * @since 0.9.0
  */
 @Immutable
 public final class BaggageUtils {
@@ -27,7 +26,6 @@ public final class BaggageUtils {
    * @param baggage the value to be set.
    * @param context the parent {@code Context}.
    * @return a new context with the given value set.
-   * @since 0.9.0
    */
   public static Context withBaggage(Baggage baggage, Context context) {
     return context.withValues(CORR_CONTEXT_KEY, baggage);
@@ -38,7 +36,6 @@ public final class BaggageUtils {
    * to an empty {@link Baggage}.
    *
    * @return the {@link Baggage} from the {@linkplain Context#current current context}.
-   * @since 0.9.0
    */
   public static Baggage getCurrentBaggage() {
     return getBaggage(Context.current());
@@ -50,7 +47,6 @@ public final class BaggageUtils {
    *
    * @param context the specified {@code Context}.
    * @return the {@link Baggage} from the specified {@code Context}.
-   * @since 0.9.0
    */
   public static Baggage getBaggage(Context context) {
     Baggage baggage = context.getValue(CORR_CONTEXT_KEY);
@@ -63,7 +59,6 @@ public final class BaggageUtils {
    *
    * @param context the specified {@code Context}.
    * @return the {@link Baggage} from the specified {@code Context}.
-   * @since 0.9.0
    */
   @Nullable
   public static Baggage getBaggageWithoutDefault(Context context) {
@@ -76,7 +71,6 @@ public final class BaggageUtils {
    *
    * @param baggage the {@link Baggage} to be added to the current {@code Context}.
    * @return the {@link Scope} for the updated {@code Context}.
-   * @since 0.9.0
    */
   public static Scope currentContextWith(Baggage baggage) {
     Context context = withBaggage(baggage, Context.current());

--- a/api/src/main/java/io/opentelemetry/baggage/BaggageUtils.java
+++ b/api/src/main/java/io/opentelemetry/baggage/BaggageUtils.java
@@ -11,10 +11,7 @@ import io.opentelemetry.context.Scope;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
-/**
- * Utility methods for accessing the {@link Baggage} contained in the {@link Context}.
- *
- */
+/** Utility methods for accessing the {@link Baggage} contained in the {@link Context}. */
 @Immutable
 public final class BaggageUtils {
   private static final ContextKey<Baggage> CORR_CONTEXT_KEY =

--- a/api/src/main/java/io/opentelemetry/baggage/DefaultBaggageManager.java
+++ b/api/src/main/java/io/opentelemetry/baggage/DefaultBaggageManager.java
@@ -11,10 +11,7 @@ import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.ThreadSafe;
 
-/**
- * No-op implementations of {@link BaggageManager}.
- *
- */
+/** No-op implementations of {@link BaggageManager}. */
 @ThreadSafe
 public final class DefaultBaggageManager implements BaggageManager {
   private static final DefaultBaggageManager INSTANCE = new DefaultBaggageManager();

--- a/api/src/main/java/io/opentelemetry/baggage/DefaultBaggageManager.java
+++ b/api/src/main/java/io/opentelemetry/baggage/DefaultBaggageManager.java
@@ -14,7 +14,6 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * No-op implementations of {@link BaggageManager}.
  *
- * @since 0.9.0
  */
 @ThreadSafe
 public final class DefaultBaggageManager implements BaggageManager {

--- a/api/src/main/java/io/opentelemetry/baggage/EmptyBaggage.java
+++ b/api/src/main/java/io/opentelemetry/baggage/EmptyBaggage.java
@@ -17,7 +17,6 @@ public class EmptyBaggage implements Baggage {
    * Returns the single instance of the {@link EmptyBaggage} class.
    *
    * @return the single instance of the {@code EmptyBaggage} class.
-   * @since 0.9.0
    */
   public static Baggage getInstance() {
     return INSTANCE;

--- a/api/src/main/java/io/opentelemetry/baggage/Entry.java
+++ b/api/src/main/java/io/opentelemetry/baggage/Entry.java
@@ -10,10 +10,7 @@ import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.internal.Utils;
 import javax.annotation.concurrent.Immutable;
 
-/**
- * String-String key-value pair, along with {@link EntryMetadata}.
- *
- */
+/** String-String key-value pair, along with {@link EntryMetadata}. */
 @Immutable
 @AutoValue
 public abstract class Entry {

--- a/api/src/main/java/io/opentelemetry/baggage/Entry.java
+++ b/api/src/main/java/io/opentelemetry/baggage/Entry.java
@@ -13,7 +13,6 @@ import javax.annotation.concurrent.Immutable;
 /**
  * String-String key-value pair, along with {@link EntryMetadata}.
  *
- * @since 0.9.0
  */
 @Immutable
 @AutoValue
@@ -28,7 +27,6 @@ public abstract class Entry {
    * @param value the entry value.
    * @param entryMetadata the entry metadata.
    * @return a {@code Entry}.
-   * @since 0.9.0
    */
   public static Entry create(String key, String value, EntryMetadata entryMetadata) {
     Utils.checkArgument(keyIsValid(key), "Invalid entry key name: %s", key);
@@ -42,7 +40,6 @@ public abstract class Entry {
    * @param key the entry key.
    * @param value the entry value.
    * @return a {@code Entry}.
-   * @since 0.9.0
    */
   public static Entry create(String key, String value) {
     return create(key, value, EntryMetadata.EMPTY);
@@ -52,7 +49,6 @@ public abstract class Entry {
    * Returns the entry's key.
    *
    * @return the entry's key.
-   * @since 0.9.0
    */
   public abstract String getKey();
 
@@ -60,7 +56,6 @@ public abstract class Entry {
    * Returns the entry's value.
    *
    * @return the entry's value.
-   * @since 0.9.0
    */
   public abstract String getValue();
 
@@ -68,7 +63,6 @@ public abstract class Entry {
    * Returns the (optional) {@link EntryMetadata} associated with this {@link Entry}.
    *
    * @return the {@code EntryMetadata}.
-   * @since 0.9.0
    */
   public abstract EntryMetadata getEntryMetadata();
 

--- a/api/src/main/java/io/opentelemetry/baggage/EntryMetadata.java
+++ b/api/src/main/java/io/opentelemetry/baggage/EntryMetadata.java
@@ -12,7 +12,6 @@ import javax.annotation.concurrent.Immutable;
  * {@link EntryMetadata} contains properties associated with an {@link Entry}. This is an opaque
  * wrapper for a String metadata value.
  *
- * @since 0.9.0
  */
 @Immutable
 @AutoValue
@@ -26,7 +25,6 @@ public abstract class EntryMetadata {
    *
    * @param metadata TTL of an {@code Entry}.
    * @return an {@code EntryMetadata}.
-   * @since 0.9.0
    */
   public static EntryMetadata create(String metadata) {
     return new AutoValue_EntryMetadata(metadata);
@@ -36,7 +34,6 @@ public abstract class EntryMetadata {
    * Returns the String value of this {@link EntryMetadata}.
    *
    * @return the raw metadata value.
-   * @since 0.9.0
    */
   public abstract String getValue();
 }

--- a/api/src/main/java/io/opentelemetry/baggage/EntryMetadata.java
+++ b/api/src/main/java/io/opentelemetry/baggage/EntryMetadata.java
@@ -11,7 +11,6 @@ import javax.annotation.concurrent.Immutable;
 /**
  * {@link EntryMetadata} contains properties associated with an {@link Entry}. This is an opaque
  * wrapper for a String metadata value.
- *
  */
 @Immutable
 @AutoValue

--- a/api/src/main/java/io/opentelemetry/baggage/spi/BaggageManagerFactory.java
+++ b/api/src/main/java/io/opentelemetry/baggage/spi/BaggageManagerFactory.java
@@ -25,7 +25,6 @@ public interface BaggageManagerFactory {
    * Creates a new {@code BaggageManager} instance.
    *
    * @return a {@code BaggageManager} instance.
-   * @since 0.9.0
    */
   BaggageManager create();
 }

--- a/api/src/main/java/io/opentelemetry/common/AttributeConsumer.java
+++ b/api/src/main/java/io/opentelemetry/common/AttributeConsumer.java
@@ -5,10 +5,7 @@
 
 package io.opentelemetry.common;
 
-/**
- * Used for iterating over all the key/value pairs in an {@link Attributes} instance.
- *
- */
+/** Used for iterating over all the key/value pairs in an {@link Attributes} instance. */
 public interface AttributeConsumer {
   <T> void consume(AttributeKey<T> key, T value);
 }

--- a/api/src/main/java/io/opentelemetry/common/AttributeConsumer.java
+++ b/api/src/main/java/io/opentelemetry/common/AttributeConsumer.java
@@ -8,7 +8,6 @@ package io.opentelemetry.common;
 /**
  * Used for iterating over all the key/value pairs in an {@link Attributes} instance.
  *
- * @since 0.9.0
  */
 public interface AttributeConsumer {
   <T> void consume(AttributeKey<T> key, T value);

--- a/api/src/main/java/io/opentelemetry/common/AttributeType.java
+++ b/api/src/main/java/io/opentelemetry/common/AttributeType.java
@@ -8,7 +8,6 @@ package io.opentelemetry.common;
 /**
  * An enum that represents all the possible value types for an {@code AttributeKey} and hence the
  * types of values that are allowed for {@link Attributes}.
- *
  */
 public enum AttributeType {
   STRING,

--- a/api/src/main/java/io/opentelemetry/common/AttributeType.java
+++ b/api/src/main/java/io/opentelemetry/common/AttributeType.java
@@ -9,7 +9,6 @@ package io.opentelemetry.common;
  * An enum that represents all the possible value types for an {@code AttributeKey} and hence the
  * types of values that are allowed for {@link Attributes}.
  *
- * @since 0.1.0
  */
 public enum AttributeType {
   STRING,

--- a/api/src/main/java/io/opentelemetry/common/LabelConsumer.java
+++ b/api/src/main/java/io/opentelemetry/common/LabelConsumer.java
@@ -10,7 +10,6 @@ package io.opentelemetry.common;
  *
  * <p>This interface should be considered to be a FunctionalInterface in the java 8+ meaning of that
  * term.
- *
  */
 public interface LabelConsumer {
   void consume(String key, String value);

--- a/api/src/main/java/io/opentelemetry/common/LabelConsumer.java
+++ b/api/src/main/java/io/opentelemetry/common/LabelConsumer.java
@@ -11,7 +11,6 @@ package io.opentelemetry.common;
  * <p>This interface should be considered to be a FunctionalInterface in the java 8+ meaning of that
  * term.
  *
- * @since 0.9.0
  */
 public interface LabelConsumer {
   void consume(String key, String value);

--- a/api/src/main/java/io/opentelemetry/internal/Obfuscated.java
+++ b/api/src/main/java/io/opentelemetry/internal/Obfuscated.java
@@ -18,7 +18,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * casts will fail under auto-instrumentation, because auto-instrumentation takes over the static
  * global providers returned by the API and points them to it's embedded SDK.
  *
- * @since 0.4.0
  */
 @ThreadSafe
 public interface Obfuscated<T> {
@@ -27,7 +26,6 @@ public interface Obfuscated<T> {
    * Returns the unobfuscated provider.
    *
    * @return the unobfuscated provider.
-   * @since 0.4.0
    */
   T unobfuscate();
 }

--- a/api/src/main/java/io/opentelemetry/internal/Obfuscated.java
+++ b/api/src/main/java/io/opentelemetry/internal/Obfuscated.java
@@ -17,7 +17,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * that are returned from the API, and cast them to their SDK specific implementations, then those
  * casts will fail under auto-instrumentation, because auto-instrumentation takes over the static
  * global providers returned by the API and points them to it's embedded SDK.
- *
  */
 @ThreadSafe
 public interface Obfuscated<T> {

--- a/api/src/main/java/io/opentelemetry/metrics/AsynchronousInstrument.java
+++ b/api/src/main/java/io/opentelemetry/metrics/AsynchronousInstrument.java
@@ -19,14 +19,12 @@ import javax.annotation.concurrent.ThreadSafe;
  * kept.
  *
  * @param <R> the callback Result type.
- * @since 0.1.0
  */
 @ThreadSafe
 public interface AsynchronousInstrument<R extends Result> extends Instrument {
   /**
    * A {@code Callback} for a {@code AsynchronousInstrument}.
    *
-   * @since 0.1.0
    */
   interface Callback<R extends Result> {
     void update(R result);
@@ -39,7 +37,6 @@ public interface AsynchronousInstrument<R extends Result> extends Instrument {
    * exported then it will never be called.
    *
    * @param callback the callback to be executed before export.
-   * @since 0.1.0
    */
   void setCallback(Callback<R> callback);
 

--- a/api/src/main/java/io/opentelemetry/metrics/AsynchronousInstrument.java
+++ b/api/src/main/java/io/opentelemetry/metrics/AsynchronousInstrument.java
@@ -22,10 +22,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public interface AsynchronousInstrument<R extends Result> extends Instrument {
-  /**
-   * A {@code Callback} for a {@code AsynchronousInstrument}.
-   *
-   */
+  /** A {@code Callback} for a {@code AsynchronousInstrument}. */
   interface Callback<R extends Result> {
     void update(R result);
   }

--- a/api/src/main/java/io/opentelemetry/metrics/BatchRecorder.java
+++ b/api/src/main/java/io/opentelemetry/metrics/BatchRecorder.java
@@ -80,7 +80,6 @@ public interface BatchRecorder {
    *
    * <p>This method records all measurements every time it is called, so make sure it is not called
    * twice if not needed.
-   *
    */
   void record();
 }

--- a/api/src/main/java/io/opentelemetry/metrics/BatchRecorder.java
+++ b/api/src/main/java/io/opentelemetry/metrics/BatchRecorder.java
@@ -22,7 +22,6 @@ public interface BatchRecorder {
    * @param valueRecorder the {@link LongValueRecorder}.
    * @param value the value to be associated with {@code valueRecorder}.
    * @return this.
-   * @since 0.1.0
    */
   BatchRecorder put(LongValueRecorder valueRecorder, long value);
 
@@ -33,7 +32,6 @@ public interface BatchRecorder {
    * @param valueRecorder the {@link DoubleValueRecorder}.
    * @param value the value to be associated with {@code valueRecorder}.
    * @return this.
-   * @since 0.1.0
    */
   BatchRecorder put(DoubleValueRecorder valueRecorder, double value);
 
@@ -44,7 +42,6 @@ public interface BatchRecorder {
    * @param counter the {@link LongCounter}.
    * @param value the value to be associated with {@code counter}.
    * @return this.
-   * @since 0.3.0
    */
   BatchRecorder put(LongCounter counter, long value);
 
@@ -55,7 +52,6 @@ public interface BatchRecorder {
    * @param counter the {@link DoubleCounter}.
    * @param value the value to be associated with {@code counter}.
    * @return this.
-   * @since 0.3.0
    */
   BatchRecorder put(DoubleCounter counter, double value);
 
@@ -66,7 +62,6 @@ public interface BatchRecorder {
    * @param upDownCounter the {@link LongCounter}.
    * @param value the value to be associated with {@code counter}.
    * @return this.
-   * @since 0.5.0
    */
   BatchRecorder put(LongUpDownCounter upDownCounter, long value);
 
@@ -77,7 +72,6 @@ public interface BatchRecorder {
    * @param upDownCounter the {@link DoubleCounter}.
    * @param value the value to be associated with {@code counter}.
    * @return this.
-   * @since 0.5.0
    */
   BatchRecorder put(DoubleUpDownCounter upDownCounter, double value);
 
@@ -87,7 +81,6 @@ public interface BatchRecorder {
    * <p>This method records all measurements every time it is called, so make sure it is not called
    * twice if not needed.
    *
-   * @since 0.1.0
    */
   void record();
 }

--- a/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
@@ -12,10 +12,7 @@ import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.ThreadSafe;
 
-/**
- * No-op implementations of {@link Meter}.
- *
- */
+/** No-op implementations of {@link Meter}. */
 @ThreadSafe
 public final class DefaultMeter implements Meter {
 

--- a/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DefaultMeter.java
@@ -15,7 +15,6 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * No-op implementations of {@link Meter}.
  *
- * @since 0.1.0
  */
 @ThreadSafe
 public final class DefaultMeter implements Meter {
@@ -32,7 +31,6 @@ public final class DefaultMeter implements Meter {
    * Returns a {@code Meter} singleton that is the default implementations for {@link Meter}.
    *
    * @return a {@code Meter} singleton that is the default implementations for {@link Meter}.
-   * @since 0.1.0
    */
   public static Meter getInstance() {
     return INSTANCE;

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleCounter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleCounter.java
@@ -36,7 +36,6 @@ import javax.annotation.concurrent.ThreadSafe;
  *   }
  * }
  * }</pre>
- *
  */
 @ThreadSafe
 public interface DoubleCounter extends SynchronousInstrument<BoundDoubleCounter> {
@@ -63,10 +62,7 @@ public interface DoubleCounter extends SynchronousInstrument<BoundDoubleCounter>
   @Override
   BoundDoubleCounter bind(Labels labels);
 
-  /**
-   * A {@code Bound Instrument} for a {@link DoubleCounter}.
-   *
-   */
+  /** A {@code Bound Instrument} for a {@link DoubleCounter}. */
   @ThreadSafe
   interface BoundDoubleCounter extends SynchronousInstrument.BoundInstrument {
     /**

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleCounter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleCounter.java
@@ -37,7 +37,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * }
  * }</pre>
  *
- * @since 0.1.0
  */
 @ThreadSafe
 public interface DoubleCounter extends SynchronousInstrument<BoundDoubleCounter> {
@@ -49,7 +48,6 @@ public interface DoubleCounter extends SynchronousInstrument<BoundDoubleCounter>
    *
    * @param increment the value to add.
    * @param labels the labels to be associated to this recording.
-   * @since 0.1.0
    */
   void add(double increment, Labels labels);
 
@@ -59,7 +57,6 @@ public interface DoubleCounter extends SynchronousInstrument<BoundDoubleCounter>
    * <p>The value added is associated with the current {@code Context} and with empty labels.
    *
    * @param increment the value to add.
-   * @since 0.8.0
    */
   void add(double increment);
 
@@ -69,7 +66,6 @@ public interface DoubleCounter extends SynchronousInstrument<BoundDoubleCounter>
   /**
    * A {@code Bound Instrument} for a {@link DoubleCounter}.
    *
-   * @since 0.1.0
    */
   @ThreadSafe
   interface BoundDoubleCounter extends SynchronousInstrument.BoundInstrument {
@@ -79,7 +75,6 @@ public interface DoubleCounter extends SynchronousInstrument<BoundDoubleCounter>
      * <p>The value added is associated with the current {@code Context}.
      *
      * @param increment the value to add.
-     * @since 0.1.0
      */
     void add(double increment);
 

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleSumObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleSumObserver.java
@@ -45,7 +45,6 @@ import javax.annotation.concurrent.ThreadSafe;
  *   }
  * }
  * }</pre>
- *
  */
 @ThreadSafe
 public interface DoubleSumObserver extends AsynchronousInstrument<DoubleResult> {

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleSumObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleSumObserver.java
@@ -46,7 +46,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * }
  * }</pre>
  *
- * @since 0.1.0
  */
 @ThreadSafe
 public interface DoubleSumObserver extends AsynchronousInstrument<DoubleResult> {

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleUpDownCounter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleUpDownCounter.java
@@ -40,7 +40,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * }
  * }</pre>
  *
- * @since 0.1.0
  */
 @ThreadSafe
 public interface DoubleUpDownCounter extends SynchronousInstrument<BoundDoubleUpDownCounter> {
@@ -52,7 +51,6 @@ public interface DoubleUpDownCounter extends SynchronousInstrument<BoundDoubleUp
    *
    * @param increment the value to add.
    * @param labels the labels to be associated to this recording.
-   * @since 0.1.0
    */
   void add(double increment, Labels labels);
 
@@ -62,7 +60,6 @@ public interface DoubleUpDownCounter extends SynchronousInstrument<BoundDoubleUp
    * <p>The value added is associated with the current {@code Context} and empty labels.
    *
    * @param increment the value to add.
-   * @since 0.8.0
    */
   void add(double increment);
 
@@ -72,7 +69,6 @@ public interface DoubleUpDownCounter extends SynchronousInstrument<BoundDoubleUp
   /**
    * A {@code Bound Instrument} for a {@link DoubleUpDownCounter}.
    *
-   * @since 0.1.0
    */
   @ThreadSafe
   interface BoundDoubleUpDownCounter extends BoundInstrument {
@@ -82,7 +78,6 @@ public interface DoubleUpDownCounter extends SynchronousInstrument<BoundDoubleUp
      * <p>The value added is associated with the current {@code Context}.
      *
      * @param increment the value to add.
-     * @since 0.1.0
      */
     void add(double increment);
 

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleUpDownCounter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleUpDownCounter.java
@@ -39,7 +39,6 @@ import javax.annotation.concurrent.ThreadSafe;
  *   }
  * }
  * }</pre>
- *
  */
 @ThreadSafe
 public interface DoubleUpDownCounter extends SynchronousInstrument<BoundDoubleUpDownCounter> {
@@ -66,10 +65,7 @@ public interface DoubleUpDownCounter extends SynchronousInstrument<BoundDoubleUp
   @Override
   BoundDoubleUpDownCounter bind(Labels labels);
 
-  /**
-   * A {@code Bound Instrument} for a {@link DoubleUpDownCounter}.
-   *
-   */
+  /** A {@code Bound Instrument} for a {@link DoubleUpDownCounter}. */
   @ThreadSafe
   interface BoundDoubleUpDownCounter extends BoundInstrument {
     /**

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleUpDownSumObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleUpDownSumObserver.java
@@ -45,7 +45,6 @@ import javax.annotation.concurrent.ThreadSafe;
  *   }
  * }
  * }</pre>
- *
  */
 @ThreadSafe
 public interface DoubleUpDownSumObserver extends AsynchronousInstrument<DoubleResult> {

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleUpDownSumObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleUpDownSumObserver.java
@@ -46,7 +46,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * }
  * }</pre>
  *
- * @since 0.1.0
  */
 @ThreadSafe
 public interface DoubleUpDownSumObserver extends AsynchronousInstrument<DoubleResult> {

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleValueObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleValueObserver.java
@@ -42,7 +42,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * }
  * }</pre>
  *
- * @since 0.5.0
  */
 @ThreadSafe
 public interface DoubleValueObserver extends AsynchronousInstrument<DoubleResult> {

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleValueObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleValueObserver.java
@@ -41,7 +41,6 @@ import javax.annotation.concurrent.ThreadSafe;
  *   }
  * }
  * }</pre>
- *
  */
 @ThreadSafe
 public interface DoubleValueObserver extends AsynchronousInstrument<DoubleResult> {

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleValueRecorder.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleValueRecorder.java
@@ -49,7 +49,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * }
  * }</pre>
  *
- * @since 0.1.0
  */
 @ThreadSafe
 public interface DoubleValueRecorder extends SynchronousInstrument<BoundDoubleValueRecorder> {
@@ -61,7 +60,6 @@ public interface DoubleValueRecorder extends SynchronousInstrument<BoundDoubleVa
    * @param value the measurement to record.
    * @param labels the set of labels to be associated to this recording
    * @throws IllegalArgumentException if value is negative.
-   * @since 0.3.0
    */
   void record(double value, Labels labels);
 
@@ -70,7 +68,6 @@ public interface DoubleValueRecorder extends SynchronousInstrument<BoundDoubleVa
    *
    * @param value the measurement to record.
    * @throws IllegalArgumentException if value is negative.
-   * @since 0.8.0
    */
   void record(double value);
 
@@ -80,7 +77,6 @@ public interface DoubleValueRecorder extends SynchronousInstrument<BoundDoubleVa
   /**
    * A {@code Bound Instrument} for a {@link DoubleValueRecorder}.
    *
-   * @since 0.1.0
    */
   @ThreadSafe
   interface BoundDoubleValueRecorder extends SynchronousInstrument.BoundInstrument {
@@ -89,7 +85,6 @@ public interface DoubleValueRecorder extends SynchronousInstrument<BoundDoubleVa
      *
      * @param value the measurement to record.
      * @throws IllegalArgumentException if value is negative.
-     * @since 0.1.0
      */
     void record(double value);
 

--- a/api/src/main/java/io/opentelemetry/metrics/DoubleValueRecorder.java
+++ b/api/src/main/java/io/opentelemetry/metrics/DoubleValueRecorder.java
@@ -48,7 +48,6 @@ import javax.annotation.concurrent.ThreadSafe;
  *   }
  * }
  * }</pre>
- *
  */
 @ThreadSafe
 public interface DoubleValueRecorder extends SynchronousInstrument<BoundDoubleValueRecorder> {
@@ -74,10 +73,7 @@ public interface DoubleValueRecorder extends SynchronousInstrument<BoundDoubleVa
   @Override
   BoundDoubleValueRecorder bind(Labels labels);
 
-  /**
-   * A {@code Bound Instrument} for a {@link DoubleValueRecorder}.
-   *
-   */
+  /** A {@code Bound Instrument} for a {@link DoubleValueRecorder}. */
   @ThreadSafe
   interface BoundDoubleValueRecorder extends SynchronousInstrument.BoundInstrument {
     /**

--- a/api/src/main/java/io/opentelemetry/metrics/Instrument.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Instrument.java
@@ -10,7 +10,6 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * Base interface for all metrics defined in this package.
  *
- * @since 0.1.0
  */
 @ThreadSafe
 @SuppressWarnings("InterfaceWithOnlyStatics")

--- a/api/src/main/java/io/opentelemetry/metrics/Instrument.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Instrument.java
@@ -7,10 +7,7 @@ package io.opentelemetry.metrics;
 
 import javax.annotation.concurrent.ThreadSafe;
 
-/**
- * Base interface for all metrics defined in this package.
- *
- */
+/** Base interface for all metrics defined in this package. */
 @ThreadSafe
 @SuppressWarnings("InterfaceWithOnlyStatics")
 public interface Instrument {

--- a/api/src/main/java/io/opentelemetry/metrics/LongCounter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongCounter.java
@@ -36,7 +36,6 @@ import javax.annotation.concurrent.ThreadSafe;
  *   }
  * }
  * }</pre>
- *
  */
 @ThreadSafe
 public interface LongCounter extends SynchronousInstrument<BoundLongCounter> {
@@ -63,10 +62,7 @@ public interface LongCounter extends SynchronousInstrument<BoundLongCounter> {
   @Override
   BoundLongCounter bind(Labels labels);
 
-  /**
-   * A {@code Bound Instrument} for a {@link LongCounter}.
-   *
-   */
+  /** A {@code Bound Instrument} for a {@link LongCounter}. */
   @ThreadSafe
   interface BoundLongCounter extends SynchronousInstrument.BoundInstrument {
 

--- a/api/src/main/java/io/opentelemetry/metrics/LongCounter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongCounter.java
@@ -37,7 +37,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * }
  * }</pre>
  *
- * @since 0.1.0
  */
 @ThreadSafe
 public interface LongCounter extends SynchronousInstrument<BoundLongCounter> {
@@ -49,7 +48,6 @@ public interface LongCounter extends SynchronousInstrument<BoundLongCounter> {
    *
    * @param increment the value to add.
    * @param labels the set of labels to be associated to this recording.
-   * @since 0.1.0
    */
   void add(long increment, Labels labels);
 
@@ -59,7 +57,6 @@ public interface LongCounter extends SynchronousInstrument<BoundLongCounter> {
    * <p>The value added is associated with the current {@code Context} and empty labels.
    *
    * @param increment the value to add.
-   * @since 0.8.0
    */
   void add(long increment);
 
@@ -69,7 +66,6 @@ public interface LongCounter extends SynchronousInstrument<BoundLongCounter> {
   /**
    * A {@code Bound Instrument} for a {@link LongCounter}.
    *
-   * @since 0.1.0
    */
   @ThreadSafe
   interface BoundLongCounter extends SynchronousInstrument.BoundInstrument {
@@ -80,7 +76,6 @@ public interface LongCounter extends SynchronousInstrument<BoundLongCounter> {
      * <p>The value added is associated with the current {@code Context}.
      *
      * @param increment the value to add.
-     * @since 0.1.0
      */
     void add(long increment);
 

--- a/api/src/main/java/io/opentelemetry/metrics/LongSumObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongSumObserver.java
@@ -46,7 +46,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * }
  * }</pre>
  *
- * @since 0.1.0
  */
 @ThreadSafe
 public interface LongSumObserver extends AsynchronousInstrument<LongResult> {

--- a/api/src/main/java/io/opentelemetry/metrics/LongSumObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongSumObserver.java
@@ -45,7 +45,6 @@ import javax.annotation.concurrent.ThreadSafe;
  *   }
  * }
  * }</pre>
- *
  */
 @ThreadSafe
 public interface LongSumObserver extends AsynchronousInstrument<LongResult> {

--- a/api/src/main/java/io/opentelemetry/metrics/LongUpDownCounter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongUpDownCounter.java
@@ -40,7 +40,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * }
  * }</pre>
  *
- * @since 0.1.0
  */
 @ThreadSafe
 public interface LongUpDownCounter extends SynchronousInstrument<BoundLongUpDownCounter> {
@@ -52,7 +51,6 @@ public interface LongUpDownCounter extends SynchronousInstrument<BoundLongUpDown
    *
    * @param increment the value to add.
    * @param labels the set of labels to be associated to this recording.
-   * @since 0.1.0
    */
   void add(long increment, Labels labels);
 
@@ -62,7 +60,6 @@ public interface LongUpDownCounter extends SynchronousInstrument<BoundLongUpDown
    * <p>The value added is associated with the current {@code Context} and empty labels.
    *
    * @param increment the value to add.
-   * @since 0.8.0
    */
   void add(long increment);
 
@@ -72,7 +69,6 @@ public interface LongUpDownCounter extends SynchronousInstrument<BoundLongUpDown
   /**
    * A {@code Bound Instrument} for a {@link LongUpDownCounter}.
    *
-   * @since 0.1.0
    */
   @ThreadSafe
   interface BoundLongUpDownCounter extends BoundInstrument {
@@ -83,7 +79,6 @@ public interface LongUpDownCounter extends SynchronousInstrument<BoundLongUpDown
      * <p>The value added is associated with the current {@code Context}.
      *
      * @param increment the value to add.
-     * @since 0.1.0
      */
     void add(long increment);
 

--- a/api/src/main/java/io/opentelemetry/metrics/LongUpDownCounter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongUpDownCounter.java
@@ -39,7 +39,6 @@ import javax.annotation.concurrent.ThreadSafe;
  *   }
  * }
  * }</pre>
- *
  */
 @ThreadSafe
 public interface LongUpDownCounter extends SynchronousInstrument<BoundLongUpDownCounter> {
@@ -66,10 +65,7 @@ public interface LongUpDownCounter extends SynchronousInstrument<BoundLongUpDown
   @Override
   BoundLongUpDownCounter bind(Labels labels);
 
-  /**
-   * A {@code Bound Instrument} for a {@link LongUpDownCounter}.
-   *
-   */
+  /** A {@code Bound Instrument} for a {@link LongUpDownCounter}. */
   @ThreadSafe
   interface BoundLongUpDownCounter extends BoundInstrument {
 

--- a/api/src/main/java/io/opentelemetry/metrics/LongUpDownSumObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongUpDownSumObserver.java
@@ -45,7 +45,6 @@ import javax.annotation.concurrent.ThreadSafe;
  *   }
  * }
  * }</pre>
- *
  */
 @ThreadSafe
 public interface LongUpDownSumObserver extends AsynchronousInstrument<LongResult> {

--- a/api/src/main/java/io/opentelemetry/metrics/LongUpDownSumObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongUpDownSumObserver.java
@@ -46,7 +46,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * }
  * }</pre>
  *
- * @since 0.1.0
  */
 @ThreadSafe
 public interface LongUpDownSumObserver extends AsynchronousInstrument<LongResult> {

--- a/api/src/main/java/io/opentelemetry/metrics/LongValueObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongValueObserver.java
@@ -41,7 +41,6 @@ import javax.annotation.concurrent.ThreadSafe;
  *   }
  * }
  * }</pre>
- *
  */
 @ThreadSafe
 public interface LongValueObserver extends AsynchronousInstrument<LongResult> {

--- a/api/src/main/java/io/opentelemetry/metrics/LongValueObserver.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongValueObserver.java
@@ -42,7 +42,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * }
  * }</pre>
  *
- * @since 0.5.0
  */
 @ThreadSafe
 public interface LongValueObserver extends AsynchronousInstrument<LongResult> {

--- a/api/src/main/java/io/opentelemetry/metrics/LongValueRecorder.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongValueRecorder.java
@@ -48,7 +48,6 @@ import javax.annotation.concurrent.ThreadSafe;
  *   }
  * }
  * }</pre>
- *
  */
 @ThreadSafe
 public interface LongValueRecorder extends SynchronousInstrument<BoundLongValueRecorder> {
@@ -74,10 +73,7 @@ public interface LongValueRecorder extends SynchronousInstrument<BoundLongValueR
   @Override
   BoundLongValueRecorder bind(Labels labels);
 
-  /**
-   * A {@code Bound Instrument} for a {@link LongValueRecorder}.
-   *
-   */
+  /** A {@code Bound Instrument} for a {@link LongValueRecorder}. */
   @ThreadSafe
   interface BoundLongValueRecorder extends SynchronousInstrument.BoundInstrument {
     /**

--- a/api/src/main/java/io/opentelemetry/metrics/LongValueRecorder.java
+++ b/api/src/main/java/io/opentelemetry/metrics/LongValueRecorder.java
@@ -49,7 +49,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * }
  * }</pre>
  *
- * @since 0.1.0
  */
 @ThreadSafe
 public interface LongValueRecorder extends SynchronousInstrument<BoundLongValueRecorder> {
@@ -61,7 +60,6 @@ public interface LongValueRecorder extends SynchronousInstrument<BoundLongValueR
    * @param value the measurement to record.
    * @param labels the set of labels to be associated to this recording
    * @throws IllegalArgumentException if value is negative.
-   * @since 0.3.0
    */
   void record(long value, Labels labels);
 
@@ -70,7 +68,6 @@ public interface LongValueRecorder extends SynchronousInstrument<BoundLongValueR
    *
    * @param value the measurement to record.
    * @throws IllegalArgumentException if value is negative.
-   * @since 0.8.0
    */
   void record(long value);
 
@@ -80,7 +77,6 @@ public interface LongValueRecorder extends SynchronousInstrument<BoundLongValueR
   /**
    * A {@code Bound Instrument} for a {@link LongValueRecorder}.
    *
-   * @since 0.1.0
    */
   @ThreadSafe
   interface BoundLongValueRecorder extends SynchronousInstrument.BoundInstrument {
@@ -89,7 +85,6 @@ public interface LongValueRecorder extends SynchronousInstrument<BoundLongValueR
      *
      * @param value the measurement to record.
      * @throws IllegalArgumentException if value is negative.
-     * @since 0.1.0
      */
     void record(long value);
 

--- a/api/src/main/java/io/opentelemetry/metrics/Meter.java
+++ b/api/src/main/java/io/opentelemetry/metrics/Meter.java
@@ -34,7 +34,6 @@ public interface Meter {
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
    * @throws IllegalArgumentException if the {@code name} does not match the requirements.
-   * @since 0.1.0
    */
   DoubleCounter.Builder doubleCounterBuilder(String name);
 
@@ -47,7 +46,6 @@ public interface Meter {
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
    * @throws IllegalArgumentException if the {@code name} does not match the requirements.
-   * @since 0.1.0
    */
   LongCounter.Builder longCounterBuilder(String name);
 
@@ -60,7 +58,6 @@ public interface Meter {
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
    * @throws IllegalArgumentException if the {@code name} does not match the requirements.
-   * @since 0.1.0
    */
   DoubleUpDownCounter.Builder doubleUpDownCounterBuilder(String name);
 
@@ -73,7 +70,6 @@ public interface Meter {
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
    * @throws IllegalArgumentException if the {@code name} does not match the requirements.
-   * @since 0.1.0
    */
   LongUpDownCounter.Builder longUpDownCounterBuilder(String name);
 
@@ -86,7 +82,6 @@ public interface Meter {
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
    * @throws IllegalArgumentException if the {@code name} does not match the requirements.
-   * @since 0.1.0
    */
   DoubleValueRecorder.Builder doubleValueRecorderBuilder(String name);
 
@@ -99,7 +94,6 @@ public interface Meter {
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
    * @throws IllegalArgumentException if the {@code name} does not match the requirements.
-   * @since 0.1.0
    */
   LongValueRecorder.Builder longValueRecorderBuilder(String name);
 
@@ -112,7 +106,6 @@ public interface Meter {
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
    * @throws IllegalArgumentException if the {@code name} does not match the requirements.
-   * @since 0.1.0
    */
   DoubleSumObserver.Builder doubleSumObserverBuilder(String name);
 
@@ -125,7 +118,6 @@ public interface Meter {
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
    * @throws IllegalArgumentException if the {@code name} does not match the requirements.
-   * @since 0.1.0
    */
   LongSumObserver.Builder longSumObserverBuilder(String name);
 
@@ -138,7 +130,6 @@ public interface Meter {
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
    * @throws IllegalArgumentException if the {@code name} does not match the requirements.
-   * @since 0.1.0
    */
   DoubleUpDownSumObserver.Builder doubleUpDownSumObserverBuilder(String name);
 
@@ -151,7 +142,6 @@ public interface Meter {
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
    * @throws IllegalArgumentException if the {@code name} does not match the requirements.
-   * @since 0.1.0
    */
   LongUpDownSumObserver.Builder longUpDownSumObserverBuilder(String name);
 
@@ -164,7 +154,6 @@ public interface Meter {
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
    * @throws IllegalArgumentException if the {@code name} does not match the requirements.
-   * @since 0.1.0
    */
   DoubleValueObserver.Builder doubleValueObserverBuilder(String name);
 
@@ -177,7 +166,6 @@ public interface Meter {
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
    * @throws IllegalArgumentException if the {@code name} does not match the requirements.
-   * @since 0.1.0
    */
   LongValueObserver.Builder longValueObserverBuilder(String name);
 
@@ -188,7 +176,6 @@ public interface Meter {
    * @param keyValuePairs The set of labels to associate with this recorder and all it's recordings.
    * @return a {@code MeasureBatchRecorder} that can be use to atomically record a set of
    *     measurements associated with different Measures.
-   * @since 0.1.0
    */
   BatchRecorder newBatchRecorder(String... keyValuePairs);
 }

--- a/api/src/main/java/io/opentelemetry/metrics/MeterProvider.java
+++ b/api/src/main/java/io/opentelemetry/metrics/MeterProvider.java
@@ -13,7 +13,6 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * @see io.opentelemetry.OpenTelemetry
  * @see io.opentelemetry.metrics.Meter
- * @since 0.1.0
  */
 @ThreadSafe
 public interface MeterProvider {
@@ -24,7 +23,6 @@ public interface MeterProvider {
    * @param instrumentationName The name of the instrumentation library, not the name of the
    *     instrument*ed* library.
    * @return a tracer instance.
-   * @since 0.1.0
    */
   Meter get(String instrumentationName);
 
@@ -35,7 +33,6 @@ public interface MeterProvider {
    *     instrument*ed* library.
    * @param instrumentationVersion The version of the instrumentation library.
    * @return a tracer instance.
-   * @since 0.1.0
    */
   Meter get(String instrumentationName, String instrumentationVersion);
 }

--- a/api/src/main/java/io/opentelemetry/metrics/SynchronousInstrument.java
+++ b/api/src/main/java/io/opentelemetry/metrics/SynchronousInstrument.java
@@ -17,7 +17,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * properties of the associated trace and distributed correlation values.
  *
  * @param <B> the specific type of Bound Instrument this instrument can provide.
- * @since 0.3.0
  */
 @ThreadSafe
 public interface SynchronousInstrument<B extends BoundInstrument> extends Instrument {
@@ -31,7 +30,6 @@ public interface SynchronousInstrument<B extends BoundInstrument> extends Instru
    * @param labels the set of labels, as key-value pairs.
    * @return a {@code Bound Instrument}
    * @throws NullPointerException if {@code labelValues} is null.
-   * @since 0.1.0
    */
   B bind(Labels labels);
 
@@ -42,7 +40,6 @@ public interface SynchronousInstrument<B extends BoundInstrument> extends Instru
      * <p>After this method returns the current instance {@code Bound} is considered invalid (not
      * being managed by the instrument).
      *
-     * @since 0.3.0
      */
     void unbind();
   }

--- a/api/src/main/java/io/opentelemetry/metrics/SynchronousInstrument.java
+++ b/api/src/main/java/io/opentelemetry/metrics/SynchronousInstrument.java
@@ -39,7 +39,6 @@ public interface SynchronousInstrument<B extends BoundInstrument> extends Instru
      *
      * <p>After this method returns the current instance {@code Bound} is considered invalid (not
      * being managed by the instrument).
-     *
      */
     void unbind();
   }

--- a/api/src/main/java/io/opentelemetry/metrics/spi/MeterProviderFactory.java
+++ b/api/src/main/java/io/opentelemetry/metrics/spi/MeterProviderFactory.java
@@ -25,7 +25,6 @@ public interface MeterProviderFactory {
    * Creates a new meter registry instance.
    *
    * @return a meter factory instance.
-   * @since 0.1.0
    */
   MeterProvider create();
 }

--- a/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
@@ -15,7 +15,6 @@ import javax.annotation.concurrent.Immutable;
  *
  * <p>Used also to stop tracing, see {@link Tracer#withSpan}.
  *
- * @since 0.1.0
  */
 @Immutable
 public final class DefaultSpan implements Span {
@@ -26,7 +25,6 @@ public final class DefaultSpan implements Span {
    * Returns a {@link DefaultSpan} with an invalid {@link SpanContext}.
    *
    * @return a {@code DefaultSpan} with an invalid {@code SpanContext}.
-   * @since 0.1.0
    */
   public static Span getInvalid() {
     return INVALID;
@@ -37,7 +35,6 @@ public final class DefaultSpan implements Span {
    *
    * @param spanContext the {@code SpanContext}.
    * @return a {@link DefaultSpan}.
-   * @since 0.1.0
    */
   public static Span create(SpanContext spanContext) {
     return new DefaultSpan(spanContext);

--- a/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultSpan.java
@@ -14,7 +14,6 @@ import javax.annotation.concurrent.Immutable;
  * implementation is available. All operations are no-op except context propagation.
  *
  * <p>Used also to stop tracing, see {@link Tracer#withSpan}.
- *
  */
 @Immutable
 public final class DefaultSpan implements Span {

--- a/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
@@ -17,7 +17,6 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * No-op implementations of {@link Tracer}.
  *
- * @since 0.1.0
  */
 @ThreadSafe
 public final class DefaultTracer implements Tracer {
@@ -27,7 +26,6 @@ public final class DefaultTracer implements Tracer {
    * Returns a {@code Tracer} singleton that is the default implementations for {@link Tracer}.
    *
    * @return a {@code Tracer} singleton that is the default implementations for {@link Tracer}.
-   * @since 0.1.0
    */
   public static Tracer getInstance() {
     return INSTANCE;

--- a/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
@@ -14,10 +14,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
-/**
- * No-op implementations of {@link Tracer}.
- *
- */
+/** No-op implementations of {@link Tracer}. */
 @ThreadSafe
 public final class DefaultTracer implements Tracer {
   private static final DefaultTracer INSTANCE = new DefaultTracer();

--- a/api/src/main/java/io/opentelemetry/trace/EndSpanOptions.java
+++ b/api/src/main/java/io/opentelemetry/trace/EndSpanOptions.java
@@ -11,17 +11,13 @@ import javax.annotation.concurrent.Immutable;
 /**
  * A class that enables overriding the default values used when ending a {@link Span}. Allows
  * overriding the endTimestamp.
- *
  */
 @Immutable
 @AutoValue
 public abstract class EndSpanOptions {
   private static final EndSpanOptions DEFAULT = builder().build();
 
-  /**
-   * The default {@code EndSpanOptions}.
-   *
-   */
+  /** The default {@code EndSpanOptions}. */
   static EndSpanOptions getDefault() {
     return DEFAULT;
   }
@@ -44,10 +40,7 @@ public abstract class EndSpanOptions {
    */
   public abstract long getEndTimestamp();
 
-  /**
-   * Builder class for {@link EndSpanOptions}.
-   *
-   */
+  /** Builder class for {@link EndSpanOptions}. */
   @AutoValue.Builder
   public abstract static class Builder {
     /**

--- a/api/src/main/java/io/opentelemetry/trace/EndSpanOptions.java
+++ b/api/src/main/java/io/opentelemetry/trace/EndSpanOptions.java
@@ -12,7 +12,6 @@ import javax.annotation.concurrent.Immutable;
  * A class that enables overriding the default values used when ending a {@link Span}. Allows
  * overriding the endTimestamp.
  *
- * @since 0.1
  */
 @Immutable
 @AutoValue
@@ -22,7 +21,6 @@ public abstract class EndSpanOptions {
   /**
    * The default {@code EndSpanOptions}.
    *
-   * @since 0.1
    */
   static EndSpanOptions getDefault() {
     return DEFAULT;
@@ -32,7 +30,6 @@ public abstract class EndSpanOptions {
    * Returns a new {@link Builder} with default options.
    *
    * @return a new {@code Builder} with default options.
-   * @since 0.1
    */
   public static Builder builder() {
     return new AutoValue_EndSpanOptions.Builder().setEndTimestamp(0);
@@ -44,14 +41,12 @@ public abstract class EndSpanOptions {
    * <p>Important this is NOT equivalent with System.nanoTime().
    *
    * @return the end timestamp.
-   * @since 0.1
    */
   public abstract long getEndTimestamp();
 
   /**
    * Builder class for {@link EndSpanOptions}.
    *
-   * @since 0.1
    */
   @AutoValue.Builder
   public abstract static class Builder {
@@ -62,7 +57,6 @@ public abstract class EndSpanOptions {
      *
      * @param endTimestamp the end timestamp in nanos since epoch.
      * @return this.
-     * @since 0.1
      */
     public abstract Builder setEndTimestamp(long endTimestamp);
 
@@ -70,7 +64,6 @@ public abstract class EndSpanOptions {
      * Builds and returns a {@code EndSpanOptions} with the desired settings.
      *
      * @return a {@code EndSpanOptions} with the desired settings.
-     * @since 0.1
      */
     public abstract EndSpanOptions build();
 

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -17,7 +17,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * <p>Spans are created by the {@link Builder#startSpan} method.
  *
  * <p>{@code Span} <b>must</b> be ended by calling {@link #end()}.
- *
  */
 @ThreadSafe
 public interface Span {
@@ -25,24 +24,16 @@ public interface Span {
   /**
    * Type of span. Can be used to specify additional relationships between spans in addition to a
    * parent/child relationship.
-   *
    */
   enum Kind {
-    /**
-     * Default value. Indicates that the span is used internally.
-     *
-     */
+    /** Default value. Indicates that the span is used internally. */
     INTERNAL,
 
-    /**
-     * Indicates that the span covers server-side handling of an RPC or other remote request.
-     *
-     */
+    /** Indicates that the span covers server-side handling of an RPC or other remote request. */
     SERVER,
 
     /**
      * Indicates that the span covers the client-side wrapper around an RPC or other remote request.
-     *
      */
     CLIENT,
 
@@ -50,7 +41,6 @@ public interface Span {
      * Indicates that the span describes producer sending a message to a broker. Unlike client and
      * server, there is no direct critical path latency relationship between producer and consumer
      * spans.
-     *
      */
     PRODUCER,
 
@@ -58,7 +48,6 @@ public interface Span {
      * Indicates that the span describes consumer receiving a message from a broker. Unlike client
      * and server, there is no direct critical path latency relationship between producer and
      * consumer spans.
-     *
      */
     CONSUMER
   }
@@ -246,7 +235,6 @@ public interface Span {
    *
    * <p>Only the timing of the first end call for a given {@code Span} will be recorded, and
    * implementations are free to ignore all further calls.
-   *
    */
   void end();
 
@@ -364,7 +352,6 @@ public interface Span {
    *
    * <p>If your Java version is less than Java SE 7, see {@link Builder#startSpan} for usage
    * examples.
-   *
    */
   interface Builder {
 

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -18,7 +18,6 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <p>{@code Span} <b>must</b> be ended by calling {@link #end()}.
  *
- * @since 0.1.0
  */
 @ThreadSafe
 public interface Span {
@@ -27,27 +26,23 @@ public interface Span {
    * Type of span. Can be used to specify additional relationships between spans in addition to a
    * parent/child relationship.
    *
-   * @since 0.1.0
    */
   enum Kind {
     /**
      * Default value. Indicates that the span is used internally.
      *
-     * @since 0.1.0
      */
     INTERNAL,
 
     /**
      * Indicates that the span covers server-side handling of an RPC or other remote request.
      *
-     * @since 0.1.0
      */
     SERVER,
 
     /**
      * Indicates that the span covers the client-side wrapper around an RPC or other remote request.
      *
-     * @since 0.1.0
      */
     CLIENT,
 
@@ -56,7 +51,6 @@ public interface Span {
      * server, there is no direct critical path latency relationship between producer and consumer
      * spans.
      *
-     * @since 0.1.0
      */
     PRODUCER,
 
@@ -65,7 +59,6 @@ public interface Span {
      * and server, there is no direct critical path latency relationship between producer and
      * consumer spans.
      *
-     * @since 0.1.0
      */
     CONSUMER
   }
@@ -82,7 +75,6 @@ public interface Span {
    *
    * @param key the key for this attribute.
    * @param value the value for this attribute.
-   * @since 0.1.0
    */
   void setAttribute(String key, @Nonnull String value);
 
@@ -95,7 +87,6 @@ public interface Span {
    *
    * @param key the key for this attribute.
    * @param value the value for this attribute.
-   * @since 0.1.0
    */
   void setAttribute(String key, long value);
 
@@ -108,7 +99,6 @@ public interface Span {
    *
    * @param key the key for this attribute.
    * @param value the value for this attribute.
-   * @since 0.1.0
    */
   void setAttribute(String key, double value);
 
@@ -121,7 +111,6 @@ public interface Span {
    *
    * @param key the key for this attribute.
    * @param value the value for this attribute.
-   * @since 0.1.0
    */
   void setAttribute(String key, boolean value);
 
@@ -133,7 +122,6 @@ public interface Span {
    *
    * @param key the key for this attribute.
    * @param value the value for this attribute.
-   * @since 0.1.0
    */
   <T> void setAttribute(AttributeKey<T> key, @Nonnull T value);
 
@@ -143,7 +131,6 @@ public interface Span {
    *
    * @param key the key for this attribute.
    * @param value the value for this attribute.
-   * @since 0.1.0
    */
   default void setAttribute(AttributeKey<Long> key, int value) {
     setAttribute(key, (long) value);
@@ -153,7 +140,6 @@ public interface Span {
    * Adds an event to the {@link Span}. The timestamp of the event will be the current time.
    *
    * @param name the name of the event.
-   * @since 0.1.0
    */
   void addEvent(String name);
 
@@ -168,7 +154,6 @@ public interface Span {
    *
    * @param name the name of the event.
    * @param timestamp the explicit event timestamp in nanos since epoch.
-   * @since 0.1.0
    */
   void addEvent(String name, long timestamp);
 
@@ -179,7 +164,6 @@ public interface Span {
    * @param name the name of the event.
    * @param attributes the attributes that will be added; these are associated with this event, not
    *     the {@code Span} as for {@code setAttribute()}.
-   * @since 0.1.0
    */
   void addEvent(String name, Attributes attributes);
 
@@ -196,7 +180,6 @@ public interface Span {
    * @param attributes the attributes that will be added; these are associated with this event, not
    *     the {@code Span} as for {@code setAttribute()}.
    * @param timestamp the explicit event timestamp in nanos since epoch.
-   * @since 0.1.0
    */
   void addEvent(String name, Attributes attributes, long timestamp);
 
@@ -210,7 +193,6 @@ public interface Span {
    * previous calls.
    *
    * @param canonicalCode the {@link StatusCanonicalCode} to set.
-   * @since 0.9.0
    */
   void setStatus(StatusCanonicalCode canonicalCode);
 
@@ -225,7 +207,6 @@ public interface Span {
    *
    * @param canonicalCode the {@link StatusCanonicalCode} to set.
    * @param description the description of the {@code Status}.
-   * @since 0.9.0
    */
   void setStatus(StatusCanonicalCode canonicalCode, String description);
 
@@ -237,7 +218,6 @@ public interface Span {
    * #recordException(Throwable, Attributes)} if you know that an exception is escaping.
    *
    * @param exception the {@link Throwable} to record.
-   * @since 0.7.0
    */
   void recordException(Throwable exception);
 
@@ -246,7 +226,6 @@ public interface Span {
    *
    * @param exception the {@link Throwable} to record.
    * @param additionalAttributes the additional {@link Attributes} to record.
-   * @since 0.8.0
    */
   void recordException(Throwable exception, Attributes additionalAttributes);
 
@@ -259,7 +238,6 @@ public interface Span {
    * implementation.
    *
    * @param name the {@code Span} name.
-   * @since 0.1
    */
   void updateName(String name);
 
@@ -269,7 +247,6 @@ public interface Span {
    * <p>Only the timing of the first end call for a given {@code Span} will be recorded, and
    * implementations are free to ignore all further calls.
    *
-   * @since 0.1.0
    */
   void end();
 
@@ -283,7 +260,6 @@ public interface Span {
    * explicit values are required, use {@link #end()}.
    *
    * @param endOptions the explicit {@link EndSpanOptions} for this {@code Span}.
-   * @since 0.1.0
    */
   void end(EndSpanOptions endOptions);
 
@@ -291,7 +267,6 @@ public interface Span {
    * Returns the {@code SpanContext} associated with this {@code Span}.
    *
    * @return the {@code SpanContext} associated with this {@code Span}.
-   * @since 0.1.0
    */
   SpanContext getContext();
 
@@ -300,7 +275,6 @@ public interface Span {
    * #addEvent(String)}, {@link #setAttribute(String, long)}).
    *
    * @return {@code true} if this {@code Span} records tracing events.
-   * @since 0.1.0
    */
   boolean isRecording();
 
@@ -391,7 +365,6 @@ public interface Span {
    * <p>If your Java version is less than Java SE 7, see {@link Builder#startSpan} for usage
    * examples.
    *
-   * @since 0.1.0
    */
   interface Builder {
 
@@ -408,7 +381,6 @@ public interface Span {
      * @param context the {@code Context}.
      * @return this.
      * @throws NullPointerException if {@code context} is {@code null}.
-     * @since 0.7.0
      */
     Builder setParent(Context context);
 
@@ -419,7 +391,6 @@ public interface Span {
      * <p>Observe that any previously set parent will be discarded.
      *
      * @return this.
-     * @since 0.1.0
      */
     Builder setNoParent();
 
@@ -433,7 +404,6 @@ public interface Span {
      * @param spanContext the context of the linked {@code Span}.
      * @return this.
      * @throws NullPointerException if {@code spanContext} is {@code null}.
-     * @since 0.1.0
      */
     Builder addLink(SpanContext spanContext);
 
@@ -449,7 +419,6 @@ public interface Span {
      * @return this.
      * @throws NullPointerException if {@code spanContext} is {@code null}.
      * @throws NullPointerException if {@code attributes} is {@code null}.
-     * @since 0.1.0
      */
     Builder addLink(SpanContext spanContext, Attributes attributes);
 
@@ -467,7 +436,6 @@ public interface Span {
      * @param value the value for this attribute.
      * @return this.
      * @throws NullPointerException if {@code key} is {@code null}.
-     * @since 0.3.0
      */
     Builder setAttribute(String key, @Nonnull String value);
 
@@ -482,7 +450,6 @@ public interface Span {
      * @param value the value for this attribute.
      * @return this.
      * @throws NullPointerException if {@code key} is {@code null}.
-     * @since 0.3.0
      */
     Builder setAttribute(String key, long value);
 
@@ -497,7 +464,6 @@ public interface Span {
      * @param value the value for this attribute.
      * @return this.
      * @throws NullPointerException if {@code key} is {@code null}.
-     * @since 0.3.0
      */
     Builder setAttribute(String key, double value);
 
@@ -512,7 +478,6 @@ public interface Span {
      * @param value the value for this attribute.
      * @return this.
      * @throws NullPointerException if {@code key} is {@code null}.
-     * @since 0.3.0
      */
     Builder setAttribute(String key, boolean value);
 
@@ -527,7 +492,6 @@ public interface Span {
      * @return this.
      * @throws NullPointerException if {@code key} is {@code null}.
      * @throws NullPointerException if {@code value} is {@code null}.
-     * @since 0.3.0
      */
     <T> Builder setAttribute(AttributeKey<T> key, @Nonnull T value);
 
@@ -537,7 +501,6 @@ public interface Span {
      *
      * @param spanKind the kind of the newly created {@code Span}.
      * @return this.
-     * @since 0.1.0
      */
     Builder setSpanKind(Span.Kind spanKind);
 
@@ -552,7 +515,6 @@ public interface Span {
      * @param startTimestamp the explicit start timestamp of the newly created {@code Span} in nanos
      *     since epoch.
      * @return this.
-     * @since 0.1.0
      */
     Builder setStartTimestamp(long startTimestamp);
 
@@ -587,7 +549,6 @@ public interface Span {
      * }</pre>
      *
      * @return the newly created {@code Span}.
-     * @since 0.1.0
      */
     Span startSpan();
   }

--- a/api/src/main/java/io/opentelemetry/trace/SpanContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanContext.java
@@ -15,7 +15,6 @@ import javax.annotation.concurrent.Immutable;
  * trace_id} and {@link SpanId span_id}) associated with the {@link Span} and a set of options
  * (currently only whether the context is sampled or not), as well as the {@link TraceState
  * traceState} and the {@link boolean remote} flag.
- *
  */
 @Immutable
 @AutoValue
@@ -88,7 +87,6 @@ public abstract class SpanContext {
   /**
    * Returns the byte[] representation of the trace identifier associated with this {@link
    * SpanContext}.
-   *
    */
   @Memoized
   public byte[] getTraceIdBytes() {
@@ -107,7 +105,6 @@ public abstract class SpanContext {
   /**
    * Returns the byte[] representation of the span identifier associated with this {@link
    * SpanContext}.
-   *
    */
   @Memoized
   public byte[] getSpanIdBytes() {

--- a/api/src/main/java/io/opentelemetry/trace/SpanContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanContext.java
@@ -16,7 +16,6 @@ import javax.annotation.concurrent.Immutable;
  * (currently only whether the context is sampled or not), as well as the {@link TraceState
  * traceState} and the {@link boolean remote} flag.
  *
- * @since 0.1.0
  */
 @Immutable
 @AutoValue
@@ -46,7 +45,6 @@ public abstract class SpanContext {
    * @param traceFlags the byte representation of the {@link TraceFlags}
    * @param traceState the trace state for the span context.
    * @return a new {@code SpanContext} with the given identifiers and options.
-   * @since 0.1.0
    */
   public static SpanContext create(
       String traceIdHex, String spanIdHex, byte traceFlags, TraceState traceState) {
@@ -68,7 +66,6 @@ public abstract class SpanContext {
    * @param traceFlags the byte representation of the {@link TraceFlags}
    * @param traceState the trace state for the span context.
    * @return a new {@code SpanContext} with the given identifiers and options.
-   * @since 0.1.0
    */
   public static SpanContext createFromRemoteParent(
       String traceIdHex, String spanIdHex, byte traceFlags, TraceState traceState) {
@@ -83,7 +80,6 @@ public abstract class SpanContext {
    * Returns the trace identifier associated with this {@code SpanContext}.
    *
    * @return the trace identifier associated with this {@code SpanContext}.
-   * @since 0.1.0
    */
   public String getTraceIdAsHexString() {
     return getTraceIdHex();
@@ -93,7 +89,6 @@ public abstract class SpanContext {
    * Returns the byte[] representation of the trace identifier associated with this {@link
    * SpanContext}.
    *
-   * @since 0.8.0
    */
   @Memoized
   public byte[] getTraceIdBytes() {
@@ -104,7 +99,6 @@ public abstract class SpanContext {
    * Returns the span identifier associated with this {@code SpanContext}.
    *
    * @return the span identifier associated with this {@code SpanContext}.
-   * @since 0.1.0
    */
   public String getSpanIdAsHexString() {
     return getSpanIdHex();
@@ -114,7 +108,6 @@ public abstract class SpanContext {
    * Returns the byte[] representation of the span identifier associated with this {@link
    * SpanContext}.
    *
-   * @since 0.8.0
    */
   @Memoized
   public byte[] getSpanIdBytes() {
@@ -138,7 +131,6 @@ public abstract class SpanContext {
    * Returns the {@code TraceState} associated with this {@code SpanContext}.
    *
    * @return the {@code TraceState} associated with this {@code SpanContext}.
-   * @since 0.1.0
    */
   public abstract TraceState getTraceState();
 
@@ -146,7 +138,6 @@ public abstract class SpanContext {
    * Returns {@code true} if this {@code SpanContext} is valid.
    *
    * @return {@code true} if this {@code SpanContext} is valid.
-   * @since 0.1.0
    */
   @Memoized
   public boolean isValid() {
@@ -157,7 +148,6 @@ public abstract class SpanContext {
    * Returns {@code true} if the {@code SpanContext} was propagated from a remote parent.
    *
    * @return {@code true} if the {@code SpanContext} was propagated from a remote parent.
-   * @since 0.1.0
    */
   public abstract boolean isRemote();
 }

--- a/api/src/main/java/io/opentelemetry/trace/SpanId.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanId.java
@@ -11,7 +11,6 @@ import javax.annotation.concurrent.Immutable;
  * Helper methods for dealing with a span identifier. A valid span identifier is an 8-byte array
  * with at least one non-zero byte. In base-16 representation, a 16 character hex String, where at
  * least one of the characters is not a '0'.
- *
  */
 @Immutable
 public final class SpanId {
@@ -33,10 +32,7 @@ public final class SpanId {
     return SIZE;
   }
 
-  /**
-   * Returns the length of the base16 (hex) representation of the {@code SpanId}.
-   *
-   */
+  /** Returns the length of the base16 (hex) representation of the {@code SpanId}. */
   public static int getHexLength() {
     return HEX_SIZE;
   }

--- a/api/src/main/java/io/opentelemetry/trace/SpanId.java
+++ b/api/src/main/java/io/opentelemetry/trace/SpanId.java
@@ -12,7 +12,6 @@ import javax.annotation.concurrent.Immutable;
  * with at least one non-zero byte. In base-16 representation, a 16 character hex String, where at
  * least one of the characters is not a '0'.
  *
- * @since 0.1.0
  */
 @Immutable
 public final class SpanId {
@@ -29,7 +28,6 @@ public final class SpanId {
    * Returns the size in bytes of the {@code SpanId}.
    *
    * @return the size in bytes of the {@code SpanId}.
-   * @since 0.1.0
    */
   public static int getSize() {
     return SIZE;
@@ -38,7 +36,6 @@ public final class SpanId {
   /**
    * Returns the length of the base16 (hex) representation of the {@code SpanId}.
    *
-   * @since 0.8.0
    */
   public static int getHexLength() {
     return HEX_SIZE;
@@ -48,7 +45,6 @@ public final class SpanId {
    * Returns the invalid {@code SpanId}. All bytes are 0.
    *
    * @return the invalid {@code SpanId}.
-   * @since 0.1.0
    */
   public static String getInvalid() {
     return INVALID;
@@ -80,7 +76,6 @@ public final class SpanId {
    * @throws NullPointerException if {@code src} is null.
    * @throws IllegalArgumentException if not enough characters in the {@code src} from the {@code
    *     srcOffset}.
-   * @since 0.1.0
    */
   public static byte[] bytesFromHex(String src, int srcOffset) {
     return BigendianEncoding.bytesFromBase16(src, srcOffset, HEX_SIZE);
@@ -91,7 +86,6 @@ public final class SpanId {
    * at least one non-zero byte.
    *
    * @return {@code true} if the span identifier is valid.
-   * @since 0.1.0
    */
   public static boolean isValid(String spanId) {
     return (spanId.length() == HEX_SIZE)

--- a/api/src/main/java/io/opentelemetry/trace/StatusCanonicalCode.java
+++ b/api/src/main/java/io/opentelemetry/trace/StatusCanonicalCode.java
@@ -8,7 +8,6 @@ package io.opentelemetry.trace;
 /**
  * The set of canonical status codes. If new codes are added over time they must choose a numerical
  * value that does not collide with any previously used value.
- *
  */
 public enum StatusCanonicalCode {
 

--- a/api/src/main/java/io/opentelemetry/trace/StatusCanonicalCode.java
+++ b/api/src/main/java/io/opentelemetry/trace/StatusCanonicalCode.java
@@ -9,7 +9,6 @@ package io.opentelemetry.trace;
  * The set of canonical status codes. If new codes are added over time they must choose a numerical
  * value that does not collide with any previously used value.
  *
- * @since 0.1.0
  */
 public enum StatusCanonicalCode {
 
@@ -35,7 +34,6 @@ public enum StatusCanonicalCode {
    * Returns the numerical value of the code.
    *
    * @return the numerical value of the code.
-   * @since 0.1.0
    */
   public int value() {
     return value;

--- a/api/src/main/java/io/opentelemetry/trace/TraceFlags.java
+++ b/api/src/main/java/io/opentelemetry/trace/TraceFlags.java
@@ -11,7 +11,6 @@ import javax.annotation.concurrent.Immutable;
  * Helper methods for dealing with trace flags options. These options are propagated to all child
  * {@link Span spans}. These determine features such as whether a {@code Span} should be traced. It
  * is implemented as a bitmask.
- *
  */
 @Immutable
 public final class TraceFlags {
@@ -25,10 +24,7 @@ public final class TraceFlags {
   private static final int SIZE = 1;
   private static final int BASE16_SIZE = 2 * SIZE;
 
-  /**
-   * Returns the size in Hex of trace flags.
-   *
-   */
+  /** Returns the size in Hex of trace flags. */
   public static int getHexLength() {
     return BASE16_SIZE;
   }

--- a/api/src/main/java/io/opentelemetry/trace/TraceFlags.java
+++ b/api/src/main/java/io/opentelemetry/trace/TraceFlags.java
@@ -12,7 +12,6 @@ import javax.annotation.concurrent.Immutable;
  * {@link Span spans}. These determine features such as whether a {@code Span} should be traced. It
  * is implemented as a bitmask.
  *
- * @since 0.1.0
  */
 @Immutable
 public final class TraceFlags {
@@ -29,7 +28,6 @@ public final class TraceFlags {
   /**
    * Returns the size in Hex of trace flags.
    *
-   * @since 0.9.0
    */
   public static int getHexLength() {
     return BASE16_SIZE;
@@ -39,7 +37,6 @@ public final class TraceFlags {
    * Returns the default {@code TraceFlags}.
    *
    * @return the default {@code TraceFlags}.
-   * @since 0.1.0
    */
   public static byte getDefault() {
     return DEFAULT;

--- a/api/src/main/java/io/opentelemetry/trace/TraceId.java
+++ b/api/src/main/java/io/opentelemetry/trace/TraceId.java
@@ -12,7 +12,6 @@ import javax.annotation.concurrent.Immutable;
  * Helper methods for dealing with a trace identifier. A valid trace identifier is a 16-byte array
  * with at least one non-zero byte. In base-16 representation, a 32 character hex String, where at
  * least one of the characters is not a '0'.
- *
  */
 @Immutable
 public final class TraceId {
@@ -33,10 +32,7 @@ public final class TraceId {
     return SIZE_IN_BYTES;
   }
 
-  /**
-   * Returns the length of the base16 (hex) representation of the {@code TraceId}.
-   *
-   */
+  /** Returns the length of the base16 (hex) representation of the {@code TraceId}. */
   public static int getHexLength() {
     return HEX_SIZE;
   }

--- a/api/src/main/java/io/opentelemetry/trace/TraceId.java
+++ b/api/src/main/java/io/opentelemetry/trace/TraceId.java
@@ -13,7 +13,6 @@ import javax.annotation.concurrent.Immutable;
  * with at least one non-zero byte. In base-16 representation, a 32 character hex String, where at
  * least one of the characters is not a '0'.
  *
- * @since 0.1.0
  */
 @Immutable
 public final class TraceId {
@@ -29,7 +28,6 @@ public final class TraceId {
    * Returns the size in bytes of the {@code TraceId}.
    *
    * @return the size in bytes of the {@code TraceId}.
-   * @since 0.1.0
    */
   public static int getSize() {
     return SIZE_IN_BYTES;
@@ -38,7 +36,6 @@ public final class TraceId {
   /**
    * Returns the length of the base16 (hex) representation of the {@code TraceId}.
    *
-   * @since 0.8.0
    */
   public static int getHexLength() {
     return HEX_SIZE;
@@ -48,7 +45,6 @@ public final class TraceId {
    * Returns the invalid {@code TraceId}. All bytes are '\0'.
    *
    * @return the invalid {@code TraceId}.
-   * @since 0.1.0
    */
   public static String getInvalid() {
     return INVALID;
@@ -67,7 +63,6 @@ public final class TraceId {
    *
    * @param idHi the higher part of the {@code TraceId}.
    * @param idLo the lower part of the {@code TraceId}.
-   * @since 0.1.0
    */
   public static String fromLongs(long idHi, long idLo) {
     char[] chars = getTemporaryBuffer();
@@ -95,7 +90,6 @@ public final class TraceId {
    * @throws NullPointerException if {@code src} is null.
    * @throws IllegalArgumentException if not enough characters in the {@code src} from the {@code
    *     srcOffset}.
-   * @since 0.1.0
    */
   public static byte[] bytesFromHex(String src, int srcOffset) {
     Objects.requireNonNull(src, "src");
@@ -110,7 +104,6 @@ public final class TraceId {
    * @param destOffset the starting offset in the destination buffer.
    * @throws IndexOutOfBoundsException if {@code destOffset + 2 * TraceId.getSize()} is greater than
    *     {@code dest.length}.
-   * @since 0.1.0
    */
   public static void copyHexInto(byte[] traceId, char[] dest, int destOffset) {
     BigendianEncoding.longToBase16String(
@@ -124,7 +117,6 @@ public final class TraceId {
    * at least one non-zero byte.
    *
    * @return {@code true} if the {@code TraceId} is valid.
-   * @since 0.1.0
    */
   public static boolean isValid(CharSequence traceId) {
     return (traceId.length() == HEX_SIZE)
@@ -136,7 +128,6 @@ public final class TraceId {
    * Returns the lowercase base16 encoding of this {@code TraceId}.
    *
    * @return the lowercase base16 encoding of this {@code TraceId}.
-   * @since 0.1.0
    */
   public static String bytesToHex(byte[] traceId) {
     char[] chars = new char[HEX_SIZE];

--- a/api/src/main/java/io/opentelemetry/trace/TraceState.java
+++ b/api/src/main/java/io/opentelemetry/trace/TraceState.java
@@ -26,7 +26,6 @@ import javax.annotation.concurrent.Immutable;
  *
  * <p>Value is opaque string up to 256 characters printable ASCII RFC0020 characters (i.e., the
  * range 0x20 to 0x7E) except comma , and =.
- *
  */
 @Immutable
 @AutoValue
@@ -90,10 +89,7 @@ public abstract class TraceState {
     return new Builder(this);
   }
 
-  /**
-   * Builder class for {@link TraceState}.
-   *
-   */
+  /** Builder class for {@link TraceState}. */
   public static final class Builder {
     private final TraceState parent;
     @Nullable private ArrayList<Entry> entries;
@@ -171,10 +167,7 @@ public abstract class TraceState {
     }
   }
 
-  /**
-   * Immutable key-value pair for {@code TraceState}.
-   *
-   */
+  /** Immutable key-value pair for {@code TraceState}. */
   @Immutable
   @AutoValue
   public abstract static class Entry {

--- a/api/src/main/java/io/opentelemetry/trace/TraceState.java
+++ b/api/src/main/java/io/opentelemetry/trace/TraceState.java
@@ -27,7 +27,6 @@ import javax.annotation.concurrent.Immutable;
  * <p>Value is opaque string up to 256 characters printable ASCII RFC0020 characters (i.e., the
  * range 0x20 to 0x7E) except comma , and =.
  *
- * @since 0.1.0
  */
 @Immutable
 @AutoValue
@@ -43,7 +42,6 @@ public abstract class TraceState {
    * Returns the default {@code TraceState} with no entries.
    *
    * @return the default {@code TraceState}.
-   * @since 0.1.0
    */
   public static TraceState getDefault() {
     return DEFAULT;
@@ -56,7 +54,6 @@ public abstract class TraceState {
    * @param key with which the specified value is to be associated
    * @return the value to which the specified key is mapped, or null if this map contains no mapping
    *     for the key.
-   * @since 0.1.0
    */
   @Nullable
   public String get(String key) {
@@ -72,7 +69,6 @@ public abstract class TraceState {
    * Returns a {@link List} view of the mappings contained in this {@code TraceState}.
    *
    * @return a {@link List} view of the mappings contained in this {@code TraceState}.
-   * @since 0.1.0
    */
   public abstract List<Entry> getEntries();
 
@@ -80,7 +76,6 @@ public abstract class TraceState {
    * Returns a {@code Builder} based on an empty {@code TraceState}.
    *
    * @return a {@code Builder} based on an empty {@code TraceState}.
-   * @since 0.1.0
    */
   public static Builder builder() {
     return new Builder(Builder.EMPTY);
@@ -90,7 +85,6 @@ public abstract class TraceState {
    * Returns a {@code Builder} based on this {@code TraceState}.
    *
    * @return a {@code Builder} based on this {@code TraceState}.
-   * @since 0.1.0
    */
   public Builder toBuilder() {
     return new Builder(this);
@@ -99,7 +93,6 @@ public abstract class TraceState {
   /**
    * Builder class for {@link TraceState}.
    *
-   * @since 0.1.0
    */
   public static final class Builder {
     private final TraceState parent;
@@ -122,7 +115,6 @@ public abstract class TraceState {
      * @param key the key for the {@code Entry} to be added.
      * @param value the value for the {@code Entry} to be added.
      * @return this.
-     * @since 0.1.0
      */
     public Builder set(String key, String value) {
       // Initially create the Entry to validate input.
@@ -148,7 +140,6 @@ public abstract class TraceState {
      *
      * @param key the key for the {@code Entry} to be removed.
      * @return this.
-     * @since 0.1.0
      */
     public Builder remove(String key) {
       Objects.requireNonNull(key, "key");
@@ -171,7 +162,6 @@ public abstract class TraceState {
      * and removing duplicate entries.
      *
      * @return a TraceState with the new entries.
-     * @since 0.1.0
      */
     public TraceState build() {
       if (entries == null) {
@@ -184,7 +174,6 @@ public abstract class TraceState {
   /**
    * Immutable key-value pair for {@code TraceState}.
    *
-   * @since 0.1.0
    */
   @Immutable
   @AutoValue
@@ -195,7 +184,6 @@ public abstract class TraceState {
      * @param key the Entry's key.
      * @param value the Entry's value.
      * @return the new {@code Entry}.
-     * @since 0.1.0
      */
     public static Entry create(String key, String value) {
       Objects.requireNonNull(key, "key");
@@ -209,7 +197,6 @@ public abstract class TraceState {
      * Returns the key {@code String}.
      *
      * @return the key {@code String}.
-     * @since 0.1.0
      */
     public abstract String getKey();
 
@@ -217,7 +204,6 @@ public abstract class TraceState {
      * Returns the value {@code String}.
      *
      * @return the value {@code String}.
-     * @since 0.1.0
      */
     public abstract String getValue();
 

--- a/api/src/main/java/io/opentelemetry/trace/Tracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/Tracer.java
@@ -56,7 +56,6 @@ import javax.annotation.concurrent.ThreadSafe;
  *   }
  * }
  * }</pre>
- *
  */
 @ThreadSafe
 public interface Tracer {

--- a/api/src/main/java/io/opentelemetry/trace/Tracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/Tracer.java
@@ -57,7 +57,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * }
  * }</pre>
  *
- * @since 0.1.0
  */
 @ThreadSafe
 public interface Tracer {
@@ -71,7 +70,6 @@ public interface Tracer {
    * @return a default {@code Span} that does nothing and has an invalid {@link SpanContext} if no
    *     {@code Span} is associated with the current Context, otherwise the current {@code Span}
    *     from the Context.
-   * @since 0.1.0
    */
   Span getCurrentSpan();
 
@@ -123,7 +121,6 @@ public interface Tracer {
    * @return an object that defines a scope where the given {@link Span} will be set to the current
    *     Context.
    * @throws NullPointerException if {@code span} is {@code null}.
-   * @since 0.1.0
    */
   @MustBeClosed
   Scope withSpan(Span span);
@@ -136,7 +133,6 @@ public interface Tracer {
    * @param spanName The name of the returned Span.
    * @return a {@code Span.Builder} to create and start a new {@code Span}.
    * @throws NullPointerException if {@code spanName} is {@code null}.
-   * @since 0.1.0
    */
   Span.Builder spanBuilder(String spanName);
 }

--- a/api/src/main/java/io/opentelemetry/trace/TracerProvider.java
+++ b/api/src/main/java/io/opentelemetry/trace/TracerProvider.java
@@ -14,7 +14,6 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * @see io.opentelemetry.OpenTelemetry
  * @see io.opentelemetry.trace.Tracer
- * @since 0.1.0
  */
 @ThreadSafe
 public interface TracerProvider {
@@ -25,7 +24,6 @@ public interface TracerProvider {
    * @param instrumentationName The name of the instrumentation library, not the name of the
    *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.
    * @return a tracer instance.
-   * @since 0.1.0
    */
   Tracer get(String instrumentationName);
 
@@ -37,7 +35,6 @@ public interface TracerProvider {
    * @param instrumentationVersion The version of the instrumentation library (e.g.,
    *     "semver:1.0.0").
    * @return a tracer instance.
-   * @since 0.1.0
    */
   Tracer get(String instrumentationName, String instrumentationVersion);
 }

--- a/api/src/main/java/io/opentelemetry/trace/TracingContextUtils.java
+++ b/api/src/main/java/io/opentelemetry/trace/TracingContextUtils.java
@@ -14,7 +14,6 @@ import javax.annotation.concurrent.Immutable;
 /**
  * Util methods/functionality to interact with the {@link Context}.
  *
- * @since 0.1.0
  */
 @Immutable
 public final class TracingContextUtils {
@@ -27,7 +26,6 @@ public final class TracingContextUtils {
    * @param span the value to be set.
    * @param context the parent {@code Context}.
    * @return a new context with the given value set.
-   * @since 0.1.0
    */
   public static Context withSpan(Span span, Context context) {
     return context.withValues(CONTEXT_SPAN_KEY, span);
@@ -38,7 +36,6 @@ public final class TracingContextUtils {
    * {@link Span}.
    *
    * @return the {@link Span} from the current {@code Context}.
-   * @since 0.3.0
    */
   public static Span getCurrentSpan() {
     return getSpan(io.opentelemetry.context.Context.current());
@@ -50,7 +47,6 @@ public final class TracingContextUtils {
    *
    * @param context the specified {@code Context}.
    * @return the {@link Span} from the specified {@code Context}.
-   * @since 0.3.0
    */
   public static Span getSpan(Context context) {
     Span span = context.getValue(CONTEXT_SPAN_KEY);
@@ -63,7 +59,6 @@ public final class TracingContextUtils {
    *
    * @param context the specified {@code Context}.
    * @return the {@link Span} from the specified {@code Context}.
-   * @since 0.1.0
    */
   @Nullable
   public static Span getSpanWithoutDefault(Context context) {
@@ -76,7 +71,6 @@ public final class TracingContextUtils {
    *
    * @param span the {@link Span} to be added to the current {@code Context}.
    * @return the {@link Scope} for the updated {@code Context}.
-   * @since 0.1.0
    */
   public static Scope currentContextWith(Span span) {
     return withSpan(span, io.opentelemetry.context.Context.current()).makeCurrent();

--- a/api/src/main/java/io/opentelemetry/trace/TracingContextUtils.java
+++ b/api/src/main/java/io/opentelemetry/trace/TracingContextUtils.java
@@ -11,10 +11,7 @@ import io.opentelemetry.context.Scope;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
-/**
- * Util methods/functionality to interact with the {@link Context}.
- *
- */
+/** Util methods/functionality to interact with the {@link Context}. */
 @Immutable
 public final class TracingContextUtils {
   private static final ContextKey<Span> CONTEXT_SPAN_KEY =

--- a/api/src/main/java/io/opentelemetry/trace/spi/TracerProviderFactory.java
+++ b/api/src/main/java/io/opentelemetry/trace/spi/TracerProviderFactory.java
@@ -25,7 +25,6 @@ public interface TracerProviderFactory {
    * Creates a new TracerProvider.
    *
    * @return a new TracerProvider.
-   * @since 0.1.0
    */
   TracerProvider create();
 }

--- a/context_prop/src/main/java/io/opentelemetry/context/propagation/ContextPropagators.java
+++ b/context_prop/src/main/java/io/opentelemetry/context/propagation/ContextPropagators.java
@@ -67,7 +67,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * }
  * }</pre>
  *
- * @since 0.3.0
  */
 @ThreadSafe
 public interface ContextPropagators {
@@ -80,7 +79,6 @@ public interface ContextPropagators {
    * instance.
    *
    * @return the {@link TextMapPropagator} propagator to inject and extract data.
-   * @since 0.3.0
    */
   TextMapPropagator getTextMapPropagator();
 }

--- a/context_prop/src/main/java/io/opentelemetry/context/propagation/ContextPropagators.java
+++ b/context_prop/src/main/java/io/opentelemetry/context/propagation/ContextPropagators.java
@@ -66,7 +66,6 @@ import javax.annotation.concurrent.ThreadSafe;
  *   }
  * }
  * }</pre>
- *
  */
 @ThreadSafe
 public interface ContextPropagators {

--- a/context_prop/src/main/java/io/opentelemetry/context/propagation/DefaultContextPropagators.java
+++ b/context_prop/src/main/java/io/opentelemetry/context/propagation/DefaultContextPropagators.java
@@ -21,7 +21,6 @@ import java.util.Set;
  *
  * <p>The propagation fields retrieved from all registered propagators are de-duplicated.
  *
- * @since 0.3.0
  */
 public final class DefaultContextPropagators implements ContextPropagators {
   private final TextMapPropagator textMapPropagator;
@@ -36,7 +35,6 @@ public final class DefaultContextPropagators implements ContextPropagators {
    * object.
    *
    * @return a {@link DefaultContextPropagators.Builder}.
-   * @since 0.3.0
    */
   public static Builder builder() {
     return new Builder();
@@ -60,7 +58,6 @@ public final class DefaultContextPropagators implements ContextPropagators {
    *     .build();
    * }</pre>
    *
-   * @since 0.3.0
    */
   public static final class Builder {
     List<TextMapPropagator> textPropagators = new ArrayList<>();
@@ -74,7 +71,6 @@ public final class DefaultContextPropagators implements ContextPropagators {
      * @param textMapPropagator the propagator to be added.
      * @return this.
      * @throws NullPointerException if {@code textMapPropagator} is {@code null}.
-     * @since 0.3.0
      */
     public Builder addTextMapPropagator(TextMapPropagator textMapPropagator) {
       if (textMapPropagator == null) {
@@ -89,7 +85,6 @@ public final class DefaultContextPropagators implements ContextPropagators {
      * Builds a new {@code ContextPropagators} with the specified propagators.
      *
      * @return the newly created {@code ContextPropagators} instance.
-     * @since 0.3.0
      */
     public ContextPropagators build() {
       if (textPropagators.isEmpty()) {

--- a/context_prop/src/main/java/io/opentelemetry/context/propagation/DefaultContextPropagators.java
+++ b/context_prop/src/main/java/io/opentelemetry/context/propagation/DefaultContextPropagators.java
@@ -20,7 +20,6 @@ import java.util.Set;
  * synchronically upon injection and extraction.
  *
  * <p>The propagation fields retrieved from all registered propagators are de-duplicated.
- *
  */
 public final class DefaultContextPropagators implements ContextPropagators {
   private final TextMapPropagator textMapPropagator;
@@ -57,7 +56,6 @@ public final class DefaultContextPropagators implements ContextPropagators {
    *     .addTextMapPropagator(new MyCustomContextPropagator())
    *     .build();
    * }</pre>
-   *
    */
   public static final class Builder {
     List<TextMapPropagator> textPropagators = new ArrayList<>();

--- a/context_prop/src/main/java/io/opentelemetry/context/propagation/TextMapPropagator.java
+++ b/context_prop/src/main/java/io/opentelemetry/context/propagation/TextMapPropagator.java
@@ -37,7 +37,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * }
  * }</pre>
  *
- * @since 0.1.0
  */
 @ThreadSafe
 public interface TextMapPropagator {
@@ -50,7 +49,6 @@ public interface TextMapPropagator {
    * successive calls should clear these fields first.
    *
    * @return list of fields that will be used by this formatter.
-   * @since 0.1.0
    */
   // The use cases of this are:
   // * allow pre-allocation of fields, especially in systems like gRPC Metadata
@@ -66,7 +64,6 @@ public interface TextMapPropagator {
    * @param carrier holds propagation fields. For example, an outgoing message or http request.
    * @param setter invoked for each propagation key to add or remove.
    * @param <C> carrier of propagation fields, such as an http request
-   * @since 0.1.0
    */
   <C> void inject(Context context, @Nullable C carrier, Setter<C> setter);
 
@@ -77,7 +74,6 @@ public interface TextMapPropagator {
    * allocations.
    *
    * @param <C> carrier of propagation fields, such as an http request
-   * @since 0.1.0
    */
   interface Setter<C> {
 
@@ -91,7 +87,6 @@ public interface TextMapPropagator {
      *     facilitate implementations as java lambdas, this parameter may be null.
      * @param key the key of the field.
      * @param value the value of the field.
-     * @since 0.1.0
      */
     void set(@Nullable C carrier, String key, String value);
   }
@@ -108,7 +103,6 @@ public interface TextMapPropagator {
    * @param getter invoked for each propagation key to get.
    * @param <C> carrier of propagation fields, such as an http request.
    * @return the {@code Context} containing the extracted value.
-   * @since 0.1.0
    */
   <C> Context extract(Context context, C carrier, Getter<C> getter);
 
@@ -119,7 +113,6 @@ public interface TextMapPropagator {
    * allocations.
    *
    * @param <C> carrier of propagation fields, such as an http request.
-   * @since 0.1.0
    */
   interface Getter<C> {
 
@@ -129,7 +122,6 @@ public interface TextMapPropagator {
      * @param carrier carrier of propagation fields, such as an http request.
      * @param key the key of the field.
      * @return the first value of the given propagation {@code key} or returns {@code null}.
-     * @since 0.1.0
      */
     @Nullable
     String get(C carrier, String key);

--- a/context_prop/src/main/java/io/opentelemetry/context/propagation/TextMapPropagator.java
+++ b/context_prop/src/main/java/io/opentelemetry/context/propagation/TextMapPropagator.java
@@ -36,7 +36,6 @@ import javax.annotation.concurrent.ThreadSafe;
  *   }
  * }
  * }</pre>
- *
  */
 @ThreadSafe
 public interface TextMapPropagator {

--- a/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryTracing.java
+++ b/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryTracing.java
@@ -35,7 +35,6 @@ import javax.annotation.concurrent.Immutable;
  *   }
  * </code></pre>
  *
- * @since 0.1.0
  */
 @AutoValue
 @Immutable
@@ -44,7 +43,6 @@ public abstract class InMemoryTracing {
    * Returns the {@code TracerSdkManagement} passed during construction.
    *
    * @return the {@code TracerSdkManagement} passed during construction.
-   * @since 0.1.0
    */
   abstract TracerSdkManagement getTracerSdkManagement();
 
@@ -52,7 +50,6 @@ public abstract class InMemoryTracing {
    * Returns the installed {@link InMemorySpanExporter}.
    *
    * @return the installed {@link InMemorySpanExporter}.
-   * @since 0.1.0
    */
   public abstract InMemorySpanExporter getSpanExporter();
 
@@ -68,7 +65,6 @@ public abstract class InMemoryTracing {
   /**
    * Builder for {@link InMemoryTracing}.
    *
-   * @since 0.3.0
    */
   @AutoValue.Builder
   public abstract static class Builder {
@@ -84,7 +80,6 @@ public abstract class InMemoryTracing {
      * Builds a new {@link InMemoryTracing} with current settings.
      *
      * @return a {@code InMemoryTracing}.
-     * @since 0.3.0
      */
     public final InMemoryTracing build() {
       // install the HttpTraceContext propagator into the API for testing with.

--- a/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryTracing.java
+++ b/exporters/inmemory/src/main/java/io/opentelemetry/exporters/inmemory/InMemoryTracing.java
@@ -34,7 +34,6 @@ import javax.annotation.concurrent.Immutable;
  *     assertThat(spans.get(0).getName()).isEqualTo("span");
  *   }
  * </code></pre>
- *
  */
 @AutoValue
 @Immutable
@@ -62,10 +61,7 @@ public abstract class InMemoryTracing {
     return new AutoValue_InMemoryTracing.Builder();
   }
 
-  /**
-   * Builder for {@link InMemoryTracing}.
-   *
-   */
+  /** Builder for {@link InMemoryTracing}. */
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder setTracerSdkManagement(TracerSdkManagement tracerSdkManagement);

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporter.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporter.java
@@ -213,7 +213,6 @@ public final class JaegerGrpcSpanExporter implements SpanExporter {
      *
      * @param endpoint The Jaeger endpoint URL, ex. "jaegerhost:14250".
      * @return this.
-     * @since 0.7.0
      */
     public Builder setEndpoint(String endpoint) {
       this.endpoint = endpoint;
@@ -236,7 +235,6 @@ public final class JaegerGrpcSpanExporter implements SpanExporter {
      *
      * @param configMap {@link Map} holding the configuration values.
      * @return this.
-     * @since 0.7.0
      */
     @Override
     protected Builder fromConfigMap(

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcMetricExporter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcMetricExporter.java
@@ -152,7 +152,6 @@ public final class OtlpGrpcMetricExporter implements MetricExporter {
    * environment. If a configuration value is missing, it uses the default value.
    *
    * @return a new {@link OtlpGrpcMetricExporter} instance.
-   * @since 0.5.0
    */
   public static OtlpGrpcMetricExporter getDefault() {
     return builder().readEnvironmentVariables().readSystemProperties().build();

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
@@ -154,7 +154,6 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
    * environment. If a configuration value is missing, it uses the default value.
    *
    * @return a new {@link OtlpGrpcSpanExporter} instance.
-   * @since 0.5.0
    */
   public static OtlpGrpcSpanExporter getDefault() {
     return builder().readEnvironmentVariables().readSystemProperties().build();

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporter.java
@@ -314,7 +314,6 @@ public final class ZipkinSpanExporter implements SpanExporter {
      * @return this.
      * @see io.opentelemetry.sdk.resources.Resource
      * @see io.opentelemetry.sdk.resources.ResourceAttributes
-     * @since 0.4.0
      */
     public Builder setServiceName(String serviceName) {
       this.serviceName = serviceName;
@@ -329,7 +328,6 @@ public final class ZipkinSpanExporter implements SpanExporter {
      *
      * @param sender the Zipkin sender implementation.
      * @return this.
-     * @since 0.4.0
      */
     public Builder setSender(Sender sender) {
       this.sender = sender;
@@ -343,7 +341,6 @@ public final class ZipkinSpanExporter implements SpanExporter {
      * @param encoder the {@code BytesEncoder} to use.
      * @return this.
      * @see SpanBytesEncoder
-     * @since 0.4.0
      */
     public Builder setEncoder(BytesEncoder<Span> encoder) {
       this.encoder = encoder;
@@ -357,7 +354,6 @@ public final class ZipkinSpanExporter implements SpanExporter {
      * @param endpoint The Zipkin endpoint URL, ex. "http://zipkinhost:9411/api/v2/spans".
      * @return this.
      * @see OkHttpSender
-     * @since 0.4.0
      */
     public Builder setEndpoint(String endpoint) {
       this.endpoint = endpoint;
@@ -389,7 +385,6 @@ public final class ZipkinSpanExporter implements SpanExporter {
      * Builds a {@link ZipkinSpanExporter}.
      *
      * @return a {@code ZipkinSpanExporter}.
-     * @since 0.4.0
      */
     public ZipkinSpanExporter build() {
       if (sender == null) {

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagator.java
@@ -48,7 +48,6 @@ import javax.annotation.concurrent.Immutable;
  *   .extract(context, carrier, carrierGetter);
  * }</pre>
  *
- * @since 0.6.0
  */
 @Immutable
 public class TraceMultiPropagator implements TextMapPropagator {
@@ -71,7 +70,6 @@ public class TraceMultiPropagator implements TextMapPropagator {
    * object.
    *
    * @return a {@link TraceMultiPropagator.Builder}.
-   * @since 0.6.0
    */
   public static Builder builder() {
     return new Builder();
@@ -82,7 +80,6 @@ public class TraceMultiPropagator implements TextMapPropagator {
    * read-only.
    *
    * @return list of fields defined in all the registered propagators.
-   * @since 0.6.0
    */
   @Override
   public List<String> fields() {
@@ -97,7 +94,6 @@ public class TraceMultiPropagator implements TextMapPropagator {
    * @param carrier holds propagation fields. For example, an outgoing message or http request.
    * @param setter invoked for each propagation key to add or remove.
    * @param <C> carrier of propagation fields, such as an http request
-   * @since 0.6.0
    */
   @Override
   public <C> void inject(Context context, C carrier, Setter<C> setter) {
@@ -116,7 +112,6 @@ public class TraceMultiPropagator implements TextMapPropagator {
    * @param getter invoked for each propagation key to get.
    * @param <C> carrier of propagation fields, such as an http request.
    * @return the {@code Context} containing the extracted value.
-   * @since 0.6.0
    */
   @Override
   public <C> Context extract(Context context, C carrier, Getter<C> getter) {
@@ -138,7 +133,6 @@ public class TraceMultiPropagator implements TextMapPropagator {
    * {@link Builder} is used to construct a new {@code TraceMultiPropagator} object with the
    * specified propagators.
    *
-   * @since 0.6.0
    */
   public static class Builder {
     private final List<TextMapPropagator> propagators;
@@ -156,7 +150,6 @@ public class TraceMultiPropagator implements TextMapPropagator {
      * @param propagator the propagator to be added.
      * @return this.
      * @throws NullPointerException if {@code propagator} is {@code null}.
-     * @since 0.6.0
      */
     public Builder addPropagator(TextMapPropagator propagator) {
       Objects.requireNonNull(propagator, "propagator");
@@ -169,7 +162,6 @@ public class TraceMultiPropagator implements TextMapPropagator {
      * Builds a new {@code TraceMultiPropagator} with the specified propagators.
      *
      * @return the newly created {@code TraceMultiPropagator} instance.
-     * @since 0.6.0
      */
     public TraceMultiPropagator build() {
       return new TraceMultiPropagator(propagators);

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagator.java
@@ -47,7 +47,6 @@ import javax.annotation.concurrent.Immutable;
  * Context context = OpenTelemetry.getPropagators().getTextMapPropagator()
  *   .extract(context, carrier, carrierGetter);
  * }</pre>
- *
  */
 @Immutable
 public class TraceMultiPropagator implements TextMapPropagator {
@@ -132,7 +131,6 @@ public class TraceMultiPropagator implements TextMapPropagator {
   /**
    * {@link Builder} is used to construct a new {@code TraceMultiPropagator} object with the
    * specified propagators.
-   *
    */
   public static class Builder {
     private final List<TextMapPropagator> propagators;

--- a/extensions/trace_utils/src/main/java/io/opentelemetry/extensions/trace/MessageEvent.java
+++ b/extensions/trace_utils/src/main/java/io/opentelemetry/extensions/trace/MessageEvent.java
@@ -21,7 +21,6 @@ import javax.annotation.concurrent.Immutable;
  * <p>It requires a {@link Type type} and a message id that serves to uniquely identify each
  * message. It can optionally have information about the message size.
  *
- * @since 0.1.0
  */
 @Immutable
 public final class MessageEvent {
@@ -35,19 +34,16 @@ public final class MessageEvent {
   /**
    * Available types for a {@code MessageEvent}.
    *
-   * @since 0.1.0
    */
   public enum Type {
     /**
      * When the message was sent.
      *
-     * @since 0.1.0
      */
     SENT,
     /**
      * When the message was received.
      *
-     * @since 0.1.0
      */
     RECEIVED,
   }
@@ -62,7 +58,6 @@ public final class MessageEvent {
    *     available use 0.
    * @param compressedSize represents the compressed size in bytes of this message. If not available
    *     use 0.
-   * @since 0.1.0
    */
   public static void record(
       Span span, Type type, long messageId, long uncompressedSize, long compressedSize) {

--- a/extensions/trace_utils/src/main/java/io/opentelemetry/extensions/trace/MessageEvent.java
+++ b/extensions/trace_utils/src/main/java/io/opentelemetry/extensions/trace/MessageEvent.java
@@ -20,7 +20,6 @@ import javax.annotation.concurrent.Immutable;
  *
  * <p>It requires a {@link Type type} and a message id that serves to uniquely identify each
  * message. It can optionally have information about the message size.
- *
  */
 @Immutable
 public final class MessageEvent {
@@ -31,20 +30,11 @@ public final class MessageEvent {
   private static final AttributeKey<Long> COMPRESSED_SIZE = longKey("message.compressed_size");
   private static final AttributeKey<Long> UNCOMPRESSED_SIZE = longKey("message.uncompressed_size");
 
-  /**
-   * Available types for a {@code MessageEvent}.
-   *
-   */
+  /** Available types for a {@code MessageEvent}. */
   public enum Type {
-    /**
-     * When the message was sent.
-     *
-     */
+    /** When the message was sent. */
     SENT,
-    /**
-     * When the message was received.
-     *
-     */
+    /** When the message was received. */
     RECEIVED,
   }
 

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/TraceShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/TraceShim.java
@@ -19,7 +19,6 @@ public final class TraceShim {
    * {@code OpenTelemetry.getBaggageManager()}.
    *
    * @return a {@code io.opentracing.Tracer}.
-   * @since 0.1.0
    */
   public static io.opentracing.Tracer createTracerShim() {
     return new TracerShim(
@@ -36,7 +35,6 @@ public final class TraceShim {
    * @param tracerProvider the {@code TracerProvider} used by this shim.
    * @param contextManager the {@code BaggageManager} used by this shim.
    * @return a {@code io.opentracing.Tracer}.
-   * @since 0.1.0
    */
   public static io.opentracing.Tracer createTracerShim(
       TracerProvider tracerProvider, BaggageManager contextManager) {

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/resources/ResourcesConfig.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/resources/ResourcesConfig.java
@@ -47,7 +47,6 @@ public abstract class ResourcesConfig {
    * Returns the default {@code ResourcesConfig}.
    *
    * @return the default {@code ResourcesConfig}.
-   * @since 0.9.0
    */
   public static ResourcesConfig getDefault() {
     return DEFAULT;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
@@ -82,7 +82,6 @@ public final class IntervalMetricReader {
    * the environment. If a configuration value is missing, it uses the default value.
    *
    * @return a new {@link Builder} for {@link IntervalMetricReader}.
-   * @since 0.4.0
    */
   public static Builder builderFromDefaultSources() {
     return builder().readEnvironmentVariables().readSystemProperties();

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/data/ImmutableStatus.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/data/ImmutableStatus.java
@@ -60,7 +60,6 @@ abstract class ImmutableStatus implements SpanData.Status {
    *
    * @param description the new description of the {@code Status}.
    * @return The newly created {@code Status} with the given description.
-   * @since 0.1.0
    */
   public static SpanData.Status create(
       StatusCanonicalCode canonicalCode, @Nullable String description) {

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
@@ -217,7 +217,6 @@ public interface SpanData {
      * Returns the {@code SpanContext}.
      *
      * @return the {@code SpanContext}.
-     * @since 0.1.0
      */
     SpanContext getContext();
 
@@ -225,7 +224,6 @@ public interface SpanData {
      * Returns the set of attributes.
      *
      * @return the set of attributes.
-     * @since 0.1.0
      */
     Attributes getAttributes();
 
@@ -272,7 +270,6 @@ public interface SpanData {
      * Return the name of the {@code Event}.
      *
      * @return the name of the {@code Event}.
-     * @since 0.1.0
      */
     String getName();
 
@@ -280,7 +277,6 @@ public interface SpanData {
      * Return the attributes of the {@code Event}.
      *
      * @return the attributes of the {@code Event}.
-     * @since 0.1.0
      */
     Attributes getAttributes();
 

--- a/sdk_extensions/logging/src/main/java/io/opentelemetry/sdk/logging/data/AnyValue.java
+++ b/sdk_extensions/logging/src/main/java/io/opentelemetry/sdk/logging/data/AnyValue.java
@@ -16,7 +16,6 @@ import javax.annotation.concurrent.Immutable;
  * types of values: {@code String}, {@code boolean}, {@code int}, {@code double}, {@code array}, or
  * {@code kvlist}. represented through {@code AnyValue.Type}. A {@code array} or a {@code kvlist}
  * can in turn hold other {@code AnyValue} instances, allowing for mapping to JSON-like structures.
- *
  */
 @Immutable
 public abstract class AnyValue {

--- a/sdk_extensions/logging/src/main/java/io/opentelemetry/sdk/logging/data/AnyValue.java
+++ b/sdk_extensions/logging/src/main/java/io/opentelemetry/sdk/logging/data/AnyValue.java
@@ -17,7 +17,6 @@ import javax.annotation.concurrent.Immutable;
  * {@code kvlist}. represented through {@code AnyValue.Type}. A {@code array} or a {@code kvlist}
  * can in turn hold other {@code AnyValue} instances, allowing for mapping to JSON-like structures.
  *
- * @since 0.9.0
  */
 @Immutable
 public abstract class AnyValue {

--- a/sdk_extensions/tracing_incubator/src/main/java/io/opentelemetry/sdk/extensions/incubator/trace/data/SpanDataBuilder.java
+++ b/sdk_extensions/tracing_incubator/src/main/java/io/opentelemetry/sdk/extensions/incubator/trace/data/SpanDataBuilder.java
@@ -107,10 +107,7 @@ public abstract class SpanDataBuilder implements SpanData {
     return false;
   }
 
-  /**
-   * A {@code Builder} class for {@link SpanDataBuilder}.
-   *
-   */
+  /** A {@code Builder} class for {@link SpanDataBuilder}. */
   @AutoValue.Builder
   abstract static class Builder {
 

--- a/sdk_extensions/tracing_incubator/src/main/java/io/opentelemetry/sdk/extensions/incubator/trace/data/SpanDataBuilder.java
+++ b/sdk_extensions/tracing_incubator/src/main/java/io/opentelemetry/sdk/extensions/incubator/trace/data/SpanDataBuilder.java
@@ -110,7 +110,6 @@ public abstract class SpanDataBuilder implements SpanData {
   /**
    * A {@code Builder} class for {@link SpanDataBuilder}.
    *
-   * @since 0.1.0
    */
   @AutoValue.Builder
   abstract static class Builder {

--- a/testing_internal/src/main/java/io/opentelemetry/sdk/trace/TestSpanData.java
+++ b/testing_internal/src/main/java/io/opentelemetry/sdk/trace/TestSpanData.java
@@ -21,7 +21,6 @@ import javax.annotation.concurrent.Immutable;
 
 /**
  * Immutable representation of all data collected by the {@link io.opentelemetry.trace.Span} class.
- *
  */
 @Immutable
 @AutoValue
@@ -48,10 +47,7 @@ public abstract class TestSpanData implements SpanData {
         .setTotalAttributeCount(0);
   }
 
-  /**
-   * A {@code Builder} class for {@link TestSpanData}.
-   *
-   */
+  /** A {@code Builder} class for {@link TestSpanData}. */
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/testing_internal/src/main/java/io/opentelemetry/sdk/trace/TestSpanData.java
+++ b/testing_internal/src/main/java/io/opentelemetry/sdk/trace/TestSpanData.java
@@ -22,7 +22,6 @@ import javax.annotation.concurrent.Immutable;
 /**
  * Immutable representation of all data collected by the {@link io.opentelemetry.trace.Span} class.
  *
- * @since 0.1.0
  */
 @Immutable
 @AutoValue
@@ -32,7 +31,6 @@ public abstract class TestSpanData implements SpanData {
    * Creates a new Builder for creating an SpanData instance.
    *
    * @return a new Builder.
-   * @since 0.1.0
    */
   public static Builder builder() {
     return new AutoValue_TestSpanData.Builder()
@@ -53,7 +51,6 @@ public abstract class TestSpanData implements SpanData {
   /**
    * A {@code Builder} class for {@link TestSpanData}.
    *
-   * @since 0.1.0
    */
   @AutoValue.Builder
   public abstract static class Builder {
@@ -68,7 +65,6 @@ public abstract class TestSpanData implements SpanData {
      * Create a new SpanData instance from the data in this.
      *
      * @return a new SpanData instance
-     * @since 0.1.0
      */
     public TestSpanData build() {
       // make unmodifiable copies of any collections
@@ -108,7 +104,6 @@ public abstract class TestSpanData implements SpanData {
      *
      * @param parentSpanId the SpanId of the parent
      * @return this.
-     * @since 0.1.0
      */
     public abstract Builder setParentSpanId(String parentSpanId);
 
@@ -117,7 +112,6 @@ public abstract class TestSpanData implements SpanData {
      *
      * @param resource the Resource that generated this span.
      * @return this
-     * @since 0.1.0
      */
     public abstract Builder setResource(Resource resource);
 
@@ -127,7 +121,6 @@ public abstract class TestSpanData implements SpanData {
      * @param instrumentationLibraryInfo the instrumentation library of the tracer which created
      *     this span.
      * @return this
-     * @since 0.2.0
      */
     public abstract Builder setInstrumentationLibraryInfo(
         InstrumentationLibraryInfo instrumentationLibraryInfo);
@@ -137,7 +130,6 @@ public abstract class TestSpanData implements SpanData {
      *
      * @param name the name.
      * @return this
-     * @since 0.1.0
      */
     public abstract Builder setName(String name);
 
@@ -146,7 +138,6 @@ public abstract class TestSpanData implements SpanData {
      *
      * @param epochNanos the start epoch timestamp in nanos.
      * @return this
-     * @since 0.1.0
      */
     public abstract Builder setStartEpochNanos(long epochNanos);
 
@@ -155,7 +146,6 @@ public abstract class TestSpanData implements SpanData {
      *
      * @param epochNanos the end epoch timestamp in nanos.
      * @return this
-     * @since 0.1.0
      */
     public abstract Builder setEndEpochNanos(long epochNanos);
 
@@ -166,7 +156,6 @@ public abstract class TestSpanData implements SpanData {
      * @param attributes {@link ReadableAttributes} for this span.
      * @return this
      * @see ReadableAttributes
-     * @since 0.1.0
      */
     public abstract Builder setAttributes(ReadableAttributes attributes);
 
@@ -176,7 +165,6 @@ public abstract class TestSpanData implements SpanData {
      * @param events A List&lt;Event&gt; of events associated with this span.
      * @return this
      * @see Event
-     * @since 0.1.0
      */
     public abstract Builder setEvents(List<Event> events);
 
@@ -185,7 +173,6 @@ public abstract class TestSpanData implements SpanData {
      *
      * @param status The Status of this span.
      * @return this
-     * @since 0.1.0
      */
     public abstract Builder setStatus(Status status);
 
@@ -194,7 +181,6 @@ public abstract class TestSpanData implements SpanData {
      *
      * @param kind The Kind of span.
      * @return this
-     * @since 0.1.0
      */
     public abstract Builder setKind(Kind kind);
 
@@ -203,7 +189,6 @@ public abstract class TestSpanData implements SpanData {
      *
      * @param links A List&lt;Link&gt;
      * @return this
-     * @since 0.1.0
      */
     public abstract Builder setLinks(List<SpanData.Link> links);
 
@@ -212,7 +197,6 @@ public abstract class TestSpanData implements SpanData {
      *
      * @param hasRemoteParent A boolean indicating if the span has a remote parent.
      * @return this
-     * @since 0.3.0
      */
     public abstract Builder setHasRemoteParent(boolean hasRemoteParent);
 
@@ -221,7 +205,6 @@ public abstract class TestSpanData implements SpanData {
      *
      * @param hasEnded A boolean indicating if the span has been ended.
      * @return this
-     * @since 0.4.0
      */
     public abstract Builder setHasEnded(boolean hasEnded);
 
@@ -230,7 +213,6 @@ public abstract class TestSpanData implements SpanData {
      *
      * @param totalRecordedEvents The total number of events recorded.
      * @return this
-     * @since 0.4.0
      */
     public abstract Builder setTotalRecordedEvents(int totalRecordedEvents);
 
@@ -239,7 +221,6 @@ public abstract class TestSpanData implements SpanData {
      *
      * @param totalRecordedLinks The total number of links recorded.
      * @return this
-     * @since 0.4.0
      */
     public abstract Builder setTotalRecordedLinks(int totalRecordedLinks);
 


### PR DESCRIPTION
@jkwatson I think we previously decided to remove these until 1.0.0 since nothing's stable before then anyways, but think we only did so in certain packages.