### PR TITLE
Update error prone plugin to support toolchains.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -8,7 +8,7 @@ pluginManagement {
         id "io.morethan.jmhreport" version "0.9.0"
         id "me.champeau.gradle.jmh" version "0.5.0"
         id "nebula.release" version "15.1.0"
-        id "net.ltgt.errorprone" version "1.2.0"
+        id "net.ltgt.errorprone" version "1.3.0"
         id "org.unbroken-dome.test-sets" version "3.0.1"
         id "ru.vyarus.animalsniffer" version "1.5.1"
     }


### PR DESCRIPTION
When running build with Gradle 8, error prone plugin logs a warning that's been fixed.