### PR TITLE
Miscelleneous cleanup

### DIFF
--- a/api/src/main/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagator.java
+++ b/api/src/main/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagator.java
@@ -29,6 +29,8 @@ public final class W3CBaggagePropagator implements TextMapPropagator {
     return INSTANCE;
   }
 
+  private W3CBaggagePropagator() {}
+
   @Override
   public List<String> fields() {
     return FIELDS;

--- a/api/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
+++ b/api/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
@@ -25,7 +25,7 @@ class W3CBaggagePropagatorTest {
 
   @Test
   void extract_noBaggageHeader() {
-    W3CBaggagePropagator propagator = new W3CBaggagePropagator();
+    W3CBaggagePropagator propagator = W3CBaggagePropagator.getInstance();
 
     Context result =
         propagator.extract(Context.root(), ImmutableMap.<String, String>of(), Map::get);
@@ -35,7 +35,7 @@ class W3CBaggagePropagatorTest {
 
   @Test
   void extract_emptyBaggageHeader() {
-    W3CBaggagePropagator propagator = new W3CBaggagePropagator();
+    W3CBaggagePropagator propagator = W3CBaggagePropagator.getInstance();
 
     Context result =
         propagator.extract(Context.root(), ImmutableMap.of("baggage", ""), ImmutableMap::get);
@@ -45,7 +45,7 @@ class W3CBaggagePropagatorTest {
 
   @Test
   void extract_singleEntry() {
-    W3CBaggagePropagator propagator = new W3CBaggagePropagator();
+    W3CBaggagePropagator propagator = W3CBaggagePropagator.getInstance();
 
     Context result =
         propagator.extract(
@@ -57,7 +57,7 @@ class W3CBaggagePropagatorTest {
 
   @Test
   void extract_multiEntry() {
-    W3CBaggagePropagator propagator = new W3CBaggagePropagator();
+    W3CBaggagePropagator propagator = W3CBaggagePropagator.getInstance();
 
     Context result =
         propagator.extract(
@@ -71,7 +71,7 @@ class W3CBaggagePropagatorTest {
 
   @Test
   void extract_duplicateKeys() {
-    W3CBaggagePropagator propagator = new W3CBaggagePropagator();
+    W3CBaggagePropagator propagator = W3CBaggagePropagator.getInstance();
 
     Context result =
         propagator.extract(
@@ -83,7 +83,7 @@ class W3CBaggagePropagatorTest {
 
   @Test
   void extract_withMetadata() {
-    W3CBaggagePropagator propagator = new W3CBaggagePropagator();
+    W3CBaggagePropagator propagator = W3CBaggagePropagator.getInstance();
 
     Context result =
         propagator.extract(
@@ -100,7 +100,7 @@ class W3CBaggagePropagatorTest {
 
   @Test
   void extract_fullComplexities() {
-    W3CBaggagePropagator propagator = new W3CBaggagePropagator();
+    W3CBaggagePropagator propagator = W3CBaggagePropagator.getInstance();
 
     Context result =
         propagator.extract(
@@ -126,7 +126,7 @@ class W3CBaggagePropagatorTest {
    */
   @Test
   void extract_invalidHeader() {
-    W3CBaggagePropagator propagator = new W3CBaggagePropagator();
+    W3CBaggagePropagator propagator = W3CBaggagePropagator.getInstance();
 
     Context result =
         propagator.extract(
@@ -142,7 +142,7 @@ class W3CBaggagePropagatorTest {
 
   @Test
   void inject_noBaggage() {
-    W3CBaggagePropagator propagator = new W3CBaggagePropagator();
+    W3CBaggagePropagator propagator = W3CBaggagePropagator.getInstance();
     Map<String, String> carrier = new HashMap<>();
     propagator.inject(Context.root(), carrier, Map::put);
     assertThat(carrier).isEmpty();
@@ -151,7 +151,7 @@ class W3CBaggagePropagatorTest {
   @Test
   void inject_emptyBaggage() {
     Baggage baggage = Baggage.empty();
-    W3CBaggagePropagator propagator = new W3CBaggagePropagator();
+    W3CBaggagePropagator propagator = W3CBaggagePropagator.getInstance();
     Map<String, String> carrier = new HashMap<>();
     propagator.inject(Context.root().with(baggage), carrier, Map::put);
     assertThat(carrier).isEmpty();
@@ -164,7 +164,7 @@ class W3CBaggagePropagatorTest {
             .put("nometa", "nometa-value")
             .put("meta", "meta-value", EntryMetadata.create("somemetadata; someother=foo"))
             .build();
-    W3CBaggagePropagator propagator = new W3CBaggagePropagator();
+    W3CBaggagePropagator propagator = W3CBaggagePropagator.getInstance();
     Map<String, String> carrier = new HashMap<>();
     propagator.inject(Context.root().with(baggage), carrier, Map::put);
     assertThat(carrier)

--- a/opentracing_shim/README.md
+++ b/opentracing_shim/README.md
@@ -8,11 +8,11 @@ It takes OpenTelemetry Tracer and exposes it as an implementation of an OpenTrac
 There are 2 ways to expose an OpenTracing tracer: 
 1. From the global OpenTelemetry configuration: 
     ```java
-    Tracer tracer = TraceShim.createTracerShim();
+    Tracer tracer = OpenTracingShim.createTracerShim();
     ```
-1. From the provided `TracerProvider` and `CorrelationContextManager`:
+1. From a provided `OpenTelemetry` instance:
     ```java
-    Tracer tracer = TraceShim.createTracerShim(tracerProvider, contextManager);
+    Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry);
     ```
 
 Optionally register the tracer as the OpenTracing GlobalTracer:

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/OpenTracingShim.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/OpenTracingShim.java
@@ -8,10 +8,13 @@ package io.opentelemetry.opentracingshim;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
-import java.util.Objects;
 
-public final class TraceShim {
-  private TraceShim() {}
+/**
+ * Factory for creating an OpenTracing {@link io.opentracing.Tracer} that is implemented using the
+ * OpenTelemetry APIs.
+ */
+public final class OpenTracingShim {
+  private OpenTracingShim() {}
 
   /**
    * Creates a {@code io.opentracing.Tracer} shim out of {@code
@@ -23,20 +26,6 @@ public final class TraceShim {
     return new TracerShim(
         new TelemetryInfo(
             getTracer(OpenTelemetry.getGlobalTracerProvider()),
-            OpenTelemetry.getGlobalPropagators()));
-  }
-
-  /**
-   * Creates a {@code io.opentracing.Tracer} shim out the specified {@code Tracer}. This uses
-   * ContextPropagators from the global {@link OpenTelemetry} instance.
-   *
-   * @param tracerProvider the {@code TracerProvider} used by this shim.
-   * @return a {@code io.opentracing.Tracer}.
-   */
-  public static io.opentracing.Tracer createTracerShim(TracerProvider tracerProvider) {
-    return new TracerShim(
-        new TelemetryInfo(
-            getTracer(Objects.requireNonNull(tracerProvider, "tracerProvider")),
             OpenTelemetry.getGlobalPropagators()));
   }
 

--- a/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/package-info.java
+++ b/opentracing_shim/src/main/java/io/opentelemetry/opentracingshim/package-info.java
@@ -5,7 +5,7 @@
 
 /**
  * An OpenTracing implementation that delegates to the OpenTelemetry SDK. Use {@link
- * io.opentelemetry.opentracingshim.TraceShim} to create tracers using this implementation.
+ * io.opentelemetry.opentracingshim.OpenTracingShim} to create tracers using this implementation.
  */
 @ParametersAreNonnullByDefault
 package io.opentelemetry.opentracingshim;

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/OpenTracingShimTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/OpenTracingShimTest.java
@@ -6,37 +6,20 @@
 package io.opentelemetry.opentracingshim;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import org.junit.jupiter.api.Test;
 
-class TraceShimTest {
+class OpenTracingShimTest {
 
   @Test
   void createTracerShim_default() {
-    TracerShim tracerShim = (TracerShim) TraceShim.createTracerShim();
+    TracerShim tracerShim = (TracerShim) OpenTracingShim.createTracerShim();
     assertEquals(OpenTelemetry.getGlobalTracer("opentracingshim"), tracerShim.tracer());
-  }
-
-  @Test
-  void createTracerShim_nullTracer() {
-    assertThrows(
-        NullPointerException.class,
-        () -> TraceShim.createTracerShim((TracerProvider) null),
-        "tracerProvider");
-  }
-
-  @Test
-  void createTracerShim() {
-    TracerSdkProvider sdk = TracerSdkProvider.builder().build();
-    TracerShim tracerShim = (TracerShim) TraceShim.createTracerShim(sdk);
-    assertEquals(sdk.get("opentracingshim"), tracerShim.tracer());
   }
 
   @Test
@@ -46,7 +29,7 @@ class TraceShimTest {
     when(openTelemetry.getTracerProvider()).thenReturn(sdk);
     when(openTelemetry.getPropagators()).thenReturn(mock(ContextPropagators.class));
 
-    TracerShim tracerShim = (TracerShim) TraceShim.createTracerShim(openTelemetry);
+    TracerShim tracerShim = (TracerShim) OpenTracingShim.createTracerShim(openTelemetry);
     assertEquals(sdk.get("opentracingshim"), tracerShim.tracer());
   }
 }

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import io.opentelemetry.opentracingshim.TraceShim;
+import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentracing.Scope;
@@ -27,8 +27,7 @@ class OpenTelemetryInteroperabilityTest {
   private final io.opentelemetry.api.trace.Tracer tracer =
       otelTesting.getOpenTelemetry().getTracer("opentracingshim");
 
-  private final Tracer otTracer =
-      TraceShim.createTracerShim(otelTesting.getOpenTelemetry().getTracerProvider());
+  private final Tracer otTracer = OpenTracingShim.createTracerShim(otelTesting.getOpenTelemetry());
 
   @Test
   void sdkContinuesOpenTracingTrace() {

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/activespanreplacement/ActiveSpanReplacementTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/activespanreplacement/ActiveSpanReplacementTest.java
@@ -14,9 +14,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
-import io.opentelemetry.opentracingshim.TraceShim;
+import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentracing.Scope;
@@ -32,9 +33,11 @@ import org.junit.jupiter.api.Test;
 class ActiveSpanReplacementTest {
 
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
+  private final OpenTelemetry openTelemetry =
+      OpenTelemetry.get().toBuilder().setTracerProvider(sdk).build();
   private final InMemoryTracing inMemoryTracing =
       InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
-  private final Tracer tracer = TraceShim.createTracerShim(sdk);
+  private final Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry);
   private final ExecutorService executor = Executors.newCachedThreadPool();
 
   @Test

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/actorpropagation/ActorPropagationTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/actorpropagation/ActorPropagationTest.java
@@ -9,9 +9,10 @@ import static io.opentelemetry.opentracingshim.testbed.TestUtils.getByKind;
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.getOneByKind;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span.Kind;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
-import io.opentelemetry.opentracingshim.TraceShim;
+import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentracing.Scope;
@@ -37,9 +38,11 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("FutureReturnValueIgnored")
 class ActorPropagationTest {
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
+  private final OpenTelemetry openTelemetry =
+      OpenTelemetry.get().toBuilder().setTracerProvider(sdk).build();
   private final InMemoryTracing inMemoryTracing =
       InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
-  private final Tracer tracer = TraceShim.createTracerShim(sdk);
+  private final Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry);
   private Phaser phaser;
 
   @BeforeEach

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/baggagehandling/BaggageHandlingTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/baggagehandling/BaggageHandlingTest.java
@@ -7,8 +7,9 @@ package io.opentelemetry.opentracingshim.testbed.baggagehandling;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
-import io.opentelemetry.opentracingshim.TraceShim;
+import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
@@ -20,9 +21,11 @@ import org.junit.jupiter.api.Test;
 
 public final class BaggageHandlingTest {
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
+  private final OpenTelemetry openTelemetry =
+      OpenTelemetry.get().toBuilder().setTracerProvider(sdk).build();
   private final InMemoryTracing inMemoryTracing =
       InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
-  private final Tracer tracer = TraceShim.createTracerShim(sdk);
+  private final Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry);
   private final ExecutorService executor = Executors.newCachedThreadPool();
 
   @Test

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/clientserver/TestClientServerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/clientserver/TestClientServerTest.java
@@ -12,9 +12,11 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span.Kind;
+import io.opentelemetry.api.trace.propagation.HttpTraceContext;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
-import io.opentelemetry.opentracingshim.TraceShim;
+import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentracing.Tracer;
@@ -26,11 +28,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class TestClientServerTest {
-
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
+  private final OpenTelemetry openTelemetry =
+      OpenTelemetry.get().toBuilder()
+          .setTracerProvider(sdk)
+          .setPropagators(HttpTraceContext::getInstance)
+          .build();
   private final InMemoryTracing inMemoryTracing =
       InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
-  private final Tracer tracer = TraceShim.createTracerShim(sdk);
+  private final Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry);
   private final ArrayBlockingQueue<Message> queue = new ArrayBlockingQueue<>(10);
   private Server server;
 

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/concurrentcommonrequesthandler/HandlerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/concurrentcommonrequesthandler/HandlerTest.java
@@ -13,10 +13,11 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span.Kind;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
-import io.opentelemetry.opentracingshim.TraceShim;
+import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentracing.Scope;
@@ -36,9 +37,11 @@ import org.junit.jupiter.api.Test;
 class HandlerTest {
 
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
+  private final OpenTelemetry openTelemetry =
+      OpenTelemetry.get().toBuilder().setTracerProvider(sdk).build();
   private final InMemoryTracing inMemoryTracing =
       InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
-  private final Tracer tracer = TraceShim.createTracerShim(sdk);
+  private final Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry);
   private final Client client = new Client(new RequestHandler(tracer));
 
   @BeforeEach

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/errorreporting/ErrorReportingTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/errorreporting/ErrorReportingTest.java
@@ -11,9 +11,10 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
-import io.opentelemetry.opentracingshim.TraceShim;
+import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
@@ -32,11 +33,12 @@ import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("FutureReturnValueIgnored")
 public final class ErrorReportingTest {
-
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
+  private final OpenTelemetry openTelemetry =
+      OpenTelemetry.get().toBuilder().setTracerProvider(sdk).build();
   private final InMemoryTracing inMemoryTracing =
       InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
-  private final Tracer tracer = TraceShim.createTracerShim(sdk);
+  private final Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry);
   private final ExecutorService executor = Executors.newCachedThreadPool();
 
   /* Very simple error handling **/

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/latespanfinish/LateSpanFinishTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/latespanfinish/LateSpanFinishTest.java
@@ -11,8 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
-import io.opentelemetry.opentracingshim.TraceShim;
+import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentracing.Scope;
@@ -27,9 +28,11 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("FutureReturnValueIgnored")
 public final class LateSpanFinishTest {
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
+  private final OpenTelemetry openTelemetry =
+      OpenTelemetry.get().toBuilder().setTracerProvider(sdk).build();
   private final InMemoryTracing inMemoryTracing =
       InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
-  private final Tracer tracer = TraceShim.createTracerShim(sdk);
+  private final Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry);
   private final ExecutorService executor = Executors.newCachedThreadPool();
 
   @Test

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/listenerperrequest/ListenerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/listenerperrequest/ListenerTest.java
@@ -8,9 +8,10 @@ package io.opentelemetry.opentracingshim.testbed.listenerperrequest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
-import io.opentelemetry.opentracingshim.TraceShim;
+import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentracing.Tracer;
@@ -20,9 +21,11 @@ import org.junit.jupiter.api.Test;
 /** Each request has own instance of ResponseListener. */
 class ListenerTest {
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
+  private final OpenTelemetry openTelemetry =
+      OpenTelemetry.get().toBuilder().setTracerProvider(sdk).build();
   private final InMemoryTracing inMemoryTracing =
       InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
-  private final Tracer tracer = TraceShim.createTracerShim(sdk);
+  private final Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry);
 
   @Test
   void test() throws Exception {

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/multiplecallbacks/MultipleCallbacksTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/multiplecallbacks/MultipleCallbacksTest.java
@@ -11,8 +11,9 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
-import io.opentelemetry.opentracingshim.TraceShim;
+import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentracing.Scope;
@@ -32,9 +33,11 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("FutureReturnValueIgnored")
 class MultipleCallbacksTest {
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
+  private final OpenTelemetry openTelemetry =
+      OpenTelemetry.get().toBuilder().setTracerProvider(sdk).build();
   private final InMemoryTracing inMemoryTracing =
       InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
-  private final Tracer tracer = TraceShim.createTracerShim(sdk);
+  private final Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry);
 
   @Test
   void test() {

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/nestedcallbacks/NestedCallbacksTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/nestedcallbacks/NestedCallbacksTest.java
@@ -12,9 +12,10 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.ReadableAttributes;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
-import io.opentelemetry.opentracingshim.TraceShim;
+import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentracing.Scope;
@@ -28,11 +29,12 @@ import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("FutureReturnValueIgnored")
 public final class NestedCallbacksTest {
-
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
+  private final OpenTelemetry openTelemetry =
+      OpenTelemetry.get().toBuilder().setTracerProvider(sdk).build();
   private final InMemoryTracing inMemoryTracing =
       InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
-  private final Tracer tracer = TraceShim.createTracerShim(sdk);
+  private final Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry);
   private final ExecutorService executor = Executors.newCachedThreadPool();
 
   @Test

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/promisepropagation/PromisePropagationTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/promisepropagation/PromisePropagationTest.java
@@ -9,10 +9,11 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.getByAttr;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
-import io.opentelemetry.opentracingshim.TraceShim;
+import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentracing.Scope;
@@ -36,9 +37,11 @@ import org.junit.jupiter.api.Test;
  */
 class PromisePropagationTest {
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
+  private final OpenTelemetry openTelemetry =
+      OpenTelemetry.get().toBuilder().setTracerProvider(sdk).build();
   private final InMemoryTracing inMemoryTracing =
       InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
-  private final Tracer tracer = TraceShim.createTracerShim(sdk);
+  private final Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry);
   private Phaser phaser;
 
   @BeforeEach

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/statelesscommonrequesthandler/HandlerTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/statelesscommonrequesthandler/HandlerTest.java
@@ -7,8 +7,9 @@ package io.opentelemetry.opentracingshim.testbed.statelesscommonrequesthandler;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
-import io.opentelemetry.opentracingshim.TraceShim;
+import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentracing.Tracer;
@@ -25,9 +26,11 @@ import org.junit.jupiter.api.Test;
 public final class HandlerTest {
 
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
+  private final OpenTelemetry openTelemetry =
+      OpenTelemetry.get().toBuilder().setTracerProvider(sdk).build();
   private final InMemoryTracing inMemoryTracing =
       InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
-  private final Tracer tracer = TraceShim.createTracerShim(sdk);
+  private final Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry);
   private final Client client = new Client(new RequestHandler(tracer));
 
   @BeforeEach

--- a/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/suspendresumepropagation/SuspendResumePropagationTest.java
+++ b/opentracing_shim/src/test/java/io/opentelemetry/opentracingshim/testbed/suspendresumepropagation/SuspendResumePropagationTest.java
@@ -7,9 +7,10 @@ package io.opentelemetry.opentracingshim.testbed.suspendresumepropagation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.exporters.inmemory.InMemoryTracing;
-import io.opentelemetry.opentracingshim.TraceShim;
+import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentracing.Tracer;
@@ -25,9 +26,11 @@ import org.junit.jupiter.api.Test;
  */
 class SuspendResumePropagationTest {
   private final TracerSdkProvider sdk = TracerSdkProvider.builder().build();
+  private final OpenTelemetry openTelemetry =
+      OpenTelemetry.get().toBuilder().setTracerProvider(sdk).build();
   private final InMemoryTracing inMemoryTracing =
       InMemoryTracing.builder().setTracerSdkManagement(sdk).build();
-  private final Tracer tracer = TraceShim.createTracerShim(sdk);
+  private final Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry);
 
   @BeforeEach
   void before() {}


### PR DESCRIPTION
* Rename TraceShim factory to OpenTracingShim
* Remove factory method from OpenTracingShim which used mixed pieces of the openTelemetry components.
* Made the constructor for W3CBaggagePropagator private.
* Updated OpenTracingShim README