### PR TITLE
add some basic benchmarks for various baggage operations

### DIFF
--- a/api/baggage/src/jmh/java/io/opentelemetry/api/baggage/BaggageBenchmark.java
+++ b/api/baggage/src/jmh/java/io/opentelemetry/api/baggage/BaggageBenchmark.java
@@ -17,7 +17,6 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
@@ -28,16 +27,12 @@ public class BaggageBenchmark {
   @Param({"0", "1", "10", "100"})
   public int itemsToAdd;
 
-  private List<String> keys;
-  private List<String> values;
+  // pre-allocate the keys & values to remove one possible confounding factor
+  private static final List<String> keys = new ArrayList<>(100);
+  private static final List<String> values = new ArrayList<>(100);
 
-  @Setup
-  public void setUp() {
-    keys = new ArrayList<>(itemsToAdd);
-    values = new ArrayList<>(itemsToAdd);
-
-    // pre-allocate the keys & values to remove one possible confounding factor
-    for (int i = 0; i < itemsToAdd; i++) {
+  static {
+    for (int i = 0; i < 100; i++) {
       keys.add("key" + i);
       values.add("value" + i);
     }

--- a/api/src/jmh/java/io/opentelemetry/api/trace/BaggageBenchmarks.java
+++ b/api/src/jmh/java/io/opentelemetry/api/trace/BaggageBenchmarks.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.trace;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageBuilder;
+import io.opentelemetry.context.Context;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@SuppressWarnings("JavadocMethod")
+@State(Scope.Thread)
+public class BaggageBenchmarks {
+
+  @Param({"0", "1", "10", "100"})
+  public int itemsToAdd;
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @Fork(1)
+  @Measurement(iterations = 15, time = 1)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  @Warmup(iterations = 5, time = 1)
+  public Baggage baggageItemBenchmark() {
+    BaggageBuilder builder = Baggage.builder();
+    for (int i = 0; i < itemsToAdd; i++) {
+      builder.put("key" + i, "value" + i);
+    }
+    return builder.build();
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @Fork(1)
+  @Measurement(iterations = 15, time = 1)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  @Warmup(iterations = 5, time = 1)
+  public Baggage baggageToBuilderBenchmark() {
+    Baggage baggage = Baggage.empty();
+    for (int i = 0; i < itemsToAdd; i++) {
+      baggage = baggage.toBuilder().put("key" + i, "value" + i).build();
+    }
+    return baggage;
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @Fork(1)
+  @Measurement(iterations = 15, time = 1)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  @Warmup(iterations = 5, time = 1)
+  public Baggage baggageParentBenchmark() {
+    Baggage baggage = Baggage.empty();
+    Context context = Context.root().with(baggage);
+    for (int i = 0; i < itemsToAdd; i++) {
+      baggage = Baggage.builder().put("key" + i, "value" + i).setParent(context).build();
+      context = context.with(baggage);
+    }
+    return baggage;
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @Fork(1)
+  @Measurement(iterations = 15, time = 1)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  @Warmup(iterations = 5, time = 1)
+  public Baggage baggageParentBenchmark_noContent() {
+    Baggage baggage = Baggage.empty();
+    Context context = Context.root().with(baggage);
+    for (int i = 0; i < itemsToAdd; i++) {
+      baggage = Baggage.builder().setParent(context).build();
+      context = context.with(baggage);
+    }
+    return baggage;
+  }
+}


### PR DESCRIPTION
Resolves #791 

The benchmarks here are for 0,1,10 and 100 items for each of the 4 different scenarios.

![image](https://user-images.githubusercontent.com/858731/101390377-94952c80-3877-11eb-9575-28fdc2d2f71e.png)



```
Benchmark                                                                       (itemsToAdd)  Mode  Cnt       Score       Error   Units
BaggageBenchmark.baggageItemBenchmark                                                      0  avgt   15      25.129 ±     0.717   ns/op
BaggageBenchmark.baggageItemBenchmark:·gc.alloc.rate                                       0  avgt   15    3035.656 ±    81.597  MB/sec
BaggageBenchmark.baggageItemBenchmark:·gc.alloc.rate.norm                                  0  avgt   15     120.000 ±     0.001    B/op
BaggageBenchmark.baggageItemBenchmark:·gc.churn.G1_Eden_Space                              0  avgt   15    3041.779 ±   131.702  MB/sec
BaggageBenchmark.baggageItemBenchmark:·gc.churn.G1_Eden_Space.norm                         0  avgt   15     120.222 ±     3.292    B/op
BaggageBenchmark.baggageItemBenchmark:·gc.churn.G1_Old_Gen                                 0  avgt   15       0.004 ±     0.003  MB/sec
BaggageBenchmark.baggageItemBenchmark:·gc.churn.G1_Old_Gen.norm                            0  avgt   15      ≈ 10⁻⁴                B/op
BaggageBenchmark.baggageItemBenchmark:·gc.count                                            0  avgt   15     259.000              counts
BaggageBenchmark.baggageItemBenchmark:·gc.time                                             0  avgt   15     111.000                  ms
BaggageBenchmark.baggageItemBenchmark                                                      1  avgt   15      92.714 ±     1.209   ns/op
BaggageBenchmark.baggageItemBenchmark:·gc.alloc.rate                                       1  avgt   15    1644.047 ±    21.016  MB/sec
BaggageBenchmark.baggageItemBenchmark:·gc.alloc.rate.norm                                  1  avgt   15     240.000 ±     0.001    B/op
BaggageBenchmark.baggageItemBenchmark:·gc.churn.G1_Eden_Space                              1  avgt   15    1654.261 ±    95.332  MB/sec
BaggageBenchmark.baggageItemBenchmark:·gc.churn.G1_Eden_Space.norm                         1  avgt   15     241.503 ±    13.824    B/op
BaggageBenchmark.baggageItemBenchmark:·gc.churn.G1_Old_Gen                                 1  avgt   15       0.002 ±     0.002  MB/sec
BaggageBenchmark.baggageItemBenchmark:·gc.churn.G1_Old_Gen.norm                            1  avgt   15      ≈ 10⁻³                B/op
BaggageBenchmark.baggageItemBenchmark:·gc.count                                            1  avgt   15     141.000              counts
BaggageBenchmark.baggageItemBenchmark:·gc.time                                             1  avgt   15      65.000                  ms
BaggageBenchmark.baggageItemBenchmark                                                     10  avgt   15     771.125 ±     9.200   ns/op
BaggageBenchmark.baggageItemBenchmark:·gc.alloc.rate                                      10  avgt   15     705.019 ±     8.002  MB/sec
BaggageBenchmark.baggageItemBenchmark:·gc.alloc.rate.norm                                 10  avgt   15     856.001 ±     0.002    B/op
BaggageBenchmark.baggageItemBenchmark:·gc.churn.G1_Eden_Space                             10  avgt   15     706.164 ±     0.933  MB/sec
BaggageBenchmark.baggageItemBenchmark:·gc.churn.G1_Eden_Space.norm                        10  avgt   15     857.488 ±    10.500    B/op
BaggageBenchmark.baggageItemBenchmark:·gc.churn.G1_Old_Gen                                10  avgt   15       0.002 ±     0.001  MB/sec
BaggageBenchmark.baggageItemBenchmark:·gc.churn.G1_Old_Gen.norm                           10  avgt   15       0.003 ±     0.002    B/op
BaggageBenchmark.baggageItemBenchmark:·gc.count                                           10  avgt   15     105.000              counts
BaggageBenchmark.baggageItemBenchmark:·gc.time                                            10  avgt   15      40.000                  ms
BaggageBenchmark.baggageItemBenchmark                                                    100  avgt   15   11329.149 ±   170.070   ns/op
BaggageBenchmark.baggageItemBenchmark:·gc.alloc.rate                                     100  avgt   15     447.224 ±     6.920  MB/sec
BaggageBenchmark.baggageItemBenchmark:·gc.alloc.rate.norm                                100  avgt   15    7976.013 ±     0.034    B/op
BaggageBenchmark.baggageItemBenchmark:·gc.churn.G1_Eden_Space                            100  avgt   15     450.719 ±    55.720  MB/sec
BaggageBenchmark.baggageItemBenchmark:·gc.churn.G1_Eden_Space.norm                       100  avgt   15    8038.497 ±   987.124    B/op
BaggageBenchmark.baggageItemBenchmark:·gc.churn.G1_Old_Gen                               100  avgt   15       0.002 ±     0.003  MB/sec
BaggageBenchmark.baggageItemBenchmark:·gc.churn.G1_Old_Gen.norm                          100  avgt   15       0.035 ±     0.051    B/op
BaggageBenchmark.baggageItemBenchmark:·gc.count                                          100  avgt   15      67.000              counts
BaggageBenchmark.baggageItemBenchmark:·gc.time                                           100  avgt   15      25.000                  ms
BaggageBenchmark.baggageParentBenchmark                                                    0  avgt   15      10.221 ±     0.224   ns/op
BaggageBenchmark.baggageParentBenchmark:·gc.alloc.rate                                     0  avgt   15    1491.731 ±    32.007  MB/sec
BaggageBenchmark.baggageParentBenchmark:·gc.alloc.rate.norm                                0  avgt   15      24.000 ±     0.001    B/op
BaggageBenchmark.baggageParentBenchmark:·gc.churn.G1_Eden_Space                            0  avgt   15    1496.393 ±    64.661  MB/sec
BaggageBenchmark.baggageParentBenchmark:·gc.churn.G1_Eden_Space.norm                       0  avgt   15      24.074 ±     0.837    B/op
BaggageBenchmark.baggageParentBenchmark:·gc.churn.G1_Old_Gen                               0  avgt   15       0.001 ±     0.001  MB/sec
BaggageBenchmark.baggageParentBenchmark:·gc.churn.G1_Old_Gen.norm                          0  avgt   15      ≈ 10⁻⁵                B/op
BaggageBenchmark.baggageParentBenchmark:·gc.count                                          0  avgt   15     153.000              counts
BaggageBenchmark.baggageParentBenchmark:·gc.time                                           0  avgt   15      62.000                  ms
BaggageBenchmark.baggageParentBenchmark                                                    1  avgt   15     118.326 ±     1.481   ns/op
BaggageBenchmark.baggageParentBenchmark:·gc.alloc.rate                                     1  avgt   15    1718.494 ±    21.620  MB/sec
BaggageBenchmark.baggageParentBenchmark:·gc.alloc.rate.norm                                1  avgt   15     320.000 ±     0.001    B/op
BaggageBenchmark.baggageParentBenchmark:·gc.churn.G1_Eden_Space                            1  avgt   15    1713.595 ±    86.829  MB/sec
BaggageBenchmark.baggageParentBenchmark:·gc.churn.G1_Eden_Space.norm                       1  avgt   15     319.042 ±    14.552    B/op
BaggageBenchmark.baggageParentBenchmark:·gc.churn.G1_Old_Gen                               1  avgt   15       0.002 ±     0.002  MB/sec
BaggageBenchmark.baggageParentBenchmark:·gc.churn.G1_Old_Gen.norm                          1  avgt   15      ≈ 10⁻³                B/op
BaggageBenchmark.baggageParentBenchmark:·gc.count                                          1  avgt   15     146.000              counts
BaggageBenchmark.baggageParentBenchmark:·gc.time                                           1  avgt   15      68.000                  ms
BaggageBenchmark.baggageParentBenchmark                                                   10  avgt   15    3977.633 ±    62.635   ns/op
BaggageBenchmark.baggageParentBenchmark:·gc.alloc.rate                                    10  avgt   15     982.083 ±    14.850  MB/sec
BaggageBenchmark.baggageParentBenchmark:·gc.alloc.rate.norm                               10  avgt   15    6152.004 ±     0.012    B/op
BaggageBenchmark.baggageParentBenchmark:·gc.churn.G1_Eden_Space                           10  avgt   15     987.224 ±    71.887  MB/sec
BaggageBenchmark.baggageParentBenchmark:·gc.churn.G1_Eden_Space.norm                      10  avgt   15    6184.874 ±   452.713    B/op
BaggageBenchmark.baggageParentBenchmark:·gc.churn.G1_Old_Gen                              10  avgt   15       0.002 ±     0.001  MB/sec
BaggageBenchmark.baggageParentBenchmark:·gc.churn.G1_Old_Gen.norm                         10  avgt   15       0.011 ±     0.008    B/op
BaggageBenchmark.baggageParentBenchmark:·gc.count                                         10  avgt   15     101.000              counts
BaggageBenchmark.baggageParentBenchmark:·gc.time                                          10  avgt   15      41.000                  ms
BaggageBenchmark.baggageParentBenchmark                                                  100  avgt   15  468079.784 ±  5002.079   ns/op
BaggageBenchmark.baggageParentBenchmark:·gc.alloc.rate                                   100  avgt   15     425.955 ±     4.704  MB/sec
BaggageBenchmark.baggageParentBenchmark:·gc.alloc.rate.norm                              100  avgt   15  313952.529 ±     1.394    B/op
BaggageBenchmark.baggageParentBenchmark:·gc.churn.G1_Eden_Space                          100  avgt   15     430.627 ±    49.500  MB/sec
BaggageBenchmark.baggageParentBenchmark:·gc.churn.G1_Eden_Space.norm                     100  avgt   15  317359.433 ± 35829.324    B/op
BaggageBenchmark.baggageParentBenchmark:·gc.churn.G1_Old_Gen                             100  avgt   15       0.002 ±     0.001  MB/sec
BaggageBenchmark.baggageParentBenchmark:·gc.churn.G1_Old_Gen.norm                        100  avgt   15       1.542 ±     0.902    B/op
BaggageBenchmark.baggageParentBenchmark:·gc.count                                        100  avgt   15      64.000              counts
BaggageBenchmark.baggageParentBenchmark:·gc.time                                         100  avgt   15      23.000                  ms
BaggageBenchmark.baggageParentBenchmark_noContent                                          0  avgt   15      10.226 ±     0.207   ns/op
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.alloc.rate                           0  avgt   15    1490.986 ±    30.017  MB/sec
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.alloc.rate.norm                      0  avgt   15      24.000 ±     0.001    B/op
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.churn.G1_Eden_Space                  0  avgt   15    1487.544 ±    80.517  MB/sec
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.churn.G1_Eden_Space.norm             0  avgt   15      23.939 ±     1.069    B/op
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.churn.G1_Old_Gen                     0  avgt   15       0.001 ±     0.001  MB/sec
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.churn.G1_Old_Gen.norm                0  avgt   15      ≈ 10⁻⁵                B/op
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.count                                0  avgt   15     152.000              counts
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.time                                 0  avgt   15      62.000                  ms
BaggageBenchmark.baggageParentBenchmark_noContent                                          1  avgt   15      49.688 ±     0.872   ns/op
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.alloc.rate                           1  avgt   15    2554.822 ±    44.222  MB/sec
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.alloc.rate.norm                      1  avgt   15     200.000 ±     0.001    B/op
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.churn.G1_Eden_Space                  1  avgt   15    2564.362 ±    94.304  MB/sec
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.churn.G1_Eden_Space.norm             1  avgt   15     200.745 ±     6.459    B/op
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.churn.G1_Old_Gen                     1  avgt   15       0.004 ±     0.002  MB/sec
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.churn.G1_Old_Gen.norm                1  avgt   15      ≈ 10⁻³                B/op
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.count                                1  avgt   15     219.000              counts
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.time                                 1  avgt   15      99.000                  ms
BaggageBenchmark.baggageParentBenchmark_noContent                                         10  avgt   15     316.118 ±     4.488   ns/op
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.alloc.rate                          10  avgt   15    2812.121 ±    40.809  MB/sec
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.alloc.rate.norm                     10  avgt   15    1400.000 ±     0.001    B/op
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.churn.G1_Eden_Space                 10  avgt   15    2812.564 ±   120.082  MB/sec
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.churn.G1_Eden_Space.norm            10  avgt   15    1400.003 ±    48.778    B/op
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.churn.G1_Old_Gen                    10  avgt   15       0.003 ±     0.001  MB/sec
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.churn.G1_Old_Gen.norm               10  avgt   15       0.001 ±     0.001    B/op
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.count                               10  avgt   15     186.000              counts
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.time                                10  avgt   15      93.000                  ms
BaggageBenchmark.baggageParentBenchmark_noContent                                        100  avgt   15    3503.121 ±    30.072   ns/op
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.alloc.rate                         100  avgt   15    2905.655 ±    23.747  MB/sec
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.alloc.rate.norm                    100  avgt   15   16040.004 ±     0.010    B/op
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.churn.G1_Eden_Space                100  avgt   15    2909.937 ±   106.258  MB/sec
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.churn.G1_Eden_Space.norm           100  avgt   15   16063.257 ±   556.193    B/op
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.churn.G1_Old_Gen                   100  avgt   15       0.003 ±     0.002  MB/sec
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.churn.G1_Old_Gen.norm              100  avgt   15       0.015 ±     0.013    B/op
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.count                              100  avgt   15     199.000              counts
BaggageBenchmark.baggageParentBenchmark_noContent:·gc.time                               100  avgt   15      99.000                  ms
BaggageBenchmark.baggageToBuilderBenchmark                                                 0  avgt   15       2.496 ±     0.038   ns/op
BaggageBenchmark.baggageToBuilderBenchmark:·gc.alloc.rate                                  0  avgt   15       0.001 ±     0.002  MB/sec
BaggageBenchmark.baggageToBuilderBenchmark:·gc.alloc.rate.norm                             0  avgt   15      ≈ 10⁻⁶                B/op
BaggageBenchmark.baggageToBuilderBenchmark:·gc.count                                       0  avgt   15         ≈ 0              counts
BaggageBenchmark.baggageToBuilderBenchmark                                                 1  avgt   15     115.387 ±     1.575   ns/op
BaggageBenchmark.baggageToBuilderBenchmark:·gc.alloc.rate                                  1  avgt   15    1451.636 ±    20.154  MB/sec
BaggageBenchmark.baggageToBuilderBenchmark:·gc.alloc.rate.norm                             1  avgt   15     264.000 ±     0.001    B/op
BaggageBenchmark.baggageToBuilderBenchmark:·gc.churn.G1_Eden_Space                         1  avgt   15    1450.429 ±    71.549  MB/sec
BaggageBenchmark.baggageToBuilderBenchmark:·gc.churn.G1_Eden_Space.norm                    1  avgt   15     263.765 ±    12.114    B/op
BaggageBenchmark.baggageToBuilderBenchmark:·gc.churn.G1_Old_Gen                            1  avgt   15       0.002 ±     0.001  MB/sec
BaggageBenchmark.baggageToBuilderBenchmark:·gc.churn.G1_Old_Gen.norm                       1  avgt   15      ≈ 10⁻³                B/op
BaggageBenchmark.baggageToBuilderBenchmark:·gc.count                                       1  avgt   15     149.000              counts
BaggageBenchmark.baggageToBuilderBenchmark:·gc.time                                        1  avgt   15      64.000                  ms
BaggageBenchmark.baggageToBuilderBenchmark                                                10  avgt   15    3134.037 ±    37.989   ns/op
BaggageBenchmark.baggageToBuilderBenchmark:·gc.alloc.rate                                 10  avgt   15     960.178 ±    11.599  MB/sec
BaggageBenchmark.baggageToBuilderBenchmark:·gc.alloc.rate.norm                            10  avgt   15    4744.004 ±     0.010    B/op
BaggageBenchmark.baggageToBuilderBenchmark:·gc.churn.G1_Eden_Space                        10  avgt   15     967.081 ±     1.922  MB/sec
BaggageBenchmark.baggageToBuilderBenchmark:·gc.churn.G1_Eden_Space.norm                   10  avgt   15    4778.685 ±    59.368    B/op
BaggageBenchmark.baggageToBuilderBenchmark:·gc.churn.G1_Old_Gen                           10  avgt   15       0.002 ±     0.002  MB/sec
BaggageBenchmark.baggageToBuilderBenchmark:·gc.churn.G1_Old_Gen.norm                      10  avgt   15       0.010 ±     0.008    B/op
BaggageBenchmark.baggageToBuilderBenchmark:·gc.count                                      10  avgt   15     120.000              counts
BaggageBenchmark.baggageToBuilderBenchmark:·gc.time                                       10  avgt   15      49.000                  ms
BaggageBenchmark.baggageToBuilderBenchmark                                               100  avgt   15  400883.491 ±  3981.205   ns/op
BaggageBenchmark.baggageToBuilderBenchmark:·gc.alloc.rate                                100  avgt   15     444.326 ±     4.280  MB/sec
BaggageBenchmark.baggageToBuilderBenchmark:·gc.alloc.rate.norm                           100  avgt   15  280864.455 ±     1.207    B/op
BaggageBenchmark.baggageToBuilderBenchmark:·gc.churn.G1_Eden_Space                       100  avgt   15     448.485 ±    55.284  MB/sec
BaggageBenchmark.baggageToBuilderBenchmark:·gc.churn.G1_Eden_Space.norm                  100  avgt   15  283369.040 ± 33549.280    B/op
BaggageBenchmark.baggageToBuilderBenchmark:·gc.churn.G1_Old_Gen                          100  avgt   15       0.001 ±     0.001  MB/sec
BaggageBenchmark.baggageToBuilderBenchmark:·gc.churn.G1_Old_Gen.norm                     100  avgt   15       0.892 ±     0.754    B/op
BaggageBenchmark.baggageToBuilderBenchmark:·gc.count                                     100  avgt   15      67.000              counts
BaggageBenchmark.baggageToBuilderBenchmark:·gc.time                                      100  avgt   15      25.000                  ms

```