### PR TITLE
Get the 0.11.0 tag properly in the history

### DIFF
--- a/sdk-extensions/zpages/README.md
+++ b/sdk-extensions/zpages/README.md
@@ -22,14 +22,14 @@ For Maven, add the following to your `pom.xml`:
   <dependency>
     <groupId>io.opentelemetry</groupId>
     <artifactId>opentelemetry-sdk-extension-zpages</artifactId>
-    <version>0.12.0-SNAPSHOT</version>
+    <version>0.11.0</version>
   </dependency>
 </dependencies>
 ```
 
 For Gradle, add the following to your dependencies:
 ```groovy
-implementation 'io.opentelemetry:opentelemetry-sdk-extension-zpages:0.12.0-SNAPSHOT'
+implementation 'io.opentelemetry:opentelemetry-sdk-extension-zpages:0.11.0'
 ```
 
 ### Register the zPages


### PR DESCRIPTION
It also happens to fix a doc bug that snuck in previously.

Hopefully this resolves #2098 in a better way than #2100 does.