### PR TITLE
Adding micro-benchmarks for AwsXRayPropagator

### DIFF
--- a/extensions/trace-propagators/src/jmh/java/io/opentelemetry/extension/trace/propagation/PropagatorContextExtractBenchmark.java
+++ b/extensions/trace-propagators/src/jmh/java/io/opentelemetry/extension/trace/propagation/PropagatorContextExtractBenchmark.java
@@ -264,4 +264,51 @@ public class PropagatorContextExtractBenchmark {
       return traceHeaders;
     }
   }
+
+  /** Benchmark for extracting context from AWS X-Ray trace header. */
+  public static class AwsXrayHeaderContextExtractBenchmark extends AbstractContextExtractBenchmark {
+
+    private static final List<Map<String, String>> traceHeaders =
+        Arrays.asList(
+            Collections.singletonMap(
+                AwsXRayPropagator.TRACE_HEADER_KEY,
+                "Root=1-8a3c60f7-d188f8fa79d48a391a778fa6;Parent=53995c3f42cd8ad8;Sampled=1"),
+            Collections.singletonMap(
+                AwsXRayPropagator.TRACE_HEADER_KEY,
+                "Root=1-8a3c60f7-d188f8fa79d48a391a778fa6;Parent=53995c3f42cd8ad8;Sampled=0"),
+            Collections.singletonMap(
+                AwsXRayPropagator.TRACE_HEADER_KEY,
+                "Parent=53995c3f42cd8ad8;Sampled=1;Root=1-8a3c60f7-d188f8fa79d48a391a778fa6"),
+            Collections.singletonMap(
+                AwsXRayPropagator.TRACE_HEADER_KEY,
+                "Root=1-57ff426a-80c11c39b0c928905eb0828d;Parent=53995c3f42cd8ad8;Sampled=1"),
+            Collections.singletonMap(
+                AwsXRayPropagator.TRACE_HEADER_KEY,
+                "Root=1-57ff426a-80c11c39b0c928905eb0828d;Parent=12345c3f42cd8ad8;Sampled=0"));
+
+    private final TextMapPropagator.Getter<Map<String, String>> getter =
+        new TextMapPropagator.Getter<Map<String, String>>() {
+          @Override
+          public Iterable<String> keys(Map<String, String> carrier) {
+            return carrier.keySet();
+          }
+
+          @Override
+          public String get(Map<String, String> carrier, String key) {
+            return carrier.get(key);
+          }
+        };
+
+    private final AwsXRayPropagator xrayPropagator = AwsXRayPropagator.getInstance();
+
+    @Override
+    protected Context doExtract() {
+      return xrayPropagator.extract(Context.current(), getCarrier(), getter);
+    }
+
+    @Override
+    protected List<Map<String, String>> getHeaders() {
+      return traceHeaders;
+    }
+  }
 }

--- a/extensions/trace-propagators/src/jmh/java/io/opentelemetry/extension/trace/propagation/PropagatorContextInjectBenchmark.java
+++ b/extensions/trace-propagators/src/jmh/java/io/opentelemetry/extension/trace/propagation/PropagatorContextInjectBenchmark.java
@@ -134,4 +134,21 @@ public class PropagatorContextInjectBenchmark {
       b3Propagator.inject(context, carrier, setter);
     }
   }
+
+  /** Benchmark for injecting trace context into AWS X-Ray headers. */
+  public static class AwsXRayPropagatorInjectBenchmark extends AbstractContextInjectBenchmark {
+    private final AwsXRayPropagator xrayPropagator = AwsXRayPropagator.getInstance();
+    private final TextMapPropagator.Setter<Map<String, String>> setter =
+        new TextMapPropagator.Setter<Map<String, String>>() {
+          @Override
+          public void set(Map<String, String> carrier, String key, String value) {
+            carrier.put(key, value);
+          }
+        };
+
+    @Override
+    protected void doInject(Context context, Map<String, String> carrier) {
+      xrayPropagator.inject(context, carrier, setter);
+    }
+  }
 }


### PR DESCRIPTION
Running the benchmark on an **m5.xlarge AWS EC2 instance, with 16 GB of memory and 4 vCPUs** for the trace propagators:

```shell
Benchmark                                                                                                               Mode  Cnt     Score     Error   Units
PropagatorContextExtractBenchmark.AwsXrayHeaderContextExtractBenchmark.measureExtract                                   avgt   15   373.515 ±   3.002   ns/op
PropagatorContextExtractBenchmark.AwsXrayHeaderContextExtractBenchmark.measureExtract:·gc.alloc.rate                    avgt   15   980.100 ±   7.732  MB/sec
PropagatorContextExtractBenchmark.AwsXrayHeaderContextExtractBenchmark.measureExtract:·gc.alloc.rate.norm               avgt   15   576.000 ±   0.001    B/op
PropagatorContextExtractBenchmark.AwsXrayHeaderContextExtractBenchmark.measureExtract:·gc.churn.G1_Eden_Space           avgt   15   983.743 ±  39.088  MB/sec
PropagatorContextExtractBenchmark.AwsXrayHeaderContextExtractBenchmark.measureExtract:·gc.churn.G1_Eden_Space.norm      avgt   15   578.150 ±  22.868    B/op
PropagatorContextExtractBenchmark.AwsXrayHeaderContextExtractBenchmark.measureExtract:·gc.churn.G1_Old_Gen              avgt   15     0.001 ±   0.001  MB/sec
PropagatorContextExtractBenchmark.AwsXrayHeaderContextExtractBenchmark.measureExtract:·gc.churn.G1_Old_Gen.norm         avgt   15     0.001 ±   0.001    B/op
PropagatorContextExtractBenchmark.AwsXrayHeaderContextExtractBenchmark.measureExtract:·gc.count                         avgt   15   104.000            counts
PropagatorContextExtractBenchmark.AwsXrayHeaderContextExtractBenchmark.measureExtract:·gc.time                          avgt   15    46.000                ms
PropagatorContextExtractBenchmark.B3MultipleHeaderContextExtractBenchmark.measureExtract                                avgt   15   361.828 ±   9.720   ns/op
PropagatorContextExtractBenchmark.B3MultipleHeaderContextExtractBenchmark.measureExtract:·gc.alloc.rate                 avgt   15  1026.242 ±  27.054  MB/sec
PropagatorContextExtractBenchmark.B3MultipleHeaderContextExtractBenchmark.measureExtract:·gc.alloc.rate.norm            avgt   15   584.000 ±   0.001    B/op
PropagatorContextExtractBenchmark.B3MultipleHeaderContextExtractBenchmark.measureExtract:·gc.churn.G1_Eden_Space        avgt   15  1031.130 ±  69.392  MB/sec
PropagatorContextExtractBenchmark.B3MultipleHeaderContextExtractBenchmark.measureExtract:·gc.churn.G1_Eden_Space.norm   avgt   15   586.779 ±  35.753    B/op
PropagatorContextExtractBenchmark.B3MultipleHeaderContextExtractBenchmark.measureExtract:·gc.churn.G1_Old_Gen           avgt   15     0.002 ±   0.002  MB/sec
PropagatorContextExtractBenchmark.B3MultipleHeaderContextExtractBenchmark.measureExtract:·gc.churn.G1_Old_Gen.norm      avgt   15     0.001 ±   0.001    B/op
PropagatorContextExtractBenchmark.B3MultipleHeaderContextExtractBenchmark.measureExtract:·gc.count                      avgt   15   109.000            counts
PropagatorContextExtractBenchmark.B3MultipleHeaderContextExtractBenchmark.measureExtract:·gc.time                       avgt   15    54.000                ms
PropagatorContextExtractBenchmark.B3SingleHeaderContextExtractBenchmark.measureExtract                                  avgt   15   481.646 ±   7.940   ns/op
PropagatorContextExtractBenchmark.B3SingleHeaderContextExtractBenchmark.measureExtract:·gc.alloc.rate                   avgt   15  1140.253 ±  18.442  MB/sec
PropagatorContextExtractBenchmark.B3SingleHeaderContextExtractBenchmark.measureExtract:·gc.alloc.rate.norm              avgt   15   864.001 ±   0.001    B/op
PropagatorContextExtractBenchmark.B3SingleHeaderContextExtractBenchmark.measureExtract:·gc.churn.G1_Eden_Space          avgt   15  1141.462 ±  89.279  MB/sec
PropagatorContextExtractBenchmark.B3SingleHeaderContextExtractBenchmark.measureExtract:·gc.churn.G1_Eden_Space.norm     avgt   15   865.157 ±  69.899    B/op
PropagatorContextExtractBenchmark.B3SingleHeaderContextExtractBenchmark.measureExtract:·gc.churn.G1_Old_Gen             avgt   15     0.002 ±   0.001  MB/sec
PropagatorContextExtractBenchmark.B3SingleHeaderContextExtractBenchmark.measureExtract:·gc.churn.G1_Old_Gen.norm        avgt   15     0.001 ±   0.001    B/op
PropagatorContextExtractBenchmark.B3SingleHeaderContextExtractBenchmark.measureExtract:·gc.count                        avgt   15   100.000            counts
PropagatorContextExtractBenchmark.B3SingleHeaderContextExtractBenchmark.measureExtract:·gc.time                         avgt   15    56.000                ms
PropagatorContextExtractBenchmark.JaegerContextExtractBenchmark.measureExtract                                          avgt   15   331.902 ±   6.003   ns/op
PropagatorContextExtractBenchmark.JaegerContextExtractBenchmark.measureExtract:·gc.alloc.rate                           avgt   15   796.724 ±  14.140  MB/sec
PropagatorContextExtractBenchmark.JaegerContextExtractBenchmark.measureExtract:·gc.alloc.rate.norm                      avgt   15   416.000 ±   0.001    B/op
PropagatorContextExtractBenchmark.JaegerContextExtractBenchmark.measureExtract:·gc.churn.G1_Eden_Space                  avgt   15   804.166 ±  74.032  MB/sec
PropagatorContextExtractBenchmark.JaegerContextExtractBenchmark.measureExtract:·gc.churn.G1_Eden_Space.norm             avgt   15   420.005 ±  39.509    B/op
PropagatorContextExtractBenchmark.JaegerContextExtractBenchmark.measureExtract:·gc.churn.G1_Old_Gen                     avgt   15     0.002 ±   0.002  MB/sec
PropagatorContextExtractBenchmark.JaegerContextExtractBenchmark.measureExtract:·gc.churn.G1_Old_Gen.norm                avgt   15     0.001 ±   0.001    B/op
PropagatorContextExtractBenchmark.JaegerContextExtractBenchmark.measureExtract:·gc.count                                avgt   15    85.000            counts
PropagatorContextExtractBenchmark.JaegerContextExtractBenchmark.measureExtract:·gc.time                                 avgt   15    61.000                ms
PropagatorContextExtractBenchmark.JaegerUrlEncodedContextExtractBenchmark.measureExtract                                avgt   15   925.299 ±   9.897   ns/op
PropagatorContextExtractBenchmark.JaegerUrlEncodedContextExtractBenchmark.measureExtract:·gc.alloc.rate                 avgt   15   478.071 ±   5.015  MB/sec
PropagatorContextExtractBenchmark.JaegerUrlEncodedContextExtractBenchmark.measureExtract:·gc.alloc.rate.norm            avgt   15   696.001 ±   0.003    B/op
PropagatorContextExtractBenchmark.JaegerUrlEncodedContextExtractBenchmark.measureExtract:·gc.churn.G1_Eden_Space        avgt   15   476.607 ±  36.832  MB/sec
PropagatorContextExtractBenchmark.JaegerUrlEncodedContextExtractBenchmark.measureExtract:·gc.churn.G1_Eden_Space.norm   avgt   15   694.033 ±  55.470    B/op
PropagatorContextExtractBenchmark.JaegerUrlEncodedContextExtractBenchmark.measureExtract:·gc.churn.G1_Old_Gen           avgt   15     0.001 ±   0.001  MB/sec
PropagatorContextExtractBenchmark.JaegerUrlEncodedContextExtractBenchmark.measureExtract:·gc.churn.G1_Old_Gen.norm      avgt   15     0.002 ±   0.001    B/op
PropagatorContextExtractBenchmark.JaegerUrlEncodedContextExtractBenchmark.measureExtract:·gc.count                      avgt   15    73.000            counts
PropagatorContextExtractBenchmark.JaegerUrlEncodedContextExtractBenchmark.measureExtract:·gc.time                       avgt   15    29.000                ms
PropagatorContextInjectBenchmark.AwsXRayPropagatorInjectBenchmark.measureInject                                         avgt   15   143.762 ±   0.491   ns/op
PropagatorContextInjectBenchmark.AwsXRayPropagatorInjectBenchmark.measureInject:·gc.alloc.rate                          avgt   15  1732.788 ±   5.972  MB/sec
PropagatorContextInjectBenchmark.AwsXRayPropagatorInjectBenchmark.measureInject:·gc.alloc.rate.norm                     avgt   15   392.000 ±   0.001    B/op
PropagatorContextInjectBenchmark.AwsXRayPropagatorInjectBenchmark.measureInject:·gc.churn.G1_Eden_Space                 avgt   15  1737.387 ± 113.079  MB/sec
PropagatorContextInjectBenchmark.AwsXRayPropagatorInjectBenchmark.measureInject:·gc.churn.G1_Eden_Space.norm            avgt   15   393.052 ±  25.769    B/op
PropagatorContextInjectBenchmark.AwsXRayPropagatorInjectBenchmark.measureInject:·gc.churn.G1_Old_Gen                    avgt   15     0.003 ±   0.002  MB/sec
PropagatorContextInjectBenchmark.AwsXRayPropagatorInjectBenchmark.measureInject:·gc.churn.G1_Old_Gen.norm               avgt   15     0.001 ±   0.001    B/op
PropagatorContextInjectBenchmark.AwsXRayPropagatorInjectBenchmark.measureInject:·gc.count                               avgt   15   127.000            counts
PropagatorContextInjectBenchmark.AwsXRayPropagatorInjectBenchmark.measureInject:·gc.time                                avgt   15    74.000                ms
PropagatorContextInjectBenchmark.B3MultipleHeaderContextInjectBenchmark.measureInject                                   avgt   15    44.609 ±   0.316   ns/op
PropagatorContextInjectBenchmark.B3MultipleHeaderContextInjectBenchmark.measureInject:·gc.alloc.rate                    avgt   15   227.928 ±   1.677  MB/sec
PropagatorContextInjectBenchmark.B3MultipleHeaderContextInjectBenchmark.measureInject:·gc.alloc.rate.norm               avgt   15    16.000 ±   0.001    B/op
PropagatorContextInjectBenchmark.B3MultipleHeaderContextInjectBenchmark.measureInject:·gc.churn.G1_Eden_Space           avgt   15   228.223 ±  51.322  MB/sec
PropagatorContextInjectBenchmark.B3MultipleHeaderContextInjectBenchmark.measureInject:·gc.churn.G1_Eden_Space.norm      avgt   15    16.028 ±   3.645    B/op
PropagatorContextInjectBenchmark.B3MultipleHeaderContextInjectBenchmark.measureInject:·gc.churn.G1_Old_Gen              avgt   15     0.003 ±   0.012  MB/sec
PropagatorContextInjectBenchmark.B3MultipleHeaderContextInjectBenchmark.measureInject:·gc.churn.G1_Old_Gen.norm         avgt   15    ≈ 10⁻⁴              B/op
PropagatorContextInjectBenchmark.B3MultipleHeaderContextInjectBenchmark.measureInject:·gc.churn.G1_Survivor_Space       avgt   15     0.089 ±   0.368  MB/sec
PropagatorContextInjectBenchmark.B3MultipleHeaderContextInjectBenchmark.measureInject:·gc.churn.G1_Survivor_Space.norm  avgt   15     0.006 ±   0.026    B/op
PropagatorContextInjectBenchmark.B3MultipleHeaderContextInjectBenchmark.measureInject:·gc.count                         avgt   15    35.000            counts
PropagatorContextInjectBenchmark.B3MultipleHeaderContextInjectBenchmark.measureInject:·gc.time                          avgt   15    24.000                ms
PropagatorContextInjectBenchmark.B3SingleHeaderContextInjectBenchmark.measureInject                                     avgt   15    76.872 ±   1.160   ns/op
PropagatorContextInjectBenchmark.B3SingleHeaderContextInjectBenchmark.measureInject:·gc.alloc.rate                      avgt   15  2513.517 ±  37.704  MB/sec
PropagatorContextInjectBenchmark.B3SingleHeaderContextInjectBenchmark.measureInject:·gc.alloc.rate.norm                 avgt   15   304.000 ±   0.001    B/op
PropagatorContextInjectBenchmark.B3SingleHeaderContextInjectBenchmark.measureInject:·gc.churn.G1_Eden_Space             avgt   15  2521.594 ±  63.022  MB/sec
PropagatorContextInjectBenchmark.B3SingleHeaderContextInjectBenchmark.measureInject:·gc.churn.G1_Eden_Space.norm        avgt   15   305.006 ±   7.553    B/op
PropagatorContextInjectBenchmark.B3SingleHeaderContextInjectBenchmark.measureInject:·gc.churn.G1_Old_Gen                avgt   15     0.003 ±   0.002  MB/sec
PropagatorContextInjectBenchmark.B3SingleHeaderContextInjectBenchmark.measureInject:·gc.churn.G1_Old_Gen.norm           avgt   15    ≈ 10⁻³              B/op
PropagatorContextInjectBenchmark.B3SingleHeaderContextInjectBenchmark.measureInject:·gc.count                           avgt   15   166.000            counts
PropagatorContextInjectBenchmark.B3SingleHeaderContextInjectBenchmark.measureInject:·gc.time                            avgt   15   103.000                ms
PropagatorContextInjectBenchmark.JaegerContextInjectBenchmark.measureInject                                             avgt   15    80.328 ±   0.761   ns/op
PropagatorContextInjectBenchmark.JaegerContextInjectBenchmark.measureInject:·gc.alloc.rate                              avgt   15  1898.883 ±  17.670  MB/sec
PropagatorContextInjectBenchmark.JaegerContextInjectBenchmark.measureInject:·gc.alloc.rate.norm                         avgt   15   240.000 ±   0.001    B/op
PropagatorContextInjectBenchmark.JaegerContextInjectBenchmark.measureInject:·gc.churn.G1_Eden_Space                     avgt   15  1901.648 ± 100.229  MB/sec
PropagatorContextInjectBenchmark.JaegerContextInjectBenchmark.measureInject:·gc.churn.G1_Eden_Space.norm                avgt   15   240.343 ±  12.285    B/op
PropagatorContextInjectBenchmark.JaegerContextInjectBenchmark.measureInject:·gc.churn.G1_Old_Gen                        avgt   15     0.003 ±   0.002  MB/sec
PropagatorContextInjectBenchmark.JaegerContextInjectBenchmark.measureInject:·gc.churn.G1_Old_Gen.norm                   avgt   15    ≈ 10⁻³              B/op
PropagatorContextInjectBenchmark.JaegerContextInjectBenchmark.measureInject:·gc.count                                   avgt   15   139.000            counts
PropagatorContextInjectBenchmark.JaegerContextInjectBenchmark.measureInject:·gc.time                                    avgt   15    77.000                ms
```