### PR TITLE
Deprecate trace-utils

### DIFF
--- a/extensions/trace-utils/README.md
+++ b/extensions/trace-utils/README.md
@@ -1,7 +1,9 @@
-OpenTelemetry Contrib Trace Utils
+OpenTelemetry Contrib Trace Utils (deprecated)
 ======================================================
 
 [![Javadocs][javadoc-image]][javadoc-url]
 
 [javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-contrib-trace-utils.svg
 [javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-contrib-trace-utils
+
+This artifact is deprecated and will be removed.

--- a/extensions/trace-utils/src/main/java/io/opentelemetry/extension/trace/CurrentSpanUtils.java
+++ b/extensions/trace-utils/src/main/java/io/opentelemetry/extension/trace/CurrentSpanUtils.java
@@ -11,7 +11,13 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import java.util.concurrent.Callable;
 
-/** Util methods/functionality to interact with the {@link Span} in the {@link Context}. */
+/**
+ * Util methods/functionality to interact with the {@link Span} in the {@link Context}.
+ *
+ * @deprecated Span should never be propagated by itself. Instead of this class, use {@code
+ *     Context.with(span).wrap(...)}. This class will be removed in SDK 0.13.0.
+ */
+@Deprecated
 public final class CurrentSpanUtils {
   // No instance of this class.
   private CurrentSpanUtils() {}

--- a/extensions/trace-utils/src/main/java/io/opentelemetry/extension/trace/MessageEvent.java
+++ b/extensions/trace-utils/src/main/java/io/opentelemetry/extension/trace/MessageEvent.java
@@ -21,8 +21,11 @@ import javax.annotation.concurrent.Immutable;
  *
  * <p>It requires a {@link Type type} and a message id that serves to uniquely identify each
  * message. It can optionally have information about the message size.
+ *
+ * @deprecated This class will be removed in SDK 0.13.0.
  */
 @Immutable
+@Deprecated
 public final class MessageEvent {
 
   private static final String EVENT_NAME = "message";

--- a/extensions/trace-utils/src/main/java/io/opentelemetry/extension/trace/MessageEvent.java
+++ b/extensions/trace-utils/src/main/java/io/opentelemetry/extension/trace/MessageEvent.java
@@ -22,7 +22,9 @@ import javax.annotation.concurrent.Immutable;
  * <p>It requires a {@link Type type} and a message id that serves to uniquely identify each
  * message. It can optionally have information about the message size.
  *
- * @deprecated This class will be removed in SDK 0.13.0.
+ * @deprecated This class will be removed in SDK 0.13.0. If these attributes are useful to you,
+ *     consider filing an issue or a PR to have them added to {@link
+ *     io.opentelemetry.api.trace.attributes.SemanticAttributes}.
  */
 @Immutable
 @Deprecated

--- a/extensions/trace-utils/src/test/java/io/opentelemetry/extension/trace/CurrentSpanUtilsTest.java
+++ b/extensions/trace-utils/src/test/java/io/opentelemetry/extension/trace/CurrentSpanUtilsTest.java
@@ -18,7 +18,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-@SuppressWarnings("deprecation")  // CurrentSpanUtils is going to be removed.
+@SuppressWarnings("deprecation") // CurrentSpanUtils is going to be removed.
 class CurrentSpanUtilsTest {
   @Spy private Span span;
 

--- a/extensions/trace-utils/src/test/java/io/opentelemetry/extension/trace/CurrentSpanUtilsTest.java
+++ b/extensions/trace-utils/src/test/java/io/opentelemetry/extension/trace/CurrentSpanUtilsTest.java
@@ -18,7 +18,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-@SuppressWarnings("deprecation")
+@SuppressWarnings("deprecation")  // CurrentSpanUtils is going to be removed.
 class CurrentSpanUtilsTest {
   @Spy private Span span;
 

--- a/extensions/trace-utils/src/test/java/io/opentelemetry/extension/trace/CurrentSpanUtilsTest.java
+++ b/extensions/trace-utils/src/test/java/io/opentelemetry/extension/trace/CurrentSpanUtilsTest.java
@@ -18,6 +18,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("deprecation")
 class CurrentSpanUtilsTest {
   @Spy private Span span;
 


### PR DESCRIPTION
If anyone wants to keep these classes, let me know. `MessageEvent` seems very strange to me, I guess it should be related to the semantic attributes somehow. I'm pushing to delete it. `CurrentSpanUtils` is not useful really unless using the `boolean endSpan` feature. I've marked it for deprecation, but if anyone wants to keep this, I would probably remove the `boolean endSpan` since I don't think it should ever be used if not for it's auto-end-span functionality.