### PR TITLE
Add a static builder method to the OpenTelemetry interface.

### DIFF
--- a/api/src/main/java/io/opentelemetry/api/OpenTelemetry.java
+++ b/api/src/main/java/io/opentelemetry/api/OpenTelemetry.java
@@ -216,4 +216,9 @@ public interface OpenTelemetry {
    */
   @Deprecated
   OpenTelemetryBuilder<?> toBuilder();
+
+  /** Returns a new {@link OpenTelemetryBuilder}. */
+  static OpenTelemetryBuilder<?> builder() {
+    return new DefaultOpenTelemetry.Builder();
+  }
 }

--- a/api/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
+++ b/api/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
 import io.opentelemetry.api.metrics.BatchRecorder;
 import io.opentelemetry.api.metrics.DoubleCounter;
@@ -64,6 +65,24 @@ class OpenTelemetryTest {
     assertThat(OpenTelemetry.getGlobalMeterProvider())
         .isSameAs(OpenTelemetry.getGlobalMeterProvider());
     assertThat(OpenTelemetry.getGlobalPropagators()).isSameAs(OpenTelemetry.getGlobalPropagators());
+  }
+
+  @Test
+  void builder() {
+    MeterProvider meterProvider = mock(MeterProvider.class);
+    TracerProvider tracerProvider = mock(TracerProvider.class);
+    ContextPropagators contextPropagators = mock(ContextPropagators.class);
+    OpenTelemetry openTelemetry =
+        OpenTelemetry.builder()
+            .setMeterProvider(meterProvider)
+            .setTracerProvider(tracerProvider)
+            .setPropagators(contextPropagators)
+            .build();
+
+    assertThat(openTelemetry).isNotNull();
+    assertThat(openTelemetry.getMeterProvider()).isSameAs(meterProvider);
+    assertThat(openTelemetry.getTracerProvider()).isSameAs(tracerProvider);
+    assertThat(openTelemetry.getPropagators()).isSameAs(contextPropagators);
   }
 
   @Test


### PR DESCRIPTION
Perhaps resolves #1834 

/cc @Oberon00 Does this close the loop on using the tracing SDK alone without the other pieces?