### PR TITLE
Changes TextMapPropagator.fields() return type from List to Collection

### DIFF
--- a/api/src/main/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagator.java
+++ b/api/src/main/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagator.java
@@ -12,6 +12,7 @@ import io.opentelemetry.api.baggage.BaggageBuilder;
 import io.opentelemetry.api.baggage.EntryMetadata;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
+import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -32,7 +33,7 @@ public final class W3CBaggagePropagator implements TextMapPropagator {
   private W3CBaggagePropagator() {}
 
   @Override
-  public List<String> fields() {
+  public Collection<String> fields() {
     return FIELDS;
   }
 

--- a/api/src/main/java/io/opentelemetry/api/trace/propagation/HttpTraceContext.java
+++ b/api/src/main/java/io/opentelemetry/api/trace/propagation/HttpTraceContext.java
@@ -7,7 +7,7 @@ package io.opentelemetry.api.trace.propagation;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import java.util.List;
+import java.util.Collection;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -33,7 +33,7 @@ public final class HttpTraceContext implements TextMapPropagator {
   }
 
   @Override
-  public List<String> fields() {
+  public Collection<String> fields() {
     return W3CTraceContextPropagator.getInstance().fields();
   }
 

--- a/api/src/main/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagator.java
+++ b/api/src/main/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagator.java
@@ -18,6 +18,7 @@ import io.opentelemetry.api.trace.TraceStateBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -69,7 +70,7 @@ public final class W3CTraceContextPropagator {
   private static final TextMapPropagator INSTANCE =
       new TextMapPropagator() {
         @Override
-        public List<String> fields() {
+        public Collection<String> fields() {
           return FIELDS;
         }
 

--- a/context/src/main/java/io/opentelemetry/context/propagation/MultiTextMapPropagator.java
+++ b/context/src/main/java/io/opentelemetry/context/propagation/MultiTextMapPropagator.java
@@ -7,6 +7,7 @@ package io.opentelemetry.context.propagation;
 
 import io.opentelemetry.context.Context;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -15,7 +16,7 @@ import javax.annotation.Nullable;
 
 final class MultiTextMapPropagator implements TextMapPropagator {
   private final TextMapPropagator[] textPropagators;
-  private final List<String> allFields;
+  private final Collection<String> allFields;
 
   MultiTextMapPropagator(List<TextMapPropagator> textPropagators) {
     this.textPropagators = new TextMapPropagator[textPropagators.size()];
@@ -24,7 +25,7 @@ final class MultiTextMapPropagator implements TextMapPropagator {
   }
 
   @Override
-  public List<String> fields() {
+  public Collection<String> fields() {
     return allFields;
   }
 

--- a/context/src/main/java/io/opentelemetry/context/propagation/NoopTextMapPropagator.java
+++ b/context/src/main/java/io/opentelemetry/context/propagation/NoopTextMapPropagator.java
@@ -6,8 +6,8 @@
 package io.opentelemetry.context.propagation;
 
 import io.opentelemetry.context.Context;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import javax.annotation.Nullable;
 
 final class NoopTextMapPropagator implements TextMapPropagator {
@@ -18,7 +18,7 @@ final class NoopTextMapPropagator implements TextMapPropagator {
   }
 
   @Override
-  public List<String> fields() {
+  public Collection<String> fields() {
     return Collections.emptyList();
   }
 

--- a/context/src/main/java/io/opentelemetry/context/propagation/TextMapPropagator.java
+++ b/context/src/main/java/io/opentelemetry/context/propagation/TextMapPropagator.java
@@ -8,6 +8,7 @@ package io.opentelemetry.context.propagation;
 import io.opentelemetry.context.Context;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -87,12 +88,12 @@ public interface TextMapPropagator {
    * clear fields as they couldn't have been set before. If it is a mutable, retryable object,
    * successive calls should clear these fields first.
    *
-   * @return list of fields that will be used by this formatter.
+   * @return the fields that will be used by this formatter.
    */
   // The use cases of this are:
   // * allow pre-allocation of fields, especially in systems like gRPC Metadata
   // * allow a single-pass over an iterator
-  List<String> fields();
+  Collection<String> fields();
 
   /**
    * Injects the value downstream, for example as HTTP headers. The carrier may be null to

--- a/context/src/test/java/io/opentelemetry/context/propagation/DefaultPropagatorsTest.java
+++ b/context/src/test/java/io/opentelemetry/context/propagation/DefaultPropagatorsTest.java
@@ -10,9 +10,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -71,7 +71,7 @@ class DefaultPropagatorsTest {
         ContextPropagators.create(
             TextMapPropagator.composite(propagator1, propagator2, propagator3, propagator4));
 
-    List<String> fields = propagators.getTextMapPropagator().fields();
+    Collection<String> fields = propagators.getTextMapPropagator().fields();
     assertThat(fields).containsExactly("prop1", "prop2");
   }
 
@@ -106,7 +106,7 @@ class DefaultPropagatorsTest {
     }
 
     @Override
-    public List<String> fields() {
+    public Collection<String> fields() {
       return Collections.singletonList(name);
     }
 

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/AwsXRayPropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/AwsXRayPropagator.java
@@ -13,8 +13,8 @@ import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
@@ -61,7 +61,7 @@ public class AwsXRayPropagator implements TextMapPropagator {
   private static final char IS_SAMPLED = '1';
   private static final char NOT_SAMPLED = '0';
 
-  private static final List<String> FIELDS = Collections.singletonList(TRACE_HEADER_KEY);
+  private static final Collection<String> FIELDS = Collections.singletonList(TRACE_HEADER_KEY);
 
   private static final AwsXRayPropagator INSTANCE = new AwsXRayPropagator();
 
@@ -74,7 +74,7 @@ public class AwsXRayPropagator implements TextMapPropagator {
   }
 
   @Override
-  public List<String> fields() {
+  public Collection<String> fields() {
     return FIELDS;
   }
 

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3Propagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3Propagator.java
@@ -9,8 +9,8 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -62,7 +62,7 @@ public class B3Propagator implements TextMapPropagator {
   static final char NOT_SAMPLED = '0';
   static final char DEBUG_SAMPLED = 'd';
 
-  private static final List<String> FIELDS =
+  private static final Collection<String> FIELDS =
       Collections.unmodifiableList(
           Arrays.asList(TRACE_ID_HEADER, SPAN_ID_HEADER, SAMPLED_HEADER, COMBINED_HEADER));
 
@@ -117,7 +117,7 @@ public class B3Propagator implements TextMapPropagator {
   }
 
   @Override
-  public List<String> fields() {
+  public Collection<String> fields() {
     return FIELDS;
   }
 

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/JaegerPropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/JaegerPropagator.java
@@ -17,8 +17,8 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -65,7 +65,7 @@ public class JaegerPropagator implements TextMapPropagator {
   private static final byte SAMPLED = TraceFlags.getSampled();
   private static final byte NOT_SAMPLED = TraceFlags.getDefault();
 
-  private static final List<String> FIELDS = Collections.singletonList(PROPAGATION_HEADER);
+  private static final Collection<String> FIELDS = Collections.singletonList(PROPAGATION_HEADER);
 
   private static final JaegerPropagator INSTANCE = new JaegerPropagator();
 
@@ -78,7 +78,7 @@ public class JaegerPropagator implements TextMapPropagator {
   }
 
   @Override
-  public List<String> fields() {
+  public Collection<String> fields() {
     return FIELDS;
   }
 

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/OtTracerPropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/OtTracerPropagator.java
@@ -13,8 +13,8 @@ import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -31,7 +31,7 @@ public class OtTracerPropagator implements TextMapPropagator {
   static final String TRACE_ID_HEADER = "ot-tracer-traceid";
   static final String SPAN_ID_HEADER = "ot-tracer-spanid";
   static final String SAMPLED_HEADER = "ot-tracer-sampled";
-  private static final List<String> FIELDS =
+  private static final Collection<String> FIELDS =
       Collections.unmodifiableList(Arrays.asList(TRACE_ID_HEADER, SPAN_ID_HEADER, SAMPLED_HEADER));
 
   private static final OtTracerPropagator INSTANCE = new OtTracerPropagator();
@@ -45,7 +45,7 @@ public class OtTracerPropagator implements TextMapPropagator {
   }
 
   @Override
-  public List<String> fields() {
+  public Collection<String> fields() {
     return FIELDS;
   }
 

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagator.java
@@ -12,6 +12,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -76,7 +77,7 @@ public class TraceMultiPropagator implements TextMapPropagator {
   }
 
   private final TextMapPropagator[] propagators;
-  private final List<String> propagatorsFields;
+  private final Collection<String> propagatorsFields;
 
   private TraceMultiPropagator(List<TextMapPropagator> propagatorList) {
     this.propagators = new TextMapPropagator[propagatorList.size()];
@@ -108,7 +109,7 @@ public class TraceMultiPropagator implements TextMapPropagator {
    * @return list of fields defined in all the registered propagators.
    */
   @Override
-  public List<String> fields() {
+  public Collection<String> fields() {
     return propagatorsFields;
   }
 

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagatorTest.java
@@ -20,8 +20,8 @@ import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
@@ -70,7 +70,7 @@ class TraceMultiPropagatorTest {
         TraceMultiPropagator.create(
             new EmptyPropagator("foo", "bar"), new EmptyPropagator("hello", "world"));
 
-    List<String> fields = prop.fields();
+    Collection<String> fields = prop.fields();
     assertThat(fields).containsExactly("foo", "bar", "hello", "world");
   }
 
@@ -81,7 +81,7 @@ class TraceMultiPropagatorTest {
             new EmptyPropagator("foo", "bar", "foo"),
             new EmptyPropagator("hello", "world", "world", "bar"));
 
-    List<String> fields = prop.fields();
+    Collection<String> fields = prop.fields();
     assertThat(fields).containsExactly("foo", "bar", "hello", "world");
   }
 
@@ -91,7 +91,7 @@ class TraceMultiPropagatorTest {
         TraceMultiPropagator.create(
             new EmptyPropagator("foo", "bar"), new EmptyPropagator("hello", "world"));
 
-    List<String> fields = prop.fields();
+    Collection<String> fields = prop.fields();
     assertThrows(UnsupportedOperationException.class, () -> fields.add("hi"));
   }
 
@@ -169,14 +169,14 @@ class TraceMultiPropagatorTest {
   }
 
   private static class EmptyPropagator implements TextMapPropagator {
-    List<String> fields;
+    Collection<String> fields;
 
     public EmptyPropagator(String... fields) {
       this.fields = Arrays.asList(fields);
     }
 
     @Override
-    public List<String> fields() {
+    public Collection<String> fields() {
       return fields;
     }
 


### PR DESCRIPTION
- changes the return type of the fields() method in TextMapPropagator from List<String> to Collection<String>

Addresses: #2011 