### PR TITLE
Ignore invalid usage of TraceState instead of throwing.

### DIFF
--- a/api/src/main/java/io/opentelemetry/api/trace/TraceState.java
+++ b/api/src/main/java/io/opentelemetry/api/trace/TraceState.java
@@ -137,5 +137,4 @@ public abstract class TraceState {
 
     Entry() {}
   }
-
 }

--- a/api/src/main/java/io/opentelemetry/api/trace/TraceState.java
+++ b/api/src/main/java/io/opentelemetry/api/trace/TraceState.java
@@ -6,10 +6,8 @@
 package io.opentelemetry.api.trace;
 
 import com.google.auto.value.AutoValue;
-import io.opentelemetry.api.internal.Utils;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -30,12 +28,7 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 @AutoValue
 public abstract class TraceState {
-  private static final int KEY_MAX_SIZE = 256;
-  private static final int VALUE_MAX_SIZE = 256;
-  private static final int MAX_KEY_VALUE_PAIRS = 32;
   private static final TraceState DEFAULT = TraceState.builder().build();
-  private static final int MAX_TENANT_ID_SIZE = 240;
-  public static final int MAX_VENDOR_ID_SIZE = 13;
 
   /**
    * Returns the default {@code TraceState} with no entries.
@@ -107,7 +100,6 @@ public abstract class TraceState {
   }
 
   static TraceState create(List<Entry> entries) {
-    Utils.checkState(entries.size() <= MAX_KEY_VALUE_PAIRS, "Invalid size");
     return new AutoValue_TraceState(Collections.unmodifiableList(entries));
   }
 
@@ -126,10 +118,6 @@ public abstract class TraceState {
      */
     // Visible for testing
     static Entry create(String key, String value) {
-      Objects.requireNonNull(key, "key");
-      Objects.requireNonNull(value, "value");
-      Utils.checkArgument(validateKey(key), "Invalid key %s", key);
-      Utils.checkArgument(validateValue(value), "Invalid value %s", value);
       return new AutoValue_TraceState_Entry(key, value);
     }
 
@@ -150,78 +138,4 @@ public abstract class TraceState {
     Entry() {}
   }
 
-  // Key is opaque string up to 256 characters printable. It MUST begin with a lowercase letter, and
-  // can only contain lowercase letters a-z, digits 0-9, underscores _, dashes -, asterisks *, and
-  // forward slashes /.  For multi-tenant vendor scenarios, an at sign (@) can be used to prefix the
-  // vendor name. The tenant id (before the '@') is limited to 240 characters and the vendor id is
-  // limited to 13 characters. If in the multi-tenant vendor format, then the first character
-  // may additionally be digit.
-  //
-  // todo: benchmark this implementation
-  private static boolean validateKey(String key) {
-    if (key.length() > KEY_MAX_SIZE
-        || key.isEmpty()
-        || isNotLowercaseLetterOrDigit(key.charAt(0))) {
-      return false;
-    }
-    boolean isMultiTenantVendorKey = false;
-    for (int i = 1; i < key.length(); i++) {
-      char c = key.charAt(i);
-      if (isNotLegalKeyCharacter(c)) {
-        return false;
-      }
-      if (c == '@') {
-        // you can't have 2 '@' signs
-        if (isMultiTenantVendorKey) {
-          return false;
-        }
-        isMultiTenantVendorKey = true;
-        // tenant id (the part to the left of the '@' sign) must be 240 characters or less
-        if (i > MAX_TENANT_ID_SIZE) {
-          return false;
-        }
-        // vendor id (the part to the right of the '@' sign) must be 13 characters or less
-        if (key.length() - i > MAX_VENDOR_ID_SIZE) {
-          return false;
-        }
-      }
-    }
-    if (!isMultiTenantVendorKey) {
-      // if it's not the vendor format (with an '@' sign), the key must start with a letter.
-      return isNotDigit(key.charAt(0));
-    }
-    return true;
-  }
-
-  private static boolean isNotLegalKeyCharacter(char c) {
-    return isNotLowercaseLetterOrDigit(c)
-        && c != '_'
-        && c != '-'
-        && c != '@'
-        && c != '*'
-        && c != '/';
-  }
-
-  private static boolean isNotLowercaseLetterOrDigit(char ch) {
-    return (ch < 'a' || ch > 'z') && isNotDigit(ch);
-  }
-
-  private static boolean isNotDigit(char ch) {
-    return ch < '0' || ch > '9';
-  }
-
-  // Value is opaque string up to 256 characters printable ASCII RFC0020 characters (i.e., the range
-  // 0x20 to 0x7E) except comma , and =.
-  private static boolean validateValue(String value) {
-    if (value.length() > VALUE_MAX_SIZE || value.charAt(value.length() - 1) == ' ' /* '\u0020' */) {
-      return false;
-    }
-    for (int i = 0; i < value.length(); i++) {
-      char c = value.charAt(i);
-      if (c == ',' || c == '=' || c < ' ' /* '\u0020' */ || c > '~' /* '\u007E' */) {
-        return false;
-      }
-    }
-    return true;
-  }
 }

--- a/api/src/main/java/io/opentelemetry/api/trace/TraceStateBuilder.java
+++ b/api/src/main/java/io/opentelemetry/api/trace/TraceStateBuilder.java
@@ -12,9 +12,16 @@ import javax.annotation.Nullable;
 
 /** A builder of {@link TraceState}. */
 public final class TraceStateBuilder {
+  public static final int MAX_VENDOR_ID_SIZE = 13;
+
   // Needs to be in this class to avoid initialization deadlock because super class depends on
   // subclass (the auto-value generate class).
   private static final TraceState EMPTY = TraceState.create(Collections.emptyList());
+
+  private static final int MAX_KEY_VALUE_PAIRS = 32;
+  private static final int KEY_MAX_SIZE = 256;
+  private static final int VALUE_MAX_SIZE = 256;
+  private static final int MAX_TENANT_ID_SIZE = 240;
 
   private final TraceState parent;
   @Nullable private ArrayList<TraceState.Entry> entries;
@@ -37,6 +44,11 @@ public final class TraceStateBuilder {
    * @return this.
    */
   public TraceStateBuilder set(String key, String value) {
+    if (!isKeyValid(key)
+        || !isValueValid(value)
+        || (entries != null && entries.size() >= MAX_KEY_VALUE_PAIRS)) {
+      return this;
+    }
     // Initially create the Entry to validate input.
     TraceState.Entry entry = TraceState.Entry.create(key, value);
     if (entries == null) {
@@ -62,7 +74,9 @@ public final class TraceStateBuilder {
    * @return this.
    */
   public TraceStateBuilder remove(String key) {
-    Objects.requireNonNull(key, "key");
+    if (key == null) {
+      return this;
+    }
     if (entries == null) {
       // Copy entries from the parent.
       entries = new ArrayList<>(parent.getEntries());
@@ -88,5 +102,86 @@ public final class TraceStateBuilder {
       return parent;
     }
     return TraceState.create(entries);
+  }
+
+  // Key is opaque string up to 256 characters printable. It MUST begin with a lowercase letter, and
+  // can only contain lowercase letters a-z, digits 0-9, underscores _, dashes -, asterisks *, and
+  // forward slashes /.  For multi-tenant vendor scenarios, an at sign (@) can be used to prefix the
+  // vendor name. The tenant id (before the '@') is limited to 240 characters and the vendor id is
+  // limited to 13 characters. If in the multi-tenant vendor format, then the first character
+  // may additionally be digit.
+  //
+  // todo: benchmark this implementation
+  private static boolean isKeyValid(@Nullable String key) {
+    if (key == null) {
+      return false;
+    }
+    if (key.length() > KEY_MAX_SIZE
+        || key.isEmpty()
+        || isNotLowercaseLetterOrDigit(key.charAt(0))) {
+      return false;
+    }
+    boolean isMultiTenantVendorKey = false;
+    for (int i = 1; i < key.length(); i++) {
+      char c = key.charAt(i);
+      if (isNotLegalKeyCharacter(c)) {
+        return false;
+      }
+      if (c == '@') {
+        // you can't have 2 '@' signs
+        if (isMultiTenantVendorKey) {
+          return false;
+        }
+        isMultiTenantVendorKey = true;
+        // tenant id (the part to the left of the '@' sign) must be 240 characters or less
+        if (i > MAX_TENANT_ID_SIZE) {
+          return false;
+        }
+        // vendor id (the part to the right of the '@' sign) must be 13 characters or less
+        if (key.length() - i > MAX_VENDOR_ID_SIZE) {
+          return false;
+        }
+      }
+    }
+    if (!isMultiTenantVendorKey) {
+      // if it's not the vendor format (with an '@' sign), the key must start with a letter.
+      return isNotDigit(key.charAt(0));
+    }
+    return true;
+  }
+
+  private static boolean isNotLegalKeyCharacter(char c) {
+    return isNotLowercaseLetterOrDigit(c)
+        && c != '_'
+        && c != '-'
+        && c != '@'
+        && c != '*'
+        && c != '/';
+  }
+
+  private static boolean isNotLowercaseLetterOrDigit(char ch) {
+    return (ch < 'a' || ch > 'z') && isNotDigit(ch);
+  }
+
+  private static boolean isNotDigit(char ch) {
+    return ch < '0' || ch > '9';
+  }
+
+  // Value is opaque string up to 256 characters printable ASCII RFC0020 characters (i.e., the range
+  // 0x20 to 0x7E) except comma , and =.
+  private static boolean isValueValid(@Nullable String value) {
+    if (value == null) {
+      return false;
+    }
+    if (value.length() > VALUE_MAX_SIZE || value.charAt(value.length() - 1) == ' ' /* '\u0020' */) {
+      return false;
+    }
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (c == ',' || c == '=' || c < ' ' /* '\u0020' */ || c > '~' /* '\u007E' */) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/api/src/test/java/io/opentelemetry/api/trace/TraceStateTest.java
+++ b/api/src/test/java/io/opentelemetry/api/trace/TraceStateTest.java
@@ -67,14 +67,12 @@ class TraceStateTest {
 
   @Test
   void disallowsNullKey() {
-    assertThrows(
-        NullPointerException.class, () -> EMPTY.toBuilder().set(null, FIRST_VALUE).build());
+    assertThat(EMPTY.toBuilder().set(null, FIRST_VALUE).build()).isEqualTo(EMPTY);
   }
 
   @Test
   void invalidFirstKeyCharacter() {
-    assertThrows(
-        IllegalArgumentException.class, () -> EMPTY.toBuilder().set("$_key", FIRST_VALUE).build());
+    assertThat(EMPTY.toBuilder().set("$_key", FIRST_VALUE).build()).isEqualTo(EMPTY);
   }
 
   @Test
@@ -92,8 +90,7 @@ class TraceStateTest {
 
   @Test
   void invalidKeyCharacters() {
-    assertThrows(
-        IllegalArgumentException.class, () -> EMPTY.toBuilder().set("kEy_1", FIRST_VALUE).build());
+    assertThat(EMPTY.toBuilder().set("kEy_1", FIRST_VALUE).build()).isEqualTo(EMPTY);
   }
 
   @Test
@@ -111,9 +108,8 @@ class TraceStateTest {
 
   @Test
   void testVendorIdLongerThan13Characters_longTenantId() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> EMPTY.toBuilder().set("12345678901234567890@nrabcdefghijkl", FIRST_VALUE).build());
+    assertThat(EMPTY.toBuilder().set("12345678901234567890@nrabcdefghijkl", FIRST_VALUE).build())
+        .isEqualTo(EMPTY);
   }
 
   @Test
@@ -121,22 +117,17 @@ class TraceStateTest {
     char[] chars = new char[241];
     Arrays.fill(chars, 'a');
     String tenantId = new String(chars);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> EMPTY.toBuilder().set(tenantId + "@nr", FIRST_VALUE).build());
+    assertThat(EMPTY.toBuilder().set(tenantId + "@nr", FIRST_VALUE).build()).isEqualTo(EMPTY);
   }
 
   @Test
   void testNonVendorFormatFirstKeyCharacter() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> EMPTY.toBuilder().set("1acdfrgs", FIRST_VALUE).build());
+    assertThat(EMPTY.toBuilder().set("1acdfrgs", FIRST_VALUE).build()).isEqualTo(EMPTY);
   }
 
   @Test
   void testMultipleAtSignNotAllowed() {
-    assertThrows(
-        IllegalArgumentException.class, () -> EMPTY.toBuilder().set("1@n@r@", FIRST_VALUE).build());
+    assertThat(EMPTY.toBuilder().set("1@n@r@", FIRST_VALUE).build()).isEqualTo(EMPTY);
   }
 
   @Test
@@ -144,8 +135,7 @@ class TraceStateTest {
     char[] chars = new char[257];
     Arrays.fill(chars, 'a');
     String longKey = new String(chars);
-    assertThrows(
-        IllegalArgumentException.class, () -> EMPTY.toBuilder().set(longKey, FIRST_VALUE).build());
+    assertThat(EMPTY.toBuilder().set(longKey, FIRST_VALUE).build()).isEqualTo(EMPTY);
   }
 
   @Test
@@ -168,27 +158,22 @@ class TraceStateTest {
 
   @Test
   void disallowsNullValue() {
-    assertThrows(NullPointerException.class, () -> EMPTY.toBuilder().set(FIRST_KEY, null).build());
+    assertThat(EMPTY.toBuilder().set(FIRST_KEY, null).build()).isEqualTo(EMPTY);
   }
 
   @Test
   void valueCannotContainEqual() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> EMPTY.toBuilder().set(FIRST_KEY, "my_vakue=5").build());
+    assertThat(EMPTY.toBuilder().set(FIRST_KEY, "my_vakue=5").build()).isEqualTo(EMPTY);
   }
 
   @Test
   void valueCannotContainComma() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> EMPTY.toBuilder().set(FIRST_KEY, "first,second").build());
+    assertThat(EMPTY.toBuilder().set(FIRST_KEY, "first,second").build()).isEqualTo(EMPTY);
   }
 
   @Test
   void valueCannotContainTrailingSpaces() {
-    assertThrows(
-        IllegalArgumentException.class, () -> EMPTY.toBuilder().set(FIRST_KEY, "first ").build());
+    assertThat(EMPTY.toBuilder().set(FIRST_KEY, "first ").build()).isEqualTo(EMPTY);
   }
 
   @Test
@@ -196,8 +181,7 @@ class TraceStateTest {
     char[] chars = new char[257];
     Arrays.fill(chars, 'a');
     String longValue = new String(chars);
-    assertThrows(
-        IllegalArgumentException.class, () -> EMPTY.toBuilder().set(FIRST_KEY, longValue).build());
+    assertThat(EMPTY.toBuilder().set(FIRST_KEY, longValue).build()).isEqualTo(EMPTY);
   }
 
   @Test
@@ -272,8 +256,8 @@ class TraceStateTest {
 
   @Test
   void remove_NullNotAllowed() {
-    assertThrows(
-        NullPointerException.class, () -> multiValueTraceState.toBuilder().remove(null).build());
+    assertThat(multiValueTraceState.toBuilder().remove(null).build())
+        .isEqualTo(multiValueTraceState);
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/api/trace/TraceStateTest.java
+++ b/api/src/test/java/io/opentelemetry/api/trace/TraceStateTest.java
@@ -7,7 +7,6 @@ package io.opentelemetry.api.trace;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.testing.EqualsTester;
 import java.util.Arrays;
@@ -101,9 +100,7 @@ class TraceStateTest {
 
   @Test
   void testVendorIdLongerThan13Characters() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> EMPTY.toBuilder().set("1@nrabcdefghijkl", FIRST_VALUE).build());
+    assertThat(EMPTY.toBuilder().set("1@nrabcdefghijkl", FIRST_VALUE).build()).isEqualTo(EMPTY);
   }
 
   @Test


### PR DESCRIPTION
Similar to #1964 and because of https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/error-handling.md#basic-error-handling-principles