### PR TITLE
Add paths-ignore for PR Build

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - "**.md"
 
 jobs:
   build:

--- a/.github/workflows/pr-examples-build.yml
+++ b/.github/workflows/pr-examples-build.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - 'examples/**'
+      - '!**.md'
 jobs:
   build:
     name: Build


### PR DESCRIPTION
It's not necessary to run this build workflow when only  `*.md` files are modified. Please consider if that make sense.