### PR TITLE
Split global functionality into a separate class

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/DefaultOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/DefaultOpenTelemetry.java
@@ -8,9 +8,6 @@ package io.opentelemetry.api;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
-import io.opentelemetry.spi.OpenTelemetryFactory;
-import java.util.ServiceLoader;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -19,32 +16,6 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class DefaultOpenTelemetry implements OpenTelemetry {
-  private static final Object mutex = new Object();
-  @Nullable private static volatile OpenTelemetry globalOpenTelemetry;
-
-  private final TracerProvider tracerProvider;
-  private final MeterProvider meterProvider;
-  private volatile ContextPropagators propagators;
-
-  static OpenTelemetry getGlobalOpenTelemetry() {
-    if (globalOpenTelemetry == null) {
-      synchronized (mutex) {
-        if (globalOpenTelemetry == null) {
-          OpenTelemetryFactory openTelemetryFactory = loadSpi(OpenTelemetryFactory.class);
-          if (openTelemetryFactory != null) {
-            globalOpenTelemetry = openTelemetryFactory.create();
-          } else {
-            globalOpenTelemetry = builder().build();
-          }
-        }
-      }
-    }
-    return globalOpenTelemetry;
-  }
-
-  static void setGlobalOpenTelemetry(OpenTelemetry openTelemetry) {
-    globalOpenTelemetry = openTelemetry;
-  }
 
   /**
    * Returns a builder for the {@link DefaultOpenTelemetry}.
@@ -54,6 +25,11 @@ public class DefaultOpenTelemetry implements OpenTelemetry {
   public static DefaultOpenTelemetryBuilder builder() {
     return new DefaultOpenTelemetryBuilder();
   }
+
+  private final TracerProvider tracerProvider;
+  private final MeterProvider meterProvider;
+
+  private volatile ContextPropagators propagators;
 
   @Override
   public void setPropagators(ContextPropagators propagators) {
@@ -80,35 +56,5 @@ public class DefaultOpenTelemetry implements OpenTelemetry {
     this.tracerProvider = tracerProvider;
     this.meterProvider = meterProvider;
     this.propagators = propagators;
-  }
-
-  /**
-   * Load provider class via {@link ServiceLoader}. A specific provider class can be requested via
-   * setting a system property with FQCN.
-   *
-   * @param providerClass a provider class
-   * @param <T> provider type
-   * @return a provider or null if not found
-   * @throws IllegalStateException if a specified provider is not found
-   */
-  @Nullable
-  static <T> T loadSpi(Class<T> providerClass) {
-    String specifiedProvider = System.getProperty(providerClass.getName());
-    ServiceLoader<T> providers = ServiceLoader.load(providerClass);
-    for (T provider : providers) {
-      if (specifiedProvider == null || specifiedProvider.equals(provider.getClass().getName())) {
-        return provider;
-      }
-    }
-    if (specifiedProvider != null) {
-      throw new IllegalStateException(
-          String.format("Service provider %s not found", specifiedProvider));
-    }
-    return null;
-  }
-
-  // for testing
-  static void reset() {
-    globalOpenTelemetry = null;
   }
 }

--- a/api/all/src/main/java/io/opentelemetry/api/DefaultOpenTelemetryBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/DefaultOpenTelemetryBuilder.java
@@ -47,8 +47,7 @@ public class DefaultOpenTelemetryBuilder
   public OpenTelemetry build() {
     MeterProvider meterProvider = this.meterProvider;
     if (meterProvider == null) {
-      MeterProviderFactory meterProviderFactory =
-          DefaultOpenTelemetry.loadSpi(MeterProviderFactory.class);
+      MeterProviderFactory meterProviderFactory = Utils.loadSpi(MeterProviderFactory.class);
       if (meterProviderFactory != null) {
         meterProvider = meterProviderFactory.create();
       } else {
@@ -58,8 +57,7 @@ public class DefaultOpenTelemetryBuilder
 
     TracerProvider tracerProvider = this.tracerProvider;
     if (tracerProvider == null) {
-      TracerProviderFactory tracerProviderFactory =
-          DefaultOpenTelemetry.loadSpi(TracerProviderFactory.class);
+      TracerProviderFactory tracerProviderFactory = Utils.loadSpi(TracerProviderFactory.class);
       if (tracerProviderFactory != null) {
         tracerProvider = tracerProviderFactory.create();
       } else {

--- a/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api;
+
+import static java.util.Objects.requireNonNull;
+
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerProvider;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.spi.OpenTelemetryFactory;
+import io.opentelemetry.spi.metrics.MeterProviderFactory;
+import io.opentelemetry.spi.trace.TracerProviderFactory;
+import javax.annotation.Nullable;
+
+/**
+ * A global singleton for the entrypoint to telemetry functionality for tracing, metrics and
+ * baggage.
+ *
+ * <p>The global singleton can be retrieved by {@link #get()}. The default for the returned {@link
+ * OpenTelemetry}, if none has been set via {@link #set(OpenTelemetry)}, will be created with any
+ * {@link OpenTelemetryFactory}, {@link TracerProviderFactory} or {@link MeterProviderFactory} found
+ * on the classpath, or otherwise will be default, with no-op behavior.
+ *
+ * <p>If using the OpenTelemetry SDK, you may want to instantiate the {@link OpenTelemetry} to
+ * provide configuration, for example of {@code Resource} or {@code Sampler}. See {@code
+ * OpenTelemetrySdk} and {@code OpenTelemetrySdk.builder} for information on how to construct the
+ * SDK {@link OpenTelemetry}.
+ *
+ * @see TracerProvider
+ * @see MeterProvider
+ * @see ContextPropagators
+ */
+public final class GlobalOpenTelemetry {
+  private static final Object mutex = new Object();
+  @Nullable private static volatile OpenTelemetry globalOpenTelemetry;
+
+  private GlobalOpenTelemetry() {}
+
+  /**
+   * Returns the registered global {@link OpenTelemetry}. If no call to {@link #set(OpenTelemetry)}
+   * has been made so far, a default {@link OpenTelemetry} composed of functionality any {@link
+   * OpenTelemetryFactory}, {@link TracerProviderFactory} or{@link MeterProviderFactory}, found on
+   * the classpath, or otherwise will be default, with no-op behavior.
+   *
+   * @throws IllegalStateException if a provider has been specified by system property using the
+   *     interface FQCN but the specified provider cannot be found.
+   */
+  public static OpenTelemetry get() {
+    if (globalOpenTelemetry == null) {
+      synchronized (mutex) {
+        if (globalOpenTelemetry == null) {
+          OpenTelemetryFactory openTelemetryFactory = Utils.loadSpi(OpenTelemetryFactory.class);
+          if (openTelemetryFactory != null) {
+            set(openTelemetryFactory.create());
+          } else {
+            set(DefaultOpenTelemetry.builder().build());
+          }
+        }
+      }
+    }
+    return globalOpenTelemetry;
+  }
+
+  /**
+   * Sets the {@link OpenTelemetry} that should be the global instance. Future calls to {@link
+   * #get()} will return the provided {@link OpenTelemetry} instance. This should be called once as
+   * early as possible in your application initialization logic, often in a {@code static} block in
+   * your main class.
+   */
+  public static void set(OpenTelemetry openTelemetry) {
+    globalOpenTelemetry = openTelemetry;
+  }
+
+  // for testing
+  static void reset() {
+    globalOpenTelemetry = null;
+  }
+
+  /** Returns the globally registered {@link TracerProvider}. */
+  public static TracerProvider getTracerProvider() {
+    return get().getTracerProvider();
+  }
+
+  /**
+   * Gets or creates a named tracer instance from the globally registered {@link TracerProvider}.
+   *
+   * <p>This is a shortcut method for {@code getTracerProvider().get(instrumentationName)}
+   *
+   * @param instrumentationName The name of the instrumentation library, not the name of the
+   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.
+   * @return a tracer instance.
+   */
+  public static Tracer getTracer(String instrumentationName) {
+    return get().getTracer(instrumentationName);
+  }
+
+  /**
+   * Gets or creates a named and versioned tracer instance from the globally registered {@link
+   * TracerProvider}.
+   *
+   * <p>This is a shortcut method for {@code getTracerProvider().get(instrumentationName,
+   * instrumentationVersion)}
+   *
+   * @param instrumentationName The name of the instrumentation library, not the name of the
+   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.
+   * @param instrumentationVersion The version of the instrumentation library (e.g., "1.0.0").
+   * @return a tracer instance.
+   */
+  public static Tracer getTracer(String instrumentationName, String instrumentationVersion) {
+    return get().getTracer(instrumentationName, instrumentationVersion);
+  }
+
+  /** Returns the globally registered {@link MeterProvider}. */
+  public static MeterProvider getMeterProvider() {
+    return get().getMeterProvider();
+  }
+
+  /**
+   * Gets or creates a named meter instance from the globally registered {@link MeterProvider}.
+   *
+   * <p>This is a shortcut method for {@code getMeterProvider().get(instrumentationName)}
+   *
+   * @param instrumentationName The name of the instrumentation library, not the name of the
+   *     instrument*ed* library.
+   * @return a tracer instance.
+   */
+  public static Meter getMeter(String instrumentationName) {
+    return get().getMeter(instrumentationName);
+  }
+
+  /**
+   * Gets or creates a named and versioned meter instance from the globally registered {@link
+   * MeterProvider}.
+   *
+   * <p>This is a shortcut method for {@code getMeterProvider().get(instrumentationName,
+   * instrumentationVersion)}
+   *
+   * @param instrumentationName The name of the instrumentation library, not the name of the
+   *     instrument*ed* library.
+   * @param instrumentationVersion The version of the instrumentation library.
+   * @return a tracer instance.
+   */
+  public static Meter getMeter(String instrumentationName, String instrumentationVersion) {
+    return get().getMeter(instrumentationName, instrumentationVersion);
+  }
+
+  /**
+   * Returns the globally registered {@link ContextPropagators} for remote propagation of a context.
+   */
+  public static ContextPropagators getPropagators() {
+    return get().getPropagators();
+  }
+
+  /**
+   * Sets the globally registered {@link ContextPropagators} for remote propagation of a context.
+   */
+  public static void setPropagators(ContextPropagators propagators) {
+    requireNonNull(propagators, "propagators");
+    get().setPropagators(propagators);
+  }
+}

--- a/api/all/src/main/java/io/opentelemetry/api/OpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/OpenTelemetry.java
@@ -36,108 +36,103 @@ import io.opentelemetry.spi.trace.TracerProviderFactory;
 public interface OpenTelemetry {
 
   /**
-   * Returns the registered global {@link OpenTelemetry}. If no call to {@link #set(OpenTelemetry)}
-   * has been made so far, a default {@link OpenTelemetry} composed of functionality any {@link
-   * OpenTelemetryFactory}, {@link TracerProviderFactory} or{@link MeterProviderFactory}, found on
-   * the classpath, or otherwise will be default, with no-op behavior.
+   * Returns the registered global {@link OpenTelemetry}.
    *
-   * @throws IllegalStateException if a provider has been specified by system property using the
-   *     interface FQCN but the specified provider cannot be found.
+   * @deprecated use {@link GlobalOpenTelemetry#get()}
    */
+  @Deprecated
   static OpenTelemetry get() {
-    return DefaultOpenTelemetry.getGlobalOpenTelemetry();
+    return GlobalOpenTelemetry.get();
   }
 
   /**
-   * Sets the {@link OpenTelemetry} that should be the global instance. Future calls to {@link
-   * #get()} will return the provided {@link OpenTelemetry} instance. This should be called once as
-   * early as possible in your application initialization logic, often in a {@code static} block in
-   * your main class.
+   * Sets the {@link OpenTelemetry} that should be the global instance.
+   *
+   * @deprecated use {@link GlobalOpenTelemetry#set(OpenTelemetry)}
    */
+  @Deprecated
   static void set(OpenTelemetry openTelemetry) {
-    DefaultOpenTelemetry.setGlobalOpenTelemetry(openTelemetry);
+    GlobalOpenTelemetry.set(openTelemetry);
   }
 
-  /** Returns the globally registered {@link TracerProvider}. */
+  /**
+   * Returns the globally registered {@link TracerProvider}.
+   *
+   * @deprecated use {@link GlobalOpenTelemetry#getTracerProvider()}
+   */
+  @Deprecated
   static TracerProvider getGlobalTracerProvider() {
-    return DefaultOpenTelemetry.getGlobalOpenTelemetry().getTracerProvider();
+    return get().getTracerProvider();
   }
 
   /**
    * Gets or creates a named tracer instance from the globally registered {@link TracerProvider}.
    *
-   * <p>This is a shortcut method for {@code getGlobalTracerProvider().get(instrumentationName)}
-   *
-   * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.
-   * @return a tracer instance.
+   * @deprecated use {@link GlobalOpenTelemetry#getTracer(String)}
    */
+  @Deprecated
   static Tracer getGlobalTracer(String instrumentationName) {
-    return DefaultOpenTelemetry.getGlobalOpenTelemetry().getTracer(instrumentationName);
+    return get().getTracer(instrumentationName);
   }
 
   /**
    * Gets or creates a named and versioned tracer instance from the globally registered {@link
    * TracerProvider}.
    *
-   * <p>This is a shortcut method for {@code getGlobalTracerProvider().get(instrumentationName,
-   * instrumentationVersion)}
-   *
-   * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.
-   * @param instrumentationVersion The version of the instrumentation library (e.g., "1.0.0").
-   * @return a tracer instance.
+   * @deprecated use {@link GlobalOpenTelemetry#getTracer(String, String)}
    */
+  @Deprecated
   static Tracer getGlobalTracer(String instrumentationName, String instrumentationVersion) {
-    return DefaultOpenTelemetry.getGlobalOpenTelemetry()
-        .getTracer(instrumentationName, instrumentationVersion);
+    return get().getTracer(instrumentationName, instrumentationVersion);
   }
 
-  /** Returns the globally registered {@link MeterProvider}. */
+  /**
+   * Returns the globally registered {@link MeterProvider}.
+   *
+   * @deprecated use {@link GlobalOpenTelemetry#getMeterProvider()}
+   */
+  @Deprecated
   static MeterProvider getGlobalMeterProvider() {
-    return DefaultOpenTelemetry.getGlobalOpenTelemetry().getMeterProvider();
+    return get().getMeterProvider();
   }
 
   /**
    * Gets or creates a named meter instance from the globally registered {@link MeterProvider}.
    *
-   * <p>This is a shortcut method for {@code getGlobalMeterProvider().get(instrumentationName)}
-   *
-   * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library.
-   * @return a tracer instance.
+   * @deprecated use {@link GlobalOpenTelemetry#getMeter(String)}
    */
+  @Deprecated
   static Meter getGlobalMeter(String instrumentationName) {
-    return DefaultOpenTelemetry.getGlobalOpenTelemetry().getMeter(instrumentationName);
+    return get().getMeter(instrumentationName);
   }
 
   /**
    * Gets or creates a named and versioned meter instance from the globally registered {@link
    * MeterProvider}.
    *
-   * <p>This is a shortcut method for {@code getGlobalMeterProvider().get(instrumentationName,
-   * instrumentationVersion)}
-   *
-   * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library.
-   * @param instrumentationVersion The version of the instrumentation library.
-   * @return a tracer instance.
+   * @deprecated use {@link GlobalOpenTelemetry#getMeter(String, String)}
    */
+  @Deprecated
   static Meter getGlobalMeter(String instrumentationName, String instrumentationVersion) {
-    return DefaultOpenTelemetry.getGlobalOpenTelemetry()
-        .getMeter(instrumentationName, instrumentationVersion);
+    return get().getMeter(instrumentationName, instrumentationVersion);
   }
 
   /**
    * Returns the globally registered {@link ContextPropagators} for remote propagation of a context.
+   *
+   * @deprecated use {@link GlobalOpenTelemetry#getPropagators()}
    */
+  @Deprecated
   static ContextPropagators getGlobalPropagators() {
-    return DefaultOpenTelemetry.getGlobalOpenTelemetry().getPropagators();
+    return get().getPropagators();
   }
 
   /**
    * Sets the globally registered {@link ContextPropagators} for remote propagation of a context.
+   *
+   * @deprecated use {@link GlobalOpenTelemetry#setPropagators(ContextPropagators)}
    */
+  @Deprecated
   static void setGlobalPropagators(ContextPropagators propagators) {
     requireNonNull(propagators, "propagators");
     get().setPropagators(propagators);

--- a/api/all/src/main/java/io/opentelemetry/api/Utils.java
+++ b/api/all/src/main/java/io/opentelemetry/api/Utils.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api;
+
+import java.util.ServiceLoader;
+import javax.annotation.Nullable;
+
+final class Utils {
+  private Utils() {}
+
+  /**
+   * Load provider class via {@link ServiceLoader}. A specific provider class can be requested via
+   * setting a system property with FQCN.
+   *
+   * @param providerClass a provider class
+   * @param <T> provider type
+   * @return a provider or null if not found
+   * @throws IllegalStateException if a specified provider is not found
+   */
+  @Nullable
+  static <T> T loadSpi(Class<T> providerClass) {
+    String specifiedProvider = System.getProperty(providerClass.getName());
+    ServiceLoader<T> providers = ServiceLoader.load(providerClass);
+    for (T provider : providers) {
+      if (specifiedProvider == null || specifiedProvider.equals(provider.getClass().getName())) {
+        return provider;
+      }
+    }
+    if (specifiedProvider != null) {
+      throw new IllegalStateException(
+          String.format("Service provider %s not found", specifiedProvider));
+    }
+    return null;
+  }
+}

--- a/api/all/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
@@ -45,27 +45,27 @@ class OpenTelemetryTest {
 
   @BeforeAll
   static void beforeClass() {
-    DefaultOpenTelemetry.reset();
+    GlobalOpenTelemetry.reset();
   }
 
   @AfterEach
   void after() {
-    DefaultOpenTelemetry.reset();
+    GlobalOpenTelemetry.reset();
     System.clearProperty(TracerProviderFactory.class.getName());
     System.clearProperty(MeterProviderFactory.class.getName());
   }
 
   @Test
   void testDefault() {
-    assertThat(OpenTelemetry.getGlobalTracerProvider().getClass().getSimpleName())
+    assertThat(GlobalOpenTelemetry.getTracerProvider().getClass().getSimpleName())
         .isEqualTo("DefaultTracerProvider");
-    assertThat(OpenTelemetry.getGlobalTracerProvider())
-        .isSameAs(OpenTelemetry.getGlobalTracerProvider());
-    assertThat(OpenTelemetry.getGlobalMeterProvider().getClass().getSimpleName())
+    assertThat(GlobalOpenTelemetry.getTracerProvider())
+        .isSameAs(GlobalOpenTelemetry.getTracerProvider());
+    assertThat(GlobalOpenTelemetry.getMeterProvider().getClass().getSimpleName())
         .isEqualTo("DefaultMeterProvider");
-    assertThat(OpenTelemetry.getGlobalMeterProvider())
-        .isSameAs(OpenTelemetry.getGlobalMeterProvider());
-    assertThat(OpenTelemetry.getGlobalPropagators()).isSameAs(OpenTelemetry.getGlobalPropagators());
+    assertThat(GlobalOpenTelemetry.getMeterProvider())
+        .isSameAs(GlobalOpenTelemetry.getMeterProvider());
+    assertThat(GlobalOpenTelemetry.getPropagators()).isSameAs(GlobalOpenTelemetry.getPropagators());
   }
 
   @Test
@@ -95,9 +95,9 @@ class OpenTelemetryTest {
             SecondTracerProviderFactory.class);
     try {
       assertThat(
-              (OpenTelemetry.getGlobalTracerProvider().get("")
+              (GlobalOpenTelemetry.getTracerProvider().get("")
                       instanceof FirstTracerProviderFactory)
-                  || (OpenTelemetry.getGlobalTracerProvider().get("")
+                  || (GlobalOpenTelemetry.getTracerProvider().get("")
                       instanceof SecondTracerProviderFactory))
           .isTrue();
     } finally {
@@ -115,7 +115,7 @@ class OpenTelemetryTest {
     System.setProperty(
         TracerProviderFactory.class.getName(), SecondTracerProviderFactory.class.getName());
     try {
-      assertThat(OpenTelemetry.getGlobalTracerProvider().get(""))
+      assertThat(GlobalOpenTelemetry.getTracerProvider().get(""))
           .isInstanceOf(SecondTracerProviderFactory.class);
     } finally {
       assertThat(serviceFile.delete()).isTrue();
@@ -125,7 +125,7 @@ class OpenTelemetryTest {
   @Test
   void testTracerNotFound() {
     System.setProperty(TracerProviderFactory.class.getName(), "io.does.not.exists");
-    assertThrows(IllegalStateException.class, () -> OpenTelemetry.getGlobalTracer("testTracer"));
+    assertThrows(IllegalStateException.class, () -> GlobalOpenTelemetry.getTracer("testTracer"));
   }
 
   @Test
@@ -137,11 +137,11 @@ class OpenTelemetryTest {
             SecondMeterProviderFactory.class);
     try {
       assertThat(
-              (OpenTelemetry.getGlobalMeterProvider() instanceof FirstMeterProviderFactory)
-                  || (OpenTelemetry.getGlobalMeterProvider() instanceof SecondMeterProviderFactory))
+              (GlobalOpenTelemetry.getMeterProvider() instanceof FirstMeterProviderFactory)
+                  || (GlobalOpenTelemetry.getMeterProvider() instanceof SecondMeterProviderFactory))
           .isTrue();
-      assertThat(OpenTelemetry.getGlobalMeterProvider())
-          .isEqualTo(OpenTelemetry.getGlobalMeterProvider());
+      assertThat(GlobalOpenTelemetry.getMeterProvider())
+          .isEqualTo(GlobalOpenTelemetry.getMeterProvider());
     } finally {
       assertThat(serviceFile.delete()).isTrue();
     }
@@ -157,10 +157,10 @@ class OpenTelemetryTest {
     System.setProperty(
         MeterProviderFactory.class.getName(), SecondMeterProviderFactory.class.getName());
     try {
-      assertThat(OpenTelemetry.getGlobalMeterProvider())
+      assertThat(GlobalOpenTelemetry.getMeterProvider())
           .isInstanceOf(SecondMeterProviderFactory.class);
-      assertThat(OpenTelemetry.getGlobalMeterProvider())
-          .isEqualTo(OpenTelemetry.getGlobalMeterProvider());
+      assertThat(GlobalOpenTelemetry.getMeterProvider())
+          .isEqualTo(GlobalOpenTelemetry.getMeterProvider());
     } finally {
       assertThat(serviceFile.delete()).isTrue();
     }
@@ -169,14 +169,14 @@ class OpenTelemetryTest {
   @Test
   void testMeterNotFound() {
     System.setProperty(MeterProviderFactory.class.getName(), "io.does.not.exists");
-    assertThrows(IllegalStateException.class, OpenTelemetry::getGlobalMeterProvider);
+    assertThrows(IllegalStateException.class, GlobalOpenTelemetry::getMeterProvider);
   }
 
   @Test
   void testGlobalPropagatorsSet() {
     ContextPropagators propagators = ContextPropagators.noop();
-    OpenTelemetry.setGlobalPropagators(propagators);
-    assertThat(OpenTelemetry.getGlobalPropagators()).isEqualTo(propagators);
+    GlobalOpenTelemetry.setPropagators(propagators);
+    assertThat(GlobalOpenTelemetry.getPropagators()).isEqualTo(propagators);
   }
 
   @Test
@@ -238,7 +238,7 @@ class OpenTelemetryTest {
 
   @Test
   void testPropagatorsSetNull() {
-    assertThrows(NullPointerException.class, () -> OpenTelemetry.setGlobalPropagators(null));
+    assertThrows(NullPointerException.class, () -> GlobalOpenTelemetry.setPropagators(null));
   }
 
   private static File createService(Class<?> service, Class<?>... impls) throws IOException {

--- a/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftIntegrationTest.java
+++ b/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftIntegrationTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.exporter.jaeger.thrift;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -36,7 +36,7 @@ class JaegerThriftIntegrationTest {
   private static final String JAEGER_VERSION = "1.17";
   private static final String SERVICE_NAME = "E2E-test";
   private static final String JAEGER_URL = "http://localhost";
-  private final Tracer tracer = OpenTelemetry.getGlobalTracer(getClass().getCanonicalName());
+  private final Tracer tracer = GlobalOpenTelemetry.getTracer(getClass().getCanonicalName());
 
   @Container
   public static GenericContainer<?> jaegerContainer =

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerIntegrationTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerIntegrationTest.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -36,7 +36,7 @@ class JaegerIntegrationTest {
   private static final int COLLECTOR_PORT = 14250;
   private static final String SERVICE_NAME = "E2E-test";
   private static final String JAEGER_URL = "http://localhost";
-  private final Tracer tracer = OpenTelemetry.getGlobalTracer(getClass().getCanonicalName());
+  private final Tracer tracer = GlobalOpenTelemetry.getTracer(getClass().getCanonicalName());
 
   @Container
   public static GenericContainer<?> jaegerContainer =

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporter/otlp/OtlpGrpcSpanExporter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporter/otlp/OtlpGrpcSpanExporter.java
@@ -10,7 +10,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
@@ -78,12 +78,12 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
   private final long deadlineMs;
 
   private final LongCounter spansSeen =
-      OpenTelemetry.getGlobalMeter("io.opentelemetry.exporters.otlp")
+      GlobalOpenTelemetry.getMeter("io.opentelemetry.exporters.otlp")
           .longCounterBuilder("spansSeenByExporter")
           .build();
 
   private final LongCounter spansExported =
-      OpenTelemetry.getGlobalMeter("io.opentelemetry.exporters.otlp")
+      GlobalOpenTelemetry.getMeter("io.opentelemetry.exporters.otlp")
           .longCounterBuilder("spansExportedByExporter")
           .build();
 

--- a/extensions/kotlin/src/test/kotlin/io/opentelemetry/extension/kotlin/KotlinCoroutinesTest.kt
+++ b/extensions/kotlin/src/test/kotlin/io/opentelemetry/extension/kotlin/KotlinCoroutinesTest.kt
@@ -1,6 +1,6 @@
 package io.opentelemetry.extension.kotlin
 
-import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.ContextKey
@@ -37,7 +37,7 @@ class KotlinCoroutinesTest {
 
     @Test
     fun runWithSpan() {
-        val span = OpenTelemetry.getGlobalTracer("test").spanBuilder("test").startSpan()
+        val span = GlobalOpenTelemetry.getTracer("test").spanBuilder("test").startSpan()
         assertThat(Span.current()).isEqualTo(Span.getInvalid())
         runBlocking(Dispatchers.Default + span.asContextElement()) {
             assertThat(Span.current()).isEqualTo(span)

--- a/integration-tests/src/main/java/io/opentelemetry/SendTraceToJaeger.java
+++ b/integration-tests/src/main/java/io/opentelemetry/SendTraceToJaeger.java
@@ -7,7 +7,7 @@ package io.opentelemetry;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter;
@@ -20,7 +20,7 @@ public class SendTraceToJaeger {
   private final int port; // = 14250;
 
   // OTel API
-  private final Tracer tracer = OpenTelemetry.getGlobalTracer("io.opentelemetry.SendTraceToJaeger");
+  private final Tracer tracer = GlobalOpenTelemetry.getTracer("io.opentelemetry.SendTraceToJaeger");
 
   public SendTraceToJaeger(String ip, int port) {
     this.ip = ip;

--- a/integration-tests/tracecontext/src/main/java/io/opentelemetry/Application.java
+++ b/integration-tests/tracecontext/src/main/java/io/opentelemetry/Application.java
@@ -6,6 +6,7 @@
 package io.opentelemetry;
 
 import com.google.gson.Gson;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
@@ -33,9 +34,9 @@ public class Application {
   private static final OpenTelemetry openTelemetry;
 
   static {
-    OpenTelemetry.setGlobalPropagators(
+    GlobalOpenTelemetry.setPropagators(
         ContextPropagators.create(W3CTraceContextPropagator.getInstance()));
-    openTelemetry = OpenTelemetry.get();
+    openTelemetry = GlobalOpenTelemetry.get();
   }
 
   private Application() {}

--- a/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/SpanConverter.java
+++ b/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/SpanConverter.java
@@ -18,7 +18,7 @@ import io.opencensus.trace.TraceOptions;
 import io.opencensus.trace.Tracestate;
 import io.opencensus.trace.export.SpanData;
 import io.opencensus.trace.export.SpanData.TimedEvent;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -70,7 +70,7 @@ class SpanConverter {
       "message.event.size.compressed";
 
   private static final Tracer TRACER =
-      OpenTelemetry.getGlobalTracer("io.opencensus.opentelemetry.migration");
+      GlobalOpenTelemetry.getTracer("io.opencensus.opentelemetry.migration");
 
   private SpanConverter() {}
 

--- a/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/TraceInteroperabilityTest.java
+++ b/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/TraceInteroperabilityTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.when;
 
 import io.opencensus.trace.Tracing;
 import io.opencensus.trace.samplers.Samplers;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
@@ -51,7 +51,7 @@ class TraceInteroperabilityTest {
 
   @Test
   void testParentChildRelationshipsAreExportedCorrectly() {
-    Tracer tracer = OpenTelemetry.getGlobalTracer("io.opentelemetry.test.scoped.span.1");
+    Tracer tracer = GlobalOpenTelemetry.getTracer("io.opentelemetry.test.scoped.span.1");
     Span span = tracer.spanBuilder("OpenTelemetrySpan").startSpan();
     try (Scope scope = Context.current().with(span).makeCurrent()) {
       span.addEvent("OpenTelemetry: Event 1");
@@ -179,7 +179,7 @@ class TraceInteroperabilityTest {
   }
 
   private static void createOpenTelemetryScopedSpan() {
-    Tracer tracer = OpenTelemetry.getGlobalTracer("io.opentelemetry.test.scoped.span.2");
+    Tracer tracer = GlobalOpenTelemetry.getTracer("io.opentelemetry.test.scoped.span.2");
     Span span = tracer.spanBuilder("OpenTelemetrySpan2").startSpan();
     try (Scope scope = Context.current().with(span).makeCurrent()) {
       span.addEvent("OpenTelemetry2: Event 1");

--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/OpenTracingShim.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/OpenTracingShim.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.opentracingshim;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
@@ -17,16 +18,16 @@ public final class OpenTracingShim {
   private OpenTracingShim() {}
 
   /**
-   * Creates a {@code io.opentracing.Tracer} shim out of {@code
-   * OpenTelemetry.getGlobalTracerProvider()} and {@code OpenTelemetry.getGlobalPropagators()}.
+   * Creates a {@code io.opentracing.Tracer} shim out of {@code OpenTelemetry.getTracerProvider()}
+   * and {@code OpenTelemetry.getPropagators()}.
    *
    * @return a {@code io.opentracing.Tracer}.
    */
   public static io.opentracing.Tracer createTracerShim() {
     return new TracerShim(
         new TelemetryInfo(
-            getTracer(OpenTelemetry.getGlobalTracerProvider()),
-            OpenTelemetry.getGlobalPropagators()));
+            getTracer(GlobalOpenTelemetry.getTracerProvider()),
+            GlobalOpenTelemetry.getPropagators()));
   }
 
   /**

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/OpenTracingShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/OpenTracingShimTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -19,7 +20,7 @@ class OpenTracingShimTest {
   @Test
   void createTracerShim_default() {
     TracerShim tracerShim = (TracerShim) OpenTracingShim.createTracerShim();
-    assertThat(tracerShim.tracer()).isEqualTo(OpenTelemetry.getGlobalTracer("opentracingshim"));
+    assertThat(tracerShim.tracer()).isEqualTo(GlobalOpenTelemetry.getTracer("opentracingshim"));
   }
 
   @Test

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanBuilderShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanBuilderShimTest.java
@@ -8,7 +8,7 @@ package io.opentelemetry.opentracingshim;
 import static io.opentelemetry.opentracingshim.TestUtils.getBaggageMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import org.junit.jupiter.api.Test;
@@ -18,7 +18,7 @@ class SpanBuilderShimTest {
   private final SdkTracerProvider tracerSdkFactory = SdkTracerProvider.builder().build();
   private final Tracer tracer = tracerSdkFactory.get("SpanShimTest");
   private final TelemetryInfo telemetryInfo =
-      new TelemetryInfo(tracer, OpenTelemetry.getGlobalPropagators());
+      new TelemetryInfo(tracer, GlobalOpenTelemetry.getPropagators());
 
   private static final String SPAN_NAME = "Span";
 

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
@@ -8,7 +8,7 @@ package io.opentelemetry.opentracingshim;
 import static io.opentelemetry.opentracingshim.TestUtils.getBaggageMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -22,7 +22,7 @@ class SpanShimTest {
   private final SdkTracerProvider tracerSdkFactory = SdkTracerProvider.builder().build();
   private final Tracer tracer = tracerSdkFactory.get("SpanShimTest");
   private final TelemetryInfo telemetryInfo =
-      new TelemetryInfo(tracer, OpenTelemetry.getGlobalPropagators());
+      new TelemetryInfo(tracer, GlobalOpenTelemetry.getPropagators());
   private Span span;
 
   private static final String SPAN_NAME = "Span";

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/TracerShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/TracerShimTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.opentracingshim;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
@@ -33,8 +33,8 @@ class TracerShimTest {
     tracerShim =
         new TracerShim(
             new TelemetryInfo(
-                OpenTelemetry.getGlobalTracer("opentracingshim"),
-                OpenTelemetry.getGlobalPropagators()));
+                GlobalOpenTelemetry.getTracer("opentracingshim"),
+                GlobalOpenTelemetry.getPropagators()));
   }
 
   @Test

--- a/perf-harness/src/test/java/io/opentelemetry/perf/OtlpPipelineStressTest.java
+++ b/perf-harness/src/test/java/io/opentelemetry/perf/OtlpPipelineStressTest.java
@@ -10,7 +10,7 @@ import eu.rekawek.toxiproxy.ToxiproxyClient;
 import eu.rekawek.toxiproxy.model.ToxicDirection;
 import eu.rekawek.toxiproxy.model.ToxicList;
 import eu.rekawek.toxiproxy.model.toxic.Timeout;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
@@ -203,7 +203,7 @@ public class OtlpPipelineStressTest {
 
   private static void runOnce(Integer numberOfSpans, int numberOfMillisToRunFor)
       throws InterruptedException {
-    Tracer tracer = OpenTelemetry.getGlobalTracer("io.opentelemetry.perf");
+    Tracer tracer = GlobalOpenTelemetry.getTracer("io.opentelemetry.perf");
     long start = System.currentTimeMillis();
     int i = 0;
     while (numberOfSpans == null

--- a/sdk-extensions/jfr-events/src/test/java/io/opentelemetry/sdk/extension/jfr/JfrSpanProcessorTest.java
+++ b/sdk-extensions/jfr-events/src/test/java/io/opentelemetry/sdk/extension/jfr/JfrSpanProcessorTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.extension.jfr;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.ContextStorage;
@@ -34,7 +34,7 @@ class JfrSpanProcessorTest {
 
   /** Simple test to validate JFR events for Span and Scope. */
   public JfrSpanProcessorTest() {
-    tracer = OpenTelemetry.getGlobalTracer("JfrSpanProcessorTest");
+    tracer = GlobalOpenTelemetry.getTracer("JfrSpanProcessorTest");
   }
 
   /**

--- a/sdk-extensions/logging/src/main/java/io/opentelemetry/sdk/logging/export/BatchLogProcessor.java
+++ b/sdk-extensions/logging/src/main/java/io/opentelemetry/sdk/logging/export/BatchLogProcessor.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.sdk.logging.export;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.internal.Utils;
 import io.opentelemetry.api.metrics.LongCounter;
@@ -70,7 +70,7 @@ public class BatchLogProcessor implements LogProcessor {
 
   private static class Worker implements Runnable {
     static {
-      Meter meter = OpenTelemetry.getGlobalMeter("io.opentelemetry.sdk.logging");
+      Meter meter = GlobalOpenTelemetry.getMeter("io.opentelemetry.sdk.logging");
       LongCounter logRecordsProcessed =
           meter
               .longCounterBuilder("logRecordsProcessed")

--- a/sdk-extensions/zpages/src/jmh/java/io/opentelemetry/sdk/extension/zpages/TracezDataAggregatorBenchmark.java
+++ b/sdk-extensions/zpages/src/jmh/java/io/opentelemetry/sdk/extension/zpages/TracezDataAggregatorBenchmark.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.sdk.extension.zpages;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
@@ -30,7 +30,7 @@ public class TracezDataAggregatorBenchmark {
   private static final String runningSpan = "RUNNING_SPAN";
   private static final String latencySpan = "LATENCY_SPAN";
   private static final String errorSpan = "ERROR_SPAN";
-  private final Tracer tracer = OpenTelemetry.getGlobalTracer("TracezDataAggregatorBenchmark");
+  private final Tracer tracer = GlobalOpenTelemetry.getTracer("TracezDataAggregatorBenchmark");
   private final TracezSpanProcessor spanProcessor = TracezSpanProcessor.builder().build();
   private final TracezDataAggregator dataAggregator = new TracezDataAggregator(spanProcessor);
 

--- a/sdk-extensions/zpages/src/jmh/java/io/opentelemetry/sdk/extension/zpages/TracezSpanBucketsBenchmark.java
+++ b/sdk-extensions/zpages/src/jmh/java/io/opentelemetry/sdk/extension/zpages/TracezSpanBucketsBenchmark.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.sdk.extension.zpages;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.trace.ReadableSpan;
@@ -32,7 +32,7 @@ public class TracezSpanBucketsBenchmark {
   @Setup(Level.Trial)
   public final void setup() {
     bucket = new TracezSpanBuckets();
-    Tracer tracer = OpenTelemetry.getGlobalTracer("TracezZPageBenchmark");
+    Tracer tracer = GlobalOpenTelemetry.getTracer("TracezZPageBenchmark");
     Span span = tracer.spanBuilder(spanName).startSpan();
     span.end();
     readableSpan = (ReadableSpan) span;

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanAttributeTruncateBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanAttributeTruncateBenchmark.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.sdk.trace;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span.Kind;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -26,7 +26,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @State(Scope.Benchmark)
 public class SpanAttributeTruncateBenchmark {
 
-  private final Tracer tracerSdk = OpenTelemetry.getGlobalTracer("benchmarkTracer");
+  private final Tracer tracerSdk = GlobalOpenTelemetry.getTracer("benchmarkTracer");
   private SdkSpanBuilder sdkSpanBuilder;
 
   public final String shortValue = "short";

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBenchmark.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.trace.export;
 
 import com.google.common.collect.ImmutableList;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.common.CompletableResultCode;
@@ -79,7 +79,7 @@ public class BatchSpanProcessorBenchmark {
     processor = BatchSpanProcessor.builder(exporter).build();
 
     ImmutableList.Builder<Span> spans = ImmutableList.builderWithExpectedSize(spanCount);
-    Tracer tracer = OpenTelemetry.getGlobalTracerProvider().get("benchmarkTracer");
+    Tracer tracer = GlobalOpenTelemetry.getTracerProvider().get("benchmarkTracer");
     for (int i = 0; i < spanCount; i++) {
       spans.add(tracer.spanBuilder("span").startSpan());
     }

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorDroppedSpansBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorDroppedSpansBenchmark.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.sdk.trace.export;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.common.CompletableResultCode;
@@ -65,7 +65,7 @@ public class BatchSpanProcessorDroppedSpansBenchmark {
       SpanExporter exporter = new DelayingSpanExporter();
       processor = BatchSpanProcessor.builder(exporter).build();
 
-      tracer = OpenTelemetry.getGlobalTracerProvider().get("benchmarkTracer");
+      tracer = GlobalOpenTelemetry.getTracerProvider().get("benchmarkTracer");
     }
 
     @TearDown(Level.Trial)

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorFlushBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorFlushBenchmark.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.trace.export;
 
 import com.google.common.collect.ImmutableList;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.common.CompletableResultCode;
@@ -79,7 +79,7 @@ public class BatchSpanProcessorFlushBenchmark {
     processor = BatchSpanProcessor.builder(exporter).build();
 
     ImmutableList.Builder<Span> spans = ImmutableList.builderWithExpectedSize(spanCount);
-    Tracer tracer = OpenTelemetry.getGlobalTracerProvider().get("benchmarkTracer");
+    Tracer tracer = GlobalOpenTelemetry.getTracerProvider().get("benchmarkTracer");
     for (int i = 0; i < spanCount; i++) {
       spans.add(tracer.spanBuilder("span").startSpan());
     }

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -9,6 +9,7 @@ import static java.util.Objects.requireNonNull;
 
 import io.opentelemetry.api.DefaultOpenTelemetry;
 import io.opentelemetry.api.DefaultOpenTelemetryBuilder;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.trace.Tracer;
@@ -42,12 +43,12 @@ public final class OpenTelemetrySdk extends DefaultOpenTelemetry {
 
   /** Returns the global {@link OpenTelemetrySdk}. */
   public static OpenTelemetrySdk get() {
-    return (OpenTelemetrySdk) OpenTelemetry.get();
+    return (OpenTelemetrySdk) GlobalOpenTelemetry.get();
   }
 
   /** Returns the global {@link SdkTracerManagement}. */
   public static SdkTracerManagement getGlobalTracerManagement() {
-    TracerProvider tracerProvider = OpenTelemetry.get().getTracerProvider();
+    TracerProvider tracerProvider = GlobalOpenTelemetry.get().getTracerProvider();
     if (!(tracerProvider instanceof ObfuscatedTracerProvider)) {
       throw new IllegalStateException(
           "Trying to access global TracerSdkManagement but global TracerProvider is not an "
@@ -58,7 +59,7 @@ public final class OpenTelemetrySdk extends DefaultOpenTelemetry {
 
   /** Returns the global {@link MeterSdkProvider}. */
   public static MeterSdkProvider getGlobalMeterProvider() {
-    return (MeterSdkProvider) OpenTelemetry.get().getMeterProvider();
+    return (MeterSdkProvider) GlobalOpenTelemetry.get().getMeterProvider();
   }
 
   private static final AtomicBoolean INITIALIZED_GLOBAL = new AtomicBoolean();
@@ -230,7 +231,7 @@ public final class OpenTelemetrySdk extends DefaultOpenTelemetry {
               resource == null ? Resource.getDefault() : resource);
       // Automatically initialize global OpenTelemetry with the first SDK we build.
       if (INITIALIZED_GLOBAL.compareAndSet(/* expectedValue= */ false, /* newValue= */ true)) {
-        OpenTelemetry.set(sdk);
+        GlobalOpenTelemetry.set(sdk);
       }
       return sdk;
     }

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import io.opentelemetry.api.DefaultOpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.MeterProvider;
@@ -48,41 +49,42 @@ class OpenTelemetrySdkTest {
 
   @Test
   void testGetGlobal() {
-    assertThat(OpenTelemetrySdk.get()).isSameAs(OpenTelemetry.get());
+    assertThat(OpenTelemetrySdk.get()).isSameAs(GlobalOpenTelemetry.get());
   }
 
   @Test
   void testGetTracerManagementWhenNotTracerSdk() {
-    OpenTelemetry previous = OpenTelemetry.get();
+    OpenTelemetry previous = GlobalOpenTelemetry.get();
     assertThatCode(OpenTelemetrySdk::getGlobalTracerManagement).doesNotThrowAnyException();
     try {
-      OpenTelemetry.set(DefaultOpenTelemetry.builder().setTracerProvider(tracerProvider).build());
+      GlobalOpenTelemetry.set(
+          DefaultOpenTelemetry.builder().setTracerProvider(tracerProvider).build());
       assertThatThrownBy(OpenTelemetrySdk::getGlobalTracerManagement)
           .isInstanceOf(IllegalStateException.class);
     } finally {
-      OpenTelemetry.set(previous);
+      GlobalOpenTelemetry.set(previous);
     }
   }
 
   @Test
   void testGlobalDefault() {
     assertThat(((SdkTracerProvider) OpenTelemetrySdk.getGlobalTracerManagement()).get(""))
-        .isSameAs(OpenTelemetry.getGlobalTracerProvider().get(""));
+        .isSameAs(GlobalOpenTelemetry.getTracerProvider().get(""));
     assertThat(OpenTelemetrySdk.getGlobalMeterProvider())
-        .isSameAs(OpenTelemetry.getGlobalMeterProvider());
+        .isSameAs(GlobalOpenTelemetry.getMeterProvider());
     assertThat(OpenTelemetrySdk.getGlobalTracerManagement()).isNotNull();
   }
 
   @Test
   void testShortcutVersions() {
-    assertThat(OpenTelemetry.getGlobalTracer("testTracer1"))
-        .isEqualTo(OpenTelemetry.getGlobalTracerProvider().get("testTracer1"));
-    assertThat(OpenTelemetry.getGlobalTracer("testTracer2", "testVersion"))
-        .isEqualTo(OpenTelemetry.getGlobalTracerProvider().get("testTracer2", "testVersion"));
-    assertThat(OpenTelemetry.getGlobalMeter("testMeter1"))
-        .isEqualTo(OpenTelemetry.getGlobalMeterProvider().get("testMeter1"));
-    assertThat(OpenTelemetry.getGlobalMeter("testMeter2", "testVersion"))
-        .isEqualTo(OpenTelemetry.getGlobalMeterProvider().get("testMeter2", "testVersion"));
+    assertThat(GlobalOpenTelemetry.getTracer("testTracer1"))
+        .isEqualTo(GlobalOpenTelemetry.getTracerProvider().get("testTracer1"));
+    assertThat(GlobalOpenTelemetry.getTracer("testTracer2", "testVersion"))
+        .isEqualTo(GlobalOpenTelemetry.getTracerProvider().get("testTracer2", "testVersion"));
+    assertThat(GlobalOpenTelemetry.getMeter("testMeter1"))
+        .isEqualTo(GlobalOpenTelemetry.getMeterProvider().get("testMeter1"));
+    assertThat(GlobalOpenTelemetry.getMeter("testMeter2", "testVersion"))
+        .isEqualTo(GlobalOpenTelemetry.getMeterProvider().get("testMeter2", "testVersion"));
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/spi/MeterProviderFactorySdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/spi/MeterProviderFactorySdkTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.metrics.spi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.sdk.metrics.MeterSdkProvider;
 import org.junit.jupiter.api.Test;
 
@@ -15,6 +15,6 @@ import org.junit.jupiter.api.Test;
 class MeterProviderFactorySdkTest {
   @Test
   void testDefault() {
-    assertThat(OpenTelemetry.getGlobalMeterProvider()).isInstanceOf(MeterSdkProvider.class);
+    assertThat(GlobalOpenTelemetry.getMeterProvider()).isInstanceOf(MeterSdkProvider.class);
   }
 }

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/exporter/InMemoryMetricExporter.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/exporter/InMemoryMetricExporter.java
@@ -27,7 +27,7 @@ import java.util.concurrent.LinkedBlockingQueue;
  *
  *   // creating InMemoryMetricExporter
  *   private final InMemoryMetricExporter exporter = InMemoryMetricExporter.create();
- *   private final MeterSdkProvider meterSdkProvider = OpenTelemetrySdk.getGlobalMeterProvider();
+ *   private final MeterSdkProvider meterSdkProvider = OpenTelemetrySdk.getMeterProvider();
  *   private final Meter meter = meterSdkProvider.get("InMemoryMetricExporterExample");
  *   private IntervalMetricReader intervalMetricReader;
  *

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/junit4/OpenTelemetryRule.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/junit4/OpenTelemetryRule.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.testing.junit4;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
@@ -97,13 +98,13 @@ public class OpenTelemetryRule extends ExternalResource {
 
   @Override
   protected void before() throws Throwable {
-    previousGlobalOpenTelemetry = OpenTelemetry.get();
-    OpenTelemetry.set(openTelemetry);
+    previousGlobalOpenTelemetry = GlobalOpenTelemetry.get();
+    GlobalOpenTelemetry.set(openTelemetry);
     clearSpans();
   }
 
   @Override
   protected void after() {
-    OpenTelemetry.set(previousGlobalOpenTelemetry);
+    GlobalOpenTelemetry.set(previousGlobalOpenTelemetry);
   }
 }

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtension.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtension.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.testing.junit5;
 
 import static io.opentelemetry.sdk.testing.assertj.TracesAssert.assertThat;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
@@ -125,12 +126,12 @@ public class OpenTelemetryExtension
 
   @Override
   public void beforeAll(ExtensionContext context) {
-    previousGlobalOpenTelemetry = OpenTelemetry.get();
-    OpenTelemetry.set(openTelemetry);
+    previousGlobalOpenTelemetry = GlobalOpenTelemetry.get();
+    GlobalOpenTelemetry.set(openTelemetry);
   }
 
   @Override
   public void afterAll(ExtensionContext context) {
-    OpenTelemetry.set(previousGlobalOpenTelemetry);
+    GlobalOpenTelemetry.set(previousGlobalOpenTelemetry);
   }
 }

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit4/OpenTelemetryRuleTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit4/OpenTelemetryRuleTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.testing.junit4;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import org.junit.AfterClass;
@@ -24,12 +25,12 @@ public class OpenTelemetryRuleTest {
   // Class callbacks happen outside the rule so we can verify the restoration behavior in them.
   @BeforeClass
   public static void beforeTest() {
-    openTelemetryBeforeTest = OpenTelemetry.get();
+    openTelemetryBeforeTest = GlobalOpenTelemetry.get();
   }
 
   @AfterClass
   public static void afterTest() {
-    assertThat(OpenTelemetry.get()).isSameAs(openTelemetryBeforeTest);
+    assertThat(GlobalOpenTelemetry.get()).isSameAs(openTelemetryBeforeTest);
   }
 
   private Tracer tracer;

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.testing.junit5;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
@@ -30,12 +31,12 @@ class OpenTelemetryExtensionTest {
   // Class callbacks happen outside the rule so we can verify the restoration behavior in them.
   @BeforeAll
   public static void beforeTest() {
-    openTelemetryBeforeTest = OpenTelemetry.get();
+    openTelemetryBeforeTest = GlobalOpenTelemetry.get();
   }
 
   @AfterAll
   public static void afterTest() {
-    assertThat(OpenTelemetry.get()).isSameAs(openTelemetryBeforeTest);
+    assertThat(GlobalOpenTelemetry.get()).isSameAs(openTelemetryBeforeTest);
   }
 
   private final Tracer tracer = otelTesting.getOpenTelemetry().getTracer("test");

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.sdk.trace.export;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongCounter.BoundLongCounter;
@@ -169,7 +169,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
       this.maxExportBatchSize = maxExportBatchSize;
       this.exporterTimeoutMillis = exporterTimeoutMillis;
       this.queue = queue;
-      Meter meter = OpenTelemetry.getGlobalMeter("io.opentelemetry.sdk.trace");
+      Meter meter = GlobalOpenTelemetry.getMeter("io.opentelemetry.sdk.trace");
       meter
           .longValueObserverBuilder("queueSize")
           .setDescription("The number of spans queued")

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/spi/TracerProviderFactorySdkTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/spi/TracerProviderFactorySdkTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.trace.spi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import org.junit.jupiter.api.Test;
@@ -18,6 +18,6 @@ class TracerProviderFactorySdkTest {
   @Test
   void testDefault() {
     Tracer tracerSdk = SdkTracerProvider.builder().build().get("");
-    assertThat(OpenTelemetry.getGlobalTracerProvider().get("")).isInstanceOf(tracerSdk.getClass());
+    assertThat(GlobalOpenTelemetry.getTracerProvider().get("")).isInstanceOf(tracerSdk.getClass());
   }
 }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/testbed/clientserver/Client.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/testbed/clientserver/Client.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.sdk.trace.testbed.clientserver;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Span.Kind;
 import io.opentelemetry.api.trace.Tracer;
@@ -30,7 +30,7 @@ final class Client {
     span.setAttribute("component", "example-client");
 
     try (Scope ignored = span.makeCurrent()) {
-      OpenTelemetry.getGlobalPropagators()
+      GlobalOpenTelemetry.getPropagators()
           .getTextMapPropagator()
           .inject(Context.current(), message, Message::put);
       queue.put(message);

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/testbed/clientserver/Server.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/testbed/clientserver/Server.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.sdk.trace.testbed.clientserver;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Span.Kind;
 import io.opentelemetry.api.trace.Tracer;
@@ -27,7 +27,7 @@ final class Server extends Thread {
 
   private void process(Message message) {
     Context context =
-        OpenTelemetry.getGlobalPropagators()
+        GlobalOpenTelemetry.getPropagators()
             .getTextMapPropagator()
             .extract(
                 Context.current(),


### PR DESCRIPTION
This ensure clear separation of functionality. This PR does not change any functionality, it just restructures the code to separate global functionality from
the Default implementation. Also helps to ensure that Global initialization does not happen by mistake when working only with the default implementation.

Also it helps with methods like `OpenTelemetry.get()` and `OpenTelemetry.set()` to understand they are interacting with global instance

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>