### PR TITLE
Remove Guava dependencies from SDK

### DIFF
--- a/sdk/all/build.gradle
+++ b/sdk/all/build.gradle
@@ -16,8 +16,6 @@ dependencies {
             project(':opentelemetry-sdk-metrics'),
             project(':opentelemetry-sdk-trace')
 
-    implementation libraries.guava
-
     annotationProcessor libraries.auto_value
 
     testAnnotationProcessor libraries.auto_value
@@ -32,6 +30,7 @@ dependencies {
         // dependencies.
         transitive = false
     }
+    jmh libraries.guava
 
     signature libraries.android_signature
 }

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -252,6 +252,7 @@ public final class OpenTelemetrySdk extends DefaultOpenTelemetry {
    * @see Obfuscated
    */
   @ThreadSafe
+  // Visible for testing
   static class ObfuscatedTracerProvider implements TracerProvider, Obfuscated<TracerProvider> {
 
     private final TracerProvider delegate;

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -7,7 +7,6 @@ package io.opentelemetry.sdk;
 
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.api.DefaultOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.internal.Obfuscated;
@@ -253,7 +252,6 @@ public final class OpenTelemetrySdk extends DefaultOpenTelemetry {
    * @see Obfuscated
    */
   @ThreadSafe
-  @VisibleForTesting
   static class ObfuscatedTracerProvider implements TracerProvider, Obfuscated<TracerProvider> {
 
     private final TracerProvider delegate;

--- a/sdk/common/build.gradle
+++ b/sdk/common/build.gradle
@@ -12,8 +12,6 @@ ext.propertiesDir = "build/generated/properties/io/opentelemetry/sdk/common"
 dependencies {
     api project(':opentelemetry-api')
 
-    implementation libraries.guava
-
     annotationProcessor libraries.auto_value
 
     testAnnotationProcessor libraries.auto_value

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/export/ConfigBuilder.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/export/ConfigBuilder.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.sdk.common.export;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Maps;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,7 +24,7 @@ import javax.annotation.Nullable;
  */
 public abstract class ConfigBuilder<T> {
 
-  @VisibleForTesting
+  // Visible for testing
   protected enum NamingConvention {
     DOT {
       @Override
@@ -65,7 +63,9 @@ public abstract class ConfigBuilder<T> {
 
   /** Sets the configuration values from the given {@link Properties} object. */
   public T readProperties(Properties properties) {
-    return fromConfigMap(Maps.fromProperties(properties), NamingConvention.DOT);
+    Map<String, String> map = new HashMap<>(properties.size());
+    properties.forEach((key, value) -> map.put((String) key, (String) value));
+    return fromConfigMap(map, NamingConvention.DOT);
   }
 
   /** Sets the configuration values from environment variables. */

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/export/ConfigBuilder.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/export/ConfigBuilder.java
@@ -63,8 +63,9 @@ public abstract class ConfigBuilder<T> {
 
   /** Sets the configuration values from the given {@link Properties} object. */
   public T readProperties(Properties properties) {
-    Map<String, String> map = new HashMap<>(properties.size());
-    properties.forEach((key, value) -> map.put((String) key, (String) value));
+    // Properties incorrectly implements Map<Object, Object> but we know it only has Strings.
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Map<String, String> map = (Map) properties;
     return fromConfigMap(map, NamingConvention.DOT);
   }
 

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/resources/EnvAutodetectResource.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/resources/EnvAutodetectResource.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.sdk.resources;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.sdk.common.export.ConfigBuilder;
@@ -33,7 +32,7 @@ final class EnvAutodetectResource {
    * Values may be quoted or unquoted in general.
    * If a value contains whitespaces, =, or " characters, it must always be quoted.
    */
-  @VisibleForTesting
+  // Visible for testing
   static Attributes parseResourceAttributes(@Nullable String rawEnvAttributes) {
     if (rawEnvAttributes == null) {
       return Attributes.empty();

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/resources/ResourcesConfig.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/resources/ResourcesConfig.java
@@ -5,15 +5,16 @@
 
 package io.opentelemetry.sdk.resources;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.auto.value.AutoValue;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableSet;
 import io.opentelemetry.sdk.common.export.ConfigBuilder;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -69,7 +70,8 @@ public abstract class ResourcesConfig {
    * @return a new {@link Builder}.
    */
   public static Builder builder() {
-    return new AutoValue_ResourcesConfig.Builder().setDisabledResourceProviders(ImmutableSet.of());
+    return new AutoValue_ResourcesConfig.Builder()
+        .setDisabledResourceProviders(Collections.emptySet());
   }
 
   /**
@@ -94,7 +96,7 @@ public abstract class ResourcesConfig {
      * @param configMap {@link Map} holding the configuration values.
      * @return this
      */
-    @VisibleForTesting
+    // Visible for testing
     @Override
     protected Builder fromConfigMap(
         Map<String, String> configMap, NamingConvention namingConvention) {
@@ -103,8 +105,11 @@ public abstract class ResourcesConfig {
       String stringValue = getStringProperty(OTEL_JAVA_DISABLED_RESOURCES_PROVIDERS, configMap);
       if (stringValue != null) {
         this.setDisabledResourceProviders(
-            ImmutableSet.copyOf(
-                Splitter.on(',').omitEmptyStrings().trimResults().split(stringValue)));
+            Collections.unmodifiableSet(
+                Arrays.stream(stringValue.split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.toSet())));
       }
       return this;
     }
@@ -128,8 +133,7 @@ public abstract class ResourcesConfig {
      */
     public ResourcesConfig build() {
       ResourcesConfig resourcesConfig = autoBuild();
-      Preconditions.checkArgument(
-          resourcesConfig.getDisabledResourceProviders() != null, "disabledResourceProviders");
+      requireNonNull(resourcesConfig.getDisabledResourceProviders(), "disabledResourceProviders");
       return resourcesConfig;
     }
   }

--- a/sdk/metrics/build.gradle
+++ b/sdk/metrics/build.gradle
@@ -14,8 +14,6 @@ dependencies {
     api project(':opentelemetry-api'),
             project(':opentelemetry-sdk-common')
 
-    implementation libraries.guava
-
     annotationProcessor libraries.auto_value
 
     testAnnotationProcessor libraries.auto_value
@@ -23,6 +21,7 @@ dependencies {
 
     testCompile project(path: ':opentelemetry-sdk-common', configuration: 'testClasses')
 
+    testImplementation libraries.guava
     testImplementation project(':opentelemetry-sdk-testing')
     testImplementation libraries.junit_pioneer
 

--- a/sdk/trace/build.gradle
+++ b/sdk/trace/build.gradle
@@ -14,7 +14,6 @@ dependencies {
     api project(':opentelemetry-api'),
             project(':opentelemetry-sdk-common')
 
-    implementation libraries.guava
 
     annotationProcessor libraries.auto_value
 
@@ -23,6 +22,7 @@ dependencies {
 
     testCompile project(path: ':opentelemetry-sdk-common', configuration: 'testClasses')
 
+    testImplementation libraries.guava
     testImplementation project(':opentelemetry-sdk-testing')
     testImplementation libraries.junit_pioneer
 

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SpanBuilderSdk.java
@@ -10,7 +10,6 @@ import static io.opentelemetry.api.common.AttributeKey.doubleKey;
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.api.common.AttributeConsumer;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -261,13 +260,13 @@ final class SpanBuilderSdk implements SpanBuilder {
     }
   }
 
-  @VisibleForTesting
+  // Visible for testing
   static boolean isRecording(SamplingResult.Decision decision) {
     return SamplingResult.Decision.RECORD_ONLY.equals(decision)
         || SamplingResult.Decision.RECORD_AND_SAMPLE.equals(decision);
   }
 
-  @VisibleForTesting
+  // Visible for testing
   static boolean isSampled(SamplingResult.Decision decision) {
     return SamplingResult.Decision.RECORD_AND_SAMPLE.equals(decision);
   }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
@@ -6,8 +6,6 @@
 package io.opentelemetry.sdk.trace.config;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import io.opentelemetry.api.internal.Utils;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.sdk.common.export.ConfigBuilder;
@@ -191,7 +189,7 @@ public abstract class TraceConfig {
      * @param configMap {@link Map} holding the configuration values.
      * @return this
      */
-    @VisibleForTesting
+    // Visible for testing
     @Override
     protected Builder fromConfigMap(
         Map<String, String> configMap, Builder.NamingConvention namingConvention) {
@@ -352,16 +350,26 @@ public abstract class TraceConfig {
      */
     public TraceConfig build() {
       TraceConfig traceConfig = autoBuild();
-      Preconditions.checkArgument(
-          traceConfig.getMaxNumberOfAttributes() > 0, "maxNumberOfAttributes");
-      Preconditions.checkArgument(traceConfig.getMaxNumberOfEvents() > 0, "maxNumberOfEvents");
-      Preconditions.checkArgument(traceConfig.getMaxNumberOfLinks() > 0, "maxNumberOfLinks");
-      Preconditions.checkArgument(
-          traceConfig.getMaxNumberOfAttributesPerEvent() > 0, "maxNumberOfAttributesPerEvent");
-      Preconditions.checkArgument(
-          traceConfig.getMaxNumberOfAttributesPerLink() > 0, "maxNumberOfAttributesPerLink");
-      Preconditions.checkArgument(
-          traceConfig.getMaxLengthOfAttributeValues() >= -1, "maxLengthOfAttributeValues");
+      if (traceConfig.getMaxNumberOfAttributes() <= 0) {
+        throw new IllegalArgumentException("maxNumberOfAttributes must be greater than 0");
+      }
+      if (traceConfig.getMaxNumberOfEvents() <= 0) {
+        throw new IllegalArgumentException("maxNumberOfEvents must be greater than 0");
+      }
+      if (traceConfig.getMaxNumberOfLinks() <= 0) {
+        throw new IllegalArgumentException("maxNumberOfLinks must be greater than 0");
+      }
+      if (traceConfig.getMaxNumberOfAttributesPerEvent() <= 0) {
+        throw new IllegalArgumentException("maxNumberOfAttributesPerEvent must be greater than 0");
+      }
+      if (traceConfig.getMaxNumberOfAttributesPerLink() <= 0) {
+        throw new IllegalArgumentException("maxNumberOfAttributesPerLink must be greater than 0");
+      }
+      if (traceConfig.getMaxLengthOfAttributeValues() < -1) {
+        throw new IllegalArgumentException(
+            "maxLengthOfAttributeValues must be -1 to "
+                + "disable length restriction, or 0 or higher to enable length restriction");
+      }
       return traceConfig;
     }
   }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.sdk.trace.export;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.internal.Utils;
@@ -316,11 +315,16 @@ public final class BatchSpanProcessor implements SpanProcessor {
     private static final String KEY_EXPORT_TIMEOUT_MILLIS = "otel.bsp.export.timeout.millis";
     private static final String KEY_SAMPLED = "otel.bsp.export.sampled";
 
-    @VisibleForTesting static final long DEFAULT_SCHEDULE_DELAY_MILLIS = 5000;
-    @VisibleForTesting static final int DEFAULT_MAX_QUEUE_SIZE = 2048;
-    @VisibleForTesting static final int DEFAULT_MAX_EXPORT_BATCH_SIZE = 512;
-    @VisibleForTesting static final int DEFAULT_EXPORT_TIMEOUT_MILLIS = 30_000;
-    @VisibleForTesting static final boolean DEFAULT_EXPORT_ONLY_SAMPLED = true;
+    // Visible for testing
+    static final long DEFAULT_SCHEDULE_DELAY_MILLIS = 5000;
+    // Visible for testing
+    static final int DEFAULT_MAX_QUEUE_SIZE = 2048;
+    // Visible for testing
+    static final int DEFAULT_MAX_EXPORT_BATCH_SIZE = 512;
+    // Visible for testing
+    static final int DEFAULT_EXPORT_TIMEOUT_MILLIS = 30_000;
+    // Visible for testing
+    static final boolean DEFAULT_EXPORT_ONLY_SAMPLED = true;
 
     private final SpanExporter spanExporter;
     private long scheduleDelayMillis = DEFAULT_SCHEDULE_DELAY_MILLIS;
@@ -382,7 +386,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
       return this;
     }
 
-    @VisibleForTesting
+    // Visible for testing
     boolean getExportOnlySampled() {
       return exportOnlySampled;
     }
@@ -402,7 +406,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
       return this;
     }
 
-    @VisibleForTesting
+    // Visible for testing
     long getScheduleDelayMillis() {
       return scheduleDelayMillis;
     }
@@ -421,7 +425,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
       return this;
     }
 
-    @VisibleForTesting
+    // Visible for testing
     int getExporterTimeoutMillis() {
       return exporterTimeoutMillis;
     }
@@ -444,7 +448,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
       return this;
     }
 
-    @VisibleForTesting
+    // Visible for testing
     int getMaxQueueSize() {
       return maxQueueSize;
     }
@@ -465,7 +469,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
       return this;
     }
 
-    @VisibleForTesting
+    // Visible for testing
     int getMaxExportBatchSize() {
       return maxExportBatchSize;
     }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.sdk.trace.export;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.export.ConfigBuilder;
@@ -114,7 +113,8 @@ public final class SimpleSpanProcessor implements SpanProcessor {
 
     private static final String KEY_SAMPLED = "otel.ssp.export.sampled";
 
-    @VisibleForTesting static final boolean DEFAULT_EXPORT_ONLY_SAMPLED = true;
+    // Visible for testing
+    static final boolean DEFAULT_EXPORT_ONLY_SAMPLED = true;
     private final SpanExporter spanExporter;
     private boolean exportOnlySampled = DEFAULT_EXPORT_ONLY_SAMPLED;
 
@@ -157,7 +157,7 @@ public final class SimpleSpanProcessor implements SpanProcessor {
       return this;
     }
 
-    @VisibleForTesting
+    // Visible for testing
     boolean getExportOnlySampled() {
       return exportOnlySampled;
     }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/TraceIdRatioBasedSampler.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/TraceIdRatioBasedSampler.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.sdk.trace.samplers;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.base.Preconditions;
 import io.opentelemetry.api.common.ReadableAttributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.TraceId;
@@ -29,7 +28,9 @@ abstract class TraceIdRatioBasedSampler implements Sampler {
   TraceIdRatioBasedSampler() {}
 
   static TraceIdRatioBasedSampler create(double ratio) {
-    Preconditions.checkArgument(ratio >= 0.0 && ratio <= 1.0, "ratio must be in range [0.0, 1.0]");
+    if (ratio < 0.0 || ratio > 1.0) {
+      throw new IllegalArgumentException("ratio must be in range [0.0, 1.0]");
+    }
     long idUpperBound;
     // Special case the limits, to avoid any possible issues with lack of precision across
     // double/long boundaries. For probability == 0.0, we use Long.MIN_VALUE as this guarantees


### PR DESCRIPTION
For #1944 

Remaining are gRPC-based artifacts (always use guava), opencensus shim (it's going away in new implementation type), and jfr (will probably use weak-lock-free for it after https://github.com/raphw/weak-lock-free/pull/12)