### PR TITLE
Remove duplicate getters and builder options from SDK

### DIFF
--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.sdk;
 
-import static java.util.Objects.requireNonNull;
-
 import io.opentelemetry.api.DefaultOpenTelemetry;
 import io.opentelemetry.api.DefaultOpenTelemetryBuilder;
 import io.opentelemetry.api.GlobalOpenTelemetry;
@@ -15,17 +13,9 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
-import io.opentelemetry.sdk.common.Clock;
-import io.opentelemetry.sdk.internal.SystemClock;
 import io.opentelemetry.sdk.metrics.MeterSdkProvider;
-import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.sdk.trace.IdGenerator;
 import io.opentelemetry.sdk.trace.SdkTracerManagement;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
-import io.opentelemetry.sdk.trace.SpanProcessor;
-import io.opentelemetry.sdk.trace.config.TraceConfig;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -64,28 +54,11 @@ public final class OpenTelemetrySdk extends DefaultOpenTelemetry {
 
   private static final AtomicBoolean INITIALIZED_GLOBAL = new AtomicBoolean();
 
-  private final Clock clock;
-  private final Resource resource;
-
   private OpenTelemetrySdk(
       TracerProvider tracerProvider,
       MeterProvider meterProvider,
-      ContextPropagators contextPropagators,
-      Clock clock,
-      Resource resource) {
+      ContextPropagators contextPropagators) {
     super(tracerProvider, meterProvider, contextPropagators);
-    this.clock = clock;
-    this.resource = resource;
-  }
-
-  /** Returns the {@link Resource} for this {@link OpenTelemetrySdk}. */
-  public Resource getResource() {
-    return resource;
-  }
-
-  /** Returns the {@link Clock} for this {@link OpenTelemetrySdk}. */
-  public Clock getClock() {
-    return clock;
   }
 
   /** Returns the {@link SdkTracerManagement} for this {@link OpenTelemetrySdk}. */
@@ -95,12 +68,6 @@ public final class OpenTelemetrySdk extends DefaultOpenTelemetry {
 
   /** A builder for configuring an {@link OpenTelemetrySdk}. */
   public static class Builder extends DefaultOpenTelemetryBuilder {
-    private Clock clock;
-    private Resource resource;
-    private final List<SpanProcessor> spanProcessors = new ArrayList<>();
-    private IdGenerator idGenerator;
-    private TraceConfig traceConfig;
-
     /**
      * Sets the {@link SdkTracerProvider} to use. This can be used to configure tracing settings by
      * returning the instance created by a {@link SdkTracerProvider.Builder}.
@@ -147,128 +114,26 @@ public final class OpenTelemetrySdk extends DefaultOpenTelemetry {
     }
 
     /**
-     * Sets the {@link Clock} to be used for measuring timings.
-     *
-     * <p>If you use {@link #setTracerProvider(TracerProvider)}, this will be ignored for purposes
-     * of configuring the TracerProvider.
-     *
-     * @param clock The clock to use for all temporal needs.
-     * @return this
-     */
-    public Builder setClock(Clock clock) {
-      requireNonNull(clock, "clock");
-      this.clock = clock;
-      return this;
-    }
-
-    /**
-     * Sets the {@link Resource} to be attached to all telemetry reported by this SDK.
-     *
-     * <p>If you use {@link #setTracerProvider(TracerProvider)}, this will be ignored for purposes
-     * of configuring the TracerProvider.
-     *
-     * @param resource A Resource implementation.
-     * @return this
-     */
-    public Builder setResource(Resource resource) {
-      requireNonNull(resource, "resource");
-      this.resource = resource;
-      return this;
-    }
-
-    /**
-     * Add a SpanProcessor to the span pipeline that will be built.
-     *
-     * @return this
-     */
-    public Builder addSpanProcessor(SpanProcessor spanProcessor) {
-      spanProcessors.add(spanProcessor);
-      return this;
-    }
-
-    /**
-     * Set the {@link IdGenerator} that will be used by the SDK for generating trace and span ids.
-     *
-     * <p>Using {@link #setTracerProvider(TracerProvider)} will override this setting.
-     *
-     * @return this
-     */
-    public Builder setIdGenerator(IdGenerator idGenerator) {
-      this.idGenerator = idGenerator;
-      return this;
-    }
-
-    /**
-     * Set the {@link TraceConfig} that will be initially set on the Tracing SDK.
-     *
-     * <p>Using {@link #setTracerProvider(TracerProvider)} will override this setting.
-     *
-     * @return this
-     */
-    public Builder setTraceConfig(TraceConfig traceConfig) {
-      this.traceConfig = traceConfig;
-      return this;
-    }
-
-    /**
      * Returns a new {@link OpenTelemetrySdk} built with the configuration of this {@link Builder}.
      */
     @Override
     public OpenTelemetrySdk build() {
-      MeterProvider meterProvider = buildMeterProvider();
-      SdkTracerProvider tracerProvider = buildTracerProvider();
+      if (meterProvider == null) {
+        meterProvider = MeterSdkProvider.builder().build();
+      }
 
-      for (SpanProcessor spanProcessor : spanProcessors) {
-        tracerProvider.addSpanProcessor(spanProcessor);
+      if (tracerProvider == null) {
+        tracerProvider = SdkTracerProvider.builder().build();
       }
 
       OpenTelemetrySdk sdk =
           new OpenTelemetrySdk(
-              new ObfuscatedTracerProvider(tracerProvider),
-              meterProvider,
-              super.propagators,
-              clock == null ? SystemClock.getInstance() : clock,
-              resource == null ? Resource.getDefault() : resource);
+              new ObfuscatedTracerProvider(tracerProvider), meterProvider, super.propagators);
       // Automatically initialize global OpenTelemetry with the first SDK we build.
       if (INITIALIZED_GLOBAL.compareAndSet(/* expectedValue= */ false, /* newValue= */ true)) {
         GlobalOpenTelemetry.set(sdk);
       }
       return sdk;
-    }
-
-    private SdkTracerProvider buildTracerProvider() {
-      TracerProvider tracerProvider = super.tracerProvider;
-      if (tracerProvider != null) {
-        return (SdkTracerProvider) tracerProvider;
-      }
-      SdkTracerProvider.Builder tracerProviderBuilder = SdkTracerProvider.builder();
-      if (clock != null) {
-        tracerProviderBuilder.setClock(clock);
-      }
-      if (resource != null) {
-        tracerProviderBuilder.setResource(resource);
-      }
-      if (idGenerator != null) {
-        tracerProviderBuilder.setIdGenerator(idGenerator);
-      }
-      if (traceConfig != null) {
-        tracerProviderBuilder.setTraceConfig(traceConfig);
-      }
-      return tracerProviderBuilder.build();
-    }
-
-    private MeterProvider buildMeterProvider() {
-      if (super.meterProvider != null) {
-        return super.meterProvider;
-      }
-      MeterSdkProvider.Builder meterProviderBuilder = MeterSdkProvider.builder();
-      if (clock != null) {
-        meterProviderBuilder.setClock(clock);
-      }
-      if (resource != null) {
-        meterProviderBuilder.setResource(resource);
-      }
-      return meterProviderBuilder.build();
     }
   }
 

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -11,28 +11,22 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 import io.opentelemetry.api.DefaultOpenTelemetry;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.MeterProvider;
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk.ObfuscatedTracerProvider;
 import io.opentelemetry.sdk.common.Clock;
-import io.opentelemetry.sdk.internal.SystemClock;
 import io.opentelemetry.sdk.metrics.MeterSdkProvider;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.IdGenerator;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
-import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
-import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
-import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -97,27 +91,20 @@ class OpenTelemetrySdkTest {
                 assertThat(obfuscatedTracerProvider.unobfuscate())
                     .isInstanceOf(SdkTracerProvider.class));
     assertThat(openTelemetry.getMeterProvider()).isInstanceOf(MeterSdkProvider.class);
-    assertThat(openTelemetry.getResource()).isEqualTo(Resource.getDefault());
-    assertThat(openTelemetry.getClock()).isEqualTo(SystemClock.getInstance());
   }
 
   @Test
   void building() {
-    Resource resource = Resource.create(Attributes.builder().put("cat", "meow").build());
     OpenTelemetrySdk openTelemetry =
         OpenTelemetrySdk.builder()
             .setTracerProvider(tracerProvider)
             .setMeterProvider(meterProvider)
             .setPropagators(propagators)
-            .setClock(clock)
-            .setResource(resource)
             .build();
     assertThat(((ObfuscatedTracerProvider) openTelemetry.getTracerProvider()).unobfuscate())
         .isEqualTo(tracerProvider);
     assertThat(openTelemetry.getMeterProvider()).isEqualTo(meterProvider);
     assertThat(openTelemetry.getPropagators()).isEqualTo(propagators);
-    assertThat(openTelemetry.getResource()).isEqualTo(resource);
-    assertThat(openTelemetry.getClock()).isEqualTo(clock);
   }
 
   @Test
@@ -127,10 +114,15 @@ class OpenTelemetrySdkTest {
     TraceConfig traceConfig = mock(TraceConfig.class);
     OpenTelemetrySdk openTelemetry =
         OpenTelemetrySdk.builder()
-            .setClock(clock)
-            .setResource(resource)
-            .setIdGenerator(idGenerator)
-            .setTraceConfig(traceConfig)
+            .setTracerProvider(
+                SdkTracerProvider.builder()
+                    .setClock(clock)
+                    .setResource(resource)
+                    .setIdGenerator(idGenerator)
+                    .setTraceConfig(traceConfig)
+                    .build())
+            .setMeterProvider(
+                MeterSdkProvider.builder().setResource(resource).setClock(clock).build())
             .build();
     TracerProvider unobfuscatedTracerProvider =
         ((ObfuscatedTracerProvider) openTelemetry.getTracerProvider()).unobfuscate();
@@ -152,29 +144,6 @@ class OpenTelemetrySdkTest {
         .extracting("sharedState")
         .hasFieldOrPropertyWithValue("clock", clock)
         .hasFieldOrPropertyWithValue("resource", resource);
-
-    assertThat(openTelemetry.getResource()).isSameAs(resource);
-    assertThat(openTelemetry.getClock()).isSameAs(clock);
-  }
-
-  @Test
-  void addSpanProcessors() {
-    SpanProcessor spanProcessor1 = mock(SpanProcessor.class);
-    SpanProcessor spanProcessor2 = mock(SpanProcessor.class);
-    OpenTelemetrySdk openTelemetrySdk =
-        OpenTelemetrySdk.builder()
-            .addSpanProcessor(spanProcessor1)
-            .addSpanProcessor(spanProcessor2)
-            .build();
-
-    TracerProvider tracerProvider = openTelemetrySdk.getTracerProvider();
-    Span span = tracerProvider.get("test").spanBuilder("test").startSpan();
-    span.end();
-
-    verify(spanProcessor1).isStartRequired();
-    verify(spanProcessor1).isEndRequired();
-    verify(spanProcessor2).isStartRequired();
-    verify(spanProcessor2).isEndRequired();
   }
 
   @Test
@@ -211,30 +180,23 @@ class OpenTelemetrySdkTest {
 
     OpenTelemetrySdk.Builder sdkBuilder =
         OpenTelemetrySdk.builder()
-            .addSpanProcessor(mock(SpanProcessor.class))
-            .addSpanProcessor(SimpleSpanProcessor.builder(mock(SpanExporter.class)).build())
-            .setIdGenerator(mock(IdGenerator.class))
-            .setPropagators(ContextPropagators.create(mock(TextMapPropagator.class)))
-            .setClock(mock(Clock.class))
-            .setResource(mock(Resource.class));
-
-    SdkTracerProvider sdkTracerProvider =
-        SdkTracerProvider.builder()
-            .setClock(mock(Clock.class))
-            .setIdGenerator(mock(IdGenerator.class))
-            .setResource(mock(Resource.class))
-            .setTraceConfig(newConfig)
-            .build();
-
-    MeterSdkProvider meterSdkProvider =
-        MeterSdkProvider.builder()
-            .setClock(mock(Clock.class))
-            .setResource(mock(Resource.class))
-            .build();
-
-    sdkBuilder.setTracerProvider(sdkTracerProvider);
-    sdkBuilder.setMeterProvider(meterSdkProvider);
-    sdkBuilder.setTraceConfig(newConfig);
+            .setTracerProvider(
+                SdkTracerProvider.builder()
+                    // TODO: Add support to configure SpanProcessor the builder.
+                    // .addSpanProcessor(SimpleSpanProcessor.builder(
+                    //     mock(SpanExporter.class)).build())
+                    // .addSpanProcessor(SimpleSpanProcessor.builder(
+                    //     mock(SpanExporter.class)).build())
+                    .setClock(mock(Clock.class))
+                    .setIdGenerator(mock(IdGenerator.class))
+                    .setResource(mock(Resource.class))
+                    .setTraceConfig(newConfig)
+                    .build())
+            .setMeterProvider(
+                MeterSdkProvider.builder()
+                    .setClock(mock(Clock.class))
+                    .setResource(mock(Resource.class))
+                    .build());
 
     sdkBuilder.build();
   }
@@ -245,7 +207,11 @@ class OpenTelemetrySdkTest {
   @Test
   void trivialOpenTelemetrySdkConfigurationDemo() {
     OpenTelemetrySdk.builder()
-        .addSpanProcessor(SimpleSpanProcessor.builder(mock(SpanExporter.class)).build())
+        .setTracerProvider(
+            SdkTracerProvider.builder()
+                // TODO: Add support to configure SpanProcessor the builder.
+                // .addSpanProcessor(SimpleSpanProcessor.builder(mock(SpanExporter.class)).build())
+                .build())
         .setPropagators(ContextPropagators.create(mock(TextMapPropagator.class)))
         .build();
   }
@@ -255,16 +221,26 @@ class OpenTelemetrySdkTest {
   @Test
   void minimalOpenTelemetrySdkConfigurationDemo() {
     OpenTelemetrySdk.builder()
-        .addSpanProcessor(SimpleSpanProcessor.builder(mock(SpanExporter.class)).build())
+        .setTracerProvider(
+            SdkTracerProvider.builder()
+                // TODO: Add support to configure SpanProcessor the builder.
+                // .addSpanProcessor(SimpleSpanProcessor.builder(mock(SpanExporter.class)).build())
+                .setTraceConfig(
+                    TraceConfig.getDefault().toBuilder().setSampler(mock(Sampler.class)).build())
+                .build())
         .setPropagators(ContextPropagators.create(mock(TextMapPropagator.class)))
-        .setTraceConfig(
-            TraceConfig.getDefault().toBuilder().setSampler(mock(Sampler.class)).build())
         .build();
 
     OpenTelemetrySdk.builder()
-        .addSpanProcessor(SimpleSpanProcessor.builder(mock(SpanExporter.class)).build())
+        .setTracerProvider(
+            SdkTracerProvider.builder()
+                // TODO: Add support to configure SpanProcessor the builder.
+                // .addSpanProcessor(SimpleSpanProcessor.builder(mock(SpanExporter.class)).build())
+                .setTraceConfig(
+                    TraceConfig.getDefault().toBuilder().setSampler(mock(Sampler.class)).build())
+                .setIdGenerator(mock(IdGenerator.class))
+                .build())
         .setPropagators(ContextPropagators.create(mock(TextMapPropagator.class)))
-        .setIdGenerator(mock(IdGenerator.class))
         .build();
   }
 }


### PR DESCRIPTION
For reasons see https://github.com/open-telemetry/opentelemetry-java/pull/2223#issuecomment-741095083, and just apply the basic rule of defining an API, when in doubt don't add it, we can always add more functionality, but we cannot remove it.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>