### PR TITLE
Ensure all public classes in the API are final

### DIFF
--- a/api/src/main/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagator.java
+++ b/api/src/main/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagator.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
 /**
  * {@link TextMapPropagator} that implements the W3C specification for baggage header propagation.
  */
-public class W3CBaggagePropagator implements TextMapPropagator {
+public final class W3CBaggagePropagator implements TextMapPropagator {
 
   private static final String FIELD = "baggage";
   private static final List<String> FIELDS = singletonList(FIELD);

--- a/api/src/main/java/io/opentelemetry/api/trace/propagation/HttpTraceContext.java
+++ b/api/src/main/java/io/opentelemetry/api/trace/propagation/HttpTraceContext.java
@@ -32,7 +32,7 @@ import javax.annotation.concurrent.Immutable;
  * href=https://github.com/w3c/distributed-tracing>w3c/distributed-tracing</a>.
  */
 @Immutable
-public class HttpTraceContext implements TextMapPropagator {
+public final class HttpTraceContext implements TextMapPropagator {
   private static final Logger logger = Logger.getLogger(HttpTraceContext.class.getName());
 
   private static final TraceState TRACE_STATE_DEFAULT = TraceState.builder().build();


### PR DESCRIPTION
We don't want users to extend classes that are not interfaces in our API

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>