### PR TITLE
Have DefaultContext.root() method return root instead of direct field…

### DIFF
--- a/context/src/main/java/io/opentelemetry/context/Context.java
+++ b/context/src/main/java/io/opentelemetry/context/Context.java
@@ -80,7 +80,7 @@ public interface Context {
    * is only a workaround hiding an underlying context propagation issue.
    */
   static Context root() {
-    return DefaultContext.ROOT;
+    return DefaultContext.root();
   }
 
   /**

--- a/context/src/main/java/io/opentelemetry/context/DefaultContext.java
+++ b/context/src/main/java/io/opentelemetry/context/DefaultContext.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
 
 final class DefaultContext implements Context {
 
-  static final Context ROOT = new DefaultContext();
+  private static final Context ROOT = new DefaultContext();
 
   /**
    * Returns the default {@link ContextStorage} used to attach {@link Context}s to scopes of
@@ -35,6 +35,10 @@ final class DefaultContext implements Context {
    */
   static ContextStorage threadLocalStorage() {
     return ThreadLocalContextStorage.INSTANCE;
+  }
+
+  static Context root() {
+    return ROOT;
   }
 
   @Nullable private final PersistentHashArrayMappedTrie.Node<ContextKey<?>, Object> entries;


### PR DESCRIPTION
… access.

Similar to `LazyStorage.get`, to interop with root context in agent we need a package-private method that returns the root instead of a field. 