### PR TITLE
Rename getHasRemoteParent and getHasEnded to remove get.

### DIFF
--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporters/zipkin/ZipkinSpanExporter.java
@@ -185,7 +185,7 @@ public final class ZipkinSpanExporter implements SpanExporter {
   private static Span.Kind toSpanKind(SpanData spanData) {
     // This is a hack because the Span API did not have SpanKind.
     if (spanData.getKind() == Kind.SERVER
-        || (spanData.getKind() == null && Boolean.TRUE.equals(spanData.getHasRemoteParent()))) {
+        || (spanData.getKind() == null && Boolean.TRUE.equals(spanData.hasRemoteParent()))) {
       return Span.Kind.SERVER;
     }
 

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
@@ -46,7 +46,7 @@ abstract class SpanWrapper implements SpanData {
 
   abstract long endEpochNanos();
 
-  abstract boolean hasEnded();
+  abstract boolean internalHasEnded();
 
   /**
    * Note: the collections that are passed into this creator method are assumed to be immutable to
@@ -152,13 +152,13 @@ abstract class SpanWrapper implements SpanData {
   }
 
   @Override
-  public boolean getHasRemoteParent() {
+  public boolean hasRemoteParent() {
     return delegate().hasRemoteParent();
   }
 
   @Override
-  public boolean getHasEnded() {
-    return hasEnded();
+  public boolean hasEnded() {
+    return internalHasEnded();
   }
 
   @Override

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
@@ -136,14 +136,14 @@ public interface SpanData {
    * @return {@code true} if the parent is on a different process. {@code false} if this is a root
    *     span.
    */
-  boolean getHasRemoteParent();
+  boolean hasRemoteParent();
 
   /**
    * Returns whether this Span has already been ended.
    *
    * @return {@code true} if the span has already been ended, {@code false} if not.
    */
-  boolean getHasEnded();
+  boolean hasEnded();
 
   /**
    * The total number of {@link Event} events that were recorded on this span. This number may be

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -237,7 +237,7 @@ class RecordEventsReadableSpanTest {
     // toSpanData was called.
     assertThat(spanData.getAttributes().size()).isEqualTo(attributes.size());
     assertThat(spanData.getAttributes().get(stringKey("anotherKey"))).isNull();
-    assertThat(spanData.getHasEnded()).isFalse();
+    assertThat(spanData.hasEnded()).isFalse();
     assertThat(spanData.getEndEpochNanos()).isEqualTo(0);
     assertThat(spanData.getName()).isEqualTo(SPAN_NAME);
     assertThat(spanData.getEvents()).isEmpty();
@@ -247,7 +247,7 @@ class RecordEventsReadableSpanTest {
     spanData = span.toSpanData();
     assertThat(spanData.getAttributes().size()).isEqualTo(attributes.size() + 1);
     assertThat(spanData.getAttributes().get(stringKey("anotherKey"))).isEqualTo("anotherValue");
-    assertThat(spanData.getHasEnded()).isTrue();
+    assertThat(spanData.hasEnded()).isTrue();
     assertThat(spanData.getEndEpochNanos()).isGreaterThan(0);
     assertThat(spanData.getName()).isEqualTo("changedName");
     assertThat(spanData.getEvents()).hasSize(1);
@@ -293,7 +293,7 @@ class RecordEventsReadableSpanTest {
   void getSpanHasRemoteParent() {
     RecordEventsReadableSpan span = createTestSpan(Kind.SERVER);
     try {
-      assertThat(span.toSpanData().getHasRemoteParent()).isTrue();
+      assertThat(span.toSpanData().hasRemoteParent()).isTrue();
     } finally {
       span.end();
     }
@@ -791,7 +791,7 @@ class RecordEventsReadableSpanTest {
     assertThat(spanData.getTraceId()).isEqualTo(traceId);
     assertThat(spanData.getSpanId()).isEqualTo(spanId);
     assertThat(spanData.getParentSpanId()).isEqualTo(parentSpanId);
-    assertThat(spanData.getHasRemoteParent()).isEqualTo(EXPECTED_HAS_REMOTE_PARENT);
+    assertThat(spanData.hasRemoteParent()).isEqualTo(EXPECTED_HAS_REMOTE_PARENT);
     assertThat(spanData.getTraceState()).isEqualTo(TraceState.getDefault());
     assertThat(spanData.getResource()).isEqualTo(resource);
     assertThat(spanData.getInstrumentationLibraryInfo()).isEqualTo(instrumentationLibraryInfo);
@@ -801,7 +801,7 @@ class RecordEventsReadableSpanTest {
     assertThat(spanData.getStartEpochNanos()).isEqualTo(startEpochNanos);
     assertThat(spanData.getEndEpochNanos()).isEqualTo(endEpochNanos);
     assertThat(spanData.getStatus().getCanonicalCode()).isEqualTo(status.getCanonicalCode());
-    assertThat(spanData.getHasEnded()).isEqualTo(hasEnded);
+    assertThat(spanData.hasEnded()).isEqualTo(hasEnded);
 
     // verify equality manually, since the implementations don't all equals with each other.
     ReadableAttributes spanDataAttributes = spanData.getAttributes();

--- a/sdk_extensions/tracing_incubator/src/main/java/io/opentelemetry/sdk/extensions/incubator/trace/data/DelegatingSpanData.java
+++ b/sdk_extensions/tracing_incubator/src/main/java/io/opentelemetry/sdk/extensions/incubator/trace/data/DelegatingSpanData.java
@@ -127,13 +127,13 @@ public abstract class DelegatingSpanData implements SpanData {
   }
 
   @Override
-  public boolean getHasRemoteParent() {
-    return delegate.getHasRemoteParent();
+  public boolean hasRemoteParent() {
+    return delegate.hasRemoteParent();
   }
 
   @Override
-  public boolean getHasEnded() {
-    return delegate.getHasEnded();
+  public boolean hasEnded() {
+    return delegate.hasEnded();
   }
 
   @Override
@@ -173,8 +173,8 @@ public abstract class DelegatingSpanData implements SpanData {
           && getLinks().equals(that.getLinks())
           && getStatus().equals(that.getStatus())
           && getEndEpochNanos() == that.getEndEpochNanos()
-          && getHasRemoteParent() == that.getHasRemoteParent()
-          && getHasEnded() == that.getHasEnded()
+          && hasRemoteParent() == that.hasRemoteParent()
+          && hasEnded() == that.hasEnded()
           && getTotalRecordedEvents() == that.getTotalRecordedEvents()
           && getTotalRecordedLinks() == that.getTotalRecordedLinks()
           && getTotalAttributeCount() == that.getTotalAttributeCount();
@@ -216,9 +216,9 @@ public abstract class DelegatingSpanData implements SpanData {
     code *= 1000003;
     code ^= (int) ((getEndEpochNanos() >>> 32) ^ getEndEpochNanos());
     code *= 1000003;
-    code ^= getHasRemoteParent() ? 1231 : 1237;
+    code ^= hasRemoteParent() ? 1231 : 1237;
     code *= 1000003;
-    code ^= getHasEnded() ? 1231 : 1237;
+    code ^= hasEnded() ? 1231 : 1237;
     code *= 1000003;
     code ^= getTotalRecordedEvents();
     code *= 1000003;
@@ -277,10 +277,10 @@ public abstract class DelegatingSpanData implements SpanData {
         + getEndEpochNanos()
         + ", "
         + "hasRemoteParent="
-        + getHasRemoteParent()
+        + hasRemoteParent()
         + ", "
         + "hasEnded="
-        + getHasEnded()
+        + hasEnded()
         + ", "
         + "totalRecordedEvents="
         + getTotalRecordedEvents()

--- a/sdk_extensions/tracing_incubator/src/main/java/io/opentelemetry/sdk/extensions/incubator/trace/data/SpanDataBuilder.java
+++ b/sdk_extensions/tracing_incubator/src/main/java/io/opentelemetry/sdk/extensions/incubator/trace/data/SpanDataBuilder.java
@@ -59,8 +59,8 @@ public abstract class SpanDataBuilder implements SpanData {
         .setLinks(spanData.getLinks())
         .setStatus(spanData.getStatus())
         .setEndEpochNanos(spanData.getEndEpochNanos())
-        .setHasRemoteParent(spanData.getHasRemoteParent())
-        .setHasEnded(spanData.getHasEnded())
+        .setHasRemoteParent(spanData.hasRemoteParent())
+        .setHasEnded(spanData.hasEnded())
         .setTotalRecordedEvents(spanData.getTotalRecordedEvents())
         .setTotalRecordedLinks(spanData.getTotalRecordedLinks())
         .setTotalAttributeCount(spanData.getTotalAttributeCount());
@@ -71,6 +71,20 @@ public abstract class SpanDataBuilder implements SpanData {
   }
 
   abstract Builder autoToBuilder();
+
+  abstract boolean getInternalHasEnded();
+
+  abstract boolean getInternalHasRemoteParent();
+
+  @Override
+  public final boolean hasEnded() {
+    return getInternalHasEnded();
+  }
+
+  @Override
+  public final boolean hasRemoteParent() {
+    return getInternalHasRemoteParent();
+  }
 
   // AutoValue won't generate equals that compares with SpanData interface but generates hash code
   // fine.
@@ -98,8 +112,8 @@ public abstract class SpanDataBuilder implements SpanData {
           && getLinks().equals(that.getLinks())
           && getStatus().equals(that.getStatus())
           && getEndEpochNanos() == that.getEndEpochNanos()
-          && getHasRemoteParent() == that.getHasRemoteParent()
-          && getHasEnded() == that.getHasEnded()
+          && hasRemoteParent() == that.hasRemoteParent()
+          && hasEnded() == that.hasEnded()
           && getTotalRecordedEvents() == that.getTotalRecordedEvents()
           && getTotalRecordedLinks() == that.getTotalRecordedLinks()
           && getTotalAttributeCount() == that.getTotalAttributeCount();
@@ -148,9 +162,17 @@ public abstract class SpanDataBuilder implements SpanData {
 
     public abstract Builder setLinks(List<Link> links);
 
-    public abstract Builder setHasRemoteParent(boolean hasRemoteParent);
+    abstract Builder setInternalHasRemoteParent(boolean hasRemoteParent);
 
-    public abstract Builder setHasEnded(boolean hasEnded);
+    public final Builder setHasRemoteParent(boolean hasRemoteParent) {
+      return setInternalHasRemoteParent(hasRemoteParent);
+    }
+
+    abstract Builder setInternalHasEnded(boolean hasEnded);
+
+    public final Builder setHasEnded(boolean hasEnded) {
+      return setInternalHasEnded(hasEnded);
+    }
 
     public abstract Builder setTotalRecordedEvents(int totalRecordedEvents);
 

--- a/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/TracezZPageHandler.java
+++ b/sdk_extensions/zpages/src/main/java/io/opentelemetry/sdk/extensions/zpages/TracezZPageHandler.java
@@ -274,7 +274,7 @@ final class TracezZPageHandler extends ZPageHandler {
     calendar.setTimeInMillis(TimeUnit.NANOSECONDS.toMillis(span.getStartEpochNanos()));
     long microsField = TimeUnit.NANOSECONDS.toMicros(span.getStartEpochNanos());
     String elapsedSecondsStr =
-        span.getHasEnded()
+        span.hasEnded()
             ? String.format("%.6f", (span.getEndEpochNanos() - span.getStartEpochNanos()) * 1.0e-9)
             : "";
     formatter.format(

--- a/testing_internal/src/main/java/io/opentelemetry/sdk/trace/TestSpanData.java
+++ b/testing_internal/src/main/java/io/opentelemetry/sdk/trace/TestSpanData.java
@@ -48,6 +48,20 @@ public abstract class TestSpanData implements SpanData {
         .setTotalAttributeCount(0);
   }
 
+  abstract boolean getInternalHasEnded();
+
+  abstract boolean getInternalHasRemoteParent();
+
+  @Override
+  public final boolean hasEnded() {
+    return getInternalHasEnded();
+  }
+
+  @Override
+  public final boolean hasRemoteParent() {
+    return getInternalHasRemoteParent();
+  }
+
   /** A {@code Builder} class for {@link TestSpanData}. */
   @AutoValue.Builder
   public abstract static class Builder {
@@ -189,13 +203,19 @@ public abstract class TestSpanData implements SpanData {
      */
     public abstract Builder setLinks(List<SpanData.Link> links);
 
+    abstract Builder setInternalHasRemoteParent(boolean hasRemoteParent);
+
     /**
      * Sets to true if the span has a parent on a different process.
      *
      * @param hasRemoteParent A boolean indicating if the span has a remote parent.
      * @return this
      */
-    public abstract Builder setHasRemoteParent(boolean hasRemoteParent);
+    public final Builder setHasRemoteParent(boolean hasRemoteParent) {
+      return setInternalHasRemoteParent(hasRemoteParent);
+    }
+
+    abstract Builder setInternalHasEnded(boolean hasEnded);
 
     /**
      * Sets to true if the span has been ended.
@@ -203,7 +223,9 @@ public abstract class TestSpanData implements SpanData {
      * @param hasEnded A boolean indicating if the span has been ended.
      * @return this
      */
-    public abstract Builder setHasEnded(boolean hasEnded);
+    public final Builder setHasEnded(boolean hasEnded) {
+      return setInternalHasEnded(hasEnded);
+    }
 
     /**
      * Set the total number of events recorded on this span.

--- a/testing_internal/src/test/java/io/opentelemetry/sdk/trace/TestSpanDataTest.java
+++ b/testing_internal/src/test/java/io/opentelemetry/sdk/trace/TestSpanDataTest.java
@@ -38,7 +38,7 @@ class TestSpanDataTest {
     assertThat(spanData.getLinks()).isEqualTo(emptyList());
     assertThat(spanData.getInstrumentationLibraryInfo())
         .isSameAs(InstrumentationLibraryInfo.getEmpty());
-    assertThat(spanData.getHasRemoteParent()).isFalse();
+    assertThat(spanData.hasRemoteParent()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
It's either all `get` or no `get` so this seems the way to allow a mix.

Alternatively, `isEnded` and `isParentRemote` would be allowed without hacking, but the latter sounds bad to me (but still better than `isRemoteParent` which is incorrect)

Fixes #1910