### PR TITLE
Replace all assertions with AssetJ's assertThat

### DIFF
--- a/api/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
+++ b/api/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
@@ -7,7 +7,6 @@ package io.opentelemetry.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.opentelemetry.api.metrics.BatchRecorder;
 import io.opentelemetry.api.metrics.DoubleCounter;
@@ -77,10 +76,10 @@ class OpenTelemetryTest {
             FirstTracerProviderFactory.class,
             SecondTracerProviderFactory.class);
     try {
-      assertTrue(
+      assertThat(
           (OpenTelemetry.getGlobalTracerProvider().get("") instanceof FirstTracerProviderFactory)
               || (OpenTelemetry.getGlobalTracerProvider().get("")
-                  instanceof SecondTracerProviderFactory));
+                  instanceof SecondTracerProviderFactory)).isTrue();
     } finally {
       serviceFile.delete();
     }
@@ -117,9 +116,10 @@ class OpenTelemetryTest {
             FirstMeterProviderFactory.class,
             SecondMeterProviderFactory.class);
     try {
-      assertTrue(
+      assertThat(
           (OpenTelemetry.getGlobalMeterProvider() instanceof FirstMeterProviderFactory)
-              || (OpenTelemetry.getGlobalMeterProvider() instanceof SecondMeterProviderFactory));
+              || (OpenTelemetry.getGlobalMeterProvider() instanceof SecondMeterProviderFactory))
+          .isTrue();
       assertThat(OpenTelemetry.getGlobalMeterProvider())
           .isEqualTo(OpenTelemetry.getGlobalMeterProvider());
     } finally {

--- a/api/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
+++ b/api/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
@@ -77,9 +77,11 @@ class OpenTelemetryTest {
             SecondTracerProviderFactory.class);
     try {
       assertThat(
-          (OpenTelemetry.getGlobalTracerProvider().get("") instanceof FirstTracerProviderFactory)
-              || (OpenTelemetry.getGlobalTracerProvider().get("")
-                  instanceof SecondTracerProviderFactory)).isTrue();
+              (OpenTelemetry.getGlobalTracerProvider().get("")
+                      instanceof FirstTracerProviderFactory)
+                  || (OpenTelemetry.getGlobalTracerProvider().get("")
+                      instanceof SecondTracerProviderFactory))
+          .isTrue();
     } finally {
       serviceFile.delete();
     }
@@ -117,8 +119,8 @@ class OpenTelemetryTest {
             SecondMeterProviderFactory.class);
     try {
       assertThat(
-          (OpenTelemetry.getGlobalMeterProvider() instanceof FirstMeterProviderFactory)
-              || (OpenTelemetry.getGlobalMeterProvider() instanceof SecondMeterProviderFactory))
+              (OpenTelemetry.getGlobalMeterProvider() instanceof FirstMeterProviderFactory)
+                  || (OpenTelemetry.getGlobalMeterProvider() instanceof SecondMeterProviderFactory))
           .isTrue();
       assertThat(OpenTelemetry.getGlobalMeterProvider())
           .isEqualTo(OpenTelemetry.getGlobalMeterProvider());

--- a/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/AdapterTest.java
+++ b/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/AdapterTest.java
@@ -15,8 +15,6 @@ import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.jaegertracing.thriftjava.Log;
 import io.jaegertracing.thriftjava.SpanRef;
@@ -64,7 +62,7 @@ class AdapterTest {
     List<io.jaegertracing.thriftjava.Span> jaegerSpans = Adapter.toJaeger(spans);
 
     // the span contents are checked somewhere else
-    assertEquals(1, jaegerSpans.size());
+    assertThat(jaegerSpans).hasSize(1);
   }
 
   @Test
@@ -114,7 +112,7 @@ class AdapterTest {
     Collection<Log> logs = Adapter.toJaegerLogs(Collections.singletonList(eventsData));
 
     // verify
-    assertEquals(1, logs.size());
+    assertThat(logs).hasSize(1);
   }
 
   @Test
@@ -126,7 +124,7 @@ class AdapterTest {
     Log log = Adapter.toJaegerLog(event);
 
     // verify
-    assertEquals(2, log.getFieldsSize());
+    assertThat(log.getFieldsSize()).isEqualTo(2);
 
     assertThat(getValue(log.getFields(), Adapter.KEY_LOG_EVENT).getVStr())
         .isEqualTo("the log message");
@@ -180,7 +178,7 @@ class AdapterTest {
     Collection<SpanRef> spanRefs = Adapter.toSpanRefs(Collections.singletonList(link));
 
     // verify
-    assertEquals(1, spanRefs.size()); // the actual span ref is tested in another test
+    assertThat(spanRefs).hasSize(1); // the actual span ref is tested in another test
   }
 
   @Test
@@ -216,7 +214,7 @@ class AdapterTest {
             .setTotalRecordedLinks(0)
             .build();
 
-    assertNotNull(Adapter.toJaeger(span));
+    assertThat(Adapter.toJaeger(span)).isNotNull();
   }
 
   @Test

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/AdapterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/AdapterTest.java
@@ -13,10 +13,7 @@ import static io.opentelemetry.api.common.AttributeKey.longArrayKey;
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.util.Durations;
 import com.google.protobuf.util.Timestamps;
@@ -62,7 +59,7 @@ class AdapterTest {
     Collection<Model.Span> jaegerSpans = Adapter.toJaeger(spans);
 
     // the span contents are checked somewhere else
-    assertEquals(1, jaegerSpans.size());
+    assertThat(jaegerSpans).hasSize(1);
   }
 
   @Test
@@ -75,34 +72,34 @@ class AdapterTest {
 
     // test
     Model.Span jaegerSpan = Adapter.toJaeger(span);
-    assertEquals(TraceProtoUtils.toProtoTraceId(span.getTraceId()), jaegerSpan.getTraceId());
-    assertEquals(TraceProtoUtils.toProtoSpanId(span.getSpanId()), jaegerSpan.getSpanId());
-    assertEquals("GET /api/endpoint", jaegerSpan.getOperationName());
-    assertEquals(Timestamps.fromMillis(startMs), jaegerSpan.getStartTime());
-    assertEquals(duration, Durations.toMillis(jaegerSpan.getDuration()));
+    assertThat(jaegerSpan.getTraceId()).isEqualTo(TraceProtoUtils.toProtoTraceId(span.getTraceId()));
+    assertThat(jaegerSpan.getSpanId()).isEqualTo(TraceProtoUtils.toProtoSpanId(span.getSpanId()));
+    assertThat(jaegerSpan.getOperationName()).isEqualTo("GET /api/endpoint");
+    assertThat(jaegerSpan.getStartTime()).isEqualTo(Timestamps.fromMillis(startMs));
+    assertThat(Durations.toMillis(jaegerSpan.getDuration())).isEqualTo(duration);
 
-    assertEquals(5, jaegerSpan.getTagsCount());
+    assertThat(jaegerSpan.getTagsCount()).isEqualTo(5);
     Model.KeyValue keyValue = getValue(jaegerSpan.getTagsList(), Adapter.KEY_SPAN_KIND);
-    assertNotNull(keyValue);
-    assertEquals("server", keyValue.getVStr());
+    assertThat(keyValue).isNotNull();
+    assertThat(keyValue.getVStr()).isEqualTo("server");
     keyValue = getValue(jaegerSpan.getTagsList(), Adapter.KEY_SPAN_STATUS_CODE);
-    assertNotNull(keyValue);
-    assertEquals(0, keyValue.getVInt64());
-    assertEquals(Model.ValueType.INT64, keyValue.getVType());
+    assertThat(keyValue).isNotNull();
+    assertThat(keyValue.getVInt64()).isEqualTo(0);
+    assertThat(keyValue.getVType()).isEqualTo(Model.ValueType.INT64);
     keyValue = getValue(jaegerSpan.getTagsList(), Adapter.KEY_SPAN_STATUS_MESSAGE);
-    assertNotNull(keyValue);
-    assertEquals("", keyValue.getVStr());
+    assertThat(keyValue).isNotNull();
+    assertThat(keyValue.getVStr()).isEmpty();
 
-    assertEquals(1, jaegerSpan.getLogsCount());
+    assertThat(jaegerSpan.getLogsCount()).isEqualTo(1);
     Model.Log log = jaegerSpan.getLogs(0);
     keyValue = getValue(log.getFieldsList(), Adapter.KEY_LOG_EVENT);
-    assertNotNull(keyValue);
-    assertEquals("the log message", keyValue.getVStr());
+    assertThat(keyValue).isNotNull();
+    assertThat(keyValue.getVStr()).isEqualTo("the log message");
     keyValue = getValue(log.getFieldsList(), "foo");
-    assertNotNull(keyValue);
-    assertEquals("bar", keyValue.getVStr());
+    assertThat(keyValue).isNotNull();
+    assertThat(keyValue.getVStr()).isEqualTo("bar");
 
-    assertEquals(2, jaegerSpan.getReferencesCount());
+    assertThat(jaegerSpan.getReferencesCount()).isEqualTo(2);
 
     assertHasFollowsFrom(jaegerSpan);
     assertHasParent(jaegerSpan);
@@ -117,7 +114,7 @@ class AdapterTest {
     Collection<Model.Log> logs = Adapter.toJaegerLogs(Collections.singletonList(eventsData));
 
     // verify
-    assertEquals(1, logs.size());
+    assertThat(logs).hasSize(1);
   }
 
   @Test
@@ -129,23 +126,23 @@ class AdapterTest {
     Model.Log log = Adapter.toJaegerLog(event);
 
     // verify
-    assertEquals(2, log.getFieldsCount());
+    assertThat(log.getFieldsCount()).isEqualTo(2);
 
     Model.KeyValue keyValue = getValue(log.getFieldsList(), Adapter.KEY_LOG_EVENT);
-    assertNotNull(keyValue);
-    assertEquals("the log message", keyValue.getVStr());
+    assertThat(keyValue).isNotNull();
+    assertThat(keyValue.getVStr()).isEqualTo("the log message");
     keyValue = getValue(log.getFieldsList(), "foo");
-    assertNotNull(keyValue);
-    assertEquals("bar", keyValue.getVStr());
+    assertThat(keyValue).isNotNull();
+    assertThat(keyValue.getVStr()).isEqualTo("bar");
     keyValue = getValue(log.getFieldsList(), Adapter.KEY_EVENT_DROPPED_ATTRIBUTES_COUNT);
-    assertNull(keyValue);
+    assertThat(keyValue).isNull();
 
     // verify dropped_attributes_count
     event = getTimedEvent(3);
     log = Adapter.toJaegerLog(event);
     keyValue = getValue(log.getFieldsList(), Adapter.KEY_EVENT_DROPPED_ATTRIBUTES_COUNT);
-    assertNotNull(keyValue);
-    assertEquals(2, keyValue.getVInt64());
+    assertThat(keyValue).isNotNull();
+    assertThat(keyValue.getVInt64()).isEqualTo(2);
   }
 
   @Test
@@ -165,27 +162,27 @@ class AdapterTest {
         Adapter.toKeyValue(stringArrayKey("valueArrayS"), Arrays.asList("foobar", "barfoo"));
 
     // verify
-    assertTrue(kvB.getVBool());
-    assertEquals(Model.ValueType.BOOL, kvB.getVType());
-    assertEquals(1., kvD.getVFloat64(), 0);
-    assertEquals(Model.ValueType.FLOAT64, kvD.getVType());
-    assertEquals(2, kvI.getVInt64());
-    assertEquals(Model.ValueType.INT64, kvI.getVType());
-    assertEquals("foobar", kvS.getVStr());
-    assertEquals("foobar", kvS.getVStrBytes().toStringUtf8());
-    assertEquals(Model.ValueType.STRING, kvS.getVType());
-    assertEquals("[true,false]", kvArrayB.getVStr());
-    assertEquals("[true,false]", kvArrayB.getVStrBytes().toStringUtf8());
-    assertEquals(Model.ValueType.STRING, kvArrayB.getVType());
-    assertEquals("[1.2345,6.789]", kvArrayD.getVStr());
-    assertEquals("[1.2345,6.789]", kvArrayD.getVStrBytes().toStringUtf8());
-    assertEquals(Model.ValueType.STRING, kvArrayD.getVType());
-    assertEquals("[12345,67890]", kvArrayI.getVStr());
-    assertEquals("[12345,67890]", kvArrayI.getVStrBytes().toStringUtf8());
-    assertEquals(Model.ValueType.STRING, kvArrayI.getVType());
-    assertEquals("[\"foobar\",\"barfoo\"]", kvArrayS.getVStr());
-    assertEquals("[\"foobar\",\"barfoo\"]", kvArrayS.getVStrBytes().toStringUtf8());
-    assertEquals(Model.ValueType.STRING, kvArrayS.getVType());
+    assertThat(kvB.getVBool()).isTrue();
+    assertThat(kvB.getVType()).isEqualTo(Model.ValueType.BOOL);
+    assertThat(kvD.getVFloat64()).isEqualTo(1.);
+    assertThat(kvD.getVType()).isEqualTo(Model.ValueType.FLOAT64);
+    assertThat(kvI.getVInt64()).isEqualTo(2);
+    assertThat(kvI.getVType()).isEqualTo(Model.ValueType.INT64);
+    assertThat(kvS.getVStr()).isEqualTo("foobar");
+    assertThat(kvS.getVStrBytes().toStringUtf8()).isEqualTo("foobar");
+    assertThat(kvS.getVType()).isEqualTo(Model.ValueType.STRING);
+    assertThat(kvArrayB.getVStr()).isEqualTo("[true,false]");
+    assertThat(kvArrayB.getVStrBytes().toStringUtf8()).isEqualTo("[true,false]");
+    assertThat(kvArrayB.getVType()).isEqualTo(Model.ValueType.STRING);
+    assertThat(kvArrayD.getVStr()).isEqualTo("[1.2345,6.789]");
+    assertThat(kvArrayD.getVStrBytes().toStringUtf8()).isEqualTo("[1.2345,6.789]");
+    assertThat(kvArrayD.getVType()).isEqualTo(Model.ValueType.STRING);
+    assertThat(kvArrayI.getVStr()).isEqualTo("[12345,67890]");
+    assertThat(kvArrayI.getVStrBytes().toStringUtf8()).isEqualTo("[12345,67890]");
+    assertThat(kvArrayI.getVType()).isEqualTo(Model.ValueType.STRING);
+    assertThat(kvArrayS.getVStr()).isEqualTo("[\"foobar\",\"barfoo\"]");
+    assertThat(kvArrayS.getVStrBytes().toStringUtf8()).isEqualTo("[\"foobar\",\"barfoo\"]");
+    assertThat(kvArrayS.getVType()).isEqualTo(Model.ValueType.STRING);
   }
 
   @Test
@@ -198,7 +195,7 @@ class AdapterTest {
     Collection<Model.SpanRef> spanRefs = Adapter.toSpanRefs(Collections.singletonList(link));
 
     // verify
-    assertEquals(1, spanRefs.size()); // the actual span ref is tested in another test
+    assertThat(spanRefs).hasSize(1); // the actual span ref is tested in another test
   }
 
   @Test
@@ -210,9 +207,9 @@ class AdapterTest {
     Model.SpanRef spanRef = Adapter.toSpanRef(link);
 
     // verify
-    assertEquals(TraceProtoUtils.toProtoSpanId(SPAN_ID), spanRef.getSpanId());
-    assertEquals(TraceProtoUtils.toProtoTraceId(TRACE_ID), spanRef.getTraceId());
-    assertEquals(Model.SpanRefType.FOLLOWS_FROM, spanRef.getRefType());
+    assertThat(spanRef.getSpanId()).isEqualTo(TraceProtoUtils.toProtoSpanId(SPAN_ID));
+    assertThat(spanRef.getTraceId()).isEqualTo(TraceProtoUtils.toProtoTraceId(TRACE_ID));
+    assertThat(spanRef.getRefType()).isEqualTo(Model.SpanRefType.FOLLOWS_FROM);
   }
 
   @Test
@@ -233,7 +230,7 @@ class AdapterTest {
             .setTotalRecordedLinks(0)
             .build();
 
-    assertNotNull(Adapter.toJaeger(span));
+    assertThat(Adapter.toJaeger(span)).isNotNull();
   }
 
   @Test
@@ -263,11 +260,11 @@ class AdapterTest {
 
     Model.Span jaegerSpan = Adapter.toJaeger(span);
     Model.KeyValue errorType = getValue(jaegerSpan.getTagsList(), "error.type");
-    assertNotNull(errorType);
-    assertEquals(this.getClass().getName(), errorType.getVStr());
+    assertThat(errorType).isNotNull();
+    assertThat(errorType.getVStr()).isEqualTo(this.getClass().getName());
     Model.KeyValue error = getValue(jaegerSpan.getTagsList(), "error");
-    assertNotNull(error);
-    assertTrue(error.getVBool());
+    assertThat(error).isNotNull();
+    assertThat(error.getVBool()).isTrue();
   }
 
   private static Event getTimedEvent() {
@@ -326,23 +323,23 @@ class AdapterTest {
     boolean found = false;
     for (Model.SpanRef spanRef : jaegerSpan.getReferencesList()) {
       if (Model.SpanRefType.FOLLOWS_FROM.equals(spanRef.getRefType())) {
-        assertEquals(TraceProtoUtils.toProtoTraceId(LINK_TRACE_ID), spanRef.getTraceId());
-        assertEquals(TraceProtoUtils.toProtoSpanId(LINK_SPAN_ID), spanRef.getSpanId());
+        assertThat(spanRef.getTraceId()).isEqualTo(TraceProtoUtils.toProtoTraceId(LINK_TRACE_ID));
+        assertThat(spanRef.getSpanId()).isEqualTo(TraceProtoUtils.toProtoSpanId(LINK_SPAN_ID));
         found = true;
       }
     }
-    assertTrue(found, "Should have found the follows-from reference");
+    assertThat(found).withFailMessage("Should have found the follows-from reference").isTrue();
   }
 
   private static void assertHasParent(Model.Span jaegerSpan) {
     boolean found = false;
     for (Model.SpanRef spanRef : jaegerSpan.getReferencesList()) {
       if (Model.SpanRefType.CHILD_OF.equals(spanRef.getRefType())) {
-        assertEquals(TraceProtoUtils.toProtoTraceId(TRACE_ID), spanRef.getTraceId());
-        assertEquals(TraceProtoUtils.toProtoSpanId(PARENT_SPAN_ID), spanRef.getSpanId());
+        assertThat(spanRef.getTraceId()).isEqualTo(TraceProtoUtils.toProtoTraceId(TRACE_ID));
+        assertThat(spanRef.getSpanId()).isEqualTo(TraceProtoUtils.toProtoSpanId(PARENT_SPAN_ID));
         found = true;
       }
     }
-    assertTrue(found, "Should have found the parent reference");
+    assertThat(found).withFailMessage("Should have found the parent reference").isTrue();
   }
 }

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/AdapterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/AdapterTest.java
@@ -72,7 +72,8 @@ class AdapterTest {
 
     // test
     Model.Span jaegerSpan = Adapter.toJaeger(span);
-    assertThat(jaegerSpan.getTraceId()).isEqualTo(TraceProtoUtils.toProtoTraceId(span.getTraceId()));
+    assertThat(jaegerSpan.getTraceId())
+        .isEqualTo(TraceProtoUtils.toProtoTraceId(span.getTraceId()));
     assertThat(jaegerSpan.getSpanId()).isEqualTo(TraceProtoUtils.toProtoSpanId(span.getSpanId()));
     assertThat(jaegerSpan.getOperationName()).isEqualTo("GET /api/endpoint");
     assertThat(jaegerSpan.getStartTime()).isEqualTo(Timestamps.fromMillis(startMs));

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterTest.java
@@ -6,8 +6,6 @@
 package io.opentelemetry.exporter.jaeger;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.mock;
@@ -120,14 +118,14 @@ class JaegerGrpcSpanExporterTest {
     verify(service).postSpans(requestCaptor.capture(), ArgumentMatchers.any());
 
     Model.Batch batch = requestCaptor.getValue().getBatch();
-    assertEquals("GET /api/endpoint", batch.getSpans(0).getOperationName());
-    assertEquals(TraceProtoUtils.toProtoSpanId(SPAN_ID), batch.getSpans(0).getSpanId());
+    assertThat(batch.getSpans(0).getOperationName()).isEqualTo("GET /api/endpoint");
+    assertThat(batch.getSpans(0).getSpanId()).isEqualTo(TraceProtoUtils.toProtoSpanId(SPAN_ID));
 
-    assertEquals(
-        "resource-attr-value",
+    assertThat(
         getTagValue(batch.getProcess().getTagsList(), "resource-attr-key")
             .orElseThrow(() -> new AssertionError("resource-attr-key not found"))
-            .getVStr());
+            .getVStr()
+    ).isEqualTo("resource-attr-value");
 
     verifyBatch(batch);
   }
@@ -188,7 +186,7 @@ class JaegerGrpcSpanExporterTest {
     verify(service, times(2)).postSpans(requestCaptor.capture(), ArgumentMatchers.any());
 
     List<Collector.PostSpansRequest> requests = requestCaptor.getAllValues();
-    assertEquals(2, requests.size());
+    assertThat(requests).hasSize(2);
     for (Collector.PostSpansRequest request : requests) {
       Model.Batch batch = request.getBatch();
 
@@ -199,14 +197,14 @@ class JaegerGrpcSpanExporterTest {
       Optional<Model.KeyValue> processTag2 =
           getTagValue(batch.getProcess().getTagsList(), "resource-attr-key-2");
       if (processTag.isPresent()) {
-        assertFalse(processTag2.isPresent());
-        assertEquals("GET /api/endpoint/1", batch.getSpans(0).getOperationName());
-        assertEquals(TraceProtoUtils.toProtoSpanId(SPAN_ID), batch.getSpans(0).getSpanId());
-        assertEquals("resource-attr-value-1", processTag.get().getVStr());
+        assertThat(processTag2.isPresent()).isFalse();
+        assertThat(batch.getSpans(0).getOperationName()).isEqualTo("GET /api/endpoint/1");
+        assertThat(batch.getSpans(0).getSpanId()).isEqualTo(TraceProtoUtils.toProtoSpanId(SPAN_ID));
+        assertThat(processTag.get().getVStr()).isEqualTo("resource-attr-value-1");
       } else if (processTag2.isPresent()) {
-        assertEquals("GET /api/endpoint/2", batch.getSpans(0).getOperationName());
-        assertEquals(TraceProtoUtils.toProtoSpanId(SPAN_ID_2), batch.getSpans(0).getSpanId());
-        assertEquals("resource-attr-value-2", processTag2.get().getVStr());
+        assertThat(batch.getSpans(0).getOperationName()).isEqualTo("GET /api/endpoint/2");
+        assertThat(batch.getSpans(0).getSpanId()).isEqualTo(TraceProtoUtils.toProtoSpanId(SPAN_ID_2));
+        assertThat(processTag2.get().getVStr()).isEqualTo("resource-attr-value-2");
       } else {
         fail("No process tag resource-attr-key-1 or resource-attr-key-2");
       }
@@ -214,40 +212,35 @@ class JaegerGrpcSpanExporterTest {
   }
 
   private static void verifyBatch(Model.Batch batch) throws Exception {
-    assertEquals(1, batch.getSpansCount());
-    assertEquals(TraceProtoUtils.toProtoTraceId(TRACE_ID), batch.getSpans(0).getTraceId());
-    assertEquals("test", batch.getProcess().getServiceName());
-    assertEquals(4, batch.getProcess().getTagsCount());
+    assertThat(batch.getSpansCount()).isEqualTo(1);
+    assertThat(batch.getSpans(0).getTraceId()).isEqualTo(TraceProtoUtils.toProtoTraceId(TRACE_ID));
+    assertThat(batch.getProcess().getServiceName()).isEqualTo("test");
+    assertThat(batch.getProcess().getTagsCount()).isEqualTo(4);
 
-    assertEquals(
-        "io.opentelemetry.auto",
-        getSpanTagValue(batch.getSpans(0), "otel.library.name")
-            .orElseThrow(() -> new AssertionError("otel.library.name not found"))
-            .getVStr());
+    assertThat(getSpanTagValue(batch.getSpans(0), "otel.library.name")
+        .orElseThrow(() -> new AssertionError("otel.library.name not found"))
+        .getVStr()
+    ).isEqualTo("io.opentelemetry.auto");
 
-    assertEquals(
-        "1.0.0",
-        getSpanTagValue(batch.getSpans(0), "otel.library.version")
-            .orElseThrow(() -> new AssertionError("otel.library.version not found"))
-            .getVStr());
+    assertThat(getSpanTagValue(batch.getSpans(0), "otel.library.version")
+        .orElseThrow(() -> new AssertionError("otel.library.version not found"))
+        .getVStr()
+    ).isEqualTo("1.0.0");
 
-    assertEquals(
-        InetAddress.getLocalHost().getHostAddress(),
-        getTagValue(batch.getProcess().getTagsList(), "ip")
-            .orElseThrow(() -> new AssertionError("ip not found"))
-            .getVStr());
+    assertThat(getTagValue(batch.getProcess().getTagsList(), "ip")
+        .orElseThrow(() -> new AssertionError("ip not found"))
+        .getVStr()
+    ).isEqualTo(InetAddress.getLocalHost().getHostAddress());
 
-    assertEquals(
-        InetAddress.getLocalHost().getHostName(),
-        getTagValue(batch.getProcess().getTagsList(), "hostname")
-            .orElseThrow(() -> new AssertionError("hostname not found"))
-            .getVStr());
+    assertThat(getTagValue(batch.getProcess().getTagsList(), "hostname")
+        .orElseThrow(() -> new AssertionError("hostname not found"))
+        .getVStr()
+    ).isEqualTo(InetAddress.getLocalHost().getHostName());
 
-    assertEquals(
-        "opentelemetry-java",
-        getTagValue(batch.getProcess().getTagsList(), "jaeger.version")
-            .orElseThrow(() -> new AssertionError("jaeger.version not found"))
-            .getVStr());
+    assertThat(getTagValue(batch.getProcess().getTagsList(), "jaeger.version")
+        .orElseThrow(() -> new AssertionError("jaeger.version not found"))
+        .getVStr()
+    ).isEqualTo("opentelemetry-java");
   }
 
   private static Optional<Model.KeyValue> getSpanTagValue(Model.Span span, String tagKey) {

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterTest.java
@@ -122,10 +122,10 @@ class JaegerGrpcSpanExporterTest {
     assertThat(batch.getSpans(0).getSpanId()).isEqualTo(TraceProtoUtils.toProtoSpanId(SPAN_ID));
 
     assertThat(
-        getTagValue(batch.getProcess().getTagsList(), "resource-attr-key")
-            .orElseThrow(() -> new AssertionError("resource-attr-key not found"))
-            .getVStr()
-    ).isEqualTo("resource-attr-value");
+            getTagValue(batch.getProcess().getTagsList(), "resource-attr-key")
+                .orElseThrow(() -> new AssertionError("resource-attr-key not found"))
+                .getVStr())
+        .isEqualTo("resource-attr-value");
 
     verifyBatch(batch);
   }
@@ -203,7 +203,8 @@ class JaegerGrpcSpanExporterTest {
         assertThat(processTag.get().getVStr()).isEqualTo("resource-attr-value-1");
       } else if (processTag2.isPresent()) {
         assertThat(batch.getSpans(0).getOperationName()).isEqualTo("GET /api/endpoint/2");
-        assertThat(batch.getSpans(0).getSpanId()).isEqualTo(TraceProtoUtils.toProtoSpanId(SPAN_ID_2));
+        assertThat(batch.getSpans(0).getSpanId())
+            .isEqualTo(TraceProtoUtils.toProtoSpanId(SPAN_ID_2));
         assertThat(processTag2.get().getVStr()).isEqualTo("resource-attr-value-2");
       } else {
         fail("No process tag resource-attr-key-1 or resource-attr-key-2");
@@ -217,30 +218,35 @@ class JaegerGrpcSpanExporterTest {
     assertThat(batch.getProcess().getServiceName()).isEqualTo("test");
     assertThat(batch.getProcess().getTagsCount()).isEqualTo(4);
 
-    assertThat(getSpanTagValue(batch.getSpans(0), "otel.library.name")
-        .orElseThrow(() -> new AssertionError("otel.library.name not found"))
-        .getVStr()
-    ).isEqualTo("io.opentelemetry.auto");
+    assertThat(
+            getSpanTagValue(batch.getSpans(0), "otel.library.name")
+                .orElseThrow(() -> new AssertionError("otel.library.name not found"))
+                .getVStr())
+        .isEqualTo("io.opentelemetry.auto");
 
-    assertThat(getSpanTagValue(batch.getSpans(0), "otel.library.version")
-        .orElseThrow(() -> new AssertionError("otel.library.version not found"))
-        .getVStr()
-    ).isEqualTo("1.0.0");
+    assertThat(
+            getSpanTagValue(batch.getSpans(0), "otel.library.version")
+                .orElseThrow(() -> new AssertionError("otel.library.version not found"))
+                .getVStr())
+        .isEqualTo("1.0.0");
 
-    assertThat(getTagValue(batch.getProcess().getTagsList(), "ip")
-        .orElseThrow(() -> new AssertionError("ip not found"))
-        .getVStr()
-    ).isEqualTo(InetAddress.getLocalHost().getHostAddress());
+    assertThat(
+            getTagValue(batch.getProcess().getTagsList(), "ip")
+                .orElseThrow(() -> new AssertionError("ip not found"))
+                .getVStr())
+        .isEqualTo(InetAddress.getLocalHost().getHostAddress());
 
-    assertThat(getTagValue(batch.getProcess().getTagsList(), "hostname")
-        .orElseThrow(() -> new AssertionError("hostname not found"))
-        .getVStr()
-    ).isEqualTo(InetAddress.getLocalHost().getHostName());
+    assertThat(
+            getTagValue(batch.getProcess().getTagsList(), "hostname")
+                .orElseThrow(() -> new AssertionError("hostname not found"))
+                .getVStr())
+        .isEqualTo(InetAddress.getLocalHost().getHostName());
 
-    assertThat(getTagValue(batch.getProcess().getTagsList(), "jaeger.version")
-        .orElseThrow(() -> new AssertionError("jaeger.version not found"))
-        .getVStr()
-    ).isEqualTo("opentelemetry-java");
+    assertThat(
+            getTagValue(batch.getProcess().getTagsList(), "jaeger.version")
+                .orElseThrow(() -> new AssertionError("jaeger.version not found"))
+                .getVStr())
+        .isEqualTo("opentelemetry-java");
   }
 
   private static Optional<Model.KeyValue> getSpanTagValue(Model.Span span, String tagKey) {

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/OpenTracingShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/OpenTracingShimTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.opentracingshim;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -19,7 +19,7 @@ class OpenTracingShimTest {
   @Test
   void createTracerShim_default() {
     TracerShim tracerShim = (TracerShim) OpenTracingShim.createTracerShim();
-    assertEquals(OpenTelemetry.getGlobalTracer("opentracingshim"), tracerShim.tracer());
+    assertThat(tracerShim.tracer()).isEqualTo(OpenTelemetry.getGlobalTracer("opentracingshim"));
   }
 
   @Test
@@ -30,6 +30,6 @@ class OpenTracingShimTest {
     when(openTelemetry.getPropagators()).thenReturn(mock(ContextPropagators.class));
 
     TracerShim tracerShim = (TracerShim) OpenTracingShim.createTracerShim(openTelemetry);
-    assertEquals(sdk.get("opentracingshim"), tracerShim.tracer());
+    assertThat(tracerShim.tracer()).isEqualTo(sdk.get("opentracingshim"));
   }
 }

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanBuilderShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanBuilderShimTest.java
@@ -32,7 +32,8 @@ class SpanBuilderShimTest {
           (SpanShim) new SpanBuilderShim(telemetryInfo, SPAN_NAME).asChildOf(parentSpan).start();
       try {
         assertThat("value1").isEqualTo(childSpan.getBaggageItem("key1"));
-        assertThat(getBaggageMap(parentSpan.context().baggageItems())).isEqualTo(getBaggageMap(childSpan.context().baggageItems()));
+        assertThat(getBaggageMap(parentSpan.context().baggageItems()))
+            .isEqualTo(getBaggageMap(childSpan.context().baggageItems()));
       } finally {
         childSpan.finish();
       }
@@ -52,7 +53,8 @@ class SpanBuilderShimTest {
               new SpanBuilderShim(telemetryInfo, SPAN_NAME).asChildOf(parentSpan.context()).start();
       try {
         assertThat("value1").isEqualTo(childSpan.getBaggageItem("key1"));
-        assertThat(getBaggageMap(parentSpan.context().baggageItems())).isEqualTo(getBaggageMap(childSpan.context().baggageItems()));
+        assertThat(getBaggageMap(parentSpan.context().baggageItems()))
+            .isEqualTo(getBaggageMap(childSpan.context().baggageItems()));
       } finally {
         childSpan.finish();
       }

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanBuilderShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanBuilderShimTest.java
@@ -6,8 +6,7 @@
 package io.opentelemetry.opentracingshim;
 
 import static io.opentelemetry.opentracingshim.TestUtils.getBaggageMap;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
@@ -32,10 +31,8 @@ class SpanBuilderShimTest {
       SpanShim childSpan =
           (SpanShim) new SpanBuilderShim(telemetryInfo, SPAN_NAME).asChildOf(parentSpan).start();
       try {
-        assertEquals(childSpan.getBaggageItem("key1"), "value1");
-        assertEquals(
-            getBaggageMap(childSpan.context().baggageItems()),
-            getBaggageMap(parentSpan.context().baggageItems()));
+        assertThat("value1").isEqualTo(childSpan.getBaggageItem("key1"));
+        assertThat(getBaggageMap(parentSpan.context().baggageItems())).isEqualTo(getBaggageMap(childSpan.context().baggageItems()));
       } finally {
         childSpan.finish();
       }
@@ -54,10 +51,8 @@ class SpanBuilderShimTest {
           (SpanShim)
               new SpanBuilderShim(telemetryInfo, SPAN_NAME).asChildOf(parentSpan.context()).start();
       try {
-        assertEquals(childSpan.getBaggageItem("key1"), "value1");
-        assertEquals(
-            getBaggageMap(childSpan.context().baggageItems()),
-            getBaggageMap(parentSpan.context().baggageItems()));
+        assertThat("value1").isEqualTo(childSpan.getBaggageItem("key1"));
+        assertThat(getBaggageMap(parentSpan.context().baggageItems())).isEqualTo(getBaggageMap(childSpan.context().baggageItems()));
       } finally {
         childSpan.finish();
       }
@@ -75,7 +70,7 @@ class SpanBuilderShimTest {
       SpanShim childSpan =
           (SpanShim) new SpanBuilderShim(telemetryInfo, SPAN_NAME).asChildOf(parentSpan).start();
       try {
-        assertFalse(childSpan.context().baggageItems().iterator().hasNext());
+        assertThat(childSpan.context().baggageItems().iterator().hasNext()).isFalse();
       } finally {
         childSpan.finish();
       }

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
@@ -44,8 +44,10 @@ class SpanShimTest {
     SpanContextShim contextShim = (SpanContextShim) spanShim.context();
     assertThat(contextShim).isNotNull();
     assertThat(span.getSpanContext()).isEqualTo(contextShim.getSpanContext());
-    assertThat(span.getSpanContext().getTraceIdAsHexString().toString()).isEqualTo(contextShim.toTraceId());
-    assertThat(span.getSpanContext().getSpanIdAsHexString().toString()).isEqualTo(contextShim.toSpanId());
+    assertThat(span.getSpanContext().getTraceIdAsHexString().toString())
+        .isEqualTo(contextShim.toTraceId());
+    assertThat(span.getSpanContext().getSpanIdAsHexString().toString())
+        .isEqualTo(contextShim.toSpanId());
     assertThat(contextShim.baggageItems().iterator().hasNext()).isFalse();
   }
 
@@ -89,6 +91,7 @@ class SpanShimTest {
     spanShim2.setBaggageItem("key1", "value2");
     assertThat(spanShim1.getBaggageItem("key1")).isEqualTo("value2");
     assertThat(spanShim2.getBaggageItem("key1")).isEqualTo("value2");
-    assertThat(getBaggageMap(spanShim2.context().baggageItems())).isEqualTo(getBaggageMap(spanShim1.context().baggageItems()));
+    assertThat(getBaggageMap(spanShim2.context().baggageItems()))
+        .isEqualTo(getBaggageMap(spanShim1.context().baggageItems()));
   }
 }

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
@@ -6,11 +6,7 @@
 package io.opentelemetry.opentracingshim;
 
 import static io.opentelemetry.opentracingshim.TestUtils.getBaggageMap;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
@@ -46,11 +42,11 @@ class SpanShimTest {
     SpanShim spanShim = new SpanShim(telemetryInfo, span);
 
     SpanContextShim contextShim = (SpanContextShim) spanShim.context();
-    assertNotNull(contextShim);
-    assertEquals(contextShim.getSpanContext(), span.getSpanContext());
-    assertEquals(contextShim.toTraceId(), span.getSpanContext().getTraceIdAsHexString().toString());
-    assertEquals(contextShim.toSpanId(), span.getSpanContext().getSpanIdAsHexString().toString());
-    assertFalse(contextShim.baggageItems().iterator().hasNext());
+    assertThat(contextShim).isNotNull();
+    assertThat(span.getSpanContext()).isEqualTo(contextShim.getSpanContext());
+    assertThat(span.getSpanContext().getTraceIdAsHexString().toString()).isEqualTo(contextShim.toTraceId());
+    assertThat(span.getSpanContext().getSpanIdAsHexString().toString()).isEqualTo(contextShim.toSpanId());
+    assertThat(contextShim.baggageItems().iterator().hasNext()).isFalse();
   }
 
   @Test
@@ -59,15 +55,15 @@ class SpanShimTest {
 
     spanShim.setBaggageItem("key1", "value1");
     spanShim.setBaggageItem("key2", "value2");
-    assertEquals(spanShim.getBaggageItem("key1"), "value1");
-    assertEquals(spanShim.getBaggageItem("key2"), "value2");
+    assertThat("value1").isEqualTo(spanShim.getBaggageItem("key1"));
+    assertThat("value2").isEqualTo(spanShim.getBaggageItem("key2"));
 
     SpanContextShim contextShim = (SpanContextShim) spanShim.context();
-    assertNotNull(contextShim);
+    assertThat(contextShim).isNotNull();
     Map<String, String> baggageMap = getBaggageMap(contextShim.baggageItems());
-    assertEquals(2, baggageMap.size());
-    assertEquals(baggageMap.get("key1"), "value1");
-    assertEquals(baggageMap.get("key2"), "value2");
+    assertThat(baggageMap.size()).isEqualTo(2);
+    assertThat("value1").isEqualTo(baggageMap.get("key1"));
+    assertThat("value2").isEqualTo(baggageMap.get("key2"));
   }
 
   @Test
@@ -77,9 +73,9 @@ class SpanShimTest {
 
     spanShim.setBaggageItem("key1", "value1");
     SpanContextShim contextShim2 = (SpanContextShim) spanShim.context();
-    assertNotEquals(contextShim1, contextShim2);
-    assertFalse(contextShim1.baggageItems().iterator().hasNext()); /* original, empty */
-    assertTrue(contextShim2.baggageItems().iterator().hasNext()); /* updated, with values */
+    assertThat(contextShim2).isNotEqualTo(contextShim1);
+    assertThat(contextShim1.baggageItems().iterator().hasNext()).isFalse(); /* original, empty */
+    assertThat(contextShim2.baggageItems().iterator()).hasNext(); /* updated, with values */
   }
 
   @Test
@@ -91,10 +87,8 @@ class SpanShimTest {
      * referring to the same Span.*/
     SpanShim spanShim2 = new SpanShim(telemetryInfo, span);
     spanShim2.setBaggageItem("key1", "value2");
-    assertEquals(spanShim1.getBaggageItem("key1"), "value2");
-    assertEquals(spanShim2.getBaggageItem("key1"), "value2");
-    assertEquals(
-        getBaggageMap(spanShim1.context().baggageItems()),
-        getBaggageMap(spanShim2.context().baggageItems()));
+    assertThat(spanShim1.getBaggageItem("key1")).isEqualTo("value2");
+    assertThat(spanShim2.getBaggageItem("key1")).isEqualTo("value2");
+    assertThat(getBaggageMap(spanShim2.context().baggageItems())).isEqualTo(getBaggageMap(spanShim1.context().baggageItems()));
   }
 }

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/TracerShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/TracerShimTest.java
@@ -6,9 +6,6 @@
 package io.opentelemetry.opentracingshim;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentracing.Scope;
@@ -42,10 +39,10 @@ class TracerShimTest {
 
   @Test
   void defaultTracer() {
-    assertNotNull(tracerShim.buildSpan("one"));
-    assertNotNull(tracerShim.scopeManager());
-    assertNull(tracerShim.activeSpan());
-    assertNull(tracerShim.scopeManager().activeSpan());
+    assertThat(tracerShim.buildSpan("one")).isNotNull();
+    assertThat(tracerShim.scopeManager()).isNotNull();
+    assertThat(tracerShim.activeSpan()).isNull();
+    assertThat(tracerShim.scopeManager().activeSpan()).isNull();
   }
 
   @Test
@@ -53,32 +50,32 @@ class TracerShimTest {
     Span otSpan = tracerShim.buildSpan("one").start();
     io.opentelemetry.api.trace.Span span = ((SpanShim) otSpan).getSpan();
 
-    assertNull(tracerShim.activeSpan());
-    assertNull(tracerShim.scopeManager().activeSpan());
+    assertThat(tracerShim.activeSpan()).isNull();
+    assertThat(tracerShim.scopeManager().activeSpan()).isNull();
 
     try (Scope scope = tracerShim.activateSpan(otSpan)) {
-      assertNotNull(tracerShim.activeSpan());
-      assertNotNull(tracerShim.scopeManager().activeSpan());
-      assertEquals(span, ((SpanShim) tracerShim.activeSpan()).getSpan());
-      assertEquals(span, ((SpanShim) tracerShim.scopeManager().activeSpan()).getSpan());
+      assertThat(tracerShim.activeSpan()).isNotNull();
+      assertThat(tracerShim.scopeManager().activeSpan()).isNotNull();
+      assertThat(((SpanShim) tracerShim.activeSpan()).getSpan()).isEqualTo(span);
+      assertThat(((SpanShim) tracerShim.scopeManager().activeSpan()).getSpan()).isEqualTo(span);
     }
 
-    assertNull(tracerShim.activeSpan());
-    assertNull(tracerShim.scopeManager().activeSpan());
+    assertThat(tracerShim.activeSpan()).isNull();
+    assertThat(tracerShim.scopeManager().activeSpan()).isNull();
   }
 
   @Test
   void extract_nullContext() {
     SpanContext result =
         tracerShim.extract(Format.Builtin.TEXT_MAP, new TextMapAdapter(Collections.emptyMap()));
-    assertNull(result);
+    assertThat(result).isNull();
   }
 
   @Test
   void inject_nullContext() {
     Map<String, String> map = new HashMap<>();
     tracerShim.inject(null, Format.Builtin.TEXT_MAP, new TextMapAdapter(map));
-    assertEquals(0, map.size());
+    assertThat(map).isEmpty();
   }
 
   @Test

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/OpenTelemetryInteroperabilityTest.java
@@ -5,9 +5,7 @@
 
 package io.opentelemetry.opentracingshim.testbed;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
@@ -38,10 +36,10 @@ class OpenTelemetryInteroperabilityTest {
       otSpan.finish();
     }
     assertThat(io.opentelemetry.api.trace.Span.current().getSpanContext().isValid()).isFalse();
-    assertNull(otTracer.activeSpan());
+    assertThat(otTracer.activeSpan()).isNull();
 
     List<SpanData> finishedSpans = otelTesting.getSpans();
-    assertEquals(2, finishedSpans.size());
+    assertThat(finishedSpans).hasSize(2);
     TestUtils.assertSameTrace(finishedSpans);
   }
 
@@ -55,10 +53,10 @@ class OpenTelemetryInteroperabilityTest {
     }
 
     assertThat(io.opentelemetry.api.trace.Span.current().getSpanContext().isValid()).isFalse();
-    assertNull(otTracer.activeSpan());
+    assertThat(otTracer.activeSpan()).isNull();
 
     List<SpanData> finishedSpans = otelTesting.getSpans();
-    assertEquals(2, finishedSpans.size());
+    assertThat(finishedSpans).hasSize(2);
     TestUtils.assertSameTrace(finishedSpans);
   }
 }

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/TestUtils.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/TestUtils.java
@@ -5,8 +5,7 @@
 
 package io.opentelemetry.opentracingshim.testbed;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span.Kind;
@@ -133,9 +132,10 @@ public final class TestUtils {
   public static void assertSameTrace(List<SpanData> spans) {
     for (int i = 0; i < spans.size() - 1; i++) {
       // TODO - Include nanos in this comparison.
-      assertTrue(spans.get(spans.size() - 1).getEndEpochNanos() >= spans.get(i).getEndEpochNanos());
-      assertEquals(spans.get(spans.size() - 1).getTraceId(), spans.get(i).getTraceId());
-      assertEquals(spans.get(spans.size() - 1).getSpanId(), spans.get(i).getParentSpanId());
+      assertThat(spans.get(i).getEndEpochNanos())
+          .isLessThanOrEqualTo(spans.get(spans.size() - 1).getEndEpochNanos());
+      assertThat(spans.get(i).getTraceId()).isEqualTo(spans.get(spans.size() - 1).getTraceId());
+      assertThat(spans.get(i).getParentSpanId()).isEqualTo(spans.get(spans.size() - 1).getSpanId());
     }
   }
 }

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/baggagehandling/BaggageHandlingTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/baggagehandling/BaggageHandlingTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.opentracingshim.testbed.baggagehandling;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
@@ -55,8 +55,8 @@ public final class BaggageHandlingTest {
     /* Single call, no need to use await() */
     f.get(5, TimeUnit.SECONDS);
 
-    assertEquals(2, otelTesting.getSpans().size());
-    assertEquals(span.getBaggageItem("key1"), "value2");
-    assertEquals(span.getBaggageItem("newkey"), "newvalue");
+    assertThat(otelTesting.getSpans()).hasSize(2);
+    assertThat("value2").isEqualTo(span.getBaggageItem("key1"));
+    assertThat("newvalue").isEqualTo(span.getBaggageItem("newkey"));
   }
 }

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/clientserver/TestClientServerTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/clientserver/TestClientServerTest.java
@@ -7,10 +7,9 @@ package io.opentelemetry.opentracingshim.testbed.clientserver;
 
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.finishedSpansSize;
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.sortByStartTime;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.opentelemetry.api.trace.Span.Kind;
 import io.opentelemetry.opentracingshim.OpenTracingShim;
@@ -53,13 +52,13 @@ class TestClientServerTest {
     await().atMost(15, TimeUnit.SECONDS).until(finishedSpansSize(otelTesting), equalTo(2));
 
     List<SpanData> finished = otelTesting.getSpans();
-    assertEquals(2, finished.size());
+    assertThat(finished).hasSize(2);
 
     finished = sortByStartTime(finished);
-    assertEquals(finished.get(0).getTraceId(), finished.get(1).getTraceId());
-    assertEquals(Kind.CLIENT, finished.get(0).getKind());
-    assertEquals(Kind.SERVER, finished.get(1).getKind());
+    assertThat(finished.get(1).getTraceId()).isEqualTo(finished.get(0).getTraceId());
+    assertThat(finished.get(0).getKind()).isEqualTo(Kind.CLIENT);
+    assertThat(finished.get(1).getKind()).isEqualTo(Kind.SERVER);
 
-    assertNull(tracer.scopeManager().activeSpan());
+    assertThat(tracer.scopeManager().activeSpan()).isNull();
   }
 }

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/errorreporting/ErrorReportingTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/errorreporting/ErrorReportingTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.opentracingshim.testbed.errorreporting;
 
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.finishedSpansSize;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/errorreporting/ErrorReportingTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/errorreporting/ErrorReportingTest.java
@@ -6,10 +6,10 @@
 package io.opentelemetry.opentracingshim.testbed.errorreporting;
 
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.finishedSpansSize;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.opentracingshim.OpenTracingShim;
@@ -50,11 +50,11 @@ public final class ErrorReportingTest {
       span.finish();
     }
 
-    assertNull(tracer.scopeManager().activeSpan());
+    assertThat(tracer.scopeManager().activeSpan()).isNull();
 
     List<SpanData> spans = otelTesting.getSpans();
-    assertEquals(spans.size(), 1);
-    assertEquals(spans.get(0).getStatus().getCanonicalCode(), StatusCode.ERROR);
+    assertThat(spans).hasSize(1);
+    assertThat(StatusCode.ERROR).isEqualTo(spans.get(0).getStatus().getCanonicalCode());
   }
 
   /* Error handling in a callback capturing/activating the Span */
@@ -75,8 +75,8 @@ public final class ErrorReportingTest {
     await().atMost(5, TimeUnit.SECONDS).until(finishedSpansSize(otelTesting), equalTo(1));
 
     List<SpanData> spans = otelTesting.getSpans();
-    assertEquals(spans.size(), 1);
-    assertEquals(spans.get(0).getStatus().getCanonicalCode(), StatusCode.ERROR);
+    assertThat(spans).hasSize(1);
+    assertThat(StatusCode.ERROR).isEqualTo(spans.get(0).getStatus().getCanonicalCode());
   }
 
   /* Error handling for a max-retries task (such as url fetching).
@@ -103,15 +103,15 @@ public final class ErrorReportingTest {
     Tags.ERROR.set(span, true); // Could not fetch anything.
     span.finish();
 
-    assertNull(tracer.scopeManager().activeSpan());
+    assertThat(tracer.scopeManager().activeSpan()).isNull();
 
     List<SpanData> spans = otelTesting.getSpans();
-    assertEquals(spans.size(), 1);
-    assertEquals(spans.get(0).getStatus().getCanonicalCode(), StatusCode.ERROR);
+    assertThat(spans).hasSize(1);
+    assertThat(StatusCode.ERROR).isEqualTo(spans.get(0).getStatus().getCanonicalCode());
 
     List<Event> events = spans.get(0).getEvents();
-    assertEquals(events.size(), maxRetries);
-    assertEquals(events.get(0).getName(), Tags.ERROR.getKey());
+    assertThat(events).hasSize(maxRetries);
+    assertThat(Tags.ERROR.getKey()).isEqualTo(events.get(0).getName());
     /* TODO: Handle actual objects being passed to log/events. */
     /*assertNotNull(events.get(0).getEvent().getAttributes().get(Fields.ERROR_OBJECT));*/
   }
@@ -141,8 +141,8 @@ public final class ErrorReportingTest {
     await().atMost(5, TimeUnit.SECONDS).until(finishedSpansSize(otelTesting), equalTo(1));
 
     List<SpanData> spans = otelTesting.getSpans();
-    assertEquals(spans.size(), 1);
-    assertEquals(spans.get(0).getStatus().getCanonicalCode(), StatusCode.ERROR);
+    assertThat(spans).hasSize(1);
+    assertThat(StatusCode.ERROR).isEqualTo(spans.get(0).getStatus().getCanonicalCode());
   }
 
   static class ScopedRunnable implements Runnable {

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/latespanfinish/LateSpanFinishTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/latespanfinish/LateSpanFinishTest.java
@@ -7,9 +7,7 @@ package io.opentelemetry.opentracingshim.testbed.latespanfinish;
 
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.assertSameTrace;
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.sleep;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
@@ -47,14 +45,15 @@ public final class LateSpanFinishTest {
 
     // Children finish order is not guaranteed, but parent should finish *last*.
     List<SpanData> spans = otelTesting.getSpans();
-    assertEquals(3, spans.size());
-    assertTrue(spans.get(0).getName().startsWith("task"));
-    assertTrue(spans.get(1).getName().startsWith("task"));
-    assertEquals("parent", spans.get(2).getName());
+    assertThat(spans).hasSize(3);
+    assertThat(spans.get(0).getName()).startsWith("task");
+    assertThat(spans.get(0).getName()).startsWith("task");
+    assertThat(spans.get(1).getName()).startsWith("task");
+    assertThat(spans.get(2).getName()).isEqualTo("parent");
 
     assertSameTrace(spans);
 
-    assertNull(tracer.scopeManager().activeSpan());
+    assertThat(tracer.scopeManager().activeSpan()).isNull();
   }
 
   /*

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/listenerperrequest/ListenerTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/listenerperrequest/ListenerTest.java
@@ -5,10 +5,9 @@
 
 package io.opentelemetry.opentracingshim.testbed.listenerperrequest;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static io.opentelemetry.api.trace.Span.Kind.CLIENT;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -28,12 +27,12 @@ class ListenerTest {
   void test() throws Exception {
     Client client = new Client(tracer);
     Object response = client.send("message").get();
-    assertEquals("message:response", response);
+    assertThat(response).isEqualTo("message:response");
 
     List<SpanData> finished = otelTesting.getSpans();
-    assertEquals(1, finished.size());
-    assertEquals(finished.get(0).getKind(), Span.Kind.CLIENT);
+    assertThat(finished).hasSize(1);
+    assertThat(CLIENT).isEqualTo(finished.get(0).getKind());
 
-    assertNull(tracer.scopeManager().activeSpan());
+    assertThat(tracer.scopeManager().activeSpan()).isNull();
   }
 }

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/multiplecallbacks/MultipleCallbacksTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/multiplecallbacks/MultipleCallbacksTest.java
@@ -6,10 +6,9 @@
 package io.opentelemetry.opentracingshim.testbed.multiplecallbacks;
 
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.finishedSpansSize;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
@@ -54,15 +53,15 @@ class MultipleCallbacksTest {
     await().atMost(15, TimeUnit.SECONDS).until(finishedSpansSize(otelTesting), equalTo(4));
 
     List<SpanData> spans = otelTesting.getSpans();
-    assertEquals(4, spans.size());
-    assertEquals("parent", spans.get(0).getName());
+    assertThat(spans).hasSize(4);
+    assertThat(spans.get(0).getName()).isEqualTo("parent");
 
     SpanData parentSpan = spans.get(0);
     for (int i = 1; i < 4; i++) {
-      assertEquals(parentSpan.getTraceId(), spans.get(i).getTraceId());
-      assertEquals(parentSpan.getSpanId(), spans.get(i).getParentSpanId());
+      assertThat(spans.get(i).getTraceId()).isEqualTo(parentSpan.getTraceId());
+      assertThat(spans.get(i).getParentSpanId()).isEqualTo(parentSpan.getSpanId());
     }
 
-    assertNull(tracer.scopeManager().activeSpan());
+    assertThat(tracer.scopeManager().activeSpan()).isNull();
   }
 }

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/nestedcallbacks/NestedCallbacksTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/nestedcallbacks/NestedCallbacksTest.java
@@ -7,10 +7,9 @@ package io.opentelemetry.opentracingshim.testbed.nestedcallbacks;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.finishedSpansSize;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.opentelemetry.api.common.ReadableAttributes;
 import io.opentelemetry.opentracingshim.OpenTracingShim;
@@ -43,16 +42,16 @@ public final class NestedCallbacksTest {
     await().atMost(15, TimeUnit.SECONDS).until(finishedSpansSize(otelTesting), equalTo(1));
 
     List<SpanData> spans = otelTesting.getSpans();
-    assertEquals(1, spans.size());
-    assertEquals("one", spans.get(0).getName());
+    assertThat(spans).hasSize(1);
+    assertThat(spans.get(0).getName()).isEqualTo("one");
 
     ReadableAttributes attrs = spans.get(0).getAttributes();
-    assertEquals(3, attrs.size());
+    assertThat(attrs.size()).isEqualTo(3);
     for (int i = 1; i <= 3; i++) {
-      assertEquals(Integer.toString(i), spans.get(0).getAttributes().get(stringKey("key" + i)));
+      assertThat(spans.get(0).getAttributes().get(stringKey("key" + i))).isEqualTo(Integer.toString(i));
     }
 
-    assertNull(tracer.scopeManager().activeSpan());
+    assertThat(tracer.scopeManager().activeSpan()).isNull();
   }
 
   private void submitCallbacks(final Span span) {

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/nestedcallbacks/NestedCallbacksTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/nestedcallbacks/NestedCallbacksTest.java
@@ -48,7 +48,8 @@ public final class NestedCallbacksTest {
     ReadableAttributes attrs = spans.get(0).getAttributes();
     assertThat(attrs.size()).isEqualTo(3);
     for (int i = 1; i <= 3; i++) {
-      assertThat(spans.get(0).getAttributes().get(stringKey("key" + i))).isEqualTo(Integer.toString(i));
+      assertThat(spans.get(0).getAttributes().get(stringKey("key" + i)))
+          .isEqualTo(Integer.toString(i));
     }
 
     assertThat(tracer.scopeManager().activeSpan()).isNull();

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/statelesscommonrequesthandler/HandlerTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/statelesscommonrequesthandler/HandlerTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.opentracingshim.testbed.statelesscommonrequesthandler;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
@@ -34,11 +34,11 @@ public final class HandlerTest {
     Future<String> responseFuture2 = client.send("message2");
     Future<String> responseFuture3 = client.send("message3");
 
-    assertEquals("message3:response", responseFuture3.get(5, TimeUnit.SECONDS));
-    assertEquals("message2:response", responseFuture2.get(5, TimeUnit.SECONDS));
-    assertEquals("message:response", responseFuture.get(5, TimeUnit.SECONDS));
+    assertThat(responseFuture3.get(5, TimeUnit.SECONDS)).isEqualTo("message3:response");
+    assertThat(responseFuture2.get(5, TimeUnit.SECONDS)).isEqualTo("message2:response");
+    assertThat(responseFuture.get(5, TimeUnit.SECONDS)).isEqualTo("message:response");
 
     List<SpanData> finished = otelTesting.getSpans();
-    assertEquals(3, finished.size());
+    assertThat(finished).hasSize(3);
   }
 }

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/RateLimiterTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/RateLimiterTest.java
@@ -5,9 +5,7 @@
 
 package io.opentelemetry.sdk.extension.trace.jaeger.sampler;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.common.Clock;
 import java.util.ArrayList;
@@ -48,31 +46,31 @@ class RateLimiterTest {
 
     long currentTime = TimeUnit.MICROSECONDS.toNanos(100);
     clock.timeNanos = currentTime;
-    assertTrue(limiter.checkCredit(1.0));
-    assertTrue(limiter.checkCredit(1.0));
-    assertFalse(limiter.checkCredit(1.0));
+    assertThat(limiter.checkCredit(1.0)).isTrue();
+    assertThat(limiter.checkCredit(1.0)).isTrue();
+    assertThat(limiter.checkCredit(1.0)).isFalse();
     // move time 250ms forward, not enough credits to pay for 1.0 item
     currentTime += TimeUnit.MILLISECONDS.toNanos(250);
     clock.timeNanos = currentTime;
-    assertFalse(limiter.checkCredit(1.0));
+    assertThat(limiter.checkCredit(1.0)).isFalse();
 
     // move time 500ms forward, now enough credits to pay for 1.0 item
     currentTime += TimeUnit.MILLISECONDS.toNanos(500);
     clock.timeNanos = currentTime;
 
-    assertTrue(limiter.checkCredit(1.0));
-    assertFalse(limiter.checkCredit(1.0));
+    assertThat(limiter.checkCredit(1.0)).isTrue();
+    assertThat(limiter.checkCredit(1.0)).isFalse();
 
     // move time 5s forward, enough to accumulate credits for 10 messages, but it should still be
     // capped at 2
     currentTime += TimeUnit.MILLISECONDS.toNanos(5000);
     clock.timeNanos = currentTime;
 
-    assertTrue(limiter.checkCredit(1.0));
-    assertTrue(limiter.checkCredit(1.0));
-    assertFalse(limiter.checkCredit(1.0));
-    assertFalse(limiter.checkCredit(1.0));
-    assertFalse(limiter.checkCredit(1.0));
+    assertThat(limiter.checkCredit(1.0)).isTrue();
+    assertThat(limiter.checkCredit(1.0)).isTrue();
+    assertThat(limiter.checkCredit(1.0)).isFalse();
+    assertThat(limiter.checkCredit(1.0)).isFalse();
+    assertThat(limiter.checkCredit(1.0)).isFalse();
   }
 
   @Test
@@ -82,31 +80,31 @@ class RateLimiterTest {
 
     long currentTime = TimeUnit.MICROSECONDS.toNanos(100);
     clock.timeNanos = currentTime;
-    assertTrue(limiter.checkCredit(0.25));
-    assertTrue(limiter.checkCredit(0.25));
-    assertFalse(limiter.checkCredit(0.25));
+    assertThat(limiter.checkCredit(0.25)).isTrue();
+    assertThat(limiter.checkCredit(0.25)).isTrue();
+    assertThat(limiter.checkCredit(0.25)).isFalse();
     // move time 250ms forward, not enough credits to pay for 1.0 item
     currentTime += TimeUnit.MILLISECONDS.toNanos(250);
     clock.timeNanos = currentTime;
-    assertFalse(limiter.checkCredit(0.25));
+    assertThat(limiter.checkCredit(0.25)).isFalse();
 
     // move time 500ms forward, now enough credits to pay for 1.0 item
     currentTime += TimeUnit.MILLISECONDS.toNanos(500);
     clock.timeNanos = currentTime;
 
-    assertTrue(limiter.checkCredit(0.25));
-    assertFalse(limiter.checkCredit(0.25));
+    assertThat(limiter.checkCredit(0.25)).isTrue();
+    assertThat(limiter.checkCredit(0.25)).isFalse();
 
     // move time 5s forward, enough to accumulate credits for 10 messages, but it should still be
     // capped at 2
     currentTime += TimeUnit.MILLISECONDS.toNanos(5000);
     clock.timeNanos = currentTime;
 
-    assertTrue(limiter.checkCredit(0.25));
-    assertTrue(limiter.checkCredit(0.25));
-    assertFalse(limiter.checkCredit(0.25));
-    assertFalse(limiter.checkCredit(0.25));
-    assertFalse(limiter.checkCredit(0.25));
+    assertThat(limiter.checkCredit(0.25)).isTrue();
+    assertThat(limiter.checkCredit(0.25)).isTrue();
+    assertThat(limiter.checkCredit(0.25)).isFalse();
+    assertThat(limiter.checkCredit(0.25)).isFalse();
+    assertThat(limiter.checkCredit(0.25)).isFalse();
   }
 
   @Test
@@ -116,16 +114,16 @@ class RateLimiterTest {
 
     long currentTime = TimeUnit.MICROSECONDS.toNanos(100);
     clock.timeNanos = currentTime;
-    assertTrue(limiter.checkCredit(1.0));
-    assertFalse(limiter.checkCredit(1.0));
+    assertThat(limiter.checkCredit(1.0)).isTrue();
+    assertThat(limiter.checkCredit(1.0)).isFalse();
 
     // move time 20s forward, enough to accumulate credits for 2 messages, but it should still be
     // capped at 1
     currentTime += TimeUnit.MILLISECONDS.toNanos(20000);
     clock.timeNanos = currentTime;
 
-    assertTrue(limiter.checkCredit(1.0));
-    assertFalse(limiter.checkCredit(1.0));
+    assertThat(limiter.checkCredit(1.0)).isTrue();
+    assertThat(limiter.checkCredit(1.0)).isFalse();
   }
 
   /**
@@ -138,25 +136,25 @@ class RateLimiterTest {
     clock.timeNanos = TimeUnit.MILLISECONDS.toNanos(-1_000_000);
     RateLimiter limiter = new RateLimiter(1000, 100, clock);
 
-    assertTrue(limiter.checkCredit(100)); // consume initial (max) balance
-    assertFalse(limiter.checkCredit(1));
+    assertThat(limiter.checkCredit(100)).isTrue(); // consume initial (max) balance
+    assertThat(limiter.checkCredit(1)).isFalse();
 
     clock.timeNanos += TimeUnit.MILLISECONDS.toNanos(49); // add 49 credits
-    assertFalse(limiter.checkCredit(50));
+    assertThat(limiter.checkCredit(50)).isFalse();
 
     clock.timeNanos += TimeUnit.MILLISECONDS.toNanos(1); // add one credit
-    assertTrue(limiter.checkCredit(50)); // consume accrued balance
-    assertFalse(limiter.checkCredit(1));
+    assertThat(limiter.checkCredit(50)).isTrue(); // consume accrued balance
+    assertThat(limiter.checkCredit(1)).isFalse();
 
     clock.timeNanos +=
         TimeUnit.MILLISECONDS.toNanos(1_000_000); // add a lot of credits (max out balance)
-    assertTrue(limiter.checkCredit(1)); // take one credit
+    assertThat(limiter.checkCredit(1)).isTrue(); // take one credit
 
     clock.timeNanos +=
         TimeUnit.MILLISECONDS.toNanos(1_000_000); // add a lot of credits (max out balance)
-    assertFalse(limiter.checkCredit(101)); // can't consume more than max balance
-    assertTrue(limiter.checkCredit(100)); // consume max balance
-    assertFalse(limiter.checkCredit(1));
+    assertThat(limiter.checkCredit(101)).isFalse(); // can't consume more than max balance
+    assertThat(limiter.checkCredit(100)).isTrue(); // consume max balance
+    assertThat(limiter.checkCredit(1)).isFalse();
   }
 
   /** Validates concurrent credit check correctness. */
@@ -186,10 +184,9 @@ class RateLimiterTest {
     }
     executorService.shutdown();
     executorService.awaitTermination(1, TimeUnit.SECONDS);
-    assertEquals(
-        numWorkers * creditsPerWorker,
-        count.get(),
-        "Exactly the allocated number of credits must be consumed");
-    assertFalse(limiter.checkCredit(1));
+    assertThat(count.get())
+        .withFailMessage("Exactly the allocated number of credits must be consumed")
+        .isEqualTo(numWorkers * creditsPerWorker);
+    assertThat(limiter.checkCredit(1)).isFalse();
   }
 }

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/RateLimitingSamplerTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/RateLimitingSamplerTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.sdk.extension.trace.jaeger.sampler;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
@@ -88,16 +87,15 @@ class RateLimitingSamplerTest {
                     Collections.emptyList())
                 .getDecision())
         .isEqualTo(SamplingResult.Decision.DROP);
-    assertEquals(2, samplingResult.getAttributes().size());
-    assertEquals(1d, samplingResult.getAttributes().get(RateLimitingSampler.SAMPLER_PARAM));
-    assertEquals(
-        RateLimitingSampler.TYPE,
-        samplingResult.getAttributes().get(RateLimitingSampler.SAMPLER_TYPE));
+    assertThat(samplingResult.getAttributes().size()).isEqualTo(2);
+    assertThat(samplingResult.getAttributes().get(RateLimitingSampler.SAMPLER_PARAM)).isEqualTo(1d);
+    assertThat(samplingResult.getAttributes().get(RateLimitingSampler.SAMPLER_TYPE)).isEqualTo(
+        RateLimitingSampler.TYPE);
   }
 
   @Test
   void description() {
     RateLimitingSampler sampler = new RateLimitingSampler(15);
-    assertEquals("RateLimitingSampler{15.00}", sampler.getDescription());
+    assertThat(sampler.getDescription()).isEqualTo("RateLimitingSampler{15.00}");
   }
 }

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/RateLimitingSamplerTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/RateLimitingSamplerTest.java
@@ -89,8 +89,8 @@ class RateLimitingSamplerTest {
         .isEqualTo(SamplingResult.Decision.DROP);
     assertThat(samplingResult.getAttributes().size()).isEqualTo(2);
     assertThat(samplingResult.getAttributes().get(RateLimitingSampler.SAMPLER_PARAM)).isEqualTo(1d);
-    assertThat(samplingResult.getAttributes().get(RateLimitingSampler.SAMPLER_TYPE)).isEqualTo(
-        RateLimitingSampler.TYPE);
+    assertThat(samplingResult.getAttributes().get(RateLimitingSampler.SAMPLER_TYPE))
+        .isEqualTo(RateLimitingSampler.TYPE);
   }
 
   @Test

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -15,7 +15,6 @@ import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -41,6 +40,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 /** Unit tests for {@link SpanBuilderSdk}. */
@@ -783,10 +783,10 @@ class SpanBuilderSdkTest {
             tracerSdk.spanBuilder(SPAN_NAME).setParent(parentContext).startSpan();
     try {
       Mockito.verify(mockedSpanProcessor)
-          .onStart(Mockito.same(parentContext), Mockito.same((ReadWriteSpan) span));
+          .onStart(ArgumentMatchers.same(parentContext), ArgumentMatchers.same((ReadWriteSpan) span));
       assertThat(span.getSpanContext().getTraceIdAsHexString())
           .isNotEqualTo(parent.getSpanContext().getTraceIdAsHexString());
-      assertFalse(SpanId.isValid(span.toSpanData().getParentSpanId()));
+      assertThat(SpanId.isValid(span.toSpanData().getParentSpanId())).isFalse();
     } finally {
       span.end();
     }

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -783,7 +783,8 @@ class SpanBuilderSdkTest {
             tracerSdk.spanBuilder(SPAN_NAME).setParent(parentContext).startSpan();
     try {
       Mockito.verify(mockedSpanProcessor)
-          .onStart(ArgumentMatchers.same(parentContext), ArgumentMatchers.same((ReadWriteSpan) span));
+          .onStart(
+              ArgumentMatchers.same(parentContext), ArgumentMatchers.same((ReadWriteSpan) span));
       assertThat(span.getSpanContext().getTraceIdAsHexString())
           .isNotEqualTo(parent.getSpanContext().getTraceIdAsHexString());
       assertThat(SpanId.isValid(span.toSpanData().getParentSpanId())).isFalse();

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/testbed/clientserver/TestClientServerTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/testbed/clientserver/TestClientServerTest.java
@@ -8,7 +8,6 @@ package io.opentelemetry.sdk.trace.testbed.clientserver;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Span.Kind;
@@ -56,7 +55,7 @@ class TestClientServerTest {
         .until(TestUtils.finishedSpansSize(otelTesting), equalTo(2));
 
     List<SpanData> finished = otelTesting.getSpans();
-    assertEquals(2, finished.size());
+    assertThat(finished).hasSize(2);
 
     finished = TestUtils.sortByStartTime(finished);
     assertThat(finished.get(0).getTraceId()).isEqualTo(finished.get(1).getTraceId());

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/testbed/errorreporting/ErrorReportingTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/testbed/errorreporting/ErrorReportingTest.java
@@ -8,7 +8,6 @@ package io.opentelemetry.sdk.trace.testbed.errorreporting;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
@@ -103,8 +102,8 @@ public final class ErrorReportingTest {
     assertThat(spans.get(0).getStatus().getCanonicalCode()).isEqualTo(StatusCode.ERROR);
 
     List<Event> events = spans.get(0).getEvents();
-    assertEquals(events.size(), maxRetries);
-    assertEquals(events.get(0).getName(), "error");
+    assertThat(events).hasSize(maxRetries);
+    assertThat("error").isEqualTo(events.get(0).getName());
   }
 
   /* Error handling for a mocked layer automatically capturing/activating
@@ -131,8 +130,8 @@ public final class ErrorReportingTest {
     await().atMost(5, TimeUnit.SECONDS).until(TestUtils.finishedSpansSize(otelTesting), equalTo(1));
 
     List<SpanData> spans = otelTesting.getSpans();
-    assertEquals(spans.size(), 1);
-    assertEquals(spans.get(0).getStatus().getCanonicalCode(), StatusCode.ERROR);
+    assertThat(spans).hasSize(1);
+    assertThat(StatusCode.ERROR).isEqualTo(spans.get(0).getStatus().getCanonicalCode());
   }
 
   private static class ScopedRunnable implements Runnable {

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/testbed/statelesscommonrequesthandler/HandlerTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/testbed/statelesscommonrequesthandler/HandlerTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.sdk.trace.testbed.statelesscommonrequesthandler;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
@@ -35,11 +35,11 @@ public final class HandlerTest {
     Future<String> responseFuture2 = client.send("message2");
     Future<String> responseFuture3 = client.send("message3");
 
-    assertEquals("message3:response", responseFuture3.get(5, TimeUnit.SECONDS));
-    assertEquals("message2:response", responseFuture2.get(5, TimeUnit.SECONDS));
-    assertEquals("message:response", responseFuture.get(5, TimeUnit.SECONDS));
+    assertThat(responseFuture3.get(5, TimeUnit.SECONDS)).isEqualTo("message3:response");
+    assertThat(responseFuture2.get(5, TimeUnit.SECONDS)).isEqualTo("message2:response");
+    assertThat(responseFuture.get(5, TimeUnit.SECONDS)).isEqualTo("message:response");
 
     List<SpanData> finished = otelTesting.getSpans();
-    assertEquals(3, finished.size());
+    assertThat(finished).hasSize(3);
   }
 }


### PR DESCRIPTION
Remove uses of JUnit 4 and JUnit 5 assert* where a functional equivalent exists in AssertJ. JUnit 5's assertThrows remains.

Fixes #1994

Conversion was done primarily using automated replacement, but I tried to find places where manual improvements could be made. For example, when the expected/actual were obviously in the wrong order for `assertEquals` or where `assertThat(list).hasSize(n)` could replace `assertEquals(n, list.size())`