### PR TITLE
Split off PR build to separate workflow

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -1,0 +1,67 @@
+name: "Continuous Build"
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+        include:
+          - os: ubuntu-latest
+            testAdditionalJavaVersions: true
+            coverage: true
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - id: setup-java-8
+        name: Setup Java 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+          java-package: jre
+      - id: setup-java-11
+        name: Setup Java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: burrunan/gradle-cache-action@v1.5
+        with:
+          remote-build-cache-proxy-enabled: false
+          arguments: check --stacktrace ${{ matrix.coverage && ':opentelemetry-all:jacocoTestReport' || '' }}
+          properties: |
+            testAdditionalJavaVersions=${{ matrix.testAdditionalJavaVersions }}
+            enable.docker.tests=${{ matrix.os == 'ubuntu-latest' }}
+            org.gradle.java.installations.paths=${{ steps.setup-java-8.outputs.path }},${{ steps.setup-java-11.outputs.path }}
+      - uses: codecov/codecov-action@v1
+        if: ${{ matrix.coverage }}
+  publish-snapshots:
+    name: Publish snapshots to JFrog
+    if: ${{ github.event_name == 'push' }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - id: setup-java-11
+        name: Setup Java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: burrunan/gradle-cache-action@v1.5
+        with:
+          remote-build-cache-proxy-enabled: false
+          # TODO(anuraaga): Remove version specifier after next release creates a tag on master.
+          arguments: artifactoryPublish -Prelease.version=0.10.0-SNAPSHOT
+        env:
+          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+          BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,10 +1,7 @@
-name: "Continuous Build"
+name: "PR Build"
 
 on:
   pull_request:
-    branches:
-      - master
-  push:
     branches:
       - master
 
@@ -46,25 +43,3 @@ jobs:
             org.gradle.java.installations.paths=${{ steps.setup-java-8.outputs.path }},${{ steps.setup-java-11.outputs.path }}
       - uses: codecov/codecov-action@v1
         if: ${{ matrix.coverage }}
-  publish-snapshots:
-    name: Publish snapshots to JFrog
-    if: ${{ github.event_name == 'push' }}
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-      - id: setup-java-11
-        name: Setup Java 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-      - uses: burrunan/gradle-cache-action@v1.5
-        with:
-          remote-build-cache-proxy-enabled: false
-          # TODO(anuraaga): Remove version specifier after next release creates a tag on master.
-          arguments: artifactoryPublish -Prelease.version=0.10.0-SNAPSHOT
-        env:
-          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-          BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}


### PR DESCRIPTION
There is a small disruption to contributor experience with the single file because GitHub does not collapse the checks if any are skipped. It seems like something they should fix - but these files shouldn't have much churn anyways so even with some blatant duplication I think this is better.