### PR TITLE
Allow subclassing SpanContext by other packages

### DIFF
--- a/api/src/main/java/io/opentelemetry/api/trace/SpanContext.java
+++ b/api/src/main/java/io/opentelemetry/api/trace/SpanContext.java
@@ -71,9 +71,9 @@ public abstract class SpanContext {
     return create(traceIdHex, spanIdHex, traceFlags, traceState, /* remote=*/ true);
   }
 
-  abstract String getTraceIdHex();
+  protected abstract String getTraceIdHex();
 
-  abstract String getSpanIdHex();
+  protected abstract String getSpanIdHex();
 
   /**
    * Returns the trace identifier associated with this {@code SpanContext}.


### PR DESCRIPTION
Having abstract methods with default visibility makes the class not able to be subclassed by other packages.
Changing to protected to maintain the intended restrictions from #1594, but allowing it to be subclassed.