### PR TITLE
Refactoring span benchmarking as per the spec

### DIFF
--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanBenchmark.java
@@ -26,29 +26,27 @@ import org.openjdk.jmh.annotations.Warmup;
 @State(Scope.Benchmark)
 public class SpanBenchmark {
   private static SpanBuilderSdk spanBuilderSdk;
-  private final Resource serviceResource = Resource.create(Attributes.builder()
-      .put("service.name", "benchmark1")
-      .put("service.version", "123.456.89")
-      .put("service.instance.id", "123ab456-a123-12ab-12ab-12340a1abc12")
-      .build()
-  );
+  private final Resource serviceResource =
+      Resource.create(
+          Attributes.builder()
+              .put("service.name", "benchmark1")
+              .put("service.version", "123.456.89")
+              .put("service.instance.id", "123ab456-a123-12ab-12ab-12340a1abc12")
+              .build());
 
   @Setup(Level.Trial)
   public final void setup() {
-    TracerSdkProvider tracerProvider = TracerSdkProvider.builder()
-        .setResource(serviceResource)
-        .build();
+    TracerSdkProvider tracerProvider =
+        TracerSdkProvider.builder().setResource(serviceResource).build();
 
     TraceConfig alwaysOn =
-        tracerProvider.getActiveTraceConfig().toBuilder()
-            .setSampler(Sampler.alwaysOn())
-            .build();
+        tracerProvider.getActiveTraceConfig().toBuilder().setSampler(Sampler.alwaysOn()).build();
     tracerProvider.updateActiveTraceConfig(alwaysOn);
 
     Tracer tracerSdk = tracerProvider.get("benchmarkTracer");
-    spanBuilderSdk = (SpanBuilderSdk) tracerSdk
-        .spanBuilder("benchmarkSpanBuilder")
-        .setAttribute("longAttribute", 33L);
+    spanBuilderSdk =
+        (SpanBuilderSdk)
+            tracerSdk.spanBuilder("benchmarkSpanBuilder").setAttribute("longAttribute", 33L);
   }
 
   @Benchmark


### PR DESCRIPTION
Making the following changes to span creation according to the [span configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/performance-benchmark.md#span-configuration) for performance benchmarking:
- Adding a service resource
- Adding the always on sampler
- Adding a single long type attribute
- Adding an event with no attributes

The benchmark result on a m5.xlarge EC2 instance:

```shell
Benchmark                                                                         Mode  Cnt     Score     Error   Units
SpanBenchmark.simpleSpanStartAddEventEnd_01Thread                                thrpt   10  3274.915 ±  16.454  ops/ms
SpanBenchmark.simpleSpanStartAddEventEnd_01Thread:·gc.alloc.rate                 thrpt   10   882.267 ±   3.930  MB/sec
SpanBenchmark.simpleSpanStartAddEventEnd_01Thread:·gc.alloc.rate.norm            thrpt   10   424.000 ±   0.001    B/op
SpanBenchmark.simpleSpanStartAddEventEnd_01Thread:·gc.churn.G1_Eden_Space        thrpt   10   893.436 ± 102.937  MB/sec
SpanBenchmark.simpleSpanStartAddEventEnd_01Thread:·gc.churn.G1_Eden_Space.norm   thrpt   10   429.436 ±  51.007    B/op
SpanBenchmark.simpleSpanStartAddEventEnd_01Thread:·gc.churn.G1_Old_Gen           thrpt   10     0.001 ±   0.002  MB/sec
SpanBenchmark.simpleSpanStartAddEventEnd_01Thread:·gc.churn.G1_Old_Gen.norm      thrpt   10     0.001 ±   0.001    B/op
SpanBenchmark.simpleSpanStartAddEventEnd_01Thread:·gc.count                      thrpt   10    63.000            counts
SpanBenchmark.simpleSpanStartAddEventEnd_01Thread:·gc.time                       thrpt   10    34.000                ms
SpanBenchmark.simpleSpanStartAddEventEnd_02Threads                               thrpt   10  4865.498 ±  73.035  ops/ms
SpanBenchmark.simpleSpanStartAddEventEnd_02Threads:·gc.alloc.rate                thrpt   10  1309.461 ±  20.750  MB/sec
SpanBenchmark.simpleSpanStartAddEventEnd_02Threads:·gc.alloc.rate.norm           thrpt   10   424.001 ±   0.002    B/op
SpanBenchmark.simpleSpanStartAddEventEnd_02Threads:·gc.churn.G1_Eden_Space       thrpt   10  1316.544 ± 126.221  MB/sec
SpanBenchmark.simpleSpanStartAddEventEnd_02Threads:·gc.churn.G1_Eden_Space.norm  thrpt   10   426.263 ±  39.532    B/op
SpanBenchmark.simpleSpanStartAddEventEnd_02Threads:·gc.churn.G1_Old_Gen          thrpt   10     0.003 ±   0.002  MB/sec
SpanBenchmark.simpleSpanStartAddEventEnd_02Threads:·gc.churn.G1_Old_Gen.norm     thrpt   10     0.001 ±   0.001    B/op
SpanBenchmark.simpleSpanStartAddEventEnd_02Threads:·gc.count                     thrpt   10    77.000            counts
SpanBenchmark.simpleSpanStartAddEventEnd_02Threads:·gc.time                      thrpt   10    46.000                ms
SpanBenchmark.simpleSpanStartAddEventEnd_05Threads                               thrpt   10  6313.366 ±  50.898  ops/ms
SpanBenchmark.simpleSpanStartAddEventEnd_05Threads:·gc.alloc.rate                thrpt   10  1705.337 ±  14.369  MB/sec
SpanBenchmark.simpleSpanStartAddEventEnd_05Threads:·gc.alloc.rate.norm           thrpt   10   424.000 ±   0.001    B/op
SpanBenchmark.simpleSpanStartAddEventEnd_05Threads:·gc.churn.G1_Eden_Space       thrpt   10  1704.363 ± 152.672  MB/sec
SpanBenchmark.simpleSpanStartAddEventEnd_05Threads:·gc.churn.G1_Eden_Space.norm  thrpt   10   423.786 ±  38.624    B/op
SpanBenchmark.simpleSpanStartAddEventEnd_05Threads:·gc.churn.G1_Old_Gen          thrpt   10     0.002 ±   0.002  MB/sec
SpanBenchmark.simpleSpanStartAddEventEnd_05Threads:·gc.churn.G1_Old_Gen.norm     thrpt   10     0.001 ±   0.001    B/op
SpanBenchmark.simpleSpanStartAddEventEnd_05Threads:·gc.count                     thrpt   10    84.000            counts
SpanBenchmark.simpleSpanStartAddEventEnd_05Threads:·gc.time                      thrpt   10    63.000                ms
SpanBenchmark.simpleSpanStartAddEventEnd_10Threads                               thrpt   10  6310.809 ± 140.526  ops/ms
SpanBenchmark.simpleSpanStartAddEventEnd_10Threads:·gc.alloc.rate                thrpt   10  1717.626 ±  41.551  MB/sec
SpanBenchmark.simpleSpanStartAddEventEnd_10Threads:·gc.alloc.rate.norm           thrpt   10   424.001 ±   0.001    B/op
SpanBenchmark.simpleSpanStartAddEventEnd_10Threads:·gc.churn.G1_Eden_Space       thrpt   10  1743.940 ± 118.514  MB/sec
SpanBenchmark.simpleSpanStartAddEventEnd_10Threads:·gc.churn.G1_Eden_Space.norm  thrpt   10   430.611 ±  31.704    B/op
SpanBenchmark.simpleSpanStartAddEventEnd_10Threads:·gc.churn.G1_Old_Gen          thrpt   10     0.002 ±   0.002  MB/sec
SpanBenchmark.simpleSpanStartAddEventEnd_10Threads:·gc.churn.G1_Old_Gen.norm     thrpt   10     0.001 ±   0.001    B/op
SpanBenchmark.simpleSpanStartAddEventEnd_10Threads:·gc.count                     thrpt   10    88.000            counts
SpanBenchmark.simpleSpanStartAddEventEnd_10Threads:·gc.time                      thrpt   10    73.000                ms
```
