### PR TITLE
Reject null instrumentationName for Meters and Tracers

### DIFF
--- a/api/src/main/java/io/opentelemetry/api/metrics/DefaultMeterProvider.java
+++ b/api/src/main/java/io/opentelemetry/api/metrics/DefaultMeterProvider.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.api.metrics;
 
 import javax.annotation.concurrent.ThreadSafe;
+import java.util.Objects;
 
 @ThreadSafe
 final class DefaultMeterProvider implements MeterProvider {
@@ -23,6 +24,7 @@ final class DefaultMeterProvider implements MeterProvider {
 
   @Override
   public Meter get(String instrumentationName, String instrumentationVersion) {
+    Objects.requireNonNull(instrumentationName);
     return Meter.getDefault();
   }
 

--- a/api/src/main/java/io/opentelemetry/api/trace/DefaultTracerProvider.java
+++ b/api/src/main/java/io/opentelemetry/api/trace/DefaultTracerProvider.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.api.trace;
 
 import javax.annotation.concurrent.ThreadSafe;
+import java.util.Objects;
 
 @ThreadSafe
 class DefaultTracerProvider implements TracerProvider {
@@ -23,6 +24,7 @@ class DefaultTracerProvider implements TracerProvider {
 
   @Override
   public Tracer get(String instrumentationName, String instrumentationVersion) {
+    Objects.requireNonNull(instrumentationName);
     return Tracer.getDefault();
   }
 

--- a/api/src/test/java/io/opentelemetry/api/metrics/DefaultMeterProviderTest.java
+++ b/api/src/test/java/io/opentelemetry/api/metrics/DefaultMeterProviderTest.java
@@ -1,0 +1,14 @@
+package io.opentelemetry.api.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class DefaultMeterProviderTest {
+
+  @Test
+  void rejectsNullInstrumentationName() {
+    assertThrows(NullPointerException.class, () -> DefaultMeterProvider.getInstance().get(null));
+    assertThrows(NullPointerException.class, () -> DefaultMeterProvider.getInstance().get(null, "1.0.0"));
+  }
+}

--- a/api/src/test/java/io/opentelemetry/api/trace/DefaultTracerProviderTest.java
+++ b/api/src/test/java/io/opentelemetry/api/trace/DefaultTracerProviderTest.java
@@ -1,0 +1,14 @@
+package io.opentelemetry.api.trace;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DefaultTracerProviderTest {
+
+  @Test
+  void rejectsNullInstrumentationName() {
+    assertThrows(NullPointerException.class, () -> DefaultTracerProvider.getInstance().get(null));
+    assertThrows(NullPointerException.class, () -> DefaultTracerProvider.getInstance().get(null, "1.0.0"));
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkRegistryTest.java
@@ -101,4 +101,10 @@ class MeterSdkRegistryTest {
                 Collections.singletonList(
                     LongPoint.create(testClock.now(), testClock.now(), Labels.empty(), 10))));
   }
+
+  @Test
+  void rejectsNullInstrumentationName() {
+    assertThrows(NullPointerException.class, () -> meterProvider.get(null));
+    assertThrows(NullPointerException.class, () -> meterProvider.get(null, "1.0.0"));
+  }
 }

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkProviderTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkProviderTest.java
@@ -134,4 +134,10 @@ class TracerSdkProviderTest {
     assertThat(span.getSpanContext().isValid()).isFalse();
     span.end();
   }
+
+  @Test
+  void rejectsNullInstrumentationName() {
+    assertThrows(NullPointerException.class, () -> tracerFactory.get(null));
+    assertThrows(NullPointerException.class, () -> tracerFactory.get(null, "1.0.0"));
+  }
 }


### PR DESCRIPTION
The parameters were already marked as being @Nonnull. However, the SDK implementation failed when null was passed, while the API allowed null. The result is that one may publish a library that compiles and tests fine, but fails when the SDK is applied by an application developer.

This change adds test to verify the non-null behavior is consistently enforced, and adds checks to the API to enforce non-null. These checks will prevent library authors from creating libraries that crash at runtime.

Fixes #1879