### PR TITLE
Keep Span Attributes in order, as the spec strongly suggests.

### DIFF
--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/AttributesMap.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/AttributesMap.java
@@ -7,9 +7,9 @@ package io.opentelemetry.sdk.trace;
 
 import io.opentelemetry.api.common.AttributeConsumer;
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.ReadableAttributes;
-import java.util.HashMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -19,13 +19,18 @@ import java.util.Map;
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 final class AttributesMap implements ReadableAttributes {
-  private final Map<AttributeKey, Object> data = new HashMap<>();
+  private final Map<AttributeKey, Object> data;
 
   private final long capacity;
   private int totalAddedValues = 0;
 
-  AttributesMap(long capacity) {
+  private AttributesMap(long capacity, Map<AttributeKey, Object> data) {
     this.capacity = capacity;
+    this.data = data;
+  }
+
+  AttributesMap(long capacity) {
+    this(capacity, new LinkedHashMap<>());
   }
 
   public <T> void put(AttributeKey<T> key, T value) {
@@ -81,12 +86,8 @@ final class AttributesMap implements ReadableAttributes {
         + '}';
   }
 
-  @SuppressWarnings("rawtypes")
   ReadableAttributes immutableCopy() {
-    Attributes.Builder builder = Attributes.builder();
-    for (Map.Entry<AttributeKey, Object> entry : data.entrySet()) {
-      builder.put(entry.getKey(), entry.getValue());
-    }
-    return builder.build();
+    Map<AttributeKey, Object> dataCopy = new LinkedHashMap<>(data);
+    return new AttributesMap(capacity, Collections.unmodifiableMap(dataCopy));
   }
 }

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/AttributesMapTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/AttributesMapTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.trace;
+
+import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.AttributeConsumer;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.ReadableAttributes;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AttributesMapTest {
+  @Test
+  void attributesAreInOrder() {
+    AttributesMap attributesMap = new AttributesMap(5);
+    attributesMap.put(longKey("one"), 1L);
+    attributesMap.put(longKey("three"), 3L);
+    attributesMap.put(longKey("two"), 2L);
+    attributesMap.put(longKey("four"), 4L);
+    attributesMap.put(longKey("five"), 5L);
+
+    List<String> expectedKeyOrder = Arrays.asList("one", "three", "two", "four", "five");
+    List<Long> expectedValueOrder = Arrays.asList(1L, 3L, 2L, 4L, 5L);
+
+    assertOrdering(attributesMap, expectedKeyOrder, expectedValueOrder);
+    assertOrdering(attributesMap.immutableCopy(), expectedKeyOrder, expectedValueOrder);
+  }
+
+  private void assertOrdering(
+      ReadableAttributes attributes, List<String> expectedKeyOrder, List<Long> expectedValueOrder) {
+    attributes.forEach(
+        new AttributeConsumer() {
+          private int counter = 0;
+
+          @Override
+          public <T> void accept(AttributeKey<T> key, T value) {
+            String k = key.getKey();
+            Long val = (Long) value;
+            assertThat(val).isEqualTo(expectedValueOrder.get(counter));
+            assertThat(k).isEqualTo(expectedKeyOrder.get(counter++));
+          }
+        });
+  }
+}


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/common/common.md#attributes

This only changes attributes attached to Spans. Other attributes are sorted in lexigraphical order, by key, at the moment.

I don't know why the spec says that we should keep them in order...that feels like an odd expectation, especially for Java users who would probably think of them like a `Map`, which wouldn't provide ordering guarantees, normally.