### PR TITLE
Add workflow to copy docker hub images to bintray and use in integration tests.

### DIFF
--- a/.github/workflows/docker-test-containers.yml
+++ b/.github/workflows/docker-test-containers.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Docker login
         uses: docker/login-action@v1
         with:
+          registry: open-telemetry-docker-dev.bintray.io
           username: ${{ secrets.BINTRAY_USER }}
           password: ${{ secrets.BINTRAY_KEY }}
       - name: Pull and push

--- a/.github/workflows/docker-test-containers.yml
+++ b/.github/workflows/docker-test-containers.yml
@@ -1,0 +1,30 @@
+name: Copy test container docker images
+
+on:
+  schedule:
+    - cron: "23 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  copy-images:
+    strategy:
+      matrix:
+        include:
+          - source: jaegertracing/all-in-one:1.17
+            target_tag: jaeger
+          - source: otel/opentelemetry-collector-dev:latest
+            target_tag: otel-collector-dev
+          - source: shopify/toxiproxy:latest
+            target_tag: toxiproxy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Docker login
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.BINTRAY_USER }}
+          password: ${{ secrets.BINTRAY_KEY }}
+      - name: Pull and push
+        run: |
+          docker pull ${{ matrix.source }}
+          docker tag ${{ matrix.source }} open-telemetry-docker-dev.bintray.io/java-test-containers:${{ matrix.target_tag }}
+          docker push open-telemetry-docker-dev.bintray.io/java-test-containers:${{ matrix.target_tag }}

--- a/.github/workflows/docker-test-containers.yml
+++ b/.github/workflows/docker-test-containers.yml
@@ -16,6 +16,8 @@ jobs:
             target_tag: otel-collector-dev
           - source: shopify/toxiproxy:latest
             target_tag: toxiproxy
+          - source: adoptopenjdk/openjdk8:latest
+            target_tag: openjdk8
     runs-on: ubuntu-latest
     steps:
       - name: Docker login

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerIntegrationTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporters/jaeger/JaegerIntegrationTest.java
@@ -34,14 +34,13 @@ class JaegerIntegrationTest {
 
   private static final int QUERY_PORT = 16686;
   private static final int COLLECTOR_PORT = 14250;
-  private static final String JAEGER_VERSION = "1.17";
   private static final String SERVICE_NAME = "E2E-test";
   private static final String JAEGER_URL = "http://localhost";
   private final Tracer tracer = OpenTelemetry.getGlobalTracer(getClass().getCanonicalName());
 
   @Container
   public static GenericContainer<?> jaegerContainer =
-      new GenericContainer<>("jaegertracing/all-in-one:" + JAEGER_VERSION)
+      new GenericContainer<>("open-telemetry-docker-dev.bintray.io/java-test-containers:jaeger")
           .withExposedPorts(COLLECTOR_PORT, QUERY_PORT)
           .waitingFor(new HttpWaitStrategy().forPath("/"));
 

--- a/integration_tests/src/test/java/io/opentelemetry/JaegerExporterIntegrationTest.java
+++ b/integration_tests/src/test/java/io/opentelemetry/JaegerExporterIntegrationTest.java
@@ -54,7 +54,8 @@ class JaegerExporterIntegrationTest {
   @Container
   public static GenericContainer jaegerContainer =
       new GenericContainer<>(
-              DockerImageName.parse("open-telemetry-docker-dev.bintray.io/java-test-containers:jaeger"))
+              DockerImageName.parse(
+                  "open-telemetry-docker-dev.bintray.io/java-test-containers:jaeger"))
           .withNetwork(network)
           .withNetworkAliases(JAEGER_HOSTNAME)
           .withExposedPorts(COLLECTOR_PORT, QUERY_PORT)
@@ -64,7 +65,9 @@ class JaegerExporterIntegrationTest {
   @SuppressWarnings("rawtypes")
   @Container
   public static GenericContainer jaegerExampleAppContainer =
-      new GenericContainer(DockerImageName.parse("open-telemetry-docker-dev.bintray.io/java-test-containers:openjdk8"))
+      new GenericContainer(
+              DockerImageName.parse(
+                  "open-telemetry-docker-dev.bintray.io/java-test-containers:openjdk8"))
           .withNetwork(network)
           .withCopyFileToContainer(MountableFile.forHostPath(ARCHIVE_NAME), "/app/" + APP_NAME)
           .withCommand(

--- a/integration_tests/src/test/java/io/opentelemetry/JaegerExporterIntegrationTest.java
+++ b/integration_tests/src/test/java/io/opentelemetry/JaegerExporterIntegrationTest.java
@@ -44,7 +44,6 @@ class JaegerExporterIntegrationTest {
 
   private static final int QUERY_PORT = 16686;
   private static final int COLLECTOR_PORT = 14250;
-  private static final String JAEGER_VERSION = "1.17";
   private static final String SERVICE_NAME = "integration test";
   private static final String JAEGER_HOSTNAME = "jaeger";
   private static final String JAEGER_URL = "http://localhost";
@@ -55,7 +54,7 @@ class JaegerExporterIntegrationTest {
   @Container
   public static GenericContainer jaegerContainer =
       new GenericContainer<>(
-              DockerImageName.parse("jaegertracing/all-in-one:" + JAEGER_VERSION + ":latest"))
+              DockerImageName.parse("open-telemetry-docker-dev.bintray.io/java-test-containers:jaeger"))
           .withNetwork(network)
           .withNetworkAliases(JAEGER_HOSTNAME)
           .withExposedPorts(COLLECTOR_PORT, QUERY_PORT)
@@ -65,7 +64,7 @@ class JaegerExporterIntegrationTest {
   @SuppressWarnings("rawtypes")
   @Container
   public static GenericContainer jaegerExampleAppContainer =
-      new GenericContainer(DockerImageName.parse("adoptopenjdk/openjdk8:latest"))
+      new GenericContainer(DockerImageName.parse("open-telemetry-docker-dev.bintray.io/java-test-containers:openjdk8"))
           .withNetwork(network)
           .withCopyFileToContainer(MountableFile.forHostPath(ARCHIVE_NAME), "/app/" + APP_NAME)
           .withCommand(

--- a/perf_harness/src/test/java/io/opentelemetry/perf/OtlpPipelineStressTest.java
+++ b/perf_harness/src/test/java/io/opentelemetry/perf/OtlpPipelineStressTest.java
@@ -59,7 +59,9 @@ public class OtlpPipelineStressTest {
 
   @Container
   public static GenericContainer<?> collectorContainer =
-      new GenericContainer<>(DockerImageName.parse("open-telemetry-docker-dev.bintray.io/java-test-containers:otel-collector-dev"))
+      new GenericContainer<>(
+              DockerImageName.parse(
+                  "open-telemetry-docker-dev.bintray.io/java-test-containers:otel-collector-dev"))
           .withNetwork(network)
           .withNetworkAliases("otel-collector")
           .withExposedPorts(OTLP_RECEIVER_PORT)
@@ -83,7 +85,9 @@ public class OtlpPipelineStressTest {
 
   @Container
   public static GenericContainer<?> toxiproxyContainer =
-      new GenericContainer<>(DockerImageName.parse("open-telemetry-docker-dev.bintray.io/java-test-containers:toxiproxy"))
+      new GenericContainer<>(
+              DockerImageName.parse(
+                  "open-telemetry-docker-dev.bintray.io/java-test-containers:toxiproxy"))
           .withNetwork(network)
           .withNetworkAliases("toxiproxy")
           .withExposedPorts(TOXIPROXY_CONTROL_PORT, COLLECTOR_PROXY_PORT)

--- a/perf_harness/src/test/java/io/opentelemetry/perf/OtlpPipelineStressTest.java
+++ b/perf_harness/src/test/java/io/opentelemetry/perf/OtlpPipelineStressTest.java
@@ -59,7 +59,7 @@ public class OtlpPipelineStressTest {
 
   @Container
   public static GenericContainer<?> collectorContainer =
-      new GenericContainer<>(DockerImageName.parse("otel/opentelemetry-collector-dev:latest"))
+      new GenericContainer<>(DockerImageName.parse("open-telemetry-docker-dev.bintray.io/java-test-containers:otel-collector-dev"))
           .withNetwork(network)
           .withNetworkAliases("otel-collector")
           .withExposedPorts(OTLP_RECEIVER_PORT)
@@ -83,7 +83,7 @@ public class OtlpPipelineStressTest {
 
   @Container
   public static GenericContainer<?> toxiproxyContainer =
-      new GenericContainer<>(DockerImageName.parse("shopify/toxiproxy:latest"))
+      new GenericContainer<>(DockerImageName.parse("open-telemetry-docker-dev.bintray.io/java-test-containers:toxiproxy"))
           .withNetwork(network)
           .withNetworkAliases("toxiproxy")
           .withExposedPorts(TOXIPROXY_CONTROL_PORT, COLLECTOR_PROXY_PORT)

--- a/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/JaegerRemoteSamplerIntegrationTest.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/JaegerRemoteSamplerIntegrationTest.java
@@ -23,14 +23,13 @@ class JaegerRemoteSamplerIntegrationTest {
 
   private static final int QUERY_PORT = 16686;
   private static final int COLLECTOR_PORT = 14250;
-  private static final String JAEGER_VERSION = "1.17";
   private static final String SERVICE_NAME = "E2E-test";
   private static final String SERVICE_NAME_RATE_LIMITING = "bar";
   private static final int RATE = 150;
 
   @Container
   public static GenericContainer<?> jaegerContainer =
-      new GenericContainer<>("jaegertracing/all-in-one:" + JAEGER_VERSION)
+      new GenericContainer<>("open-telemetry-docker-dev.bintray.io/java-test-containers:jaeger")
           .withCommand("--sampling.strategies-file=/sampling.json")
           .withExposedPorts(COLLECTOR_PORT, QUERY_PORT)
           .waitingFor(new HttpWaitStrategy().forPath("/"))


### PR DESCRIPTION
Docker Hub pull limit coming up, so let's copy our images to hopefully reduce potential flakiness. Working on hopefully getting a GHCR repo which would be less backdoor (tied to GitHub permissions, etc) than bintray.