### PR TITLE
Implement more Span default methods.

### DIFF
--- a/api/trace/src/main/java/io/opentelemetry/api/trace/Span.java
+++ b/api/trace/src/main/java/io/opentelemetry/api/trace/Span.java
@@ -200,7 +200,9 @@ public interface Span extends ImplicitContextKeyed {
    * @param name the name of the event.
    * @return this.
    */
-  Span addEvent(String name);
+  default Span addEvent(String name) {
+    return addEvent(name, Attributes.empty());
+  }
 
   /**
    * Adds an event to the {@link Span} with the given {@code timestamp}, as nanos since epoch. Note,
@@ -216,7 +218,9 @@ public interface Span extends ImplicitContextKeyed {
    * @param unit the unit of the timestamp
    * @return this.
    */
-  Span addEvent(String name, long timestamp, TimeUnit unit);
+  default Span addEvent(String name, long timestamp, TimeUnit unit) {
+    return addEvent(name, Attributes.empty(), timestamp, unit);
+  }
 
   /**
    * Adds an event to the {@link Span} with the given {@code timestamp}, as nanos since epoch. Note,
@@ -335,7 +339,9 @@ public interface Span extends ImplicitContextKeyed {
    * @param exception the {@link Throwable} to record.
    * @return this.
    */
-  Span recordException(Throwable exception);
+  default Span recordException(Throwable exception) {
+    return recordException(exception, Attributes.empty());
+  }
 
   /**
    * Records information about the {@link Throwable} to the {@link Span}.

--- a/api/trace/src/main/java/io/opentelemetry/api/trace/Span.java
+++ b/api/trace/src/main/java/io/opentelemetry/api/trace/Span.java
@@ -121,7 +121,9 @@ public interface Span extends ImplicitContextKeyed {
    * @param value the value for this attribute.
    * @return this.
    */
-  Span setAttribute(String key, @Nonnull String value);
+  default Span setAttribute(String key, @Nonnull String value) {
+    return setAttribute(AttributeKey.stringKey(key), value);
+  }
 
   /**
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
@@ -134,7 +136,9 @@ public interface Span extends ImplicitContextKeyed {
    * @param value the value for this attribute.
    * @return this.
    */
-  Span setAttribute(String key, long value);
+  default Span setAttribute(String key, long value) {
+    return setAttribute(AttributeKey.longKey(key), value);
+  }
 
   /**
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
@@ -147,7 +151,9 @@ public interface Span extends ImplicitContextKeyed {
    * @param value the value for this attribute.
    * @return this.
    */
-  Span setAttribute(String key, double value);
+  default Span setAttribute(String key, double value) {
+    return setAttribute(AttributeKey.doubleKey(key), value);
+  }
 
   /**
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
@@ -160,7 +166,9 @@ public interface Span extends ImplicitContextKeyed {
    * @param value the value for this attribute.
    * @return this.
    */
-  Span setAttribute(String key, boolean value);
+  default Span setAttribute(String key, boolean value) {
+    return setAttribute(AttributeKey.booleanKey(key), value);
+  }
 
   /**
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
@@ -183,8 +191,7 @@ public interface Span extends ImplicitContextKeyed {
    * @return this.
    */
   default Span setAttribute(AttributeKey<Long> key, int value) {
-    setAttribute(key, (long) value);
-    return this;
+    return setAttribute(key, (long) value);
   }
 
   /**
@@ -299,7 +306,9 @@ public interface Span extends ImplicitContextKeyed {
    * @param statusCode the {@link StatusCode} to set.
    * @return this.
    */
-  Span setStatus(StatusCode statusCode);
+  default Span setStatus(StatusCode statusCode) {
+    return setStatus(statusCode, null);
+  }
 
   /**
    * Sets the status to the {@code Span}.

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -5,11 +5,6 @@
 
 package io.opentelemetry.sdk.trace;
 
-import static io.opentelemetry.api.common.AttributeKey.booleanKey;
-import static io.opentelemetry.api.common.AttributeKey.doubleKey;
-import static io.opentelemetry.api.common.AttributeKey.longKey;
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
-
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -253,30 +248,6 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
   }
 
   @Override
-  public ReadWriteSpan setAttribute(String key, String value) {
-    setAttribute(stringKey(key), value);
-    return this;
-  }
-
-  @Override
-  public ReadWriteSpan setAttribute(String key, long value) {
-    setAttribute(longKey(key), value);
-    return this;
-  }
-
-  @Override
-  public ReadWriteSpan setAttribute(String key, double value) {
-    setAttribute(doubleKey(key), value);
-    return this;
-  }
-
-  @Override
-  public ReadWriteSpan setAttribute(String key, boolean value) {
-    setAttribute(booleanKey(key), value);
-    return this;
-  }
-
-  @Override
   public <T> ReadWriteSpan setAttribute(AttributeKey<T> key, T value) {
     if (key == null || key.getKey() == null || key.getKey().length() == 0 || value == null) {
       return this;
@@ -376,12 +347,6 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
       }
       totalRecordedEvents++;
     }
-  }
-
-  @Override
-  public ReadWriteSpan setStatus(StatusCode statusCode) {
-    setStatus(statusCode, null);
-    return this;
   }
 
   @Override


### PR DESCRIPTION
I noticed that shims like in https://github.com/open-telemetry/opentelemetry-java/pull/2060 would be easier to write with boring implementations in default methods.