### PR TITLE
Remove unused fields from AbstractInstrument

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractAsynchronousInstrument.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractAsynchronousInstrument.java
@@ -18,15 +18,15 @@ abstract class AbstractAsynchronousInstrument<T extends AsynchronousInstrument.R
     extends AbstractInstrument implements AsynchronousInstrument<T> {
   @Nullable private final Callback<T> metricUpdater;
   private final ReentrantLock collectLock = new ReentrantLock();
+  private final InstrumentAccumulator instrumentAccumulator;
 
   AbstractAsynchronousInstrument(
       InstrumentDescriptor descriptor,
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState,
       InstrumentAccumulator instrumentAccumulator,
       @Nullable Callback<T> metricUpdater) {
-    super(descriptor, meterProviderSharedState, meterSharedState, instrumentAccumulator);
+    super(descriptor);
     this.metricUpdater = metricUpdater;
+    this.instrumentAccumulator = instrumentAccumulator;
   }
 
   @Override
@@ -36,7 +36,6 @@ abstract class AbstractAsynchronousInstrument<T extends AsynchronousInstrument.R
     }
     collectLock.lock();
     try {
-      final InstrumentAccumulator instrumentAccumulator = getInstrumentAccumulator();
       metricUpdater.update(newResult(instrumentAccumulator));
       return instrumentAccumulator.completeCollectionCycle();
     } finally {
@@ -61,16 +60,9 @@ abstract class AbstractAsynchronousInstrument<T extends AsynchronousInstrument.R
       extends AbstractAsynchronousInstrument<LongResult> {
     AbstractLongAsynchronousInstrument(
         InstrumentDescriptor descriptor,
-        MeterProviderSharedState meterProviderSharedState,
-        MeterSharedState meterSharedState,
         InstrumentAccumulator instrumentAccumulator,
         @Nullable Callback<LongResult> metricUpdater) {
-      super(
-          descriptor,
-          meterProviderSharedState,
-          meterSharedState,
-          instrumentAccumulator,
-          metricUpdater);
+      super(descriptor, instrumentAccumulator, metricUpdater);
     }
 
     @Override
@@ -99,16 +91,9 @@ abstract class AbstractAsynchronousInstrument<T extends AsynchronousInstrument.R
       extends AbstractAsynchronousInstrument<DoubleResult> {
     AbstractDoubleAsynchronousInstrument(
         InstrumentDescriptor descriptor,
-        MeterProviderSharedState meterProviderSharedState,
-        MeterSharedState meterSharedState,
         InstrumentAccumulator instrumentAccumulator,
         @Nullable Callback<DoubleResult> metricUpdater) {
-      super(
-          descriptor,
-          meterProviderSharedState,
-          meterSharedState,
-          instrumentAccumulator,
-          metricUpdater);
+      super(descriptor, instrumentAccumulator, metricUpdater);
     }
 
     @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
@@ -17,36 +17,14 @@ import java.util.Objects;
 abstract class AbstractInstrument implements Instrument {
 
   private final InstrumentDescriptor descriptor;
-  private final MeterProviderSharedState meterProviderSharedState;
-  private final MeterSharedState meterSharedState;
-  private final InstrumentAccumulator instrumentAccumulator;
 
   // All arguments cannot be null because they are checked in the abstract builder classes.
-  AbstractInstrument(
-      InstrumentDescriptor descriptor,
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState,
-      InstrumentAccumulator instrumentAccumulator) {
+  AbstractInstrument(InstrumentDescriptor descriptor) {
     this.descriptor = descriptor;
-    this.meterProviderSharedState = meterProviderSharedState;
-    this.meterSharedState = meterSharedState;
-    this.instrumentAccumulator = instrumentAccumulator;
   }
 
   final InstrumentDescriptor getDescriptor() {
     return descriptor;
-  }
-
-  final MeterProviderSharedState getMeterProviderSharedState() {
-    return meterProviderSharedState;
-  }
-
-  final MeterSharedState getMeterSharedState() {
-    return meterSharedState;
-  }
-
-  final InstrumentAccumulator getInstrumentAccumulator() {
-    return instrumentAccumulator;
   }
 
   /**
@@ -112,14 +90,6 @@ abstract class AbstractInstrument implements Instrument {
       return getThis();
     }
 
-    final MeterProviderSharedState getMeterProviderSharedState() {
-      return meterProviderSharedState;
-    }
-
-    final MeterSharedState getMeterSharedState() {
-      return meterSharedState;
-    }
-
     final InstrumentDescriptor getInstrumentDescriptor(
         InstrumentType type, InstrumentValueType valueType) {
       return InstrumentDescriptor.create(name, description, unit, type, valueType);
@@ -128,7 +98,7 @@ abstract class AbstractInstrument implements Instrument {
     abstract B getThis();
 
     final <I extends AbstractInstrument> I register(I instrument) {
-      return getMeterSharedState().getInstrumentRegistry().register(instrument);
+      return meterSharedState.getInstrumentRegistry().register(instrument);
     }
 
     protected InstrumentAccumulator getBatcher(InstrumentDescriptor descriptor) {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleCounterSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleCounterSdk.java
@@ -15,11 +15,8 @@ final class DoubleCounterSdk extends AbstractSynchronousInstrument<BoundInstrume
     implements DoubleCounter {
 
   private DoubleCounterSdk(
-      InstrumentDescriptor descriptor,
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState,
-      InstrumentAccumulator instrumentAccumulator) {
-    super(descriptor, meterProviderSharedState, meterSharedState, instrumentAccumulator);
+      InstrumentDescriptor descriptor, InstrumentAccumulator instrumentAccumulator) {
+    super(descriptor, instrumentAccumulator);
   }
 
   @Override
@@ -78,12 +75,7 @@ final class DoubleCounterSdk extends AbstractSynchronousInstrument<BoundInstrume
     public DoubleCounterSdk build() {
       InstrumentDescriptor instrumentDescriptor =
           getInstrumentDescriptor(InstrumentType.COUNTER, InstrumentValueType.DOUBLE);
-      return register(
-          new DoubleCounterSdk(
-              instrumentDescriptor,
-              getMeterProviderSharedState(),
-              getMeterSharedState(),
-              getBatcher(instrumentDescriptor)));
+      return register(new DoubleCounterSdk(instrumentDescriptor, getBatcher(instrumentDescriptor)));
     }
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleSumObserverSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleSumObserverSdk.java
@@ -16,16 +16,9 @@ final class DoubleSumObserverSdk extends AbstractDoubleAsynchronousInstrument
 
   DoubleSumObserverSdk(
       InstrumentDescriptor descriptor,
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState,
       InstrumentAccumulator instrumentAccumulator,
       @Nullable Callback<DoubleResult> metricUpdater) {
-    super(
-        descriptor,
-        meterProviderSharedState,
-        meterSharedState,
-        instrumentAccumulator,
-        metricUpdater);
+    super(descriptor, instrumentAccumulator, metricUpdater);
   }
 
   static final class Builder
@@ -59,11 +52,7 @@ final class DoubleSumObserverSdk extends AbstractDoubleAsynchronousInstrument
           getInstrumentDescriptor(InstrumentType.SUM_OBSERVER, InstrumentValueType.DOUBLE);
       DoubleSumObserverSdk instrument =
           new DoubleSumObserverSdk(
-              instrumentDescriptor,
-              getMeterProviderSharedState(),
-              getMeterSharedState(),
-              getBatcher(instrumentDescriptor),
-              callback);
+              instrumentDescriptor, getBatcher(instrumentDescriptor), callback);
       return register(instrument);
     }
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleUpDownCounterSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleUpDownCounterSdk.java
@@ -15,11 +15,8 @@ final class DoubleUpDownCounterSdk extends AbstractSynchronousInstrument<BoundIn
     implements DoubleUpDownCounter {
 
   private DoubleUpDownCounterSdk(
-      InstrumentDescriptor descriptor,
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState,
-      InstrumentAccumulator instrumentAccumulator) {
-    super(descriptor, meterProviderSharedState, meterSharedState, instrumentAccumulator);
+      InstrumentDescriptor descriptor, InstrumentAccumulator instrumentAccumulator) {
+    super(descriptor, instrumentAccumulator);
   }
 
   @Override
@@ -73,11 +70,7 @@ final class DoubleUpDownCounterSdk extends AbstractSynchronousInstrument<BoundIn
       InstrumentDescriptor instrumentDescriptor =
           getInstrumentDescriptor(InstrumentType.UP_DOWN_COUNTER, InstrumentValueType.DOUBLE);
       return register(
-          new DoubleUpDownCounterSdk(
-              instrumentDescriptor,
-              getMeterProviderSharedState(),
-              getMeterSharedState(),
-              getBatcher(instrumentDescriptor)));
+          new DoubleUpDownCounterSdk(instrumentDescriptor, getBatcher(instrumentDescriptor)));
     }
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleUpDownSumObserverSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleUpDownSumObserverSdk.java
@@ -16,16 +16,9 @@ final class DoubleUpDownSumObserverSdk extends AbstractDoubleAsynchronousInstrum
 
   DoubleUpDownSumObserverSdk(
       InstrumentDescriptor descriptor,
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState,
       InstrumentAccumulator instrumentAccumulator,
       @Nullable Callback<DoubleResult> metricUpdater) {
-    super(
-        descriptor,
-        meterProviderSharedState,
-        meterSharedState,
-        instrumentAccumulator,
-        metricUpdater);
+    super(descriptor, instrumentAccumulator, metricUpdater);
   }
 
   static final class Builder
@@ -59,11 +52,7 @@ final class DoubleUpDownSumObserverSdk extends AbstractDoubleAsynchronousInstrum
           getInstrumentDescriptor(InstrumentType.UP_DOWN_SUM_OBSERVER, InstrumentValueType.DOUBLE);
       DoubleUpDownSumObserverSdk instrument =
           new DoubleUpDownSumObserverSdk(
-              instrumentDescriptor,
-              getMeterProviderSharedState(),
-              getMeterSharedState(),
-              getBatcher(instrumentDescriptor),
-              callback);
+              instrumentDescriptor, getBatcher(instrumentDescriptor), callback);
       return register(instrument);
     }
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleValueObserverSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleValueObserverSdk.java
@@ -16,16 +16,9 @@ final class DoubleValueObserverSdk extends AbstractDoubleAsynchronousInstrument
 
   DoubleValueObserverSdk(
       InstrumentDescriptor descriptor,
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState,
       InstrumentAccumulator instrumentAccumulator,
       @Nullable Callback<DoubleResult> metricUpdater) {
-    super(
-        descriptor,
-        meterProviderSharedState,
-        meterSharedState,
-        instrumentAccumulator,
-        metricUpdater);
+    super(descriptor, instrumentAccumulator, metricUpdater);
   }
 
   static final class Builder
@@ -59,11 +52,7 @@ final class DoubleValueObserverSdk extends AbstractDoubleAsynchronousInstrument
           getInstrumentDescriptor(InstrumentType.VALUE_OBSERVER, InstrumentValueType.DOUBLE);
       DoubleValueObserverSdk instrument =
           new DoubleValueObserverSdk(
-              instrumentDescriptor,
-              getMeterProviderSharedState(),
-              getMeterSharedState(),
-              getBatcher(instrumentDescriptor),
-              callback);
+              instrumentDescriptor, getBatcher(instrumentDescriptor), callback);
       return register(instrument);
     }
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdk.java
@@ -15,11 +15,8 @@ final class DoubleValueRecorderSdk extends AbstractSynchronousInstrument<BoundIn
     implements DoubleValueRecorder {
 
   private DoubleValueRecorderSdk(
-      InstrumentDescriptor descriptor,
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState,
-      InstrumentAccumulator instrumentAccumulator) {
-    super(descriptor, meterProviderSharedState, meterSharedState, instrumentAccumulator);
+      InstrumentDescriptor descriptor, InstrumentAccumulator instrumentAccumulator) {
+    super(descriptor, instrumentAccumulator);
   }
 
   @Override
@@ -73,11 +70,7 @@ final class DoubleValueRecorderSdk extends AbstractSynchronousInstrument<BoundIn
       InstrumentDescriptor instrumentDescriptor =
           getInstrumentDescriptor(InstrumentType.VALUE_RECORDER, InstrumentValueType.DOUBLE);
       return register(
-          new DoubleValueRecorderSdk(
-              instrumentDescriptor,
-              getMeterProviderSharedState(),
-              getMeterSharedState(),
-              getBatcher(instrumentDescriptor)));
+          new DoubleValueRecorderSdk(instrumentDescriptor, getBatcher(instrumentDescriptor)));
     }
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongCounterSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongCounterSdk.java
@@ -15,11 +15,8 @@ final class LongCounterSdk extends AbstractSynchronousInstrument<BoundInstrument
     implements LongCounter {
 
   private LongCounterSdk(
-      InstrumentDescriptor descriptor,
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState,
-      InstrumentAccumulator instrumentAccumulator) {
-    super(descriptor, meterProviderSharedState, meterSharedState, instrumentAccumulator);
+      InstrumentDescriptor descriptor, InstrumentAccumulator instrumentAccumulator) {
+    super(descriptor, instrumentAccumulator);
   }
 
   @Override
@@ -78,12 +75,7 @@ final class LongCounterSdk extends AbstractSynchronousInstrument<BoundInstrument
     public LongCounterSdk build() {
       InstrumentDescriptor instrumentDescriptor =
           getInstrumentDescriptor(InstrumentType.COUNTER, InstrumentValueType.LONG);
-      return register(
-          new LongCounterSdk(
-              instrumentDescriptor,
-              getMeterProviderSharedState(),
-              getMeterSharedState(),
-              getBatcher(instrumentDescriptor)));
+      return register(new LongCounterSdk(instrumentDescriptor, getBatcher(instrumentDescriptor)));
     }
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongSumObserverSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongSumObserverSdk.java
@@ -15,16 +15,9 @@ final class LongSumObserverSdk extends AbstractLongAsynchronousInstrument
     implements LongSumObserver {
   LongSumObserverSdk(
       InstrumentDescriptor descriptor,
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState,
       InstrumentAccumulator instrumentAccumulator,
       @Nullable Callback<LongResult> metricUpdater) {
-    super(
-        descriptor,
-        meterProviderSharedState,
-        meterSharedState,
-        instrumentAccumulator,
-        metricUpdater);
+    super(descriptor, instrumentAccumulator, metricUpdater);
   }
 
   static final class Builder
@@ -57,12 +50,7 @@ final class LongSumObserverSdk extends AbstractLongAsynchronousInstrument
       InstrumentDescriptor instrumentDescriptor =
           getInstrumentDescriptor(InstrumentType.SUM_OBSERVER, InstrumentValueType.LONG);
       LongSumObserverSdk instrument =
-          new LongSumObserverSdk(
-              instrumentDescriptor,
-              getMeterProviderSharedState(),
-              getMeterSharedState(),
-              getBatcher(instrumentDescriptor),
-              callback);
+          new LongSumObserverSdk(instrumentDescriptor, getBatcher(instrumentDescriptor), callback);
       return register(instrument);
     }
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongUpDownCounterSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongUpDownCounterSdk.java
@@ -15,11 +15,8 @@ final class LongUpDownCounterSdk extends AbstractSynchronousInstrument<BoundInst
     implements LongUpDownCounter {
 
   private LongUpDownCounterSdk(
-      InstrumentDescriptor descriptor,
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState,
-      InstrumentAccumulator instrumentAccumulator) {
-    super(descriptor, meterProviderSharedState, meterSharedState, instrumentAccumulator);
+      InstrumentDescriptor descriptor, InstrumentAccumulator instrumentAccumulator) {
+    super(descriptor, instrumentAccumulator);
   }
 
   @Override
@@ -73,11 +70,7 @@ final class LongUpDownCounterSdk extends AbstractSynchronousInstrument<BoundInst
       InstrumentDescriptor instrumentDescriptor =
           getInstrumentDescriptor(InstrumentType.UP_DOWN_COUNTER, InstrumentValueType.LONG);
       return register(
-          new LongUpDownCounterSdk(
-              instrumentDescriptor,
-              getMeterProviderSharedState(),
-              getMeterSharedState(),
-              getBatcher(instrumentDescriptor)));
+          new LongUpDownCounterSdk(instrumentDescriptor, getBatcher(instrumentDescriptor)));
     }
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongUpDownSumObserverSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongUpDownSumObserverSdk.java
@@ -15,16 +15,9 @@ final class LongUpDownSumObserverSdk extends AbstractLongAsynchronousInstrument
     implements LongUpDownSumObserver {
   LongUpDownSumObserverSdk(
       InstrumentDescriptor descriptor,
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState,
       InstrumentAccumulator instrumentAccumulator,
       @Nullable Callback<LongResult> metricUpdater) {
-    super(
-        descriptor,
-        meterProviderSharedState,
-        meterSharedState,
-        instrumentAccumulator,
-        metricUpdater);
+    super(descriptor, instrumentAccumulator, metricUpdater);
   }
 
   static final class Builder
@@ -58,11 +51,7 @@ final class LongUpDownSumObserverSdk extends AbstractLongAsynchronousInstrument
           getInstrumentDescriptor(InstrumentType.UP_DOWN_SUM_OBSERVER, InstrumentValueType.LONG);
       LongUpDownSumObserverSdk instrument =
           new LongUpDownSumObserverSdk(
-              instrumentDescriptor,
-              getMeterProviderSharedState(),
-              getMeterSharedState(),
-              getBatcher(instrumentDescriptor),
-              callback);
+              instrumentDescriptor, getBatcher(instrumentDescriptor), callback);
       return register(instrument);
     }
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongValueObserverSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongValueObserverSdk.java
@@ -16,16 +16,9 @@ final class LongValueObserverSdk extends AbstractLongAsynchronousInstrument
 
   LongValueObserverSdk(
       InstrumentDescriptor descriptor,
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState,
       InstrumentAccumulator instrumentAccumulator,
       @Nullable Callback<LongResult> metricUpdater) {
-    super(
-        descriptor,
-        meterProviderSharedState,
-        meterSharedState,
-        instrumentAccumulator,
-        metricUpdater);
+    super(descriptor, instrumentAccumulator, metricUpdater);
   }
 
   static final class Builder
@@ -59,11 +52,7 @@ final class LongValueObserverSdk extends AbstractLongAsynchronousInstrument
           getInstrumentDescriptor(InstrumentType.VALUE_OBSERVER, InstrumentValueType.LONG);
       LongValueObserverSdk instrument =
           new LongValueObserverSdk(
-              instrumentDescriptor,
-              getMeterProviderSharedState(),
-              getMeterSharedState(),
-              getBatcher(instrumentDescriptor),
-              callback);
+              instrumentDescriptor, getBatcher(instrumentDescriptor), callback);
       return register(instrument);
     }
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdk.java
@@ -15,11 +15,8 @@ final class LongValueRecorderSdk extends AbstractSynchronousInstrument<BoundInst
     implements LongValueRecorder {
 
   private LongValueRecorderSdk(
-      InstrumentDescriptor descriptor,
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState,
-      InstrumentAccumulator instrumentAccumulator) {
-    super(descriptor, meterProviderSharedState, meterSharedState, instrumentAccumulator);
+      InstrumentDescriptor descriptor, InstrumentAccumulator instrumentAccumulator) {
+    super(descriptor, instrumentAccumulator);
   }
 
   @Override
@@ -72,12 +69,7 @@ final class LongValueRecorderSdk extends AbstractSynchronousInstrument<BoundInst
     public LongValueRecorderSdk build() {
       InstrumentDescriptor descriptor =
           getInstrumentDescriptor(InstrumentType.VALUE_RECORDER, InstrumentValueType.LONG);
-      return register(
-          new LongValueRecorderSdk(
-              descriptor,
-              getMeterProviderSharedState(),
-              getMeterSharedState(),
-              getBatcher(descriptor)));
+      return register(new LongValueRecorderSdk(descriptor, getBatcher(descriptor)));
     }
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
@@ -125,9 +125,6 @@ class AbstractInstrumentBuilderTest {
         new TestInstrumentBuilder(NAME, METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE)
             .setDescription(DESCRIPTION)
             .setUnit(UNIT);
-    assertThat(testInstrumentBuilder.getMeterProviderSharedState())
-        .isSameAs(METER_PROVIDER_SHARED_STATE);
-    assertThat(testInstrumentBuilder.getMeterSharedState()).isSameAs(METER_SHARED_STATE);
 
     TestInstrument testInstrument = testInstrumentBuilder.build();
     assertThat(testInstrument).isInstanceOf(TestInstrument.class);
@@ -153,18 +150,13 @@ class AbstractInstrumentBuilderTest {
     @Override
     public TestInstrument build() {
       return new TestInstrument(
-          getInstrumentDescriptor(InstrumentType.UP_DOWN_COUNTER, InstrumentValueType.LONG),
-          getMeterProviderSharedState(),
-          getMeterSharedState());
+          getInstrumentDescriptor(InstrumentType.UP_DOWN_COUNTER, InstrumentValueType.LONG));
     }
   }
 
   private static final class TestInstrument extends AbstractInstrument {
-    TestInstrument(
-        InstrumentDescriptor descriptor,
-        MeterProviderSharedState meterProviderSharedState,
-        MeterSharedState meterSharedState) {
-      super(descriptor, meterProviderSharedState, meterSharedState, null);
+    TestInstrument(InstrumentDescriptor descriptor) {
+      super(descriptor);
     }
 
     @Override

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentTest.java
@@ -7,13 +7,9 @@ package io.opentelemetry.sdk.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;
-import io.opentelemetry.sdk.metrics.view.Aggregations;
-import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -23,37 +19,16 @@ class AbstractInstrumentTest {
   private static final InstrumentDescriptor INSTRUMENT_DESCRIPTOR =
       InstrumentDescriptor.create(
           "name", "description", "1", InstrumentType.COUNTER, InstrumentValueType.LONG);
-  private static final MeterProviderSharedState METER_PROVIDER_SHARED_STATE =
-      MeterProviderSharedState.create(TestClock.create(), Resource.getEmpty());
-  private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
-      InstrumentationLibraryInfo.create("test_abstract_instrument", "");
-  private static final MeterSharedState METER_SHARED_STATE =
-      MeterSharedState.create(INSTRUMENTATION_LIBRARY_INFO);
-  private static final InstrumentAccumulator ACCUMULATOR =
-      InstrumentAccumulator.getDeltaAllLabels(
-          INSTRUMENT_DESCRIPTOR,
-          METER_PROVIDER_SHARED_STATE,
-          METER_SHARED_STATE,
-          Aggregations.count());
 
   @Test
   void getValues() {
-    TestInstrument testInstrument =
-        new TestInstrument(
-            INSTRUMENT_DESCRIPTOR, METER_PROVIDER_SHARED_STATE, METER_SHARED_STATE, ACCUMULATOR);
+    TestInstrument testInstrument = new TestInstrument(INSTRUMENT_DESCRIPTOR);
     assertThat(testInstrument.getDescriptor()).isSameAs(INSTRUMENT_DESCRIPTOR);
-    assertThat(testInstrument.getMeterProviderSharedState()).isSameAs(METER_PROVIDER_SHARED_STATE);
-    assertThat(testInstrument.getMeterSharedState()).isSameAs(METER_SHARED_STATE);
-    assertThat(testInstrument.getInstrumentAccumulator()).isSameAs(ACCUMULATOR);
   }
 
   private static final class TestInstrument extends AbstractInstrument {
-    TestInstrument(
-        InstrumentDescriptor descriptor,
-        MeterProviderSharedState meterProviderSharedState,
-        MeterSharedState meterSharedState,
-        InstrumentAccumulator instrumentAccumulator) {
-      super(descriptor, meterProviderSharedState, meterSharedState, instrumentAccumulator);
+    TestInstrument(InstrumentDescriptor descriptor) {
+      super(descriptor);
     }
 
     @Override

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/InstrumentRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/InstrumentRegistryTest.java
@@ -9,12 +9,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;
-import io.opentelemetry.sdk.metrics.view.Aggregations;
-import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -27,22 +24,12 @@ class InstrumentRegistryTest {
   private static final InstrumentDescriptor OTHER_INSTRUMENT_DESCRIPTOR =
       InstrumentDescriptor.create(
           "name", "other_description", "1", InstrumentType.COUNTER, InstrumentValueType.LONG);
-  private static final MeterProviderSharedState METER_PROVIDER_SHARED_STATE =
-      MeterProviderSharedState.create(TestClock.create(), Resource.getEmpty());
-  private final MeterSharedState meterSharedState =
-      MeterSharedState.create(InstrumentationLibraryInfo.getEmpty());
-  private final InstrumentAccumulator accumulator =
-      InstrumentAccumulator.getDeltaAllLabels(
-          INSTRUMENT_DESCRIPTOR,
-          METER_PROVIDER_SHARED_STATE,
-          meterSharedState,
-          Aggregations.count());
 
   @Test
   void register() {
-    TestInstrument testInstrument =
-        new TestInstrument(
-            INSTRUMENT_DESCRIPTOR, METER_PROVIDER_SHARED_STATE, meterSharedState, accumulator);
+    MeterSharedState meterSharedState =
+        MeterSharedState.create(InstrumentationLibraryInfo.getEmpty());
+    TestInstrument testInstrument = new TestInstrument(INSTRUMENT_DESCRIPTOR);
     assertThat(meterSharedState.getInstrumentRegistry().register(testInstrument))
         .isSameAs(testInstrument);
     assertThat(meterSharedState.getInstrumentRegistry().register(testInstrument))
@@ -50,20 +37,15 @@ class InstrumentRegistryTest {
     assertThat(
             meterSharedState
                 .getInstrumentRegistry()
-                .register(
-                    new TestInstrument(
-                        INSTRUMENT_DESCRIPTOR,
-                        METER_PROVIDER_SHARED_STATE,
-                        meterSharedState,
-                        accumulator)))
+                .register(new TestInstrument(INSTRUMENT_DESCRIPTOR)))
         .isSameAs(testInstrument);
   }
 
   @Test
   void register_OtherDescriptor() {
-    TestInstrument testInstrument =
-        new TestInstrument(
-            INSTRUMENT_DESCRIPTOR, METER_PROVIDER_SHARED_STATE, meterSharedState, accumulator);
+    MeterSharedState meterSharedState =
+        MeterSharedState.create(InstrumentationLibraryInfo.getEmpty());
+    TestInstrument testInstrument = new TestInstrument(INSTRUMENT_DESCRIPTOR);
     assertThat(meterSharedState.getInstrumentRegistry().register(testInstrument))
         .isSameAs(testInstrument);
 
@@ -72,20 +54,15 @@ class InstrumentRegistryTest {
         () ->
             meterSharedState
                 .getInstrumentRegistry()
-                .register(
-                    new TestInstrument(
-                        OTHER_INSTRUMENT_DESCRIPTOR,
-                        METER_PROVIDER_SHARED_STATE,
-                        meterSharedState,
-                        accumulator)),
+                .register(new TestInstrument(OTHER_INSTRUMENT_DESCRIPTOR)),
         "Instrument with same name and different descriptor already created.");
   }
 
   @Test
   void register_OtherInstance() {
-    TestInstrument testInstrument =
-        new TestInstrument(
-            INSTRUMENT_DESCRIPTOR, METER_PROVIDER_SHARED_STATE, meterSharedState, accumulator);
+    MeterSharedState meterSharedState =
+        MeterSharedState.create(InstrumentationLibraryInfo.getEmpty());
+    TestInstrument testInstrument = new TestInstrument(INSTRUMENT_DESCRIPTOR);
     assertThat(meterSharedState.getInstrumentRegistry().register(testInstrument))
         .isSameAs(testInstrument);
 
@@ -94,22 +71,13 @@ class InstrumentRegistryTest {
         () ->
             meterSharedState
                 .getInstrumentRegistry()
-                .register(
-                    new OtherTestInstrument(
-                        INSTRUMENT_DESCRIPTOR,
-                        METER_PROVIDER_SHARED_STATE,
-                        meterSharedState,
-                        accumulator)),
+                .register(new OtherTestInstrument(INSTRUMENT_DESCRIPTOR)),
         "Instrument with same name and different descriptor already created.");
   }
 
   private static final class TestInstrument extends AbstractInstrument {
-    TestInstrument(
-        InstrumentDescriptor descriptor,
-        MeterProviderSharedState meterProviderSharedState,
-        MeterSharedState meterSharedState,
-        InstrumentAccumulator instrumentAccumulator) {
-      super(descriptor, meterProviderSharedState, meterSharedState, instrumentAccumulator);
+    TestInstrument(InstrumentDescriptor descriptor) {
+      super(descriptor);
     }
 
     @Override
@@ -119,12 +87,8 @@ class InstrumentRegistryTest {
   }
 
   private static final class OtherTestInstrument extends AbstractInstrument {
-    OtherTestInstrument(
-        InstrumentDescriptor descriptor,
-        MeterProviderSharedState meterProviderSharedState,
-        MeterSharedState meterSharedState,
-        InstrumentAccumulator instrumentAccumulator) {
-      super(descriptor, meterProviderSharedState, meterSharedState, instrumentAccumulator);
+    OtherTestInstrument(InstrumentDescriptor descriptor) {
+      super(descriptor);
     }
 
     @Override


### PR DESCRIPTION
Fields removed:
* MeterProviderSharedState
* MeterSharedState
* InstrumentAccumulator - moved up one level

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>