### PR TITLE
Expose ThreadLocalContextStorage publicly

### DIFF
--- a/context/src/main/java/io/opentelemetry/context/ContextStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/ContextStorage.java
@@ -34,7 +34,7 @@ package io.opentelemetry.context;
  * >
  * >   @Override
  * >   public ContextStorage get() {
- * >     ContextStorage threadLocalStorage = Context.threadLocalStorage();
+ * >     ContextStorage threadLocalStorage = ContextStorage.threadLocalStorage();
  * >     return new RequestContextStorage() {
  * >       @Override
  * >       public Scope T attach(Context toAttach) {
@@ -67,6 +67,15 @@ public interface ContextStorage {
    */
   static ContextStorage get() {
     return LazyStorage.get();
+  }
+
+  /**
+   * Returns the default {@link ContextStorage} used to attach {@link Context}s to scopes of
+   * execution. Should only be used when defining your own {@link ContextStorage} in case you want
+   * to delegate functionality to the default implementation.
+   */
+  static ContextStorage threadLocalStorage() {
+    return ThreadLocalContextStorage.INSTANCE;
   }
 
   /**

--- a/context/src/main/java/io/opentelemetry/context/ContextStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/ContextStorage.java
@@ -34,7 +34,7 @@ package io.opentelemetry.context;
  * >
  * >   @Override
  * >   public ContextStorage get() {
- * >     ContextStorage threadLocalStorage = ContextStorage.threadLocalStorage();
+ * >     ContextStorage threadLocalStorage = ThreadLocalContextStorage.INSTANCE;
  * >     return new RequestContextStorage() {
  * >       @Override
  * >       public Scope T attach(Context toAttach) {
@@ -67,15 +67,6 @@ public interface ContextStorage {
    */
   static ContextStorage get() {
     return LazyStorage.get();
-  }
-
-  /**
-   * Returns the default {@link ContextStorage} used to attach {@link Context}s to scopes of
-   * execution. Should only be used when defining your own {@link ContextStorage} in case you want
-   * to delegate functionality to the default implementation.
-   */
-  static ContextStorage threadLocalStorage() {
-    return ThreadLocalContextStorage.INSTANCE;
   }
 
   /**

--- a/context/src/main/java/io/opentelemetry/context/DefaultContext.java
+++ b/context/src/main/java/io/opentelemetry/context/DefaultContext.java
@@ -28,15 +28,6 @@ final class DefaultContext implements Context {
 
   private static final Context ROOT = new DefaultContext();
 
-  /**
-   * Returns the default {@link ContextStorage} used to attach {@link Context}s to scopes of
-   * execution. Should only be used when defining your own {@link ContextStorage} in case you want
-   * to delegate functionality to the default implementation.
-   */
-  static ContextStorage threadLocalStorage() {
-    return ThreadLocalContextStorage.INSTANCE;
-  }
-
   // Used by auto-instrumentation agent. Check with auto-instrumentation before making changes to
   // this method.
   static Context root() {

--- a/context/src/main/java/io/opentelemetry/context/LazyStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/LazyStorage.java
@@ -83,7 +83,7 @@ final class LazyStorage {
     }
 
     if (providers.isEmpty()) {
-      return DefaultContext.threadLocalStorage();
+      return ContextStorage.threadLocalStorage();
     }
 
     if (providerClassName.isEmpty()) {
@@ -98,7 +98,7 @@ final class LazyStorage {
                   + "qualified class name of the provider to use. Falling back to default "
                   + "ContextStorage. Found providers: "
                   + providers));
-      return DefaultContext.threadLocalStorage();
+      return ContextStorage.threadLocalStorage();
     }
 
     for (ContextStorageProvider provider : providers) {
@@ -114,7 +114,7 @@ final class LazyStorage {
                 + providerClassName
                 + " but found providers: "
                 + providers));
-    return DefaultContext.threadLocalStorage();
+    return ContextStorage.threadLocalStorage();
   }
 
   private LazyStorage() {}

--- a/context/src/main/java/io/opentelemetry/context/LazyStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/LazyStorage.java
@@ -83,7 +83,7 @@ final class LazyStorage {
     }
 
     if (providers.isEmpty()) {
-      return ContextStorage.threadLocalStorage();
+      return ThreadLocalContextStorage.INSTANCE;
     }
 
     if (providerClassName.isEmpty()) {
@@ -98,7 +98,7 @@ final class LazyStorage {
                   + "qualified class name of the provider to use. Falling back to default "
                   + "ContextStorage. Found providers: "
                   + providers));
-      return ContextStorage.threadLocalStorage();
+      return ThreadLocalContextStorage.INSTANCE;
     }
 
     for (ContextStorageProvider provider : providers) {
@@ -114,7 +114,7 @@ final class LazyStorage {
                 + providerClassName
                 + " but found providers: "
                 + providers));
-    return ContextStorage.threadLocalStorage();
+    return ThreadLocalContextStorage.INSTANCE;
   }
 
   private LazyStorage() {}

--- a/context/src/main/java/io/opentelemetry/context/ThreadLocalContextStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/ThreadLocalContextStorage.java
@@ -8,7 +8,7 @@ package io.opentelemetry.context;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-enum ThreadLocalContextStorage implements ContextStorage {
+public enum ThreadLocalContextStorage implements ContextStorage {
   INSTANCE;
 
   private static final Logger logger = Logger.getLogger(ThreadLocalContextStorage.class.getName());

--- a/context/src/test/java/io/opentelemetry/context/LazyStorageTest.java
+++ b/context/src/test/java/io/opentelemetry/context/LazyStorageTest.java
@@ -31,7 +31,7 @@ class LazyStorageTest {
   @Test
   public void empty_provides() {
     assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
-        .isEqualTo(ContextStorage.threadLocalStorage());
+        .isEqualTo(ThreadLocalContextStorage.INSTANCE);
   }
 
   @Test
@@ -39,7 +39,7 @@ class LazyStorageTest {
     System.setProperty(
         CONTEXT_STORAGE_PROVIDER_PROPERTY, MockContextStorageProvider.class.getName());
     assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
-        .isEqualTo(ContextStorage.threadLocalStorage());
+        .isEqualTo(ThreadLocalContextStorage.INSTANCE);
   }
 
   @Test
@@ -58,7 +58,7 @@ class LazyStorageTest {
     File serviceFile = createContextStorageProvider();
     try {
       assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
-          .isEqualTo(ContextStorage.threadLocalStorage());
+          .isEqualTo(ThreadLocalContextStorage.INSTANCE);
     } finally {
       serviceFile.delete();
     }

--- a/context/src/test/java/io/opentelemetry/context/LazyStorageTest.java
+++ b/context/src/test/java/io/opentelemetry/context/LazyStorageTest.java
@@ -31,7 +31,7 @@ class LazyStorageTest {
   @Test
   public void empty_provides() {
     assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
-        .isEqualTo(DefaultContext.threadLocalStorage());
+        .isEqualTo(ContextStorage.threadLocalStorage());
   }
 
   @Test
@@ -39,7 +39,7 @@ class LazyStorageTest {
     System.setProperty(
         CONTEXT_STORAGE_PROVIDER_PROPERTY, MockContextStorageProvider.class.getName());
     assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
-        .isEqualTo(DefaultContext.threadLocalStorage());
+        .isEqualTo(ContextStorage.threadLocalStorage());
   }
 
   @Test
@@ -58,7 +58,7 @@ class LazyStorageTest {
     File serviceFile = createContextStorageProvider();
     try {
       assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
-          .isEqualTo(DefaultContext.threadLocalStorage());
+          .isEqualTo(ContextStorage.threadLocalStorage());
     } finally {
       serviceFile.delete();
     }


### PR DESCRIPTION
Exposes the `ThreadLocalContextStorage` enum publicly to enable writing cimple `ContextStorage` implementations without having to rewrite the storage.  Updates the Javadocs for `ContextStorage` to replace the non-existent `Context#threadLocalStorage` method with `ThreadLocalContextStorage.INSTANCE`.