### PR TITLE
Add asMap for Attributes.

### DIFF
--- a/api/src/main/java/io/opentelemetry/api/common/Attributes.java
+++ b/api/src/main/java/io/opentelemetry/api/common/Attributes.java
@@ -23,7 +23,7 @@ import javax.annotation.concurrent.Immutable;
  */
 @SuppressWarnings("rawtypes")
 @Immutable
-public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey, Object>
+public abstract class Attributes extends ImmutableKeyValuePairs<AttributeKey<?>, Object>
     implements ReadableAttributes {
   private static final Attributes EMPTY = Attributes.builder().build();
 

--- a/api/src/main/java/io/opentelemetry/api/common/ReadableAttributes.java
+++ b/api/src/main/java/io/opentelemetry/api/common/ReadableAttributes.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.api.common;
 
+import java.util.Map;
+
 /**
  * A read-only container for String-keyed attributes.
  *
@@ -21,4 +23,10 @@ public interface ReadableAttributes {
 
   /** Iterates over all the key-value pairs of attributes contained by this instance. */
   void forEach(AttributeConsumer consumer);
+
+  /**
+   * Returns a read-only view of this {@link io.opentelemetry.api.common.ReadableAttributes} as a
+   * {@link Map}.
+   */
+  Map<AttributeKey<?>, Object> asMap();
 }

--- a/api/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
+++ b/api/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
@@ -12,6 +12,7 @@ import io.opentelemetry.api.common.Labels;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -42,6 +43,10 @@ public abstract class ImmutableKeyValuePairs<K, V> {
 
   public boolean isEmpty() {
     return data().isEmpty();
+  }
+
+  public Map<K, V> asMap() {
+    return ReadOnlyArrayMap.wrap(data());
   }
 
   /** Returns the value for the given {@code key}, or {@code null} if the key is not present. */

--- a/api/src/main/java/io/opentelemetry/api/internal/ReadOnlyArrayMap.java
+++ b/api/src/main/java/io/opentelemetry/api/internal/ReadOnlyArrayMap.java
@@ -55,21 +55,27 @@ final class ReadOnlyArrayMap<K, V> implements Map<K, V> {
 
   @Override
   public boolean containsKey(Object o) {
-    if (o == null) return false; // null keys are not allowed
+    if (o == null) {
+      return false; // null keys are not allowed
+    }
     return arrayIndexOfKey(o) != -1;
   }
 
   @Override
   public boolean containsValue(Object o) {
     for (int i = 0; i < array.size(); i += 2) {
-      if (value(i + 1).equals(o)) return true;
+      if (value(i + 1).equals(o)) {
+        return true;
+      }
     }
     return false;
   }
 
   @Override
   public V get(Object o) {
-    if (o == null) return null; // null keys are not allowed
+    if (o == null) {
+      return null; // null keys are not allowed
+    }
     int i = arrayIndexOfKey(o);
     return i != -1 ? value(i + 1) : null;
   }
@@ -164,10 +170,14 @@ final class ReadOnlyArrayMap<K, V> implements Map<K, V> {
 
     @Override
     public boolean contains(Object o) {
-      if (!(o instanceof Map.Entry) || ((Map.Entry<?, ?>) o).getKey() == null) return false;
+      if (!(o instanceof Map.Entry) || ((Map.Entry<?, ?>) o).getKey() == null) {
+        return false;
+      }
       Map.Entry<?, ?> that = (Map.Entry<?, ?>) o;
       int i = arrayIndexOfKey(that.getKey());
-      if (i == -1) return false;
+      if (i == -1) {
+        return false;
+      }
       return value(i + 1).equals(that.getValue());
     }
   }
@@ -178,11 +188,9 @@ final class ReadOnlyArrayMap<K, V> implements Map<K, V> {
       return size;
     }
 
-    /**
-     * By abstracting this, {@link #keySet()} {@link #values()} and {@link #entrySet()} only
-     * implement need implement two methods based on {@link #<E>}: this method and and {@link
-     * #contains(Object)}.
-     */
+    // By abstracting this, {@link #keySet()} {@link #values()} and {@link #entrySet()} only
+    // implement need implement two methods based on {@link #<E>}: this method and and {@link
+    // #contains(Object)}.
     abstract E elementAtArrayIndex(int i);
 
     @Override
@@ -210,18 +218,20 @@ final class ReadOnlyArrayMap<K, V> implements Map<K, V> {
     }
 
     final class ReadOnlyIterator implements Iterator<E> {
-      int i = 0;
+      int current = 0;
 
       @Override
       public boolean hasNext() {
-        return i < array.size();
+        return current < array.size();
       }
 
       @Override
       public E next() {
-        if (!hasNext()) throw new NoSuchElementException();
-        E result = elementAtArrayIndex(i);
-        i += 2;
+        if (!hasNext()) {
+          throw new NoSuchElementException();
+        }
+        E result = elementAtArrayIndex(current);
+        current += 2;
         return result;
       }
 
@@ -233,11 +243,17 @@ final class ReadOnlyArrayMap<K, V> implements Map<K, V> {
 
     @Override
     public boolean containsAll(Collection<?> c) {
-      if (c == null) return false;
-      if (c.isEmpty()) return true;
+      if (c == null) {
+        return false;
+      }
+      if (c.isEmpty()) {
+        return true;
+      }
 
       for (Object element : c) {
-        if (!contains(element)) return false;
+        if (!contains(element)) {
+          return false;
+        }
       }
       return true;
     }

--- a/api/src/main/java/io/opentelemetry/api/internal/ReadOnlyArrayMap.java
+++ b/api/src/main/java/io/opentelemetry/api/internal/ReadOnlyArrayMap.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Includes work from:
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentelemetry.api.internal;
+
+import java.lang.reflect.Array;
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+@SuppressWarnings("unchecked")
+final class ReadOnlyArrayMap<K, V> implements Map<K, V> {
+
+  static <K, V> Map<K, V> wrap(List<Object> array) {
+    if (array.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    return new ReadOnlyArrayMap<>(array);
+  }
+
+  private final List<Object> array;
+  private final int size;
+
+  private ReadOnlyArrayMap(List<Object> array) {
+    this.array = array;
+    this.size = array.size() / 2;
+  }
+
+  @Override
+  public int size() {
+    return size;
+  }
+
+  @Override
+  public boolean containsKey(Object o) {
+    if (o == null) return false; // null keys are not allowed
+    return arrayIndexOfKey(o) != -1;
+  }
+
+  @Override
+  public boolean containsValue(Object o) {
+    for (int i = 0; i < array.size(); i += 2) {
+      if (value(i + 1).equals(o)) return true;
+    }
+    return false;
+  }
+
+  @Override
+  public V get(Object o) {
+    if (o == null) return null; // null keys are not allowed
+    int i = arrayIndexOfKey(o);
+    return i != -1 ? value(i + 1) : null;
+  }
+
+  int arrayIndexOfKey(Object o) {
+    int result = -1;
+    for (int i = 0; i < array.size(); i += 2) {
+      if (o.equals(key(i))) {
+        return i;
+      }
+    }
+    return result;
+  }
+
+  K key(int i) {
+    return (K) array.get(i);
+  }
+
+  V value(int i) {
+    return (V) array.get(i);
+  }
+
+  @Override
+  public Set<K> keySet() {
+    return new KeySetView();
+  }
+
+  @Override
+  public Collection<V> values() {
+    return new ValuesView();
+  }
+
+  @Override
+  public Set<Map.Entry<K, V>> entrySet() {
+    return new EntrySetView();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return false;
+  }
+
+  @Override
+  public V put(K key, V value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public V remove(Object key) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void putAll(Map<? extends K, ? extends V> m) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void clear() {
+    throw new UnsupportedOperationException();
+  }
+
+  final class KeySetView extends SetView<K> {
+    @Override
+    K elementAtArrayIndex(int i) {
+      return key(i);
+    }
+
+    @Override
+    public boolean contains(Object o) {
+      return containsKey(o);
+    }
+  }
+
+  final class ValuesView extends SetView<V> {
+    @Override
+    V elementAtArrayIndex(int i) {
+      return value(i + 1);
+    }
+
+    @Override
+    public boolean contains(Object o) {
+      return containsValue(o);
+    }
+  }
+
+  final class EntrySetView extends SetView<Map.Entry<K, V>> {
+    @Override
+    Map.Entry<K, V> elementAtArrayIndex(int i) {
+      return new AbstractMap.SimpleImmutableEntry<>(key(i), value(i + 1));
+    }
+
+    @Override
+    public boolean contains(Object o) {
+      if (!(o instanceof Map.Entry) || ((Map.Entry<?, ?>) o).getKey() == null) return false;
+      Map.Entry<?, ?> that = (Map.Entry<?, ?>) o;
+      int i = arrayIndexOfKey(that.getKey());
+      if (i == -1) return false;
+      return value(i + 1).equals(that.getValue());
+    }
+  }
+
+  abstract class SetView<E> implements Set<E> {
+    @Override
+    public int size() {
+      return size;
+    }
+
+    /**
+     * By abstracting this, {@link #keySet()} {@link #values()} and {@link #entrySet()} only
+     * implement need implement two methods based on {@link #<E>}: this method and and {@link
+     * #contains(Object)}.
+     */
+    abstract E elementAtArrayIndex(int i);
+
+    @Override
+    public Iterator<E> iterator() {
+      return new ReadOnlyIterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+      return copyTo(new Object[size]);
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+      T[] result =
+          a.length >= size ? a : (T[]) Array.newInstance(a.getClass().getComponentType(), size());
+      return copyTo(result);
+    }
+
+    <T> T[] copyTo(T[] dest) {
+      for (int i = 0, d = 0; i < array.size(); i += 2) {
+        dest[d++] = (T) elementAtArrayIndex(i);
+      }
+      return dest;
+    }
+
+    final class ReadOnlyIterator implements Iterator<E> {
+      int i = 0;
+
+      @Override
+      public boolean hasNext() {
+        return i < array.size();
+      }
+
+      @Override
+      public E next() {
+        if (!hasNext()) throw new NoSuchElementException();
+        E result = elementAtArrayIndex(i);
+        i += 2;
+        return result;
+      }
+
+      @Override
+      public void remove() {
+        throw new UnsupportedOperationException();
+      }
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+      if (c == null) return false;
+      if (c.isEmpty()) return true;
+
+      for (Object element : c) {
+        if (!contains(element)) return false;
+      }
+      return true;
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return false;
+    }
+
+    @Override
+    public boolean add(E e) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder result = new StringBuilder();
+    result.append("ReadOnlyArrayMap{");
+    for (int i = 0; i < array.size(); i += 2) {
+      result.append(key(i)).append('=').append(value(i + 1));
+      result.append(',');
+    }
+    result.setLength(result.length() - 1);
+    return result.append("}").toString();
+  }
+}

--- a/api/src/test/java/io/opentelemetry/api/common/AttributesTest.java
+++ b/api/src/test/java/io/opentelemetry/api/common/AttributesTest.java
@@ -122,6 +122,8 @@ class AttributesTest {
         .isEqualTo(
             "ReadOnlyArrayMap{AttributeKeyImpl{getType=STRING, key=key1}=value1,"
                 + "AttributeKeyImpl{getType=LONG, key=key2}=333}");
+
+    assertThat(Attributes.builder().build().asMap()).isEmpty();
   }
 
   @Test

--- a/api/src/test/java/io/opentelemetry/api/common/AttributesTest.java
+++ b/api/src/test/java/io/opentelemetry/api/common/AttributesTest.java
@@ -15,9 +15,11 @@ import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -46,6 +48,80 @@ class AttributesTest {
     Attributes attributes = Attributes.of(stringKey("key"), "value");
     attributes.forEach(entriesSeen::put);
     assertThat(entriesSeen).containsExactly(entry(stringKey("key"), "value"));
+  }
+
+  @SuppressWarnings("CollectionIncompatibleType")
+  @Test
+  void asMap() {
+    Attributes attributes = Attributes.of(stringKey("key1"), "value1", longKey("key2"), 333L);
+
+    Map<AttributeKey<?>, Object> map = attributes.asMap();
+    assertThat(map)
+        .containsExactly(entry(stringKey("key1"), "value1"), entry(longKey("key2"), 333L));
+
+    assertThat(map.get(stringKey("key1"))).isEqualTo("value1");
+    assertThat(map.get(longKey("key2"))).isEqualTo(333L);
+    // Map of AttributeKey, not String
+    assertThat(map.get("key1")).isNull();
+    assertThat(map.get(null)).isNull();
+    assertThat(map.keySet()).containsExactlyInAnyOrder(stringKey("key1"), longKey("key2"));
+    assertThat(map.values()).containsExactlyInAnyOrder("value1", 333L);
+    assertThat(map.entrySet())
+        .containsExactlyInAnyOrder(
+            entry(stringKey("key1"), "value1"), entry(longKey("key2"), 333L));
+    assertThat(map.isEmpty()).isFalse();
+    assertThat(map.containsKey(stringKey("key1"))).isTrue();
+    assertThat(map.containsKey(longKey("key2"))).isTrue();
+    assertThat(map.containsKey(stringKey("key3"))).isFalse();
+    assertThat(map.containsValue("value1")).isTrue();
+    assertThat(map.containsValue(333L)).isTrue();
+    assertThat(map.containsValue("cat")).isFalse();
+    assertThatThrownBy(() -> map.put(stringKey("animal"), "cat"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> map.remove(stringKey("key1")))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> map.putAll(Collections.emptyMap()))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(map::clear).isInstanceOf(UnsupportedOperationException.class);
+
+    assertThat(map.keySet().contains(stringKey("key1"))).isTrue();
+    assertThat(map.keySet().contains(stringKey("key3"))).isFalse();
+    assertThat(map.keySet().size()).isEqualTo(2);
+    assertThat(map.keySet().toArray())
+        .containsExactlyInAnyOrder(stringKey("key1"), longKey("key2"));
+    AttributeKey<?>[] keys = new AttributeKey[2];
+    map.keySet().toArray(keys);
+    assertThat(keys).containsExactlyInAnyOrder(stringKey("key1"), longKey("key2"));
+    keys = new AttributeKey[0];
+    assertThat(map.keySet().toArray(keys))
+        .containsExactlyInAnyOrder(stringKey("key1"), longKey("key2"));
+    assertThat(keys).isEmpty(); // Didn't use input array.
+    assertThatThrownBy(() -> map.keySet().iterator().remove())
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThat(map.keySet().containsAll(singletonList(stringKey("key1")))).isTrue();
+    assertThat(map.keySet().containsAll(Arrays.asList(stringKey("key1"), stringKey("key3"))))
+        .isFalse();
+    assertThat(map.keySet().isEmpty()).isFalse();
+    assertThatThrownBy(() -> map.keySet().add(stringKey("key3")))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> map.keySet().remove(stringKey("key1")))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> map.keySet().addAll(Collections.singletonList(stringKey("key3"))))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> map.keySet().retainAll(Collections.singletonList(stringKey("key3"))))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> map.keySet().removeAll(Collections.singletonList(stringKey("key3"))))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> map.keySet().clear())
+        .isInstanceOf(UnsupportedOperationException.class);
+
+    assertThat(map.values().contains("value1")).isTrue();
+    assertThat(map.values().contains("value3")).isFalse();
+
+    assertThat(map.toString())
+        .isEqualTo(
+            "ReadOnlyArrayMap{AttributeKeyImpl{getType=STRING, key=key1}=value1,"
+                + "AttributeKeyImpl{getType=LONG, key=key2}=333}");
   }
 
   @Test

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/AttributesMap.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/AttributesMap.java
@@ -19,12 +19,12 @@ import java.util.Map;
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 final class AttributesMap implements ReadableAttributes {
-  private final Map<AttributeKey, Object> data;
+  private final Map<AttributeKey<?>, Object> data;
 
   private final long capacity;
   private int totalAddedValues = 0;
 
-  private AttributesMap(long capacity, Map<AttributeKey, Object> data) {
+  private AttributesMap(long capacity, Map<AttributeKey<?>, Object> data) {
     this.capacity = capacity;
     this.data = data;
   }
@@ -67,11 +67,16 @@ final class AttributesMap implements ReadableAttributes {
   @SuppressWarnings({"rawtypes", "unchecked"})
   @Override
   public void forEach(AttributeConsumer consumer) {
-    for (Map.Entry<AttributeKey, Object> entry : data.entrySet()) {
+    for (Map.Entry<AttributeKey<?>, Object> entry : data.entrySet()) {
       AttributeKey key = entry.getKey();
       Object value = entry.getValue();
       consumer.accept(key, value);
     }
+  }
+
+  @Override
+  public Map<AttributeKey<?>, Object> asMap() {
+    return Collections.unmodifiableMap(data);
   }
 
   @Override
@@ -87,7 +92,7 @@ final class AttributesMap implements ReadableAttributes {
   }
 
   ReadableAttributes immutableCopy() {
-    Map<AttributeKey, Object> dataCopy = new LinkedHashMap<>(data);
+    Map<AttributeKey<?>, Object> dataCopy = new LinkedHashMap<>(data);
     return new AttributesMap(capacity, Collections.unmodifiableMap(dataCopy));
   }
 }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/AttributesMapTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/AttributesMapTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.trace;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import io.opentelemetry.api.common.AttributeConsumer;
 import io.opentelemetry.api.common.AttributeKey;
@@ -30,6 +31,16 @@ class AttributesMapTest {
 
     assertOrdering(attributesMap, expectedKeyOrder, expectedValueOrder);
     assertOrdering(attributesMap.immutableCopy(), expectedKeyOrder, expectedValueOrder);
+  }
+
+  @Test
+  void asMap() {
+    AttributesMap attributesMap = new AttributesMap(2);
+    attributesMap.put(longKey("one"), 1L);
+    attributesMap.put(longKey("two"), 2L);
+
+    assertThat(attributesMap.asMap())
+        .containsExactly(entry(longKey("one"), 1L), entry(longKey("two"), 2L));
   }
 
   private void assertOrdering(


### PR DESCRIPTION
If this makes sense, I'll follow up with the rest of the types.

Implementation copied from https://github.com/openzipkin/brave/blob/master/brave/src/main/java/brave/internal/collect/UnsafeArrayMap.java

While it's possible to directly implement `Map`, I think `asMap` is better since it makes sure these are compile errors which I think they should be.

```java
Map<AttributeKey<?>, Object> attributes = Attributes.builder().build() // Users should be using Attributes type

Attributes attributes = Attributes.builder().build();
attributes.put() // Because of Map, these write operations leak into Attributes
```

`asMap` provides an intentional step to get into a read-only Map view. It's very unlikely Java would heap-allocate the wrapper in most code I think.

I considered making the unsupported operations no-op instead of throw, but in this case, I feel it's conventional enough to go with it (e.g., `Collections.emptyMap()` also throws Unsupported for all of these). But not too sure on it.