### PR TITLE
Rename getContext to getSpanContext.

### DIFF
--- a/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
+++ b/api/src/main/java/io/opentelemetry/trace/DefaultTracer.java
@@ -45,7 +45,7 @@ public final class DefaultTracer implements Tracer {
     @Override
     public Span startSpan() {
       if (spanContext == null) {
-        spanContext = TracingContextUtils.getCurrentSpan().getContext();
+        spanContext = TracingContextUtils.getCurrentSpan().getSpanContext();
       }
 
       return Span.wrap(spanContext);
@@ -54,7 +54,7 @@ public final class DefaultTracer implements Tracer {
     @Override
     public NoopSpanBuilder setParent(Context context) {
       Objects.requireNonNull(context, "context");
-      spanContext = TracingContextUtils.getSpan(context).getContext();
+      spanContext = TracingContextUtils.getSpan(context).getSpanContext();
       return this;
     }
 

--- a/api/src/main/java/io/opentelemetry/trace/PropagatedSpan.java
+++ b/api/src/main/java/io/opentelemetry/trace/PropagatedSpan.java
@@ -73,7 +73,7 @@ final class PropagatedSpan implements Span {
   public void end(EndSpanOptions endOptions) {}
 
   @Override
-  public SpanContext getContext() {
+  public SpanContext getSpanContext() {
     return spanContext;
   }
 

--- a/api/src/main/java/io/opentelemetry/trace/Span.java
+++ b/api/src/main/java/io/opentelemetry/trace/Span.java
@@ -277,7 +277,7 @@ public interface Span extends ImplicitContextKeyed {
    *
    * @return the {@code SpanContext} associated with this {@code Span}.
    */
-  SpanContext getContext();
+  SpanContext getSpanContext();
 
   /**
    * Returns {@code true} if this {@code Span} records tracing events (e.g. {@link

--- a/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
+++ b/api/src/main/java/io/opentelemetry/trace/propagation/HttpTraceContext.java
@@ -95,7 +95,7 @@ public class HttpTraceContext implements TextMapPropagator {
     Objects.requireNonNull(context, "context");
     Objects.requireNonNull(setter, "setter");
 
-    SpanContext spanContext = TracingContextUtils.getSpan(context).getContext();
+    SpanContext spanContext = TracingContextUtils.getSpan(context).getSpanContext();
     if (!spanContext.isValid()) {
       return;
     }

--- a/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/DefaultTracerTest.java
@@ -35,7 +35,8 @@ class DefaultTracerTest {
 
   @Test
   void defaultSpanBuilderWithName() {
-    assertThat(defaultTracer.spanBuilder(SPAN_NAME).startSpan().getContext().isValid()).isFalse();
+    assertThat(defaultTracer.spanBuilder(SPAN_NAME).startSpan().getSpanContext().isValid())
+        .isFalse();
   }
 
   @Test
@@ -45,7 +46,7 @@ class DefaultTracerTest {
             .spanBuilder(SPAN_NAME)
             .setParent(Context.root().with(Span.wrap(spanContext)))
             .startSpan();
-    assertThat(span.getContext()).isSameAs(spanContext);
+    assertThat(span.getSpanContext()).isSameAs(spanContext);
   }
 
   @Test
@@ -54,13 +55,13 @@ class DefaultTracerTest {
 
     Span span =
         defaultTracer.spanBuilder(SPAN_NAME).setParent(Context.root().with(parent)).startSpan();
-    assertThat(span.getContext()).isSameAs(spanContext);
+    assertThat(span.getSpanContext()).isSameAs(spanContext);
   }
 
   @Test
   void noSpanContextMakesInvalidSpans() {
     Span span = defaultTracer.spanBuilder(SPAN_NAME).startSpan();
-    assertThat(span.getContext()).isSameAs(SpanContext.getInvalid());
+    assertThat(span.getSpanContext()).isSameAs(SpanContext.getInvalid());
   }
 
   @Test
@@ -74,7 +75,7 @@ class DefaultTracerTest {
     Context context = Context.current().with(Span.wrap(spanContext));
 
     Span span = defaultTracer.spanBuilder(SPAN_NAME).setParent(context).startSpan();
-    assertThat(span.getContext()).isSameAs(spanContext);
+    assertThat(span.getSpanContext()).isSameAs(spanContext);
   }
 
   @Test
@@ -82,7 +83,7 @@ class DefaultTracerTest {
     Context context = Context.current().with(Span.wrap(spanContext));
 
     Span span = defaultTracer.spanBuilder(SPAN_NAME).setNoParent().setParent(context).startSpan();
-    assertThat(span.getContext()).isSameAs(spanContext);
+    assertThat(span.getSpanContext()).isSameAs(spanContext);
   }
 
   @Test
@@ -90,6 +91,6 @@ class DefaultTracerTest {
     Context context = Context.current().with(Span.wrap(spanContext));
 
     Span span = defaultTracer.spanBuilder(SPAN_NAME).setParent(context).setNoParent().startSpan();
-    assertThat(span.getContext()).isEqualTo(SpanContext.getInvalid());
+    assertThat(span.getSpanContext()).isEqualTo(SpanContext.getInvalid());
   }
 }

--- a/api/src/test/java/io/opentelemetry/trace/PropagatedSpanTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/PropagatedSpanTest.java
@@ -21,7 +21,7 @@ class PropagatedSpanTest {
 
   @Test
   void hasInvalidContextAndDefaultSpanOptions() {
-    SpanContext context = Span.getInvalid().getContext();
+    SpanContext context = Span.getInvalid().getSpanContext();
     assertThat(context.getTraceFlags()).isEqualTo(TraceFlags.getDefault());
     assertThat(context.getTraceState()).isEqualTo(TraceState.getDefault());
   }

--- a/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/SpanBuilderTest.java
@@ -25,15 +25,15 @@ class SpanBuilderTest {
     spanBuilder.setParent(Context.root().with(Span.wrap(null)));
     spanBuilder.setParent(Context.root());
     spanBuilder.setNoParent();
-    spanBuilder.addLink(Span.getInvalid().getContext());
-    spanBuilder.addLink(Span.getInvalid().getContext(), Attributes.empty());
+    spanBuilder.addLink(Span.getInvalid().getSpanContext());
+    spanBuilder.addLink(Span.getInvalid().getSpanContext(), Attributes.empty());
     spanBuilder.setAttribute("key", "value");
     spanBuilder.setAttribute("key", 12345L);
     spanBuilder.setAttribute("key", .12345);
     spanBuilder.setAttribute("key", true);
     spanBuilder.setAttribute(stringKey("key"), "value");
     spanBuilder.setStartTimestamp(12345L);
-    assertThat(spanBuilder.startSpan().getContext().isValid()).isFalse();
+    assertThat(spanBuilder.startSpan().getSpanContext().isValid()).isFalse();
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/trace/TracingContextUtilsTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/TracingContextUtilsTest.java
@@ -64,6 +64,6 @@ class TracingContextUtilsTest {
         assertThat(TracingContextUtils.getCurrentSpan()).isSameAs(span);
       }
     }
-    assertThat(TracingContextUtils.getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(TracingContextUtils.getCurrentSpan().getSpanContext().isValid()).isFalse();
   }
 }

--- a/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
+++ b/api/src/test/java/io/opentelemetry/trace/propagation/HttpTraceContextTest.java
@@ -48,7 +48,7 @@ class HttpTraceContextTest {
   private final HttpTraceContext httpTraceContext = HttpTraceContext.getInstance();
 
   private static SpanContext getSpanContext(Context context) {
-    return TracingContextUtils.getSpan(context).getContext();
+    return TracingContextUtils.getSpan(context).getSpanContext();
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagator.java
@@ -85,11 +85,11 @@ public class AwsXRayPropagator implements TextMapPropagator {
     Objects.requireNonNull(setter, "setter");
 
     Span span = TracingContextUtils.getSpan(context);
-    if (!span.getContext().isValid()) {
+    if (!span.getSpanContext().isValid()) {
       return;
     }
 
-    SpanContext spanContext = span.getContext();
+    SpanContext spanContext = span.getSpanContext();
 
     String otTraceId = spanContext.getTraceIdAsHexString();
     String xrayTraceId =

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
@@ -19,7 +19,7 @@ final class B3PropagatorInjectorMultipleHeaders implements B3PropagatorInjector 
     Objects.requireNonNull(context, "context");
     Objects.requireNonNull(setter, "setter");
 
-    SpanContext spanContext = TracingContextUtils.getSpan(context).getContext();
+    SpanContext spanContext = TracingContextUtils.getSpan(context).getSpanContext();
     if (!spanContext.isValid()) {
       return;
     }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorSingleHeader.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorInjectorSingleHeader.java
@@ -30,7 +30,7 @@ final class B3PropagatorInjectorSingleHeader implements B3PropagatorInjector {
     Objects.requireNonNull(context, "context");
     Objects.requireNonNull(setter, "setter");
 
-    SpanContext spanContext = TracingContextUtils.getSpan(context).getContext();
+    SpanContext spanContext = TracingContextUtils.getSpan(context).getSpanContext();
     if (!spanContext.isValid()) {
       return;
     }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagator.java
@@ -84,7 +84,7 @@ public class JaegerPropagator implements TextMapPropagator {
     Objects.requireNonNull(context, "context");
     Objects.requireNonNull(setter, "setter");
 
-    SpanContext spanContext = TracingContextUtils.getSpan(context).getContext();
+    SpanContext spanContext = TracingContextUtils.getSpan(context).getSpanContext();
     if (!spanContext.isValid()) {
       return;
     }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagator.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagator.java
@@ -55,7 +55,7 @@ public class OtTracerPropagator implements TextMapPropagator {
     if (context == null || setter == null) {
       return;
     }
-    final SpanContext spanContext = TracingContextUtils.getSpan(context).getContext();
+    final SpanContext spanContext = TracingContextUtils.getSpan(context).getSpanContext();
     if (!spanContext.isValid()) {
       return;
     }

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/AwsXRayPropagatorTest.java
@@ -248,6 +248,6 @@ class AwsXRayPropagatorTest {
   }
 
   private static SpanContext getSpanContext(Context context) {
-    return TracingContextUtils.getSpan(context).getContext();
+    return TracingContextUtils.getSpan(context).getSpanContext();
   }
 }

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/B3PropagatorTest.java
@@ -50,7 +50,7 @@ class B3PropagatorTest {
   private final B3Propagator b3PropagatorSingleHeader = B3Propagator.getInstance();
 
   private static SpanContext getSpanContext(Context context) {
-    return TracingContextUtils.getSpan(context).getContext();
+    return TracingContextUtils.getSpan(context).getSpanContext();
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/JaegerPropagatorTest.java
@@ -60,7 +60,7 @@ class JaegerPropagatorTest {
   private final JaegerPropagator jaegerPropagator = JaegerPropagator.getInstance();
 
   private static SpanContext getSpanContext(Context context) {
-    return TracingContextUtils.getSpan(context).getContext();
+    return TracingContextUtils.getSpan(context).getSpanContext();
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagatorTest.java
@@ -36,7 +36,7 @@ class OtTracerPropagatorTest {
   private final OtTracerPropagator propagator = OtTracerPropagator.getInstance();
 
   private static SpanContext getSpanContext(Context context) {
-    return TracingContextUtils.getSpan(context).getContext();
+    return TracingContextUtils.getSpan(context).getSpanContext();
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {

--- a/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagatorTest.java
+++ b/extensions/trace_propagators/src/test/java/io/opentelemetry/extensions/trace/propagation/TraceMultiPropagatorTest.java
@@ -112,12 +112,12 @@ class TraceMultiPropagatorTest {
     Map<String, String> carrier = new HashMap<>();
     prop.inject(Context.current().with(SPAN), carrier, Map::put);
 
-    assertThat(getSpan(PROPAGATOR1.extract(Context.current(), carrier, Map::get)).getContext())
-        .isEqualTo(SPAN.getContext());
-    assertThat(getSpan(PROPAGATOR2.extract(Context.current(), carrier, Map::get)).getContext())
-        .isEqualTo(SPAN.getContext());
-    assertThat(getSpan(PROPAGATOR3.extract(Context.current(), carrier, Map::get)).getContext())
-        .isEqualTo(SPAN.getContext());
+    assertThat(getSpan(PROPAGATOR1.extract(Context.current(), carrier, Map::get)).getSpanContext())
+        .isEqualTo(SPAN.getSpanContext());
+    assertThat(getSpan(PROPAGATOR2.extract(Context.current(), carrier, Map::get)).getSpanContext())
+        .isEqualTo(SPAN.getSpanContext());
+    assertThat(getSpan(PROPAGATOR3.extract(Context.current(), carrier, Map::get)).getSpanContext())
+        .isEqualTo(SPAN.getSpanContext());
   }
 
   @Test
@@ -141,8 +141,8 @@ class TraceMultiPropagatorTest {
 
     Map<String, String> carrier = new HashMap<>();
     PROPAGATOR2.inject(Context.current().with(SPAN), carrier, Map::put);
-    assertThat(getSpan(prop.extract(Context.current(), carrier, Map::get)).getContext())
-        .isEqualTo(SPAN.getContext());
+    assertThat(getSpan(prop.extract(Context.current(), carrier, Map::get)).getSpanContext())
+        .isEqualTo(SPAN.getSpanContext());
   }
 
   @Test
@@ -165,8 +165,8 @@ class TraceMultiPropagatorTest {
 
     Map<String, String> carrier = new HashMap<>();
     PROPAGATOR3.inject(Context.current().with(SPAN), carrier, Map::put);
-    assertThat(getSpan(prop.extract(Context.current(), carrier, Map::get)).getContext())
-        .isEqualTo(SPAN.getContext());
+    assertThat(getSpan(prop.extract(Context.current(), carrier, Map::get)).getSpanContext())
+        .isEqualTo(SPAN.getSpanContext());
     verify(mockPropagator).fields();
     verifyNoMoreInteractions(mockPropagator);
   }

--- a/extensions/trace_utils/src/test/java/io/opentelemetry/extensions/trace/CurrentSpanUtilsTest.java
+++ b/extensions/trace_utils/src/test/java/io/opentelemetry/extensions/trace/CurrentSpanUtilsTest.java
@@ -55,7 +55,7 @@ class CurrentSpanUtilsTest {
 
   @Test
   void withSpanRunnable() {
-    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(getCurrentSpan().getSpanContext().isValid()).isFalse();
     Runnable runnable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -63,12 +63,12 @@ class CurrentSpanUtilsTest {
         };
     CurrentSpanUtils.withSpan(span, false, runnable).run();
     verify(span, never()).end();
-    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(getCurrentSpan().getSpanContext().isValid()).isFalse();
   }
 
   @Test
   void withSpanRunnable_EndSpan() {
-    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(getCurrentSpan().getSpanContext().isValid()).isFalse();
     Runnable runnable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -76,13 +76,13 @@ class CurrentSpanUtilsTest {
         };
     CurrentSpanUtils.withSpan(span, true, runnable).run();
     verify(span).end();
-    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(getCurrentSpan().getSpanContext().isValid()).isFalse();
   }
 
   @Test
   void withSpanRunnable_WithError() {
     final AssertionError error = new AssertionError("MyError");
-    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(getCurrentSpan().getSpanContext().isValid()).isFalse();
     Runnable runnable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -92,13 +92,13 @@ class CurrentSpanUtilsTest {
     executeRunnableAndExpectError(runnable, error);
     verify(span).setStatus(StatusCode.ERROR, "MyError");
     verify(span).end();
-    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(getCurrentSpan().getSpanContext().isValid()).isFalse();
   }
 
   @Test
   void withSpanRunnable_WithErrorNoMessage() {
     final AssertionError error = new AssertionError();
-    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(getCurrentSpan().getSpanContext().isValid()).isFalse();
     Runnable runnable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -108,13 +108,13 @@ class CurrentSpanUtilsTest {
     executeRunnableAndExpectError(runnable, error);
     verify(span).setStatus(StatusCode.ERROR, "AssertionError");
     verify(span).end();
-    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(getCurrentSpan().getSpanContext().isValid()).isFalse();
   }
 
   @Test
   void withSpanCallable() throws Exception {
     final Object ret = new Object();
-    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(getCurrentSpan().getSpanContext().isValid()).isFalse();
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -123,13 +123,13 @@ class CurrentSpanUtilsTest {
         };
     assertThat(CurrentSpanUtils.withSpan(span, false, callable).call()).isEqualTo(ret);
     verify(span, never()).end();
-    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(getCurrentSpan().getSpanContext().isValid()).isFalse();
   }
 
   @Test
   void withSpanCallable_EndSpan() throws Exception {
     final Object ret = new Object();
-    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(getCurrentSpan().getSpanContext().isValid()).isFalse();
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -138,13 +138,13 @@ class CurrentSpanUtilsTest {
         };
     assertThat(CurrentSpanUtils.withSpan(span, true, callable).call()).isEqualTo(ret);
     verify(span).end();
-    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(getCurrentSpan().getSpanContext().isValid()).isFalse();
   }
 
   @Test
   void withSpanCallable_WithException() {
     final Exception exception = new Exception("MyException");
-    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(getCurrentSpan().getSpanContext().isValid()).isFalse();
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -154,13 +154,13 @@ class CurrentSpanUtilsTest {
     executeCallableAndExpectError(callable, exception);
     verify(span).setStatus(StatusCode.ERROR, "MyException");
     verify(span).end();
-    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(getCurrentSpan().getSpanContext().isValid()).isFalse();
   }
 
   @Test
   void withSpanCallable_WithExceptionNoMessage() {
     final Exception exception = new Exception();
-    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(getCurrentSpan().getSpanContext().isValid()).isFalse();
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -170,13 +170,13 @@ class CurrentSpanUtilsTest {
     executeCallableAndExpectError(callable, exception);
     verify(span).setStatus(StatusCode.ERROR, "Exception");
     verify(span).end();
-    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(getCurrentSpan().getSpanContext().isValid()).isFalse();
   }
 
   @Test
   void withSpanCallable_WithError() {
     final AssertionError error = new AssertionError("MyError");
-    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(getCurrentSpan().getSpanContext().isValid()).isFalse();
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -186,13 +186,13 @@ class CurrentSpanUtilsTest {
     executeCallableAndExpectError(callable, error);
     verify(span).setStatus(StatusCode.ERROR, "MyError");
     verify(span).end();
-    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(getCurrentSpan().getSpanContext().isValid()).isFalse();
   }
 
   @Test
   void withSpanCallable_WithErrorNoMessage() {
     final AssertionError error = new AssertionError();
-    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(getCurrentSpan().getSpanContext().isValid()).isFalse();
     Callable<Object> callable =
         () -> {
           // When we run the runnable we will have the span in the current Context.
@@ -202,7 +202,7 @@ class CurrentSpanUtilsTest {
     executeCallableAndExpectError(callable, error);
     verify(span).setStatus(StatusCode.ERROR, "AssertionError");
     verify(span).end();
-    assertThat(getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(getCurrentSpan().getSpanContext().isValid()).isFalse();
   }
 
   private static Span getCurrentSpan() {

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/Propagation.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/Propagation.java
@@ -41,11 +41,12 @@ final class Propagation extends BaseShimObject {
             .extract(Context.current(), carrierMap, TextMapGetter.INSTANCE);
 
     Span span = TracingContextUtils.getSpan(context);
-    if (!span.getContext().isValid()) {
+    if (!span.getSpanContext().isValid()) {
       return null;
     }
 
-    return new SpanContextShim(telemetryInfo, span.getContext(), BaggageUtils.getBaggage(context));
+    return new SpanContextShim(
+        telemetryInfo, span.getSpanContext(), BaggageUtils.getBaggage(context));
   }
 
   static final class TextMapSetter implements TextMapPropagator.Setter<TextMapInject> {

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/ScopeManagerShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/ScopeManagerShim.java
@@ -22,7 +22,7 @@ final class ScopeManagerShim extends BaseShimObject implements ScopeManager {
     // As OpenTracing simply returns null when no active instance is available,
     // we need to do map an invalid OpenTelemetry span to null here.
     io.opentelemetry.trace.Span span = TracingContextUtils.getCurrentSpan();
-    if (!span.getContext().isValid()) {
+    if (!span.getSpanContext().isValid()) {
       return null;
     }
 

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
@@ -58,7 +58,7 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
     if (parentSpan == null && parentSpanContext == null) {
       parentSpan = spanShim;
     } else {
-      parentLinks.add(spanShim.getSpan().getContext());
+      parentLinks.add(spanShim.getSpan().getSpanContext());
     }
 
     return this;

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
@@ -21,7 +21,7 @@ final class SpanContextShim extends BaseShimObject implements SpanContext {
   public SpanContextShim(SpanShim spanShim) {
     this(
         spanShim.telemetryInfo(),
-        spanShim.getSpan().getContext(),
+        spanShim.getSpan().getSpanContext(),
         spanShim.telemetryInfo().emptyBaggage());
   }
 

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShimTable.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShimTable.java
@@ -86,7 +86,8 @@ final class SpanContextShimTable {
       }
 
       contextShim =
-          new SpanContextShim(spanShim.telemetryInfo(), spanShim.getSpan().getContext(), baggage);
+          new SpanContextShim(
+              spanShim.telemetryInfo(), spanShim.getSpan().getSpanContext(), baggage);
       shimsMap.put(spanShim.getSpan(), contextShim);
       return contextShim;
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
@@ -47,9 +47,9 @@ class SpanShimTest {
 
     SpanContextShim contextShim = (SpanContextShim) spanShim.context();
     assertNotNull(contextShim);
-    assertEquals(contextShim.getSpanContext(), span.getContext());
-    assertEquals(contextShim.toTraceId(), span.getContext().getTraceIdAsHexString().toString());
-    assertEquals(contextShim.toSpanId(), span.getContext().getSpanIdAsHexString().toString());
+    assertEquals(contextShim.getSpanContext(), span.getSpanContext());
+    assertEquals(contextShim.toTraceId(), span.getSpanContext().getTraceIdAsHexString().toString());
+    assertEquals(contextShim.toSpanId(), span.getSpanContext().getSpanIdAsHexString().toString());
     assertFalse(contextShim.baggageItems().iterator().hasNext());
   }
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/TracerShimTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/TracerShimTest.java
@@ -80,6 +80,6 @@ class TracerShimTest {
     tracerShim.close();
     Span otSpan = tracerShim.buildSpan(null).start();
     io.opentelemetry.trace.Span span = ((SpanShim) otSpan).getSpan();
-    assertThat(span.getContext().isValid()).isFalse();
+    assertThat(span.getSpanContext().isValid()).isFalse();
   }
 }

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
@@ -43,7 +43,7 @@ class OpenTelemetryInteroperabilityTest {
     } finally {
       otSpan.finish();
     }
-    assertThat(TracingContextUtils.getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(TracingContextUtils.getCurrentSpan().getSpanContext().isValid()).isFalse();
     assertNull(otTracer.activeSpan());
 
     List<SpanData> finishedSpans = inMemoryTracing.getSpanExporter().getFinishedSpanItems();
@@ -60,7 +60,7 @@ class OpenTelemetryInteroperabilityTest {
       otelSpan.end();
     }
 
-    assertThat(TracingContextUtils.getCurrentSpan().getContext().isValid()).isFalse();
+    assertThat(TracingContextUtils.getCurrentSpan().getSpanContext().isValid()).isFalse();
     assertNull(otTracer.activeSpan());
 
     List<SpanData> finishedSpans = inMemoryTracing.getSpanExporter().getFinishedSpanItems();

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
@@ -16,7 +16,7 @@ public interface ReadableSpan {
   /**
    * Returns the {@link SpanContext} of the {@code Span}.
    *
-   * <p>Equivalent with {@link Span#getContext()}.
+   * <p>Equivalent with {@link Span#getSpanContext()}.
    *
    * @return the {@link SpanContext} of the {@code Span}.
    */

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -212,7 +212,7 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
 
   @Override
   public SpanContext getSpanContext() {
-    return getContext();
+    return context;
   }
 
   /**
@@ -454,11 +454,6 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
       hasEnded = true;
     }
     spanProcessor.onEnd(this);
-  }
-
-  @Override
-  public SpanContext getContext() {
-    return context;
   }
 
   @Override

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -252,7 +252,7 @@ public final class Samplers {
         Kind spanKind,
         ReadableAttributes attributes,
         List<Link> parentLinks) {
-      SpanContext parentSpanContext = TracingContextUtils.getSpan(parentContext).getContext();
+      SpanContext parentSpanContext = TracingContextUtils.getSpan(parentContext).getSpanContext();
       if (!parentSpanContext.isValid()) {
         return this.root.shouldSample(
             parentContext, traceId, name, spanKind, attributes, parentLinks);

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -176,7 +176,7 @@ final class SpanBuilderSdk implements Span.Builder {
     final Context parentContext =
         isRootSpan ? Context.root() : parent == null ? Context.current() : parent;
     final Span parentSpan = TracingContextUtils.getSpan(parentContext);
-    final SpanContext parentSpanContext = parentSpan.getContext();
+    final SpanContext parentSpanContext = parentSpan.getSpanContext();
     String traceId;
     String spanId = idsGenerator.generateSpanId();
     if (!parentSpanContext.isValid()) {

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
@@ -78,12 +78,12 @@ abstract class SpanWrapper implements SpanData {
 
   @Override
   public String getTraceId() {
-    return delegate().getContext().getTraceIdAsHexString();
+    return delegate().getSpanContext().getTraceIdAsHexString();
   }
 
   @Override
   public String getSpanId() {
-    return delegate().getContext().getSpanIdAsHexString();
+    return delegate().getSpanContext().getSpanIdAsHexString();
   }
 
   @Override

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -80,8 +80,8 @@ class SpanBuilderSdkTest {
   void addLink() {
     // Verify methods do not crash.
     Span.Builder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
-    spanBuilder.addLink(Span.getInvalid().getContext());
-    spanBuilder.addLink(Span.getInvalid().getContext(), Attributes.empty());
+    spanBuilder.addLink(Span.getInvalid().getSpanContext());
+    spanBuilder.addLink(Span.getInvalid().getSpanContext(), Attributes.empty());
 
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     try {
@@ -187,7 +187,7 @@ class SpanBuilderSdkTest {
   void addLinkSpanContextAttributes_nullAttributes() {
     assertThrows(
         NullPointerException.class,
-        () -> tracerSdk.spanBuilder(SPAN_NAME).addLink(Span.getInvalid().getContext(), null));
+        () -> tracerSdk.spanBuilder(SPAN_NAME).addLink(Span.getInvalid().getSpanContext(), null));
   }
 
   @Test
@@ -486,7 +486,7 @@ class SpanBuilderSdkTest {
         TestUtils.startSpanWithSampler(tracerSdkFactory, tracerSdk, SPAN_NAME, Samplers.alwaysOff())
             .startSpan();
     try {
-      assertThat(span.getContext().isSampled()).isFalse();
+      assertThat(span.getSpanContext().isSampled()).isFalse();
     } finally {
       span.end();
     }
@@ -532,7 +532,7 @@ class SpanBuilderSdkTest {
                     Collections.singletonMap(samplerAttributeKey.getKey(), "none"))
                 .startSpan();
     try {
-      assertThat(span.getContext().isSampled()).isTrue();
+      assertThat(span.getSpanContext().isSampled()).isTrue();
       assertThat(span.toSpanData().getAttributes().get(samplerAttributeKey)).isNotNull();
       assertThat(span.toSpanData().getTraceState()).isEqualTo(TraceState.getDefault());
     } finally {
@@ -585,7 +585,7 @@ class SpanBuilderSdkTest {
                     Collections.singletonMap(samplerAttributeKey.getKey(), "none"))
                 .startSpan();
     try {
-      assertThat(span.getContext().isSampled()).isTrue();
+      assertThat(span.getSpanContext().isSampled()).isTrue();
       assertThat(span.toSpanData().getAttributes().get(samplerAttributeKey)).isNotNull();
       assertThat(span.toSpanData().getTraceState())
           .isEqualTo(TraceState.builder().set("newkey", "newValue").build());
@@ -602,7 +602,7 @@ class SpanBuilderSdkTest {
             .addLink(sampledSpanContext)
             .startSpan();
     try {
-      assertThat(span.getContext().isSampled()).isFalse();
+      assertThat(span.getSpanContext().isSampled()).isFalse();
     } finally {
       if (span != null) {
         span.end();
@@ -616,8 +616,8 @@ class SpanBuilderSdkTest {
     try (Scope ignored = TracingContextUtils.currentContextWith(parent)) {
       Span span = tracerSdk.spanBuilder(SPAN_NAME).setNoParent().startSpan();
       try {
-        assertThat(span.getContext().getTraceIdAsHexString())
-            .isNotEqualTo(parent.getContext().getTraceIdAsHexString());
+        assertThat(span.getSpanContext().getTraceIdAsHexString())
+            .isNotEqualTo(parent.getSpanContext().getTraceIdAsHexString());
         Mockito.verify(mockedSpanProcessor)
             .onStart(Mockito.same((ReadWriteSpan) span), Mockito.same(Context.root()));
         Span spanNoParent =
@@ -628,8 +628,8 @@ class SpanBuilderSdkTest {
                 .setNoParent()
                 .startSpan();
         try {
-          assertThat(span.getContext().getTraceIdAsHexString())
-              .isNotEqualTo(parent.getContext().getTraceIdAsHexString());
+          assertThat(span.getSpanContext().getTraceIdAsHexString())
+              .isNotEqualTo(parent.getSpanContext().getTraceIdAsHexString());
           Mockito.verify(mockedSpanProcessor)
               .onStart(Mockito.same((ReadWriteSpan) spanNoParent), Mockito.same(Context.root()));
         } finally {
@@ -654,10 +654,10 @@ class SpanBuilderSdkTest {
       try {
         Mockito.verify(mockedSpanProcessor)
             .onStart(Mockito.same((ReadWriteSpan) span), Mockito.same(parentContext));
-        assertThat(span.getContext().getTraceIdAsHexString())
-            .isEqualTo(parent.getContext().getTraceIdAsHexString());
+        assertThat(span.getSpanContext().getTraceIdAsHexString())
+            .isEqualTo(parent.getSpanContext().getTraceIdAsHexString());
         assertThat(span.toSpanData().getParentSpanId())
-            .isEqualTo(parent.getContext().getSpanIdAsHexString());
+            .isEqualTo(parent.getSpanContext().getSpanIdAsHexString());
 
         final Context parentContext2 = Context.current().with(parent);
         RecordEventsReadableSpan span2 =
@@ -670,8 +670,8 @@ class SpanBuilderSdkTest {
         try {
           Mockito.verify(mockedSpanProcessor)
               .onStart(Mockito.same((ReadWriteSpan) span2), Mockito.same(parentContext2));
-          assertThat(span2.getContext().getTraceIdAsHexString())
-              .isEqualTo(parent.getContext().getTraceIdAsHexString());
+          assertThat(span2.getSpanContext().getTraceIdAsHexString())
+              .isEqualTo(parent.getSpanContext().getTraceIdAsHexString());
         } finally {
           span2.end();
         }
@@ -695,10 +695,10 @@ class SpanBuilderSdkTest {
       try {
         Mockito.verify(mockedSpanProcessor)
             .onStart(Mockito.same((ReadWriteSpan) span), Mockito.same(parentContext));
-        assertThat(span.getContext().getTraceIdAsHexString())
-            .isEqualTo(parent.getContext().getTraceIdAsHexString());
+        assertThat(span.getSpanContext().getTraceIdAsHexString())
+            .isEqualTo(parent.getSpanContext().getTraceIdAsHexString());
         assertThat(span.toSpanData().getParentSpanId())
-            .isEqualTo(parent.getContext().getSpanIdAsHexString());
+            .isEqualTo(parent.getSpanContext().getSpanIdAsHexString());
       } finally {
         span.end();
       }
@@ -718,10 +718,10 @@ class SpanBuilderSdkTest {
       try {
         Mockito.verify(mockedSpanProcessor)
             .onStart(Mockito.same((ReadWriteSpan) span), Mockito.same(context));
-        assertThat(span.getContext().getTraceIdAsHexString())
-            .isEqualTo(parent.getContext().getTraceIdAsHexString());
+        assertThat(span.getSpanContext().getTraceIdAsHexString())
+            .isEqualTo(parent.getSpanContext().getTraceIdAsHexString());
         assertThat(span.toSpanData().getParentSpanId())
-            .isEqualTo(parent.getContext().getSpanIdAsHexString());
+            .isEqualTo(parent.getSpanContext().getSpanIdAsHexString());
       } finally {
         span.end();
       }
@@ -745,10 +745,10 @@ class SpanBuilderSdkTest {
       try {
         Mockito.verify(mockedSpanProcessor)
             .onStart(Mockito.same((ReadWriteSpan) span), Mockito.same(emptyContext));
-        assertThat(span.getContext().getTraceIdAsHexString())
-            .isNotEqualTo(parent.getContext().getTraceIdAsHexString());
+        assertThat(span.getSpanContext().getTraceIdAsHexString())
+            .isNotEqualTo(parent.getSpanContext().getTraceIdAsHexString());
         assertThat(span.toSpanData().getParentSpanId())
-            .isNotEqualTo(parent.getContext().getSpanIdAsHexString());
+            .isNotEqualTo(parent.getSpanContext().getSpanIdAsHexString());
       } finally {
         span.end();
       }
@@ -767,10 +767,10 @@ class SpanBuilderSdkTest {
       try {
         Mockito.verify(mockedSpanProcessor)
             .onStart(Mockito.same((ReadWriteSpan) span), Mockito.same(implicitParent));
-        assertThat(span.getContext().getTraceIdAsHexString())
-            .isEqualTo(parent.getContext().getTraceIdAsHexString());
+        assertThat(span.getSpanContext().getTraceIdAsHexString())
+            .isEqualTo(parent.getSpanContext().getTraceIdAsHexString());
         assertThat(span.toSpanData().getParentSpanId())
-            .isEqualTo(parent.getContext().getSpanIdAsHexString());
+            .isEqualTo(parent.getSpanContext().getSpanIdAsHexString());
       } finally {
         span.end();
       }
@@ -790,8 +790,8 @@ class SpanBuilderSdkTest {
     try {
       Mockito.verify(mockedSpanProcessor)
           .onStart(Mockito.same((ReadWriteSpan) span), Mockito.same(parentContext));
-      assertThat(span.getContext().getTraceIdAsHexString())
-          .isNotEqualTo(parent.getContext().getTraceIdAsHexString());
+      assertThat(span.getSpanContext().getTraceIdAsHexString())
+          .isNotEqualTo(parent.getSpanContext().getTraceIdAsHexString());
       assertFalse(SpanId.isValid(span.toSpanData().getParentSpanId()));
     } finally {
       span.end();

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkProviderTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkProviderTest.java
@@ -130,7 +130,7 @@ class TracerSdkProviderTest {
   void returnNoopSpanAfterShutdown() {
     tracerFactory.shutdown();
     Span span = tracerFactory.get("noop").spanBuilder("span").startSpan();
-    assertThat(span.getContext().isValid()).isFalse();
+    assertThat(span.getSpanContext().isValid()).isFalse();
     span.end();
   }
 }

--- a/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSampler.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSampler.java
@@ -60,7 +60,7 @@ class RateLimitingSampler implements Sampler {
       ReadableAttributes attributes,
       List<Link> parentLinks) {
 
-    if (TracingContextUtils.getSpan(parentContext).getContext().isSampled()) {
+    if (TracingContextUtils.getSpan(parentContext).getSpanContext().isSampled()) {
       return Samplers.alwaysOn()
           .shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
     }

--- a/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TracezZPageHandlerTest.java
+++ b/sdk_extensions/zpages/src/test/java/io/opentelemetry/sdk/extensions/zpages/TracezZPageHandlerTest.java
@@ -276,8 +276,8 @@ class TracezZPageHandlerTest {
     assertThat(output.toString()).contains("<h2>Span Details</h2>");
     assertThat(output.toString()).contains("<b> Span Name: " + RUNNING_SPAN + "</b>");
     assertThat(output.toString()).contains("<b> Number of running: 1");
-    assertThat(output.toString()).contains(runningSpan.getContext().getTraceIdAsHexString());
-    assertThat(output.toString()).contains(runningSpan.getContext().getSpanIdAsHexString());
+    assertThat(output.toString()).contains(runningSpan.getSpanContext().getTraceIdAsHexString());
+    assertThat(output.toString()).contains(runningSpan.getSpanContext().getSpanIdAsHexString());
 
     runningSpan.end();
   }
@@ -300,10 +300,10 @@ class TracezZPageHandlerTest {
     assertThat(output.toString()).contains("<h2>Span Details</h2>");
     assertThat(output.toString()).contains("<b> Span Name: " + LATENCY_SPAN + "</b>");
     assertThat(output.toString()).contains("<b> Number of latency samples: 2");
-    assertThat(output.toString()).contains(latencySpan1.getContext().getTraceIdAsHexString());
-    assertThat(output.toString()).contains(latencySpan1.getContext().getSpanIdAsHexString());
-    assertThat(output.toString()).contains(latencySpan2.getContext().getTraceIdAsHexString());
-    assertThat(output.toString()).contains(latencySpan2.getContext().getSpanIdAsHexString());
+    assertThat(output.toString()).contains(latencySpan1.getSpanContext().getTraceIdAsHexString());
+    assertThat(output.toString()).contains(latencySpan1.getSpanContext().getSpanIdAsHexString());
+    assertThat(output.toString()).contains(latencySpan2.getSpanContext().getTraceIdAsHexString());
+    assertThat(output.toString()).contains(latencySpan2.getSpanContext().getSpanIdAsHexString());
   }
 
   @Test
@@ -324,10 +324,10 @@ class TracezZPageHandlerTest {
     assertThat(output.toString()).contains("<h2>Span Details</h2>");
     assertThat(output.toString()).contains("<b> Span Name: " + ERROR_SPAN + "</b>");
     assertThat(output.toString()).contains("<b> Number of error samples: 2");
-    assertThat(output.toString()).contains(errorSpan1.getContext().getTraceIdAsHexString());
-    assertThat(output.toString()).contains(errorSpan1.getContext().getSpanIdAsHexString());
-    assertThat(output.toString()).contains(errorSpan2.getContext().getTraceIdAsHexString());
-    assertThat(output.toString()).contains(errorSpan2.getContext().getSpanIdAsHexString());
+    assertThat(output.toString()).contains(errorSpan1.getSpanContext().getTraceIdAsHexString());
+    assertThat(output.toString()).contains(errorSpan1.getSpanContext().getSpanIdAsHexString());
+    assertThat(output.toString()).contains(errorSpan2.getSpanContext().getTraceIdAsHexString());
+    assertThat(output.toString()).contains(errorSpan2.getSpanContext().getSpanIdAsHexString());
   }
 
   @Test


### PR DESCRIPTION
To prevent the extremely confusing `Span.fromContext(context).getContext()`. Context has a different meaning in our codebase so any `getContext` should have a return type of `Context`.