### PR TITLE
Revert "Add paths-ignore for PR Build (#2017)"

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - "**.md"
 
 jobs:
   build:

--- a/.github/workflows/pr-examples-build.yml
+++ b/.github/workflows/pr-examples-build.yml
@@ -6,7 +6,6 @@ on:
       - master
     paths:
       - 'examples/**'
-      - '!**.md'
 jobs:
   build:
     name: Build


### PR DESCRIPTION
This reverts commit 72c88b61

Unfortunately, this made it so doc-only PRs can never go green, because we require the builds to pass for PRs. 