### PR TITLE
Explicitly bump CI to Java 8.0.275.

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8.0.275
-          java-package: jre
       - id: setup-java-11
         name: Setup Java 11
         uses: actions/setup-java@v1

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -26,7 +26,7 @@ jobs:
         name: Setup Java 8
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 8.0.275
           java-package: jre
       - id: setup-java-11
         name: Setup Java 11

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8.0.275
-          java-package: jre
       - id: setup-java-11
         name: Setup Java 11
         uses: actions/setup-java@v1

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -26,7 +26,7 @@ jobs:
         name: Setup Java 8
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 8.0.275
           java-package: jre
       - id: setup-java-11
         name: Setup Java 11


### PR DESCRIPTION
GitHub seems to default to 272 still - while we will want to revert this eventually to make sure it continues to be autobumped in the future, we're currently seeing core dumps that may be fixed by temporarily manual bumping.

http://openjdk.5641.n7.nabble.com/Bug-3812-New-IcedTea7-Backport-JDK-8250861-quot-Crash-in-MinINode-Ideal-PhaseGVN-bool-td431647.html