### PR TITLE
Expose foreach consumer instead of entries for trace state.

### DIFF
--- a/api/src/main/java/io/opentelemetry/api/trace/TraceState.java
+++ b/api/src/main/java/io/opentelemetry/api/trace/TraceState.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -62,6 +63,23 @@ public abstract class TraceState {
       }
     }
     return null;
+  }
+
+  /** Returns the number of entries in this {@link TraceState}. */
+  public int size() {
+    return getEntries().size();
+  }
+
+  /** Returns whether this {@link TraceState} is empty, containing no entries. */
+  public boolean isEmpty() {
+    return getEntries().isEmpty();
+  }
+
+  /** Iterates over all the key-value entries contained in this {@link TraceState}. */
+  public void forEach(BiConsumer<String, String> consumer) {
+    for (Entry entry : getEntries()) {
+      consumer.accept(entry.getKey(), entry.getValue());
+    }
   }
 
   /**
@@ -170,7 +188,7 @@ public abstract class TraceState {
   /** Immutable key-value pair for {@code TraceState}. */
   @Immutable
   @AutoValue
-  public abstract static class Entry {
+  abstract static class Entry {
     /**
      * Creates a new {@code Entry} for the {@code TraceState}.
      *
@@ -178,7 +196,8 @@ public abstract class TraceState {
      * @param value the Entry's value.
      * @return the new {@code Entry}.
      */
-    public static Entry create(String key, String value) {
+    // Visible for testing
+    static Entry create(String key, String value) {
       Objects.requireNonNull(key, "key");
       Objects.requireNonNull(value, "value");
       Utils.checkArgument(validateKey(key), "Invalid key %s", key);
@@ -191,14 +210,14 @@ public abstract class TraceState {
      *
      * @return the key {@code String}.
      */
-    public abstract String getKey();
+    abstract String getKey();
 
     /**
      * Returns the value {@code String}.
      *
      * @return the value {@code String}.
      */
-    public abstract String getValue();
+    abstract String getValue();
 
     Entry() {}
   }

--- a/api/src/main/java/io/opentelemetry/api/trace/TraceState.java
+++ b/api/src/main/java/io/opentelemetry/api/trace/TraceState.java
@@ -87,7 +87,7 @@ public abstract class TraceState {
    *
    * @return a {@link List} view of the mappings contained in this {@code TraceState}.
    */
-  public abstract List<Entry> getEntries();
+  abstract List<Entry> getEntries();
 
   /**
    * Returns a {@code Builder} based on an empty {@code TraceState}.

--- a/api/src/main/java/io/opentelemetry/api/trace/propagation/HttpTraceContext.java
+++ b/api/src/main/java/io/opentelemetry/api/trace/propagation/HttpTraceContext.java
@@ -119,21 +119,19 @@ public final class HttpTraceContext implements TextMapPropagator {
     chars[TRACE_OPTION_OFFSET - 1] = TRACEPARENT_DELIMITER;
     spanContext.copyTraceFlagsHexTo(chars, TRACE_OPTION_OFFSET);
     setter.set(carrier, TRACE_PARENT, new String(chars, 0, TRACEPARENT_HEADER_SIZE));
-    List<TraceState.Entry> entries = spanContext.getTraceState().getEntries();
-    if (entries.isEmpty()) {
+    TraceState traceState = spanContext.getTraceState();
+    if (traceState.isEmpty()) {
       // No need to add an empty "tracestate" header.
       return;
     }
     StringBuilder stringBuilder = new StringBuilder(TRACESTATE_MAX_SIZE);
-    for (TraceState.Entry entry : entries) {
-      if (stringBuilder.length() != 0) {
-        stringBuilder.append(TRACESTATE_ENTRY_DELIMITER);
-      }
-      stringBuilder
-          .append(entry.getKey())
-          .append(TRACESTATE_KEY_VALUE_DELIMITER)
-          .append(entry.getValue());
-    }
+    traceState.forEach(
+        (key, value) -> {
+          if (stringBuilder.length() != 0) {
+            stringBuilder.append(TRACESTATE_ENTRY_DELIMITER);
+          }
+          stringBuilder.append(key).append(TRACESTATE_KEY_VALUE_DELIMITER).append(value);
+        });
     setter.set(carrier, TRACE_STATE, stringBuilder.toString());
   }
 

--- a/api/src/test/java/io/opentelemetry/api/trace/TraceStateTest.java
+++ b/api/src/test/java/io/opentelemetry/api/trace/TraceStateTest.java
@@ -6,10 +6,12 @@
 package io.opentelemetry.api.trace;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.testing.EqualsTester;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link TraceState}. */
@@ -35,16 +37,32 @@ class TraceStateTest {
   }
 
   @Test
-  void getEntries() {
-    assertThat(firstTraceState.getEntries())
-        .containsExactly(TraceState.Entry.create(FIRST_KEY, FIRST_VALUE));
-    assertThat(secondTraceState.getEntries())
-        .containsExactly(TraceState.Entry.create(SECOND_KEY, SECOND_VALUE));
+  void sizeAndEmpty() {
+    assertThat(EMPTY.size()).isZero();
+    assertThat(EMPTY.isEmpty()).isTrue();
+
+    assertThat(firstTraceState.size()).isOne();
+    assertThat(firstTraceState.isEmpty()).isFalse();
+
+    assertThat(multiValueTraceState.size()).isEqualTo(2);
+    assertThat(multiValueTraceState.isEmpty()).isFalse();
+  }
+
+  @Test
+  void forEach() {
+    LinkedHashMap<String, String> entries = new LinkedHashMap<>();
+    firstTraceState.forEach(entries::put);
+    assertThat(entries).containsExactly(entry(FIRST_KEY, FIRST_VALUE));
+
+    entries.clear();
+    secondTraceState.forEach(entries::put);
+    assertThat(entries).containsExactly(entry(SECOND_KEY, SECOND_VALUE));
+
+    entries.clear();
+    multiValueTraceState.forEach(entries::put);
     // Reverse order of input.
-    assertThat(multiValueTraceState.getEntries())
-        .containsExactly(
-            TraceState.Entry.create(SECOND_KEY, SECOND_VALUE),
-            TraceState.Entry.create(FIRST_KEY, FIRST_VALUE));
+    assertThat(entries)
+        .containsExactly(entry(SECOND_KEY, SECOND_VALUE), entry(FIRST_KEY, FIRST_VALUE));
   }
 
   @Test


### PR DESCRIPTION
I noticed instead of exposing `Entry`, we can follow the same pattern as we do in `Attributes`. We could remove Entry completely in the future if wanted (presumably users will prefer us to implement `Map` in the future anyways)