### PR TITLE
Add a way to enforce default context storage implementation

### DIFF
--- a/context/build.gradle
+++ b/context/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     otelInBraveTestImplementation "io.zipkin.brave:brave:5.12.6"
 
     testImplementation libraries.awaitility
+    testImplementation libraries.junit_pioneer
 
     signature libraries.android_signature
 }

--- a/context/src/main/java/io/opentelemetry/context/DefaultContext.java
+++ b/context/src/main/java/io/opentelemetry/context/DefaultContext.java
@@ -28,15 +28,6 @@ final class DefaultContext implements Context {
 
   private static final Context ROOT = new DefaultContext();
 
-  /**
-   * Returns the default {@link ContextStorage} used to attach {@link Context}s to scopes of
-   * execution. Should only be used when defining your own {@link ContextStorage} in case you want
-   * to delegate functionality to the default implementation.
-   */
-  static ContextStorage threadLocalStorage() {
-    return ThreadLocalContextStorage.INSTANCE;
-  }
-
   // Used by auto-instrumentation agent. Check with auto-instrumentation before making changes to
   // this method.
   //

--- a/context/src/main/java/io/opentelemetry/context/LazyStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/LazyStorage.java
@@ -87,7 +87,7 @@ final class LazyStorage {
     String providerClassName = System.getProperty(CONTEXT_STORAGE_PROVIDER_PROPERTY, "");
     // Allow user to enforce default ThreadLocalContextStorage
     if (ENFORCE_DEFAULT_VALUE.equals(providerClassName)) {
-      return DefaultContext.threadLocalStorage();
+      return ContextStorage.defaultStorage();
     }
 
     List<ContextStorageProvider> providers = new ArrayList<>();
@@ -118,7 +118,7 @@ final class LazyStorage {
                   + "qualified class name of the provider to use. Falling back to default "
                   + "ContextStorage. Found providers: "
                   + providers));
-      return DefaultContext.threadLocalStorage();
+      return ContextStorage.defaultStorage();
     }
 
     for (ContextStorageProvider provider : providers) {
@@ -134,7 +134,7 @@ final class LazyStorage {
                 + providerClassName
                 + " but found providers: "
                 + providers));
-    return DefaultContext.threadLocalStorage();
+    return ContextStorage.defaultStorage();
   }
 
   private LazyStorage() {}

--- a/context/src/main/java/io/opentelemetry/context/LazyStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/LazyStorage.java
@@ -65,8 +65,7 @@ final class LazyStorage {
 
   private static final String CONTEXT_STORAGE_PROVIDER_PROPERTY =
       "io.opentelemetry.context.contextStorageProvider";
-  private static final String CONTEXT_STORAGE_PROVIDER_ENFORCE_DEFAULT_PROPERTY =
-      "io.opentelemetry.context.contextStorageProvider.enforceDefault";
+  private static final String ENFORCE_DEFAULT_VALUE = "default";
 
   private static final Logger logger = Logger.getLogger(LazyStorage.class.getName());
 
@@ -85,8 +84,8 @@ final class LazyStorage {
 
   static ContextStorage createStorage(AtomicReference<Throwable> deferredStorageFailure) {
     String providerClassName = System.getProperty(CONTEXT_STORAGE_PROVIDER_PROPERTY, "");
-    boolean enforceDefault = Boolean.getBoolean(CONTEXT_STORAGE_PROVIDER_ENFORCE_DEFAULT_PROPERTY);
-    if (enforceDefault) {
+    // enforceDefault
+    if (ENFORCE_DEFAULT_VALUE.equals(providerClassName)) {
       return DefaultContext.threadLocalStorage();
     }
 

--- a/context/src/main/java/io/opentelemetry/context/LazyStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/LazyStorage.java
@@ -65,7 +65,7 @@ final class LazyStorage {
 
   private static final String CONTEXT_STORAGE_PROVIDER_PROPERTY =
       "io.opentelemetry.context.contextStorageProvider";
-  private static final String ENFORCE_DEFAULT_VALUE = "default";
+  private static final String ENFORCE_DEFAULT_STORAGE_VALUE = "default";
 
   private static final Logger logger = Logger.getLogger(LazyStorage.class.getName());
 
@@ -84,9 +84,9 @@ final class LazyStorage {
 
   static ContextStorage createStorage(AtomicReference<Throwable> deferredStorageFailure) {
     // Get the specified SPI implementation first here
-    String providerClassName = System.getProperty(CONTEXT_STORAGE_PROVIDER_PROPERTY, "");
+    final String providerClassName = System.getProperty(CONTEXT_STORAGE_PROVIDER_PROPERTY, "");
     // Allow user to enforce default ThreadLocalContextStorage
-    if (ENFORCE_DEFAULT_VALUE.equals(providerClassName)) {
+    if (ENFORCE_DEFAULT_STORAGE_VALUE.equals(providerClassName)) {
       return ContextStorage.defaultStorage();
     }
 

--- a/context/src/main/java/io/opentelemetry/context/LazyStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/LazyStorage.java
@@ -83,8 +83,9 @@ final class LazyStorage {
   }
 
   static ContextStorage createStorage(AtomicReference<Throwable> deferredStorageFailure) {
+    // Get the specified SPI implementation first here
     String providerClassName = System.getProperty(CONTEXT_STORAGE_PROVIDER_PROPERTY, "");
-    // enforceDefault
+    // Allow user to enforce default ThreadLocalContextStorage
     if (ENFORCE_DEFAULT_VALUE.equals(providerClassName)) {
       return DefaultContext.threadLocalStorage();
     }

--- a/context/src/main/java/io/opentelemetry/context/LazyStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/LazyStorage.java
@@ -65,6 +65,8 @@ final class LazyStorage {
 
   private static final String CONTEXT_STORAGE_PROVIDER_PROPERTY =
       "io.opentelemetry.context.contextStorageProvider";
+  private static final String CONTEXT_STORAGE_PROVIDER_ENFORCE_DEFAULT_PROPERTY =
+      "io.opentelemetry.context.contextStorageProvider.enforceDefault";
 
   private static final Logger logger = Logger.getLogger(LazyStorage.class.getName());
 
@@ -83,6 +85,10 @@ final class LazyStorage {
 
   static ContextStorage createStorage(AtomicReference<Throwable> deferredStorageFailure) {
     String providerClassName = System.getProperty(CONTEXT_STORAGE_PROVIDER_PROPERTY, "");
+    boolean enforceDefault = Boolean.getBoolean(CONTEXT_STORAGE_PROVIDER_ENFORCE_DEFAULT_PROPERTY);
+    if (enforceDefault) {
+      return DefaultContext.threadLocalStorage();
+    }
 
     List<ContextStorageProvider> providers = new ArrayList<>();
     for (ContextStorageProvider provider : ServiceLoader.load(ContextStorageProvider.class)) {

--- a/context/src/test/java/io/opentelemetry/context/LazyStorageTest.java
+++ b/context/src/test/java/io/opentelemetry/context/LazyStorageTest.java
@@ -20,12 +20,15 @@ class LazyStorageTest {
 
   private static final String CONTEXT_STORAGE_PROVIDER_PROPERTY =
       "io.opentelemetry.context.contextStorageProvider";
+  private static final String CONTEXT_STORAGE_PROVIDER_ENFORCE_DEFAULT_PROPERTY =
+      "io.opentelemetry.context.contextStorageProvider.enforceDefault";
   private static final AtomicReference<Throwable> DEFERRED_STORAGE_FAILURE =
       new AtomicReference<>();
 
   @AfterEach
   public void after() {
     System.clearProperty(CONTEXT_STORAGE_PROVIDER_PROPERTY);
+    System.clearProperty(CONTEXT_STORAGE_PROVIDER_ENFORCE_DEFAULT_PROPERTY);
   }
 
   @Test
@@ -74,6 +77,13 @@ class LazyStorageTest {
     } finally {
       serviceFile.delete();
     }
+  }
+
+  @Test
+  public void enforce_default_thread_local_storage() {
+    System.setProperty(CONTEXT_STORAGE_PROVIDER_ENFORCE_DEFAULT_PROPERTY, "true");
+    assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
+        .isEqualTo(DefaultContext.threadLocalStorage());
   }
 
   private static File createContextStorageProvider() throws IOException {

--- a/context/src/test/java/io/opentelemetry/context/LazyStorageTest.java
+++ b/context/src/test/java/io/opentelemetry/context/LazyStorageTest.java
@@ -28,21 +28,21 @@ class LazyStorageTest {
 
   @Test
   @ClearSystemProperty(key = CONTEXT_STORAGE_PROVIDER_PROPERTY)
-  public void empty_providers() {
+  void empty_providers() {
     assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
         .isEqualTo(DefaultContext.threadLocalStorage());
   }
 
   @Test
   @SetSystemProperty(key = CONTEXT_STORAGE_PROVIDER_PROPERTY, value = MOCK_CONTEXT_STORAGE_PROVIDER)
-  public void set_storage_provider_property_and_empty_providers() {
+  void set_storage_provider_property_and_empty_providers() {
     assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
         .isEqualTo(DefaultContext.threadLocalStorage());
   }
 
   @Test
   @ClearSystemProperty(key = CONTEXT_STORAGE_PROVIDER_PROPERTY)
-  public void unset_storage_provider_property_and_one_providers() throws Exception {
+  void unset_storage_provider_property_and_one_providers() throws Exception {
     File serviceFile = createContextStorageProvider();
     try {
       assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE)).isEqualTo(mockContextStorage);
@@ -55,7 +55,7 @@ class LazyStorageTest {
   @SetSystemProperty(
       key = CONTEXT_STORAGE_PROVIDER_PROPERTY,
       value = "not.match.provider.class.name")
-  public void set_storage_provider_property_not_matches_one_providers() throws Exception {
+  void set_storage_provider_property_not_matches_one_providers() throws Exception {
     File serviceFile = createContextStorageProvider();
     try {
       assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
@@ -67,7 +67,7 @@ class LazyStorageTest {
 
   @Test
   @SetSystemProperty(key = CONTEXT_STORAGE_PROVIDER_PROPERTY, value = MOCK_CONTEXT_STORAGE_PROVIDER)
-  public void set_storage_provider_property_matches_one_providers() throws Exception {
+  void set_storage_provider_property_matches_one_providers() throws Exception {
     File serviceFile = createContextStorageProvider();
     try {
       assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE)).isEqualTo(mockContextStorage);
@@ -78,14 +78,14 @@ class LazyStorageTest {
 
   @Test
   @SetSystemProperty(key = CONTEXT_STORAGE_PROVIDER_PROPERTY, value = "default")
-  public void enforce_default_and_empty_providers() {
+  void enforce_default_and_empty_providers() {
     assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
         .isEqualTo(DefaultContext.threadLocalStorage());
   }
 
   @Test
   @SetSystemProperty(key = CONTEXT_STORAGE_PROVIDER_PROPERTY, value = "default")
-  public void enforce_default_and_one_providers() throws IOException {
+  void enforce_default_and_one_providers() throws IOException {
     File serviceFile = createContextStorageProvider();
     try {
       assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))

--- a/context/src/test/java/io/opentelemetry/context/LazyStorageTest.java
+++ b/context/src/test/java/io/opentelemetry/context/LazyStorageTest.java
@@ -30,14 +30,14 @@ class LazyStorageTest {
   @ClearSystemProperty(key = CONTEXT_STORAGE_PROVIDER_PROPERTY)
   void empty_providers() {
     assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
-        .isEqualTo(DefaultContext.threadLocalStorage());
+        .isEqualTo(ContextStorage.defaultStorage());
   }
 
   @Test
   @SetSystemProperty(key = CONTEXT_STORAGE_PROVIDER_PROPERTY, value = MOCK_CONTEXT_STORAGE_PROVIDER)
   void set_storage_provider_property_and_empty_providers() {
     assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
-        .isEqualTo(DefaultContext.threadLocalStorage());
+        .isEqualTo(ContextStorage.defaultStorage());
   }
 
   @Test
@@ -59,7 +59,7 @@ class LazyStorageTest {
     File serviceFile = createContextStorageProvider();
     try {
       assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
-          .isEqualTo(DefaultContext.threadLocalStorage());
+          .isEqualTo(ContextStorage.defaultStorage());
     } finally {
       serviceFile.delete();
     }
@@ -80,7 +80,7 @@ class LazyStorageTest {
   @SetSystemProperty(key = CONTEXT_STORAGE_PROVIDER_PROPERTY, value = "default")
   void enforce_default_and_empty_providers() {
     assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
-        .isEqualTo(DefaultContext.threadLocalStorage());
+        .isEqualTo(ContextStorage.defaultStorage());
   }
 
   @Test
@@ -89,7 +89,7 @@ class LazyStorageTest {
     File serviceFile = createContextStorageProvider();
     try {
       assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
-          .isEqualTo(DefaultContext.threadLocalStorage());
+          .isEqualTo(ContextStorage.defaultStorage());
     } finally {
       serviceFile.delete();
     }

--- a/context/src/test/java/io/opentelemetry/context/LazyStorageTest.java
+++ b/context/src/test/java/io/opentelemetry/context/LazyStorageTest.java
@@ -20,15 +20,12 @@ class LazyStorageTest {
 
   private static final String CONTEXT_STORAGE_PROVIDER_PROPERTY =
       "io.opentelemetry.context.contextStorageProvider";
-  private static final String CONTEXT_STORAGE_PROVIDER_ENFORCE_DEFAULT_PROPERTY =
-      "io.opentelemetry.context.contextStorageProvider.enforceDefault";
   private static final AtomicReference<Throwable> DEFERRED_STORAGE_FAILURE =
       new AtomicReference<>();
 
   @AfterEach
   public void after() {
     System.clearProperty(CONTEXT_STORAGE_PROVIDER_PROPERTY);
-    System.clearProperty(CONTEXT_STORAGE_PROVIDER_ENFORCE_DEFAULT_PROPERTY);
   }
 
   @Test
@@ -81,7 +78,7 @@ class LazyStorageTest {
 
   @Test
   public void enforce_default_thread_local_storage() {
-    System.setProperty(CONTEXT_STORAGE_PROVIDER_ENFORCE_DEFAULT_PROPERTY, "true");
+    System.setProperty(CONTEXT_STORAGE_PROVIDER_PROPERTY, "default");
     assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
         .isEqualTo(DefaultContext.threadLocalStorage());
   }

--- a/context/src/test/java/io/opentelemetry/context/LazyStorageTest.java
+++ b/context/src/test/java/io/opentelemetry/context/LazyStorageTest.java
@@ -29,13 +29,13 @@ class LazyStorageTest {
   }
 
   @Test
-  public void empty_provides() {
+  public void empty_providers() {
     assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
         .isEqualTo(DefaultContext.threadLocalStorage());
   }
 
   @Test
-  public void set_storage_provider_property_and_empty_provides() {
+  public void set_storage_provider_property_and_empty_providers() {
     System.setProperty(
         CONTEXT_STORAGE_PROVIDER_PROPERTY, MockContextStorageProvider.class.getName());
     assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
@@ -43,7 +43,7 @@ class LazyStorageTest {
   }
 
   @Test
-  public void unset_storage_provider_property_and_one_provides() throws Exception {
+  public void unset_storage_provider_property_and_one_providers() throws Exception {
     File serviceFile = createContextStorageProvider();
     try {
       assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE)).isEqualTo(mockContextStorage);
@@ -53,7 +53,7 @@ class LazyStorageTest {
   }
 
   @Test
-  public void set_storage_provider_property_not_matches_one_provides() throws Exception {
+  public void set_storage_provider_property_not_matches_one_providers() throws Exception {
     System.setProperty(CONTEXT_STORAGE_PROVIDER_PROPERTY, "not.match.provider.class.name");
     File serviceFile = createContextStorageProvider();
     try {
@@ -65,7 +65,7 @@ class LazyStorageTest {
   }
 
   @Test
-  public void set_storage_provider_property_matches_one_provides() throws Exception {
+  public void set_storage_provider_property_matches_one_providers() throws Exception {
     System.setProperty(
         CONTEXT_STORAGE_PROVIDER_PROPERTY, MockContextStorageProvider.class.getName());
     File serviceFile = createContextStorageProvider();
@@ -77,10 +77,22 @@ class LazyStorageTest {
   }
 
   @Test
-  public void enforce_default_thread_local_storage() {
+  public void enforce_default_and_empty_providers() {
     System.setProperty(CONTEXT_STORAGE_PROVIDER_PROPERTY, "default");
     assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
         .isEqualTo(DefaultContext.threadLocalStorage());
+  }
+
+  @Test
+  public void enforce_default_and_one_providers() throws IOException {
+    System.setProperty(CONTEXT_STORAGE_PROVIDER_PROPERTY, "default");
+    File serviceFile = createContextStorageProvider();
+    try {
+      assertThat(LazyStorage.createStorage(DEFERRED_STORAGE_FAILURE))
+          .isEqualTo(DefaultContext.threadLocalStorage());
+    } finally {
+      serviceFile.delete();
+    }
   }
 
   private static File createContextStorageProvider() throws IOException {


### PR DESCRIPTION
closes [https://github.com/open-telemetry/opentelemetry-java/issues/1818](https://github.com/open-telemetry/opentelemetry-java/issues/1818)