### PR TITLE
Fetch full repo in continuous build to allow computing nebula version.

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           submodules: true
       - id: setup-java-8
         name: Setup Java 8
@@ -50,6 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           submodules: true
       - id: setup-java-11
         name: Setup Java 11

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           submodules: true
       - id: setup-java-8
         name: Setup Java 8


### PR DESCRIPTION
I think in the instrumentation repo where we use the same plugin, it was ok on CircleCI since it defaults to fetching the full repo. And I noticed we don't actually have a GH version of that build there right now.