### PR TITLE
force the version number until we can get the tagging fixed.

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -60,7 +60,8 @@ jobs:
       - uses: burrunan/gradle-cache-action@v1.5
         with:
           remote-build-cache-proxy-enabled: false
-          arguments: artifactoryPublish
+          # TODO(anuraaga): Remove version specifier after next release creates a tag on master.
+          arguments: artifactoryPublish -Prelease.version=0.12.0-SNAPSHOT
         env:
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}


### PR DESCRIPTION
should temporarily resolve #2098 