### PR TITLE
Update README for extensions propagators

### DIFF
--- a/extensions/trace-propagators/README.md
+++ b/extensions/trace-propagators/README.md
@@ -5,3 +5,18 @@ OpenTelemetry Contrib Trace Propagators
 
 [javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-contrib-trace-propagators.svg
 [javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-contrib-trace-propagators
+
+This project contains [trace propagators](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/api-propagators.md) that support
+3rd-party propagation formats.  These propagators are here for convenience and are not officially
+supported by the OpenTelemetry Java maintainers.
+
+Issues/support for these propagators is only provided as a minimal "best effort", and critical
+bugs should be filed with the respective vendors themselves.
+
+* AWS X-Ray (file an issue here and mention @anuraaga)
+* OpenTracing (file an issue here and mention @carlosalberto)
+* B3 (file an issue on [the OpenZipkin repo](https://github.com/openzipkin/b3-propagation) that points here)
+* Jaeger (file an issue on [the Jaeger repo](https://github.com/jaegertracing/jaeger) that points here)
+
+Extension providers that do not receive adequate support/maintenance by their respective vendors 
+will become candidates for future removal.

--- a/extensions/trace-propagators/README.md
+++ b/extensions/trace-propagators/README.md
@@ -14,7 +14,7 @@ Issues/support for these propagators is only provided as a minimal "best effort"
 bugs should be filed with the respective vendors themselves.
 
 * AWS X-Ray (file an issue here and mention @anuraaga)
-* ListStep OpenTracing (file an issue here and mention @carlosalberto)
+* LightStep OpenTracing (file an issue here and mention @carlosalberto)
 * B3 (file an issue on [the OpenZipkin repo](https://github.com/openzipkin/b3-propagation) that points here)
 * Jaeger (file an issue on [the Jaeger repo](https://github.com/jaegertracing/jaeger) that points here)
 

--- a/extensions/trace-propagators/README.md
+++ b/extensions/trace-propagators/README.md
@@ -14,7 +14,7 @@ Issues/support for these propagators is only provided as a minimal "best effort"
 bugs should be filed with the respective vendors themselves.
 
 * AWS X-Ray (file an issue here and mention @anuraaga)
-* OpenTracing (file an issue here and mention @carlosalberto)
+* ListStep OpenTracing (file an issue here and mention @carlosalberto)
 * B3 (file an issue on [the OpenZipkin repo](https://github.com/openzipkin/b3-propagation) that points here)
 * Jaeger (file an issue on [the Jaeger repo](https://github.com/jaegertracing/jaeger) that points here)
 

--- a/extensions/trace-propagators/README.md
+++ b/extensions/trace-propagators/README.md
@@ -6,17 +6,23 @@ OpenTelemetry Contrib Trace Propagators
 [javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-contrib-trace-propagators.svg
 [javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-contrib-trace-propagators
 
-This project contains [trace propagators](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/api-propagators.md) that support
-3rd-party propagation formats.  These propagators are here for convenience and are not officially
-supported by the OpenTelemetry Java maintainers.
+This repository provides several 
+[trace propagators](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/api-propagators.md),
+used to propagate context across a distributed trace. 
+
+OpenTelemetry Java provides first-party support for 
+[B3 (OpenZipkin)](https://github.com/openzipkin/b3-propagation) and
+[Jaeger](https://github.com/jaegertracing/jaeger) propagators.  Issues with those propagators
+should be filed against this repo.
+
+This project also contains 3rd-party propagators for other formats. These propagators are here for 
+convenience and are not officially supported by the OpenTelemetry Java maintainers.
 
 Issues/support for these propagators is only provided as a minimal "best effort", and critical
 bugs should be filed with the respective vendors themselves.
 
 * AWS X-Ray (file an issue here and mention @anuraaga)
 * LightStep OpenTracing (file an issue here and mention @carlosalberto)
-* B3 (file an issue on [the OpenZipkin repo](https://github.com/openzipkin/b3-propagation) that points here)
-* Jaeger (file an issue on [the Jaeger repo](https://github.com/jaegertracing/jaeger) that points here)
 
 Extension providers that do not receive adequate support/maintenance by their respective vendors 
 will become candidates for future removal.


### PR DESCRIPTION
This is intended to address #2067.  

I took a best guess at documenting where to go for help, so maybe this is just a start...and hopefully @anuraaga and @carlosalberto are both ok with the direct mentions (if not, please say something).  Are there other maintainers to mention as well?

We can talk about this more in #2067 but @anuraaga mentioned adding a [CODEOWNERS](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-file-location) file, but those github docs didn't really suggest a good (supported) subdir location.