### PR TITLE
Add MustBeClosed to Context.makeCurrent

### DIFF
--- a/api/src/main/java/io/opentelemetry/api/baggage/BaggageUtils.java
+++ b/api/src/main/java/io/opentelemetry/api/baggage/BaggageUtils.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.api.baggage;
 
+import com.google.errorprone.annotations.MustBeClosed;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.context.Scope;
@@ -69,6 +70,7 @@ public final class BaggageUtils {
    * @param baggage the {@link Baggage} to be added to the current {@code Context}.
    * @return the {@link Scope} for the updated {@code Context}.
    */
+  @MustBeClosed
   public static Scope currentContextWith(Baggage baggage) {
     Context context = withBaggage(baggage, Context.current());
     return context.makeCurrent();

--- a/context/src/braveInOtelTest/java/io/opentelemetry/context/OpenTelemetryCurrentTraceContext.java
+++ b/context/src/braveInOtelTest/java/io/opentelemetry/context/OpenTelemetryCurrentTraceContext.java
@@ -7,6 +7,7 @@ package io.opentelemetry.context;
 
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
+import com.google.errorprone.annotations.MustBeClosed;
 
 public class OpenTelemetryCurrentTraceContext extends CurrentTraceContext {
 
@@ -18,8 +19,9 @@ public class OpenTelemetryCurrentTraceContext extends CurrentTraceContext {
     return Context.current().get(TRACE_CONTEXT_KEY);
   }
 
-  @SuppressWarnings("ReferenceEquality")
+  @SuppressWarnings({"ReferenceEquality", "MustBeClosedChecker"})
   @Override
+  @MustBeClosed
   public Scope newScope(TraceContext context) {
     Context currentOtel = Context.current();
     TraceContext currentBrave = currentOtel.get(TRACE_CONTEXT_KEY);

--- a/context/src/grpcInOtelTest/java/io/grpc/override/ContextStorageOverride.java
+++ b/context/src/grpcInOtelTest/java/io/grpc/override/ContextStorageOverride.java
@@ -19,6 +19,7 @@ public class ContextStorageOverride extends Context.Storage {
   private static final ContextKey<Context> GRPC_CONTEXT = ContextKey.named("grpc-context");
   private static final Context.Key<Scope> OTEL_SCOPE = Context.key("otel-scope");
 
+  @SuppressWarnings("MustBeClosedChecker")
   @Override
   public Context doAttach(Context toAttach) {
     io.opentelemetry.context.Context otelContext = io.opentelemetry.context.Context.current();

--- a/context/src/main/java/io/opentelemetry/context/Context.java
+++ b/context/src/main/java/io/opentelemetry/context/Context.java
@@ -22,6 +22,7 @@
 
 package io.opentelemetry.context;
 
+import com.google.errorprone.annotations.MustBeClosed;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -177,6 +178,7 @@ public interface Context {
    * assert Context.current() == prevCtx;
    * }</pre>
    */
+  @MustBeClosed
   default Scope makeCurrent() {
     return ContextStorage.get().attach(this);
   }


### PR DESCRIPTION
False positives happen only in interop cases where scopes are wrapped, but in vast amount of user code it should be precise. Agent will have to disable it though since we open scope in `onMethodEnter` and close in `onMethodExit`