### PR TITLE
Make GRPC an API dependency of Jaeger exporter

### DIFF
--- a/exporters/jaeger/build.gradle
+++ b/exporters/jaeger/build.gradle
@@ -10,11 +10,11 @@ description = 'OpenTelemetry - Jaeger Exporter'
 ext.moduleName = "io.opentelemetry.exporters.jaeger"
 
 dependencies {
-    api project(':opentelemetry-sdk')
+    api project(':opentelemetry-sdk'),
+            libraries.grpc_api
 
     implementation project(':opentelemetry-sdk-extension-otproto'),
             project(':opentelemetry-sdk'),
-            libraries.grpc_api,
             libraries.grpc_protobuf,
             libraries.grpc_stub,
             libraries.protobuf,

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporter.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporters/jaeger/JaegerGrpcSpanExporter.java
@@ -217,7 +217,7 @@ public final class JaegerGrpcSpanExporter implements SpanExporter {
     }
 
     /**
-     * Sets the managed chanel to use when communicating with the backend. Takes precedence over
+     * Sets the managed channel to use when communicating with the backend. Takes precedence over
      * {@link #setEndpoint(String)} if both are called.
      *
      * @param channel the channel to use.


### PR DESCRIPTION
The `JaegerGrpcSpanExporter.Builder` has a public method that takes a `io.grpc.ManagedChannel`. Unless the Jaeger exporter declares an api dependency on GRPC API in Gradle, Gradle consumers will not find the GRPC API on their compile path.