### PR TITLE
Make the OpenTelemetrySdk a subclass of DefaultOpenTelemetry

### DIFF
--- a/api/src/main/java/io/opentelemetry/api/DefaultOpenTelemetry.java
+++ b/api/src/main/java/io/opentelemetry/api/DefaultOpenTelemetry.java
@@ -118,10 +118,10 @@ public class DefaultOpenTelemetry implements OpenTelemetry {
   }
 
   protected static class Builder implements OpenTelemetryBuilder<Builder> {
-    private ContextPropagators propagators = DefaultContextPropagators.builder().build();
+    protected ContextPropagators propagators = DefaultContextPropagators.builder().build();
 
-    private TracerProvider tracerProvider;
-    private MeterProvider meterProvider;
+    protected TracerProvider tracerProvider;
+    protected MeterProvider meterProvider;
 
     @Override
     public Builder setTracerProvider(TracerProvider tracerProvider) {
@@ -146,26 +146,6 @@ public class DefaultOpenTelemetry implements OpenTelemetry {
 
     @Override
     public OpenTelemetry build() {
-      MeterProvider meterProvider = buildMeterProvider();
-      TracerProvider tracerProvider = buildTracerProvider();
-
-      return new DefaultOpenTelemetry(tracerProvider, meterProvider, propagators);
-    }
-
-    protected TracerProvider buildTracerProvider() {
-      TracerProvider tracerProvider = this.tracerProvider;
-      if (tracerProvider == null) {
-        TracerProviderFactory tracerProviderFactory = loadSpi(TracerProviderFactory.class);
-        if (tracerProviderFactory != null) {
-          tracerProvider = tracerProviderFactory.create();
-        } else {
-          tracerProvider = TracerProvider.getDefault();
-        }
-      }
-      return tracerProvider;
-    }
-
-    protected MeterProvider buildMeterProvider() {
       MeterProvider meterProvider = this.meterProvider;
       if (meterProvider == null) {
         MeterProviderFactory meterProviderFactory = loadSpi(MeterProviderFactory.class);
@@ -175,11 +155,18 @@ public class DefaultOpenTelemetry implements OpenTelemetry {
           meterProvider = MeterProvider.getDefault();
         }
       }
-      return meterProvider;
-    }
 
-    protected ContextPropagators buildContextPropagators() {
-      return propagators;
+      TracerProvider tracerProvider = this.tracerProvider;
+      if (tracerProvider == null) {
+        TracerProviderFactory tracerProviderFactory = loadSpi(TracerProviderFactory.class);
+        if (tracerProviderFactory != null) {
+          tracerProvider = tracerProviderFactory.create();
+        } else {
+          tracerProvider = TracerProvider.getDefault();
+        }
+      }
+
+      return new DefaultOpenTelemetry(tracerProvider, meterProvider, propagators);
     }
   }
 }

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -101,8 +101,8 @@ public final class OpenTelemetrySdk extends DefaultOpenTelemetry {
 
   /** A builder for configuring an {@link OpenTelemetrySdk}. */
   public static class Builder extends DefaultOpenTelemetry.Builder {
-    private Clock clock = MillisClock.getInstance();
-    private Resource resource = Resource.getDefault();
+    private Clock clock;
+    private Resource resource;
 
     /**
      * Sets the {@link TracerSdkProvider} to use. This can be used to configure tracing settings by
@@ -179,8 +179,8 @@ public final class OpenTelemetrySdk extends DefaultOpenTelemetry {
               new ObfuscatedTracerProvider(tracerProvider),
               meterProvider,
               super.propagators,
-              clock,
-              resource);
+              clock == null ? MillisClock.getInstance() : clock,
+              resource == null ? Resource.getDefault() : resource);
       // Automatically initialize global OpenTelemetry with the first SDK we build.
       if (INITIALIZED_GLOBAL.compareAndSet(/* expectedValue= */ false, /* newValue= */ true)) {
         OpenTelemetry.set(sdk);

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -131,6 +131,10 @@ public final class OpenTelemetrySdk extends DefaultOpenTelemetry {
      */
     @Override
     public Builder setMeterProvider(MeterProvider meterProvider) {
+      if (!(meterProvider instanceof MeterSdkProvider)) {
+        throw new IllegalArgumentException(
+            "The OpenTelemetrySdk can only be configured with a MeterSdkProvider");
+      }
       super.setMeterProvider(meterProvider);
       return this;
     }

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -10,7 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.MeterProvider;
-import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.sdk.OpenTelemetrySdk.ObfuscatedTracerProvider;
 import io.opentelemetry.sdk.common.Clock;
@@ -26,7 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class OpenTelemetrySdkTest {
 
-  @Mock private TracerProvider tracerProvider;
+  @Mock private TracerSdkProvider tracerProvider;
   @Mock private MeterProvider meterProvider;
   @Mock private ContextPropagators propagators;
   @Mock private Clock clock;
@@ -76,7 +75,8 @@ class OpenTelemetrySdkTest {
             .setClock(clock)
             .setResource(resource)
             .build();
-    assertThat(openTelemetry.getTracerProvider()).isEqualTo(tracerProvider);
+    assertThat(((ObfuscatedTracerProvider) openTelemetry.getTracerProvider()).unobfuscate())
+        .isEqualTo(tracerProvider);
     assertThat(openTelemetry.getMeterProvider()).isEqualTo(meterProvider);
     assertThat(openTelemetry.getPropagators()).isEqualTo(propagators);
     assertThat(openTelemetry.getResource()).isEqualTo(resource);

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -93,7 +93,8 @@ class OpenTelemetrySdkTest {
         ((ObfuscatedTracerProvider) openTelemetry.getTracerProvider()).unobfuscate();
 
     assertThat(unobfuscatedTracerProvider).isInstanceOf(TracerSdkProvider.class);
-    // this is not a great way to test this...
+    // Since TracerProvider is in a different package, the only alternative to this reflective
+    // approach would be to make the fields public for testing which is worse than this.
     assertThat(unobfuscatedTracerProvider)
         .extracting("sharedState")
         .hasFieldOrPropertyWithValue("clock", clock)

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -101,7 +101,8 @@ class OpenTelemetrySdkTest {
         .hasFieldOrPropertyWithValue("resource", resource);
 
     assertThat(openTelemetry.getMeterProvider()).isInstanceOf(MeterSdkProvider.class);
-    // this is not awesome
+    // Since MeterProvider is in a different package, the only alternative to this reflective
+    // approach would be to make the fields public for testing which is worse than this.
     assertThat(openTelemetry.getMeterProvider())
         .extracting("registry")
         .extracting("meterProviderSharedState")

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
@@ -37,6 +38,7 @@ class OpenTelemetrySdkTest {
         .isSameAs(OpenTelemetry.getGlobalTracerProvider().get(""));
     assertThat(OpenTelemetrySdk.getGlobalMeterProvider())
         .isSameAs(OpenTelemetry.getGlobalMeterProvider());
+    assertThat(OpenTelemetrySdk.getGlobalTracerManagement()).isNotNull();
   }
 
   @Test
@@ -111,5 +113,16 @@ class OpenTelemetrySdkTest {
 
     assertThat(openTelemetry.getResource()).isSameAs(resource);
     assertThat(openTelemetry.getClock()).isSameAs(clock);
+  }
+
+  @Test
+  void testTracerProviderAccess() {
+    OpenTelemetrySdk openTelemetry =
+        OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build();
+    assertThat(openTelemetry.getTracerProvider())
+        .asInstanceOf(type(ObfuscatedTracerProvider.class))
+        .isNotNull()
+        .matches(obfuscated -> obfuscated.unobfuscate() == tracerProvider);
+    assertThat(openTelemetry.getTracerManagement()).isNotNull();
   }
 }

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -7,6 +7,8 @@ package io.opentelemetry.sdk;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
@@ -28,7 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class OpenTelemetrySdkTest {
 
   @Mock private TracerSdkProvider tracerProvider;
-  @Mock private MeterProvider meterProvider;
+  @Mock private MeterSdkProvider meterProvider;
   @Mock private ContextPropagators propagators;
   @Mock private Clock clock;
 
@@ -124,5 +126,15 @@ class OpenTelemetrySdkTest {
         .isNotNull()
         .matches(obfuscated -> obfuscated.unobfuscate() == tracerProvider);
     assertThat(openTelemetry.getTracerManagement()).isNotNull();
+  }
+
+  @Test
+  void onlySdkInstancesAllowed() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> OpenTelemetrySdk.builder().setMeterProvider(mock(MeterProvider.class)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> OpenTelemetrySdk.builder().setTracerProvider(mock(TracerProvider.class)));
   }
 }

--- a/sdk/all/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/sdk/all/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
We discussed this possibility several times, so I thought I'd give it a try.

Feedback welcome. This resolves #2018 as well.