### PR TITLE
Remove integration tests from coverage report.

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -19,8 +19,6 @@ def subprojects = [
         project(':opentelemetry-exporters-otlp'),
         project(':opentelemetry-exporters-prometheus'),
         project(':opentelemetry-exporters-zipkin'),
-        project(':opentelemetry-integration-tests'),
-        project(':opentelemetry-integration-tests-tracecontext'),
         project(':opentelemetry-opentracing-shim'),
         project(':opentelemetry-sdk-common'),
         project(':opentelemetry-sdk-metrics'),


### PR DESCRIPTION
These don't have any coverage since the code is run in docker. A more general rule is to only have coverage of what we publish to maven - which I'll probably refactor this list into being generated programatically at some point.