### PR TITLE
Switch animal sniffer signature to gummy bears.

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     annotationProcessor libraries.auto_value
 
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 
     testImplementation libraries.jqf
 }

--- a/build.gradle
+++ b/build.gradle
@@ -337,7 +337,10 @@ configure(opentelemetryProjects) {
                 jaeger_client           : 'io.jaegertracing:jaeger-client:1.2.0', // Jaeger Client
                 zipkin_junit            : "io.zipkin.zipkin2:zipkin-junit:${zipkinVersion}",  // Zipkin JUnit rule
                 archunit                : 'com.tngtech.archunit:archunit-junit4:0.13.1', //Architectural constraints
-                jqf                     : 'edu.berkeley.cs.jqf:jqf-fuzz:1.6' // fuzz testing
+                jqf                     : 'edu.berkeley.cs.jqf:jqf-fuzz:1.6', // fuzz testing
+
+                // Tooling
+                android_signature       : 'com.toasttab.android:gummy-bears-api-24:0.2.0:coreLib@signature'
         ]
     }
 

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -29,5 +29,5 @@ dependencies {
 
     testImplementation libraries.awaitility
 
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 }

--- a/exporters/jaeger-thrift/build.gradle
+++ b/exporters/jaeger-thrift/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation project(':opentelemetry-sdk-testing')
 
     signature "org.codehaus.mojo.signature:java18:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 }
 
 animalsniffer {

--- a/exporters/jaeger/build.gradle
+++ b/exporters/jaeger/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     testRuntime "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
     signature "org.codehaus.mojo.signature:java18:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 }
 
 animalsniffer {

--- a/exporters/logging/build.gradle
+++ b/exporters/logging/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation project(':opentelemetry-sdk-testing')
 
     signature "org.codehaus.mojo.signature:java18:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 }
 
 animalsniffer {

--- a/exporters/otlp/build.gradle
+++ b/exporters/otlp/build.gradle
@@ -24,5 +24,5 @@ dependencies {
     testRuntime "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
     signature "org.codehaus.mojo.signature:java18:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 }

--- a/exporters/prometheus/build.gradle
+++ b/exporters/prometheus/build.gradle
@@ -16,5 +16,5 @@ dependencies {
     testImplementation libraries.prometheus_client_common
 
     signature "org.codehaus.mojo.signature:java18:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 }

--- a/exporters/zipkin/build.gradle
+++ b/exporters/zipkin/build.gradle
@@ -23,7 +23,7 @@ dependencies {
             libraries.zipkin_junit
 
     signature "org.codehaus.mojo.signature:java18:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 }
 
 configurations {

--- a/extensions/trace-propagators/build.gradle
+++ b/extensions/trace-propagators/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     testImplementation libraries.jaeger_client
 
     signature "org.codehaus.mojo.signature:java18:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 }

--- a/extensions/trace-utils/build.gradle
+++ b/extensions/trace-utils/build.gradle
@@ -14,5 +14,5 @@ dependencies {
     annotationProcessor libraries.auto_value
 
     signature "org.codehaus.mojo.signature:java18:1.0@signature"
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 }

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -31,7 +31,7 @@ dependencies {
             libraries.testcontainers,
             libraries.okhttp
 
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 
     tasks.withType(Test) {
         dependsOn fatJar

--- a/proto/build.gradle
+++ b/proto/build.gradle
@@ -15,7 +15,7 @@ dependencies {
             libraries.grpc_protobuf,
             libraries.grpc_stub
 
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 }
 
 animalsniffer {

--- a/sdk-extensions/aws-v1-support/build.gradle
+++ b/sdk-extensions/aws-v1-support/build.gradle
@@ -22,5 +22,5 @@ dependencies {
 
     testImplementation 'com.github.tomakehurst:wiremock-jre8:2.26.3'
 
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 }

--- a/sdk-extensions/jaeger-remote-sampler/build.gradle
+++ b/sdk-extensions/jaeger-remote-sampler/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 
     testRuntime "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 }
 
 animalsniffer {

--- a/sdk-extensions/logging/build.gradle
+++ b/sdk-extensions/logging/build.gradle
@@ -15,5 +15,5 @@ dependencies {
 
     annotationProcessor libraries.auto_value
 
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 }

--- a/sdk-extensions/otproto/build.gradle
+++ b/sdk-extensions/otproto/build.gradle
@@ -19,5 +19,5 @@ dependencies {
     testImplementation "io.grpc:grpc-testing:${grpcVersion}"
     testRuntime "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 }

--- a/sdk-extensions/resources/build.gradle
+++ b/sdk-extensions/resources/build.gradle
@@ -14,5 +14,5 @@ dependencies {
     testImplementation libraries.junit_pioneer
 
     // TODO(anuraaga): Use reflection for RuntimeMXBean which is not included in Android.
-    // signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    // signature libraries.android_signature
 }

--- a/sdk-extensions/tracing-incubator/build.gradle
+++ b/sdk-extensions/tracing-incubator/build.gradle
@@ -18,5 +18,5 @@ dependencies {
     annotationProcessor libraries.auto_value
     testImplementation project(':opentelemetry-sdk-testing')
 
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 }

--- a/sdk/all/build.gradle
+++ b/sdk/all/build.gradle
@@ -33,7 +33,7 @@ dependencies {
         transitive = false
     }
 
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 }
 
 sourceSets {

--- a/sdk/common/build.gradle
+++ b/sdk/common/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation project(':opentelemetry-sdk-testing')
     testImplementation libraries.junit_pioneer
 
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 }
 
 sourceSets {

--- a/sdk/metrics/build.gradle
+++ b/sdk/metrics/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     testImplementation project(':opentelemetry-sdk-testing')
     testImplementation libraries.junit_pioneer
 
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 }
 
 sourceSets {

--- a/sdk/tracing/build.gradle
+++ b/sdk/tracing/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     testImplementation project(':opentelemetry-sdk-testing')
     testImplementation libraries.junit_pioneer
 
-    signature "net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature"
+    signature libraries.android_signature
 }
 
 sourceSets {

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,7 +11,7 @@ pluginManagement {
         id "nebula.release" version "15.1.0"
         id "net.ltgt.errorprone" version "1.3.0"
         id "org.unbroken-dome.test-sets" version "3.0.1"
-        id "ru.vyarus.animalsniffer" version "1.5.1"
+        id "ru.vyarus.animalsniffer" version "1.5.2"
     }
 
     repositories {


### PR DESCRIPTION
As far as I can tell, the androidscents we use and is commonly documented is basically unmaintained - I can't find a project page and the last release was Android API 27 some years ago. So naturally they also don't have any signature that models the desugaring mechanism we are expecting Android users to do.

Gummy bears is a relatively new project but seems to be filling this void excellently

https://github.com/open-toast/gummy-bears

I confirmed that the new signature accepts `Instant` with the `coreLib` classifier version and fails without it

Fixes #1808

Changelog:
- Replace animalsniffer Android API check with gummy bears to recognize modern Android desugaring