### PR TITLE
Fix non-null carrier not working in extract.

### DIFF
--- a/api/src/main/java/io/opentelemetry/baggage/propagation/W3CBaggagePropagator.java
+++ b/api/src/main/java/io/opentelemetry/baggage/propagation/W3CBaggagePropagator.java
@@ -17,6 +17,7 @@ import io.opentelemetry.baggage.EntryMetadata;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * {@link TextMapPropagator} that implements the W3C specification for baggage header propagation.
@@ -70,7 +71,7 @@ public class W3CBaggagePropagator implements TextMapPropagator {
   }
 
   @Override
-  public <C> Context extract(Context context, C carrier, Getter<C> getter) {
+  public <C> Context extract(Context context, @Nullable C carrier, Getter<C> getter) {
     String baggageHeader = getter.get(carrier, FIELD);
     if (baggageHeader == null) {
       return context;

--- a/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -139,9 +140,8 @@ public class HttpTraceContext implements TextMapPropagator {
 
   @Override
   public <C /*>>> extends @NonNull Object*/> Context extract(
-      Context context, C carrier, Getter<C> getter) {
+      Context context, @Nullable C carrier, Getter<C> getter) {
     Objects.requireNonNull(context, "context");
-    Objects.requireNonNull(carrier, "carrier");
     Objects.requireNonNull(getter, "getter");
 
     SpanContext spanContext = extractImpl(carrier, getter);

--- a/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
@@ -26,7 +26,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link io.opentelemetry.trace.propagation.HttpTraceContext}. */
+/** Unit tests for {@link HttpTraceContext}. */
 class HttpTraceContextTest {
 
   private static final TraceState TRACE_STATE_DEFAULT = TraceState.builder().build();
@@ -161,6 +161,18 @@ class HttpTraceContextTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     carrier.put(TRACE_PARENT, TRACEPARENT_HEADER_SAMPLED);
     assertThat(getSpanContext(httpTraceContext.extract(Context.current(), carrier, getter)))
+        .isEqualTo(
+            SpanContext.createFromRemoteParent(
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+  }
+
+  @Test
+  void extract_NullCarrier() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    carrier.put(TRACE_PARENT, TRACEPARENT_HEADER_SAMPLED);
+    assertThat(
+            getSpanContext(
+                httpTraceContext.extract(Context.current(), null, (c, k) -> carrier.get(k))))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
                 TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));

--- a/context_prop/src/main/java/io/opentelemetry/context/propagation/DefaultContextPropagators.java
+++ b/context_prop/src/main/java/io/opentelemetry/context/propagation/DefaultContextPropagators.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * {@code DefaultContextPropagators} is the default, built-in implementation of {@link
@@ -118,14 +119,14 @@ public final class DefaultContextPropagators implements ContextPropagators {
     }
 
     @Override
-    public <C> void inject(Context context, C carrier, Setter<C> setter) {
+    public <C> void inject(Context context, @Nullable C carrier, Setter<C> setter) {
       for (int i = 0; i < textPropagators.length; i++) {
         textPropagators[i].inject(context, carrier, setter);
       }
     }
 
     @Override
-    public <C> Context extract(Context context, C carrier, Getter<C> getter) {
+    public <C> Context extract(Context context, @Nullable C carrier, Getter<C> getter) {
       for (int i = 0; i < textPropagators.length; i++) {
         context = textPropagators[i].extract(context, carrier, getter);
       }
@@ -142,10 +143,10 @@ public final class DefaultContextPropagators implements ContextPropagators {
     }
 
     @Override
-    public <C> void inject(Context context, C carrier, Setter<C> setter) {}
+    public <C> void inject(Context context, @Nullable C carrier, Setter<C> setter) {}
 
     @Override
-    public <C> Context extract(Context context, C carrier, Getter<C> getter) {
+    public <C> Context extract(Context context, @Nullable C carrier, Getter<C> getter) {
       return context;
     }
   }

--- a/context_prop/src/main/java/io/opentelemetry/context/propagation/TextMapPropagator.java
+++ b/context_prop/src/main/java/io/opentelemetry/context/propagation/TextMapPropagator.java
@@ -103,7 +103,7 @@ public interface TextMapPropagator {
    * @param <C> carrier of propagation fields, such as an http request.
    * @return the {@code Context} containing the extracted value.
    */
-  <C> Context extract(Context context, C carrier, Getter<C> getter);
+  <C> Context extract(Context context, @Nullable C carrier, Getter<C> getter);
 
   /**
    * Interface that allows a {@code TextMapPropagator} to read propagated fields from a carrier.
@@ -123,6 +123,6 @@ public interface TextMapPropagator {
      * @return the first value of the given propagation {@code key} or returns {@code null}.
      */
     @Nullable
-    String get(C carrier, String key);
+    String get(@Nullable C carrier, String key);
   }
 }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
@@ -118,8 +118,7 @@ public class AwsXRayPropagator implements TextMapPropagator {
   }
 
   @Override
-  public <C> Context extract(Context context, C carrier, Getter<C> getter) {
-    Objects.requireNonNull(carrier, "carrier");
+  public <C> Context extract(Context context, @Nullable C carrier, Getter<C> getter) {
     Objects.requireNonNull(getter, "getter");
 
     SpanContext spanContext = getSpanContextFromHeader(carrier, getter);

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3Propagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3Propagator.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -114,12 +115,12 @@ public class B3Propagator implements TextMapPropagator {
   }
 
   @Override
-  public <C> void inject(Context context, C carrier, Setter<C> setter) {
+  public <C> void inject(Context context, @Nullable C carrier, Setter<C> setter) {
     b3PropagatorInjector.inject(context, carrier, setter);
   }
 
   @Override
-  public <C> Context extract(Context context, C carrier, Getter<C> getter) {
+  public <C> Context extract(Context context, @Nullable C carrier, Getter<C> getter) {
     return Stream.<Supplier<Optional<Context>>>of(
             () -> singleHeaderExtractor.extract(context, carrier, getter),
             () -> multipleHeadersExtractor.extract(context, carrier, getter),

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -109,8 +110,7 @@ public class JaegerPropagator implements TextMapPropagator {
   }
 
   @Override
-  public <C> Context extract(Context context, C carrier, Getter<C> getter) {
-    Objects.requireNonNull(carrier, "carrier");
+  public <C> Context extract(Context context, @Nullable C carrier, Getter<C> getter) {
     Objects.requireNonNull(getter, "getter");
 
     SpanContext spanContext = getSpanContextFromHeader(carrier, getter);

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagator.java
@@ -16,6 +16,7 @@ import io.opentelemetry.trace.TracingContextUtils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -64,8 +65,9 @@ public class OtTracerPropagator implements TextMapPropagator {
   }
 
   @Override
-  public <C> Context extract(Context context, C carrier, Getter<C> getter) {
+  public <C> Context extract(Context context, @Nullable C carrier, Getter<C> getter) {
     if (context == null || getter == null) {
+      // TODO Other propagators throw exceptions here
       return context;
     }
     String incomingTraceId = getter.get(carrier, TRACE_ID_HEADER);

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagator.java
@@ -14,6 +14,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -113,7 +114,7 @@ public class TraceMultiPropagator implements TextMapPropagator {
    * @return the {@code Context} containing the extracted value.
    */
   @Override
-  public <C> Context extract(Context context, C carrier, Getter<C> getter) {
+  public <C> Context extract(Context context, @Nullable C carrier, Getter<C> getter) {
     for (int i = propagators.length - 1; i >= 0; i--) {
       context = propagators[i].extract(context, carrier, getter);
       if (isSpanContextExtracted(context)) {


### PR DESCRIPTION
The added unit tests for HttpTraceContext demonstrates one case where that is useful. A getter that handles null gracefully would be another case.

Note that inject already allowed null carriers, but extract (where these are actually more likely to happen) did not. For example, if I have a getter that handles null like an empty headerlist, I still get a NPE when using HttpTraceContext. This PR fixes that.