### PR TITLE
Update CHANGELOG 0.10.0 formatting and edit entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,57 +2,76 @@
 
 ## Unreleased
 
-- API:
-    - BUGFIX: The `package-info` file was removed from the `io.otel.context` package because it made the project incompatible with JPMS.
-    - BREAKING CHANGE: The API no longer uses the `grpc-context` as the context implementation. It now uses `io.opentelemetry.context.Context`. This is published in the `opentelemetry-context` artifact. Interactions with the context have mostly been moved to static methods in the Span and Baggage interfaces.
-    - BREAKING CHANGE: The Baggage API has been reworked to more closely match the specification. This includes the removal of the `BaggageManager`. Baggage is fully functional within the API, without needing to install an SDK.
-    - BREAKING CHANGE: All parameters are now marked as non-nullable by default.
-    - BREAKING CHANGE: There have been many updates to the semantic conventions constants. The constants are now auto-generated from the yaml specification files, so the names will now be consistent across languages. For more information, see the YAML Model for Semantic Conventions.
-    - BREAKING CHANGE: All builder-creation methods have been renamed to `.builder()`.
-    - BREAKING CHANGE: `DefaultSpan` has been removed from the public API. Instead, use `Span.wrap(spanContext)` if you need a non-functional span that propagates the trace context.
-    - BREAKING CHANGE: Some functionality from the `Tracer` interface is now available either on the `Span` interface or `Context` interface.
-    - BREAKING CHANGE: `StatusCanonicalCode` has been renamed to `StatusCode`.
-    - BREAKING CHANGE: `TextMapPropagators` could receive a null carrier passed to the extract method.
-    - BREAKING CHANGE: The `OpenTelemetry` class is now an interface, with implementations. Methods on this interface have changed their names to reflect this change. 
-    - BREAKING CHANGE: `Span.getContext()` has been renamed to `Span.getSpanContext()`.
-    - BREAKING CHANGE: `AttributesBuilder` now uses `put` instead of `add` as the method name for adding attributes.
-    - BREAKING CHANGE: All API classes have been moved into the `io.opentelemetry.api.` prefix to support JPMS users.
-    - BREAKING CHANGE: `DefaultMeter`, `DefaultMeterProvider`, `DefaultTracer` and `DefaultTracerProvider` are no longer public. You can access the same functionality with `getDefault()` methods on the `Meter`, `MeterProvider, `Tracer`, and `TracerProvider` classes, respectively.
-    - BREAKING CHANGE: `TracingContextUtils` and `BaggageUtils` are no longer public classes in the API. Instead, use the appropriate static methods on the `Span` and `Baggage` classes, or use methods on the `Context` itself.
-    - BREAKING CHANGE: The context propagation APIs have moved into the new context module.
-    - BREAKING CHANGE: TraceState entries can now be iterated via a `forEach` method, rather than having the entries exposed directly.
-    - BREAKING CHANGE: EndSpanOptions have been removed from the Span API. Now, you just set the end timestamp directly, if you need it.
-    - Enhancement: The W3C Baggage Propagator has been added.
-    - Enhancement: The B3 Propagator now handles both single and multi-header formats.
-    - Enhancement: Mutating a method on `Span` now returns the `Span` to enable call-chaining.
+### API
 
-- SDK:
-    - BREAKING CHANGE: The `SpanData.*` implementation classes were made non-public, but the interfaces are still available.
-    - BREAKING CHANGE: `SpanProcessor.onStart` now takes a `Context` as its first parameter.
-    - BREAKING CHANGE: The `Sampler` interface now takes a parent `Context`, rather than a `SpanContext`.
-    - BREAKING CHANGE: `ValueObserver` instruments now use the `LastValue` aggregation.
-    - BREAKING CHANGE: The OTLP metric exporter now emits `gauge` metrics where appropriate.
-    - BREAKING CHANGE: `ValueObserver` instruments now generate gauge metrics, rather than non-monotonic counter-style metrics.
-    - BREAKING CHANGE: `TraceConfig` configuration option names (environment variables and system properties) have been updated to match the OpenTelemetery Specification.
-    - BREAKING CHANGE: The Jaeger gRPC exporter has been updated to match the OpenTelemetry Specification. The `message` log entry attribute has been renamed to `event` and a new `dropped attributes count` attribute has been added.
-    - BREAKING CHANGE: The `IdsGenerator` interface has been renamed to `IdGenerator`, and all implementations and relevant factory methods have been renamed accordingly.
-    - BREAKING CHANGE: The `RandomIdGenerator` is now accessible via a factory method on the `IdGenerator` class, rather than being exposed itself. Use `IdsGenerator.random()` to acquire an instance.
-    - BREAKING CHANGE: Each `Sampler` has been reorganized into their own classes and moved into the `io.opentelemetry.sdk.trace.samplers` package. Factory methods that used to be on the `Samplers` class have now been moved to the `Sampler` interface.
-    - BREAKING CHANGE: The `SpanData.getHasRemoteParent()` and `SpanData.getHasEnded()` methods have been renamed to `hasRemoteParent()` and `hasEnded()` respectively.
-    - Enhancement: A new `opentelemetry-sdk-testing` module has been created with a JUnit 5 extension to assist with testing. 
-    - Enhancement: The `Sampler` interface now allows a `Sampler` implementation to update the `TraceState` that is applied to the `SpanContext` for the resulting span.
-    - A new `MetricData` gauge metric type is available. 
-    - The Prometheus metric exporter now consumes `gauge` metrics. 
-    - The Jaeger gRPC exporter now maps `Resource` entries to process tags.
-    - The OTLP protobuf definitions have been updated to the latest released version: 0.6.0. Both the Span and Metric exporters have been updated to match.
+#### Enhancements
 
-- Extensions:
-    - BREAKING CHANGE: The OpenTracing shim factory class has been renamed from `TraceShim` to `OpenTracingShim`. The factory methods have changed, due to the removal of the `BaggageManager` and the introduction of the availability of non-global `OpenTelemetry` instances.
-    - BREAKING CHANGE: The in-memory exporter(s) have been moved to the `opentelemetry-sdk-testing` artifact.
-    - A new JUnit5 extension has been added for writing tests that use the SDK. See `io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension` in the new `opentelemetry-sdk-testing` module. 
-    - This release adds a Jaeger SpanExporter which exports via the thrift-over-http protocol.
-    - All of the exporter artifacts have had the 's' removed from the word "exporters". So, for example, `opentelemetry-exporters-logging` has been renamed to `opentelemetry-exporter-logging`. 
+- The W3C Baggage Propagator is now available.
+- The B3 Propagator now handles both single and multi-header formats.
+- Mutating a method on `Span` now returns the `Span` to enable call-chaining.
 
+#### Bug fixes
+
+- The `package-info` file was removed from the `io.otel.context` package because it made the project incompatible with JPMS.
+
+#### Breaking changes
+
+- There have been many updates to the semantic conventions constants. The constants are now auto-generated from the YAML specification files, so the names will now be consistent across languages. For more information, see the [YAML Model for Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/master/semantic_conventions).
+- All API classes have been moved into the `io.opentelemetry.api.` prefix to support JPMS users.
+- The API no longer uses the `grpc-context` as the context implementation. It now uses `io.opentelemetry.context.Context`. This is published in the `opentelemetry-context` artifact. Interactions with the context were mostly moved to static methods in the `Span` and `Baggage` interfaces.
+- The Baggage API has been reworked to more closely match the specification. This includes the removal of the `BaggageManager`. Baggage is fully functional within the API, without needing to install an SDK.
+- `TracingContextUtils` and `BaggageUtils` were removed from the public API. Instead, use the appropriate static methods on the `Span` and `Baggage` classes, or use methods on the `Context` itself.
+- The context propagation APIs have moved into the new `opentelemetry-context` context module.
+- `DefaultSpan` was removed from the public API. Instead, use `Span.wrap(spanContext)` if you need a non-functional span that propagates the trace context.
+- `DefaultMeter`, `DefaultMeterProvider`, `DefaultTracer` and `DefaultTracerProvider` were removed from the public API. You can access the same functionality with `getDefault()` methods on the `Meter`, `MeterProvider, `Tracer`, and `TracerProvider` classes, respectively.
+- Some functionality from the `Tracer` interface is now available either on the `Span` interface or `Context` interface.
+- The `OpenTelemetry` class is now an interface, with implementations. Methods on this interface have changed their names to reflect this change. For more information, see [OpenTelemetry.java](/api/src/main/java/io/opentelemetry/api/OpenTelemetry.java).
+- All builder-creation methods have been renamed to `.builder()`.
+- `StatusCanonicalCode` has been renamed to `StatusCode`.
+- `Span.getContext()` has been renamed to `Span.getSpanContext()`.
+- `AttributesBuilder` now uses `put` instead of `add` as the method name for adding attributes.
+- All parameters are now marked as non-nullable by default.
+- `TextMapPropagators` could receive a null carrier passed to the extract method.
+
+### SDK
+
+#### Enhancements
+
+- A new `MetricData` gauge metric type is now available. 
+- A new `opentelemetry-sdk-testing` module with a JUnit 5 extension to assist with testing is now available.
+- The Prometheus metric exporter now consumes `gauge` metrics.
+- The Jaeger gRPC exporter now maps `Resource` entries to process tags.
+- The OTLP protobuf definitions were updated to the latest released version: 0.6.0. Both the `Span` and `Metric` exporters were updated to match.
+- The `Sampler` interface now allows a `Sampler` implementation to update the `TraceState` that is applied to the `SpanContext` for the resulting span.
+
+#### Breaking changes
+
+- `TraceConfig` configuration option names (environment variables and system properties) were renamed to match the OpenTelemetery Specification. For more information, see [TraceConfig](./QUICKSTART.md#TraceConfig).
+- The Jaeger gRPC exporter was updated to match the OpenTelemetry Specification. The `message` log entry attribute has been renamed to `event` and a new `dropped attributes count` attribute was added. For more information, see the [Overview](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/overview.md).
+- The `SpanData.getHasRemoteParent()` and `SpanData.getHasEnded()` methods were renamed to `hasRemoteParent()` and `hasEnded()`, respectively.
+- The `IdsGenerator` interface has been renamed to `IdGenerator`, and all implementations and relevant factory methods were similarly renamed.
+- The `RandomIdGenerator` is now accessible via a factory method on the `IdGenerator` class, rather than being exposed itself. Use `IdGenerator.random()` to acquire an instance.
+- The OTLP metric exporter now emits `gauge` metrics where appropriate.
+- `ValueObserver` instruments now generate gauge metrics, rather than non-monotonic counter-style metrics.
+- `ValueObserver` instruments now use the `LastValue` aggregation instead of `MinMaxSumCount`.
+- The `SpanData.*` implementation classes were removed from the public SDK, but the interfaces are still available.
+- `SpanProcessor.onStart` now takes a `Context` as its first parameter.
+- The `Sampler` interface now takes a parent `Context` rather than a `SpanContext`.
+- Each `Sampler` has been reorganized into their own classes and moved into the `io.opentelemetry.sdk.trace.samplers` package. Factory methods that used to be on the `Samplers` class were moved to the `Sampler` interface.
+
+### Extensions
+
+#### Enhancements
+
+- A new JUnit5 extension was added for writing tests. For more information, see [OpenTelemetryExtension.java](sdk/testing/src/main/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtension.java). 
+- A Jaeger `SpanExporter` which exports via the `thrift-over-http protocol` is now available.
+
+#### Breaking changes
+
+- The in-memory exporter(s) have been moved to the `opentelemetry-sdk-testing` artifact.
+- The OpenTracing shim factory class has been renamed from `TraceShim` to `OpenTracingShim`. The factory methods have changed because `BaggageManager` was removed and non-global `OpenTelemetry` instances are now available.
+- The 's' was removed from the word "exporters" for every exporter artifact. For example, `opentelemetry-exporters-logging` was renamed to `opentelemetry-exporter-logging`. 
+- The 's' was removed from the word "extensions" for every SDK extension. For example, `io.opentelemetry.sdk.extensions.otproto.TraceProtoUtils` was renamed to `io.opentelemetry.sdk.extension.otproto.TraceProtoUtils`.
 
 ## 0.9.1 - 2020-10-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@
 - The in-memory exporter(s) have been moved to the `opentelemetry-sdk-testing` artifact.
 - The OpenTracing shim factory class has been renamed from `TraceShim` to `OpenTracingShim`. The factory methods have changed because `BaggageManager` was removed and non-global `OpenTelemetry` instances are now available.
 - The 's' was removed from the word "exporters" for every exporter artifact. For example, `opentelemetry-exporters-logging` was renamed to `opentelemetry-exporter-logging`. 
-- The 's' was removed from the word "extensions" for every SDK extension. For example, `io.opentelemetry.sdk.extensions.otproto.TraceProtoUtils` was renamed to `io.opentelemetry.sdk.extension.otproto.TraceProtoUtils`.
+- The 's' was removed from the word "extensions" for the package for every SDK extension. For example, `io.opentelemetry.sdk.extensions.otproto.TraceProtoUtils` was renamed to `io.opentelemetry.sdk.extension.otproto.TraceProtoUtils`.
 
 ## 0.9.1 - 2020-10-07
 


### PR DESCRIPTION
- update formatting for unreleased CHANGELOG entries
- final edit of unreleased CHANGELOG entries
- added [PR-2002](https://github.com/open-telemetry/opentelemetry-java/pull/2002) to extensions breaking changes