### PR TITLE
Use fine logging in w3c/b3 propagator instead of info.

### DIFF
--- a/api/src/main/java/io/opentelemetry/api/trace/propagation/HttpTraceContext.java
+++ b/api/src/main/java/io/opentelemetry/api/trace/propagation/HttpTraceContext.java
@@ -175,7 +175,7 @@ public final class HttpTraceContext implements TextMapPropagator {
           contextFromParentHeader.getTraceFlags(),
           traceState);
     } catch (IllegalArgumentException e) {
-      logger.info("Unparseable tracestate header. Returning span context without state.");
+      logger.fine("Unparseable tracestate header. Returning span context without state.");
       return contextFromParentHeader;
     }
   }
@@ -191,7 +191,7 @@ public final class HttpTraceContext implements TextMapPropagator {
             && traceparent.charAt(SPAN_ID_OFFSET - 1) == TRACEPARENT_DELIMITER
             && traceparent.charAt(TRACE_OPTION_OFFSET - 1) == TRACEPARENT_DELIMITER;
     if (!isValid) {
-      logger.info("Unparseable traceparent header. Returning INVALID span context.");
+      logger.fine("Unparseable traceparent header. Returning INVALID span context.");
       return SpanContext.getInvalid();
     }
 
@@ -213,7 +213,7 @@ public final class HttpTraceContext implements TextMapPropagator {
       }
       return SpanContext.getInvalid();
     } catch (IllegalArgumentException e) {
-      logger.info("Unparseable traceparent header. Returning INVALID span context.");
+      logger.fine("Unparseable traceparent header. Returning INVALID span context.");
       return SpanContext.getInvalid();
     }
   }

--- a/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/Common.java
+++ b/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/Common.java
@@ -44,7 +44,7 @@ final class Common {
           traceFlags,
           TraceState.getDefault());
     } catch (Exception e) {
-      logger.log(Level.INFO, "Error parsing header. Returning INVALID span context.", e);
+      logger.log(Level.FINE, "Error parsing header. Returning INVALID span context.", e);
       return SpanContext.getInvalid();
     }
   }


### PR DESCRIPTION
It looks like w3c was the only one logging at info

Fixes #1963