### PR TITLE
Fix toBuilder not unobfuscating tracer.

### DIFF
--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -98,7 +98,7 @@ public final class OpenTelemetrySdk extends DefaultOpenTelemetry {
   @Deprecated
   public Builder toBuilder() {
     return new Builder()
-        .setTracerProvider(getTracerProvider())
+        .setTracerProvider(((ObfuscatedTracerProvider) getTracerProvider()).unobfuscate())
         .setMeterProvider(getMeterProvider())
         .setPropagators(getPropagators())
         .setClock(clock)

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -70,7 +70,7 @@ class OpenTelemetrySdkTest {
   }
 
   @Test
-  void testReconfigure() {
+  void testConfigure() {
     Resource resource = Resource.create(Attributes.builder().put("cat", "meow").build());
     OpenTelemetrySdk openTelemetry =
         OpenTelemetrySdk.builder()
@@ -89,7 +89,29 @@ class OpenTelemetrySdkTest {
   }
 
   @Test
-  void testReconfigure_justClockAndResource() {
+  @SuppressWarnings("deprecation") // Testing deprecated behavior
+  void testPartialReconfigure() {
+    Resource resource = Resource.create(Attributes.builder().put("cat", "meow").build());
+    OpenTelemetrySdk openTelemetry =
+        OpenTelemetrySdk.builder()
+            .setTracerProvider(tracerProvider)
+            .setMeterProvider(meterProvider)
+            .setPropagators(propagators)
+            .setClock(clock)
+            .build()
+            .toBuilder()
+            .setResource(resource)
+            .build();
+    assertThat(((ObfuscatedTracerProvider) openTelemetry.getTracerProvider()).unobfuscate())
+        .isEqualTo(tracerProvider);
+    assertThat(openTelemetry.getMeterProvider()).isEqualTo(meterProvider);
+    assertThat(openTelemetry.getPropagators()).isEqualTo(propagators);
+    assertThat(openTelemetry.getResource()).isEqualTo(resource);
+    assertThat(openTelemetry.getClock()).isEqualTo(clock);
+  }
+
+  @Test
+  void testConfigure_justClockAndResource() {
     Resource resource = Resource.create(Attributes.builder().put("cat", "meow").build());
     OpenTelemetrySdk openTelemetry =
         OpenTelemetrySdk.builder().setClock(clock).setResource(resource).build();


### PR DESCRIPTION
Goes to show how useful tobuilder was without a proper test for it...

@jkwatson I know it's deprecated, but we may want to cherrypick this since `OpenTelemetry.setGlobalPropagators` fails after installing the SDK because of this right now.