### PR TITLE
Documents that ContextStorage.current can return null

### DIFF
--- a/context/src/main/java/io/opentelemetry/context/ContextStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/ContextStorage.java
@@ -22,6 +22,8 @@
 
 package io.opentelemetry.context;
 
+import javax.annotation.Nullable;
+
 /**
  * The storage for storing and retrieving the current {@link Context}.
  *
@@ -77,8 +79,9 @@ public interface ContextStorage {
   Scope attach(Context toAttach);
 
   /**
-   * Returns the current {@link DefaultContext}. If no {@link DefaultContext} has been attached yet,
-   * this will be the {@linkplain Context#root()} root context}.
+   * Returns the current {@link Context}. If no {@link Context} has been attached yet, this will
+   * return {@code null}.
    */
+  @Nullable
   Context current();
 }

--- a/context/src/main/java/io/opentelemetry/context/ThreadLocalContextStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/ThreadLocalContextStorage.java
@@ -15,10 +15,6 @@ enum ThreadLocalContextStorage implements ContextStorage {
 
   private static final ThreadLocal<Context> THREAD_LOCAL_STORAGE = new ThreadLocal<>();
 
-  static {
-    THREAD_LOCAL_STORAGE.set(Context.root());
-  }
-
   @Override
   public Scope attach(Context toAttach) {
     if (toAttach == null) {
@@ -45,7 +41,8 @@ enum ThreadLocalContextStorage implements ContextStorage {
 
   @Override
   public Context current() {
-    return THREAD_LOCAL_STORAGE.get();
+    Context threadContext = THREAD_LOCAL_STORAGE.get();
+    return threadContext != null ? threadContext : Context.root();
   }
 
   enum NoopScope implements Scope {

--- a/context/src/main/java/io/opentelemetry/context/ThreadLocalContextStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/ThreadLocalContextStorage.java
@@ -7,6 +7,7 @@ package io.opentelemetry.context;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 enum ThreadLocalContextStorage implements ContextStorage {
   INSTANCE;
@@ -40,9 +41,9 @@ enum ThreadLocalContextStorage implements ContextStorage {
   }
 
   @Override
+  @Nullable
   public Context current() {
-    Context threadContext = THREAD_LOCAL_STORAGE.get();
-    return threadContext != null ? threadContext : Context.root();
+    return THREAD_LOCAL_STORAGE.get();
   }
 
   enum NoopScope implements Scope {


### PR DESCRIPTION
~~Currently the `ThreadLocalContextStorage` sets the `ThreadLocal` to `Context.root()` within the static constructor.  However, this only sets the value of the `ThreadLocal` for the thread that happens to execute that constructor.  For all other threads the `ThreadLocal` remains unset and `THREAD_LOCAL_STORAGE.get()` will return `null` which is likely unexpected by the consumer.~~

~~There are two options here:~~

1. ~~Have `THREAD_LOCAL_STORAGE` be a class derived from `ThreadLocal<Context>` and override the `initialValue` method to return an initial value for when the thread local has not been set for the current thread.~~
2. ~~Have `current()` check if `THREAD_LOCAL_STORAGE.get()` returns `null` and return `Context.root()` instead.~~

~~Since all reads to the `ThreadLocal` go through the `current()` method I went with the second option as I find it the easiest to understand.~~

Updates the docs and annotations on `ContextStorage#current` to make it clear that the method may return `null` if no context has been attached to the current thread.  Also removes the static constructor in `ThreadLocalContextStorage` that sets the `ThreadLocal<Context>` to `Context.root()` for the thread that invokes the constructor.