### PR TITLE
Don't repeat Java 8 support among all the subproject READMEs and at t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ This project contains the following top level components:
 
 We would love to hear from the larger community: please provide feedback proactively.
 
+## Requirements
+
+Unless otherwise noted, all published artifacts support Java 8 or higher. See [CONTRIBUTING.md](./CONTRIBUTING.md)
+for additional instructions for building this project for development.
+
 ### Note about extensions
 
 Both API and SDK extensions consist of various additional components which are excluded from the core artifacts

--- a/api/README.md
+++ b/api/README.md
@@ -2,7 +2,6 @@
 
 [![Javadocs][javadoc-image]][javadoc-url]
 
-* Java 8 and Android API Level 24 compatible.
 * The abstract classes in this directory can be subclassed to create alternative
   implementations of the OpenTelemetry library.
 

--- a/exporters/logging/README.md
+++ b/exporters/logging/README.md
@@ -2,7 +2,5 @@
 
 [![Javadocs][javadoc-image]][javadoc-url]
 
-* Java 8 compatible.
-
 [javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporters-logging.svg
 [javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporters-logging

--- a/extensions/runtime-metrics/README.md
+++ b/extensions/runtime-metrics/README.md
@@ -3,7 +3,5 @@ OpenTelemetry Contrib Runtime Metrics
 
 [![Javadocs][javadoc-image]][javadoc-url]
 
-* Java 8 compatible.
-
 [javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-contrib-runtime-metrics.svg
 [javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-contrib-runtime-metrics

--- a/extensions/trace-propagators/README.md
+++ b/extensions/trace-propagators/README.md
@@ -3,7 +3,5 @@ OpenTelemetry Contrib Trace Propagators
 
 [![Javadocs][javadoc-image]][javadoc-url]
 
-* Java 8 compatible.
-
 [javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-contrib-trace-propagators.svg
 [javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-contrib-trace-propagators

--- a/extensions/trace-utils/README.md
+++ b/extensions/trace-utils/README.md
@@ -3,7 +3,5 @@ OpenTelemetry Contrib Trace Utils
 
 [![Javadocs][javadoc-image]][javadoc-url]
 
-* Java 8 compatible.
-
 [javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-contrib-trace-utils.svg
 [javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-contrib-trace-utils

--- a/sdk-extensions/async-processor/README.md
+++ b/sdk-extensions/async-processor/README.md
@@ -6,7 +6,5 @@ An implementation of the trace `SpanProcessors` that uses
 [Disruptor](https://github.com/LMAX-Exchange/disruptor) to make all the `SpanProcessors` hooks run
 async.
 
-* Java 8 compatible.
-
 [javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-sdk-contrib-async-processor.svg
 [javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-contrib-async-processor

--- a/sdk-extensions/zpages/README.md
+++ b/sdk-extensions/zpages/README.md
@@ -5,8 +5,6 @@
 This module contains code for the OpenTelemetry Java zPages, which are a collection of dynamic HTML
 web pages embedded in your app that display stats and trace data. Learn more in [this blog post][zPages blog];
 
-* Java 8 compatible.
-
 <!--- TODO: Update javadoc -->
 [javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-sdk-contrib-auto-config.svg
 [javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-contrib-auto-config

--- a/sdk/all/README.md
+++ b/sdk/all/README.md
@@ -3,7 +3,5 @@ OpenTelemetry SDK
 
 [![Javadocs][javadoc-image]][javadoc-url]
 
-* Java 8 and Android API Level 24 compatible.
-
 [javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-sdk.svg
 [javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk


### PR DESCRIPTION
…op level, clarify that published artifacts are Java 8, but building requires additional instructions.

We used to have different compatibility among artifacts, but not anymore. We can expect some modules (like JFR) to have higher requirements but we don't need to write Java 8 support everywhere.

From #2080 