### PR TITLE
Rename Link.getContext -> Link.getSpanContext

### DIFF
--- a/exporters/jaeger-thrift/src/main/java/io/opentelemetry/exporter/jaeger/thrift/Adapter.java
+++ b/exporters/jaeger-thrift/src/main/java/io/opentelemetry/exporter/jaeger/thrift/Adapter.java
@@ -229,8 +229,8 @@ final class Adapter {
     // https://github.com/open-telemetry/opentelemetry-java/pull/481/files#r312577862
     return new SpanRef(
         SpanRefType.FOLLOWS_FROM,
-        TraceId.traceIdLowBytesAsLong(link.getContext().getTraceIdAsHexString()),
-        TraceId.traceIdHighBytesAsLong(link.getContext().getTraceIdAsHexString()),
-        SpanId.asLong(link.getContext().getSpanIdAsHexString()));
+        TraceId.traceIdLowBytesAsLong(link.getSpanContext().getTraceIdAsHexString()),
+        TraceId.traceIdHighBytesAsLong(link.getSpanContext().getTraceIdAsHexString()),
+        SpanId.asLong(link.getSpanContext().getSpanIdAsHexString()));
   }
 }

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/Adapter.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/Adapter.java
@@ -251,8 +251,9 @@ final class Adapter {
   @VisibleForTesting
   static Model.SpanRef toSpanRef(Link link) {
     Model.SpanRef.Builder builder = Model.SpanRef.newBuilder();
-    builder.setTraceId(TraceProtoUtils.toProtoTraceId(link.getContext().getTraceIdAsHexString()));
-    builder.setSpanId(TraceProtoUtils.toProtoSpanId(link.getContext().getSpanIdAsHexString()));
+    builder.setTraceId(
+        TraceProtoUtils.toProtoTraceId(link.getSpanContext().getTraceIdAsHexString()));
+    builder.setSpanId(TraceProtoUtils.toProtoSpanId(link.getSpanContext().getSpanIdAsHexString()));
 
     // we can assume that all links are *follows from*
     // https://github.com/open-telemetry/opentelemetry-java/issues/475

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporter/otlp/SpanAdapter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporter/otlp/SpanAdapter.java
@@ -139,8 +139,9 @@ final class SpanAdapter {
 
   static Span.Link toProtoSpanLink(SpanData.Link link) {
     final Span.Link.Builder builder = Span.Link.newBuilder();
-    builder.setTraceId(TraceProtoUtils.toProtoTraceId(link.getContext().getTraceIdAsHexString()));
-    builder.setSpanId(TraceProtoUtils.toProtoSpanId(link.getContext().getSpanIdAsHexString()));
+    builder.setTraceId(
+        TraceProtoUtils.toProtoTraceId(link.getSpanContext().getTraceIdAsHexString()));
+    builder.setSpanId(TraceProtoUtils.toProtoSpanId(link.getSpanContext().getSpanIdAsHexString()));
     // TODO: Set TraceState;
     Attributes attributes = link.getAttributes();
     attributes.forEach(

--- a/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/RateLimitingSampler.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/RateLimitingSampler.java
@@ -64,7 +64,7 @@ class RateLimitingSampler implements Sampler {
           .shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
     }
     for (SpanData.Link parentLink : parentLinks) {
-      if (parentLink.getContext().isSampled()) {
+      if (parentLink.getSpanContext().isSampled()) {
         return Sampler.alwaysOn()
             .shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
       }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
@@ -225,12 +225,19 @@ public interface SpanData {
       return ImmutableLink.create(spanContext, attributes, totalAttributeCount);
     }
 
+    /** Returns the {@code SpanContext} of the span this {@link Link} refers to. */
+    SpanContext getSpanContext();
+
     /**
      * Returns the {@code SpanContext}.
      *
      * @return the {@code SpanContext}.
+     * @deprecated Use {@link #getSpanContext()}
      */
-    SpanContext getContext();
+    @Deprecated
+    default SpanContext getContext() {
+      return getSpanContext();
+    }
 
     /**
      * Returns the set of attributes.


### PR DESCRIPTION
Consistency with other APIs and reduction of confusion of return type not being `Context`