### PR TITLE
Remove usages of beta Guava APIs.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -418,6 +418,8 @@ configure(opentelemetryProjects) {
         // build if error prone releases a new version with a new check
         errorprone libraries.errorprone_core
 
+        annotationProcessor "com.google.guava:guava-beta-checker:1.0"
+
         // Workaround for @javax.annotation.Generated
         // see: https://github.com/grpc/grpc-java/issues/3633
         compileOnly libraries.javax_annotations

--- a/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/SpanBucket.java
+++ b/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/SpanBucket.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.sdk.extension.zpages;
 
-import com.google.common.primitives.UnsignedInts;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -28,7 +27,7 @@ final class SpanBucket {
   }
 
   void add(ReadableSpan span) {
-    spans.set(UnsignedInts.remainder(index.getAndIncrement(), bucketSize), span);
+    spans.set(remainder(index.getAndIncrement(), bucketSize), span);
   }
 
   int size() {
@@ -49,5 +48,9 @@ final class SpanBucket {
         break;
       }
     }
+  }
+
+  private static int remainder(int dividend, int divisor) {
+    return (int) (Integer.toUnsignedLong(dividend) % Integer.toUnsignedLong(divisor));
   }
 }

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/DaemonThreadFactory.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/DaemonThreadFactory.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.sdk.common;
 
-import com.google.common.util.concurrent.MoreExecutors;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -23,7 +23,7 @@ public class DaemonThreadFactory implements ThreadFactory {
 
   @Override
   public Thread newThread(Runnable runnable) {
-    Thread t = MoreExecutors.platformThreadFactory().newThread(runnable);
+    Thread t = Executors.defaultThreadFactory().newThread(runnable);
     try {
       t.setDaemon(true);
       t.setName(namePrefix + "_" + counter.incrementAndGet());

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -631,11 +631,7 @@ class RecordEventsReadableSpanTest {
       assertThat(spanData.getEvents().size()).isEqualTo(maxNumberOfEvents);
       for (int i = 0; i < maxNumberOfEvents; i++) {
         Event expectedEvent =
-            Event.create(
-                START_EPOCH_NANOS + (maxNumberOfEvents + i) * NANOS_PER_SECOND,
-                "event2",
-                Attributes.empty(),
-                0);
+            Event.create(START_EPOCH_NANOS + i * NANOS_PER_SECOND, "event2", Attributes.empty(), 0);
         assertThat(spanData.getEvents().get(i)).isEqualTo(expectedEvent);
         assertThat(spanData.getTotalRecordedEvents()).isEqualTo(2 * maxNumberOfEvents);
       }
@@ -646,11 +642,7 @@ class RecordEventsReadableSpanTest {
     assertThat(spanData.getEvents().size()).isEqualTo(maxNumberOfEvents);
     for (int i = 0; i < maxNumberOfEvents; i++) {
       Event expectedEvent =
-          Event.create(
-              START_EPOCH_NANOS + (maxNumberOfEvents + i) * NANOS_PER_SECOND,
-              "event2",
-              Attributes.empty(),
-              0);
+          Event.create(START_EPOCH_NANOS + i * NANOS_PER_SECOND, "event2", Attributes.empty(), 0);
       assertThat(spanData.getEvents().get(i)).isEqualTo(expectedEvent);
     }
   }


### PR DESCRIPTION
Long term we have #1944 but in the meantime, we definitely can't be using beta APIs so removed them and added a checker.