### PR TITLE
Remove Context.with overloads.

### DIFF
--- a/context/src/main/java/io/opentelemetry/context/Context.java
+++ b/context/src/main/java/io/opentelemetry/context/Context.java
@@ -141,8 +141,8 @@ public interface Context {
   }
 
   /**
-   * Returns a {@link Runnable} that makes this the {@linkplain Context#current() current context} and
-   * then invokes the input {@link Runnable}.
+   * Returns a {@link Runnable} that makes this the {@linkplain Context#current() current context}
+   * and then invokes the input {@link Runnable}.
    */
   default Runnable wrap(Runnable runnable) {
     return () -> {
@@ -153,8 +153,8 @@ public interface Context {
   }
 
   /**
-   * Returns a {@link Runnable} that makes this the {@linkplain Context#current() current context} and
-   * then invokes the input {@link Runnable}.
+   * Returns a {@link Runnable} that makes this the {@linkplain Context#current() current context}
+   * and then invokes the input {@link Runnable}.
    */
   default <T> Callable<T> wrap(Callable<T> callable) {
     return () -> {
@@ -182,7 +182,8 @@ public interface Context {
 
   /**
    * Returns an {@link ScheduledExecutorService} that will execute callbacks in the given {@code
-   * executor}, making this the {@linkplain Context#current() current context} before each execution.
+   * executor}, making this the {@linkplain Context#current() current context} before each
+   * execution.
    */
   default ScheduledExecutorService wrap(ScheduledExecutorService executor) {
     return new ContextScheduledExecutorService(this, executor);

--- a/context/src/main/java/io/opentelemetry/context/Context.java
+++ b/context/src/main/java/io/opentelemetry/context/Context.java
@@ -42,7 +42,7 @@ import javax.annotation.Nullable;
  * bound context. For example:
  *
  * <pre>{@code
- * Context withCredential = Context.current().withValues(CRED_KEY, cred);
+ * Context withCredential = Context.current().with(CRED_KEY, cred);
  * withCredential.wrap(new Runnable() {
  *   public void run() {
  *      readUserRecords(userId, CRED_KEY.get());
@@ -94,7 +94,7 @@ public interface Context {
    * Returns a new context with the given key value set.
    *
    * <pre>{@code
-   * Context withCredential = Context.current().withValues(CRED_KEY, cred);
+   * Context withCredential = Context.current().with(CRED_KEY, cred);
    * withCredential.wrap(new Runnable() {
    *   public void run() {
    *      readUserRecords(userId, CRED_KEY.get());
@@ -102,12 +102,10 @@ public interface Context {
    * }).run();
    * }</pre>
    *
-   * <p>Note that multiple calls to {@code withValue} can be chained together. That is,
+   * <p>Note that multiple calls to {@link #with(ContextKey, Object)} can be chained together.
    *
    * <pre>{@code
-   * context.withValues(K1, V1, K2, V2);
-   * // is the same as
-   * context.withValue(K1, V1).withValue(K2, V2);
+   * context.with(K1, V1).with(K2, V2);
    * }</pre>
    *
    * <p>Nonetheless, {@link Context} should not be treated like a general purpose map with a large
@@ -115,45 +113,6 @@ public interface Context {
    * of separating them. But if the items are unrelated, have separate keys for them.
    */
   <V> Context with(ContextKey<V> k1, V v1);
-
-  /** Returns a new context with the given key value set. */
-  default <V1, V2> Context with(ContextKey<V1> k1, V1 v1, ContextKey<V2> k2, V2 v2) {
-    return with(k1, v1).with(k2, v2);
-  }
-
-  /** Returns a new context with the given key value set. */
-  default <V1, V2, V3> Context with(
-      ContextKey<V1> k1, V1 v1, ContextKey<V2> k2, V2 v2, ContextKey<V3> k3, V3 v3) {
-    return with(k1, v1, k2, v2).with(k3, v3);
-  }
-
-  /**
-   * Create a new context with the given key value set.
-   *
-   * <p>For more than 4 key-value pairs, note that multiple calls to {@link #with} can be chained
-   * together. That is,
-   *
-   * <pre>
-   * context.withValues(K1, V1, K2, V2);
-   * // is the same as
-   * context.withValue(K1, V1).withValue(K2, V2);
-   * </pre>
-   *
-   * <p>Nonetheless, {@link Context} should not be treated like a general purpose map with a large
-   * number of keys and values — combine multiple related items together into a single key instead
-   * of separating them. But if the items are unrelated, have separate keys for them.
-   */
-  default <V1, V2, V3, V4> Context with(
-      ContextKey<V1> k1,
-      V1 v1,
-      ContextKey<V2> k2,
-      V2 v2,
-      ContextKey<V3> k3,
-      V3 v3,
-      ContextKey<V4> k4,
-      V4 v4) {
-    return with(k1, v1, k2, v2, k3, v3).with(k4, v4);
-  }
 
   /** Returns a new {@link Context} with the given {@link ImplicitContextKeyed} set. */
   default Context with(ImplicitContextKeyed value) {
@@ -170,7 +129,7 @@ public interface Context {
    *
    * <pre>{@code
    * Context prevCtx = Context.current();
-   * try (Scope ignored = ctx.attach()) {
+   * try (Scope ignored = ctx.makeCurrent()) {
    *   assert Context.current() == ctx;
    *   ...
    * }
@@ -182,7 +141,7 @@ public interface Context {
   }
 
   /**
-   * Returns a {@link Runnable} that makes this the {@linkplain Context#current current context} and
+   * Returns a {@link Runnable} that makes this the {@linkplain Context#current() current context} and
    * then invokes the input {@link Runnable}.
    */
   default Runnable wrap(Runnable runnable) {
@@ -194,7 +153,7 @@ public interface Context {
   }
 
   /**
-   * Returns a {@link Runnable} that makes this the {@linkplain Context#current current context} and
+   * Returns a {@link Runnable} that makes this the {@linkplain Context#current() current context} and
    * then invokes the input {@link Runnable}.
    */
   default <T> Callable<T> wrap(Callable<T> callable) {
@@ -207,7 +166,7 @@ public interface Context {
 
   /**
    * Returns an {@link Executor} that will execute callbacks in the given {@code executor}, making
-   * this the {@linkplain Context#current current context} before each execution.
+   * this the {@linkplain Context#current() current context} before each execution.
    */
   default Executor wrap(Executor executor) {
     return command -> executor.execute(wrap(command));
@@ -215,7 +174,7 @@ public interface Context {
 
   /**
    * Returns an {@link ExecutorService} that will execute callbacks in the given {@code executor},
-   * making this the {@linkplain Context#current current context} before each execution.
+   * making this the {@linkplain Context#current() current context} before each execution.
    */
   default ExecutorService wrap(ExecutorService executor) {
     return new ContextExecutorService(this, executor);
@@ -223,7 +182,7 @@ public interface Context {
 
   /**
    * Returns an {@link ScheduledExecutorService} that will execute callbacks in the given {@code
-   * executor}, making this the {@linkplain Context#current current context} before each execution.
+   * executor}, making this the {@linkplain Context#current() current context} before each execution.
    */
   default ScheduledExecutorService wrap(ScheduledExecutorService executor) {
     return new ContextScheduledExecutorService(this, executor);

--- a/context/src/main/java/io/opentelemetry/context/DefaultContext.java
+++ b/context/src/main/java/io/opentelemetry/context/DefaultContext.java
@@ -66,40 +66,4 @@ final class DefaultContext implements Context {
         PersistentHashArrayMappedTrie.put(entries, k1, v1);
     return new DefaultContext(newEntries);
   }
-
-  @Override
-  public <V1, V2> Context with(ContextKey<V1> k1, V1 v1, ContextKey<V2> k2, V2 v2) {
-    PersistentHashArrayMappedTrie.Node<ContextKey<?>, Object> newEntries =
-        PersistentHashArrayMappedTrie.put(entries, k1, v1);
-    newEntries = PersistentHashArrayMappedTrie.put(newEntries, k2, v2);
-    return new DefaultContext(newEntries);
-  }
-
-  @Override
-  public <V1, V2, V3> Context with(
-      ContextKey<V1> k1, V1 v1, ContextKey<V2> k2, V2 v2, ContextKey<V3> k3, V3 v3) {
-    PersistentHashArrayMappedTrie.Node<ContextKey<?>, Object> newEntries =
-        PersistentHashArrayMappedTrie.put(entries, k1, v1);
-    newEntries = PersistentHashArrayMappedTrie.put(newEntries, k2, v2);
-    newEntries = PersistentHashArrayMappedTrie.put(newEntries, k3, v3);
-    return new DefaultContext(newEntries);
-  }
-
-  @Override
-  public <V1, V2, V3, V4> Context with(
-      ContextKey<V1> k1,
-      V1 v1,
-      ContextKey<V2> k2,
-      V2 v2,
-      ContextKey<V3> k3,
-      V3 v3,
-      ContextKey<V4> k4,
-      V4 v4) {
-    PersistentHashArrayMappedTrie.Node<ContextKey<?>, Object> newEntries =
-        PersistentHashArrayMappedTrie.put(entries, k1, v1);
-    newEntries = PersistentHashArrayMappedTrie.put(newEntries, k2, v2);
-    newEntries = PersistentHashArrayMappedTrie.put(newEntries, k3, v3);
-    newEntries = PersistentHashArrayMappedTrie.put(newEntries, k4, v4);
-    return new DefaultContext(newEntries);
-  }
 }

--- a/context/src/test/java/io/opentelemetry/context/ContextTest.java
+++ b/context/src/test/java/io/opentelemetry/context/ContextTest.java
@@ -170,31 +170,6 @@ class ContextTest {
   }
 
   @Test
-  void withTwoValues() {
-    Context context = Context.current().with(ANIMAL, "cat", FOOD, "hot dog");
-    assertThat(context.get(ANIMAL)).isEqualTo("cat");
-    assertThat(context.get(FOOD)).isEqualTo("hot dog");
-  }
-
-  @Test
-  void withThreeValues() {
-    Context context = Context.current().with(ANIMAL, "cat", FOOD, "hot dog", COOKIES, 100);
-    assertThat(context.get(ANIMAL)).isEqualTo("cat");
-    assertThat(context.get(FOOD)).isEqualTo("hot dog");
-    assertThat(context.get(COOKIES)).isEqualTo(100);
-  }
-
-  @Test
-  void withFourValues() {
-    Context context =
-        Context.current().with(ANIMAL, "cat", FOOD, "hot dog", COOKIES, 100, BAG, "prada");
-    assertThat(context.get(ANIMAL)).isEqualTo("cat");
-    assertThat(context.get(FOOD)).isEqualTo("hot dog");
-    assertThat(context.get(COOKIES)).isEqualTo(100);
-    assertThat(context.get(BAG)).isEqualTo("prada");
-  }
-
-  @Test
   void wrapRunnable() {
     AtomicReference<String> value = new AtomicReference<>();
     Runnable callback = () -> value.set(Context.current().get(ANIMAL));

--- a/context/src/test/java/io/opentelemetry/context/ContextTest.java
+++ b/context/src/test/java/io/opentelemetry/context/ContextTest.java
@@ -39,8 +39,6 @@ class ContextTest {
 
   private static final ContextKey<String> ANIMAL = ContextKey.named("animal");
   private static final ContextKey<Object> BAG = ContextKey.named("bag");
-  private static final ContextKey<String> FOOD = ContextKey.named("food");
-  private static final ContextKey<Integer> COOKIES = ContextKey.named("cookies");
 
   private static final Context CAT = Context.current().with(ANIMAL, "cat");
 


### PR DESCRIPTION
I noticed after integrating Context into the instrumentation we don't really need the `with` overloads. Also on a second thought, they seem to conflict with the recommendation in the javadoc to "combine multiple related items together into a single key instead of separating them" - it seems extremely rare you'd have key / value available to store at the same time even when they're not related (in our potential use case, it's basically when one of them is `ImplicitContextKeyed` in which case we don't have a method for combining into a single write anyways). So figured it's good to keep it small for now.

Also added some javadoc drift fixes.