### PR TITLE
Disable javadoc task for kotlin project since there isn't any. And ha…

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: burrunan/gradle-cache-action@v1.5
         with:
           remote-build-cache-proxy-enabled: false
-          arguments: check --stacktrace ${{ matrix.coverage && ':opentelemetry-all:jacocoTestReport' || '' }}
+          arguments: build --stacktrace ${{ matrix.coverage && ':opentelemetry-all:jacocoTestReport' || '' }}
           properties: |
             testAdditionalJavaVersions=${{ matrix.testAdditionalJavaVersions }}
             org.gradle.java.installations.paths=${{ steps.setup-java-8.outputs.path }},${{ steps.setup-java-11.outputs.path }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: burrunan/gradle-cache-action@v1.5
         with:
           remote-build-cache-proxy-enabled: false
-          arguments: check --stacktrace ${{ matrix.coverage && ':opentelemetry-all:jacocoTestReport' || '' }}
+          arguments: build --stacktrace ${{ matrix.coverage && ':opentelemetry-all:jacocoTestReport' || '' }}
           properties: |
             testAdditionalJavaVersions=${{ matrix.testAdditionalJavaVersions }}
             org.gradle.java.installations.paths=${{ steps.setup-java-8.outputs.path }},${{ steps.setup-java-11.outputs.path }}

--- a/extensions/kotlin/build.gradle
+++ b/extensions/kotlin/build.gradle
@@ -26,3 +26,6 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
         jvmTarget = "1.8"
     }
 }
+
+// We don't have any public Java classes
+tasks.javadoc.enabled = false


### PR DESCRIPTION
…ve CI build instead of check.

Hadn't realized check isn't enough since it doesn't check javadoc.