### PR TITLE
Update zPages readme

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -480,19 +480,25 @@ wrapper {
     gradleVersion = '6.7'
 }
 
-tasks.register("updateVersionInDocs") {
-    doLast {
-        def versionParts = version.toString().split('\\.')
-        def minorVersionNumber = Integer.parseInt(versionParts[1])
-        def nextSnapshot = "${versionParts[0]}.${minorVersionNumber + 1}.0-SNAPSHOT"
+allprojects {
+    tasks.register("updateVersionInDocs") {
+        group("documentation")
+        doLast {
+            def versionParts = version.toString().split('\\.')
+            def minorVersionNumber = Integer.parseInt(versionParts[1])
+            def nextSnapshot = "${versionParts[0]}.${minorVersionNumber + 1}.0-SNAPSHOT"
 
-        def readmeText = file("README.md").text
-        def updatedText = readmeText
-                .replaceAll("<version>\\d+\\.\\d+\\.\\d+</version>", "<version>${version}</version>")
-                .replaceAll("<version>\\d+\\.\\d+\\.\\d+-SNAPSHOT</version>", "<version>${nextSnapshot}</version>")
-                .replaceAll("implementation\\('io.opentelemetry:opentelemetry-api:\\d+\\.\\d+\\.\\d+'\\)", "implementation('io.opentelemetry:opentelemetry-api:${version}')")
-                .replaceAll("implementation\\('io.opentelemetry:opentelemetry-api:\\d+\\.\\d+\\.\\d+-SNAPSHOT'\\)", "implementation('io.opentelemetry:opentelemetry-api:${nextSnapshot}')")
-                .replaceAll("<!--VERSION_STABLE-->.*<!--/VERSION_STABLE-->", "<!--VERSION_STABLE-->${version}<!--/VERSION_STABLE-->")
-        file("README.md").text = updatedText
+            def readme = file("README.md")
+            if (!readme.exists()) return
+
+            def readmeText = readme.text
+            def updatedText = readmeText
+                    .replaceAll("<version>\\d+\\.\\d+\\.\\d+</version>", "<version>${version}</version>")
+                    .replaceAll("<version>\\d+\\.\\d+\\.\\d+-SNAPSHOT</version>", "<version>${nextSnapshot}</version>")
+                    .replaceAll("(implementation.*io\\.opentelemetry:.*:)(\\d+\\.\\d+\\.\\d+)(?!-SNAPSHOT)(.*)", "\$1${version}\$3")
+                    .replaceAll("(implementation.*io\\.opentelemetry:.*:)(\\d+\\.\\d+\\.\\d+-SNAPSHOT)(.*)", "\$1${nextSnapshot}\$3")
+                    .replaceAll("<!--VERSION_STABLE-->.*<!--/VERSION_STABLE-->", "<!--VERSION_STABLE-->${version}<!--/VERSION_STABLE-->")
+            readme.text = updatedText
+        }
     }
 }

--- a/sdk_extensions/zpages/README.md
+++ b/sdk_extensions/zpages/README.md
@@ -3,13 +3,14 @@
 [![Javadocs][javadoc-image]][javadoc-url]
 
 This module contains code for the OpenTelemetry Java zPages, which are a collection of dynamic HTML
-web pages that display stats and trace data.
+web pages embedded in your app that display stats and trace data. Learn more in [this blog post][zPages blog];
 
 * Java 8 compatible.
 
 <!--- TODO: Update javadoc -->
 [javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-sdk-contrib-auto-config.svg
 [javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-contrib-auto-config
+[zPages blog]: https://medium.com/opentelemetry/zpages-in-opentelemetry-2b080a81eb47
 
 ## Quickstart
 
@@ -19,28 +20,15 @@ For Maven, add the following to your `pom.xml`:
 ```xml
 <dependencies>
   <dependency>
-        <groupId>io.opentelemetry</groupId>
-        <artifactId>opentelemetry-api</artifactId>
-        <version>0.8.0</version>
-      </dependency>
-      <dependency>
-        <groupId>io.opentelemetry</groupId>
-        <artifactId>opentelemetry-sdk</artifactId>
-        <version>0.8.0</version>
-      </dependency>
-      <dependency>
-        <groupId>io.opentelemetry</groupId>
-        <artifactId>opentelemetry-sdk-extension-zpages</artifactId>
-        <version>0.8.0</version>
-      </dependency>
+    <groupId>io.opentelemetry</groupId>
+    <artifactId>opentelemetry-sdk-extension-zpages</artifactId>
+    <version>0.8.0</version>
+  </dependency>
 </dependencies>
 ```
 
-<!--- TODO: Verify gradle configuration -->
 For Gradle, add the following to your dependencies:
 ```groovy
-implementation 'io.opentelemetry:opentelemetry-api:0.8.0'
-implementation 'io.opentelemetry:opentelemetry-sdk:0.8.0'
 implementation 'io.opentelemetry:opentelemetry-sdk-extension-zpages:0.8.0'
 ```
 


### PR DESCRIPTION
- Add a badge to indicate the latest version. This is more reliable than manually updating the readme with releases.
- Adjust the Maven and Gradle snippets to not include a version number, since it quickly becomes out of date.
- Remove dependencies that are pulled in transitively from the Maven and Gradle snippets. They already don't include all of the transitive dependencies, so no need to only include some.
- Add a link to the blog post introducing zPages, to give more information.