### PR TITLE
Remove unnecessary setPropagators from OpenTelemetry interface

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/DefaultOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/DefaultOpenTelemetry.java
@@ -28,10 +28,10 @@ public class DefaultOpenTelemetry implements OpenTelemetry {
 
   private final TracerProvider tracerProvider;
   private final MeterProvider meterProvider;
-
   private volatile ContextPropagators propagators;
 
   @Override
+  @Deprecated
   public void setPropagators(ContextPropagators propagators) {
     this.propagators = propagators;
   }

--- a/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
@@ -158,7 +158,10 @@ public final class GlobalOpenTelemetry {
 
   /**
    * Sets the globally registered {@link ContextPropagators} for remote propagation of a context.
+   *
+   * @deprecated this will be removed soon, create a new instance if necessary.
    */
+  @Deprecated
   public static void setPropagators(ContextPropagators propagators) {
     requireNonNull(propagators, "propagators");
     get().setPropagators(propagators);

--- a/api/all/src/main/java/io/opentelemetry/api/OpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/OpenTelemetry.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.api;
 
-import static java.util.Objects.requireNonNull;
-
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.trace.Tracer;
@@ -15,6 +13,7 @@ import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.spi.OpenTelemetryFactory;
 import io.opentelemetry.spi.metrics.MeterProviderFactory;
 import io.opentelemetry.spi.trace.TracerProviderFactory;
+import java.util.Objects;
 
 /**
  * The entrypoint to telemetry functionality for tracing, metrics and baggage.
@@ -130,15 +129,20 @@ public interface OpenTelemetry {
   /**
    * Sets the globally registered {@link ContextPropagators} for remote propagation of a context.
    *
-   * @deprecated use {@link GlobalOpenTelemetry#setPropagators(ContextPropagators)}
+   * @deprecated this will be removed soon, create a new instance if necessary.
    */
   @Deprecated
   static void setGlobalPropagators(ContextPropagators propagators) {
-    requireNonNull(propagators, "propagators");
+    Objects.requireNonNull(propagators, "propagators");
     get().setPropagators(propagators);
   }
 
-  /** Sets the propagators that this instance should contain. */
+  /**
+   * Sets the propagators that this instance should contain.
+   *
+   * @deprecated this will be removed soon, create a new instance if necessary.
+   */
+  @Deprecated
   void setPropagators(ContextPropagators propagators);
 
   /** Returns the {@link TracerProvider} for this {@link OpenTelemetry}. */

--- a/api/all/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
@@ -173,6 +173,7 @@ class OpenTelemetryTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation") // tested deprecated code
   void testGlobalPropagatorsSet() {
     ContextPropagators propagators = ContextPropagators.noop();
     GlobalOpenTelemetry.setPropagators(propagators);
@@ -180,6 +181,7 @@ class OpenTelemetryTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation") // tested deprecated code
   void testPropagatorsSet() {
     ContextPropagators propagators = ContextPropagators.noop();
     OpenTelemetry instance = DefaultOpenTelemetry.builder().build();
@@ -237,6 +239,7 @@ class OpenTelemetryTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation") // tested deprecated code
   void testPropagatorsSetNull() {
     assertThrows(NullPointerException.class, () -> GlobalOpenTelemetry.setPropagators(null));
   }

--- a/integration-tests/tracecontext/src/main/java/io/opentelemetry/Application.java
+++ b/integration-tests/tracecontext/src/main/java/io/opentelemetry/Application.java
@@ -29,6 +29,7 @@ import spark.Response;
 import spark.Route;
 import spark.Spark;
 
+@SuppressWarnings("deprecation") // using deprecated code in tests
 public class Application {
   private static final Logger logger = Logger.getLogger(Application.class.getName());
   private static final OpenTelemetry openTelemetry;


### PR DESCRIPTION
Example usage in the `Application.java`.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>