### PR TITLE
Disallow null attribute array values.

### DIFF
--- a/api/src/main/java/io/opentelemetry/api/common/AttributesBuilder.java
+++ b/api/src/main/java/io/opentelemetry/api/common/AttributesBuilder.java
@@ -118,8 +118,8 @@ public class AttributesBuilder {
    *
    * @return this Builder
    */
-  public AttributesBuilder put(String key, Long... value) {
-    return put(longArrayKey(key), value == null ? null : Arrays.asList(value));
+  public AttributesBuilder put(String key, long... value) {
+    return put(longArrayKey(key), value == null ? null : toList(value));
   }
 
   /**
@@ -130,8 +130,8 @@ public class AttributesBuilder {
    *
    * @return this Builder
    */
-  public AttributesBuilder put(String key, Double... value) {
-    return put(doubleArrayKey(key), value == null ? null : Arrays.asList(value));
+  public AttributesBuilder put(String key, double... value) {
+    return put(doubleArrayKey(key), value == null ? null : toList(value));
   }
 
   /**
@@ -142,8 +142,8 @@ public class AttributesBuilder {
    *
    * @return this Builder
    */
-  public AttributesBuilder put(String key, Boolean... value) {
-    return put(booleanArrayKey(key), value == null ? null : Arrays.asList(value));
+  public AttributesBuilder put(String key, boolean... value) {
+    return put(booleanArrayKey(key), value == null ? null : toList(value));
   }
 
   /**
@@ -154,5 +154,29 @@ public class AttributesBuilder {
   public AttributesBuilder putAll(Attributes attributes) {
     attributes.forEach(this::put);
     return this;
+  }
+
+  private static List<Double> toList(double... values) {
+    Double[] boxed = new Double[values.length];
+    for (int i = 0; i < values.length; i++) {
+      boxed[i] = values[i];
+    }
+    return Arrays.asList(boxed);
+  }
+
+  private static List<Long> toList(long... values) {
+    Long[] boxed = new Long[values.length];
+    for (int i = 0; i < values.length; i++) {
+      boxed[i] = values[i];
+    }
+    return Arrays.asList(boxed);
+  }
+
+  private static List<Boolean> toList(boolean... values) {
+    Boolean[] boxed = new Boolean[values.length];
+    for (int i = 0; i < values.length; i++) {
+      boxed[i] = values[i];
+    }
+    return Arrays.asList(boxed);
   }
 }

--- a/api/src/test/java/io/opentelemetry/api/common/AttributesTest.java
+++ b/api/src/test/java/io/opentelemetry/api/common/AttributesTest.java
@@ -191,20 +191,20 @@ class AttributesTest {
     Attributes attributes =
         Attributes.builder()
             .put("string", "value1", "value2", null)
-            .put("long", null, 100L, 200L)
-            .put("double", 33.44, null, -44.33)
+            .put("long", 100L, 200L)
+            .put("double", 33.44, -44.33)
             .put("boolean", "duplicateShouldBeRemoved")
             .put(stringKey("boolean"), "true")
-            .put("boolean", false, null, true)
+            .put("boolean", false, true)
             .build();
 
     assertThat(attributes)
         .isEqualTo(
             Attributes.of(
                 stringArrayKey("string"), Arrays.asList("value1", "value2", null),
-                longArrayKey("long"), Arrays.asList(null, 100L, 200L),
-                doubleArrayKey("double"), Arrays.asList(33.44, null, -44.33),
-                booleanArrayKey("boolean"), Arrays.asList(false, null, true)));
+                longArrayKey("long"), Arrays.asList(100L, 200L),
+                doubleArrayKey("double"), Arrays.asList(33.44, -44.33),
+                booleanArrayKey("boolean"), Arrays.asList(false, true)));
   }
 
   @Test
@@ -270,9 +270,9 @@ class AttributesTest {
     builder.put("double", 1.0);
     builder.put("bool", true);
     builder.put("arrayString", new String[] {"string"});
-    builder.put("arrayLong", new Long[] {10L});
-    builder.put("arrayDouble", new Double[] {1.0});
-    builder.put("arrayBool", new Boolean[] {true});
+    builder.put("arrayLong", new long[] {10L});
+    builder.put("arrayDouble", new double[] {1.0});
+    builder.put("arrayBool", new boolean[] {true});
     assertThat(builder.build().size()).isEqualTo(9);
 
     // note: currently these are no-op calls; that behavior is not required, so if it needs to
@@ -280,9 +280,9 @@ class AttributesTest {
     builder.put(stringKey("attrValue"), null);
     builder.put("string", (String) null);
     builder.put("arrayString", (String[]) null);
-    builder.put("arrayLong", (Long[]) null);
-    builder.put("arrayDouble", (Double[]) null);
-    builder.put("arrayBool", (Boolean[]) null);
+    builder.put("arrayLong", (long[]) null);
+    builder.put("arrayDouble", (double[]) null);
+    builder.put("arrayBool", (boolean[]) null);
 
     Attributes attributes = builder.build();
     assertThat(attributes.size()).isEqualTo(9);


### PR DESCRIPTION
Thanks to https://github.com/open-telemetry/opentelemetry-specification/commit/06638fc65519a021e29a213e54feae30880ce39e#diff-500cb43b9725373c25ea03660c293e59681e6e2f6ba3eb588188ed3b83dcbdcd

This is not ABI compatible but is API compatible for practical usages of the methods so I didn't do any deprecation.