### PR TITLE
Add get() method to LazyStorage instead of accessing field directly.

### DIFF
--- a/context/src/main/java/io/opentelemetry/context/ContextStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/ContextStorage.java
@@ -66,7 +66,7 @@ public interface ContextStorage {
    * Scope#close()}.
    */
   static ContextStorage get() {
-    return LazyStorage.storage;
+    return LazyStorage.get();
   }
 
   /**

--- a/context/src/main/java/io/opentelemetry/context/LazyStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/LazyStorage.java
@@ -50,12 +50,16 @@ import java.util.logging.Logger;
 // to handle exceptions.
 final class LazyStorage {
 
+  static ContextStorage get() {
+    return storage;
+  }
+
   private static final String CONTEXT_STORAGE_PROVIDER_PROPERTY =
       "io.opentelemetry.context.contextStorageProvider";
 
   private static final Logger logger = Logger.getLogger(LazyStorage.class.getName());
 
-  static final ContextStorage storage;
+  private static final ContextStorage storage;
 
   static {
     AtomicReference<Throwable> deferredStorageFailure = new AtomicReference<>();


### PR DESCRIPTION
For agent to override the ContextStorage implementation, we have a similar classloading ordering problem as with `Span.current` so need a package private method instead to instrument.