### PR TITLE
Increase timeout for context wrap test.

### DIFF
--- a/context/src/test/java/io/opentelemetry/context/ContextTest.java
+++ b/context/src/test/java/io/opentelemetry/context/ContextTest.java
@@ -336,7 +336,7 @@ class ContextTest {
             return "bar";
           };
       List<Future<String>> futures =
-          wrapped.invokeAll(Arrays.asList(callable1, callable2), 1, TimeUnit.SECONDS);
+          wrapped.invokeAll(Arrays.asList(callable1, callable2), 10, TimeUnit.SECONDS);
       assertThat(futures.get(0).get()).isEqualTo("foo");
       assertThat(futures.get(1).get()).isEqualTo("bar");
       assertThat(value1).hasValue("cat");
@@ -376,7 +376,7 @@ class ContextTest {
             value2.set(Context.current().getValue(ANIMAL));
             return "bar";
           };
-      assertThat(wrapped.invokeAny(Arrays.asList(callable1, callable2), 1, TimeUnit.SECONDS))
+      assertThat(wrapped.invokeAny(Arrays.asList(callable1, callable2), 10, TimeUnit.SECONDS))
           .isEqualTo("bar");
       assertThat(value1).hasValue("cat");
       assertThat(value2).hasValue("cat");


### PR DESCRIPTION
I've generally found 10 seconds to be a "good default" test timeout to deal with CI issues (https://github.com/open-telemetry/opentelemetry-java/runs/1273993981?check_suite_focus=true). The only reason I didn't use 10 here was at first I didn't realize I'd need a separate thread executor (direct executor generally doesn't require a high timeout) until I started writing `WrapScheduledExecutorService` but hadn't backport the timeout bumps.