### PR TITLE
Revert "Explicitly bump CI to Java 8.0.275."

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -26,7 +26,8 @@ jobs:
         name: Setup Java 8
         uses: actions/setup-java@v1
         with:
-          java-version: 8.0.275
+          java-version: 8
+          java-package: jre
       - id: setup-java-11
         name: Setup Java 11
         uses: actions/setup-java@v1

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -26,7 +26,8 @@ jobs:
         name: Setup Java 8
         uses: actions/setup-java@v1
         with:
-          java-version: 8.0.275
+          java-version: 8
+          java-package: jre
       - id: setup-java-11
         name: Setup Java 11
         uses: actions/setup-java@v1


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-java#2072

Fixes https://github.com/open-telemetry/opentelemetry-java/issues/2073