### PR TITLE
Update the examples for the 0.12.0 release.

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -13,7 +13,7 @@ subprojects {
     version = "0.1.0-SNAPSHOT"
 
     ext {
-        opentelemetryVersion = "0.11.0"
+        opentelemetryVersion = "0.12.0"
         grpcVersion = '1.30.2'
         protobufVersion = '3.11.4'
         protocVersion = protobufVersion

--- a/examples/grpc/src/main/java/io/opentelemetry/example/grpc/HelloWorldClient.java
+++ b/examples/grpc/src/main/java/io/opentelemetry/example/grpc/HelloWorldClient.java
@@ -20,10 +20,10 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.api.trace.propagation.HttpTraceContext;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.context.propagation.DefaultContextPropagators;
+import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -117,9 +117,7 @@ public class HelloWorldClient {
 
   private static void initTracing() {
     OpenTelemetry.setGlobalPropagators(
-        DefaultContextPropagators.builder()
-            .addTextMapPropagator(HttpTraceContext.getInstance())
-            .build());
+        ContextPropagators.create(W3CTraceContextPropagator.getInstance()));
 
     // Use the OpenTelemetry SDK
     LoggingSpanExporter exporter = new LoggingSpanExporter();

--- a/examples/grpc/src/main/java/io/opentelemetry/example/grpc/HelloWorldServer.java
+++ b/examples/grpc/src/main/java/io/opentelemetry/example/grpc/HelloWorldServer.java
@@ -17,10 +17,10 @@ import io.grpc.stub.StreamObserver;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.api.trace.propagation.HttpTraceContext;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.context.propagation.DefaultContextPropagators;
+import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -168,9 +168,7 @@ public class HelloWorldServer {
   private static void initTracing() {
     // install the W3C Trace Context propagator
     OpenTelemetry.setGlobalPropagators(
-        DefaultContextPropagators.builder()
-            .addTextMapPropagator(HttpTraceContext.getInstance())
-            .build());
+        ContextPropagators.create(W3CTraceContextPropagator.getInstance()));
     // Get the tracer management instance
     TracerSdkManagement tracerManagement = OpenTelemetrySdk.getGlobalTracerManagement();
     // Set to process the the spans by the LogExporter

--- a/examples/http/src/main/java/io/opentelemetry/example/http/HttpClient.java
+++ b/examples/http/src/main/java/io/opentelemetry/example/http/HttpClient.java
@@ -9,10 +9,10 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.api.trace.propagation.HttpTraceContext;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.context.propagation.DefaultContextPropagators;
+import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -40,9 +40,7 @@ public class HttpClient {
   private static void initTracing() {
     // install the W3C Trace Context propagator
     OpenTelemetry.setGlobalPropagators(
-        DefaultContextPropagators.builder()
-            .addTextMapPropagator(HttpTraceContext.getInstance())
-            .build());
+        ContextPropagators.create(W3CTraceContextPropagator.getInstance()));
 
     // Get the tracer management instance.
     TracerSdkManagement tracerManagement = OpenTelemetrySdk.getGlobalTracerManagement();

--- a/examples/http/src/main/java/io/opentelemetry/example/http/HttpServer.java
+++ b/examples/http/src/main/java/io/opentelemetry/example/http/HttpServer.java
@@ -13,10 +13,10 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.api.trace.propagation.HttpTraceContext;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.context.propagation.DefaultContextPropagators;
+import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -122,9 +122,7 @@ public class HttpServer {
   private static void initTracing() {
     // install the W3C Trace Context propagator
     OpenTelemetry.setGlobalPropagators(
-        DefaultContextPropagators.builder()
-            .addTextMapPropagator(HttpTraceContext.getInstance())
-            .build());
+        ContextPropagators.create(W3CTraceContextPropagator.getInstance()));
 
     // Get the tracer
     TracerSdkManagement tracerManagement = OpenTelemetrySdk.getGlobalTracerManagement();

--- a/examples/metrics/src/main/java/io/opentelemetry/example/metrics/LongValueObserverExample.java
+++ b/examples/metrics/src/main/java/io/opentelemetry/example/metrics/LongValueObserverExample.java
@@ -19,9 +19,8 @@ public class LongValueObserverExample {
             .longValueObserverBuilder("jvm.memory.total")
             .setDescription("Reports JVM memory usage.")
             .setUnit("byte")
+            .setCallback(
+                result -> result.observe(Runtime.getRuntime().totalMemory(), Labels.empty()))
             .build();
-
-    observer.setCallback(
-        result -> result.observe(Runtime.getRuntime().totalMemory(), Labels.empty()));
   }
 }

--- a/examples/prometheus/src/main/java/io/opentelemetry/example/prometheus/PrometheusExample.java
+++ b/examples/prometheus/src/main/java/io/opentelemetry/example/prometheus/PrometheusExample.java
@@ -1,7 +1,6 @@
 package io.opentelemetry.example.prometheus;
 
 import io.opentelemetry.api.common.Labels;
-import io.opentelemetry.api.metrics.AsynchronousInstrument;
 import io.opentelemetry.api.metrics.LongValueObserver;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.exporter.prometheus.PrometheusCollector;
@@ -33,15 +32,8 @@ public class PrometheusExample {
             .longValueObserverBuilder("incoming.messages")
             .setDescription("No of incoming messages awaiting processing")
             .setUnit("message")
+            .setCallback(result -> result.observe(incomingMessageCount, Labels.empty()))
             .build();
-
-    observer.setCallback(
-        new LongValueObserver.Callback<LongValueObserver.LongResult>() {
-          @Override
-          public void update(AsynchronousInstrument.LongResult result) {
-            result.observe(incomingMessageCount, Labels.empty());
-          }
-        });
 
     PrometheusCollector.builder()
         .setMetricProducer(meterSdkProvider.getMetricProducer())
@@ -62,6 +54,7 @@ public class PrometheusExample {
         incomingMessageCount = ThreadLocalRandom.current().nextLong(100);
         Thread.sleep(1000);
       } catch (InterruptedException e) {
+        // ignored here
       }
     }
   }

--- a/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureSpanProcessorExample.java
+++ b/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureSpanProcessorExample.java
@@ -9,12 +9,10 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.trace.MultiSpanProcessor;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.TracerSdkManagement;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
-import java.util.Arrays;
 
 /** This example shows how to instantiate different Span Processors. */
 public class ConfigureSpanProcessorExample {
@@ -73,9 +71,10 @@ public class ConfigureSpanProcessorExample {
             .build();
     tracerProvider.addSpanProcessor(batchSpansProcessor);
 
-    // Configure the multi spans processor. A MultiSpanProcessor accepts a list of Span Processors.
+    // Configure the composite span processor. A Composite SpanProcessor accepts a list of Span
+    // Processors.
     SpanProcessor multiSpanProcessor =
-        MultiSpanProcessor.create(Arrays.asList(simpleSpansProcessor, batchSpansProcessor));
+        SpanProcessor.composite(simpleSpansProcessor, batchSpansProcessor);
     tracerProvider.addSpanProcessor(multiSpanProcessor);
   }
 }

--- a/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureTraceExample.java
+++ b/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureTraceExample.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.example;
 
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.common.ReadableAttributes;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Span.Kind;
 import io.opentelemetry.api.trace.Tracer;
@@ -102,7 +102,7 @@ class ConfigureTraceExample {
           String traceId,
           String name,
           Kind spanKind,
-          ReadableAttributes attributes,
+          Attributes attributes,
           List<Link> parentLinks) {
         return SamplingResult.create(
             name.contains("SAMPLE")


### PR DESCRIPTION
Note: the only actual breaking change that needed to be fixed was the removal of ReadableAttributes usage. Everything else is just getting rid of the deprecated usages.