### PR TITLE
WIP: Adds listener method to register callback on context change

### DIFF
--- a/context/src/main/java/io/opentelemetry/context/Context.java
+++ b/context/src/main/java/io/opentelemetry/context/Context.java
@@ -139,7 +139,7 @@ public interface Context {
    */
   @MustBeClosed
   default Scope makeCurrent() {
-    return storage().attach(this);
+    return ContextStorage.get().attach(this);
   }
 
   /**
@@ -189,9 +189,5 @@ public interface Context {
    */
   default ScheduledExecutorService wrap(ScheduledExecutorService executor) {
     return new ContextScheduledExecutorService(this, executor);
-  }
-
-  default ContextStorage storage() {
-    return ContextStorage.get();
   }
 }

--- a/context/src/main/java/io/opentelemetry/context/Context.java
+++ b/context/src/main/java/io/opentelemetry/context/Context.java
@@ -139,7 +139,7 @@ public interface Context {
    */
   @MustBeClosed
   default Scope makeCurrent() {
-    return ContextStorage.get().attach(this);
+    return storage().attach(this);
   }
 
   /**
@@ -189,5 +189,9 @@ public interface Context {
    */
   default ScheduledExecutorService wrap(ScheduledExecutorService executor) {
     return new ContextScheduledExecutorService(this, executor);
+  }
+
+  default ContextStorage storage() {
+    return ContextStorage.get();
   }
 }

--- a/context/src/main/java/io/opentelemetry/context/ContextStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/ContextStorage.java
@@ -22,6 +22,8 @@
 
 package io.opentelemetry.context;
 
+import java.util.function.Consumer;
+
 /**
  * The storage for storing and retrieving the current {@link Context}.
  *
@@ -81,4 +83,6 @@ public interface ContextStorage {
    * this will be the {@linkplain Context#root()} root context}.
    */
   Context current();
+
+  void onAttach(Consumer<Context> contextConsumer);
 }

--- a/context/src/main/java/io/opentelemetry/context/ThreadLocalContextStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/ThreadLocalContextStorage.java
@@ -15,13 +15,10 @@ enum ThreadLocalContextStorage implements ContextStorage {
 
   private static final Logger logger = Logger.getLogger(ThreadLocalContextStorage.class.getName());
 
-  private static final ThreadLocal<Context> THREAD_LOCAL_STORAGE = new ThreadLocal<>();
+  private static final ThreadLocal<Context> THREAD_LOCAL_STORAGE = ThreadLocal.withInitial(
+      Context::root);
 
   private static final AtomicReference<Consumer<Context>> onAttachConsumer = new AtomicReference<>();
-
-  static {
-    THREAD_LOCAL_STORAGE.set(Context.root());
-  }
 
   @Override
   public Scope attach(Context toAttach) {

--- a/context/src/main/java/io/opentelemetry/context/ThreadLocalContextStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/ThreadLocalContextStorage.java
@@ -46,13 +46,6 @@ enum ThreadLocalContextStorage implements ContextStorage {
     };
   }
 
-  private void onAttach(Context toAttach) {
-    Consumer<Context> consumer = onAttachConsumer.get();
-    if (consumer != null) {
-      consumer.accept(toAttach);
-    }
-  }
-
   @Override
   public Context current() {
     return THREAD_LOCAL_STORAGE.get();
@@ -61,6 +54,13 @@ enum ThreadLocalContextStorage implements ContextStorage {
   @Override
   public void onAttach(Consumer<Context> contextConsumer) {
     onAttachConsumer.updateAndGet(existing -> existing != null ? existing.andThen(contextConsumer) : contextConsumer);
+  }
+
+  private static void onAttach(Context toAttach) {
+    Consumer<Context> consumer = onAttachConsumer.get();
+    if (consumer != null) {
+      consumer.accept(toAttach);
+    }
   }
 
   enum NoopScope implements Scope {

--- a/context/src/main/java/io/opentelemetry/context/ThreadLocalContextStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/ThreadLocalContextStorage.java
@@ -15,10 +15,20 @@ enum ThreadLocalContextStorage implements ContextStorage {
 
   private static final Logger logger = Logger.getLogger(ThreadLocalContextStorage.class.getName());
 
-  private static final ThreadLocal<Context> THREAD_LOCAL_STORAGE = ThreadLocal.withInitial(
-      Context::root);
+  private static final ThreadLocal<Context> THREAD_LOCAL_STORAGE;
 
-  private static final AtomicReference<Consumer<Context>> onAttachConsumer = new AtomicReference<>();
+  private static final AtomicReference<Consumer<Context>> onAttachConsumer =
+      new AtomicReference<>();
+
+  static {
+    THREAD_LOCAL_STORAGE =
+        new ThreadLocal<Context>() {
+          @Override
+          protected Context initialValue() {
+            return Context.root();
+          }
+        };
+  }
 
   @Override
   public Scope attach(Context toAttach) {
@@ -53,7 +63,8 @@ enum ThreadLocalContextStorage implements ContextStorage {
 
   @Override
   public void onAttach(Consumer<Context> contextConsumer) {
-    onAttachConsumer.updateAndGet(existing -> existing != null ? existing.andThen(contextConsumer) : contextConsumer);
+    onAttachConsumer.updateAndGet(
+        existing -> existing != null ? existing.andThen(contextConsumer) : contextConsumer);
   }
 
   private static void onAttach(Context toAttach) {

--- a/context/src/main/java/io/opentelemetry/context/ThreadLocalContextStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/ThreadLocalContextStorage.java
@@ -15,20 +15,10 @@ enum ThreadLocalContextStorage implements ContextStorage {
 
   private static final Logger logger = Logger.getLogger(ThreadLocalContextStorage.class.getName());
 
-  private static final ThreadLocal<Context> THREAD_LOCAL_STORAGE;
+  private static final ThreadLocal<Context> THREAD_LOCAL_STORAGE = new ThreadLocal<>();
 
   private static final AtomicReference<Consumer<Context>> onAttachConsumer =
       new AtomicReference<>();
-
-  static {
-    THREAD_LOCAL_STORAGE =
-        new ThreadLocal<Context>() {
-          @Override
-          protected Context initialValue() {
-            return Context.root();
-          }
-        };
-  }
 
   @Override
   public Scope attach(Context toAttach) {
@@ -58,7 +48,8 @@ enum ThreadLocalContextStorage implements ContextStorage {
 
   @Override
   public Context current() {
-    return THREAD_LOCAL_STORAGE.get();
+    Context current = THREAD_LOCAL_STORAGE.get();
+    return current != null ? current : Context.root();
   }
 
   @Override

--- a/context/src/otelAsBraveTest/java/io/opentelemetry/context/BraveContextStorageProvider.java
+++ b/context/src/otelAsBraveTest/java/io/opentelemetry/context/BraveContextStorageProvider.java
@@ -25,7 +25,7 @@ public class BraveContextStorageProvider implements ContextStorageProvider {
   private enum BraveContextStorage implements ContextStorage {
     INSTANCE;
 
-    private final AtomicReference<Consumer<Context>> onAttachConsumer = new AtomicReference<>();
+    private static final AtomicReference<Consumer<Context>> onAttachConsumer = new AtomicReference<>();
 
     @Override
     public Scope attach(Context toAttach) {
@@ -54,7 +54,7 @@ public class BraveContextStorageProvider implements ContextStorageProvider {
       return new BraveContextWrapper(TraceContext.newBuilder().traceId(1).spanId(1).build());
     }
 
-    private void onAttach(TraceContext context) {
+    private static void onAttach(TraceContext context) {
       Consumer<Context> contextConsumer = onAttachConsumer.get();
       if (contextConsumer != null) {
         contextConsumer.accept(new BraveContextWrapper(context));

--- a/context/src/otelAsBraveTest/java/io/opentelemetry/context/BraveContextStorageProvider.java
+++ b/context/src/otelAsBraveTest/java/io/opentelemetry/context/BraveContextStorageProvider.java
@@ -25,7 +25,8 @@ public class BraveContextStorageProvider implements ContextStorageProvider {
   private enum BraveContextStorage implements ContextStorage {
     INSTANCE;
 
-    private static final AtomicReference<Consumer<Context>> onAttachConsumer = new AtomicReference<>();
+    private static final AtomicReference<Consumer<Context>> onAttachConsumer =
+        new AtomicReference<>();
 
     @Override
     public Scope attach(Context toAttach) {
@@ -63,7 +64,8 @@ public class BraveContextStorageProvider implements ContextStorageProvider {
 
     @Override
     public void onAttach(Consumer<Context> contextConsumer) {
-      onAttachConsumer.updateAndGet(existing -> existing != null ? existing.andThen(contextConsumer) : contextConsumer);
+      onAttachConsumer.updateAndGet(
+          existing -> existing != null ? existing.andThen(contextConsumer) : contextConsumer);
     }
   }
 

--- a/context/src/otelInGrpcTest/java/io/opentelemetry/context/GrpcContextStorageProvider.java
+++ b/context/src/otelInGrpcTest/java/io/opentelemetry/context/GrpcContextStorageProvider.java
@@ -20,7 +20,8 @@ public class GrpcContextStorageProvider implements ContextStorageProvider {
   private enum GrpcContextStorage implements ContextStorage {
     INSTANCE;
 
-    private static final AtomicReference<Consumer<Context>> onAttachConsumer = new AtomicReference<>();
+    private static final AtomicReference<Consumer<Context>> onAttachConsumer =
+        new AtomicReference<>();
 
     @Override
     public Scope attach(Context toAttach) {
@@ -56,7 +57,8 @@ public class GrpcContextStorageProvider implements ContextStorageProvider {
 
     @Override
     public void onAttach(Consumer<Context> contextConsumer) {
-      onAttachConsumer.updateAndGet(existing -> existing != null ? existing.andThen(contextConsumer) : contextConsumer);
+      onAttachConsumer.updateAndGet(
+          existing -> existing != null ? existing.andThen(contextConsumer) : contextConsumer);
     }
 
     private static void onAttach(io.grpc.Context toAttach) {

--- a/context/src/otelInGrpcTest/java/io/opentelemetry/context/GrpcContextStorageProvider.java
+++ b/context/src/otelInGrpcTest/java/io/opentelemetry/context/GrpcContextStorageProvider.java
@@ -20,7 +20,7 @@ public class GrpcContextStorageProvider implements ContextStorageProvider {
   private enum GrpcContextStorage implements ContextStorage {
     INSTANCE;
 
-    private final AtomicReference<Consumer<Context>> onAttachConsumer = new AtomicReference<>();
+    private static final AtomicReference<Consumer<Context>> onAttachConsumer = new AtomicReference<>();
 
     @Override
     public Scope attach(Context toAttach) {
@@ -59,7 +59,7 @@ public class GrpcContextStorageProvider implements ContextStorageProvider {
       onAttachConsumer.updateAndGet(existing -> existing != null ? existing.andThen(contextConsumer) : contextConsumer);
     }
 
-    private void onAttach(io.grpc.Context toAttach) {
+    private static void onAttach(io.grpc.Context toAttach) {
       Consumer<Context> contextConsumer = onAttachConsumer.get();
       if (contextConsumer != null) {
         contextConsumer.accept(GrpcContextWrapper.wrapperFromGrpc(toAttach));

--- a/context/src/test/java/io/opentelemetry/context/LazyStorageTest.java
+++ b/context/src/test/java/io/opentelemetry/context/LazyStorageTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.net.URL;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -102,6 +103,10 @@ class LazyStorageTest {
         @Override
         public Context current() {
           return null;
+        }
+
+        @Override
+        public void onAttach(Consumer<Context> contextConsumer) {
         }
       };
 

--- a/context/src/test/java/io/opentelemetry/context/LazyStorageTest.java
+++ b/context/src/test/java/io/opentelemetry/context/LazyStorageTest.java
@@ -106,8 +106,7 @@ class LazyStorageTest {
         }
 
         @Override
-        public void onAttach(Consumer<Context> contextConsumer) {
-        }
+        public void onAttach(Consumer<Context> contextConsumer) {}
       };
 
   public static final class MockContextStorageProvider implements ContextStorageProvider {


### PR DESCRIPTION
Prototype API for registering a callback which is triggered when the current Context for the current thread is changing.

Exposes the current `ContextStorage` from the method `Context#storage`.

Adds a new method `ContextStorage#onAttach(Consumer<Context>)` to register a callback interface which is invoked when the current context is going to be changed.

I've not touched Javadocs or tests yet, wanted to first get feedback on the API surface.

Example of usage:

```java
ContextStorage.get().onAttach(toAttach -> {

    Span currentSpan = Span.fromContextOrNull(toAttach);
    if (currentSpan != null) {
        SpanContext spanContext = currentSpan.getSpanContext();
        MDC.put("trace_id", spanContext.getTraceIdAsHexString());
        MDC.put("span_id", spanContext.getSpanIdAsHexString());
    } else {
        MDC.remove("trace_id");
        MDC.remove("span_id");
    }
});
```