### PR TITLE
Add assertj helpers for asserting traces and expose from the junit5 h…

### DIFF
--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TraceAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TraceAssert.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.testing.assertj;
+
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.assertj.core.api.AbstractIterableAssert;
+
+/** Assertions for an exported trace, a list of {@link SpanData} with the same trace ID. */
+public class TraceAssert
+    extends AbstractIterableAssert<TraceAssert, List<SpanData>, SpanData, SpanDataAssert> {
+
+  TraceAssert(List<SpanData> spanData) {
+    super(spanData, TraceAssert.class);
+  }
+
+  public TraceAssert hasTraceId(String traceId) {
+    isNotNull();
+    isNotEmpty();
+
+    String actualTraceId = actual.get(0).getTraceId();
+    if (!actualTraceId.equals(traceId)) {
+      failWithActualExpectedAndMessage(
+          actualTraceId,
+          traceId,
+          "Expected trace to have trace ID <%s> but was <%s>",
+          traceId,
+          actualTraceId);
+    }
+    return this;
+  }
+
+  /**
+   * Asserts that the trace under assertion has the same number of spans as provided {@code
+   * assertions} and executes each {@link SpanDataAssert} in {@code assertions} in order with the
+   * corresponding span.
+   */
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  public final TraceAssert hasSpansSatisfyingExactly(Consumer<SpanDataAssert>... assertions) {
+    hasSize(assertions.length);
+    zipSatisfy(
+        Arrays.asList(assertions), (span, assertion) -> assertion.accept(new SpanDataAssert(span)));
+    return this;
+  }
+
+  @Override
+  protected SpanDataAssert toAssert(SpanData value, String description) {
+    return new SpanDataAssert(value).as(description);
+  }
+
+  @Override
+  protected TraceAssert newAbstractIterableAssert(Iterable<? extends SpanData> iterable) {
+    return new TraceAssert(
+        StreamSupport.stream(iterable.spliterator(), false).collect(Collectors.toList()));
+  }
+}

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TraceAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TraceAssert.java
@@ -21,6 +21,7 @@ public class TraceAssert
     super(spanData, TraceAssert.class);
   }
 
+  /** Asserts that the trace has the given trace ID. */
   public TraceAssert hasTraceId(String traceId) {
     isNotNull();
     isNotEmpty();

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TracesAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TracesAssert.java
@@ -22,7 +22,7 @@ public class TracesAssert
         TracesAssert, List<List<SpanData>>, List<SpanData>, TraceAssert> {
 
   /**
-   * Returns an assertion for a list of traces. The traces must already be grouped into {@link
+   * Returns an assertion for a list of traces. The traces must already be grouped into {@code
    * List<SpanData>} where each list has spans with the same trace ID.
    */
   public static TracesAssert assertThat(Collection<List<SpanData>> traces) {
@@ -48,7 +48,7 @@ public class TracesAssert
    */
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final TracesAssert hasTracesSatisfyingExactly(Consumer<TraceAssert>... assertions) {
+  public final TracesAssert hasTracesSatisfyingInAnyOrder(Consumer<TraceAssert>... assertions) {
     hasSize(assertions.length);
     zipSatisfy(
         Arrays.asList(assertions), (trace, assertion) -> assertion.accept(new TraceAssert(trace)));

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TracesAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TracesAssert.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.testing.assertj;
+
+import static java.util.stream.Collectors.toList;
+
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.StreamSupport;
+import org.assertj.core.api.AbstractIterableAssert;
+
+/** Assertions for a list of exported traces. */
+public class TracesAssert
+    extends AbstractIterableAssert<
+        TracesAssert, List<List<SpanData>>, List<SpanData>, TraceAssert> {
+
+  /**
+   * Returns an assertion for a list of traces. The traces must already be grouped into {@link
+   * List<SpanData>} where each list has spans with the same trace ID.
+   */
+  public static TracesAssert assertThat(Collection<List<SpanData>> traces) {
+    for (List<SpanData> trace : traces) {
+      if (trace.stream().map(SpanData::getTraceId).distinct().count() != 1) {
+        throw new IllegalArgumentException(
+            "trace does not have consistent trace IDs, group spans into traces before calling "
+                + "this function: "
+                + trace);
+      }
+    }
+    return new TracesAssert(new ArrayList<>(traces));
+  }
+
+  TracesAssert(List<List<SpanData>> lists) {
+    super(lists, TracesAssert.class);
+  }
+
+  /**
+   * Asserts that the traces under assertion have the same number of traces as provided {@code
+   * assertions} and executes each {@link TracesAssert} in {@code assertions} in order with the
+   * corresponding trace.
+   */
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  public final TracesAssert hasTracesSatisfyingExactly(Consumer<TraceAssert>... assertions) {
+    hasSize(assertions.length);
+    zipSatisfy(
+        Arrays.asList(assertions), (trace, assertion) -> assertion.accept(new TraceAssert(trace)));
+    return this;
+  }
+
+  @Override
+  protected TraceAssert toAssert(List<SpanData> value, String description) {
+    return new TraceAssert(value).as(description);
+  }
+
+  @Override
+  protected TracesAssert newAbstractIterableAssert(Iterable<? extends List<SpanData>> iterable) {
+    return new TracesAssert(StreamSupport.stream(iterable.spliterator(), false).collect(toList()));
+  }
+}

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TracesAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TracesAssert.java
@@ -48,7 +48,7 @@ public class TracesAssert
    */
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final TracesAssert hasTracesSatisfyingInAnyOrder(Consumer<TraceAssert>... assertions) {
+  public final TracesAssert hasTracesSatisfyingExactly(Consumer<TraceAssert>... assertions) {
     hasSize(assertions.length);
     zipSatisfy(
         Arrays.asList(assertions), (trace, assertion) -> assertion.accept(new TraceAssert(trace)));

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtension.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtension.java
@@ -18,6 +18,7 @@ import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -102,7 +103,10 @@ public class OpenTelemetryExtension
    */
   public TracesAssert assertTraces() {
     Map<String, List<SpanData>> traces =
-        getSpans().stream().collect(Collectors.groupingBy(SpanData::getTraceId));
+        getSpans().stream()
+            .collect(
+                Collectors.groupingBy(
+                    SpanData::getTraceId, LinkedHashMap::new, Collectors.toList()));
     for (List<SpanData> trace : traces.values()) {
       trace.sort(Comparator.comparing(SpanData::getStartEpochNanos));
     }

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtension.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtension.java
@@ -5,16 +5,22 @@
 
 package io.opentelemetry.sdk.testing.junit5;
 
+import static io.opentelemetry.sdk.testing.assertj.TracesAssert.assertThat;
+
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.propagation.HttpTraceContext;
 import io.opentelemetry.context.propagation.DefaultContextPropagators;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.assertj.TracesAssert;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.TracerSdkManagement;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -88,6 +94,19 @@ public class OpenTelemetryExtension
   /** Returns all the exported {@link SpanData} so far. */
   public List<SpanData> getSpans() {
     return spanExporter.getFinishedSpanItems();
+  }
+
+  /**
+   * Returns a {@link TracesAssert} for asserting on the currently exported traces. This method
+   * requires AssertJ to be on the classpath.
+   */
+  public TracesAssert assertTraces() {
+    Map<String, List<SpanData>> traces =
+        getSpans().stream().collect(Collectors.groupingBy(SpanData::getTraceId));
+    for (List<SpanData> trace : traces.values()) {
+      trace.sort(Comparator.comparing(SpanData::getStartEpochNanos));
+    }
+    return assertThat(traces.values());
   }
 
   /**

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
@@ -77,7 +77,7 @@ class OpenTelemetryExtensionTest {
 
     otelTesting
         .assertTraces()
-        .hasTracesSatisfyingExactly(
+        .hasTracesSatisfyingInAnyOrder(
             trace ->
                 trace.hasSpansSatisfyingExactly(s -> s.hasName("testa1"), s -> s.hasName("testa2")),
             trace ->

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
@@ -11,6 +11,9 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.LinkedHashMap;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -75,11 +78,24 @@ class OpenTelemetryExtensionTest {
       span.end();
     }
 
+    String traceId =
+        otelTesting.getSpans().stream()
+            .collect(
+                Collectors.groupingBy(
+                    SpanData::getTraceId, LinkedHashMap::new, Collectors.toList()))
+            .values()
+            .stream()
+            .findFirst()
+            .get()
+            .get(0)
+            .getTraceId();
+
     otelTesting
         .assertTraces()
         .hasTracesSatisfyingExactly(
             trace ->
                 trace
+                    .hasTraceId(traceId)
                     .hasSpansSatisfyingExactly(s -> s.hasName("testa1"), s -> s.hasName("testa2"))
                     .first()
                     .hasName("testa1"),

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.testing.junit5;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
@@ -104,6 +105,13 @@ class OpenTelemetryExtensionTest {
                     .hasSpansSatisfyingExactly(s -> s.hasName("testb1"), s -> s.hasName("testb2"))
                     .filteredOn(s -> s.getName().endsWith("1"))
                     .hasSize(1));
+
+    assertThatThrownBy(
+            () ->
+                otelTesting
+                    .assertTraces()
+                    .hasTracesSatisfyingExactly(trace -> trace.hasTraceId("foo")))
+        .isInstanceOf(AssertionError.class);
 
     otelTesting
         .assertTraces()

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
@@ -79,6 +79,25 @@ class OpenTelemetryExtensionTest {
         .assertTraces()
         .hasTracesSatisfyingExactly(
             trace ->
+                trace
+                    .hasSpansSatisfyingExactly(s -> s.hasName("testa1"), s -> s.hasName("testa2"))
+                    .first()
+                    .hasName("testa1"),
+            trace ->
+                trace
+                    .hasSpansSatisfyingExactly(s -> s.hasName("testb1"), s -> s.hasName("testb2"))
+                    .filteredOn(s -> s.getName().endsWith("1"))
+                    .hasSize(1));
+
+    otelTesting
+        .assertTraces()
+        .first()
+        .hasSpansSatisfyingExactly(s -> s.hasName("testa1"), s -> s.hasName("testa2"));
+    otelTesting
+        .assertTraces()
+        .filteredOn(trace -> trace.size() == 2)
+        .hasTracesSatisfyingExactly(
+            trace ->
                 trace.hasSpansSatisfyingExactly(s -> s.hasName("testa1"), s -> s.hasName("testa2")),
             trace ->
                 trace.hasSpansSatisfyingExactly(

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
@@ -77,7 +77,7 @@ class OpenTelemetryExtensionTest {
 
     otelTesting
         .assertTraces()
-        .hasTracesSatisfyingInAnyOrder(
+        .hasTracesSatisfyingExactly(
             trace ->
                 trace.hasSpansSatisfyingExactly(s -> s.hasName("testa1"), s -> s.hasName("testa2")),
             trace ->


### PR DESCRIPTION
…elper.

I think this makes it very nice to assert on traces in tests. There's some future work though that requiring ordering doesn't seem very helpful here, especially for `hasTracesSatisfying`. Leaving it for now to not complicate this change too much.