### PR TITLE
Rename accumulator to processor to match Go

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
@@ -101,7 +101,7 @@ abstract class AbstractInstrument implements Instrument {
       return meterSharedState.getInstrumentRegistry().register(instrument);
     }
 
-    protected InstrumentAccumulator getBatcher(InstrumentDescriptor descriptor) {
+    protected InstrumentProcessor getBatcher(InstrumentDescriptor descriptor) {
       return meterSdk.createBatcher(descriptor, meterProviderSharedState, meterSharedState);
     }
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleCounterSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleCounterSdk.java
@@ -15,8 +15,8 @@ final class DoubleCounterSdk extends AbstractSynchronousInstrument<BoundInstrume
     implements DoubleCounter {
 
   private DoubleCounterSdk(
-      InstrumentDescriptor descriptor, InstrumentAccumulator instrumentAccumulator) {
-    super(descriptor, instrumentAccumulator);
+      InstrumentDescriptor descriptor, InstrumentProcessor instrumentProcessor) {
+    super(descriptor, instrumentProcessor);
   }
 
   @Override
@@ -35,15 +35,15 @@ final class DoubleCounterSdk extends AbstractSynchronousInstrument<BoundInstrume
   }
 
   @Override
-  BoundInstrument newBinding(InstrumentAccumulator instrumentAccumulator) {
-    return new BoundInstrument(instrumentAccumulator);
+  BoundInstrument newBinding(InstrumentProcessor instrumentProcessor) {
+    return new BoundInstrument(instrumentProcessor);
   }
 
   static final class BoundInstrument extends AbstractBoundInstrument
       implements DoubleCounter.BoundDoubleCounter {
 
-    BoundInstrument(InstrumentAccumulator instrumentAccumulator) {
-      super(instrumentAccumulator.getAggregator());
+    BoundInstrument(InstrumentProcessor instrumentProcessor) {
+      super(instrumentProcessor.getAggregator());
     }
 
     @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleSumObserverSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleSumObserverSdk.java
@@ -16,9 +16,9 @@ final class DoubleSumObserverSdk extends AbstractDoubleAsynchronousInstrument
 
   DoubleSumObserverSdk(
       InstrumentDescriptor descriptor,
-      InstrumentAccumulator instrumentAccumulator,
+      InstrumentProcessor instrumentProcessor,
       @Nullable Callback<DoubleResult> metricUpdater) {
-    super(descriptor, instrumentAccumulator, metricUpdater);
+    super(descriptor, instrumentProcessor, metricUpdater);
   }
 
   static final class Builder

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleUpDownCounterSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleUpDownCounterSdk.java
@@ -15,8 +15,8 @@ final class DoubleUpDownCounterSdk extends AbstractSynchronousInstrument<BoundIn
     implements DoubleUpDownCounter {
 
   private DoubleUpDownCounterSdk(
-      InstrumentDescriptor descriptor, InstrumentAccumulator instrumentAccumulator) {
-    super(descriptor, instrumentAccumulator);
+      InstrumentDescriptor descriptor, InstrumentProcessor instrumentProcessor) {
+    super(descriptor, instrumentProcessor);
   }
 
   @Override
@@ -32,15 +32,15 @@ final class DoubleUpDownCounterSdk extends AbstractSynchronousInstrument<BoundIn
   }
 
   @Override
-  BoundInstrument newBinding(InstrumentAccumulator instrumentAccumulator) {
-    return new BoundInstrument(instrumentAccumulator);
+  BoundInstrument newBinding(InstrumentProcessor instrumentProcessor) {
+    return new BoundInstrument(instrumentProcessor);
   }
 
   static final class BoundInstrument extends AbstractBoundInstrument
       implements BoundDoubleUpDownCounter {
 
-    BoundInstrument(InstrumentAccumulator instrumentAccumulator) {
-      super(instrumentAccumulator.getAggregator());
+    BoundInstrument(InstrumentProcessor instrumentProcessor) {
+      super(instrumentProcessor.getAggregator());
     }
 
     @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleUpDownSumObserverSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleUpDownSumObserverSdk.java
@@ -16,9 +16,9 @@ final class DoubleUpDownSumObserverSdk extends AbstractDoubleAsynchronousInstrum
 
   DoubleUpDownSumObserverSdk(
       InstrumentDescriptor descriptor,
-      InstrumentAccumulator instrumentAccumulator,
+      InstrumentProcessor instrumentProcessor,
       @Nullable Callback<DoubleResult> metricUpdater) {
-    super(descriptor, instrumentAccumulator, metricUpdater);
+    super(descriptor, instrumentProcessor, metricUpdater);
   }
 
   static final class Builder

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleValueObserverSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleValueObserverSdk.java
@@ -16,9 +16,9 @@ final class DoubleValueObserverSdk extends AbstractDoubleAsynchronousInstrument
 
   DoubleValueObserverSdk(
       InstrumentDescriptor descriptor,
-      InstrumentAccumulator instrumentAccumulator,
+      InstrumentProcessor instrumentProcessor,
       @Nullable Callback<DoubleResult> metricUpdater) {
-    super(descriptor, instrumentAccumulator, metricUpdater);
+    super(descriptor, instrumentProcessor, metricUpdater);
   }
 
   static final class Builder

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdk.java
@@ -15,8 +15,8 @@ final class DoubleValueRecorderSdk extends AbstractSynchronousInstrument<BoundIn
     implements DoubleValueRecorder {
 
   private DoubleValueRecorderSdk(
-      InstrumentDescriptor descriptor, InstrumentAccumulator instrumentAccumulator) {
-    super(descriptor, instrumentAccumulator);
+      InstrumentDescriptor descriptor, InstrumentProcessor instrumentProcessor) {
+    super(descriptor, instrumentProcessor);
   }
 
   @Override
@@ -32,15 +32,15 @@ final class DoubleValueRecorderSdk extends AbstractSynchronousInstrument<BoundIn
   }
 
   @Override
-  BoundInstrument newBinding(InstrumentAccumulator instrumentAccumulator) {
-    return new BoundInstrument(instrumentAccumulator);
+  BoundInstrument newBinding(InstrumentProcessor instrumentProcessor) {
+    return new BoundInstrument(instrumentProcessor);
   }
 
   static final class BoundInstrument extends AbstractBoundInstrument
       implements BoundDoubleValueRecorder {
 
-    BoundInstrument(InstrumentAccumulator instrumentAccumulator) {
-      super(instrumentAccumulator.getAggregator());
+    BoundInstrument(InstrumentProcessor instrumentProcessor) {
+      super(instrumentProcessor.getAggregator());
     }
 
     @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/InstrumentProcessor.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/InstrumentProcessor.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * An {@code InstrumentAccumulator} represents an internal instance of an {@code Accumulator} for a
+ * An {@code InstrumentProcessor} represents an internal instance of an {@code Accumulator} for a
  * specific {code Instrument}. It records individual measurements (via the {@code Aggregator}). It
  * batches together {@code Aggregator}s for the similar sets of labels.
  *
@@ -29,7 +29,7 @@ import java.util.Objects;
  * cycle must be protected by a lock. A collection cycle is defined by multiple calls to {@link
  * #batch(Labels, Aggregator, boolean)} followed by one {@link #completeCollectionCycle()};
  */
-final class InstrumentAccumulator {
+final class InstrumentProcessor {
   private final InstrumentDescriptor descriptor;
   private final Aggregation aggregation;
   private final Resource resource;
@@ -45,12 +45,12 @@ final class InstrumentAccumulator {
    * aggregation. "Cumulative" means that all metrics that are generated will be considered for the
    * lifetime of the Instrument being aggregated.
    */
-  static InstrumentAccumulator getCumulativeAllLabels(
+  static InstrumentProcessor getCumulativeAllLabels(
       InstrumentDescriptor descriptor,
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState meterSharedState,
       Aggregation aggregation) {
-    return new InstrumentAccumulator(
+    return new InstrumentProcessor(
         descriptor,
         aggregation,
         meterProviderSharedState.getResource(),
@@ -64,12 +64,12 @@ final class InstrumentAccumulator {
    * aggregation. "Delta" means that all metrics that are generated are only for the most recent
    * collection interval.
    */
-  static InstrumentAccumulator getDeltaAllLabels(
+  static InstrumentProcessor getDeltaAllLabels(
       InstrumentDescriptor descriptor,
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState meterSharedState,
       Aggregation aggregation) {
-    return new InstrumentAccumulator(
+    return new InstrumentProcessor(
         descriptor,
         aggregation,
         meterProviderSharedState.getResource(),
@@ -78,7 +78,7 @@ final class InstrumentAccumulator {
         /* delta= */ true);
   }
 
-  private InstrumentAccumulator(
+  private InstrumentProcessor(
       InstrumentDescriptor descriptor,
       Aggregation aggregation,
       Resource resource,
@@ -113,7 +113,7 @@ final class InstrumentAccumulator {
    * @param aggregator the {@link Aggregator} used to aggregate individual events for the given
    *     {@code LabelSetSdk}.
    * @param mappedAggregator {@code true} if the {@code Aggregator} is still in used by a binding.
-   *     If {@code false} the {@code Batcher} can reuse the {@code Aggregator} instance.
+   *     If {@code false} the {@code InstrumentProcessor} can reuse the {@code Aggregator} instance.
    */
   void batch(Labels labelSet, Aggregator aggregator, boolean mappedAggregator) {
     if (!aggregator.hasRecordings()) {
@@ -183,7 +183,7 @@ final class InstrumentAccumulator {
       return false;
     }
 
-    InstrumentAccumulator allLabels = (InstrumentAccumulator) o;
+    InstrumentProcessor allLabels = (InstrumentProcessor) o;
 
     if (startEpochNanos != allLabels.startEpochNanos) {
       return false;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongCounterSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongCounterSdk.java
@@ -14,9 +14,8 @@ import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 final class LongCounterSdk extends AbstractSynchronousInstrument<BoundInstrument>
     implements LongCounter {
 
-  private LongCounterSdk(
-      InstrumentDescriptor descriptor, InstrumentAccumulator instrumentAccumulator) {
-    super(descriptor, instrumentAccumulator);
+  private LongCounterSdk(InstrumentDescriptor descriptor, InstrumentProcessor instrumentProcessor) {
+    super(descriptor, instrumentProcessor);
   }
 
   @Override
@@ -35,15 +34,15 @@ final class LongCounterSdk extends AbstractSynchronousInstrument<BoundInstrument
   }
 
   @Override
-  BoundInstrument newBinding(InstrumentAccumulator instrumentAccumulator) {
-    return new BoundInstrument(instrumentAccumulator);
+  BoundInstrument newBinding(InstrumentProcessor instrumentProcessor) {
+    return new BoundInstrument(instrumentProcessor);
   }
 
   static final class BoundInstrument extends AbstractBoundInstrument
       implements LongCounter.BoundLongCounter {
 
-    BoundInstrument(InstrumentAccumulator instrumentAccumulator) {
-      super(instrumentAccumulator.getAggregator());
+    BoundInstrument(InstrumentProcessor instrumentProcessor) {
+      super(instrumentProcessor.getAggregator());
     }
 
     @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongSumObserverSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongSumObserverSdk.java
@@ -15,9 +15,9 @@ final class LongSumObserverSdk extends AbstractLongAsynchronousInstrument
     implements LongSumObserver {
   LongSumObserverSdk(
       InstrumentDescriptor descriptor,
-      InstrumentAccumulator instrumentAccumulator,
+      InstrumentProcessor instrumentProcessor,
       @Nullable Callback<LongResult> metricUpdater) {
-    super(descriptor, instrumentAccumulator, metricUpdater);
+    super(descriptor, instrumentProcessor, metricUpdater);
   }
 
   static final class Builder

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongUpDownCounterSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongUpDownCounterSdk.java
@@ -15,8 +15,8 @@ final class LongUpDownCounterSdk extends AbstractSynchronousInstrument<BoundInst
     implements LongUpDownCounter {
 
   private LongUpDownCounterSdk(
-      InstrumentDescriptor descriptor, InstrumentAccumulator instrumentAccumulator) {
-    super(descriptor, instrumentAccumulator);
+      InstrumentDescriptor descriptor, InstrumentProcessor instrumentProcessor) {
+    super(descriptor, instrumentProcessor);
   }
 
   @Override
@@ -32,15 +32,15 @@ final class LongUpDownCounterSdk extends AbstractSynchronousInstrument<BoundInst
   }
 
   @Override
-  BoundInstrument newBinding(InstrumentAccumulator instrumentAccumulator) {
-    return new BoundInstrument(instrumentAccumulator);
+  BoundInstrument newBinding(InstrumentProcessor instrumentProcessor) {
+    return new BoundInstrument(instrumentProcessor);
   }
 
   static final class BoundInstrument extends AbstractBoundInstrument
       implements BoundLongUpDownCounter {
 
-    BoundInstrument(InstrumentAccumulator instrumentAccumulator) {
-      super(instrumentAccumulator.getAggregator());
+    BoundInstrument(InstrumentProcessor instrumentProcessor) {
+      super(instrumentProcessor.getAggregator());
     }
 
     @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongUpDownSumObserverSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongUpDownSumObserverSdk.java
@@ -15,9 +15,9 @@ final class LongUpDownSumObserverSdk extends AbstractLongAsynchronousInstrument
     implements LongUpDownSumObserver {
   LongUpDownSumObserverSdk(
       InstrumentDescriptor descriptor,
-      InstrumentAccumulator instrumentAccumulator,
+      InstrumentProcessor instrumentProcessor,
       @Nullable Callback<LongResult> metricUpdater) {
-    super(descriptor, instrumentAccumulator, metricUpdater);
+    super(descriptor, instrumentProcessor, metricUpdater);
   }
 
   static final class Builder

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongValueObserverSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongValueObserverSdk.java
@@ -16,9 +16,9 @@ final class LongValueObserverSdk extends AbstractLongAsynchronousInstrument
 
   LongValueObserverSdk(
       InstrumentDescriptor descriptor,
-      InstrumentAccumulator instrumentAccumulator,
+      InstrumentProcessor instrumentProcessor,
       @Nullable Callback<LongResult> metricUpdater) {
-    super(descriptor, instrumentAccumulator, metricUpdater);
+    super(descriptor, instrumentProcessor, metricUpdater);
   }
 
   static final class Builder

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdk.java
@@ -15,8 +15,8 @@ final class LongValueRecorderSdk extends AbstractSynchronousInstrument<BoundInst
     implements LongValueRecorder {
 
   private LongValueRecorderSdk(
-      InstrumentDescriptor descriptor, InstrumentAccumulator instrumentAccumulator) {
-    super(descriptor, instrumentAccumulator);
+      InstrumentDescriptor descriptor, InstrumentProcessor instrumentProcessor) {
+    super(descriptor, instrumentProcessor);
   }
 
   @Override
@@ -32,15 +32,15 @@ final class LongValueRecorderSdk extends AbstractSynchronousInstrument<BoundInst
   }
 
   @Override
-  BoundInstrument newBinding(InstrumentAccumulator instrumentAccumulator) {
-    return new BoundInstrument(instrumentAccumulator);
+  BoundInstrument newBinding(InstrumentProcessor instrumentProcessor) {
+    return new BoundInstrument(instrumentProcessor);
   }
 
   static final class BoundInstrument extends AbstractBoundInstrument
       implements BoundLongValueRecorder {
 
-    BoundInstrument(InstrumentAccumulator instrumentAccumulator) {
-      super(instrumentAccumulator.getAggregator());
+    BoundInstrument(InstrumentProcessor instrumentProcessor) {
+      super(instrumentProcessor.getAggregator());
     }
 
     @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/MeterSdk.java
@@ -113,10 +113,9 @@ final class MeterSdk implements Meter {
   }
 
   /**
-   * Creates a {@link InstrumentAccumulator}, by using the {@link ViewRegistry} to do the actual
-   * work.
+   * Creates a {@link InstrumentProcessor}, by using the {@link ViewRegistry} to do the actual work.
    */
-  InstrumentAccumulator createBatcher(
+  InstrumentProcessor createBatcher(
       InstrumentDescriptor descriptor,
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState meterSharedState) {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/ViewRegistry.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/ViewRegistry.java
@@ -44,8 +44,8 @@ class ViewRegistry {
     aggregationChooser.addView(selector, specification);
   }
 
-  /** Create a new {@link InstrumentAccumulator} for use in metric recording aggregation. */
-  InstrumentAccumulator createBatcher(
+  /** Create a new {@link InstrumentProcessor} for use in metric recording aggregation. */
+  InstrumentProcessor createBatcher(
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState meterSharedState,
       InstrumentDescriptor descriptor) {
@@ -55,10 +55,10 @@ class ViewRegistry {
     Aggregation aggregation = specification.aggregation();
 
     if (Temporality.CUMULATIVE == specification.temporality()) {
-      return InstrumentAccumulator.getCumulativeAllLabels(
+      return InstrumentProcessor.getCumulativeAllLabels(
           descriptor, meterProviderSharedState, meterSharedState, aggregation);
     } else if (Temporality.DELTA == specification.temporality()) {
-      return InstrumentAccumulator.getDeltaAllLabels(
+      return InstrumentProcessor.getDeltaAllLabels(
           descriptor, meterProviderSharedState, meterSharedState, aggregation);
     }
     throw new IllegalStateException("unsupported Temporality: " + specification.temporality());

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/ViewRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/ViewRegistryTest.java
@@ -55,17 +55,17 @@ class ViewRegistryTest {
     AggregationConfiguration specification =
         AggregationConfiguration.create(
             Aggregations.count(), AggregationConfiguration.Temporality.CUMULATIVE);
-    InstrumentAccumulator expectedInstrumentAccumulator =
-        InstrumentAccumulator.getCumulativeAllLabels(
+    InstrumentProcessor expectedInstrumentProcessor =
+        InstrumentProcessor.getCumulativeAllLabels(
             descriptor, providerSharedState, meterSharedState, Aggregations.count());
 
     when(chooser.chooseAggregation(descriptor)).thenReturn(specification);
 
-    InstrumentAccumulator result =
+    InstrumentProcessor result =
         viewRegistry.createBatcher(providerSharedState, meterSharedState, descriptor);
 
     assertThat(result.generatesDeltas()).isFalse();
-    assertThat(result).isEqualTo(expectedInstrumentAccumulator);
+    assertThat(result).isEqualTo(expectedInstrumentProcessor);
 
     assertThat(result).isNotNull();
   }
@@ -87,17 +87,17 @@ class ViewRegistryTest {
     AggregationConfiguration specification =
         AggregationConfiguration.create(
             Aggregations.count(), AggregationConfiguration.Temporality.DELTA);
-    InstrumentAccumulator expectedInstrumentAccumulator =
-        InstrumentAccumulator.getDeltaAllLabels(
+    InstrumentProcessor expectedInstrumentProcessor =
+        InstrumentProcessor.getDeltaAllLabels(
             descriptor, providerSharedState, meterSharedState, Aggregations.count());
 
     when(chooser.chooseAggregation(descriptor)).thenReturn(specification);
 
-    InstrumentAccumulator result =
+    InstrumentProcessor result =
         viewRegistry.createBatcher(providerSharedState, meterSharedState, descriptor);
 
     assertThat(result.generatesDeltas()).isTrue();
-    assertThat(result).isEqualTo(expectedInstrumentAccumulator);
+    assertThat(result).isEqualTo(expectedInstrumentProcessor);
 
     assertThat(result).isNotNull();
   }


### PR DESCRIPTION
I was wrong initially, what we had as Batcher is actually the Processor in Go.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>