### PR TITLE
Deprecate the toBuilder methods on the OpenTelemetry classes

### DIFF
--- a/api/src/main/java/io/opentelemetry/api/DefaultOpenTelemetry.java
+++ b/api/src/main/java/io/opentelemetry/api/DefaultOpenTelemetry.java
@@ -55,7 +55,12 @@ public class DefaultOpenTelemetry implements OpenTelemetry {
   private final TracerProvider tracerProvider;
   private final MeterProvider meterProvider;
 
-  private final ContextPropagators propagators;
+  private volatile ContextPropagators propagators;
+
+  @Override
+  public void setPropagators(ContextPropagators propagators) {
+    this.propagators = propagators;
+  }
 
   @Override
   public TracerProvider getTracerProvider() {
@@ -110,6 +115,7 @@ public class DefaultOpenTelemetry implements OpenTelemetry {
   }
 
   @Override
+  @Deprecated
   public Builder toBuilder() {
     return new Builder()
         .setTracerProvider(tracerProvider)

--- a/api/src/main/java/io/opentelemetry/api/OpenTelemetry.java
+++ b/api/src/main/java/io/opentelemetry/api/OpenTelemetry.java
@@ -31,6 +31,7 @@ import io.opentelemetry.spi.trace.TracerProviderFactory;
  *
  * @see TracerProvider
  * @see MeterProvider
+ * @see ContextPropagators
  */
 public interface OpenTelemetry {
 
@@ -140,8 +141,11 @@ public interface OpenTelemetry {
    */
   static void setGlobalPropagators(ContextPropagators propagators) {
     requireNonNull(propagators, "propagators");
-    set(get().toBuilder().setPropagators(propagators).build());
+    get().setPropagators(propagators);
   }
+
+  /** Sets the propagators that this instance should contain. */
+  void setPropagators(ContextPropagators propagators);
 
   /** Returns the {@link TracerProvider} for this {@link OpenTelemetry}. */
   TracerProvider getTracerProvider();
@@ -206,6 +210,10 @@ public interface OpenTelemetry {
   /**
    * Returns a new {@link OpenTelemetryBuilder} with the configuration of this {@link
    * OpenTelemetry}.
+   *
+   * @deprecated This method should not be used, as it allows unexpected sharing of state across
+   *     instances. It will be removed in the next release.
    */
+  @Deprecated
   OpenTelemetryBuilder<?> toBuilder();
 }

--- a/api/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
+++ b/api/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
@@ -155,10 +155,18 @@ class OpenTelemetryTest {
   }
 
   @Test
-  void testPropagatorsSet() {
+  void testGlobalPropagatorsSet() {
     ContextPropagators propagators = DefaultContextPropagators.builder().build();
     OpenTelemetry.setGlobalPropagators(propagators);
     assertThat(OpenTelemetry.getGlobalPropagators()).isEqualTo(propagators);
+  }
+
+  @Test
+  void testPropagatorsSet() {
+    ContextPropagators propagators = DefaultContextPropagators.builder().build();
+    OpenTelemetry instance = DefaultOpenTelemetry.builder().build();
+    instance.setPropagators(propagators);
+    assertThat(instance.getPropagators()).isEqualTo(propagators);
   }
 
   @Test

--- a/integration-tests/tracecontext/src/main/java/io/opentelemetry/Application.java
+++ b/integration-tests/tracecontext/src/main/java/io/opentelemetry/Application.java
@@ -10,6 +10,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.propagation.HttpTraceContext;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.DefaultContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator.Getter;
 import io.opentelemetry.context.propagation.TextMapPropagator.Setter;
@@ -33,15 +34,12 @@ public class Application {
   private static final OpenTelemetry openTelemetry;
 
   static {
-    openTelemetry =
-        OpenTelemetry.get().toBuilder()
-            .setPropagators(
-                DefaultContextPropagators.builder()
-                    .addTextMapPropagator(HttpTraceContext.getInstance())
-                    .build())
+    ContextPropagators propagators =
+        DefaultContextPropagators.builder()
+            .addTextMapPropagator(HttpTraceContext.getInstance())
             .build();
-    // set the updated instance as the global instance, just to make sure.
-    OpenTelemetry.set(openTelemetry);
+    OpenTelemetry.setGlobalPropagators(propagators);
+    openTelemetry = OpenTelemetry.get();
   }
 
   private Application() {}

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -88,8 +88,14 @@ public final class OpenTelemetrySdk extends DefaultOpenTelemetry {
     return (TracerSdkProvider) ((ObfuscatedTracerProvider) getTracerProvider()).unobfuscate();
   }
 
-  /** Returns a new {@link Builder} initialized with the values of this {@link OpenTelemetrySdk}. */
+  /**
+   * Returns a new {@link Builder} initialized with the values of this {@link OpenTelemetrySdk}.
+   *
+   * @deprecated This method should not be used, as it allows unexpected sharing of state across
+   *     instances. It will be removed in the next release.
+   */
   @Override
+  @Deprecated
   public Builder toBuilder() {
     return new Builder()
         .setTracerProvider(getTracerProvider())


### PR DESCRIPTION
And add a method to set the propagators on an instance, so that capability is preserved.

Resolves #2088 