### PR TITLE
Expose factory for random IDs generator instead of type.

### DIFF
--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/IdsGenerator.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/IdsGenerator.java
@@ -10,6 +10,15 @@ import io.opentelemetry.api.trace.TraceId;
 
 /** Interface used by the {@link TracerSdk} to generate new {@link SpanId}s and {@link TraceId}s. */
 public interface IdsGenerator {
+
+  /**
+   * Returns a {@link IdsGenerator} that generates purely random IDs, which is the default for
+   * OpenTelemetry.
+   */
+  static IdsGenerator random() {
+    return RandomIdsGenerator.INSTANCE;
+  }
+
   /**
    * Generates a new valid {@code SpanId}.
    *

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/IdsGenerator.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/IdsGenerator.java
@@ -14,6 +14,9 @@ public interface IdsGenerator {
   /**
    * Returns a {@link IdsGenerator} that generates purely random IDs, which is the default for
    * OpenTelemetry.
+   *
+   * <p>The underlying implementation uses {@link java.util.concurrent.ThreadLocalRandom} for
+   * randomness but may change in the future.
    */
   static IdsGenerator random() {
     return RandomIdsGenerator.INSTANCE;

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/RandomIdsGenerator.java
@@ -9,11 +9,8 @@ import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceId;
 import java.util.concurrent.ThreadLocalRandom;
 
-/**
- * The default {@link IdsGenerator} which generates IDs as random numbers using {@link
- * ThreadLocalRandom}.
- */
-public final class RandomIdsGenerator implements IdsGenerator {
+enum RandomIdsGenerator implements IdsGenerator {
+  INSTANCE;
 
   private static final long INVALID_ID = 0;
 

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/TracerSdkProvider.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/TracerSdkProvider.java
@@ -91,7 +91,7 @@ public class TracerSdkProvider implements TracerProvider, TracerSdkManagement {
   public static class Builder {
 
     private Clock clock = MillisClock.getInstance();
-    private IdsGenerator idsGenerator = new RandomIdsGenerator();
+    private IdsGenerator idsGenerator = IdsGenerator.random();
     private Resource resource = Resource.getDefault();
 
     /**

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RandomIdsGeneratorTest.java
@@ -15,7 +15,7 @@ class RandomIdsGeneratorTest {
 
   @Test
   void defaults() {
-    RandomIdsGenerator generator = new RandomIdsGenerator();
+    IdsGenerator generator = IdsGenerator.random();
 
     // Can't assert values but can assert they're valid, try a lot as a sort of fuzz check.
     for (int i = 0; i < 1000; i++) {

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -64,7 +64,7 @@ class RecordEventsReadableSpanTest {
   private static final boolean EXPECTED_HAS_REMOTE_PARENT = true;
   private static final long START_EPOCH_NANOS = 1000_123_789_654L;
 
-  private final IdsGenerator idsGenerator = new RandomIdsGenerator();
+  private final IdsGenerator idsGenerator = IdsGenerator.random();
   private final String traceId = idsGenerator.generateTraceId();
   private final String spanId = idsGenerator.generateSpanId();
   private final String parentSpanId = idsGenerator.generateSpanId();

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -29,7 +29,7 @@ class SamplersTest {
   private static final String SPAN_NAME = "MySpanName";
   private static final Span.Kind SPAN_KIND = Span.Kind.INTERNAL;
   private static final int NUM_SAMPLE_TRIES = 1000;
-  private final IdsGenerator idsGenerator = new RandomIdsGenerator();
+  private final IdsGenerator idsGenerator = IdsGenerator.random();
   private final String traceId = idsGenerator.generateTraceId();
   private final String parentSpanId = idsGenerator.generateSpanId();
   private final TraceState traceState = TraceState.builder().build();

--- a/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/AwsXRayIdsGenerator.java
+++ b/sdk_extensions/aws_v1_support/src/main/java/io/opentelemetry/sdk/extensions/trace/aws/AwsXRayIdsGenerator.java
@@ -7,7 +7,6 @@ package io.opentelemetry.sdk.extensions.trace.aws;
 
 import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.sdk.trace.IdsGenerator;
-import io.opentelemetry.sdk.trace.RandomIdsGenerator;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -23,7 +22,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class AwsXRayIdsGenerator implements IdsGenerator {
 
-  private static final RandomIdsGenerator RANDOM_IDS_GENERATOR = new RandomIdsGenerator();
+  private static final IdsGenerator RANDOM_IDS_GENERATOR = IdsGenerator.random();
 
   @Override
   public String generateSpanId() {


### PR DESCRIPTION
I didn't keep the `ThreadLocalRandom` piece from the previous javadoc but am a bit on the fence. While it's an implementation detail that we may even change later, so usually wouldn't put it in a javadoc, it's an important implementation detail that users may need to know.