### PR TITLE
Deprecate the runtime-metrics code.

### DIFF
--- a/extensions/runtime-metrics/README.md
+++ b/extensions/runtime-metrics/README.md
@@ -1,6 +1,10 @@
 OpenTelemetry Contrib Runtime Metrics
 ======================================================
 
+# DEPRECATED
+The capabilities in this module have been moved to the OpenTelemetry Java Instrumentation project.
+It will be removed in the `0.13.0` release.
+
 [![Javadocs][javadoc-image]][javadoc-url]
 
 * Java 8 compatible.

--- a/extensions/runtime-metrics/src/main/java/io/opentelemetry/extension/metrics/runtime/GarbageCollector.java
+++ b/extensions/runtime-metrics/src/main/java/io/opentelemetry/extension/metrics/runtime/GarbageCollector.java
@@ -30,7 +30,11 @@ import java.util.List;
  * <pre>
  *   runtime.jvm.gc.collection{gc="PS1"} 6.7
  * </pre>
+ *
+ * @deprecated This module and classes have been moved to the OpenTelemetry Java Instrumentation
+ *     project. It will be removed in release 0.13.0.
  */
+@Deprecated
 public final class GarbageCollector {
   private static final String GC_LABEL_KEY = "gc";
 

--- a/extensions/runtime-metrics/src/main/java/io/opentelemetry/extension/metrics/runtime/MemoryPools.java
+++ b/extensions/runtime-metrics/src/main/java/io/opentelemetry/extension/metrics/runtime/MemoryPools.java
@@ -34,7 +34,11 @@ import java.util.List;
  *   runtime.jvm.memory.area{type="committed",area="nonheap"} 200000
  *   runtime.jvm.memory.area{type="used",pool="PS Eden Space"} 2000
  * </pre>
+ *
+ * @deprecated This module and classes have been moved to the OpenTelemetry Java Instrumentation
+ *     project. It will be removed in release 0.13.0.
  */
+@Deprecated
 public final class MemoryPools {
   private static final String TYPE_LABEL_KEY = "type";
   private static final String AREA_LABEL_KEY = "area";

--- a/extensions/runtime-metrics/src/main/java/io/opentelemetry/extension/metrics/runtime/package-info.java
+++ b/extensions/runtime-metrics/src/main/java/io/opentelemetry/extension/metrics/runtime/package-info.java
@@ -3,7 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/** Metric collection for the JVM runtime. */
+/**
+ * Metric collection for the JVM runtime.
+ *
+ * <p>This module and classes have been moved to the OpenTelemetry Java Instrumentation project. It
+ * will be removed in release 0.13.0.
+ */
 @ParametersAreNonnullByDefault
 package io.opentelemetry.extension.metrics.runtime;
 

--- a/extensions/runtime-metrics/src/test/java/io/opentelemetry/extension/metrics/runtime/MemoryPoolsTest.java
+++ b/extensions/runtime-metrics/src/test/java/io/opentelemetry/extension/metrics/runtime/MemoryPoolsTest.java
@@ -14,6 +14,7 @@ import io.opentelemetry.api.metrics.AsynchronousInstrument;
 import java.lang.management.MemoryUsage;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("deprecation") // still should test it, even though it's deprecated
 class MemoryPoolsTest {
 
   @Test


### PR DESCRIPTION
This module has been moved over to the instrumentation project: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/1720