### PR TITLE
Span benchmark with OTLP exporter and collector

### DIFF
--- a/sdk/all/build.gradle
+++ b/sdk/all/build.gradle
@@ -30,6 +30,18 @@ dependencies {
         // dependencies.
         transitive = false
     }
+    jmh(project(':opentelemetry-exporter-otlp')) {
+        // The opentelemetry-exporter-otlp depends on this project itself. So don't pull in
+        // the transitive dependencies.
+        transitive = false
+    }
+    // explicitly adding the opentelemetry-exporter-otlp dependencies
+    jmh(project(':opentelemetry-sdk-extension-otproto')) { transitive = false }
+    jmh(project(':opentelemetry-proto'))
+    jmh("io.grpc:grpc-api")
+    jmh("io.grpc:grpc-netty-shaded")
+    jmh("org.testcontainers:testcontainers:1.15.0") // testContainer for OTLP collector
+
     jmh libraries.guava
 
     signature libraries.android_signature

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
@@ -68,7 +68,8 @@ public class SpanPipelineBenchmark {
 
       String address = collector.getHost() + ":" + collector.getMappedPort(EXPOSED_PORT);
 
-      TraceConfig alwaysOn = TraceConfig.getDefault().toBuilder().setSampler(Sampler.alwaysOn()).build();
+      TraceConfig alwaysOn =
+          TraceConfig.getDefault().toBuilder().setSampler(Sampler.alwaysOn()).build();
 
       TracerSdkProvider tracerProvider =
           TracerSdkProvider.builder().setTraceConfig(alwaysOn).build();

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
@@ -40,7 +40,9 @@ public class SpanPipelineBenchmark {
     private static final int EXPOSED_PORT = 5678;
     private static final int HEALTH_CHECK_PORT = 13133;
     private SpanBuilderSdk spanBuilderSdk;
+
     protected abstract SpanProcessor getSpanProcessor(String collectorAddress);
+
     protected abstract void runThePipeline();
 
     protected void doWork() {
@@ -66,13 +68,11 @@ public class SpanPipelineBenchmark {
 
       String address = collector.getHost() + ":" + collector.getMappedPort(EXPOSED_PORT);
 
-      TracerSdkProvider tracerProvider = TracerSdkProvider.builder().build();
+      TraceConfig alwaysOn = TraceConfig.getDefault().toBuilder().setSampler(Sampler.alwaysOn()).build();
 
+      TracerSdkProvider tracerProvider =
+          TracerSdkProvider.builder().setTraceConfig(alwaysOn).build();
       tracerProvider.addSpanProcessor(getSpanProcessor(address));
-
-      TraceConfig alwaysOn =
-          tracerProvider.getActiveTraceConfig().toBuilder().setSampler(Sampler.alwaysOn()).build();
-      tracerProvider.updateActiveTraceConfig(alwaysOn);
 
       Tracer tracerSdk = tracerProvider.get("PipelineBenchmarkTracer");
       spanBuilderSdk = (SpanBuilderSdk) tracerSdk.spanBuilder("PipelineBenchmarkSpan");

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
@@ -5,24 +5,12 @@
 
 package io.opentelemetry.sdk.trace;
 
-import static io.opentelemetry.api.common.AttributeKey.booleanKey;
-import static io.opentelemetry.api.common.AttributeKey.doubleKey;
-import static io.opentelemetry.api.common.AttributeKey.longKey;
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
-
-import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.Span.Kind;
-import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.exporter.otlp.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
-import io.opentelemetry.sdk.trace.export.SpanExporter;
-import java.util.Collection;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
@@ -34,67 +22,66 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
 
 @State(Scope.Benchmark)
 public class SpanPipelineBenchmark {
-
-  private static final AttributeKey<String> OPERATION_KEY = stringKey("operation");
-  private static final AttributeKey<Long> LONG_ATTRIBUTE_KEY = longKey("longAttribute");
-  private static final AttributeKey<String> STRING_ATTRIBUTE_KEY = stringKey("stringAttribute");
-  private static final AttributeKey<Double> DOUBLE_ATTRIBUTE_KEY = doubleKey("doubleAttribute");
-  private static final AttributeKey<Boolean> BOOLEAN_ATTRIBUTE_KEY = booleanKey("booleanAttribute");
-  private final Tracer tracer = OpenTelemetry.getGlobalTracerProvider().get("benchmarkTracer");
+  private static SpanBuilderSdk spanBuilderSdk;
+  private static final DockerImageName OTLP_COLLECTOR_IMAGE =
+      DockerImageName.parse("otel/opentelemetry-collector-dev:latest");
+  private static final int EXPOSED_PORT = 5678;
+  private static final int HEALTH_CHECK_PORT = 13133;
 
   @Setup(Level.Trial)
   public final void setup() {
-    SpanExporter exporter = new NoOpSpanExporter();
-    OpenTelemetrySdk.getGlobalTracerManagement()
-        .addSpanProcessor(SimpleSpanProcessor.builder(exporter).build());
+    // Configuring the collector test-container
+    GenericContainer<?> collector =
+        new GenericContainer<>(OTLP_COLLECTOR_IMAGE)
+            .withExposedPorts(EXPOSED_PORT, HEALTH_CHECK_PORT)
+            .waitingFor(Wait.forHttp("/").forPort(HEALTH_CHECK_PORT))
+            .withCopyFileToContainer(
+                MountableFile.forClasspathResource("/otel.yaml"), "/etc/otel.yaml")
+            .withCommand("--config /etc/otel.yaml");
+
+    collector.start();
+
+    String address = collector.getHost() + ":" + collector.getMappedPort(EXPOSED_PORT);
+
+    TracerSdkProvider tracerProvider = TracerSdkProvider.builder().build();
+
+    SimpleSpanProcessor spanProcessor =
+        SimpleSpanProcessor.builder(
+                OtlpGrpcSpanExporter.builder().setEndpoint(address).setDeadlineMs(50000).build())
+            .build();
+
+    tracerProvider.addSpanProcessor(spanProcessor);
+
+    TraceConfig alwaysOn =
+        tracerProvider.getActiveTraceConfig().toBuilder().setSampler(Sampler.alwaysOn()).build();
+    tracerProvider.updateActiveTraceConfig(alwaysOn);
+
+    Tracer tracerSdk = tracerProvider.get("PipelineBenchmarkTracer");
+    spanBuilderSdk = (SpanBuilderSdk) tracerSdk.spanBuilder("PipelineBenchmarkSpan");
   }
 
   @Benchmark
-  @Threads(value = 5)
+  @Threads(value = 1)
   @Fork(1)
   @Warmup(iterations = 5, time = 1)
-  @Measurement(iterations = 5, time = 1)
-  @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void runThePipeline_05Threads() {
+  @Measurement(iterations = 15, time = 1)
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  public void runThePipeline_01Threads() {
     doWork();
   }
 
-  private void doWork() {
-    Span span =
-        tracer
-            .spanBuilder("benchmarkSpan")
-            .setSpanKind(Kind.CLIENT)
-            .setAttribute("key", "value")
-            .startSpan();
-    span.addEvent("started", Attributes.of(OPERATION_KEY, "some_work"));
-    span.setAttribute(LONG_ATTRIBUTE_KEY, 33L);
-    span.setAttribute(STRING_ATTRIBUTE_KEY, "test_value");
-    span.setAttribute(DOUBLE_ATTRIBUTE_KEY, 4844.44d);
-    span.setAttribute(BOOLEAN_ATTRIBUTE_KEY, false);
-    span.setStatus(StatusCode.OK);
-
-    span.addEvent("testEvent");
+  private static void doWork() {
+    Span span = spanBuilderSdk.startSpan();
+    for (int i = 0; i < 10; i++) {
+      span.setAttribute("benchmarkAttribute_" + i, "benchmarkAttrValue_" + i);
+    }
     span.end();
-  }
-
-  private static class NoOpSpanExporter implements SpanExporter {
-    @Override
-    public CompletableResultCode export(Collection<SpanData> spans) {
-      return CompletableResultCode.ofSuccess();
-    }
-
-    @Override
-    public CompletableResultCode flush() {
-      return CompletableResultCode.ofSuccess();
-    }
-
-    @Override
-    public CompletableResultCode shutdown() {
-      // no-op
-      return CompletableResultCode.ofSuccess();
-    }
   }
 }

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
@@ -9,13 +9,16 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.exporter.otlp.OtlpGrpcSpanExporter;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -27,61 +30,98 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
-@State(Scope.Benchmark)
 public class SpanPipelineBenchmark {
-  private static SpanBuilderSdk spanBuilderSdk;
-  private static final DockerImageName OTLP_COLLECTOR_IMAGE =
-      DockerImageName.parse("otel/opentelemetry-collector-dev:latest");
-  private static final int EXPOSED_PORT = 5678;
-  private static final int HEALTH_CHECK_PORT = 13133;
+  private SpanPipelineBenchmark() {}
 
-  @Setup(Level.Trial)
-  public final void setup() {
-    // Configuring the collector test-container
-    GenericContainer<?> collector =
-        new GenericContainer<>(OTLP_COLLECTOR_IMAGE)
-            .withExposedPorts(EXPOSED_PORT, HEALTH_CHECK_PORT)
-            .waitingFor(Wait.forHttp("/").forPort(HEALTH_CHECK_PORT))
-            .withCopyFileToContainer(
-                MountableFile.forClasspathResource("/otel.yaml"), "/etc/otel.yaml")
-            .withCommand("--config /etc/otel.yaml");
+  @State(Scope.Benchmark)
+  public abstract static class AbstractProcessorBenchmark {
+    private static final DockerImageName OTLP_COLLECTOR_IMAGE =
+        DockerImageName.parse("otel/opentelemetry-collector-dev:latest");
+    private static final int EXPOSED_PORT = 5678;
+    private static final int HEALTH_CHECK_PORT = 13133;
+    private SpanBuilderSdk spanBuilderSdk;
+    protected abstract SpanProcessor getSpanProcessor(String collectorAddress);
+    protected abstract void runThePipeline();
 
-    collector.start();
-
-    String address = collector.getHost() + ":" + collector.getMappedPort(EXPOSED_PORT);
-
-    TracerSdkProvider tracerProvider = TracerSdkProvider.builder().build();
-
-    SimpleSpanProcessor spanProcessor =
-        SimpleSpanProcessor.builder(
-                OtlpGrpcSpanExporter.builder().setEndpoint(address).setDeadlineMs(50000).build())
-            .build();
-
-    tracerProvider.addSpanProcessor(spanProcessor);
-
-    TraceConfig alwaysOn =
-        tracerProvider.getActiveTraceConfig().toBuilder().setSampler(Sampler.alwaysOn()).build();
-    tracerProvider.updateActiveTraceConfig(alwaysOn);
-
-    Tracer tracerSdk = tracerProvider.get("PipelineBenchmarkTracer");
-    spanBuilderSdk = (SpanBuilderSdk) tracerSdk.spanBuilder("PipelineBenchmarkSpan");
-  }
-
-  @Benchmark
-  @Threads(value = 1)
-  @Fork(1)
-  @Warmup(iterations = 5, time = 1)
-  @Measurement(iterations = 15, time = 1)
-  @OutputTimeUnit(TimeUnit.SECONDS)
-  public void runThePipeline_01Threads() {
-    doWork();
-  }
-
-  private static void doWork() {
-    Span span = spanBuilderSdk.startSpan();
-    for (int i = 0; i < 10; i++) {
-      span.setAttribute("benchmarkAttribute_" + i, "benchmarkAttrValue_" + i);
+    protected void doWork() {
+      Span span = spanBuilderSdk.startSpan();
+      for (int i = 0; i < 10; i++) {
+        span.setAttribute("benchmarkAttribute_" + i, "benchmarkAttrValue_" + i);
+      }
+      span.end();
     }
-    span.end();
+
+    @Setup(Level.Trial)
+    public void setup() {
+      // Configuring the collector test-container
+      GenericContainer<?> collector =
+          new GenericContainer<>(OTLP_COLLECTOR_IMAGE)
+              .withExposedPorts(EXPOSED_PORT, HEALTH_CHECK_PORT)
+              .waitingFor(Wait.forHttp("/").forPort(HEALTH_CHECK_PORT))
+              .withCopyFileToContainer(
+                  MountableFile.forClasspathResource("/otel.yaml"), "/etc/otel.yaml")
+              .withCommand("--config /etc/otel.yaml");
+
+      collector.start();
+
+      String address = collector.getHost() + ":" + collector.getMappedPort(EXPOSED_PORT);
+
+      TracerSdkProvider tracerProvider = TracerSdkProvider.builder().build();
+
+      tracerProvider.addSpanProcessor(getSpanProcessor(address));
+
+      TraceConfig alwaysOn =
+          tracerProvider.getActiveTraceConfig().toBuilder().setSampler(Sampler.alwaysOn()).build();
+      tracerProvider.updateActiveTraceConfig(alwaysOn);
+
+      Tracer tracerSdk = tracerProvider.get("PipelineBenchmarkTracer");
+      spanBuilderSdk = (SpanBuilderSdk) tracerSdk.spanBuilder("PipelineBenchmarkSpan");
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @Warmup(iterations = 5, time = 1)
+    @Measurement(iterations = 15, time = 1)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Fork(1)
+    @Threads(1)
+    public void measureSpanPipeline() {
+      runThePipeline();
+    }
+  }
+
+  public static class SimpleSpanProcessorBenchmark extends AbstractProcessorBenchmark {
+    @Override
+    protected SpanProcessor getSpanProcessor(String collectorAddress) {
+      return SimpleSpanProcessor.builder(
+              OtlpGrpcSpanExporter.builder()
+                  .setEndpoint(collectorAddress)
+                  .setDeadlineMs(50000)
+                  .build())
+          .build();
+    }
+
+    @Override
+    protected void runThePipeline() {
+      doWork();
+    }
+  }
+
+  public static class BatchSpanProcessorBenchmark extends AbstractProcessorBenchmark {
+
+    @Override
+    protected SpanProcessor getSpanProcessor(String collectorAddress) {
+      return BatchSpanProcessor.builder(
+              OtlpGrpcSpanExporter.builder()
+                  .setEndpoint(collectorAddress)
+                  .setDeadlineMs(50000)
+                  .build())
+          .build();
+    }
+
+    @Override
+    protected void runThePipeline() {
+      doWork();
+    }
   }
 }

--- a/sdk/all/src/jmh/resources/otel.yaml
+++ b/sdk/all/src/jmh/resources/otel.yaml
@@ -14,9 +14,6 @@ extensions:
 exporters:
   logging:
     loglevel: debug
-  otlp:
-    endpoint: backend:8080
-    insecure: true
 
 service:
   extensions: [health_check]
@@ -24,4 +21,4 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch, queued_retry]
-      exporters: [logging, otlp]
+      exporters: [logging]

--- a/sdk/all/src/jmh/resources/otel.yaml
+++ b/sdk/all/src/jmh/resources/otel.yaml
@@ -1,0 +1,27 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:5678
+
+processors:
+  batch:
+  queued_retry:
+
+extensions:
+  health_check:
+
+exporters:
+  logging:
+    loglevel: debug
+  otlp:
+    endpoint: backend:8080
+    insecure: true
+
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch, queued_retry]
+      exporters: [logging, otlp]


### PR DESCRIPTION
Refactoring the span pipeline benchmark to align it to the throughput measurement in the spec. 
The OTLP collector is spun up using testContainers and OTLP exporter is being used to send spans to the collector.

running the benchmark with `./gradlew -PjmhIncludeSingleClass=SpanPipelineBenchmark :opentelemetry-sdk:jmh` on an m5.xlarge EC2 instance gives the following result:

```shell
Benchmark                                                                                                 Mode  Cnt       Score       Error   Units
SpanPipelineBenchmark.BatchSpanProcessorBenchmark.measureSpanPipeline                                    thrpt   15  527317.589 ± 42314.216   ops/s
SpanPipelineBenchmark.BatchSpanProcessorBenchmark.measureSpanPipeline:·gc.alloc.rate                     thrpt   15     983.419 ±    81.052  MB/sec
SpanPipelineBenchmark.BatchSpanProcessorBenchmark.measureSpanPipeline:·gc.alloc.rate.norm                thrpt   15    2938.474 ±    93.300    B/op
SpanPipelineBenchmark.BatchSpanProcessorBenchmark.measureSpanPipeline:·gc.churn.G1_Eden_Space            thrpt   15     994.126 ±   176.230  MB/sec
SpanPipelineBenchmark.BatchSpanProcessorBenchmark.measureSpanPipeline:·gc.churn.G1_Eden_Space.norm       thrpt   15    2969.188 ±   428.534    B/op
SpanPipelineBenchmark.BatchSpanProcessorBenchmark.measureSpanPipeline:·gc.churn.G1_Old_Gen               thrpt   15       0.201 ±     0.180  MB/sec
SpanPipelineBenchmark.BatchSpanProcessorBenchmark.measureSpanPipeline:·gc.churn.G1_Old_Gen.norm          thrpt   15       0.595 ±     0.527    B/op
SpanPipelineBenchmark.BatchSpanProcessorBenchmark.measureSpanPipeline:·gc.churn.G1_Survivor_Space        thrpt   15       0.355 ±     0.455  MB/sec
SpanPipelineBenchmark.BatchSpanProcessorBenchmark.measureSpanPipeline:·gc.churn.G1_Survivor_Space.norm   thrpt   15       1.033 ±     1.314    B/op
SpanPipelineBenchmark.BatchSpanProcessorBenchmark.measureSpanPipeline:·gc.count                          thrpt   15      32.000              counts
SpanPipelineBenchmark.BatchSpanProcessorBenchmark.measureSpanPipeline:·gc.time                           thrpt   15     382.000                  ms
SpanPipelineBenchmark.SimpleSpanProcessorBenchmark.measureSpanPipeline                                   thrpt   15   22402.867 ±  6041.441   ops/s
SpanPipelineBenchmark.SimpleSpanProcessorBenchmark.measureSpanPipeline:·gc.alloc.rate                    thrpt   15     237.753 ±    59.024  MB/sec
SpanPipelineBenchmark.SimpleSpanProcessorBenchmark.measureSpanPipeline:·gc.alloc.rate.norm               thrpt   15   16559.668 ±   461.969    B/op
SpanPipelineBenchmark.SimpleSpanProcessorBenchmark.measureSpanPipeline:·gc.churn.G1_Eden_Space           thrpt   15     235.371 ±    79.240  MB/sec
SpanPipelineBenchmark.SimpleSpanProcessorBenchmark.measureSpanPipeline:·gc.churn.G1_Eden_Space.norm      thrpt   15   16494.578 ±  4326.637    B/op
SpanPipelineBenchmark.SimpleSpanProcessorBenchmark.measureSpanPipeline:·gc.churn.G1_Old_Gen              thrpt   15       2.665 ±    11.034  MB/sec
SpanPipelineBenchmark.SimpleSpanProcessorBenchmark.measureSpanPipeline:·gc.churn.G1_Old_Gen.norm         thrpt   15     222.285 ±   920.363    B/op
SpanPipelineBenchmark.SimpleSpanProcessorBenchmark.measureSpanPipeline:·gc.churn.G1_Survivor_Space       thrpt   15       2.863 ±     3.719  MB/sec
SpanPipelineBenchmark.SimpleSpanProcessorBenchmark.measureSpanPipeline:·gc.churn.G1_Survivor_Space.norm  thrpt   15     237.116 ±   332.514    B/op
SpanPipelineBenchmark.SimpleSpanProcessorBenchmark.measureSpanPipeline:·gc.count                         thrpt   15      33.000              counts
SpanPipelineBenchmark.SimpleSpanProcessorBenchmark.measureSpanPipeline:·gc.time                          thrpt   15    4541.000                  ms
```

Ref: [This](https://github.com/open-telemetry/opentelemetry-java/pull/2186) PR for span benchmarks without the exporter.
@jkwatson I hope this covers the part which I missed in the last PR.