### PR TITLE
Publish snapshots from GitHub CI instead of CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,12 +49,6 @@ jobs:
       - run:
           name: Cover
           command: ./gradlew check :opentelemetry-all:jacocoTestReport
-      - run:
-          name: Publish coverage
-          command:  bash <(curl -s https://codecov.io/bash)
-# Publish the snapshots using Java 8 (and only from master).
-      - run:
-          <<: *publish_snapshots_task
       - save_cache:
           paths:
             - ~/.gradle

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -46,3 +46,22 @@ jobs:
             org.gradle.java.installations.paths=${{ steps.setup-java-8.outputs.path }},${{ steps.setup-java-11.outputs.path }}
       - uses: codecov/codecov-action@v1
         if: ${{ matrix.coverage }}
+  publish-snapshots:
+    name: Publish snapshots to JFrog
+    if: ${{ github.event_name == 'push' }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - id: setup-java-11
+        name: Setup Java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: burrunan/gradle-cache-action@v1.5
+        with:
+          remote-build-cache-proxy-enabled: false
+          # TODO(anuraaga): Remove version specifier after next release creates a tag on master.
+          arguments: artifactoryPublish -Prelease.version=0.10.0-SNAPSHOT


### PR DESCRIPTION
Removes codecov publishing from CircleCI too.

After merging this and confirming it works OK, I will remove the CircleCI build.