### PR TITLE
Switch the key/value pair sorting to mergesort, because it is stable

### DIFF
--- a/api/src/test/java/io/opentelemetry/api/common/AttributesTest.java
+++ b/api/src/test/java/io/opentelemetry/api/common/AttributesTest.java
@@ -116,6 +116,23 @@ class AttributesTest {
   }
 
   @Test
+  void deduplication_oddNumberElements() {
+    Attributes one =
+        Attributes.builder()
+            .put(stringKey("key2"), "valueX")
+            .put(stringKey("key2"), "value2")
+            .put(stringKey("key1"), "value1")
+            .build();
+    Attributes two =
+        Attributes.builder()
+            .put(stringKey("key2"), "value2")
+            .put(stringKey("key1"), "value1")
+            .build();
+
+    assertThat(one).isEqualTo(two);
+  }
+
+  @Test
   void emptyAndNullKey() {
     Attributes noAttributes = Attributes.of(stringKey(""), "empty", null, "null");
 


### PR DESCRIPTION
Turns out quicksort isn't stable (equal-comparing keys don't stay in source-order).

Resolves #2043 