### PR TITLE
Remove coveralls plugin

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,6 @@ pluginManagement {
     plugins {
         id "com.diffplug.spotless" version "5.8.2"
         id "com.github.ben-manes.versions" version "0.36.0"
-        id "com.github.kt3k.coveralls" version "2.0.1"
         id "com.google.protobuf" version "0.8.14"
         id "com.jfrog.artifactory" version "4.18.0"
         id "com.jfrog.bintray" version "1.8.5"


### PR DESCRIPTION
We use codecov - presumably this is some legacy artifact.