### PR TITLE
Replace restassured test assertion with okhttp/jackson

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -248,6 +248,7 @@ configure(opentelemetryProjects) {
         findBugsJsr305Version = '3.0.2'
         grpcVersion = '1.30.2'
         guavaVersion = '28.2-android'
+        jacksonVersion = '2.11.3'
         jmhVersion = '1.19'
         junitVersion = '5.6.2'
         mockitoVersion = '3.3.3'
@@ -261,6 +262,7 @@ configure(opentelemetryProjects) {
         boms = [
                 grpc           : "io.grpc:grpc-bom:${grpcVersion}",
                 guava          : "com.google.guava:guava-bom:${guavaVersion}",
+                jackson        : "com.fasterxml.jackson:jackson-bom:2.11.3",
                 junit          : "org.junit:junit-bom:${junitVersion}",
                 protobuf       : "com.google.protobuf:protobuf-bom:${protobufVersion}",
                 zipkin_reporter: "io.zipkin.reporter2:zipkin-reporter-bom:${zipkinReporterVersion}"
@@ -302,6 +304,7 @@ configure(opentelemetryProjects) {
                 junit_vintage_engine    : 'org.junit.vintage:junit-vintage-engine',
                 mockito                 : "org.mockito:mockito-core:${mockitoVersion}",
                 mockito_junit_jupiter   : "org.mockito:mockito-junit-jupiter:${mockitoVersion}",
+                okhttp                  : 'com.squareup.okhttp3:okhttp:3.14.9',
                 system_rules            : 'com.github.stefanbirkner:system-rules:1.19.0', // env and system properties
                 slf4jsimple             : 'org.slf4j:slf4j-simple:1.7.25', // Compatibility layer
                 awaitility              : 'org.awaitility:awaitility:3.0.0', // Compatibility layer
@@ -343,6 +346,7 @@ configure(opentelemetryProjects) {
             if (it.name.endsWith('Classpath')) {
                 add(it.name, enforcedPlatform(boms.grpc))
                 add(it.name, enforcedPlatform(boms.guava))
+                add(it.name, enforcedPlatform(boms.jackson))
                 add(it.name, enforcedPlatform(boms.junit))
                 add(it.name, enforcedPlatform(boms.protobuf))
                 add(it.name, enforcedPlatform(boms.zipkin_reporter))

--- a/exporters/jaeger/build.gradle
+++ b/exporters/jaeger/build.gradle
@@ -21,8 +21,9 @@ dependencies {
             libraries.protobuf_util
 
     testImplementation "io.grpc:grpc-testing:${grpcVersion}",
+            'com.fasterxml.jackson.core:jackson-databind',
             libraries.testcontainers,
-            libraries.rest_assured
+            libraries.okhttp
 
     testImplementation project(':opentelemetry-testing-internal')
 

--- a/integration_tests/build.gradle
+++ b/integration_tests/build.gradle
@@ -27,8 +27,9 @@ dependencies {
         libraries.protobuf_util,
         "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
-    testImplementation libraries.testcontainers,
-        libraries.rest_assured
+    testImplementation 'com.fasterxml.jackson.core:jackson-databind',
+            libraries.testcontainers,
+            libraries.okhttp
 
     signature "org.codehaus.mojo.signature:java18:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"

--- a/integration_tests/src/test/java/io/opentelemetry/JaegerExporterIntegrationTest.java
+++ b/integration_tests/src/test/java/io/opentelemetry/JaegerExporterIntegrationTest.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry;
 
-import static io.restassured.RestAssured.given;
-
-import io.restassured.http.ContentType;
-import io.restassured.response.Response;
-import java.util.Map;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.concurrent.TimeUnit;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
@@ -34,6 +34,9 @@ import org.testcontainers.utility.MountableFile;
  */
 @Testcontainers
 class JaegerExporterIntegrationTest {
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final OkHttpClient client = new OkHttpClient();
 
   private static final String ARCHIVE_NAME = System.getProperty("archive.name");
   private static final String APP_NAME = "SendTraceToJaeger.jar";
@@ -87,17 +90,20 @@ class JaegerExporterIntegrationTest {
               "%s/api/traces?service=%s",
               String.format(JAEGER_URL + ":%d", jaegerContainer.getMappedPort(QUERY_PORT)),
               SERVICE_NAME);
-      Response response =
-          given()
-              .headers("Content-Type", ContentType.JSON, "Accept", ContentType.JSON)
-              .when()
-              .get(url)
-              .then()
-              .contentType(ContentType.JSON)
-              .extract()
-              .response();
-      Map<String, String> path = response.jsonPath().getMap("data[0]");
-      return path.get("traceID") != null;
+
+      Request request =
+          new Request.Builder()
+              .url(url)
+              .header("Content-Type", "application/json")
+              .header("Accept", "application/json")
+              .build();
+
+      final JsonNode json;
+      try (Response response = client.newCall(request).execute()) {
+        json = objectMapper.readTree(response.body().byteStream());
+      }
+
+      return json.get("data").get(0).get("traceID") != null;
     } catch (Exception e) {
       return false;
     }

--- a/integration_tests/tracecontext/build.gradle
+++ b/integration_tests/tracecontext/build.gradle
@@ -20,9 +20,9 @@ dependencies {
     api project(':opentelemetry-api')
 
     implementation project(':opentelemetry-sdk'),
-        project(':opentelemetry-extension-trace-propagators'),
+            project(':opentelemetry-extension-trace-propagators'),
+            libraries.okhttp,
         "com.sparkjava:spark-core:2.9.2",
-        "com.squareup.okhttp3:okhttp:3.14.9",
         "com.google.code.gson:gson:2.8.6"
 }
 

--- a/sdk_extensions/aws_v1_support/build.gradle
+++ b/sdk_extensions/aws_v1_support/build.gradle
@@ -12,11 +12,11 @@ dependencies {
     api project(':opentelemetry-api'),
             project(':opentelemetry-sdk')
 
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.11.0',
+    implementation 'com.fasterxml.jackson.core:jackson-core',
             libraries.guava,
             platform(boms.guava)
 
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.0',
+    implementation 'com.fasterxml.jackson.core:jackson-databind',
             libraries.guava,
             platform(boms.guava)
 


### PR DESCRIPTION
restassured launches a groovy runtime, which sometimes causes random failures like I saw on Java 14. The groovy is presumably to support some hip assertions, but ours are definitely not taking advantage of this complexity - switched to a normal http request / parse.

Fixes #1816 