### PR TITLE
Replace AutoValue usage in baggage with final concrete classes.

### DIFF
--- a/api/src/main/java/io/opentelemetry/api/baggage/Entry.java
+++ b/api/src/main/java/io/opentelemetry/api/baggage/Entry.java
@@ -5,17 +5,13 @@
 
 package io.opentelemetry.api.baggage;
 
-import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.internal.StringUtils;
 import io.opentelemetry.api.internal.Utils;
 import javax.annotation.concurrent.Immutable;
 
 /** String-String key-value pair, along with {@link EntryMetadata}. */
 @Immutable
-@AutoValue
-public abstract class Entry {
-
-  Entry() {}
+public final class Entry {
 
   /**
    * Creates an {@code Entry} from the given key, value and metadata.
@@ -28,7 +24,7 @@ public abstract class Entry {
   public static Entry create(String key, String value, EntryMetadata entryMetadata) {
     Utils.checkArgument(keyIsValid(key), "Invalid entry key name: %s", key);
     Utils.checkArgument(isValueValid(value), "Invalid entry value: %s", value);
-    return new AutoValue_Entry(key, value, entryMetadata);
+    return new Entry(key, value, entryMetadata);
   }
 
   /**
@@ -39,7 +35,17 @@ public abstract class Entry {
    * @return a {@code Entry}.
    */
   public static Entry create(String key, String value) {
-    return create(key, value, EntryMetadata.EMPTY);
+    return create(key, value, EntryMetadata.empty());
+  }
+
+  private final String key;
+  private final String value;
+  private final EntryMetadata entryMetadata;
+
+  private Entry(String key, String value, EntryMetadata entryMetadata) {
+    this.key = key;
+    this.value = value;
+    this.entryMetadata = entryMetadata;
   }
 
   /**
@@ -47,21 +53,63 @@ public abstract class Entry {
    *
    * @return the entry's key.
    */
-  public abstract String getKey();
+  public String getKey() {
+    return key;
+  }
 
   /**
    * Returns the entry's value.
    *
    * @return the entry's value.
    */
-  public abstract String getValue();
+  public String getValue() {
+    return value;
+  }
 
   /**
    * Returns the (optional) {@link EntryMetadata} associated with this {@link Entry}.
    *
    * @return the {@code EntryMetadata}.
    */
-  public abstract EntryMetadata getEntryMetadata();
+  public EntryMetadata getEntryMetadata() {
+    return entryMetadata;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Entry)) {
+      return false;
+    }
+    Entry entry = (Entry) o;
+    return key.equals(entry.key)
+        && value.equals(entry.value)
+        && entryMetadata.equals(entry.entryMetadata);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = key.hashCode();
+    result = 31 * result + value.hashCode();
+    result = 31 * result + entryMetadata.hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "Entry{"
+        + "key='"
+        + key
+        + '\''
+        + ", value='"
+        + value
+        + '\''
+        + ", entryMetadata="
+        + entryMetadata
+        + '}';
+  }
 
   /**
    * Determines whether the given {@code String} is a valid entry key.

--- a/api/src/main/java/io/opentelemetry/api/baggage/EntryMetadata.java
+++ b/api/src/main/java/io/opentelemetry/api/baggage/EntryMetadata.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.api.baggage;
 
-import com.google.auto.value.AutoValue;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -13,20 +12,26 @@ import javax.annotation.concurrent.Immutable;
  * wrapper for a String metadata value.
  */
 @Immutable
-@AutoValue
-public abstract class EntryMetadata {
-  public static final EntryMetadata EMPTY = create("");
+public final class EntryMetadata {
+  private static final EntryMetadata EMPTY = create("");
 
-  EntryMetadata() {}
+  /** Returns an {@link EntryMetadata} with no value. */
+  public static EntryMetadata empty() {
+    return EMPTY;
+  }
 
-  /**
-   * Creates an {@link EntryMetadata} with the given value.
-   *
-   * @param metadata TTL of an {@code Entry}.
-   * @return an {@code EntryMetadata}.
-   */
+  /** Returns an {@link EntryMetadata} with the given value. */
   public static EntryMetadata create(String metadata) {
-    return new AutoValue_EntryMetadata(metadata);
+    if (metadata == null) {
+      return empty();
+    }
+    return new EntryMetadata(metadata);
+  }
+
+  private final String metadata;
+
+  private EntryMetadata(String metadata) {
+    this.metadata = metadata;
   }
 
   /**
@@ -34,5 +39,29 @@ public abstract class EntryMetadata {
    *
    * @return the raw metadata value.
    */
-  public abstract String getValue();
+  public String getValue() {
+    return metadata;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof EntryMetadata)) {
+      return false;
+    }
+    EntryMetadata that = (EntryMetadata) o;
+    return metadata.equals(that.metadata);
+  }
+
+  @Override
+  public int hashCode() {
+    return metadata.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "'" + metadata + "'";
+  }
 }

--- a/api/src/main/java/io/opentelemetry/api/baggage/ImmutableBaggage.java
+++ b/api/src/main/java/io/opentelemetry/api/baggage/ImmutableBaggage.java
@@ -148,7 +148,7 @@ class ImmutableBaggage implements Baggage {
     public Baggage.Builder put(String key, String value) {
       entries.put(
           Objects.requireNonNull(key, "key"),
-          Entry.create(key, Objects.requireNonNull(value, "value"), EntryMetadata.EMPTY));
+          Entry.create(key, Objects.requireNonNull(value, "value"), EntryMetadata.empty()));
       return this;
     }
 

--- a/api/src/test/java/io/opentelemetry/api/baggage/EntryMetadataTest.java
+++ b/api/src/test/java/io/opentelemetry/api/baggage/EntryMetadataTest.java
@@ -25,4 +25,9 @@ class EntryMetadataTest {
         .addEqualityGroup(EntryMetadata.create("other value"))
         .testEquals();
   }
+
+  @Test
+  void nullValue() {
+    assertThat(EntryMetadata.create(null)).isEqualTo(EntryMetadata.empty());
+  }
 }

--- a/api/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
+++ b/api/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
@@ -114,7 +114,7 @@ class W3CBaggagePropagatorTest {
     Baggage expectedBaggage =
         Baggage.builder()
             .put("key1", "value1", EntryMetadata.create("metadata-key = value; othermetadata"))
-            .put("key2", "value2", EntryMetadata.EMPTY)
+            .put("key2", "value2", EntryMetadata.empty())
             .put("key3", "value3")
             .build();
     assertThat(Baggage.fromContext(result)).isEqualTo(expectedBaggage);

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
@@ -43,7 +43,7 @@ final class SpanContextShim extends BaseShimObject implements SpanContext {
     Context parentContext = Context.current().with(baggage);
 
     Baggage.Builder builder = Baggage.builder().setParent(parentContext);
-    builder.put(key, value, EntryMetadata.EMPTY);
+    builder.put(key, value, EntryMetadata.empty());
 
     return new SpanContextShim(telemetryInfo(), context, builder.build());
   }


### PR DESCRIPTION
Related to #1925. I think making public classes in the API final is a good idea, but we currently have many public abstract classes for the use of AutoValue. I think we should be consistent for public API in that all extensible classes are interface, and all non-extensible ones are final. If that means implementing (e.g., hitting some keys in IntelliJ) these methods, I think it's better than the current inconsistency. 

Here I went with making baggage classes concrete as an example - alternatively splitting interfaces and package-private AutoValue classes would make the extensibility consistent with other interfaces.