### PR TITLE
Provide default implementations for SpanProcessor.shutdown and forceFlush

### DIFF
--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/NoopSpanProcessor.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/NoopSpanProcessor.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.sdk.trace;
 
 import io.opentelemetry.context.Context;
-import io.opentelemetry.sdk.common.CompletableResultCode;
 
 final class NoopSpanProcessor implements SpanProcessor {
   private static final NoopSpanProcessor INSTANCE = new NoopSpanProcessor();
@@ -29,16 +28,6 @@ final class NoopSpanProcessor implements SpanProcessor {
   @Override
   public boolean isEndRequired() {
     return false;
-  }
-
-  @Override
-  public CompletableResultCode shutdown() {
-    return CompletableResultCode.ofSuccess();
-  }
-
-  @Override
-  public CompletableResultCode forceFlush() {
-    return CompletableResultCode.ofSuccess();
   }
 
   private NoopSpanProcessor() {}

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
@@ -57,7 +57,7 @@ public interface SpanProcessor {
    * @return a {@link CompletableResultCode} which completes when shutdown is finished.
    */
   default CompletableResultCode shutdown() {
-    return CompletableResultCode.ofSuccess();
+    return forceFlush();
   }
 
   /**

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
@@ -56,7 +56,9 @@ public interface SpanProcessor {
    *
    * @return a {@link CompletableResultCode} which completes when shutdown is finished.
    */
-  CompletableResultCode shutdown();
+  default CompletableResultCode shutdown() {
+    return CompletableResultCode.ofSuccess();
+  }
 
   /**
    * Processes all span events that have not yet been processed.
@@ -64,5 +66,7 @@ public interface SpanProcessor {
    * @return a {@link CompletableResultCode} which completes when currently queued spans are
    *     finished processing.
    */
-  CompletableResultCode forceFlush();
+  default CompletableResultCode forceFlush() {
+    return CompletableResultCode.ofSuccess();
+  }
 }

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
@@ -98,12 +98,6 @@ public final class SimpleSpanProcessor implements SpanProcessor {
     return spanExporter.shutdown();
   }
 
-  @Override
-  public CompletableResultCode forceFlush() {
-    // Do nothing.
-    return CompletableResultCode.ofSuccess();
-  }
-
   /**
    * Returns a new Builder for {@link SimpleSpanProcessor}.
    *

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -136,18 +136,6 @@ class TracerSdkTest {
     public boolean isEndRequired() {
       return true;
     }
-
-    @Override
-    public CompletableResultCode shutdown() {
-      // no-op
-      return CompletableResultCode.ofSuccess();
-    }
-
-    @Override
-    public CompletableResultCode forceFlush() {
-      // no-op
-      return CompletableResultCode.ofSuccess();
-    }
   }
 
   private static class SimpleSpanOperation implements OperationUpdater {


### PR DESCRIPTION
closes [https://github.com/open-telemetry/opentelemetry-java/issues/1997](https://github.com/open-telemetry/opentelemetry-java/issues/1997)