### PR TITLE
Only deploy to artifactory when version is snapshot version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,10 @@ subprojects {
             }
         }
 
+        artifactoryPublish {
+            enabled = version.toString().endsWith('-SNAPSHOT')
+        }
+
         // Release artifacts publishing.
         bintray {
             user = System.getenv("BINTRAY_USER")


### PR DESCRIPTION
Apparently artifactory automatically gets enabled so need to explicitly disable it. Noticed instrumentation repo is doing it too.

https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/gradle/publish.gradle#L133

Changelog:

Tooling:
- Release workflow does not attempt to deploy to artifactory snapshot repo