### PR TITLE
Reduce max workers since Gradle cheats anyways

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.parallel=true
-org.gradle.workers.max=4
+org.gradle.workers.max=2
 org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m
 
 ### Override this property to 'true' to enable the end-to-end tests that use docker.


### PR DESCRIPTION
I just noticed that this repo also has the same problem as instrumentation repo, which I filed an issue about in https://github.com/gradle/gradle/issues/14224

The actual max workers is 8, which is high enough to cause a reasonable probability of two testcontainers at the same time which usually fails. One alternative is to combine all of our testcontainer tests into one project, integration-tests, so they don't run in parallel. This seems like an OK approach to me. In the meantime, let's match the value with the instrumentation repo, which I think can help with our testcontainer woes.