### PR TITLE
Log Context's Scope.close misuse SEVERE (not FINE).

### DIFF
--- a/context/src/main/java/io/opentelemetry/context/ThreadLocalContextStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/ThreadLocalContextStorage.java
@@ -36,7 +36,7 @@ enum ThreadLocalContextStorage implements ContextStorage {
     return () -> {
       if (current() != toAttach) {
         logger.log(
-            Level.FINE,
+            Level.SEVERE,
             "Context in storage not the expected context, Scope.close was not called correctly");
       }
       THREAD_LOCAL_STORAGE.set(beforeAttach);


### PR DESCRIPTION
We could argue about WARNING, but FINE (being disabled by default) is IMHO too low for this.