### PR TITLE
Update dependencies

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -16,7 +16,8 @@ dependencies {
 
     signature libraries.android_signature
 
-    testImplementation libraries.jqf
+    testImplementation libraries.jqf,
+            libraries.guava_testlib
 }
 
 javadoc {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ import nebula.plugin.release.git.opinion.Strategies
 
 plugins {
     id "com.diffplug.spotless"
+    id "com.github.ben-manes.versions"
     id "com.jfrog.artifactory" apply false
     id "com.jfrog.bintray" apply false
     id "nebula.release"
@@ -284,17 +285,17 @@ configure(opentelemetryProjects) {
         errorProneVersion = '2.4.0'
         errorProneJavacVersion = '9+181-r4173-1'
         findBugsJsr305Version = '3.0.2'
-        grpcVersion = '1.30.2'
-        guavaVersion = '28.2-android'
+        grpcVersion = '1.33.1'
+        guavaVersion = '30.0-android'
         jacksonVersion = '2.11.3'
-        jmhVersion = '1.19'
-        junitVersion = '5.6.2'
-        mockitoVersion = '3.3.3'
+        jmhVersion = '1.26'
+        junitVersion = '5.7.0'
+        mockitoVersion = '3.6.0'
         opencensusVersion = '0.28.2'
         opentracingVersion = '0.33.0'
-        prometheusVersion = '0.8.1'
-        protobufVersion = '3.11.4'
-        protocVersion = '3.11.4'
+        prometheusVersion = '0.9.0'
+        protobufVersion = '3.14.0'
+        protocVersion = '3.14.0'
         zipkinReporterVersion = '2.12.2'
         zipkinVersion = '2.18.3'
 
@@ -337,10 +338,10 @@ configure(opentelemetryProjects) {
                 opentracing             : "io.opentracing:opentracing-api:${opentracingVersion}",
 
                 // Test dependencies.
-                assertj                 : "org.assertj:assertj-core:3.16.1",
+                assertj                 : "org.assertj:assertj-core:3.18.1",
                 guava_testlib           : "com.google.guava:guava-testlib",
-                junit                   : 'junit:junit:4.12',
-                junit_pioneer           : 'org.junit-pioneer:junit-pioneer:0.7.0',
+                junit                   : 'junit:junit:4.13.1',
+                junit_pioneer           : 'org.junit-pioneer:junit-pioneer:1.0.0',
                 junit_jupiter_api       : 'org.junit.jupiter:junit-jupiter-api',
                 junit_jupiter_engine    : 'org.junit.jupiter:junit-jupiter-engine',
                 junit_vintage_engine    : 'org.junit.vintage:junit-vintage-engine',
@@ -348,17 +349,17 @@ configure(opentelemetryProjects) {
                 mockito_junit_jupiter   : "org.mockito:mockito-junit-jupiter:${mockitoVersion}",
                 okhttp                  : 'com.squareup.okhttp3:okhttp:3.14.9',
                 system_rules            : 'com.github.stefanbirkner:system-rules:1.19.0', // env and system properties
-                slf4jsimple             : 'org.slf4j:slf4j-simple:1.7.25', // Compatibility layer
-                awaitility              : 'org.awaitility:awaitility:3.0.0', // Compatibility layer
-                testcontainers          : 'org.testcontainers:junit-jupiter:1.15.0-rc2',
+                slf4jsimple             : 'org.slf4j:slf4j-simple:1.7.30', // Compatibility layer
+                awaitility              : 'org.awaitility:awaitility:4.0.3',
+                testcontainers          : 'org.testcontainers:junit-jupiter:1.15.0',
                 rest_assured            : 'io.rest-assured:rest-assured:4.2.0',
-                jaeger_client           : 'io.jaegertracing:jaeger-client:1.2.0', // Jaeger Client
+                jaeger_client           : 'io.jaegertracing:jaeger-client:1.5.0', // Jaeger Client
                 zipkin_junit            : "io.zipkin.zipkin2:zipkin-junit:${zipkinVersion}",  // Zipkin JUnit rule
-                archunit                : 'com.tngtech.archunit:archunit-junit4:0.13.1', //Architectural constraints
+                archunit                : 'com.tngtech.archunit:archunit-junit4:0.14.1', //Architectural constraints
                 jqf                     : 'edu.berkeley.cs.jqf:jqf-fuzz:1.6', // fuzz testing
 
                 // Tooling
-                android_signature       : 'com.toasttab.android:gummy-bears-api-24:0.2.0:coreLib@signature'
+                android_signature       : 'com.toasttab.android:gummy-bears-api-24:0.3.0:coreLib@signature'
         ]
     }
 
@@ -404,12 +405,15 @@ configure(opentelemetryProjects) {
                 libraries.errorprone_annotation,
                 libraries.jsr305
 
+        testCompileOnly libraries.auto_value_annotation,
+                libraries.errorprone_annotation,
+                libraries.jsr305
+
         testImplementation libraries.junit_jupiter_api,
                 libraries.mockito,
                 libraries.mockito_junit_jupiter,
                 libraries.assertj,
-                libraries.awaitility,
-                libraries.guava_testlib
+                libraries.awaitility
 
         testRuntimeOnly libraries.junit_jupiter_engine,
                 libraries.junit_vintage_engine

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -25,11 +25,12 @@ dependencies {
     grpcInOtelTestImplementation libraries.grpc_context
     otelInGrpcTestImplementation libraries.grpc_context
 
-    braveInOtelTestImplementation "io.zipkin.brave:brave:5.12.6"
-    otelAsBraveTestImplementation "io.zipkin.brave:brave:5.12.6"
-    otelInBraveTestImplementation "io.zipkin.brave:brave:5.12.6"
+    braveInOtelTestImplementation "io.zipkin.brave:brave:5.13.1"
+    otelAsBraveTestImplementation "io.zipkin.brave:brave:5.13.1"
+    otelInBraveTestImplementation "io.zipkin.brave:brave:5.13.1"
 
     testImplementation libraries.awaitility
+    testImplementation libraries.guava
     testImplementation libraries.junit_pioneer
 
     signature libraries.android_signature

--- a/exporters/jaeger-thrift/build.gradle
+++ b/exporters/jaeger-thrift/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     api project(':opentelemetry-sdk')
 
     implementation project(':opentelemetry-sdk'),
-            "io.jaegertracing:jaeger-client:0.33.1"
+            libraries.jaeger_client
 
     testImplementation "io.grpc:grpc-testing:${grpcVersion}",
             'com.fasterxml.jackson.core:jackson-databind',

--- a/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftIntegrationTest.java
+++ b/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftIntegrationTest.java
@@ -13,7 +13,7 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -50,7 +50,7 @@ class JaegerThriftIntegrationTest {
     setupJaegerExporter();
     imitateWork();
     Awaitility.await()
-        .atMost(30, TimeUnit.MINUTES)
+        .atMost(Duration.ofSeconds(30))
         .until(JaegerThriftIntegrationTest::assertJaegerHasATrace);
   }
 

--- a/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftSpanExporterTest.java
+++ b/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftSpanExporterTest.java
@@ -36,10 +36,12 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class JaegerThriftSpanExporterTest {
 
   private static final String TRACE_ID = "a0000000000000000000000000abc123";
@@ -51,7 +53,6 @@ class JaegerThriftSpanExporterTest {
 
   @BeforeEach
   void beforeEach() {
-    MockitoAnnotations.initMocks(this);
     exporter =
         JaegerThriftSpanExporter.builder()
             .setThriftSender(thriftSender)

--- a/exporters/jaeger/build.gradle
+++ b/exporters/jaeger/build.gradle
@@ -27,6 +27,10 @@ dependencies {
 
     testImplementation project(':opentelemetry-sdk-testing')
 
+    // Protobuf plugin seems to erroneously use the non-classpath configurations for resolving
+    // dependencies.
+    testImplementation enforcedPlatform(boms.jackson)
+
     testRuntime "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
     signature "org.codehaus.mojo.signature:java18:1.0@signature"

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerIntegrationTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerIntegrationTest.java
@@ -15,7 +15,7 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -49,7 +49,7 @@ class JaegerIntegrationTest {
     setupJaegerExporter();
     imitateWork();
     Awaitility.await()
-        .atMost(30, TimeUnit.SECONDS)
+        .atMost(Duration.ofSeconds(30))
         .until(JaegerIntegrationTest::assertJaegerHaveTrace);
   }
 

--- a/exporters/prometheus/build.gradle
+++ b/exporters/prometheus/build.gradle
@@ -13,7 +13,8 @@ dependencies {
 
     implementation libraries.prometheus_client
 
-    testImplementation libraries.prometheus_client_common
+    testImplementation libraries.prometheus_client_common,
+            libraries.guava
 
     signature "org.codehaus.mojo.signature:java18:1.0@signature"
     signature libraries.android_signature

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/PrometheusCollectorTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/PrometheusCollectorTest.java
@@ -23,16 +23,17 @@ import java.io.StringWriter;
 import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class PrometheusCollectorTest {
   @Mock MetricProducer metricProducer;
   PrometheusCollector prometheusCollector;
 
   @BeforeEach
   void setUp() {
-    MockitoAnnotations.initMocks(this);
     prometheusCollector =
         PrometheusCollector.builder().setMetricProducer(metricProducer).buildAndRegister();
   }

--- a/extensions/trace-propagators/build.gradle
+++ b/extensions/trace-propagators/build.gradle
@@ -12,7 +12,8 @@ ext.moduleName = "io.opentelemetry.extension.trace.propagation"
 dependencies {
     api project(':opentelemetry-api')
 
-    testImplementation libraries.jaeger_client
+    testImplementation libraries.jaeger_client,
+            libraries.guava
 
     signature "org.codehaus.mojo.signature:java18:1.0@signature"
     signature libraries.android_signature

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagatorTest.java
@@ -24,11 +24,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class TraceMultiPropagatorTest {
   private static final TextMapPropagator PROPAGATOR1 = B3Propagator.getInstance();
   private static final TextMapPropagator PROPAGATOR2 =
@@ -56,11 +57,6 @@ class TraceMultiPropagatorTest {
               SpanId.fromLong(12345),
               TraceFlags.getDefault(),
               TraceState.getDefault()));
-
-  @BeforeEach
-  void init() {
-    MockitoAnnotations.initMocks(this);
-  }
 
   @Test
   void addPropagator_null() {

--- a/integration-tests/src/test/java/io/opentelemetry/JaegerExporterIntegrationTest.java
+++ b/integration-tests/src/test/java/io/opentelemetry/JaegerExporterIntegrationTest.java
@@ -8,7 +8,6 @@ package io.opentelemetry;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -83,7 +82,7 @@ class JaegerExporterIntegrationTest {
   @Test
   void testJaegerExampleAppIntegration() {
     Awaitility.await()
-        .atMost(30, TimeUnit.SECONDS)
+        .atMost(Duration.ofSeconds(30))
         .until(JaegerExporterIntegrationTest::assertJaegerHaveTrace);
   }
 

--- a/integration-tests/tracecontext/build.gradle
+++ b/integration-tests/tracecontext/build.gradle
@@ -23,7 +23,7 @@ dependencies {
             project(':opentelemetry-extension-trace-propagators'),
             libraries.okhttp,
             libraries.slf4jsimple,
-            "com.sparkjava:spark-core:2.9.2",
+            "com.sparkjava:spark-core:2.9.3",
             "com.google.code.gson:gson:2.8.6"
 }
 

--- a/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/InteroperabilityTest.java
+++ b/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/InteroperabilityTest.java
@@ -25,17 +25,16 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Collection;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class InteroperabilityTest {
+class InteroperabilityTest {
 
   private static final String NULL_SPAN_ID = "0000000000000000";
 
@@ -43,16 +42,15 @@ public class InteroperabilityTest {
 
   @Spy private SpanExporter spanExporter;
 
-  @Before
+  @BeforeEach
   public void init() {
-    MockitoAnnotations.initMocks(this);
     when(spanExporter.export(any())).thenReturn(CompletableResultCode.ofSuccess());
     SpanProcessor spanProcessor = SimpleSpanProcessor.builder(spanExporter).build();
     OpenTelemetrySdk.getGlobalTracerManagement().addSpanProcessor(spanProcessor);
   }
 
   @Test
-  public void testParentChildRelationshipsAreExportedCorrectly() {
+  void testParentChildRelationshipsAreExportedCorrectly() {
     Tracer tracer = OpenTelemetry.getGlobalTracer("io.opentelemetry.test.scoped.span.1");
     Span span = tracer.spanBuilder("OpenTelemetrySpan").startSpan();
     try (Scope scope = Context.current().with(span).makeCurrent()) {
@@ -96,7 +94,7 @@ public class InteroperabilityTest {
   }
 
   @Test
-  public void testParentChildRelationshipsAreExportedCorrectlyForOpenCensusOnly() {
+  void testParentChildRelationshipsAreExportedCorrectlyForOpenCensusOnly() {
     io.opencensus.trace.Tracer tracer = Tracing.getTracer();
     try (io.opencensus.common.Scope scope =
         tracer

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/activespanreplacement/ActiveSpanReplacementTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/activespanreplacement/ActiveSpanReplacementTest.java
@@ -8,7 +8,6 @@ package io.opentelemetry.opentracingshim.testbed.activespanreplacement;
 import static io.opentelemetry.api.trace.SpanId.isValid;
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.finishedSpansSize;
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.sleep;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -19,6 +18,7 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -42,7 +42,7 @@ class ActiveSpanReplacementTest {
       submitAnotherTask(span);
     }
 
-    await().atMost(15, SECONDS).until(finishedSpansSize(otelTesting), equalTo(3));
+    await().atMost(Duration.ofSeconds(15)).until(finishedSpansSize(otelTesting), equalTo(3));
 
     List<SpanData> spans = otelTesting.getSpans();
     assertThat(spans).hasSize(3);

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/clientserver/TestClientServerTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/clientserver/TestClientServerTest.java
@@ -16,9 +16,9 @@ import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentracing.Tracer;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,7 +49,7 @@ class TestClientServerTest {
     Client client = new Client(queue, tracer);
     client.send();
 
-    await().atMost(15, TimeUnit.SECONDS).until(finishedSpansSize(otelTesting), equalTo(2));
+    await().atMost(Duration.ofSeconds(15)).until(finishedSpansSize(otelTesting), equalTo(2));
 
     List<SpanData> finished = otelTesting.getSpans();
     assertThat(finished).hasSize(2);

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/errorreporting/ErrorReportingTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/errorreporting/ErrorReportingTest.java
@@ -20,12 +20,12 @@ import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.log.Fields;
 import io.opentracing.tag.Tags;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -71,7 +71,7 @@ public final class ErrorReportingTest {
           }
         });
 
-    await().atMost(5, TimeUnit.SECONDS).until(finishedSpansSize(otelTesting), equalTo(1));
+    await().atMost(Duration.ofSeconds(5)).until(finishedSpansSize(otelTesting), equalTo(1));
 
     List<SpanData> spans = otelTesting.getSpans();
     assertThat(spans).hasSize(1);
@@ -137,7 +137,7 @@ public final class ErrorReportingTest {
               tracer));
     }
 
-    await().atMost(5, TimeUnit.SECONDS).until(finishedSpansSize(otelTesting), equalTo(1));
+    await().atMost(Duration.ofSeconds(5)).until(finishedSpansSize(otelTesting), equalTo(1));
 
     List<SpanData> spans = otelTesting.getSpans();
     assertThat(spans).hasSize(1);

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/multiplecallbacks/MultipleCallbacksTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/multiplecallbacks/MultipleCallbacksTest.java
@@ -16,9 +16,9 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -50,7 +50,7 @@ class MultipleCallbacksTest {
       parentDoneLatch.countDown();
     }
 
-    await().atMost(15, TimeUnit.SECONDS).until(finishedSpansSize(otelTesting), equalTo(4));
+    await().atMost(Duration.ofSeconds(15)).until(finishedSpansSize(otelTesting), equalTo(4));
 
     List<SpanData> spans = otelTesting.getSpans();
     assertThat(spans).hasSize(4);

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/nestedcallbacks/NestedCallbacksTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/nestedcallbacks/NestedCallbacksTest.java
@@ -18,10 +18,10 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -39,7 +39,7 @@ public final class NestedCallbacksTest {
     Span span = tracer.buildSpan("one").start();
     submitCallbacks(span);
 
-    await().atMost(15, TimeUnit.SECONDS).until(finishedSpansSize(otelTesting), equalTo(1));
+    await().atMost(Duration.ofSeconds(15)).until(finishedSpansSize(otelTesting), equalTo(1));
 
     List<SpanData> spans = otelTesting.getSpans();
     assertThat(spans).hasSize(1);

--- a/perf-harness/build.gradle
+++ b/perf-harness/build.gradle
@@ -5,14 +5,6 @@ plugins {
 description = 'Performance Testing Harness'
 ext.moduleName = "io.opentelemetry.perf-harness"
 
-ext {
-    opentelemetryVersion = "0.9.1"
-    grpcVersion = '1.28.0'
-    protobufVersion = '3.11.4'
-    protocVersion = protobufVersion
-}
-
-
 dependencies {
     compile project(':opentelemetry-api'),
             project(":opentelemetry-sdk"),
@@ -20,8 +12,8 @@ dependencies {
             project(":opentelemetry-exporter-otlp"),
             project(":opentelemetry-exporter-logging")
 
-    compile("io.grpc:grpc-netty-shaded:${grpcVersion}")
-    compile("eu.rekawek.toxiproxy:toxiproxy-java:2.1.3")
+    compile("io.grpc:grpc-netty-shaded")
+    compile("eu.rekawek.toxiproxy:toxiproxy-java:2.1.4")
 
     implementation libraries.testcontainers
 }

--- a/proto/build.gradle
+++ b/proto/build.gradle
@@ -10,6 +10,11 @@ description = 'OpenTelemetry Proto'
 ext.moduleName = 'io.opentelemetry.proto'
 
 dependencies {
+    // Protobuf plugin seems to erroneously use the non-classpath configurations for resolving
+    // dependencies.
+    implementation enforcedPlatform(boms.grpc)
+    implementation enforcedPlatform(boms.protobuf)
+
     api libraries.protobuf,
             libraries.grpc_api,
             libraries.grpc_protobuf,

--- a/sdk-extensions/aws-v1-support/build.gradle
+++ b/sdk-extensions/aws-v1-support/build.gradle
@@ -20,7 +20,8 @@ dependencies {
             libraries.guava,
             platform(boms.guava)
 
-    testImplementation 'com.github.tomakehurst:wiremock-jre8:2.26.3'
+    testImplementation 'com.github.tomakehurst:wiremock-jre8:2.27.2',
+            libraries.junit
 
     signature libraries.android_signature
 }

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerIntegrationTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerIntegrationTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import io.grpc.ManagedChannelBuilder;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
@@ -46,7 +46,7 @@ class JaegerRemoteSamplerIntegrationTest {
             .build();
 
     await()
-        .atMost(10, TimeUnit.SECONDS)
+        .atMost(Duration.ofSeconds(10))
         .until(samplerIsType(remoteSampler, PerOperationSampler.class));
     assertThat(remoteSampler.getSampler()).isInstanceOf(PerOperationSampler.class);
     assertThat(remoteSampler.getDescription()).contains("0.33").doesNotContain("150");
@@ -63,7 +63,7 @@ class JaegerRemoteSamplerIntegrationTest {
             .build();
 
     await()
-        .atMost(10, TimeUnit.SECONDS)
+        .atMost(Duration.ofSeconds(10))
         .until(samplerIsType(remoteSampler, RateLimitingSampler.class));
     assertThat(remoteSampler.getSampler()).isInstanceOf(RateLimitingSampler.class);
     assertThat(((RateLimitingSampler) remoteSampler.getSampler()).getMaxTracesPerSecond())

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerTest.java
@@ -24,8 +24,8 @@ import io.opentelemetry.sdk.extension.trace.jaeger.proto.api_v2.Sampling.Samplin
 import io.opentelemetry.sdk.extension.trace.jaeger.proto.api_v2.SamplingManagerGrpc;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -95,7 +95,7 @@ class JaegerRemoteSamplerTest {
             .setServiceName(SERVICE_NAME)
             .build();
 
-    await().atMost(10, TimeUnit.SECONDS).until(samplerIsType(sampler, RateLimitingSampler.class));
+    await().atMost(Duration.ofSeconds(10)).until(samplerIsType(sampler, RateLimitingSampler.class));
 
     // verify
     verify(service).getSamplingStrategy(requestCaptor.capture(), ArgumentMatchers.any());
@@ -116,7 +116,7 @@ class JaegerRemoteSamplerTest {
         .isEqualTo("JaegerRemoteSampler{TraceIdRatioBased{0.001000}}");
 
     // wait until the sampling strategy is retrieved before exiting test method
-    await().atMost(10, TimeUnit.SECONDS).until(samplerIsType(sampler, RateLimitingSampler.class));
+    await().atMost(Duration.ofSeconds(10)).until(samplerIsType(sampler, RateLimitingSampler.class));
   }
 
   static Callable<Boolean> samplerIsType(

--- a/sdk-extensions/logging/build.gradle
+++ b/sdk-extensions/logging/build.gradle
@@ -10,7 +10,7 @@ ext.moduleName = "io.opentelemetry.sdk.extension.logging"
 
 dependencies {
     api project(':opentelemetry-sdk')
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.4'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
     testImplementation libraries.awaitility
 
     annotationProcessor libraries.auto_value

--- a/sdk-extensions/logging/src/test/java/io/opentelemetry/sdk/logging/LogSinkSdkProviderTest.java
+++ b/sdk-extensions/logging/src/test/java/io/opentelemetry/sdk/logging/LogSinkSdkProviderTest.java
@@ -15,6 +15,7 @@ import io.opentelemetry.sdk.logging.data.LogRecord.Severity;
 import io.opentelemetry.sdk.logging.export.BatchLogProcessor;
 import io.opentelemetry.sdk.logging.util.TestLogExporter;
 import io.opentelemetry.sdk.logging.util.TestLogProcessor;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
@@ -57,7 +58,7 @@ class LogSinkSdkProviderTest {
       sink.offer(createLog(Severity.WARN, "test #" + i));
     }
     // Ensure that more than batch size kicks off a flush
-    await().atMost(5, TimeUnit.SECONDS).until(() -> exporter.getRecords().size() > 0);
+    await().atMost(Duration.ofSeconds(5)).until(() -> exporter.getRecords().size() > 0);
     // Ensure that everything gets through
     CompletableResultCode result = provider.forceFlush();
     result.join(1, TimeUnit.SECONDS);

--- a/sdk-extensions/tracing-incubator/build.gradle
+++ b/sdk-extensions/tracing-incubator/build.gradle
@@ -16,7 +16,8 @@ dependencies {
 
 
     annotationProcessor libraries.auto_value
-    testImplementation project(':opentelemetry-sdk-testing')
+    testImplementation project(':opentelemetry-sdk-testing'),
+            libraries.guava_testlib
 
     signature libraries.android_signature
 }

--- a/sdk-extensions/tracing-incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/trace/data/DelegatingSpanDataTest.java
+++ b/sdk-extensions/tracing-incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/trace/data/DelegatingSpanDataTest.java
@@ -20,6 +20,7 @@ import io.opentelemetry.api.trace.attributes.SemanticAttributes;
 import io.opentelemetry.sdk.testing.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Status;
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.junit.jupiter.api.Test;
 
 class DelegatingSpanDataTest {
@@ -72,7 +73,10 @@ class DelegatingSpanDataTest {
     SpanData noopWrapper = new NoOpDelegatingSpanData(spanData);
     // Test should always verify delegation is working even when methods are added since it calls
     // each method individually.
-    assertThat(noopWrapper).isEqualToIgnoringGivenFields(spanData, "delegate");
+    assertThat(noopWrapper)
+        .usingRecursiveComparison(
+            RecursiveComparisonConfiguration.builder().withIgnoredFields("delegate").build())
+        .isEqualTo(spanData);
   }
 
   @Test

--- a/sdk-extensions/tracing-incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/trace/data/SpanDataBuilderTest.java
+++ b/sdk-extensions/tracing-incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/trace/data/SpanDataBuilderTest.java
@@ -39,7 +39,8 @@ class SpanDataBuilderTest {
   @Test
   void noOp() {
     assertThat(SpanDataBuilder.builder(TEST_SPAN_DATA).build())
-        .isEqualToComparingFieldByField(TEST_SPAN_DATA);
+        .usingRecursiveComparison()
+        .isEqualTo(TEST_SPAN_DATA);
   }
 
   @Test

--- a/sdk/common/build.gradle
+++ b/sdk/common/build.gradle
@@ -20,7 +20,8 @@ dependencies {
     testCompileOnly libraries.auto_value_annotation
 
     testImplementation project(':opentelemetry-sdk-testing')
-    testImplementation libraries.junit_pioneer
+    testImplementation libraries.junit_pioneer,
+            libraries.guava_testlib
 
     signature libraries.android_signature
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractBoundInstrumentTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractBoundInstrumentTest.java
@@ -8,20 +8,15 @@ package io.opentelemetry.sdk.metrics;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-/** Unit tests for {@link AbstractBoundInstrument}. */
+@ExtendWith(MockitoExtension.class)
 class AbstractBoundInstrumentTest {
   @Mock private Aggregator aggregator;
-
-  @BeforeEach
-  void setUp() {
-    MockitoAnnotations.initMocks(this);
-  }
 
   @Test
   void bindMapped() {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleCounterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleCounterSdkTest.java
@@ -20,6 +20,7 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.List;
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link DoubleCounterSdk}. */
@@ -99,7 +100,9 @@ class DoubleCounterSdkTest {
     doubleCounter1.add(12.1d);
 
     assertThat(doubleCounter.collectAll().get(0))
-        .isEqualToIgnoringGivenFields(doubleCounter1.collectAll().get(0), "name");
+        .usingRecursiveComparison(
+            RecursiveComparisonConfiguration.builder().withIgnoredFields("name").build())
+        .isEqualTo(doubleCounter1.collectAll().get(0));
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownCounterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownCounterSdkTest.java
@@ -20,6 +20,7 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.List;
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link DoubleUpDownCounterSdk}. */
@@ -103,7 +104,9 @@ class DoubleUpDownCounterSdkTest {
     doubleUpDownCounter1.add(12.1d);
 
     assertThat(doubleUpDownCounter.collectAll().get(0))
-        .isEqualToIgnoringGivenFields(doubleUpDownCounter1.collectAll().get(0), "name");
+        .usingRecursiveComparison(
+            RecursiveComparisonConfiguration.builder().withIgnoredFields("name").build())
+        .isEqualTo(doubleUpDownCounter1.collectAll().get(0));
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdkTest.java
@@ -23,6 +23,7 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link DoubleValueRecorderSdk}. */
@@ -138,7 +139,9 @@ class DoubleValueRecorderSdkTest {
     doubleMeasure1.record(12.1d);
 
     assertThat(doubleMeasure.collectAll().get(0))
-        .isEqualToIgnoringGivenFields(doubleMeasure1.collectAll().get(0), "name");
+        .usingRecursiveComparison(
+            RecursiveComparisonConfiguration.builder().withIgnoredFields("name").build())
+        .isEqualTo(doubleMeasure1.collectAll().get(0));
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongCounterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongCounterSdkTest.java
@@ -21,6 +21,7 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.List;
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link LongCounterSdk}. */
@@ -119,7 +120,9 @@ class LongCounterSdkTest {
     longCounter1.add(12);
 
     assertThat(longCounter.collectAll().get(0))
-        .isEqualToIgnoringGivenFields(longCounter1.collectAll().get(0), "name");
+        .usingRecursiveComparison(
+            RecursiveComparisonConfiguration.builder().withIgnoredFields("name").build())
+        .isEqualTo(longCounter1.collectAll().get(0));
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownCounterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownCounterSdkTest.java
@@ -20,6 +20,7 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.List;
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link LongUpDownCounterSdk}. */
@@ -100,7 +101,9 @@ class LongUpDownCounterSdkTest {
     longUpDownCounter1.add(12);
 
     assertThat(longUpDownCounter.collectAll().get(0))
-        .isEqualToIgnoringGivenFields(longUpDownCounter1.collectAll().get(0), "name");
+        .usingRecursiveComparison(
+            RecursiveComparisonConfiguration.builder().withIgnoredFields("name").build())
+        .isEqualTo(longUpDownCounter1.collectAll().get(0));
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdkTest.java
@@ -23,6 +23,7 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link LongValueRecorderSdk}. */
@@ -136,7 +137,9 @@ class LongValueRecorderSdkTest {
     longMeasure1.record(12);
 
     assertThat(longMeasure.collectAll().get(0))
-        .isEqualToIgnoringGivenFields(longMeasure1.collectAll().get(0), "name");
+        .usingRecursiveComparison(
+            RecursiveComparisonConfiguration.builder().withIgnoredFields("name").build())
+        .isEqualTo(longMeasure1.collectAll().get(0));
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
@@ -28,11 +28,15 @@ import javax.annotation.concurrent.GuardedBy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-/** Unit tests for {@link IntervalMetricReader}. */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class IntervalMetricReaderTest {
   private static final List<Point> LONG_POINT_LIST =
       Collections.singletonList(LongPoint.create(1000, 3000, Labels.empty(), 1234567));
@@ -51,7 +55,6 @@ class IntervalMetricReaderTest {
 
   @BeforeEach
   void setup() {
-    MockitoAnnotations.initMocks(this);
     when(metricProducer.collectAllMetrics()).thenReturn(Collections.singletonList(METRIC_DATA));
   }
 

--- a/sdk/testing/build.gradle
+++ b/sdk/testing/build.gradle
@@ -14,5 +14,7 @@ dependencies {
     compileOnly libraries.junit
     compileOnly libraries.junit_jupiter_api
 
+    testImplementation libraries.junit
+
     annotationProcessor libraries.auto_value
 }

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit4/OpenTelemetryRuleTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit4/OpenTelemetryRuleTest.java
@@ -44,10 +44,12 @@ public class OpenTelemetryRuleTest {
     tracer.spanBuilder("test").startSpan().end();
 
     assertThat(otelTesting.getSpans())
-        .hasOnlyOneElementSatisfying(span -> assertThat(span.getName()).isEqualTo("test"));
+        .singleElement()
+        .satisfies(span -> assertThat(span.getName()).isEqualTo("test"));
     // Spans cleared between tests, not when retrieving
     assertThat(otelTesting.getSpans())
-        .hasOnlyOneElementSatisfying(span -> assertThat(span.getName()).isEqualTo("test"));
+        .singleElement()
+        .satisfies(span -> assertThat(span.getName()).isEqualTo("test"));
   }
 
   // We have two tests to verify spans get cleared up between tests.
@@ -56,9 +58,11 @@ public class OpenTelemetryRuleTest {
     tracer.spanBuilder("test").startSpan().end();
 
     assertThat(otelTesting.getSpans())
-        .hasOnlyOneElementSatisfying(span -> assertThat(span.getName()).isEqualTo("test"));
+        .singleElement()
+        .satisfies(span -> assertThat(span.getName()).isEqualTo("test"));
     // Spans cleared between tests, not when retrieving
     assertThat(otelTesting.getSpans())
-        .hasOnlyOneElementSatisfying(span -> assertThat(span.getName()).isEqualTo("test"));
+        .singleElement()
+        .satisfies(span -> assertThat(span.getName()).isEqualTo("test"));
   }
 }

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
@@ -45,10 +45,12 @@ class OpenTelemetryExtensionTest {
     tracer.spanBuilder("test").startSpan().end();
 
     assertThat(otelTesting.getSpans())
-        .hasOnlyOneElementSatisfying(span -> assertThat(span.getName()).isEqualTo("test"));
+        .singleElement()
+        .satisfies(span -> assertThat(span.getName()).isEqualTo("test"));
     // Spans cleared between tests, not when retrieving
     assertThat(otelTesting.getSpans())
-        .hasOnlyOneElementSatisfying(span -> assertThat(span.getName()).isEqualTo("test"));
+        .singleElement()
+        .satisfies(span -> assertThat(span.getName()).isEqualTo("test"));
   }
 
   // We have two tests to verify spans get cleared up between tests.
@@ -57,10 +59,12 @@ class OpenTelemetryExtensionTest {
     tracer.spanBuilder("test").startSpan().end();
 
     assertThat(otelTesting.getSpans())
-        .hasOnlyOneElementSatisfying(span -> assertThat(span.getName()).isEqualTo("test"));
+        .singleElement()
+        .satisfies(span -> assertThat(span.getName()).isEqualTo("test"));
     // Spans cleared between tests, not when retrieving
     assertThat(otelTesting.getSpans())
-        .hasOnlyOneElementSatisfying(span -> assertThat(span.getName()).isEqualTo("test"));
+        .singleElement()
+        .satisfies(span -> assertThat(span.getName()).isEqualTo("test"));
   }
 
   @Test

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/MultiSpanProcessorTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/MultiSpanProcessorTest.java
@@ -18,9 +18,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class MultiSpanProcessorTest {
   @Mock private SpanProcessor spanProcessor1;
   @Mock private SpanProcessor spanProcessor2;
@@ -29,7 +34,6 @@ class MultiSpanProcessorTest {
 
   @BeforeEach
   void setUp() {
-    MockitoAnnotations.initMocks(this);
     when(spanProcessor1.isStartRequired()).thenReturn(true);
     when(spanProcessor1.isEndRequired()).thenReturn(true);
     when(spanProcessor1.forceFlush()).thenReturn(CompletableResultCode.ofSuccess());

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/NoopSpanProcessorTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/NoopSpanProcessorTest.java
@@ -8,20 +8,15 @@ package io.opentelemetry.sdk.trace;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.context.Context;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-/** Unit tests for {@link NoopSpanProcessorTest}. */
+@ExtendWith(MockitoExtension.class)
 class NoopSpanProcessorTest {
   @Mock private ReadableSpan readableSpan;
   @Mock private ReadWriteSpan readWriteSpan;
-
-  @BeforeEach
-  void setUp() {
-    MockitoAnnotations.initMocks(this);
-  }
 
   @Test
   void noCrash() {

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -53,11 +53,13 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
+@ExtendWith(MockitoExtension.class)
 class RecordEventsReadableSpanTest {
   private static final String SPAN_NAME = "MySpanName";
   private static final String SPAN_NEW_NAME = "NewName";
@@ -84,7 +86,6 @@ class RecordEventsReadableSpanTest {
 
   @BeforeEach
   void setUp() {
-    MockitoAnnotations.initMocks(this);
     attributes.put(stringKey("MyStringAttributeKey"), "MyStringAttributeValue");
     attributes.put(longKey("MyLongAttributeKey"), 123L);
     attributes.put(booleanKey("MyBooleanAttributeKey"), false);

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/TracerSdkTest.java
@@ -18,15 +18,16 @@ import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicLong;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /** Unit tests for {@link TracerSdk}. */
 // Need to suppress warnings for MustBeClosed because Android 14 does not support
 // try-with-resources.
 @SuppressWarnings("MustBeClosedChecker")
+@ExtendWith(MockitoExtension.class)
 class TracerSdkTest {
 
   private static final String SPAN_NAME = "span_name";
@@ -42,11 +43,6 @@ class TracerSdkTest {
           TracerSdkProvider.builder()
               .build()
               .get(INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION);
-
-  @BeforeEach
-  void setUp() {
-    MockitoAnnotations.initMocks(this);
-  }
 
   @Test
   void defaultSpanBuilder() {

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -32,14 +32,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-/** Unit tests for {@link BatchSpanProcessor}. */
+@ExtendWith(MockitoExtension.class)
 class BatchSpanProcessorTest {
 
   private static final String SPAN_NAME_1 = "MySpanName/1";
@@ -49,11 +49,6 @@ class BatchSpanProcessorTest {
   private final Tracer tracer = tracerSdkFactory.get("BatchSpanProcessorTest");
   private final BlockingSpanExporter blockingSpanExporter = new BlockingSpanExporter();
   @Mock private SpanExporter mockServiceHandler;
-
-  @BeforeEach
-  void setup() {
-    MockitoAnnotations.initMocks(this);
-  }
 
   @AfterEach
   void cleanup() {

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/testbed/activespanreplacement/ActiveSpanReplacementTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/testbed/activespanreplacement/ActiveSpanReplacementTest.java
@@ -17,10 +17,10 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.testbed.TestUtils;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -44,7 +44,7 @@ class ActiveSpanReplacementTest {
     }
 
     await()
-        .atMost(15, TimeUnit.SECONDS)
+        .atMost(Duration.ofSeconds(15))
         .until(TestUtils.finishedSpansSize(otelTesting), equalTo(3));
 
     List<SpanData> spans = otelTesting.getSpans();

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/testbed/clientserver/TestClientServerTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/testbed/clientserver/TestClientServerTest.java
@@ -15,9 +15,9 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.testbed.TestUtils;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,7 +51,7 @@ class TestClientServerTest {
     client.send();
 
     await()
-        .atMost(15, TimeUnit.SECONDS)
+        .atMost(Duration.ofSeconds(15))
         .until(TestUtils.finishedSpansSize(otelTesting), equalTo(2));
 
     List<SpanData> finished = otelTesting.getSpans();

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/testbed/errorreporting/ErrorReportingTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/testbed/errorreporting/ErrorReportingTest.java
@@ -17,10 +17,10 @@ import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import io.opentelemetry.sdk.trace.testbed.TestUtils;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -68,7 +68,9 @@ public final class ErrorReportingTest {
           }
         });
 
-    await().atMost(5, TimeUnit.SECONDS).until(TestUtils.finishedSpansSize(otelTesting), equalTo(1));
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .until(TestUtils.finishedSpansSize(otelTesting), equalTo(1));
 
     List<SpanData> spans = otelTesting.getSpans();
     assertThat(spans).hasSize(1);
@@ -127,7 +129,9 @@ public final class ErrorReportingTest {
               tracer));
     }
 
-    await().atMost(5, TimeUnit.SECONDS).until(TestUtils.finishedSpansSize(otelTesting), equalTo(1));
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .until(TestUtils.finishedSpansSize(otelTesting), equalTo(1));
 
     List<SpanData> spans = otelTesting.getSpans();
     assertThat(spans).hasSize(1);

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/testbed/multiplecallbacks/MultipleCallbacksTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/testbed/multiplecallbacks/MultipleCallbacksTest.java
@@ -15,9 +15,9 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.testbed.TestUtils;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -51,7 +51,7 @@ class MultipleCallbacksTest {
     }
 
     await()
-        .atMost(15, TimeUnit.SECONDS)
+        .atMost(Duration.ofSeconds(15))
         .until(TestUtils.finishedSpansSize(otelTesting), equalTo(4));
 
     List<SpanData> spans = otelTesting.getSpans();

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/testbed/nestedcallbacks/NestedCallbacksTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/testbed/nestedcallbacks/NestedCallbacksTest.java
@@ -17,10 +17,10 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.testbed.TestUtils;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -40,7 +40,7 @@ public final class NestedCallbacksTest {
     submitCallbacks(span);
 
     await()
-        .atMost(15, TimeUnit.SECONDS)
+        .atMost(Duration.ofSeconds(15))
         .until(TestUtils.finishedSpansSize(otelTesting), equalTo(1));
 
     List<SpanData> spans = otelTesting.getSpans();

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,16 +1,16 @@
 pluginManagement {
     plugins {
-        id "com.diffplug.spotless" version "5.7.0"
-        id "com.github.ben-manes.versions" version "0.20.0"
+        id "com.diffplug.spotless" version "5.8.2"
+        id "com.github.ben-manes.versions" version "0.36.0"
         id "com.github.kt3k.coveralls" version "2.0.1"
-        id "com.google.protobuf" version "0.8.8"
-        id "com.jfrog.artifactory" version "4.13.0"
-        id "com.jfrog.bintray" version "1.8.4"  // Need *specific* version.
+        id "com.google.protobuf" version "0.8.14"
+        id "com.jfrog.artifactory" version "4.18.0"
+        id "com.jfrog.bintray" version "1.8.5"
         id "io.morethan.jmhreport" version "0.9.0"
-        id "me.champeau.gradle.jmh" version "0.5.0"
-        id "nebula.release" version "15.1.0"
+        id "me.champeau.gradle.jmh" version "0.5.2"
+        id "nebula.release" version "15.3.0"
         id "net.ltgt.errorprone" version "1.3.0"
-        id "org.jetbrains.kotlin.jvm" version "1.4.10"
+        id "org.jetbrains.kotlin.jvm" version "1.4.20"
         id "org.unbroken-dome.test-sets" version "3.0.1"
         id "ru.vyarus.animalsniffer" version "1.5.2"
     }


### PR DESCRIPTION
Most changes are related to

- Deprecated methods
- Error prone not allowing `atMost(blah, seconds)`
- Strange behavior in protobuf plugin. It caused me to notice that guava_testlib is applied globally which seems a bit heavyweight, I tried to narrow it down. The best result of that is we don't continue to have a global dependency on `junit4` (we only really need it know for `ZipkinRule` and wiremock