### PR TITLE
Add a StrictContextStorage which keeps track of scope open / close to…

### DIFF
--- a/context/src/main/java/io/opentelemetry/context/ContextStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/ContextStorage.java
@@ -70,6 +70,17 @@ public interface ContextStorage {
   }
 
   /**
+   * Sets the {@link ContextStorage} being used by this application to the provided {@link
+   * ContextStorage}. This must be called as early as possible in the application or some {@link
+   * Context} may use the wrong storage, for example, as part of a static initialization block in
+   * your main class. To avoid ordering issues, for non-testing situations it is recommended to use
+   * {@link ContextStorageProvider} instead of this method.
+   */
+  static void set(ContextStorage storage) {
+    LazyStorage.set(storage);
+  }
+
+  /**
    * Sets the specified {@link Context} as the current {@link Context} and returns a {@link Scope}
    * representing the scope of execution. {@link Scope#close()} must be called when the current
    * {@link Context} should be restored to what it was before attaching {@code toAttach}.

--- a/context/src/main/java/io/opentelemetry/context/ContextStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/ContextStorage.java
@@ -34,7 +34,7 @@ package io.opentelemetry.context;
  * >
  * >   @Override
  * >   public ContextStorage get() {
- * >     ContextStorage threadLocalStorage = Context.threadLocalStorage();
+ * >     ContextStorage threadLocalStorage = ContextStorage.defaultStorage();
  * >     return new RequestContextStorage() {
  * >       @Override
  * >       public Scope T attach(Context toAttach) {
@@ -70,14 +70,10 @@ public interface ContextStorage {
   }
 
   /**
-   * Sets the {@link ContextStorage} being used by this application to the provided {@link
-   * ContextStorage}. This must be called as early as possible in the application or some {@link
-   * Context} may use the wrong storage, for example, as part of a static initialization block in
-   * your main class. To avoid ordering issues, for non-testing situations it is recommended to use
-   * {@link ContextStorageProvider} instead of this method.
+   * Returns the default {@link ContextStorage} which stores {@link Context} using a threadlocal.
    */
-  static void set(ContextStorage storage) {
-    LazyStorage.set(storage);
+  static ContextStorage defaultStorage() {
+    return ThreadLocalContextStorage.INSTANCE;
   }
 
   /**

--- a/context/src/main/java/io/opentelemetry/context/LazyStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/LazyStorage.java
@@ -56,12 +56,16 @@ final class LazyStorage {
     return storage;
   }
 
+  static void set(ContextStorage storage) {
+    LazyStorage.storage = storage;
+  }
+
   private static final String CONTEXT_STORAGE_PROVIDER_PROPERTY =
       "io.opentelemetry.context.contextStorageProvider";
 
   private static final Logger logger = Logger.getLogger(LazyStorage.class.getName());
 
-  private static final ContextStorage storage;
+  private static ContextStorage storage;
 
   static {
     AtomicReference<Throwable> deferredStorageFailure = new AtomicReference<>();

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/context/SettableContextStorageProvider.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/context/SettableContextStorageProvider.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.testing.context;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextStorage;
+import io.opentelemetry.context.ContextStorageProvider;
+import io.opentelemetry.context.Scope;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+
+/** A {@link ContextStorageProvider} which can have it's {@link ContextStorage} set at any time. */
+public class SettableContextStorageProvider implements ContextStorageProvider {
+  @Override
+  public ContextStorage get() {
+    return SettableContextStorage.INSTANCE;
+  }
+
+  /** Sets the {@link ContextStorage} to use for future context operations. */
+  public static void setContextStorage(ContextStorage storage) {
+    SettableContextStorage.delegate = storage;
+  }
+
+  /** Returns the current {@link ContextStorage}. */
+  public static ContextStorage getContextStorage() {
+    return SettableContextStorage.delegate;
+  }
+
+  private enum SettableContextStorage implements ContextStorage {
+    INSTANCE;
+
+    private static volatile ContextStorage delegate = createStorage();
+
+    @Override
+    public Scope attach(Context toAttach) {
+      return delegate.attach(toAttach);
+    }
+
+    @Override
+    public Context current() {
+      return delegate.current();
+    }
+
+    // We reimplement provider lookup, ignoring the settable provider. It's clunky but allows
+    // reconfiguring only in test, not in production.
+    private static ContextStorage createStorage() {
+      List<ContextStorageProvider> providers = new ArrayList<>();
+      for (ContextStorageProvider provider : ServiceLoader.load(ContextStorageProvider.class)) {
+        if (provider.getClass().equals(SettableContextStorageProvider.class)) {
+          continue;
+        }
+        providers.add(provider);
+      }
+
+      if (providers.isEmpty()) {
+        return ContextStorage.defaultStorage();
+      }
+
+      String providerClassName =
+          System.getProperty("io.opentelemetry.context.contextStorageProvider", "");
+      if (providerClassName.isEmpty()) {
+        if (providers.size() == 1) {
+          return providers.get(0).get();
+        }
+        return ContextStorage.defaultStorage();
+      }
+
+      for (ContextStorageProvider provider : providers) {
+        if (provider.getClass().getName().equals(providerClassName)) {
+          return provider.get();
+        }
+      }
+      return ContextStorage.defaultStorage();
+    }
+  }
+}

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/context/StrictContextStorage.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/context/StrictContextStorage.java
@@ -103,6 +103,8 @@ public class StrictContextStorage implements ContextStorage {
     while (i < stackTrace.length) {
       String className = stackTrace[i].getClassName();
       if (className.startsWith("io.opentelemetry.api.")
+          || className.startsWith(
+              "io.opentelemetry.sdk.testing.context.SettableContextStorageProvider")
           || className.startsWith("io.opentelemetry.context.")) {
         i++;
       } else {

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/context/StrictContextStorage.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/context/StrictContextStorage.java
@@ -87,10 +87,6 @@ public class StrictContextStorage implements ContextStorage {
   @Override
   public Scope attach(Context context) {
     Scope scope = delegate.attach(context);
-    if (scope == Scope.noop()) {
-      // don't track no-op scopes as they cannot leak
-      return scope;
-    }
 
     CallerStackTrace caller = new CallerStackTrace(context);
     StackTraceElement[] stackTrace = caller.getStackTrace();

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/context/StrictContextStorage.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/context/StrictContextStorage.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Includes work from:
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentelemetry.sdk.testing.context;
+
+import static java.lang.Thread.currentThread;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextStorage;
+import io.opentelemetry.context.Scope;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedBlockingDeque;
+
+/**
+ * A {@link ContextStorage} which keeps track of opened and closed {@link Scope}s, reporting caller
+ * information if a {@link Scope} is closed incorrectly or not at all. This is useful in
+ * instrumentation tests to check whether any scopes leaked.
+ *
+ * <pre>{@code
+ * > class MyInstrumentationTest {
+ * >   private static ContextStorage previousStorage;
+ * >   private static StrictContextStorage strictStorage;
+ * >
+ * >   @BeforeAll
+ * >   static void setUp() {
+ * >     previousStorage = ContextStorage.get()
+ * >     strictStorage = StrictContextStorage.create(previousStorage);
+ * >     ContextStorage.set(previousStorage);
+ * >   }
+ * >
+ * >   @AfterEach
+ * >   void checkScopes() {
+ * >     strictStorage.ensureAllClosed();
+ * >   }
+ * >
+ * >   @AfterAll
+ * >   static void tearDown() {
+ * >     ContextStorage.set(previousStorage);
+ * >   }
+ * >
+ * >   @Test
+ * >   void badTest() {
+ * >     Context.root().makeCurrent();
+ * >   }
+ * > }
+ * }</pre>
+ */
+public class StrictContextStorage implements ContextStorage {
+
+  /**
+   * Returns a new {@link StrictContextStorage} which delegates to the provided {@link
+   * ContextStorage}, wrapping created scopes to track their usage.
+   */
+  public static StrictContextStorage create(ContextStorage delegate) {
+    return new StrictContextStorage(delegate);
+  }
+
+  private final ContextStorage delegate;
+  private final BlockingQueue<CallerStackTrace> currentCallers;
+
+  private StrictContextStorage(ContextStorage delegate) {
+    this.delegate = delegate;
+    currentCallers = new LinkedBlockingDeque<>();
+  }
+
+  @Override
+  public Scope attach(Context context) {
+    Scope scope = delegate.attach(context);
+    if (scope == Scope.noop()) {
+      // don't track no-op scopes as they cannot leak
+      return scope;
+    }
+
+    CallerStackTrace caller = new CallerStackTrace(context);
+    StackTraceElement[] stackTrace = caller.getStackTrace();
+
+    // "new CallerStackTrace(context)" isn't the line we want to start the caller stack trace with
+    int i = 1;
+
+    // This skips OpenTelemetry API and Context packages which will be at the top of the stack
+    // trace above the business logic call.
+    while (i < stackTrace.length) {
+      String className = stackTrace[i].getClassName();
+      if (className.startsWith("io.opentelemetry.api.")
+          || className.startsWith("io.opentelemetry.context.")) {
+        i++;
+      } else {
+        break;
+      }
+    }
+    int from = i;
+
+    stackTrace = Arrays.copyOfRange(stackTrace, from, stackTrace.length);
+    caller.setStackTrace(stackTrace);
+
+    return new StrictScope(scope, caller, currentCallers);
+  }
+
+  @Override
+  public Context current() {
+    return delegate.current();
+  }
+
+  /**
+   * Ensures all scopes that have been created by this storage have been closed. This can be useful
+   * to call at the end of a test to make sure everything has been cleaned up.
+   *
+   * <p><em>Note:</em> It is important to close all resources prior to calling this, so that
+   * in-flight operations are not mistaken as scope leaks. If this raises an error, consider if a
+   * {@linkplain Context#wrap(Executor)} wrapped executor} is still running.
+   *
+   * @throws AssertionError if any scopes were left unclosed.
+   */
+  // AssertionError to ensure test runners render the stack trace
+  public void ensureAllClosed() {
+    List<CallerStackTrace> leakedCallers = new ArrayList<>();
+    currentCallers.drainTo(leakedCallers);
+    for (CallerStackTrace caller : leakedCallers) {
+      // Sometimes unit test runners truncate the cause of the exception.
+      // This flattens the exception as the caller of close() isn't important vs the one that leaked
+      AssertionError toThrow =
+          new AssertionError(
+              "Thread [" + caller.threadName + "] opened a scope of " + caller.context + " here:");
+      toThrow.setStackTrace(caller.getStackTrace());
+      throw toThrow;
+    }
+  }
+
+  private static final class StrictScope implements Scope {
+    final Scope delegate;
+    final BlockingQueue<CallerStackTrace> currentCallers;
+    final CallerStackTrace caller;
+
+    private StrictScope(
+        Scope delegate, CallerStackTrace caller, BlockingQueue<CallerStackTrace> currentCallers) {
+      this.delegate = delegate;
+      this.currentCallers = currentCallers;
+      this.caller = caller;
+      this.currentCallers.add(caller);
+    }
+
+    @Override
+    public void close() {
+      currentCallers.remove(caller);
+      if (currentThread().getId() != caller.threadId) {
+        throw new IllegalStateException(
+            String.format(
+                "Thread [%s] opened scope, but thread [%s] closed it",
+                caller.threadName, currentThread().getName()),
+            caller);
+      }
+      delegate.close();
+    }
+
+    @Override
+    public String toString() {
+      return caller.getMessage();
+    }
+  }
+
+  private static class CallerStackTrace extends Throwable {
+
+    private static final long serialVersionUID = 783294061323215387L;
+
+    final String threadName = currentThread().getName();
+    final long threadId = currentThread().getId();
+    final Context context;
+
+    CallerStackTrace(Context context) {
+      super("Thread [" + currentThread().getName() + "] opened scope for " + context + " here:");
+      this.context = context;
+    }
+  }
+}

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/context/StrictContextStorage.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/context/StrictContextStorage.java
@@ -46,7 +46,7 @@ import java.util.concurrent.LinkedBlockingDeque;
  * >   static void setUp() {
  * >     previousStorage = ContextStorage.get()
  * >     strictStorage = StrictContextStorage.create(previousStorage);
- * >     ContextStorage.set(previousStorage);
+ * >     ContextStorage.set(strictStorage);
  * >   }
  * >
  * >   @AfterEach

--- a/sdk/testing/src/main/resources/META-INF/services/io.opentelemetry.context.ContextStorageProvider
+++ b/sdk/testing/src/main/resources/META-INF/services/io.opentelemetry.context.ContextStorageProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.sdk.testing.context.SettableContextStorageProvider

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/context/StrictContextStorageTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/context/StrictContextStorageTest.java
@@ -56,9 +56,9 @@ class StrictContextStorageTest {
 
   @BeforeAll
   static void setUp() {
-    previousStorage = ContextStorage.get();
+    previousStorage = SettableContextStorageProvider.getContextStorage();
     strictStorage = StrictContextStorage.create(previousStorage);
-    ContextStorage.set(strictStorage);
+    SettableContextStorageProvider.setContextStorage(strictStorage);
   }
 
   // In this test we intentionally leak context so need to restore it ourselves, bypassing the
@@ -70,7 +70,7 @@ class StrictContextStorageTest {
 
   @AfterAll
   static void tearDown() {
-    ContextStorage.set(previousStorage);
+    SettableContextStorageProvider.setContextStorage(previousStorage);
   }
 
   // TODO(anuraaga): These rules conflict with error prone so one or the other needs to be

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/context/StrictContextStorageTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/context/StrictContextStorageTest.java
@@ -85,12 +85,6 @@ class StrictContextStorageTest {
     strictStorage.ensureAllClosed(); // doesn't error
   }
 
-  @Test
-  public void doesntDecorateNoop() {
-    assertThat(Context.current().makeCurrent()).isSameAs(Scope.noop());
-    strictStorage.ensureAllClosed(); // doesn't error
-  }
-
   static final class BusinessClass {
 
     static Scope businessMethodMakeContextCurrent() {

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/context/StrictContextStorageTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/context/StrictContextStorageTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Includes work from:
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentelemetry.sdk.testing.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
+import io.opentelemetry.context.ContextStorage;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.trace.IdGenerator;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("MustBeClosedChecker")
+class StrictContextStorageTest {
+
+  private static final ContextKey<String> ANIMAL = ContextKey.named("animal");
+  private static final IdGenerator IDS_GENERATOR = IdGenerator.random();
+  private static final String TRACE_ID = IDS_GENERATOR.generateTraceId();
+  private static final String SPAN_ID = IDS_GENERATOR.generateSpanId();
+
+  private static final Span SPAN =
+      Span.wrap(
+          SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
+
+  private static ContextStorage previousStorage;
+  private static StrictContextStorage strictStorage;
+
+  @BeforeAll
+  static void setUp() {
+    previousStorage = ContextStorage.get();
+    strictStorage = StrictContextStorage.create(previousStorage);
+    ContextStorage.set(strictStorage);
+  }
+
+  // In this test we intentionally leak context so need to restore it ourselves, bypassing the
+  // strict storage.
+  @AfterEach
+  void resetContext() {
+    previousStorage.attach(Context.root());
+  }
+
+  @AfterAll
+  static void tearDown() {
+    ContextStorage.set(previousStorage);
+  }
+
+  // TODO(anuraaga): These rules conflict with error prone so one or the other needs to be
+  // disabled.
+  @SuppressWarnings({"checkstyle:EmptyBlock", "checkstyle:WhitespaceAround"})
+  @Test
+  void decorator_close_afterCorrectUsage() {
+    try (Scope ws = Context.current().with(ANIMAL, "cat").makeCurrent()) {
+      try (Scope ws2 = Context.current().with(ANIMAL, "dog").makeCurrent()) {}
+    }
+
+    strictStorage.ensureAllClosed(); // doesn't error
+  }
+
+  @Test
+  public void doesntDecorateNoop() {
+    assertThat(Context.current().makeCurrent()).isSameAs(Scope.noop());
+    strictStorage.ensureAllClosed(); // doesn't error
+  }
+
+  static final class BusinessClass {
+
+    static Scope businessMethodMakeContextCurrent() {
+      return Context.current().with(ANIMAL, "cat").makeCurrent();
+    }
+
+    static Scope businessMethodMakeSpanCurrent() {
+      return SPAN.makeCurrent();
+    }
+
+    private BusinessClass() {}
+  }
+
+  @Test
+  public void scope_close_onWrongThread_newScope() throws Exception {
+    scope_close_onWrongThread(
+        BusinessClass::businessMethodMakeContextCurrent, "businessMethodMakeContextCurrent");
+  }
+
+  @Test
+  public void decorator_close_withLeakedScope_onWrongThread_newScope() throws Exception {
+    decorator_close_withLeakedScope(
+        BusinessClass::businessMethodMakeContextCurrent, "businessMethodMakeContextCurrent");
+  }
+
+  @Test
+  public void scope_close_onWrongThread_withSpanInScope() throws Exception {
+    scope_close_onWrongThread(
+        BusinessClass::businessMethodMakeSpanCurrent, "businessMethodMakeSpanCurrent");
+  }
+
+  @Test
+  public void decorator_close_withLeakedScope_withSpanInScope() throws Exception {
+    decorator_close_withLeakedScope(
+        BusinessClass::businessMethodMakeSpanCurrent, "businessMethodMakeSpanCurrent");
+  }
+
+  void scope_close_onWrongThread(Supplier<Scope> method, String methodName) throws Exception {
+    AtomicReference<Scope> closeable = new AtomicReference<>();
+    Thread t1 = new Thread(() -> closeable.set(method.get()));
+    t1.setName("t1");
+    t1.start();
+    t1.join();
+
+    AtomicReference<Throwable> errorCatcher = new AtomicReference<>();
+
+    Thread t2 =
+        new Thread(
+            () -> {
+              try {
+                closeable.get().close();
+              } catch (Throwable t) {
+                errorCatcher.set(t);
+              }
+            });
+    t2.setName("t2");
+    t2.start();
+    t2.join();
+
+    assertThat(errorCatcher.get())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Thread [t1] opened scope, but thread [t2] closed it")
+        .satisfies(
+            e ->
+                assertThat(e.getCause().getMessage())
+                    .matches("Thread \\[t1\\] opened scope for .* here:"))
+        .satisfies(e -> assertStackTraceStartsWithMethod(e.getCause(), methodName));
+  }
+
+  @SuppressWarnings("ReturnValueIgnored")
+  void decorator_close_withLeakedScope(Supplier<Scope> method, String methodName) throws Exception {
+    Thread thread = new Thread(method::get);
+    thread.setName("t1");
+    thread.start();
+    thread.join();
+
+    assertThatThrownBy(strictStorage::ensureAllClosed)
+        .isInstanceOf(AssertionError.class)
+        .satisfies(
+            t -> assertThat(t.getMessage()).matches("Thread \\[t1\\] opened a scope of .* here:"))
+        .hasNoCause()
+        .satisfies(t -> assertStackTraceStartsWithMethod(t, methodName));
+  }
+
+  static void assertStackTraceStartsWithMethod(Throwable throwable, String methodName) {
+    assertThat(throwable.getStackTrace()[0].getMethodName()).isEqualTo(methodName);
+  }
+}


### PR DESCRIPTION
… throw errors when it's incorrect for tests.

If this looks good and merged, I'd followup with a junit extension which when applied, automatically checks scopes without additional code. JUnit extensions can also be applied globally via properties file, applying it to builds in an easy way.

Mostly copied from https://github.com/openzipkin/brave/blob/master/brave/src/main/java/brave/propagation/StrictScopeDecorator.java

Part of #1794