### PR TITLE
Revert "Remove getCurrentContext and withSpan from Tracer"

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -51,7 +51,7 @@ To create a basic span, you only need to specify the name of the span.
 The start and end time of the span is automatically set by the OpenTelemetry SDK.
 ```java
 Span span = tracer.spanBuilder("my span").startSpan();
-try (Scope scope = TracingContextUtils.currentContextWith(span)) {
+try (Scope scope = tracer.withSpan(span)) {
 	// your use case
 	...
 } catch (Throwable t) {
@@ -87,7 +87,7 @@ The OpenTelemetry API offers also an automated way to propagate the `parentSpan`
 ```java
 void a() {
   Span parentSpan = tracer.spanBuilder("a").startSpan();
-  try(Scope scope = TracingContextUtils.currentContextWith(parentSpan)) {
+  try(Scope scope = tracer.withSpan(parentSpan)) {
     b();
   } finally {
     parentSpan.end();
@@ -96,9 +96,9 @@ void a() {
 void b() {
   Span childSpan = tracer.spanBuilder("b")
     // NOTE: setParent(parentSpan) is not required; 
-    // `TracingContextUtils.getCurrentSpan()` is automatically added as parent
+    // `tracer.getCurrentSpan()` is automatically added as parent
     .startSpan();
-  try(Scope scope = TracingContextUtils.currentContextWith(childSpan)) {
+  try(Scope scope = tracer.withSpan(childSpan)) {
     // do stuff
   } finally {
     childSpan.end();
@@ -185,7 +185,7 @@ TextMapPropagator.Setter<HttpURLConnection> setter =
 
 URL url = new URL("http://127.0.0.1:8080/resource");
 Span outGoing = tracer.spanBuilder("/resource").setSpanKind(Span.Kind.CLIENT).startSpan();
-try (Scope scope = TracingContextUtils.currentContextWith(outGoing)) {
+try (Scope scope = tracer.withSpan(outGoing)) {
   // Semantic Convention.
   // (Observe that to set these, Span does not *need* to be the current instance.)
   outGoing.setAttribute("http.method", "GET");

--- a/api/src/jmh/java/io/opentelemetry/trace/DefaultTracerBenchmarks.java
+++ b/api/src/jmh/java/io/opentelemetry/trace/DefaultTracerBenchmarks.java
@@ -34,7 +34,7 @@ public class DefaultTracerBenchmarks {
   @Warmup(iterations = 5, time = 1)
   public void measureFullSpanLifecycle() {
     span = tracer.spanBuilder("span").startSpan();
-    try (io.opentelemetry.context.Scope ignored = TracingContextUtils.currentContextWith(span)) {
+    try (io.opentelemetry.context.Scope ignored = tracer.withSpan(span)) {
       // no-op
     } finally {
       span.end();
@@ -59,7 +59,7 @@ public class DefaultTracerBenchmarks {
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   @Warmup(iterations = 5, time = 1)
   public void measureScopeLifecycle() {
-    try (io.opentelemetry.context.Scope ignored = TracingContextUtils.currentContextWith(span)) {
+    try (io.opentelemetry.context.Scope ignored = tracer.withSpan(span)) {
       // no-op
     }
   }
@@ -71,7 +71,7 @@ public class DefaultTracerBenchmarks {
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   @Warmup(iterations = 5, time = 1)
   public void measureGetCurrentSpan() {
-    TracingContextUtils.getCurrentSpan();
+    tracer.getCurrentSpan();
   }
 
   @TearDown(Level.Iteration)

--- a/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
@@ -8,6 +8,7 @@ package io.opentelemetry.trace;
 import io.opentelemetry.common.AttributeKey;
 import io.opentelemetry.common.Attributes;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.internal.Utils;
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -25,6 +26,16 @@ public final class DefaultTracer implements Tracer {
    */
   public static Tracer getInstance() {
     return INSTANCE;
+  }
+
+  @Override
+  public Span getCurrentSpan() {
+    return TracingContextUtils.getCurrentSpan();
+  }
+
+  @Override
+  public Scope withSpan(Span span) {
+    return TracingContextUtils.currentContextWith(span);
   }
 
   @Override

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -299,8 +299,8 @@ public interface Span {
    *   void doWork {
    *     // Create a Span as a child of the current Span.
    *     Span span = tracer.spanBuilder("MyChildSpan").startSpan();
-   *     try (Scope ss = TracingContextUtils.currentContextWith(span)) {
-   *       TracingContextUtils.getCurrentSpan().addEvent("my event");
+   *     try (Scope ss = tracer.withSpan(span)) {
+   *       tracer.getCurrentSpan().addEvent("my event");
    *       doSomeWork();  // Here the new span is in the current Context, so it can be used
    *                      // implicitly anywhere down the stack.
    *     } finally {
@@ -327,8 +327,8 @@ public interface Span {
    *   }
    *
    *   public void onExecuteHandler(ServerCallHandler serverCallHandler) {
-   *     try (Scope ws = TracingContextUtils.currentContextWith(mySpan)) {
-   *       TracingContextUtils.getCurrentSpan().addEvent("Start rpc execution.");
+   *     try (Scope ws = tracer.withSpan(mySpan)) {
+   *       tracer.getCurrentSpan().addEvent("Start rpc execution.");
    *       serverCallHandler.run();  // Here the new span is in the current Context, so it can be
    *                                 // used implicitly anywhere down the stack.
    *     }

--- a/api/src/main/java/io/opentelemetry/trace/Tracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/Tracer.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.trace;
 
+import com.google.errorprone.annotations.MustBeClosed;
+import io.opentelemetry.context.Scope;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -25,10 +27,10 @@ import javax.annotation.concurrent.ThreadSafe;
  *   private static final Tracer tracer = OpenTelemetry.getTracer();
  *   void doWork() {
  *     Span span = tracer.spanBuilder("MyClass.DoWork").startSpan();
- *     try(Scope ss = TracingContextUtils.currentContextWith(span)) {
- *       TracingContextUtils.getCurrentSpan().addEvent("Starting the work.");
+ *     try(Scope ss = tracer.withSpan(span)) {
+ *       tracer.getCurrentSpan().addEvent("Starting the work.");
  *       doWorkInternal();
- *       TracingContextUtils.getCurrentSpan().addEvent("Finished working.");
+ *       tracer.getCurrentSpan().addEvent("Finished working.");
  *     } finally {
  *       span.end();
  *     }
@@ -57,6 +59,72 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public interface Tracer {
+  /**
+   * Gets the current Span from the current Context.
+   *
+   * <p>To install a {@link Span} to the current Context use {@link #withSpan(Span)}.
+   *
+   * <p>startSpan methods do NOT modify the current Context {@code Span}.
+   *
+   * @return a default {@code Span} that does nothing and has an invalid {@link SpanContext} if no
+   *     {@code Span} is associated with the current Context, otherwise the current {@code Span}
+   *     from the Context.
+   */
+  Span getCurrentSpan();
+
+  /**
+   * Enters the scope of code where the given {@link Span} is in the current Context, and returns an
+   * object that represents that scope. The scope is exited when the returned object is closed.
+   *
+   * <p>Supports try-with-resource idiom.
+   *
+   * <p>Can be called with {@code Span.getPropagated(span.getContext())} to enter a scope of code
+   * where tracing is stopped.
+   *
+   * <p>Example of usage:
+   *
+   * <pre>{@code
+   * private static Tracer tracer = OpenTelemetry.getTracer();
+   * void doWork() {
+   *   // Create a Span as a child of the current Span.
+   *   Span span = tracer.spanBuilder("my span").startSpan();
+   *   try (Scope ws = tracer.withSpan(span)) {
+   *     tracer.getCurrentSpan().addEvent("my event");
+   *     doSomeOtherWork();  // Here "span" is the current Span.
+   *   }
+   *   span.end();
+   * }
+   * }</pre>
+   *
+   * <p>Prior to Java SE 7, you can use a finally block to ensure that a resource is closed
+   * regardless of whether the try statement completes normally or abruptly.
+   *
+   * <p>Example of usage prior to Java SE7:
+   *
+   * <pre>{@code
+   * private static Tracer tracer = OpenTelemetry.getTracer();
+   * void doWork() {
+   *   // Create a Span as a child of the current Span.
+   *   Span span = tracer.spanBuilder("my span").startSpan();
+   *   Scope ws = tracer.withSpan(span);
+   *   try {
+   *     tracer.getCurrentSpan().addEvent("my event");
+   *     doSomeOtherWork();  // Here "span" is the current Span.
+   *   } finally {
+   *     ws.close();
+   *   }
+   *   span.end();
+   * }
+   * }</pre>
+   *
+   * @param span The {@link Span} to be set to the current Context.
+   * @return an object that defines a scope where the given {@link Span} will be set to the current
+   *     Context.
+   * @throws NullPointerException if {@code span} is {@code null}.
+   */
+  @MustBeClosed
+  Scope withSpan(Span span);
+
   /**
    * Returns a {@link Span.Builder} to create and start a new {@link Span}.
    *

--- a/api/src/main/java/io/opentelemetry/trace/TracingContextUtils.java
+++ b/api/src/main/java/io/opentelemetry/trace/TracingContextUtils.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.trace;
 
-import com.google.errorprone.annotations.MustBeClosed;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.context.Scope;
@@ -67,25 +66,9 @@ public final class TracingContextUtils {
    * Returns a new {@link Scope} encapsulating the provided {@link Span} added to the current {@code
    * Context}.
    *
-   * <p>Example of usage:
-   *
-   * <pre>{@code
-   * private static Tracer tracer = OpenTelemetry.getTracer();
-   * void doWork() {
-   *   // Create a Span as a child of the current Span.
-   *   Span span = tracer.spanBuilder("my span").startSpan();
-   *   try (Scope ws = TracingContextUtils.currentContextWith(span)) {
-   *     TracingContextUtils.getCurrentSpan().addEvent("my event");
-   *     doSomeOtherWork();  // Here "span" is the current Span.
-   *   }
-   *   span.end();
-   * }
-   * }</pre>
-   *
    * @param span the {@link Span} to be added to the current {@code Context}.
    * @return the {@link Scope} for the updated {@code Context}.
    */
-  @MustBeClosed
   public static Scope currentContextWith(Span span) {
     return withSpan(span, io.opentelemetry.context.Context.current()).makeCurrent();
   }

--- a/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
+++ b/api/src/test/java/io/opentelemetry/OpenTelemetryTest.java
@@ -248,6 +248,18 @@ class OpenTelemetryTest {
 
     @Nullable
     @Override
+    public Span getCurrentSpan() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Scope withSpan(Span span) {
+      return null;
+    }
+
+    @Nullable
+    @Override
     public Span.Builder spanBuilder(String spanName) {
       return null;
     }

--- a/api/src/test/java/io/opentelemetry/trace/TracingContextUtilsTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TracingContextUtilsTest.java
@@ -12,6 +12,7 @@ import io.opentelemetry.context.Scope;
 import org.junit.jupiter.api.Test;
 
 class TracingContextUtilsTest {
+
   @Test
   void testGetCurrentSpan_Default() {
     Span span = TracingContextUtils.getCurrentSpan();
@@ -50,20 +51,5 @@ class TracingContextUtilsTest {
     Span span = Span.wrap(SpanContext.getInvalid());
     Context context = TracingContextUtils.withSpan(span, Context.current());
     assertThat(TracingContextUtils.getSpanWithoutDefault(context)).isSameAs(span);
-  }
-
-  @Test
-  void testInProcessContext() {
-    Span span = Span.wrap(SpanContext.getInvalid());
-    try (Scope scope = TracingContextUtils.currentContextWith(span)) {
-      assertThat(TracingContextUtils.getCurrentSpan()).isSameAs(span);
-      Span secondSpan = Span.wrap(SpanContext.getInvalid());
-      try (Scope secondScope = TracingContextUtils.currentContextWith(secondSpan)) {
-        assertThat(TracingContextUtils.getCurrentSpan()).isSameAs(secondSpan);
-      } finally {
-        assertThat(TracingContextUtils.getCurrentSpan()).isSameAs(span);
-      }
-    }
-    assertThat(TracingContextUtils.getCurrentSpan().getContext().isValid()).isFalse();
   }
 }

--- a/context/src/main/java/io/opentelemetry/context/Scope.java
+++ b/context/src/main/java/io/opentelemetry/context/Scope.java
@@ -13,7 +13,7 @@ import io.opentelemetry.context.ThreadLocalContextStorage.NoopScope;
  * you use this class with a {@code try-with-resources} block:
  *
  * <pre>{@code
- * try (Scope ignored = TracingContextUtils.currentContextWith(span)) {
+ * try (Scope ignored = tracer.withSpan(span)) {
  *   ...
  * }
  * }</pre>

--- a/context_prop/src/main/java/io/opentelemetry/context/propagation/ContextPropagators.java
+++ b/context_prop/src/main/java/io/opentelemetry/context/propagation/ContextPropagators.java
@@ -22,7 +22,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * <pre>{@code
  * private static final Tracer tracer = OpenTelemetry.getTracer();
  * void onSendRequest() {
- *   try (Scope scope = TracingContextUtils.currentContextWith(span)) {
+ *   try (Scope scope = tracer.withSpan(span)) {
  *     ContextPropagators propagators = OpenTelemetry.getPropagators();
  *     TextMapPropagator textMapPropagator = propagators.getTextMapPropagator();
  *
@@ -59,7 +59,7 @@ import javax.annotation.concurrent.ThreadSafe;
  *   Span span = tracer.spanBuilder("MyRequest")
  *       .setParent(context)
  *       .setSpanKind(Span.Kind.SERVER).startSpan();
- *   try (Scope ss = TracingContextUtils.currentContextWith(span)) {
+ *   try (Scope ss = tracer.withSpan(span)) {
  *     // Handle request and send response back.
  *   } finally {
  *     span.end();

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -13,7 +13,7 @@ which try-with-resources does not allow. Take this example:
 
 ```java
 Span span = tracer.spanBuilder("someWork").startSpan();
-try (Scope scope = TracingContextUtils.currentContextWith(span)) {
+try (Scope scope = tracer.withSpan(span)) {
     // Do things.
 } catch (Exception ex) {
     span.recordException(ex);

--- a/examples/grpc/src/main/java/io/opentelemetry/example/HelloWorldClient.java
+++ b/examples/grpc/src/main/java/io/opentelemetry/example/HelloWorldClient.java
@@ -90,7 +90,7 @@ public class HelloWorldClient {
     span.setAttribute("net.peer.port", this.serverPort);
 
     // Set the context with the current span
-    try (Scope scope = TracingContextUtils.currentContextWith(span)) {
+    try (Scope scope = tracer.withSpan(span)) {
       HelloRequest request = HelloRequest.newBuilder().setName(name).build();
       try {
         HelloReply response = blockingStub.sayHello(request);

--- a/examples/grpc/src/main/java/io/opentelemetry/example/HelloWorldClientStream.java
+++ b/examples/grpc/src/main/java/io/opentelemetry/example/HelloWorldClientStream.java
@@ -95,7 +95,7 @@ public class HelloWorldClientStream {
     StreamObserver<HelloRequest> requestObserver;
 
     // Set the context with the current span
-    try (Scope scope = TracingContextUtils.currentContextWith(span)) {
+    try (Scope scope = tracer.withSpan(span)) {
       HelloReplyStreamObserver replyObserver = new HelloReplyStreamObserver();
       requestObserver = asyncStub.sayHelloStream(replyObserver);
       for (String name : names) {
@@ -126,14 +126,14 @@ public class HelloWorldClientStream {
 
     @Override
     public void onNext(HelloReply value) {
-      Span span = TracingContextUtils.getCurrentSpan();
+      Span span = tracer.getCurrentSpan();
       span.addEvent("Data received: " + value.getMessage());
       logger.info(value.getMessage());
     }
 
     @Override
     public void onError(Throwable t) {
-      Span span = TracingContextUtils.getCurrentSpan();
+      Span span = tracer.getCurrentSpan();
       logger.log(Level.WARNING, "RPC failed: {0}", t.getMessage());
       span.setStatus(StatusCanonicalCode.ERROR, "gRPC status: " + t.getMessage());
     }

--- a/examples/http/src/main/java/io/opentelemetry/example/http/HttpClient.java
+++ b/examples/http/src/main/java/io/opentelemetry/example/http/HttpClient.java
@@ -55,7 +55,7 @@ public class HttpClient {
     // Name convention for the Span is not yet defined.
     // See: https://github.com/open-telemetry/opentelemetry-specification/issues/270
     Span span = tracer.spanBuilder("/").setSpanKind(Span.Kind.CLIENT).startSpan();
-    try (Scope scope = TracingContextUtils.currentContextWith(span)) {
+    try (Scope scope = tracer.withSpan(span)) {
       // TODO provide semantic convention attributes to Span.Builder
       span.setAttribute("component", "http");
       span.setAttribute("http.method", "GET");

--- a/examples/http/src/main/java/io/opentelemetry/example/http/HttpServer.java
+++ b/examples/http/src/main/java/io/opentelemetry/example/http/HttpServer.java
@@ -43,7 +43,7 @@ public class HttpServer {
       Span span =
           tracer.spanBuilder("/").setParent(context).setSpanKind(Span.Kind.SERVER).startSpan();
 
-      try (Scope scope = TracingContextUtils.currentContextWith(span)) {
+      try (Scope scope = tracer.withSpan(span)) {
         // Set the Semantic Convention
         span.setAttribute("component", "http");
         span.setAttribute("http.method", "GET");

--- a/examples/metrics/src/main/java/io/opentelemetry/example/metrics/DoubleCounterExample.java
+++ b/examples/metrics/src/main/java/io/opentelemetry/example/metrics/DoubleCounterExample.java
@@ -36,7 +36,7 @@ public class DoubleCounterExample {
   public static void main(String[] args) {
     Span span = tracer.spanBuilder("calculate space").setSpanKind(Kind.INTERNAL).startSpan();
     DoubleCounterExample example = new DoubleCounterExample();
-    try (Scope scope = TracingContextUtils.currentContextWith(span)) {
+    try (Scope scope = tracer.withSpan(span)) {
       List<String> extensionsToFind = new ArrayList<>();
       extensionsToFind.add("dll");
       extensionsToFind.add("png");

--- a/examples/metrics/src/main/java/io/opentelemetry/example/metrics/LongCounterExample.java
+++ b/examples/metrics/src/main/java/io/opentelemetry/example/metrics/LongCounterExample.java
@@ -37,7 +37,7 @@ public class LongCounterExample {
   public static void main(String[] args) {
     Span span = tracer.spanBuilder("workflow").setSpanKind(Kind.INTERNAL).startSpan();
     LongCounterExample example = new LongCounterExample();
-    try (Scope scope = TracingContextUtils.currentContextWith(span)) {
+    try (Scope scope = tracer.withSpan(span)) {
       homeDirectoryCounter.add(1); // count root directory
       example.findFile("file_to_find.txt", homeDirectory);
     } catch (Exception e) {

--- a/examples/otlp/src/main/java/io/opentelemetry/example/OtlpExporterExample.java
+++ b/examples/otlp/src/main/java/io/opentelemetry/example/OtlpExporterExample.java
@@ -55,7 +55,7 @@ public class OtlpExporterExample {
 
     for (int i = 0; i < 10; i++) {
       Span exampleSpan = tracer.spanBuilder("exampleSpan").startSpan();
-      try (Scope scope = TracingContextUtils.currentContextWith(exampleSpan)) {
+      try (Scope scope = tracer.withSpan(exampleSpan)) {
         counter.add(1);
         exampleSpan.setAttribute("good", "true");
         exampleSpan.setAttribute("exampleNumber", i);

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/ScopeManagerShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/ScopeManagerShim.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.opentracingshim;
 
-import io.opentelemetry.trace.TracingContextUtils;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
@@ -21,7 +20,7 @@ final class ScopeManagerShim extends BaseShimObject implements ScopeManager {
   public Span activeSpan() {
     // As OpenTracing simply returns null when no active instance is available,
     // we need to do map an invalid OpenTelemetry span to null here.
-    io.opentelemetry.trace.Span span = TracingContextUtils.getCurrentSpan();
+    io.opentelemetry.trace.Span span = tracer().getCurrentSpan();
     if (!span.getContext().isValid()) {
       return null;
     }
@@ -34,7 +33,7 @@ final class ScopeManagerShim extends BaseShimObject implements ScopeManager {
   @SuppressWarnings("MustBeClosedChecker")
   public Scope activate(Span span) {
     io.opentelemetry.trace.Span actualSpan = getActualSpan(span);
-    return new ScopeShim(TracingContextUtils.currentContextWith(actualSpan));
+    return new ScopeShim(tracer().withSpan(actualSpan));
   }
 
   static io.opentelemetry.trace.Span getActualSpan(Span span) {

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
@@ -15,7 +15,6 @@ import io.opentelemetry.exporters.inmemory.InMemoryTracing;
 import io.opentelemetry.opentracingshim.TraceShim;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.trace.TracingContextUtils;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
@@ -46,7 +45,7 @@ class OpenTelemetryInteroperabilityTest {
     } finally {
       otSpan.finish();
     }
-    assertThat(TracingContextUtils.getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(tracer.getCurrentSpan().getContext().isValid()).isFalse();
     assertNull(otTracer.activeSpan());
 
     List<SpanData> finishedSpans = inMemoryTracing.getSpanExporter().getFinishedSpanItems();
@@ -57,13 +56,13 @@ class OpenTelemetryInteroperabilityTest {
   @Test
   void openTracingContinuesSdkTrace() {
     io.opentelemetry.trace.Span otelSpan = tracer.spanBuilder("otel_span").startSpan();
-    try (io.opentelemetry.context.Scope scope = TracingContextUtils.currentContextWith(otelSpan)) {
+    try (io.opentelemetry.context.Scope scope = tracer.withSpan(otelSpan)) {
       otTracer.buildSpan("ot_span").start().finish();
     } finally {
       otelSpan.end();
     }
 
-    assertThat(TracingContextUtils.getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(tracer.getCurrentSpan().getContext().isValid()).isFalse();
     assertNull(otTracer.activeSpan());
 
     List<SpanData> finishedSpans = inMemoryTracing.getSpanExporter().getFinishedSpanItems();

--- a/perf_harness/src/main/java/io/opentelemetry/perf/OtlpPipelineDriver.java
+++ b/perf_harness/src/main/java/io/opentelemetry/perf/OtlpPipelineDriver.java
@@ -22,7 +22,6 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -105,7 +104,7 @@ public class OtlpPipelineDriver {
         : i < numberOfSpans) {
       //    for (int i = 0; i < 10000; i++) {
       Span exampleSpan = tracer.spanBuilder("exampleSpan").startSpan();
-      try (Scope scope = TracingContextUtils.currentContextWith(exampleSpan)) {
+      try (Scope scope = tracer.withSpan(exampleSpan)) {
         exampleSpan.setAttribute("exampleNumber", i++);
         exampleSpan.setAttribute("attribute0", "attvalue-0");
         exampleSpan.setAttribute("attribute1", "attvalue-1");

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/TracerSdk.java
@@ -5,10 +5,12 @@
 
 package io.opentelemetry.sdk.trace;
 
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.trace.DefaultTracer;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
+import io.opentelemetry.trace.TracingContextUtils;
 
 /** {@link TracerSdk} is SDK implementation of {@link Tracer}. */
 final class TracerSdk implements Tracer {
@@ -18,6 +20,16 @@ final class TracerSdk implements Tracer {
   TracerSdk(TracerSharedState sharedState, InstrumentationLibraryInfo instrumentationLibraryInfo) {
     this.sharedState = sharedState;
     this.instrumentationLibraryInfo = instrumentationLibraryInfo;
+  }
+
+  @Override
+  public Span getCurrentSpan() {
+    return TracingContextUtils.getCurrentSpan();
+  }
+
+  @Override
+  public Scope withSpan(Span span) {
+    return TracingContextUtils.currentContextWith(span);
   }
 
   @Override

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -613,7 +613,7 @@ class SpanBuilderSdkTest {
   @Test
   void noParent() {
     Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
-    try (Scope ignored = TracingContextUtils.currentContextWith(parent)) {
+    try (Scope ignored = tracerSdk.withSpan(parent)) {
       Span span = tracerSdk.spanBuilder(SPAN_NAME).setNoParent().startSpan();
       try {
         assertThat(span.getContext().getTraceIdAsHexString())
@@ -760,7 +760,7 @@ class SpanBuilderSdkTest {
   @Test
   void parentCurrentSpan() {
     Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
-    try (Scope ignored = TracingContextUtils.currentContextWith(parent)) {
+    try (Scope ignored = tracerSdk.withSpan(parent)) {
       final Context implicitParent = Context.current();
       RecordEventsReadableSpan span =
           (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).startSpan();
@@ -809,7 +809,7 @@ class SpanBuilderSdkTest {
   @Test
   void parent_clockIsSame() {
     Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
-    try (Scope scope = TracingContextUtils.currentContextWith(parent)) {
+    try (Scope scope = tracerSdk.withSpan(parent)) {
       RecordEventsReadableSpan span =
           (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).startSpan();
 
@@ -822,7 +822,7 @@ class SpanBuilderSdkTest {
   @Test
   void parentCurrentSpan_clockIsSame() {
     Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
-    try (Scope ignored = TracingContextUtils.currentContextWith(parent)) {
+    try (Scope ignored = tracerSdk.withSpan(parent)) {
       RecordEventsReadableSpan span =
           (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).startSpan();
 

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/activespanreplacement/ActiveSpanReplacementTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/activespanreplacement/ActiveSpanReplacementTest.java
@@ -18,7 +18,6 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Tracer;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -38,7 +37,7 @@ class ActiveSpanReplacementTest {
   void test() {
     // Start an isolated task and query for its result in another task/thread
     Span span = tracer.spanBuilder("initial").startSpan();
-    try (Scope scope = TracingContextUtils.currentContextWith(span)) {
+    try (Scope scope = tracer.withSpan(span)) {
       // Explicitly pass a Span to be finished once a late calculation is done.
       submitAnotherTask(span);
     }
@@ -61,7 +60,7 @@ class ActiveSpanReplacementTest {
     assertThat(spans.get(0).getTraceId()).isNotEqualTo(spans.get(1).getTraceId());
     assertThat(spans.get(0).getParentSpanId()).isEqualTo(SpanId.getInvalid());
 
-    assertThat(TracingContextUtils.getCurrentSpan()).isSameAs(Span.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(Span.getInvalid());
   }
 
   private void submitAnotherTask(final Span initialSpan) {
@@ -70,11 +69,11 @@ class ActiveSpanReplacementTest {
         () -> {
           // Create a new Span for this task
           Span taskSpan = tracer.spanBuilder("task").startSpan();
-          try (Scope scope = TracingContextUtils.currentContextWith(taskSpan)) {
+          try (Scope scope = tracer.withSpan(taskSpan)) {
 
             // Simulate work strictly related to the initial Span
             // and finish it.
-            try (Scope initialScope = TracingContextUtils.currentContextWith(initialSpan)) {
+            try (Scope initialScope = tracer.withSpan(initialSpan)) {
               sleep(50);
             } finally {
               initialSpan.end();
@@ -82,7 +81,7 @@ class ActiveSpanReplacementTest {
 
             // Restore the span for this task and create a subspan
             Span subTaskSpan = tracer.spanBuilder("subtask").startSpan();
-            try (Scope subTaskScope = TracingContextUtils.currentContextWith(subTaskSpan)) {
+            try (Scope subTaskScope = tracer.withSpan(subTaskSpan)) {
               sleep(50);
             } finally {
               subTaskSpan.end();

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/actorpropagation/Actor.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/actorpropagation/Actor.java
@@ -10,7 +10,6 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.Tracer;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -45,7 +44,7 @@ final class Actor implements AutoCloseable {
                   .setParent(parent)
                   .setSpanKind(Kind.CONSUMER)
                   .startSpan();
-          try (Scope ignored = TracingContextUtils.currentContextWith(child)) {
+          try (Scope ignored = tracer.withSpan(child)) {
             phaser.arriveAndAwaitAdvance(); // child tracer started
             child.addEvent("received " + message);
             phaser.arriveAndAwaitAdvance(); // assert size

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/actorpropagation/ActorPropagationTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/actorpropagation/ActorPropagationTest.java
@@ -15,7 +15,6 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.Tracer;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -49,7 +48,7 @@ class ActorPropagationTest {
       phaser.register();
       Span parent = tracer.spanBuilder("actorTell").setSpanKind(Kind.PRODUCER).startSpan();
       parent.setAttribute("component", "example-actor");
-      try (Scope ignored = TracingContextUtils.currentContextWith(parent)) {
+      try (Scope ignored = tracer.withSpan(parent)) {
         actor.tell("my message 1");
         actor.tell("my message 2");
       } finally {
@@ -73,7 +72,7 @@ class ActorPropagationTest {
       assertThat(TestUtils.getByKind(finished, Span.Kind.CONSUMER)).hasSize(2);
       assertThat(TestUtils.getOneByKind(finished, Span.Kind.PRODUCER)).isNotNull();
 
-      assertThat(TracingContextUtils.getCurrentSpan()).isSameAs(Span.getInvalid());
+      assertThat(tracer.getCurrentSpan()).isSameAs(Span.getInvalid());
     }
   }
 
@@ -86,7 +85,7 @@ class ActorPropagationTest {
       Span span = tracer.spanBuilder("actorAsk").setSpanKind(Kind.PRODUCER).startSpan();
       span.setAttribute("component", "example-actor");
 
-      try (Scope ignored = TracingContextUtils.currentContextWith(span)) {
+      try (Scope ignored = tracer.withSpan(span)) {
         future1 = actor.ask("my message 1");
         future2 = actor.ask("my message 2");
       } finally {
@@ -114,7 +113,7 @@ class ActorPropagationTest {
       assertThat(TestUtils.getByKind(finished, Span.Kind.CONSUMER)).hasSize(2);
       assertThat(TestUtils.getOneByKind(finished, Span.Kind.PRODUCER)).isNotNull();
 
-      assertThat(TracingContextUtils.getCurrentSpan()).isSameAs(Span.getInvalid());
+      assertThat(tracer.getCurrentSpan()).isSameAs(Span.getInvalid());
     }
   }
 }

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/clientserver/Client.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/clientserver/Client.java
@@ -11,7 +11,6 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.Tracer;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.concurrent.ArrayBlockingQueue;
 
 final class Client {
@@ -30,7 +29,7 @@ final class Client {
     Span span = tracer.spanBuilder("send").setSpanKind(Kind.CLIENT).startSpan();
     span.setAttribute("component", "example-client");
 
-    try (Scope ignored = TracingContextUtils.currentContextWith(span)) {
+    try (Scope ignored = tracer.withSpan(span)) {
       OpenTelemetry.getPropagators()
           .getTextMapPropagator()
           .inject(Context.current(), message, Message::put);

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/clientserver/Server.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/clientserver/Server.java
@@ -12,7 +12,6 @@ import io.opentelemetry.context.propagation.TextMapPropagator.Getter;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.Tracer;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.concurrent.ArrayBlockingQueue;
 import javax.annotation.Nullable;
 
@@ -44,9 +43,9 @@ final class Server extends Thread {
         tracer.spanBuilder("receive").setSpanKind(Kind.SERVER).setParent(context).startSpan();
     span.setAttribute("component", "example-server");
 
-    try (Scope ignored = TracingContextUtils.currentContextWith(span)) {
+    try (Scope ignored = tracer.withSpan(span)) {
       // Simulate work.
-      TracingContextUtils.getCurrentSpan().addEvent("DoWork");
+      tracer.getCurrentSpan().addEvent("DoWork");
     } finally {
       span.end();
     }

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/clientserver/TestClientServerTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/clientserver/TestClientServerTest.java
@@ -17,7 +17,6 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.Tracer;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -63,6 +62,6 @@ class TestClientServerTest {
     assertThat(finished.get(0).getKind()).isEqualTo(Kind.CLIENT);
     assertThat(finished.get(1).getKind()).isEqualTo(Kind.SERVER);
 
-    assertThat(TracingContextUtils.getCurrentSpan()).isSameAs(Span.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(Span.getInvalid());
   }
 }

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/concurrentcommonrequesthandler/HandlerTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/concurrentcommonrequesthandler/HandlerTest.java
@@ -60,14 +60,14 @@ class HandlerTest {
     assertThat(finished.get(0).getParentSpanId()).isEqualTo(SpanId.getInvalid());
     assertThat(finished.get(1).getParentSpanId()).isEqualTo(SpanId.getInvalid());
 
-    assertThat(TracingContextUtils.getCurrentSpan()).isSameAs(Span.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(Span.getInvalid());
   }
 
   /** Active parent is not picked up by child. */
   @Test
   void parent_not_picked_up() throws Exception {
     Span parentSpan = tracer.spanBuilder("parent").startSpan();
-    try (Scope ignored = TracingContextUtils.currentContextWith(parentSpan)) {
+    try (Scope ignored = tracer.withSpan(parentSpan)) {
       String response = client.send("no_parent").get(15, TimeUnit.SECONDS);
       assertThat(response).isEqualTo("no_parent:response");
     } finally {
@@ -97,7 +97,7 @@ class HandlerTest {
   void bad_solution_to_set_parent() throws Exception {
     Client client;
     Span parentSpan = tracer.spanBuilder("parent").startSpan();
-    try (Scope ignored = TracingContextUtils.currentContextWith(parentSpan)) {
+    try (Scope ignored = tracer.withSpan(parentSpan)) {
       client =
           new Client(
               new RequestHandler(

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/latespanfinish/LateSpanFinishTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/latespanfinish/LateSpanFinishTest.java
@@ -14,7 +14,6 @@ import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -51,7 +50,7 @@ public final class LateSpanFinishTest {
 
     TestUtils.assertSameTrace(spans);
 
-    assertThat(TracingContextUtils.getCurrentSpan()).isSameAs(Span.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(Span.getInvalid());
   }
 
   /*
@@ -64,9 +63,9 @@ public final class LateSpanFinishTest {
         () -> {
           /* Alternative to calling activate() is to pass it manually to asChildOf() for each
            * created Span. */
-          try (Scope scope = TracingContextUtils.currentContextWith(parentSpan)) {
+          try (Scope scope = tracer.withSpan(parentSpan)) {
             Span childSpan = tracer.spanBuilder("task1").startSpan();
-            try (Scope childScope = TracingContextUtils.currentContextWith(childSpan)) {
+            try (Scope childScope = tracer.withSpan(childSpan)) {
               TestUtils.sleep(55);
             } finally {
               childSpan.end();
@@ -76,9 +75,9 @@ public final class LateSpanFinishTest {
 
     executor.submit(
         () -> {
-          try (Scope scope = TracingContextUtils.currentContextWith(parentSpan)) {
+          try (Scope scope = tracer.withSpan(parentSpan)) {
             Span childSpan = tracer.spanBuilder("task2").startSpan();
-            try (Scope childScope = TracingContextUtils.currentContextWith(childSpan)) {
+            try (Scope childScope = tracer.withSpan(childSpan)) {
               TestUtils.sleep(85);
             } finally {
               childSpan.end();

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/listenerperrequest/ListenerTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/listenerperrequest/ListenerTest.java
@@ -13,7 +13,6 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.Tracer;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +33,6 @@ class ListenerTest {
     assertThat(finished).hasSize(1);
     assertThat(finished.get(0).getKind()).isEqualTo(Kind.CLIENT);
 
-    assertThat(TracingContextUtils.getCurrentSpan()).isSameAs(Span.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(Span.getInvalid());
   }
 }

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/multiplecallbacks/Client.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/multiplecallbacks/Client.java
@@ -9,7 +9,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -31,7 +30,7 @@ class Client {
     return executor.submit(
         () -> {
           Span span = tracer.spanBuilder("subtask").setParent(parent).startSpan();
-          try (Scope subtaskScope = TracingContextUtils.currentContextWith(span)) {
+          try (Scope subtaskScope = tracer.withSpan(span)) {
             // Simulate work - make sure we finish *after* the parent Span.
             parentDoneLatch.await();
           } finally {

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/multiplecallbacks/MultipleCallbacksTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/multiplecallbacks/MultipleCallbacksTest.java
@@ -16,7 +16,6 @@ import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -41,7 +40,7 @@ class MultipleCallbacksTest {
     Client client = new Client(tracer, parentDoneLatch);
 
     Span span = tracer.spanBuilder("parent").startSpan();
-    try (Scope scope = TracingContextUtils.currentContextWith(span)) {
+    try (Scope scope = tracer.withSpan(span)) {
       client.send("task1");
       client.send("task2");
       client.send("task3");
@@ -64,6 +63,6 @@ class MultipleCallbacksTest {
       assertThat(spans.get(i).getParentSpanId()).isEqualTo(parentSpan.getSpanId());
     }
 
-    assertThat(TracingContextUtils.getCurrentSpan()).isSameAs(Span.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(Span.getInvalid());
   }
 }

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/nestedcallbacks/NestedCallbacksTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/nestedcallbacks/NestedCallbacksTest.java
@@ -18,7 +18,6 @@ import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -54,24 +53,24 @@ public final class NestedCallbacksTest {
       assertThat(attrs.get(stringKey("key" + i))).isEqualTo(Integer.toString(i));
     }
 
-    assertThat(TracingContextUtils.getCurrentSpan()).isSameAs(Span.getInvalid());
+    assertThat(tracer.getCurrentSpan()).isSameAs(Span.getInvalid());
   }
 
   private void submitCallbacks(final Span span) {
 
     executor.submit(
         () -> {
-          try (Scope ignored = TracingContextUtils.currentContextWith(span)) {
+          try (Scope ignored = tracer.withSpan(span)) {
             span.setAttribute("key1", "1");
 
             executor.submit(
                 () -> {
-                  try (Scope ignored12 = TracingContextUtils.currentContextWith(span)) {
+                  try (Scope ignored12 = tracer.withSpan(span)) {
                     span.setAttribute("key2", "2");
 
                     executor.submit(
                         () -> {
-                          try (Scope ignored1 = TracingContextUtils.currentContextWith(span)) {
+                          try (Scope ignored1 = tracer.withSpan(span)) {
                             span.setAttribute("key3", "3");
                           } finally {
                             span.end();

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/promisepropagation/Promise.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/promisepropagation/Promise.java
@@ -9,7 +9,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -44,7 +43,7 @@ final class Promise<T> {
           () -> {
             Span childSpan = tracer.spanBuilder("success").setParent(parent).startSpan();
             childSpan.setAttribute("component", "success");
-            try (Scope ignored = TracingContextUtils.currentContextWith(childSpan)) {
+            try (Scope ignored = tracer.withSpan(childSpan)) {
               callback.accept(result);
             } finally {
               childSpan.end();
@@ -61,7 +60,7 @@ final class Promise<T> {
           () -> {
             Span childSpan = tracer.spanBuilder("error").setParent(parent).startSpan();
             childSpan.setAttribute("component", "error");
-            try (Scope ignored = TracingContextUtils.currentContextWith(childSpan)) {
+            try (Scope ignored = tracer.withSpan(childSpan)) {
               callback.accept(error);
             } finally {
               childSpan.end();

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/promisepropagation/PromisePropagationTest.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/promisepropagation/PromisePropagationTest.java
@@ -17,7 +17,6 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Tracer;
-import io.opentelemetry.trace.TracingContextUtils;
 import java.util.List;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.atomic.AtomicReference;
@@ -54,18 +53,18 @@ class PromisePropagationTest {
       Span parentSpan = tracer.spanBuilder("promises").startSpan();
       parentSpan.setAttribute("component", "example-promises");
 
-      try (Scope ignored = TracingContextUtils.currentContextWith(parentSpan)) {
+      try (Scope ignored = tracer.withSpan(parentSpan)) {
         Promise<String> successPromise = new Promise<>(context, tracer);
 
         successPromise.onSuccess(
             s -> {
-              TracingContextUtils.getCurrentSpan().addEvent("Promised 1 " + s);
+              tracer.getCurrentSpan().addEvent("Promised 1 " + s);
               successResult1.set(s);
               phaser.arriveAndAwaitAdvance(); // result set
             });
         successPromise.onSuccess(
             s -> {
-              TracingContextUtils.getCurrentSpan().addEvent("Promised 2 " + s);
+              tracer.getCurrentSpan().addEvent("Promised 2 " + s);
               successResult2.set(s);
               phaser.arriveAndAwaitAdvance(); // result set
             });

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/statelesscommonrequesthandler/RequestHandler.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/statelesscommonrequesthandler/RequestHandler.java
@@ -9,7 +9,6 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.Tracer;
-import io.opentelemetry.trace.TracingContextUtils;
 
 /**
  * One instance per Client. 'beforeRequest' and 'afterResponse' are executed in the same thread for
@@ -31,13 +30,13 @@ final class RequestHandler {
   /** beforeRequest handler....... */
   public void beforeRequest(Object request) {
     Span span = tracer.spanBuilder(OPERATION_NAME).setSpanKind(Kind.SERVER).startSpan();
-    tlsScope.set(TracingContextUtils.currentContextWith(span));
+    tlsScope.set(tracer.withSpan(span));
   }
 
   /** afterResponse handler....... */
   public void afterResponse(Object response) {
     // Finish the Span
-    TracingContextUtils.getCurrentSpan().end();
+    tracer.getCurrentSpan().end();
 
     // Deactivate the Span
     tlsScope.get().close();

--- a/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/suspendresumepropagation/SuspendResume.java
+++ b/sdk_extensions/testbed/src/test/java/io/opentelemetry/sdk/extensions/trace/testbed/suspendresumepropagation/SuspendResume.java
@@ -8,21 +8,24 @@ package io.opentelemetry.sdk.extensions.trace.testbed.suspendresumepropagation;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
-import io.opentelemetry.trace.TracingContextUtils;
 
 final class SuspendResume {
+  private final Tracer tracer;
   private final Span span;
 
   public SuspendResume(int id, Tracer tracer) {
+    // Passed along here for testing. Normally should be referenced via GlobalTracer.get().
+    this.tracer = tracer;
+
     Span span = tracer.spanBuilder("job " + id).startSpan();
     span.setAttribute("component", "suspend-resume");
-    try (Scope scope = TracingContextUtils.currentContextWith(span)) {
+    try (Scope scope = tracer.withSpan(span)) {
       this.span = span;
     }
   }
 
   public void doPart(String name) {
-    try (Scope scope = TracingContextUtils.currentContextWith(span)) {
+    try (Scope scope = tracer.withSpan(span)) {
       span.addEvent("part: " + name);
     }
   }


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-java#1809

Per comments from @jkwatson let's revert this and go back to the drawing board.