### PR TITLE
remove test dependency on grpc

### DIFF
--- a/exporters/jaeger-thrift/build.gradle
+++ b/exporters/jaeger-thrift/build.gradle
@@ -14,8 +14,7 @@ dependencies {
     implementation project(':opentelemetry-sdk'),
             libraries.jaeger_client
 
-    testImplementation "io.grpc:grpc-testing:${grpcVersion}",
-            'com.fasterxml.jackson.core:jackson-databind',
+    testImplementation 'com.fasterxml.jackson.core:jackson-databind',
             libraries.testcontainers,
             libraries.okhttp
 

--- a/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftSpanExporterTest.java
+++ b/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftSpanExporterTest.java
@@ -8,7 +8,6 @@ package io.opentelemetry.exporter.jaeger.thrift;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
-import com.google.common.collect.Lists;
 import io.jaegertracing.internal.exceptions.SenderException;
 import io.jaegertracing.thrift.internal.senders.ThriftSender;
 import io.jaegertracing.thriftjava.Process;
@@ -29,6 +28,7 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Status;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -170,7 +170,7 @@ class JaegerThriftSpanExporterTest {
             .build();
 
     // test
-    CompletableResultCode result = exporter.export(Lists.newArrayList(span, span2));
+    CompletableResultCode result = exporter.export(Arrays.asList(span, span2));
     result.join(1, TimeUnit.SECONDS);
     assertThat(result.isSuccess()).isEqualTo(true);
 


### PR DESCRIPTION
This removes an unnecessary dependency from `jaeger-thrift` on grpc