### PR TITLE
Use hyphen for thread name prefix.

### DIFF
--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/DaemonThreadFactory.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/DaemonThreadFactory.java
@@ -26,7 +26,7 @@ public class DaemonThreadFactory implements ThreadFactory {
     Thread t = Executors.defaultThreadFactory().newThread(runnable);
     try {
       t.setDaemon(true);
-      t.setName(namePrefix + "_" + counter.incrementAndGet());
+      t.setName(namePrefix + "-" + counter.incrementAndGet());
     } catch (SecurityException e) {
       // Well, we tried.
     }


### PR DESCRIPTION
Extreme nit, but I think during IntelliJ debugging I've noticed it's much more common to use a hyphen for this