### PR TITLE
Change MetricData to be consistent with protos, move creation to the Aggregation

### DIFF
--- a/exporters/logging/src/test/java/io/opentelemetry/exporter/logging/LoggingMetricExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporter/logging/LoggingMetricExporterTest.java
@@ -14,7 +14,6 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
-import io.opentelemetry.sdk.metrics.data.MetricData.SummaryPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.ValueAtPercentile;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Arrays;
@@ -51,46 +50,53 @@ class LoggingMetricExporterTest {
         InstrumentationLibraryInfo.create("manualInstrumentation", "1.0");
     exporter.export(
         Arrays.asList(
-            MetricData.create(
+            MetricData.createDoubleSummary(
                 resource,
                 instrumentationLibraryInfo,
                 "measureOne",
                 "A summarized test measure",
                 "ms",
-                MetricData.Type.SUMMARY,
-                Collections.singletonList(
-                    SummaryPoint.create(
-                        nowEpochNanos,
-                        nowEpochNanos + 245,
-                        Labels.of("a", "b", "c", "d"),
-                        1010,
-                        50000,
-                        Arrays.asList(
-                            ValueAtPercentile.create(0.0, 25),
-                            ValueAtPercentile.create(100.0, 433))))),
-            MetricData.create(
+                MetricData.DoubleSummaryData.create(
+                    Collections.singletonList(
+                        MetricData.DoubleSummaryPoint.create(
+                            nowEpochNanos,
+                            nowEpochNanos + 245,
+                            Labels.of("a", "b", "c", "d"),
+                            1010,
+                            50000,
+                            Arrays.asList(
+                                ValueAtPercentile.create(0.0, 25),
+                                ValueAtPercentile.create(100.0, 433)))))),
+            MetricData.createLongSum(
                 resource,
                 instrumentationLibraryInfo,
                 "counterOne",
                 "A simple counter",
                 "one",
-                MetricData.Type.LONG_SUM,
-                Collections.singletonList(
-                    LongPoint.create(
-                        nowEpochNanos, nowEpochNanos + 245, Labels.of("z", "y", "x", "w"), 1010))),
-            MetricData.create(
+                MetricData.LongSumData.create(
+                    true,
+                    MetricData.AggregationTemporality.CUMULATIVE,
+                    Collections.singletonList(
+                        LongPoint.create(
+                            nowEpochNanos,
+                            nowEpochNanos + 245,
+                            Labels.of("z", "y", "x", "w"),
+                            1010)))),
+            MetricData.createDoubleSum(
                 resource,
                 instrumentationLibraryInfo,
                 "observedValue",
                 "an observer gauge",
                 "kb",
-                MetricData.Type.NON_MONOTONIC_DOUBLE_SUM,
-                Collections.singletonList(
-                    DoublePoint.create(
-                        nowEpochNanos,
-                        nowEpochNanos + 245,
-                        Labels.of("1", "2", "3", "4"),
-                        33.7767)))));
+                MetricData.DoubleSumData.create(
+                    true,
+                    MetricData.AggregationTemporality.CUMULATIVE,
+                    Collections.singletonList(
+                        DoublePoint.create(
+                            nowEpochNanos,
+                            nowEpochNanos + 245,
+                            Labels.of("1", "2", "3", "4"),
+                            33.7767))))));
   }
 
   @Test

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporter/otlp/MetricAdapter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporter/otlp/MetricAdapter.java
@@ -25,10 +25,6 @@ import io.opentelemetry.proto.metrics.v1.Metric;
 import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.data.MetricData;
-import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
-import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
-import io.opentelemetry.sdk.metrics.data.MetricData.Point;
-import io.opentelemetry.sdk.metrics.data.MetricData.SummaryPoint;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -69,7 +65,7 @@ final class MetricAdapter {
       groupByResourceAndLibrary(Collection<MetricData> metricDataList) {
     Map<Resource, Map<InstrumentationLibraryInfo, List<Metric>>> result = new HashMap<>();
     for (MetricData metricData : metricDataList) {
-      if (metricData.getPoints().isEmpty()) {
+      if (metricData.isEmpty()) {
         // If no points available then ignore.
         continue;
       }
@@ -98,72 +94,69 @@ final class MetricAdapter {
             .setDescription(metricData.getDescription())
             .setUnit(metricData.getUnit());
 
-    boolean monotonic = false;
-
     switch (metricData.getType()) {
       case LONG_SUM:
-        monotonic = true;
-        // fall through
-      case NON_MONOTONIC_LONG_SUM:
+        MetricData.LongSumData longSumData = metricData.getLongSumData();
         builder.setIntSum(
             IntSum.newBuilder()
-                .setIsMonotonic(monotonic)
-                .setAggregationTemporality(mapToTemporality(metricData.getType()))
-                .addAllDataPoints(toIntDataPoints(metricData.getPoints()))
+                .setIsMonotonic(longSumData.isMonotonic())
+                .setAggregationTemporality(
+                    mapToTemporality(longSumData.getAggregationTemporality()))
+                .addAllDataPoints(toIntDataPoints(longSumData.getPoints()))
                 .build());
         break;
       case DOUBLE_SUM:
-        monotonic = true;
-        // fall through
-      case NON_MONOTONIC_DOUBLE_SUM:
+        MetricData.DoubleSumData doubleSumData = metricData.getDoubleSumData();
         builder.setDoubleSum(
             DoubleSum.newBuilder()
-                .setIsMonotonic(monotonic)
-                .setAggregationTemporality(mapToTemporality(metricData.getType()))
-                .addAllDataPoints(toDoubleDataPoints(metricData.getPoints()))
+                .setIsMonotonic(doubleSumData.isMonotonic())
+                .setAggregationTemporality(
+                    mapToTemporality(doubleSumData.getAggregationTemporality()))
+                .addAllDataPoints(toDoubleDataPoints(doubleSumData.getPoints()))
                 .build());
         break;
       case SUMMARY:
+        MetricData.DoubleSummaryData doubleSummaryData = metricData.getDoubleSummaryData();
         builder.setDoubleHistogram(
             DoubleHistogram.newBuilder()
-                .setAggregationTemporality(mapToTemporality(metricData.getType()))
-                .addAllDataPoints(toSummaryDataPoints(metricData.getPoints()))
+                // TODO: This is a bug, but preserve the logic and fix it later.
+                .setAggregationTemporality(AGGREGATION_TEMPORALITY_DELTA)
+                .addAllDataPoints(toSummaryDataPoints(doubleSummaryData.getPoints()))
                 .build());
         break;
       case LONG_GAUGE:
+        MetricData.LongGaugeData longGaugeData = metricData.getLongGaugeData();
         builder.setIntGauge(
             IntGauge.newBuilder()
-                .addAllDataPoints(toIntDataPoints(metricData.getPoints()))
+                .addAllDataPoints(toIntDataPoints(longGaugeData.getPoints()))
                 .build());
         break;
       case DOUBLE_GAUGE:
+        MetricData.DoubleGaugeData doubleGaugeData = metricData.getDoubleGaugeData();
         builder.setDoubleGauge(
             DoubleGauge.newBuilder()
-                .addAllDataPoints(toDoubleDataPoints(metricData.getPoints()))
+                .addAllDataPoints(toDoubleDataPoints(doubleGaugeData.getPoints()))
                 .build());
         break;
     }
     return builder.build();
   }
 
-  private static AggregationTemporality mapToTemporality(MetricData.Type type) {
-    switch (type) {
-      case NON_MONOTONIC_LONG_SUM:
-      case NON_MONOTONIC_DOUBLE_SUM:
-      case LONG_SUM:
-      case DOUBLE_SUM:
+  private static AggregationTemporality mapToTemporality(
+      MetricData.AggregationTemporality temporality) {
+    switch (temporality) {
+      case CUMULATIVE:
         return AGGREGATION_TEMPORALITY_CUMULATIVE;
-      case SUMMARY:
+      case DELTA:
         return AGGREGATION_TEMPORALITY_DELTA;
-      default:
-        return AGGREGATION_TEMPORALITY_UNSPECIFIED;
     }
+    return AGGREGATION_TEMPORALITY_UNSPECIFIED;
   }
 
-  static List<IntDataPoint> toIntDataPoints(Collection<Point> points) {
+  static List<IntDataPoint> toIntDataPoints(Collection<MetricData.Point> points) {
     List<IntDataPoint> result = new ArrayList<>(points.size());
-    for (Point point : points) {
-      LongPoint longPoint = (LongPoint) point;
+    for (MetricData.Point point : points) {
+      MetricData.LongPoint longPoint = (MetricData.LongPoint) point;
       IntDataPoint.Builder builder =
           IntDataPoint.newBuilder()
               .setStartTimeUnixNano(longPoint.getStartEpochNanos())
@@ -178,16 +171,16 @@ final class MetricAdapter {
     return result;
   }
 
-  static Collection<DoubleDataPoint> toDoubleDataPoints(Collection<Point> points) {
+  static Collection<DoubleDataPoint> toDoubleDataPoints(Collection<MetricData.Point> points) {
     List<DoubleDataPoint> result = new ArrayList<>(points.size());
-    for (Point point : points) {
-      DoublePoint doublePoint = (DoublePoint) point;
+    for (MetricData.Point point : points) {
+      MetricData.DoublePoint doublePoint = (MetricData.DoublePoint) point;
       DoubleDataPoint.Builder builder =
           DoubleDataPoint.newBuilder()
-              .setStartTimeUnixNano(doublePoint.getStartEpochNanos())
-              .setTimeUnixNano(doublePoint.getEpochNanos())
+              .setStartTimeUnixNano(point.getStartEpochNanos())
+              .setTimeUnixNano(point.getEpochNanos())
               .setValue(doublePoint.getValue());
-      Collection<StringKeyValue> labels = toProtoLabels(doublePoint.getLabels());
+      Collection<StringKeyValue> labels = toProtoLabels(point.getLabels());
       if (!labels.isEmpty()) {
         builder.addAllLabels(labels);
       }
@@ -196,24 +189,24 @@ final class MetricAdapter {
     return result;
   }
 
-  static List<DoubleHistogramDataPoint> toSummaryDataPoints(Collection<Point> points) {
+  static List<DoubleHistogramDataPoint> toSummaryDataPoints(Collection<MetricData.Point> points) {
     List<DoubleHistogramDataPoint> result = new ArrayList<>(points.size());
-    for (Point point : points) {
-      SummaryPoint summaryPoint = (SummaryPoint) point;
+    for (MetricData.Point point : points) {
+      MetricData.DoubleSummaryPoint doubleSummaryPoint = (MetricData.DoubleSummaryPoint) point;
       DoubleHistogramDataPoint.Builder builder =
           DoubleHistogramDataPoint.newBuilder()
-              .setStartTimeUnixNano(summaryPoint.getStartEpochNanos())
-              .setTimeUnixNano(summaryPoint.getEpochNanos())
-              .setCount(summaryPoint.getCount())
-              .setSum(summaryPoint.getSum());
-      List<StringKeyValue> labels = toProtoLabels(summaryPoint.getLabels());
+              .setStartTimeUnixNano(point.getStartEpochNanos())
+              .setTimeUnixNano(point.getEpochNanos())
+              .setCount(doubleSummaryPoint.getCount())
+              .setSum(doubleSummaryPoint.getSum());
+      List<StringKeyValue> labels = toProtoLabels(point.getLabels());
       if (!labels.isEmpty()) {
         builder.addAllLabels(labels);
       }
       // Not calling directly addAllPercentileValues because that generates couple of unnecessary
       // allocations if empty list.
-      if (!summaryPoint.getPercentileValues().isEmpty()) {
-        addBucketValues(summaryPoint.getPercentileValues(), builder);
+      if (!doubleSummaryPoint.getPercentileValues().isEmpty()) {
+        addBucketValues(doubleSummaryPoint.getPercentileValues(), builder);
       }
       result.add(builder.build());
     }

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporter/otlp/MetricAdapterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporter/otlp/MetricAdapterTest.java
@@ -145,7 +145,7 @@ class MetricAdapterTest {
     assertThat(
             MetricAdapter.toSummaryDataPoints(
                 singletonList(
-                    MetricData.SummaryPoint.create(
+                    MetricData.DoubleSummaryPoint.create(
                         123,
                         456,
                         Labels.of("k", "v"),
@@ -167,9 +167,9 @@ class MetricAdapterTest {
     assertThat(
             MetricAdapter.toSummaryDataPoints(
                 ImmutableList.of(
-                    MetricData.SummaryPoint.create(
+                    MetricData.DoubleSummaryPoint.create(
                         123, 456, Labels.empty(), 7, 15.3, Collections.emptyList()),
-                    MetricData.SummaryPoint.create(
+                    MetricData.DoubleSummaryPoint.create(
                         321,
                         654,
                         Labels.of("k", "v"),
@@ -204,14 +204,17 @@ class MetricAdapterTest {
   void toProtoMetric_monotonic() {
     assertThat(
             MetricAdapter.toProtoMetric(
-                MetricData.create(
+                MetricData.createLongSum(
                     Resource.getEmpty(),
                     InstrumentationLibraryInfo.getEmpty(),
                     "name",
                     "description",
                     "1",
-                    MetricData.Type.LONG_SUM,
-                    singletonList(MetricData.LongPoint.create(123, 456, Labels.of("k", "v"), 5)))))
+                    MetricData.LongSumData.create(
+                        /* isMonotonic= */ true,
+                        MetricData.AggregationTemporality.CUMULATIVE,
+                        singletonList(
+                            MetricData.LongPoint.create(123, 456, Labels.of("k", "v"), 5))))))
         .isEqualTo(
             Metric.newBuilder()
                 .setName("name")
@@ -237,15 +240,17 @@ class MetricAdapterTest {
                 .build());
     assertThat(
             MetricAdapter.toProtoMetric(
-                MetricData.create(
+                MetricData.createDoubleSum(
                     Resource.getEmpty(),
                     InstrumentationLibraryInfo.getEmpty(),
                     "name",
                     "description",
                     "1",
-                    MetricData.Type.DOUBLE_SUM,
-                    singletonList(
-                        MetricData.DoublePoint.create(123, 456, Labels.of("k", "v"), 5.1)))))
+                    MetricData.DoubleSumData.create(
+                        /* isMonotonic= */ true,
+                        MetricData.AggregationTemporality.CUMULATIVE,
+                        singletonList(
+                            MetricData.DoublePoint.create(123, 456, Labels.of("k", "v"), 5.1))))))
         .isEqualTo(
             Metric.newBuilder()
                 .setName("name")
@@ -275,14 +280,17 @@ class MetricAdapterTest {
   void toProtoMetric_nonMonotonic() {
     assertThat(
             MetricAdapter.toProtoMetric(
-                MetricData.create(
+                MetricData.createLongSum(
                     Resource.getEmpty(),
                     InstrumentationLibraryInfo.getEmpty(),
                     "name",
                     "description",
                     "1",
-                    MetricData.Type.NON_MONOTONIC_LONG_SUM,
-                    singletonList(MetricData.LongPoint.create(123, 456, Labels.of("k", "v"), 5)))))
+                    MetricData.LongSumData.create(
+                        /* isMonotonic= */ false,
+                        MetricData.AggregationTemporality.CUMULATIVE,
+                        singletonList(
+                            MetricData.LongPoint.create(123, 456, Labels.of("k", "v"), 5))))))
         .isEqualTo(
             Metric.newBuilder()
                 .setName("name")
@@ -308,15 +316,17 @@ class MetricAdapterTest {
                 .build());
     assertThat(
             MetricAdapter.toProtoMetric(
-                MetricData.create(
+                MetricData.createDoubleSum(
                     Resource.getEmpty(),
                     InstrumentationLibraryInfo.getEmpty(),
                     "name",
                     "description",
                     "1",
-                    MetricData.Type.NON_MONOTONIC_DOUBLE_SUM,
-                    singletonList(
-                        MetricData.DoublePoint.create(123, 456, Labels.of("k", "v"), 5.1)))))
+                    MetricData.DoubleSumData.create(
+                        /* isMonotonic= */ false,
+                        MetricData.AggregationTemporality.CUMULATIVE,
+                        singletonList(
+                            MetricData.DoublePoint.create(123, 456, Labels.of("k", "v"), 5.1))))))
         .isEqualTo(
             Metric.newBuilder()
                 .setName("name")
@@ -346,14 +356,15 @@ class MetricAdapterTest {
   void toProtoMetric_gauges() {
     assertThat(
             MetricAdapter.toProtoMetric(
-                MetricData.create(
+                MetricData.createLongGauge(
                     Resource.getEmpty(),
                     InstrumentationLibraryInfo.getEmpty(),
                     "name",
                     "description",
                     "1",
-                    MetricData.Type.LONG_GAUGE,
-                    singletonList(MetricData.LongPoint.create(123, 456, Labels.of("k", "v"), 5)))))
+                    MetricData.LongGaugeData.create(
+                        singletonList(
+                            MetricData.LongPoint.create(123, 456, Labels.of("k", "v"), 5))))))
         .isEqualTo(
             Metric.newBuilder()
                 .setName("name")
@@ -377,15 +388,15 @@ class MetricAdapterTest {
                 .build());
     assertThat(
             MetricAdapter.toProtoMetric(
-                MetricData.create(
+                MetricData.createDoubleGauge(
                     Resource.getEmpty(),
                     InstrumentationLibraryInfo.getEmpty(),
                     "name",
                     "description",
                     "1",
-                    MetricData.Type.DOUBLE_GAUGE,
-                    singletonList(
-                        MetricData.DoublePoint.create(123, 456, Labels.of("k", "v"), 5.1)))))
+                    MetricData.DoubleGaugeData.create(
+                        singletonList(
+                            MetricData.DoublePoint.create(123, 456, Labels.of("k", "v"), 5.1))))))
         .isEqualTo(
             Metric.newBuilder()
                 .setName("name")
@@ -413,16 +424,16 @@ class MetricAdapterTest {
   void toProtoMetric_summary() {
     assertThat(
             MetricAdapter.toProtoMetric(
-                MetricData.create(
+                MetricData.createDoubleSummary(
                     Resource.getEmpty(),
                     InstrumentationLibraryInfo.getEmpty(),
                     "name",
                     "description",
                     "1",
-                    MetricData.Type.SUMMARY,
-                    singletonList(
-                        MetricData.SummaryPoint.create(
-                            123, 456, Labels.of("k", "v"), 5, 33d, emptyList())))))
+                    MetricData.DoubleSummaryData.create(
+                        singletonList(
+                            MetricData.DoubleSummaryPoint.create(
+                                123, 456, Labels.of("k", "v"), 5, 33d, emptyList()))))))
         .isEqualTo(
             Metric.newBuilder()
                 .setName("name")
@@ -492,42 +503,54 @@ class MetricAdapterTest {
     assertThat(
             MetricAdapter.toProtoResourceMetrics(
                 ImmutableList.of(
-                    MetricData.create(
+                    MetricData.createDoubleSum(
                         resource,
                         instrumentationLibraryInfo,
                         "name",
                         "description",
                         "1",
-                        MetricData.Type.DOUBLE_SUM,
-                        Collections.singletonList(
-                            MetricData.DoublePoint.create(123, 456, Labels.of("k", "v"), 5.0))),
-                    MetricData.create(
+                        MetricData.DoubleSumData.create(
+                            /* isMonotonic= */ true,
+                            MetricData.AggregationTemporality.CUMULATIVE,
+                            Collections.singletonList(
+                                MetricData.DoublePoint.create(
+                                    123, 456, Labels.of("k", "v"), 5.0)))),
+                    MetricData.createDoubleSum(
                         resource,
                         instrumentationLibraryInfo,
                         "name",
                         "description",
                         "1",
-                        MetricData.Type.DOUBLE_SUM,
-                        Collections.singletonList(
-                            MetricData.DoublePoint.create(123, 456, Labels.of("k", "v"), 5.0))),
-                    MetricData.create(
+                        MetricData.DoubleSumData.create(
+                            /* isMonotonic= */ true,
+                            MetricData.AggregationTemporality.CUMULATIVE,
+                            Collections.singletonList(
+                                MetricData.DoublePoint.create(
+                                    123, 456, Labels.of("k", "v"), 5.0)))),
+                    MetricData.createDoubleSum(
                         Resource.getEmpty(),
                         instrumentationLibraryInfo,
                         "name",
                         "description",
                         "1",
-                        MetricData.Type.DOUBLE_SUM,
-                        Collections.singletonList(
-                            MetricData.DoublePoint.create(123, 456, Labels.of("k", "v"), 5.0))),
-                    MetricData.create(
+                        MetricData.DoubleSumData.create(
+                            /* isMonotonic= */ true,
+                            MetricData.AggregationTemporality.CUMULATIVE,
+                            Collections.singletonList(
+                                MetricData.DoublePoint.create(
+                                    123, 456, Labels.of("k", "v"), 5.0)))),
+                    MetricData.createDoubleSum(
                         Resource.getEmpty(),
                         InstrumentationLibraryInfo.getEmpty(),
                         "name",
                         "description",
                         "1",
-                        MetricData.Type.DOUBLE_SUM,
-                        Collections.singletonList(
-                            MetricData.DoublePoint.create(123, 456, Labels.of("k", "v"), 5.0))))))
+                        MetricData.DoubleSumData.create(
+                            /* isMonotonic= */ true,
+                            MetricData.AggregationTemporality.CUMULATIVE,
+                            Collections.singletonList(
+                                MetricData.DoublePoint.create(
+                                    123, 456, Labels.of("k", "v"), 5.0)))))))
         .containsExactlyInAnyOrder(
             ResourceMetrics.newBuilder()
                 .setResource(resourceProto)

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporter/otlp/OtlpGrpcMetricExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporter/otlp/OtlpGrpcMetricExporterTest.java
@@ -248,34 +248,26 @@ class OtlpGrpcMetricExporterTest {
   private static MetricData generateFakeMetric() {
     long startNs = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
     long endNs = startNs + TimeUnit.MILLISECONDS.toNanos(900);
-    return MetricData.create(
+    return MetricData.createLongSum(
         Resource.getEmpty(),
         InstrumentationLibraryInfo.getEmpty(),
         "name",
         "description",
         "1",
-        MetricData.Type.LONG_SUM,
-        Collections.singletonList(LongPoint.create(startNs, endNs, Labels.of("k", "v"), 5)));
+        MetricData.LongSumData.create(
+            /* isMonotonic= */ true,
+            MetricData.AggregationTemporality.CUMULATIVE,
+            Collections.singletonList(LongPoint.create(startNs, endNs, Labels.of("k", "v"), 5))));
   }
 
   private static final class FakeCollector extends MetricsServiceGrpc.MetricsServiceImplBase {
     private final List<ResourceMetrics> receivedMetrics = new ArrayList<>();
     private Status returnedStatus = Status.OK;
-    private long delayMs = 0;
 
     @Override
     public void export(
         ExportMetricsServiceRequest request,
         StreamObserver<ExportMetricsServiceResponse> responseObserver) {
-
-      if (delayMs > 0) {
-        try {
-          // add a delay to simulate export taking a long time
-          TimeUnit.MILLISECONDS.sleep(delayMs);
-        } catch (InterruptedException e) {
-          // do nothing
-        }
-      }
 
       receivedMetrics.addAll(request.getResourceMetricsList());
       responseObserver.onNext(ExportMetricsServiceResponse.newBuilder().build());
@@ -296,10 +288,6 @@ class OtlpGrpcMetricExporterTest {
 
     void setReturnedStatus(Status returnedStatus) {
       this.returnedStatus = returnedStatus;
-    }
-
-    void setCollectorDelay(long delayMs) {
-      this.delayMs = delayMs;
     }
   }
 }

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/MetricAdapter.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/MetricAdapter.java
@@ -10,9 +10,9 @@ import static io.prometheus.client.Collector.doubleToGoString;
 import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
+import io.opentelemetry.sdk.metrics.data.MetricData.DoubleSummaryPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.Point;
-import io.opentelemetry.sdk.metrics.data.MetricData.SummaryPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.ValueAtPercentile;
 import io.prometheus.client.Collector;
 import io.prometheus.client.Collector.MetricFamilySamples;
@@ -47,29 +47,40 @@ final class MetricAdapter {
   // Converts a MetricData to a Prometheus MetricFamilySamples.
   static MetricFamilySamples toMetricFamilySamples(MetricData metricData) {
     String cleanMetricName = cleanMetricName(metricData.getName());
-    Collector.Type type = toMetricFamilyType(metricData.getType());
+    Collector.Type type = toMetricFamilyType(metricData);
 
     return new MetricFamilySamples(
         cleanMetricName,
         type,
         metricData.getDescription(),
-        toSamples(cleanMetricName, metricData.getType(), metricData.getPoints()));
+        toSamples(cleanMetricName, metricData.getType(), getPoints(metricData)));
   }
 
   private static String cleanMetricName(String descriptorMetricName) {
     return Collector.sanitizeMetricName(descriptorMetricName);
   }
 
-  static Collector.Type toMetricFamilyType(MetricData.Type type) {
-    switch (type) {
-      case NON_MONOTONIC_LONG_SUM:
-      case NON_MONOTONIC_DOUBLE_SUM:
+  static Collector.Type toMetricFamilyType(MetricData metricData) {
+    switch (metricData.getType()) {
       case LONG_GAUGE:
       case DOUBLE_GAUGE:
         return Collector.Type.GAUGE;
       case LONG_SUM:
+        MetricData.LongSumData longSumData = metricData.getLongSumData();
+        if (longSumData.isMonotonic()
+            && longSumData.getAggregationTemporality()
+                == MetricData.AggregationTemporality.CUMULATIVE) {
+          return Collector.Type.COUNTER;
+        }
+        return Collector.Type.GAUGE;
       case DOUBLE_SUM:
-        return Collector.Type.COUNTER;
+        MetricData.DoubleSumData doubleSumData = metricData.getDoubleSumData();
+        if (doubleSumData.isMonotonic()
+            && doubleSumData.getAggregationTemporality()
+                == MetricData.AggregationTemporality.CUMULATIVE) {
+          return Collector.Type.COUNTER;
+        }
+        return Collector.Type.GAUGE;
       case SUMMARY:
         return Collector.Type.SUMMARY;
     }
@@ -95,19 +106,17 @@ final class MetricAdapter {
 
       switch (type) {
         case DOUBLE_SUM:
-        case NON_MONOTONIC_DOUBLE_SUM:
         case DOUBLE_GAUGE:
           DoublePoint doublePoint = (DoublePoint) point;
           samples.add(new Sample(name, labelNames, labelValues, doublePoint.getValue()));
           break;
         case LONG_SUM:
-        case NON_MONOTONIC_LONG_SUM:
         case LONG_GAUGE:
           LongPoint longPoint = (LongPoint) point;
           samples.add(new Sample(name, labelNames, labelValues, longPoint.getValue()));
           break;
         case SUMMARY:
-          addSummarySamples((SummaryPoint) point, name, labelNames, labelValues, samples);
+          addSummarySamples((DoubleSummaryPoint) point, name, labelNames, labelValues, samples);
           break;
       }
     }
@@ -132,16 +141,17 @@ final class MetricAdapter {
   }
 
   private static void addSummarySamples(
-      SummaryPoint summaryPoint,
+      DoubleSummaryPoint doubleSummaryPoint,
       String name,
       List<String> labelNames,
       List<String> labelValues,
       List<Sample> samples) {
     samples.add(
-        new Sample(name + SAMPLE_SUFFIX_COUNT, labelNames, labelValues, summaryPoint.getCount()));
+        new Sample(
+            name + SAMPLE_SUFFIX_COUNT, labelNames, labelValues, doubleSummaryPoint.getCount()));
     samples.add(
-        new Sample(name + SAMPLE_SUFFIX_SUM, labelNames, labelValues, summaryPoint.getSum()));
-    List<ValueAtPercentile> valueAtPercentiles = summaryPoint.getPercentileValues();
+        new Sample(name + SAMPLE_SUFFIX_SUM, labelNames, labelValues, doubleSummaryPoint.getSum()));
+    List<ValueAtPercentile> valueAtPercentiles = doubleSummaryPoint.getPercentileValues();
     List<String> labelNamesWithQuantile = new ArrayList<>(labelNames.size());
     labelNamesWithQuantile.addAll(labelNames);
     labelNamesWithQuantile.add(LABEL_NAME_QUANTILE);
@@ -161,6 +171,22 @@ final class MetricAdapter {
       return numPoints * 4;
     }
     return numPoints;
+  }
+
+  private static Collection<MetricData.Point> getPoints(MetricData metricData) {
+    switch (metricData.getType()) {
+      case DOUBLE_GAUGE:
+        return metricData.getDoubleGaugeData().getPoints();
+      case DOUBLE_SUM:
+        return metricData.getDoubleSumData().getPoints();
+      case LONG_GAUGE:
+        return metricData.getLongGaugeData().getPoints();
+      case LONG_SUM:
+        return metricData.getLongSumData().getPoints();
+      case SUMMARY:
+        return metricData.getDoubleSummaryData().getPoints();
+    }
+    return Collections.emptyList();
   }
 
   private MetricAdapter() {}

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/MetricAdapterTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/MetricAdapterTest.java
@@ -23,22 +23,181 @@ import org.junit.jupiter.api.Test;
 /** Unit tests for {@link MetricAdapter}. */
 class MetricAdapterTest {
 
+  private static final MetricData MONOTONIC_CUMULATIVE_DOUBLE_SUM =
+      MetricData.createDoubleSum(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          MetricData.DoubleSumData.create(
+              /* isMonotonic= */ true,
+              MetricData.AggregationTemporality.CUMULATIVE,
+              Collections.singletonList(
+                  MetricData.DoublePoint.create(123, 456, Labels.of("kp", "vp"), 5))));
+  private static final MetricData NON_MONOTONIC_CUMULATIVE_DOUBLE_SUM =
+      MetricData.createDoubleSum(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          MetricData.DoubleSumData.create(
+              /* isMonotonic= */ false,
+              MetricData.AggregationTemporality.CUMULATIVE,
+              Collections.singletonList(
+                  MetricData.DoublePoint.create(123, 456, Labels.of("kp", "vp"), 5))));
+  private static final MetricData MONOTONIC_DELTA_DOUBLE_SUM =
+      MetricData.createDoubleSum(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          MetricData.DoubleSumData.create(
+              /* isMonotonic= */ true,
+              MetricData.AggregationTemporality.DELTA,
+              Collections.singletonList(
+                  MetricData.DoublePoint.create(123, 456, Labels.of("kp", "vp"), 5))));
+  private static final MetricData NON_MONOTONIC_DELTA_DOUBLE_SUM =
+      MetricData.createDoubleSum(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          MetricData.DoubleSumData.create(
+              /* isMonotonic= */ false,
+              MetricData.AggregationTemporality.DELTA,
+              Collections.singletonList(
+                  MetricData.DoublePoint.create(123, 456, Labels.of("kp", "vp"), 5))));
+  private static final MetricData MONOTONIC_CUMULATIVE_LONG_SUM =
+      MetricData.createLongSum(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          MetricData.LongSumData.create(
+              /* isMonotonic= */ true,
+              MetricData.AggregationTemporality.CUMULATIVE,
+              Collections.singletonList(
+                  MetricData.LongPoint.create(123, 456, Labels.of("kp", "vp"), 5))));
+  private static final MetricData NON_MONOTONIC_CUMULATIVE_LONG_SUM =
+      MetricData.createLongSum(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          MetricData.LongSumData.create(
+              /* isMonotonic= */ false,
+              MetricData.AggregationTemporality.CUMULATIVE,
+              Collections.singletonList(
+                  MetricData.LongPoint.create(123, 456, Labels.of("kp", "vp"), 5))));
+  private static final MetricData MONOTONIC_DELTA_LONG_SUM =
+      MetricData.createLongSum(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          MetricData.LongSumData.create(
+              /* isMonotonic= */ true,
+              MetricData.AggregationTemporality.DELTA,
+              Collections.singletonList(
+                  MetricData.LongPoint.create(123, 456, Labels.of("kp", "vp"), 5))));
+  private static final MetricData NON_MONOTONIC_DELTA_LONG_SUM =
+      MetricData.createLongSum(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          MetricData.LongSumData.create(
+              /* isMonotonic= */ false,
+              MetricData.AggregationTemporality.DELTA,
+              Collections.singletonList(
+                  MetricData.LongPoint.create(123, 456, Labels.of("kp", "vp"), 5))));
+
+  private static final MetricData DOUBLE_GAUGE =
+      MetricData.createDoubleGauge(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          MetricData.DoubleGaugeData.create(
+              Collections.singletonList(
+                  MetricData.DoublePoint.create(123, 456, Labels.of("kp", "vp"), 5))));
+  private static final MetricData LONG_GAUGE =
+      MetricData.createLongGauge(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          MetricData.LongGaugeData.create(
+              Collections.singletonList(
+                  MetricData.LongPoint.create(123, 456, Labels.of("kp", "vp"), 5))));
+  private static final MetricData SUMMARY =
+      MetricData.createDoubleSummary(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          MetricData.DoubleSummaryData.create(
+              Collections.singletonList(
+                  MetricData.DoubleSummaryPoint.create(
+                      123, 456, Labels.of("kp", "vp"), 5, 7, Collections.emptyList()))));
+
   @Test
   void toProtoMetricDescriptorType() {
-    assertThat(MetricAdapter.toMetricFamilyType(MetricData.Type.NON_MONOTONIC_DOUBLE_SUM))
-        .isEqualTo(Collector.Type.GAUGE);
-    assertThat(MetricAdapter.toMetricFamilyType(MetricData.Type.NON_MONOTONIC_LONG_SUM))
-        .isEqualTo(Collector.Type.GAUGE);
-    assertThat(MetricAdapter.toMetricFamilyType(MetricData.Type.DOUBLE_SUM))
-        .isEqualTo(Collector.Type.COUNTER);
-    assertThat(MetricAdapter.toMetricFamilyType(MetricData.Type.LONG_SUM))
-        .isEqualTo(Collector.Type.COUNTER);
-    assertThat(MetricAdapter.toMetricFamilyType(MetricData.Type.SUMMARY))
-        .isEqualTo(Collector.Type.SUMMARY);
-    assertThat(MetricAdapter.toMetricFamilyType(MetricData.Type.DOUBLE_GAUGE))
-        .isEqualTo(Collector.Type.GAUGE);
-    assertThat(MetricAdapter.toMetricFamilyType(MetricData.Type.LONG_GAUGE))
-        .isEqualTo(Collector.Type.GAUGE);
+    MetricFamilySamples metricFamilySamples =
+        MetricAdapter.toMetricFamilySamples(MONOTONIC_CUMULATIVE_DOUBLE_SUM);
+    assertThat(metricFamilySamples.type).isEqualTo(Collector.Type.COUNTER);
+    assertThat(metricFamilySamples.samples).hasSize(1);
+
+    metricFamilySamples = MetricAdapter.toMetricFamilySamples(NON_MONOTONIC_CUMULATIVE_DOUBLE_SUM);
+    assertThat(metricFamilySamples.type).isEqualTo(Collector.Type.GAUGE);
+    assertThat(metricFamilySamples.samples).hasSize(1);
+
+    metricFamilySamples = MetricAdapter.toMetricFamilySamples(MONOTONIC_DELTA_DOUBLE_SUM);
+    assertThat(metricFamilySamples.type).isEqualTo(Collector.Type.GAUGE);
+    assertThat(metricFamilySamples.samples).hasSize(1);
+
+    metricFamilySamples = MetricAdapter.toMetricFamilySamples(NON_MONOTONIC_DELTA_DOUBLE_SUM);
+    assertThat(metricFamilySamples.type).isEqualTo(Collector.Type.GAUGE);
+    assertThat(metricFamilySamples.samples).hasSize(1);
+
+    metricFamilySamples = MetricAdapter.toMetricFamilySamples(MONOTONIC_CUMULATIVE_LONG_SUM);
+    assertThat(metricFamilySamples.type).isEqualTo(Collector.Type.COUNTER);
+    assertThat(metricFamilySamples.samples).hasSize(1);
+
+    metricFamilySamples = MetricAdapter.toMetricFamilySamples(NON_MONOTONIC_CUMULATIVE_LONG_SUM);
+    assertThat(metricFamilySamples.type).isEqualTo(Collector.Type.GAUGE);
+    assertThat(metricFamilySamples.samples).hasSize(1);
+
+    metricFamilySamples = MetricAdapter.toMetricFamilySamples(MONOTONIC_DELTA_LONG_SUM);
+    assertThat(metricFamilySamples.type).isEqualTo(Collector.Type.GAUGE);
+    assertThat(metricFamilySamples.samples).hasSize(1);
+
+    metricFamilySamples = MetricAdapter.toMetricFamilySamples(NON_MONOTONIC_DELTA_LONG_SUM);
+    assertThat(metricFamilySamples.type).isEqualTo(Collector.Type.GAUGE);
+    assertThat(metricFamilySamples.samples).hasSize(1);
+
+    metricFamilySamples = MetricAdapter.toMetricFamilySamples(SUMMARY);
+    assertThat(metricFamilySamples.type).isEqualTo(Collector.Type.SUMMARY);
+    assertThat(metricFamilySamples.samples).hasSize(2);
+
+    metricFamilySamples = MetricAdapter.toMetricFamilySamples(DOUBLE_GAUGE);
+    assertThat(metricFamilySamples.type).isEqualTo(Collector.Type.GAUGE);
+    assertThat(metricFamilySamples.samples).hasSize(1);
+
+    metricFamilySamples = MetricAdapter.toMetricFamilySamples(LONG_GAUGE);
+    assertThat(metricFamilySamples.type).isEqualTo(Collector.Type.GAUGE);
+    assertThat(metricFamilySamples.samples).hasSize(1);
   }
 
   @Test
@@ -46,24 +205,6 @@ class MetricAdapterTest {
     assertThat(
             MetricAdapter.toSamples("full_name", MetricData.Type.LONG_SUM, Collections.emptyList()))
         .isEmpty();
-
-    assertThat(
-            MetricAdapter.toSamples(
-                "full_name",
-                MetricData.Type.NON_MONOTONIC_LONG_SUM,
-                Collections.singletonList(
-                    MetricData.LongPoint.create(123, 456, Labels.of("kp", "vp"), 5))))
-        .containsExactly(
-            new Sample("full_name", ImmutableList.of("kp"), ImmutableList.of("vp"), 5));
-
-    assertThat(
-            MetricAdapter.toSamples(
-                "full_name",
-                MetricData.Type.NON_MONOTONIC_LONG_SUM,
-                Collections.singletonList(
-                    MetricData.LongPoint.create(123, 456, Labels.of("kp", "vp"), 5))))
-        .containsExactly(
-            new Sample("full_name", ImmutableList.of("kp"), ImmutableList.of("vp"), 5));
 
     assertThat(
             MetricAdapter.toSamples(
@@ -92,7 +233,7 @@ class MetricAdapterTest {
   void toSamples_DoublePoints() {
     assertThat(
             MetricAdapter.toSamples(
-                "full_name", MetricData.Type.NON_MONOTONIC_DOUBLE_SUM, Collections.emptyList()))
+                "full_name", MetricData.Type.DOUBLE_SUM, Collections.emptyList()))
         .isEmpty();
 
     assertThat(
@@ -103,17 +244,6 @@ class MetricAdapterTest {
                     MetricData.DoublePoint.create(123, 456, Labels.of("kp", "vp"), 5))))
         .containsExactly(
             new Sample("full_name", ImmutableList.of("kp"), ImmutableList.of("vp"), 5));
-
-    assertThat(
-            MetricAdapter.toSamples(
-                "full_name",
-                MetricData.Type.NON_MONOTONIC_DOUBLE_SUM,
-                ImmutableList.of(
-                    MetricData.DoublePoint.create(123, 456, Labels.empty(), 5),
-                    MetricData.DoublePoint.create(321, 654, Labels.of("kp", "vp"), 7))))
-        .containsExactly(
-            new Sample("full_name", Collections.emptyList(), Collections.emptyList(), 5),
-            new Sample("full_name", ImmutableList.of("kp"), ImmutableList.of("vp"), 7));
 
     assertThat(
             MetricAdapter.toSamples(
@@ -138,7 +268,7 @@ class MetricAdapterTest {
                 "full_name",
                 MetricData.Type.SUMMARY,
                 ImmutableList.of(
-                    MetricData.SummaryPoint.create(
+                    MetricData.DoubleSummaryPoint.create(
                         321,
                         654,
                         Labels.of("kp", "vp"),
@@ -159,9 +289,9 @@ class MetricAdapterTest {
                 "full_name",
                 MetricData.Type.SUMMARY,
                 ImmutableList.of(
-                    MetricData.SummaryPoint.create(
+                    MetricData.DoubleSummaryPoint.create(
                         123, 456, Labels.empty(), 7, 15.3, Collections.emptyList()),
-                    MetricData.SummaryPoint.create(
+                    MetricData.DoubleSummaryPoint.create(
                         321,
                         654,
                         Labels.of("kp", "vp"),
@@ -189,17 +319,7 @@ class MetricAdapterTest {
 
   @Test
   void toMetricFamilySamples() {
-    MetricData metricData =
-        MetricData.create(
-            Resource.create(Attributes.of(stringKey("kr"), "vr")),
-            InstrumentationLibraryInfo.create("full", "version"),
-            "instrument.name",
-            "description",
-            "1",
-            MetricData.Type.DOUBLE_SUM,
-            Collections.singletonList(
-                MetricData.DoublePoint.create(123, 456, Labels.of("kp", "vp"), 5)));
-
+    MetricData metricData = MONOTONIC_CUMULATIVE_DOUBLE_SUM;
     assertThat(MetricAdapter.toMetricFamilySamples(metricData))
         .isEqualTo(
             new MetricFamilySamples(

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/PrometheusCollectorTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/PrometheusCollectorTest.java
@@ -55,23 +55,27 @@ class PrometheusCollectorTest {
 
   private static ImmutableList<MetricData> generateTestData() {
     return ImmutableList.of(
-        MetricData.create(
+        MetricData.createLongSum(
             Resource.create(Attributes.of(stringKey("kr"), "vr")),
             InstrumentationLibraryInfo.create("grpc", "version"),
             "grpc.name",
             "long_description",
             "1",
-            MetricData.Type.LONG_SUM,
-            Collections.singletonList(
-                MetricData.LongPoint.create(123, 456, Labels.of("kp", "vp"), 5))),
-        MetricData.create(
+            MetricData.LongSumData.create(
+                /* isMonotonic= */ true,
+                MetricData.AggregationTemporality.CUMULATIVE,
+                Collections.singletonList(
+                    MetricData.LongPoint.create(123, 456, Labels.of("kp", "vp"), 5)))),
+        MetricData.createDoubleSum(
             Resource.create(Attributes.of(stringKey("kr"), "vr")),
             InstrumentationLibraryInfo.create("http", "version"),
             "http.name",
             "double_description",
             "1",
-            MetricData.Type.DOUBLE_SUM,
-            Collections.singletonList(
-                MetricData.DoublePoint.create(123, 456, Labels.of("kp", "vp"), 3.5))));
+            MetricData.DoubleSumData.create(
+                /* isMonotonic= */ true,
+                MetricData.AggregationTemporality.CUMULATIVE,
+                Collections.singletonList(
+                    MetricData.DoublePoint.create(123, 456, Labels.of("kp", "vp"), 3.5)))));
   }
 }

--- a/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/OpenTelemetryMetricsExporter.java
+++ b/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/OpenTelemetryMetricsExporter.java
@@ -22,8 +22,8 @@ import io.opentelemetry.api.common.LabelsBuilder;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
+import io.opentelemetry.sdk.metrics.data.MetricData.DoubleSummaryPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
-import io.opentelemetry.sdk.metrics.data.MetricData.SummaryPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.ValueAtPercentile;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.ArrayList;
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class OpenTelemetryMetricsExporter extends MetricExporter {
   private static final Logger LOGGER =
@@ -91,17 +92,9 @@ public class OpenTelemetryMetricsExporter extends MetricExporter {
         for (Point point : timeSeries.getPoints()) {
           type = mapAndAddPoint(unsupportedTypes, metric, labels, points, point);
         }
-        MetricData.Type metricDataType = mapType(type);
-        if (metricDataType != null) {
-          metricData.add(
-              MetricData.create(
-                  Resource.getDefault(),
-                  INSTRUMENTATION_LIBRARY_INFO,
-                  metric.getMetricDescriptor().getName(),
-                  metric.getMetricDescriptor().getDescription(),
-                  metric.getMetricDescriptor().getUnit(),
-                  metricDataType,
-                  points));
+        MetricData md = toMetricData(type, metric.getMetricDescriptor(), points);
+        if (md != null) {
+          metricData.add(md);
         }
       }
     }
@@ -150,8 +143,9 @@ public class OpenTelemetryMetricsExporter extends MetricExporter {
   }
 
   @Nonnull
-  private static SummaryPoint mapSummaryPoint(Labels labels, Point point, long timestampNanos) {
-    return SummaryPoint.create(
+  private static MetricData.DoubleSummaryPoint mapSummaryPoint(
+      Labels labels, Point point, long timestampNanos) {
+    return DoubleSummaryPoint.create(
         timestampNanos,
         timestampNanos,
         labels,
@@ -199,21 +193,59 @@ public class OpenTelemetryMetricsExporter extends MetricExporter {
             .match(Double::longValue, arg -> arg, arg -> null, arg -> null, arg -> null));
   }
 
-  private static MetricData.Type mapType(MetricDescriptor.Type type) {
-    if (type == null) {
+  @Nullable
+  private static MetricData toMetricData(
+      MetricDescriptor.Type type,
+      MetricDescriptor metricDescriptor,
+      List<MetricData.Point> points) {
+    if (metricDescriptor.getType() == null) {
       return null;
     }
     switch (type) {
       case GAUGE_INT64:
-        return MetricData.Type.LONG_GAUGE;
+        return MetricData.createLongGauge(
+            Resource.getDefault(),
+            INSTRUMENTATION_LIBRARY_INFO,
+            metricDescriptor.getName(),
+            metricDescriptor.getDescription(),
+            metricDescriptor.getUnit(),
+            MetricData.LongGaugeData.create(points));
+
       case GAUGE_DOUBLE:
-        return MetricData.Type.DOUBLE_GAUGE;
+        return MetricData.createDoubleGauge(
+            Resource.getDefault(),
+            INSTRUMENTATION_LIBRARY_INFO,
+            metricDescriptor.getName(),
+            metricDescriptor.getDescription(),
+            metricDescriptor.getUnit(),
+            MetricData.DoubleGaugeData.create(points));
+
       case CUMULATIVE_INT64:
-        return MetricData.Type.LONG_SUM;
+        return MetricData.createLongSum(
+            Resource.getDefault(),
+            INSTRUMENTATION_LIBRARY_INFO,
+            metricDescriptor.getName(),
+            metricDescriptor.getDescription(),
+            metricDescriptor.getUnit(),
+            MetricData.LongSumData.create(
+                true, MetricData.AggregationTemporality.CUMULATIVE, points));
       case CUMULATIVE_DOUBLE:
-        return MetricData.Type.DOUBLE_SUM;
+        return MetricData.createDoubleSum(
+            Resource.getDefault(),
+            INSTRUMENTATION_LIBRARY_INFO,
+            metricDescriptor.getName(),
+            metricDescriptor.getDescription(),
+            metricDescriptor.getUnit(),
+            MetricData.DoubleSumData.create(
+                true, MetricData.AggregationTemporality.CUMULATIVE, points));
       case SUMMARY:
-        return MetricData.Type.SUMMARY;
+        return MetricData.createDoubleSummary(
+            Resource.getDefault(),
+            INSTRUMENTATION_LIBRARY_INFO,
+            metricDescriptor.getName(),
+            metricDescriptor.getDescription(),
+            metricDescriptor.getUnit(),
+            MetricData.DoubleSummaryData.create(points));
       default:
         return null;
     }

--- a/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/MetricInteroperabilityTest.java
+++ b/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/MetricInteroperabilityTest.java
@@ -71,8 +71,8 @@ public class MetricInteroperabilityTest {
     assertThat(metric.getDescription()).isEqualTo("The sum of the task latencies.");
     assertThat(metric.getUnit()).isEqualTo("ms");
     assertThat(metric.getType()).isEqualTo(MetricData.Type.LONG_SUM);
-    assertThat(metric.getPoints().size()).isEqualTo(1);
-    Point point = metric.getPoints().iterator().next();
+    assertThat(metric.getLongSumData().getPoints().size()).isEqualTo(1);
+    Point point = metric.getLongSumData().getPoints().iterator().next();
     assertThat(((LongPoint) point).getValue()).isEqualTo(50);
     assertThat(point.getLabels().size()).isEqualTo(1);
     assertThat(point.getLabels().get(tagKey.getName())).isEqualTo(tagValue.asString());

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractAsynchronousInstrument.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractAsynchronousInstrument.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.util.List;
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractDoubleAsynchronousInstrumentBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractDoubleAsynchronousInstrumentBuilder.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.api.metrics.AsynchronousInstrument;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import java.util.function.BiFunction;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.metrics;
 import io.opentelemetry.api.internal.StringUtils;
 import io.opentelemetry.api.internal.Utils;
 import io.opentelemetry.api.metrics.Instrument;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractLongAsynchronousInstrumentBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractLongAsynchronousInstrumentBuilder.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.api.metrics.AsynchronousInstrument;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import java.util.function.BiFunction;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractSynchronousInstrument.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractSynchronousInstrument.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.api.common.Labels;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.util.List;
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractSynchronousInstrumentBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractSynchronousInstrumentBuilder.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import java.util.function.BiFunction;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AggregationChooser.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AggregationChooser.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.view.AggregationConfiguration;
 import io.opentelemetry.sdk.metrics.view.Aggregations;
 import io.opentelemetry.sdk.metrics.view.InstrumentSelector;
@@ -17,16 +19,16 @@ import java.util.regex.Pattern;
 class AggregationChooser {
   private static final AggregationConfiguration CUMULATIVE_SUM =
       AggregationConfiguration.create(
-          Aggregations.sum(), AggregationConfiguration.Temporality.CUMULATIVE);
+          Aggregations.sum(), MetricData.AggregationTemporality.CUMULATIVE);
   private static final AggregationConfiguration DELTA_SUMMARY =
       AggregationConfiguration.create(
-          Aggregations.minMaxSumCount(), AggregationConfiguration.Temporality.DELTA);
+          Aggregations.minMaxSumCount(), MetricData.AggregationTemporality.DELTA);
   private static final AggregationConfiguration CUMULATIVE_LAST_VALUE =
       AggregationConfiguration.create(
-          Aggregations.lastValue(), AggregationConfiguration.Temporality.CUMULATIVE);
+          Aggregations.lastValue(), MetricData.AggregationTemporality.CUMULATIVE);
   private static final AggregationConfiguration DELTA_LAST_VALUE =
       AggregationConfiguration.create(
-          Aggregations.lastValue(), AggregationConfiguration.Temporality.DELTA);
+          Aggregations.lastValue(), MetricData.AggregationTemporality.DELTA);
 
   private final Map<InstrumentSelector, AggregationConfiguration> configuration =
       new ConcurrentHashMap<>();

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleCounterSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleCounterSdk.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.metrics.DoubleCounter;
 import io.opentelemetry.sdk.metrics.DoubleCounterSdk.BoundInstrument;
 import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleSumObserverSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleSumObserverSdk.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.api.metrics.DoubleSumObserver;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleUpDownCounterSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleUpDownCounterSdk.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.metrics.DoubleUpDownCounter;
 import io.opentelemetry.sdk.metrics.DoubleUpDownCounterSdk.BoundInstrument;
 import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleUpDownSumObserverSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleUpDownSumObserverSdk.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.api.metrics.DoubleUpDownSumObserver;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleValueObserverSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleValueObserverSdk.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.api.metrics.DoubleValueObserver;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdk.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.metrics.DoubleValueRecorder;
 import io.opentelemetry.sdk.metrics.DoubleValueRecorderSdk.BoundInstrument;
 import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongCounterSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongCounterSdk.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.sdk.metrics.LongCounterSdk.BoundInstrument;
 import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongSumObserverSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongSumObserverSdk.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.api.metrics.LongSumObserver;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongUpDownCounterSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongUpDownCounterSdk.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.metrics.LongUpDownCounter;
 import io.opentelemetry.sdk.metrics.LongUpDownCounterSdk.BoundInstrument;
 import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongUpDownSumObserverSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongUpDownSumObserverSdk.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.api.metrics.LongUpDownSumObserver;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongValueObserverSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongValueObserverSdk.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.api.metrics.LongValueObserver;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdk.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.metrics.LongValueRecorder;
 import io.opentelemetry.sdk.metrics.LongValueRecorderSdk.BoundInstrument;
 import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/ViewRegistry.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/ViewRegistry.java
@@ -5,9 +5,10 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.view.Aggregation;
 import io.opentelemetry.sdk.metrics.view.AggregationConfiguration;
-import io.opentelemetry.sdk.metrics.view.AggregationConfiguration.Temporality;
 import io.opentelemetry.sdk.metrics.view.InstrumentSelector;
 
 // notes:
@@ -54,10 +55,10 @@ class ViewRegistry {
 
     Aggregation aggregation = specification.aggregation();
 
-    if (Temporality.CUMULATIVE == specification.temporality()) {
+    if (MetricData.AggregationTemporality.CUMULATIVE == specification.temporality()) {
       return InstrumentProcessor.getCumulativeAllLabels(
           descriptor, meterProviderSharedState, meterSharedState, aggregation);
-    } else if (Temporality.DELTA == specification.temporality()) {
+    } else if (MetricData.AggregationTemporality.DELTA == specification.temporality()) {
       return InstrumentProcessor.getDeltaAllLabels(
           descriptor, meterProviderSharedState, meterSharedState, aggregation);
     }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCount.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCount.java
@@ -7,8 +7,8 @@ package io.opentelemetry.sdk.metrics.aggregator;
 
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.opentelemetry.api.common.Labels;
+import io.opentelemetry.sdk.metrics.data.MetricData.DoubleSummaryPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.Point;
-import io.opentelemetry.sdk.metrics.data.MetricData.SummaryPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.ValueAtPercentile;
 import java.util.Arrays;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -108,12 +108,12 @@ public final class DoubleMinMaxSumCount extends AbstractAggregator {
     }
 
     @Nullable
-    private SummaryPoint toPoint(long startEpochNanos, long epochNanos, Labels labels) {
+    private DoubleSummaryPoint toPoint(long startEpochNanos, long epochNanos, Labels labels) {
       lock.readLock().lock();
       try {
         return count == 0
             ? null
-            : SummaryPoint.create(
+            : DoubleSummaryPoint.create(
                 startEpochNanos,
                 epochNanos,
                 labels,

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCount.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCount.java
@@ -7,8 +7,8 @@ package io.opentelemetry.sdk.metrics.aggregator;
 
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.opentelemetry.api.common.Labels;
+import io.opentelemetry.sdk.metrics.data.MetricData.DoubleSummaryPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.Point;
-import io.opentelemetry.sdk.metrics.data.MetricData.SummaryPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.ValueAtPercentile;
 import java.util.Arrays;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -108,13 +108,12 @@ public final class LongMinMaxSumCount extends AbstractAggregator {
       }
     }
 
-    @Nullable
-    private SummaryPoint toPoint(long startEpochNanos, long epochNanos, Labels labels) {
+    private DoubleSummaryPoint toPoint(long startEpochNanos, long epochNanos, Labels labels) {
       lock.readLock().lock();
       try {
         return count == 0
             ? null
-            : SummaryPoint.create(
+            : DoubleSummaryPoint.create(
                 startEpochNanos,
                 epochNanos,
                 labels,

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/common/InstrumentDescriptor.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/common/InstrumentDescriptor.java
@@ -3,18 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.metrics;
+package io.opentelemetry.sdk.metrics.common;
 
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.extension.memoized.Memoized;
-import io.opentelemetry.sdk.metrics.common.InstrumentType;
-import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import javax.annotation.concurrent.Immutable;
 
 @AutoValue
 @Immutable
-abstract class InstrumentDescriptor {
-  static InstrumentDescriptor create(
+public abstract class InstrumentDescriptor {
+  public static InstrumentDescriptor create(
       String name,
       String description,
       String unit,
@@ -23,15 +21,15 @@ abstract class InstrumentDescriptor {
     return new AutoValue_InstrumentDescriptor(name, description, unit, type, valueType);
   }
 
-  abstract String getName();
+  public abstract String getName();
 
-  abstract String getDescription();
+  public abstract String getDescription();
 
-  abstract String getUnit();
+  public abstract String getUnit();
 
-  abstract InstrumentType getType();
+  public abstract InstrumentType getType();
 
-  abstract InstrumentValueType getValueType();
+  public abstract InstrumentValueType getValueType();
 
   @Memoized
   @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/Aggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/Aggregation.java
@@ -5,10 +5,16 @@
 
 package io.opentelemetry.sdk.metrics.view;
 
+import io.opentelemetry.api.common.Labels;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.aggregator.AggregatorFactory;
-import io.opentelemetry.sdk.metrics.common.InstrumentType;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.Map;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -29,30 +35,23 @@ public interface Aggregation {
   AggregatorFactory getAggregatorFactory(InstrumentValueType instrumentValueType);
 
   /**
-   * Returns the {@link MetricData.Type} that this {@code Aggregation} will produce.
+   * Returns the {@link MetricData} that this {@code Aggregation} will produce.
    *
-   * @param instrumentType the type of the {@code Instrument}.
-   * @param instrumentValueType the type of recorded values for the {@code Instrument}.
+   * @param resource the Resource associated with the {@code Instrument}.
+   * @param instrumentationLibraryInfo the InstrumentationLibraryInfo associated with the {@code
+   *     Instrument}.
+   * @param descriptor the InstrumentDescriptor of the {@code Instrument}.
+   * @param aggregatorMap the map of Labels to Aggregators.
+   * @param startEpochNanos the startEpochNanos for the {@code Point}.
+   * @param epochNanos the epochNanos for the {@code Point}.
    * @return the {@link MetricData.Type} that this {@code Aggregation} will produce.
    */
-  MetricData.Type getDescriptorType(
-      InstrumentType instrumentType, InstrumentValueType instrumentValueType);
-
-  /**
-   * Returns the unit that this {@code Aggregation} will produce.
-   *
-   * @param initialUnit the initial unit for the {@code Instrument}'s measurements.
-   * @return the unit that this {@code Aggregation} will produce.
-   */
-  String getUnit(String initialUnit);
-
-  /**
-   * Returns {@code true} if this {@code Aggregation} can be applied to the given {@code
-   * InstrumentType}.
-   *
-   * @param instrumentType the type of the {@code Instrument}.
-   * @return {@code true} if this {@code Aggregation} can be applied to the given {@code
-   *     InstrumentType}.
-   */
-  boolean availableForInstrument(InstrumentType instrumentType);
+  @Nullable
+  MetricData toMetricData(
+      Resource resource,
+      InstrumentationLibraryInfo instrumentationLibraryInfo,
+      InstrumentDescriptor descriptor,
+      Map<Labels, Aggregator> aggregatorMap,
+      long startEpochNanos,
+      long epochNanos);
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/AggregationConfiguration.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/AggregationConfiguration.java
@@ -6,13 +6,13 @@
 package io.opentelemetry.sdk.metrics.view;
 
 import com.google.auto.value.AutoValue;
-import io.opentelemetry.api.metrics.Instrument;
+import io.opentelemetry.sdk.metrics.data.MetricData;
 import javax.annotation.concurrent.Immutable;
 
 /**
  * An AggregationConfiguration describes how an aggregation should be performed. It includes both an
  * {@link Aggregation} which implements what shape of aggregation is created (i.e. histogram, sum,
- * minMaxSumCount, etc), and a {@link AggregationConfiguration.Temporality} which describes whether
+ * minMaxSumCount, etc), and a {@link MetricData.AggregationTemporality} which describes whether
  * aggregations should be reset with every collection interval, or continue to accumulate across
  * collection intervals.
  */
@@ -21,21 +21,17 @@ import javax.annotation.concurrent.Immutable;
 public abstract class AggregationConfiguration {
 
   /** Returns a new configuration with the provided options. */
-  public static AggregationConfiguration create(Aggregation aggregation, Temporality temporality) {
-    return new AutoValue_AggregationConfiguration(aggregation, temporality);
+  public static AggregationConfiguration create(
+      Aggregation aggregation, MetricData.AggregationTemporality aggregationTemporality) {
+    return new AutoValue_AggregationConfiguration(aggregation, aggregationTemporality);
   }
 
   /** Returns the {@link Aggregation} that should be used for this View. */
   public abstract Aggregation aggregation();
 
-  /** Returns the {@link Temporality} that should be used for this View (delta vs. cumulative). */
-  public abstract Temporality temporality();
-
-  /** An enumeration which describes the time period over which metrics should be aggregated. */
-  public enum Temporality {
-    /** Metrics will be aggregated only over the most recent collection interval. */
-    DELTA,
-    /** Metrics will be aggregated over the lifetime of the associated {@link Instrument}. */
-    CUMULATIVE
-  }
+  /**
+   * Returns the {@link MetricData.AggregationTemporality} that should be used for this View (delta
+   * vs. cumulative).
+   */
+  public abstract MetricData.AggregationTemporality temporality();
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/Aggregations.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/Aggregations.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.sdk.metrics.view;
 
+import io.opentelemetry.api.common.Labels;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.aggregator.DoubleLastValueAggregator;
 import io.opentelemetry.sdk.metrics.aggregator.DoubleMinMaxSumCount;
@@ -13,9 +16,15 @@ import io.opentelemetry.sdk.metrics.aggregator.LongLastValueAggregator;
 import io.opentelemetry.sdk.metrics.aggregator.LongMinMaxSumCount;
 import io.opentelemetry.sdk.metrics.aggregator.LongSumAggregator;
 import io.opentelemetry.sdk.metrics.aggregator.NoopAggregator;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 public class Aggregations {
@@ -38,19 +47,6 @@ public class Aggregations {
    */
   public static Aggregation count() {
     return Count.INSTANCE;
-  }
-
-  /**
-   * Returns an {@code Aggregation} that calculates distribution stats on recorded measurements.
-   * Distribution includes sum, count, histogram, and sum of squared deviations.
-   *
-   * <p>The boundaries for the buckets in the underlying histogram needs to be sorted.
-   *
-   * @param bucketBoundaries bucket boundaries to use for distribution.
-   * @return an {@code Aggregation} that calculates distribution stats on recorded measurements.
-   */
-  public static Aggregation distributionWithExplicitBounds(Double... bucketBoundaries) {
-    return new Distribution(bucketBoundaries);
   }
 
   /**
@@ -84,20 +80,24 @@ public class Aggregations {
     }
 
     @Override
-    public MetricData.Type getDescriptorType(
-        InstrumentType instrumentType, InstrumentValueType instrumentValueType) {
-      return MetricData.Type.SUMMARY;
-    }
-
-    @Override
-    public String getUnit(String initialUnit) {
-      return initialUnit;
-    }
-
-    @Override
-    public boolean availableForInstrument(InstrumentType instrumentType) {
-      return instrumentType == InstrumentType.VALUE_OBSERVER
-          || instrumentType == InstrumentType.VALUE_RECORDER;
+    public MetricData toMetricData(
+        Resource resource,
+        InstrumentationLibraryInfo instrumentationLibraryInfo,
+        InstrumentDescriptor descriptor,
+        Map<Labels, Aggregator> aggregatorMap,
+        long startEpochNanos,
+        long epochNanos) {
+      if (aggregatorMap.isEmpty()) {
+        return null;
+      }
+      List<MetricData.Point> points = getPointList(aggregatorMap, startEpochNanos, epochNanos);
+      return MetricData.createDoubleSummary(
+          resource,
+          instrumentationLibraryInfo,
+          descriptor.getName(),
+          descriptor.getDescription(),
+          descriptor.getUnit(),
+          MetricData.DoubleSummaryData.create(points));
     }
 
     @Override
@@ -118,34 +118,19 @@ public class Aggregations {
     }
 
     @Override
-    public MetricData.Type getDescriptorType(
-        InstrumentType instrumentType, InstrumentValueType instrumentValueType) {
-      switch (instrumentType) {
-        case COUNTER:
-        case SUM_OBSERVER:
-          return instrumentValueType == InstrumentValueType.LONG
-              ? MetricData.Type.LONG_SUM
-              : MetricData.Type.DOUBLE_SUM;
-        case UP_DOWN_COUNTER:
-        case VALUE_RECORDER:
-        case UP_DOWN_SUM_OBSERVER:
-        case VALUE_OBSERVER:
-          return instrumentValueType == InstrumentValueType.LONG
-              ? MetricData.Type.NON_MONOTONIC_LONG_SUM
-              : MetricData.Type.NON_MONOTONIC_DOUBLE_SUM;
-      }
-      throw new IllegalArgumentException("Unsupported instrument/value types");
-    }
-
-    @Override
-    public String getUnit(String initialUnit) {
-      return initialUnit;
-    }
-
-    @Override
-    public boolean availableForInstrument(InstrumentType instrumentType) {
-      // Available for all instruments.
-      return true;
+    public MetricData toMetricData(
+        Resource resource,
+        InstrumentationLibraryInfo instrumentationLibraryInfo,
+        InstrumentDescriptor descriptor,
+        Map<Labels, Aggregator> aggregatorMap,
+        long startEpochNanos,
+        long epochNanos) {
+      List<MetricData.Point> points = getPointList(aggregatorMap, startEpochNanos, epochNanos);
+      boolean isMonotonic =
+          descriptor.getType() == InstrumentType.COUNTER
+              || descriptor.getType() == InstrumentType.SUM_OBSERVER;
+      return getSumMetricData(
+          resource, instrumentationLibraryInfo, descriptor, points, isMonotonic);
     }
 
     @Override
@@ -165,56 +150,23 @@ public class Aggregations {
     }
 
     @Override
-    public MetricData.Type getDescriptorType(
-        InstrumentType instrumentType, InstrumentValueType instrumentValueType) {
-      return MetricData.Type.LONG_SUM;
-    }
+    public MetricData toMetricData(
+        Resource resource,
+        InstrumentationLibraryInfo instrumentationLibraryInfo,
+        InstrumentDescriptor descriptor,
+        Map<Labels, Aggregator> aggregatorMap,
+        long startEpochNanos,
+        long epochNanos) {
+      List<MetricData.Point> points = getPointList(aggregatorMap, startEpochNanos, epochNanos);
 
-    @Override
-    public String getUnit(String initialUnit) {
-      return "1";
-    }
-
-    @Override
-    public boolean availableForInstrument(InstrumentType instrumentType) {
-      // Available for all instruments.
-      return true;
-    }
-
-    @Override
-    public String toString() {
-      return getClass().getSimpleName();
-    }
-  }
-
-  @Immutable
-  private static final class Distribution implements Aggregation {
-    private final AggregatorFactory factory;
-
-    Distribution(Double... bucketBoundaries) {
-      // TODO: Implement distribution aggregator and use it here.
-      this.factory = NoopAggregator.getFactory();
-    }
-
-    @Override
-    public AggregatorFactory getAggregatorFactory(InstrumentValueType instrumentValueType) {
-      return factory;
-    }
-
-    @Override
-    public MetricData.Type getDescriptorType(
-        InstrumentType instrumentType, InstrumentValueType instrumentValueType) {
-      throw new UnsupportedOperationException("Implement this");
-    }
-
-    @Override
-    public String getUnit(String initialUnit) {
-      return initialUnit;
-    }
-
-    @Override
-    public boolean availableForInstrument(InstrumentType instrumentType) {
-      throw new UnsupportedOperationException("Implement this");
+      return MetricData.createLongSum(
+          resource,
+          instrumentationLibraryInfo,
+          descriptor.getName(),
+          descriptor.getDescription(),
+          "1",
+          MetricData.LongSumData.create(
+              /* isMonotonic= */ true, MetricData.AggregationTemporality.CUMULATIVE, points));
     }
 
     @Override
@@ -235,44 +187,106 @@ public class Aggregations {
     }
 
     @Override
-    public MetricData.Type getDescriptorType(
-        InstrumentType instrumentType, InstrumentValueType instrumentValueType) {
-      switch (instrumentType) {
+    public MetricData toMetricData(
+        Resource resource,
+        InstrumentationLibraryInfo instrumentationLibraryInfo,
+        InstrumentDescriptor descriptor,
+        Map<Labels, Aggregator> aggregatorMap,
+        long startEpochNanos,
+        long epochNanos) {
+      List<MetricData.Point> points = getPointList(aggregatorMap, startEpochNanos, epochNanos);
+
+      switch (descriptor.getType()) {
         case SUM_OBSERVER:
-          return instrumentValueType == InstrumentValueType.LONG
-              ? MetricData.Type.LONG_SUM
-              : MetricData.Type.DOUBLE_SUM;
+          return getSumMetricData(
+              resource, instrumentationLibraryInfo, descriptor, points, /* isMonotonic= */ true);
         case UP_DOWN_SUM_OBSERVER:
-          return instrumentValueType == InstrumentValueType.LONG
-              ? MetricData.Type.NON_MONOTONIC_LONG_SUM
-              : MetricData.Type.NON_MONOTONIC_DOUBLE_SUM;
+          return getSumMetricData(
+              resource, instrumentationLibraryInfo, descriptor, points, /* isMonotonic= */ false);
         case VALUE_OBSERVER:
-          return instrumentValueType == InstrumentValueType.LONG
-              ? MetricData.Type.LONG_GAUGE
-              : MetricData.Type.DOUBLE_GAUGE;
-        default:
-          // Do not change this unless the limitations of the current LastValueAggregator are fixed.
-          throw new IllegalArgumentException(
-              "Unsupported instrument/value types: " + instrumentType + "/" + instrumentValueType);
+          return getGaugeMetricData(resource, instrumentationLibraryInfo, descriptor, points);
+        case COUNTER:
+        case UP_DOWN_COUNTER:
+        case VALUE_RECORDER:
       }
-    }
-
-    @Override
-    public String getUnit(String initialUnit) {
-      return initialUnit;
-    }
-
-    @Override
-    public boolean availableForInstrument(InstrumentType instrumentType) {
-      // Do not change this unless the limitations of the current LastValueAggregator are fixed.
-      return instrumentType == InstrumentType.SUM_OBSERVER
-          || instrumentType == InstrumentType.UP_DOWN_SUM_OBSERVER;
+      return null;
     }
 
     @Override
     public String toString() {
       return getClass().getSimpleName();
     }
+  }
+
+  @Nullable
+  private static MetricData getSumMetricData(
+      Resource resource,
+      InstrumentationLibraryInfo instrumentationLibraryInfo,
+      InstrumentDescriptor descriptor,
+      List<MetricData.Point> points,
+      boolean isMonotonic) {
+    switch (descriptor.getValueType()) {
+      case LONG:
+        return MetricData.createLongSum(
+            resource,
+            instrumentationLibraryInfo,
+            descriptor.getName(),
+            descriptor.getDescription(),
+            descriptor.getUnit(),
+            MetricData.LongSumData.create(
+                isMonotonic, MetricData.AggregationTemporality.CUMULATIVE, points));
+      case DOUBLE:
+        return MetricData.createDoubleSum(
+            resource,
+            instrumentationLibraryInfo,
+            descriptor.getName(),
+            descriptor.getDescription(),
+            descriptor.getUnit(),
+            MetricData.DoubleSumData.create(
+                isMonotonic, MetricData.AggregationTemporality.CUMULATIVE, points));
+    }
+    return null;
+  }
+
+  @Nullable
+  private static MetricData getGaugeMetricData(
+      Resource resource,
+      InstrumentationLibraryInfo instrumentationLibraryInfo,
+      InstrumentDescriptor descriptor,
+      List<MetricData.Point> points) {
+    switch (descriptor.getValueType()) {
+      case LONG:
+        return MetricData.createLongGauge(
+            resource,
+            instrumentationLibraryInfo,
+            descriptor.getName(),
+            descriptor.getDescription(),
+            descriptor.getUnit(),
+            MetricData.LongGaugeData.create(points));
+      case DOUBLE:
+        return MetricData.createDoubleGauge(
+            resource,
+            instrumentationLibraryInfo,
+            descriptor.getName(),
+            descriptor.getDescription(),
+            descriptor.getUnit(),
+            MetricData.DoubleGaugeData.create(points));
+    }
+    return null;
+  }
+
+  private static List<MetricData.Point> getPointList(
+      Map<Labels, Aggregator> aggregatorMap, long startEpochNanos, long epochNanos) {
+    List<MetricData.Point> points = new ArrayList<>(aggregatorMap.size());
+    aggregatorMap.forEach(
+        (labels, aggregator) -> {
+          MetricData.Point point = aggregator.toPoint(startEpochNanos, epochNanos, labels);
+          if (point == null) {
+            return;
+          }
+          points.add(point);
+        });
+    return points;
   }
 
   private Aggregations() {}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.api.internal.StringUtils;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AggregationChooserTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AggregationChooserTest.java
@@ -7,8 +7,10 @@ package io.opentelemetry.sdk.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
+import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.view.AggregationConfiguration;
 import io.opentelemetry.sdk.metrics.view.Aggregations;
 import io.opentelemetry.sdk.metrics.view.InstrumentSelector;
@@ -20,7 +22,7 @@ class AggregationChooserTest {
   void selection_onType() {
     AggregationConfiguration configuration =
         AggregationConfiguration.create(
-            Aggregations.sum(), AggregationConfiguration.Temporality.DELTA);
+            Aggregations.sum(), MetricData.AggregationTemporality.DELTA);
 
     AggregationChooser aggregationChooser = new AggregationChooser();
     aggregationChooser.addView(
@@ -38,14 +40,14 @@ class AggregationChooserTest {
                     "", "", "", InstrumentType.UP_DOWN_COUNTER, InstrumentValueType.LONG)))
         .isEqualTo(
             AggregationConfiguration.create(
-                Aggregations.sum(), AggregationConfiguration.Temporality.CUMULATIVE));
+                Aggregations.sum(), MetricData.AggregationTemporality.CUMULATIVE));
   }
 
   @Test
   void selection_onName() {
     AggregationConfiguration configuration =
         AggregationConfiguration.create(
-            Aggregations.sum(), AggregationConfiguration.Temporality.DELTA);
+            Aggregations.sum(), MetricData.AggregationTemporality.DELTA);
 
     AggregationChooser aggregationChooser = new AggregationChooser();
     aggregationChooser.addView(
@@ -62,17 +64,17 @@ class AggregationChooserTest {
                     "default", "", "", InstrumentType.UP_DOWN_COUNTER, InstrumentValueType.LONG)))
         .isEqualTo(
             AggregationConfiguration.create(
-                Aggregations.sum(), AggregationConfiguration.Temporality.CUMULATIVE));
+                Aggregations.sum(), MetricData.AggregationTemporality.CUMULATIVE));
   }
 
   @Test
   void selection_moreSpecificWins() {
     AggregationConfiguration configuration1 =
         AggregationConfiguration.create(
-            Aggregations.sum(), AggregationConfiguration.Temporality.DELTA);
+            Aggregations.sum(), MetricData.AggregationTemporality.DELTA);
     AggregationConfiguration configuration2 =
         AggregationConfiguration.create(
-            Aggregations.count(), AggregationConfiguration.Temporality.DELTA);
+            Aggregations.count(), MetricData.AggregationTemporality.DELTA);
 
     AggregationChooser aggregationChooser = new AggregationChooser();
     aggregationChooser.addView(
@@ -101,7 +103,7 @@ class AggregationChooserTest {
   void selection_regex() {
     AggregationConfiguration configuration1 =
         AggregationConfiguration.create(
-            Aggregations.sum(), AggregationConfiguration.Temporality.DELTA);
+            Aggregations.sum(), MetricData.AggregationTemporality.DELTA);
 
     AggregationChooser aggregationChooser = new AggregationChooser();
     aggregationChooser.addView(
@@ -128,7 +130,7 @@ class AggregationChooserTest {
                     "default", "", "", InstrumentType.UP_DOWN_COUNTER, InstrumentValueType.LONG)))
         .isEqualTo(
             AggregationConfiguration.create(
-                Aggregations.sum(), AggregationConfiguration.Temporality.CUMULATIVE));
+                Aggregations.sum(), MetricData.AggregationTemporality.CUMULATIVE));
   }
 
   @Test
@@ -140,41 +142,41 @@ class AggregationChooserTest {
                     "", "", "", InstrumentType.COUNTER, InstrumentValueType.LONG)))
         .isEqualTo(
             AggregationConfiguration.create(
-                Aggregations.sum(), AggregationConfiguration.Temporality.CUMULATIVE));
+                Aggregations.sum(), MetricData.AggregationTemporality.CUMULATIVE));
     assertThat(
             aggregationChooser.chooseAggregation(
                 InstrumentDescriptor.create(
                     "", "", "", InstrumentType.UP_DOWN_COUNTER, InstrumentValueType.LONG)))
         .isEqualTo(
             AggregationConfiguration.create(
-                Aggregations.sum(), AggregationConfiguration.Temporality.CUMULATIVE));
+                Aggregations.sum(), MetricData.AggregationTemporality.CUMULATIVE));
     assertThat(
             aggregationChooser.chooseAggregation(
                 InstrumentDescriptor.create(
                     "", "", "", InstrumentType.VALUE_RECORDER, InstrumentValueType.LONG)))
         .isEqualTo(
             AggregationConfiguration.create(
-                Aggregations.minMaxSumCount(), AggregationConfiguration.Temporality.DELTA));
+                Aggregations.minMaxSumCount(), MetricData.AggregationTemporality.DELTA));
     assertThat(
             aggregationChooser.chooseAggregation(
                 InstrumentDescriptor.create(
                     "", "", "", InstrumentType.SUM_OBSERVER, InstrumentValueType.LONG)))
         .isEqualTo(
             AggregationConfiguration.create(
-                Aggregations.lastValue(), AggregationConfiguration.Temporality.CUMULATIVE));
+                Aggregations.lastValue(), MetricData.AggregationTemporality.CUMULATIVE));
     assertThat(
             aggregationChooser.chooseAggregation(
                 InstrumentDescriptor.create(
                     "", "", "", InstrumentType.VALUE_OBSERVER, InstrumentValueType.LONG)))
         .isEqualTo(
             AggregationConfiguration.create(
-                Aggregations.lastValue(), AggregationConfiguration.Temporality.DELTA));
+                Aggregations.lastValue(), MetricData.AggregationTemporality.DELTA));
     assertThat(
             aggregationChooser.chooseAggregation(
                 InstrumentDescriptor.create(
                     "", "", "", InstrumentType.UP_DOWN_SUM_OBSERVER, InstrumentValueType.LONG)))
         .isEqualTo(
             AggregationConfiguration.create(
-                Aggregations.lastValue(), AggregationConfiguration.Temporality.CUMULATIVE));
+                Aggregations.lastValue(), MetricData.AggregationTemporality.CUMULATIVE));
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleCounterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleCounterSdkTest.java
@@ -61,20 +61,17 @@ class DoubleCounterSdkTest {
             .setUnit("ms")
             .build();
     List<MetricData> metricDataList = doubleCounter.collectAll();
-    assertThat(metricDataList).hasSize(1);
-    MetricData metricData = metricDataList.get(0);
-    assertThat(metricData.getName()).isEqualTo("testCounter");
-    assertThat(metricData.getDescription()).isEqualTo("My very own counter");
-    assertThat(metricData.getUnit()).isEqualTo("ms");
-    assertThat(metricData.getType()).isEqualTo(MetricData.Type.DOUBLE_SUM);
-    assertThat(metricData.getResource()).isEqualTo(RESOURCE);
-    assertThat(metricData.getInstrumentationLibraryInfo()).isEqualTo(INSTRUMENTATION_LIBRARY_INFO);
-    assertThat(metricData.getPoints()).isEmpty();
+    assertThat(metricDataList).isEmpty();
   }
 
   @Test
   void collectMetrics_WithOneRecord() {
-    DoubleCounterSdk doubleCounter = testSdk.doubleCounterBuilder("testCounter").build();
+    DoubleCounterSdk doubleCounter =
+        testSdk
+            .doubleCounterBuilder("testCounter")
+            .setDescription("My very own counter")
+            .setUnit("ms")
+            .build();
     testClock.advanceNanos(SECOND_NANOS);
     doubleCounter.add(12.1d, Labels.empty());
     List<MetricData> metricDataList = doubleCounter.collectAll();
@@ -82,10 +79,13 @@ class DoubleCounterSdkTest {
     MetricData metricData = metricDataList.get(0);
     assertThat(metricData.getResource()).isEqualTo(RESOURCE);
     assertThat(metricData.getInstrumentationLibraryInfo()).isEqualTo(INSTRUMENTATION_LIBRARY_INFO);
-    assertThat(metricData.getPoints()).hasSize(1);
+    assertThat(metricData.getName()).isEqualTo("testCounter");
+    assertThat(metricData.getDescription()).isEqualTo("My very own counter");
+    assertThat(metricData.getUnit()).isEqualTo("ms");
+    assertThat(metricData.getType()).isEqualTo(MetricData.Type.DOUBLE_SUM);
     // TODO: This is not perfect because we compare double values using direct equal, maybe worth
     //  changing to do a proper comparison for double values, here and everywhere else.
-    assertThat(metricData.getPoints())
+    assertThat(metricData.getDoubleSumData().getPoints())
         .containsExactly(
             DoublePoint.create(
                 testClock.now() - SECOND_NANOS, testClock.now(), Labels.empty(), 12.1d));
@@ -124,8 +124,7 @@ class DoubleCounterSdkTest {
       List<MetricData> metricDataList = doubleCounter.collectAll();
       assertThat(metricDataList).hasSize(1);
       MetricData metricData = metricDataList.get(0);
-      assertThat(metricData.getPoints()).hasSize(2);
-      assertThat(metricData.getPoints())
+      assertThat(metricData.getDoubleSumData().getPoints())
           .containsExactly(
               DoublePoint.create(startTime, firstCollect, Labels.of("K", "V"), 555.9d),
               DoublePoint.create(startTime, firstCollect, Labels.empty(), 33.5d));
@@ -139,8 +138,7 @@ class DoubleCounterSdkTest {
       metricDataList = doubleCounter.collectAll();
       assertThat(metricDataList).hasSize(1);
       metricData = metricDataList.get(0);
-      assertThat(metricData.getPoints()).hasSize(2);
-      assertThat(metricData.getPoints())
+      assertThat(metricData.getDoubleSumData().getPoints())
           .containsExactly(
               DoublePoint.create(startTime, secondCollect, Labels.of("K", "V"), 777.9d),
               DoublePoint.create(startTime, secondCollect, Labels.empty(), 44.5d));
@@ -213,7 +211,7 @@ class DoubleCounterSdkTest {
     stressTestBuilder.build().run();
     List<MetricData> metricDataList = doubleCounter.collectAll();
     assertThat(metricDataList).hasSize(1);
-    assertThat(metricDataList.get(0).getPoints())
+    assertThat(metricDataList.get(0).getDoubleSumData().getPoints())
         .containsExactly(
             DoublePoint.create(testClock.now(), testClock.now(), Labels.of("K", "V"), 80_000));
   }
@@ -242,7 +240,7 @@ class DoubleCounterSdkTest {
     stressTestBuilder.build().run();
     List<MetricData> metricDataList = doubleCounter.collectAll();
     assertThat(metricDataList).hasSize(1);
-    assertThat(metricDataList.get(0).getPoints())
+    assertThat(metricDataList.get(0).getDoubleSumData().getPoints())
         .containsExactly(
             DoublePoint.create(
                 testClock.now(), testClock.now(), Labels.of(keys[0], values[0]), 40_000),

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleSumObserverSdkTest.java
@@ -40,16 +40,7 @@ class DoubleSumObserverSdkTest {
             .setDescription("My own DoubleSumObserver")
             .setUnit("ms")
             .build();
-    assertThat(doubleSumObserver.collectAll())
-        .containsExactly(
-            MetricData.create(
-                RESOURCE,
-                INSTRUMENTATION_LIBRARY_INFO,
-                "testObserver",
-                "My own DoubleSumObserver",
-                "ms",
-                MetricData.Type.DOUBLE_SUM,
-                Collections.emptyList()));
+    assertThat(doubleSumObserver.collectAll()).isEmpty();
   }
 
   @Test
@@ -61,16 +52,7 @@ class DoubleSumObserverSdkTest {
             .setUnit("ms")
             .setUpdater(result -> {})
             .build();
-    assertThat(doubleSumObserver.collectAll())
-        .containsExactly(
-            MetricData.create(
-                RESOURCE,
-                INSTRUMENTATION_LIBRARY_INFO,
-                "testObserver",
-                "My own DoubleSumObserver",
-                "ms",
-                MetricData.Type.DOUBLE_SUM,
-                Collections.emptyList()));
+    assertThat(doubleSumObserver.collectAll()).isEmpty();
   }
 
   @Test
@@ -78,39 +60,45 @@ class DoubleSumObserverSdkTest {
     DoubleSumObserverSdk doubleSumObserver =
         testSdk
             .doubleSumObserverBuilder("testObserver")
+            .setDescription("My own DoubleSumObserver")
+            .setUnit("ms")
             .setUpdater(result -> result.observe(12.1d, Labels.of("k", "v")))
             .build();
     testClock.advanceNanos(SECOND_NANOS);
     assertThat(doubleSumObserver.collectAll())
         .containsExactly(
-            MetricData.create(
+            MetricData.createDoubleSum(
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 "testObserver",
-                "",
-                "1",
-                MetricData.Type.DOUBLE_SUM,
-                Collections.singletonList(
-                    DoublePoint.create(
-                        testClock.now() - SECOND_NANOS,
-                        testClock.now(),
-                        Labels.of("k", "v"),
-                        12.1d))));
+                "My own DoubleSumObserver",
+                "ms",
+                MetricData.DoubleSumData.create(
+                    /* isMonotonic= */ true,
+                    MetricData.AggregationTemporality.CUMULATIVE,
+                    Collections.singletonList(
+                        DoublePoint.create(
+                            testClock.now() - SECOND_NANOS,
+                            testClock.now(),
+                            Labels.of("k", "v"),
+                            12.1d)))));
     testClock.advanceNanos(SECOND_NANOS);
     assertThat(doubleSumObserver.collectAll())
         .containsExactly(
-            MetricData.create(
+            MetricData.createDoubleSum(
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 "testObserver",
-                "",
-                "1",
-                MetricData.Type.DOUBLE_SUM,
-                Collections.singletonList(
-                    DoublePoint.create(
-                        testClock.now() - 2 * SECOND_NANOS,
-                        testClock.now(),
-                        Labels.of("k", "v"),
-                        12.1d))));
+                "My own DoubleSumObserver",
+                "ms",
+                MetricData.DoubleSumData.create(
+                    /* isMonotonic= */ true,
+                    MetricData.AggregationTemporality.CUMULATIVE,
+                    Collections.singletonList(
+                        DoublePoint.create(
+                            testClock.now() - 2 * SECOND_NANOS,
+                            testClock.now(),
+                            Labels.of("k", "v"),
+                            12.1d)))));
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownCounterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownCounterSdkTest.java
@@ -62,15 +62,7 @@ class DoubleUpDownCounterSdkTest {
             .setUnit("ms")
             .build();
     List<MetricData> metricDataList = doubleUpDownCounter.collectAll();
-    assertThat(metricDataList).hasSize(1);
-    MetricData metricData = metricDataList.get(0);
-    assertThat(metricData.getName()).isEqualTo("testUpDownCounter");
-    assertThat(metricData.getDescription()).isEqualTo("My very own counter");
-    assertThat(metricData.getUnit()).isEqualTo("ms");
-    assertThat(metricData.getType()).isEqualTo(MetricData.Type.NON_MONOTONIC_DOUBLE_SUM);
-    assertThat(metricData.getResource()).isEqualTo(RESOURCE);
-    assertThat(metricData.getInstrumentationLibraryInfo()).isEqualTo(INSTRUMENTATION_LIBRARY_INFO);
-    assertThat(metricData.getPoints()).isEmpty();
+    assertThat(metricDataList).isEmpty();
   }
 
   @Test
@@ -84,10 +76,9 @@ class DoubleUpDownCounterSdkTest {
     MetricData metricData = metricDataList.get(0);
     assertThat(metricData.getResource()).isEqualTo(RESOURCE);
     assertThat(metricData.getInstrumentationLibraryInfo()).isEqualTo(INSTRUMENTATION_LIBRARY_INFO);
-    assertThat(metricData.getPoints()).hasSize(1);
     // TODO: This is not perfect because we compare double values using direct equal, maybe worth
     //  changing to do a proper comparison for double values, here and everywhere else.
-    assertThat(metricData.getPoints())
+    assertThat(metricData.getDoubleSumData().getPoints())
         .containsExactly(
             DoublePoint.create(
                 testClock.now() - SECOND_NANOS, testClock.now(), Labels.empty(), 12.1d));
@@ -129,8 +120,7 @@ class DoubleUpDownCounterSdkTest {
       List<MetricData> metricDataList = doubleUpDownCounter.collectAll();
       assertThat(metricDataList).hasSize(1);
       MetricData metricData = metricDataList.get(0);
-      assertThat(metricData.getPoints()).hasSize(2);
-      assertThat(metricData.getPoints())
+      assertThat(metricData.getDoubleSumData().getPoints())
           .containsExactly(
               DoublePoint.create(startTime, firstCollect, Labels.of("K", "V"), 555.9d),
               DoublePoint.create(startTime, firstCollect, Labels.empty(), 33.5d));
@@ -144,8 +134,7 @@ class DoubleUpDownCounterSdkTest {
       metricDataList = doubleUpDownCounter.collectAll();
       assertThat(metricDataList).hasSize(1);
       metricData = metricDataList.get(0);
-      assertThat(metricData.getPoints()).hasSize(2);
-      assertThat(metricData.getPoints())
+      assertThat(metricData.getDoubleSumData().getPoints())
           .containsExactly(
               DoublePoint.create(startTime, secondCollect, Labels.of("K", "V"), 777.9d),
               DoublePoint.create(startTime, secondCollect, Labels.empty(), 44.5d));
@@ -209,7 +198,7 @@ class DoubleUpDownCounterSdkTest {
     stressTestBuilder.build().run();
     List<MetricData> metricDataList = doubleUpDownCounter.collectAll();
     assertThat(metricDataList).hasSize(1);
-    assertThat(metricDataList.get(0).getPoints())
+    assertThat(metricDataList.get(0).getDoubleSumData().getPoints())
         .containsExactly(
             DoublePoint.create(testClock.now(), testClock.now(), Labels.of("K", "V"), 80_000));
   }
@@ -240,7 +229,7 @@ class DoubleUpDownCounterSdkTest {
     stressTestBuilder.build().run();
     List<MetricData> metricDataList = doubleUpDownCounter.collectAll();
     assertThat(metricDataList).hasSize(1);
-    assertThat(metricDataList.get(0).getPoints())
+    assertThat(metricDataList.get(0).getDoubleSumData().getPoints())
         .containsExactly(
             DoublePoint.create(
                 testClock.now(), testClock.now(), Labels.of(keys[0], values[0]), 40_000),

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownSumObserverSdkTest.java
@@ -40,16 +40,7 @@ class DoubleUpDownSumObserverSdkTest {
             .setDescription("My own DoubleUpDownSumObserver")
             .setUnit("ms")
             .build();
-    assertThat(doubleUpDownSumObserver.collectAll())
-        .containsExactly(
-            MetricData.create(
-                RESOURCE,
-                INSTRUMENTATION_LIBRARY_INFO,
-                "testObserver",
-                "My own DoubleUpDownSumObserver",
-                "ms",
-                MetricData.Type.NON_MONOTONIC_DOUBLE_SUM,
-                Collections.emptyList()));
+    assertThat(doubleUpDownSumObserver.collectAll()).isEmpty();
   }
 
   @Test
@@ -61,16 +52,7 @@ class DoubleUpDownSumObserverSdkTest {
             .setUnit("ms")
             .setUpdater(result -> {})
             .build();
-    assertThat(doubleUpDownSumObserver.collectAll())
-        .containsExactly(
-            MetricData.create(
-                RESOURCE,
-                INSTRUMENTATION_LIBRARY_INFO,
-                "testObserver",
-                "My own DoubleUpDownSumObserver",
-                "ms",
-                MetricData.Type.NON_MONOTONIC_DOUBLE_SUM,
-                Collections.emptyList()));
+    assertThat(doubleUpDownSumObserver.collectAll()).isEmpty();
   }
 
   @Test
@@ -83,34 +65,38 @@ class DoubleUpDownSumObserverSdkTest {
     testClock.advanceNanos(SECOND_NANOS);
     assertThat(doubleUpDownSumObserver.collectAll())
         .containsExactly(
-            MetricData.create(
+            MetricData.createDoubleSum(
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 "testObserver",
                 "",
                 "1",
-                MetricData.Type.NON_MONOTONIC_DOUBLE_SUM,
-                Collections.singletonList(
-                    DoublePoint.create(
-                        testClock.now() - SECOND_NANOS,
-                        testClock.now(),
-                        Labels.of("k", "v"),
-                        12.1d))));
+                MetricData.DoubleSumData.create(
+                    /* isMonotonic= */ false,
+                    MetricData.AggregationTemporality.CUMULATIVE,
+                    Collections.singletonList(
+                        DoublePoint.create(
+                            testClock.now() - SECOND_NANOS,
+                            testClock.now(),
+                            Labels.of("k", "v"),
+                            12.1d)))));
     testClock.advanceNanos(SECOND_NANOS);
     assertThat(doubleUpDownSumObserver.collectAll())
         .containsExactly(
-            MetricData.create(
+            MetricData.createDoubleSum(
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 "testObserver",
                 "",
                 "1",
-                MetricData.Type.NON_MONOTONIC_DOUBLE_SUM,
-                Collections.singletonList(
-                    DoublePoint.create(
-                        testClock.now() - 2 * SECOND_NANOS,
-                        testClock.now(),
-                        Labels.of("k", "v"),
-                        12.1d))));
+                MetricData.DoubleSumData.create(
+                    /* isMonotonic= */ false,
+                    MetricData.AggregationTemporality.CUMULATIVE,
+                    Collections.singletonList(
+                        DoublePoint.create(
+                            testClock.now() - 2 * SECOND_NANOS,
+                            testClock.now(),
+                            Labels.of("k", "v"),
+                            12.1d)))));
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueObserverSdkTest.java
@@ -41,16 +41,7 @@ class DoubleValueObserverSdkTest {
             .setDescription("My own DoubleValueObserver")
             .setUnit("ms")
             .build();
-    assertThat(doubleValueObserver.collectAll())
-        .containsExactly(
-            MetricData.create(
-                RESOURCE,
-                INSTRUMENTATION_LIBRARY_INFO,
-                "testObserver",
-                "My own DoubleValueObserver",
-                "ms",
-                MetricData.Type.DOUBLE_GAUGE,
-                Collections.emptyList()));
+    assertThat(doubleValueObserver.collectAll()).isEmpty();
   }
 
   @Test
@@ -62,16 +53,7 @@ class DoubleValueObserverSdkTest {
             .setUnit("ms")
             .setUpdater(result -> {})
             .build();
-    assertThat(doubleValueObserver.collectAll())
-        .containsExactly(
-            MetricData.create(
-                RESOURCE,
-                INSTRUMENTATION_LIBRARY_INFO,
-                "testObserver",
-                "My own DoubleValueObserver",
-                "ms",
-                MetricData.Type.DOUBLE_GAUGE,
-                Collections.emptyList()));
+    assertThat(doubleValueObserver.collectAll()).isEmpty();
   }
 
   @Test
@@ -79,39 +61,41 @@ class DoubleValueObserverSdkTest {
     DoubleValueObserverSdk doubleValueObserver =
         testSdk
             .doubleValueObserverBuilder("testObserver")
+            .setDescription("My own DoubleValueObserver")
+            .setUnit("ms")
             .setUpdater(result -> result.observe(12.1d, Labels.of("k", "v")))
             .build();
     testClock.advanceNanos(SECOND_NANOS);
     assertThat(doubleValueObserver.collectAll())
         .containsExactly(
-            MetricData.create(
+            MetricData.createDoubleGauge(
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 "testObserver",
-                "",
-                "1",
-                MetricData.Type.DOUBLE_GAUGE,
-                Collections.singletonList(
-                    DoublePoint.create(
-                        testClock.now() - SECOND_NANOS,
-                        testClock.now(),
-                        Labels.of("k", "v"),
-                        12.1d))));
+                "My own DoubleValueObserver",
+                "ms",
+                MetricData.DoubleGaugeData.create(
+                    Collections.singletonList(
+                        DoublePoint.create(
+                            testClock.now() - SECOND_NANOS,
+                            testClock.now(),
+                            Labels.of("k", "v"),
+                            12.1d)))));
     testClock.advanceNanos(SECOND_NANOS);
     assertThat(doubleValueObserver.collectAll())
         .containsExactly(
-            MetricData.create(
+            MetricData.createDoubleGauge(
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 "testObserver",
-                "",
-                "1",
-                MetricData.Type.DOUBLE_GAUGE,
-                Collections.singletonList(
-                    DoublePoint.create(
-                        testClock.now() - SECOND_NANOS,
-                        testClock.now(),
-                        Labels.of("k", "v"),
-                        12.1d))));
+                "My own DoubleValueObserver",
+                "ms",
+                MetricData.DoubleGaugeData.create(
+                    Collections.singletonList(
+                        DoublePoint.create(
+                            testClock.now() - SECOND_NANOS,
+                            testClock.now(),
+                            Labels.of("k", "v"),
+                            12.1d)))));
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdkTest.java
@@ -17,7 +17,7 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.metrics.StressTestRunner.OperationUpdater;
 import io.opentelemetry.sdk.metrics.data.MetricData;
-import io.opentelemetry.sdk.metrics.data.MetricData.SummaryPoint;
+import io.opentelemetry.sdk.metrics.data.MetricData.DoubleSummaryPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.ValueAtPercentile;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Arrays;
@@ -64,42 +64,11 @@ class DoubleValueRecorderSdkTest {
             .setDescription("My very own measure")
             .setUnit("ms")
             .build();
-    assertThat(doubleMeasure).isInstanceOf(DoubleValueRecorderSdk.class);
-    List<MetricData> metricDataList = doubleMeasure.collectAll();
-    assertThat(metricDataList)
-        .containsExactly(
-            MetricData.create(
-                RESOURCE,
-                INSTRUMENTATION_LIBRARY_INFO,
-                "testRecorder",
-                "My very own measure",
-                "ms",
-                MetricData.Type.SUMMARY,
-                Collections.emptyList()));
-  }
-
-  @Test
-  void collectMetrics_EmptyCollectionCycle() {
-    DoubleValueRecorderSdk doubleMeasure =
-        testSdk
-            .doubleValueRecorderBuilder("testRecorder")
-            .setDescription("My very own measure")
-            .setUnit("ms")
-            .build();
     doubleMeasure.bind(Labels.of("key", "value"));
     testClock.advanceNanos(SECOND_NANOS);
 
     List<MetricData> metricDataList = doubleMeasure.collectAll();
-    assertThat(metricDataList)
-        .containsExactly(
-            MetricData.create(
-                RESOURCE,
-                INSTRUMENTATION_LIBRARY_INFO,
-                "testRecorder",
-                "My very own measure",
-                "ms",
-                MetricData.Type.SUMMARY,
-                Collections.emptyList()));
+    assertThat(metricDataList).isEmpty();
   }
 
   @Test
@@ -111,21 +80,21 @@ class DoubleValueRecorderSdkTest {
     List<MetricData> metricDataList = doubleMeasure.collectAll();
     assertThat(metricDataList)
         .containsExactly(
-            MetricData.create(
+            MetricData.createDoubleSummary(
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 "testRecorder",
                 "",
                 "1",
-                MetricData.Type.SUMMARY,
-                Collections.singletonList(
-                    SummaryPoint.create(
-                        testClock.now() - SECOND_NANOS,
-                        testClock.now(),
-                        Labels.empty(),
-                        1,
-                        12.1d,
-                        valueAtPercentiles(12.1d, 12.1d)))));
+                MetricData.DoubleSummaryData.create(
+                    Collections.singletonList(
+                        DoubleSummaryPoint.create(
+                            testClock.now() - SECOND_NANOS,
+                            testClock.now(),
+                            Labels.empty(),
+                            1,
+                            12.1d,
+                            valueAtPercentiles(12.1d, 12.1d))))));
   }
 
   @Test
@@ -164,16 +133,16 @@ class DoubleValueRecorderSdkTest {
       List<MetricData> metricDataList = doubleMeasure.collectAll();
       assertThat(metricDataList).hasSize(1);
       MetricData metricData = metricDataList.get(0);
-      assertThat(metricData.getPoints())
+      assertThat(metricData.getDoubleSummaryData().getPoints())
           .containsExactlyInAnyOrder(
-              SummaryPoint.create(
+              MetricData.DoubleSummaryPoint.create(
                   startTime,
                   firstCollect,
                   Labels.empty(),
                   2,
                   -1.0d,
                   valueAtPercentiles(-13.1d, 12.1d)),
-              SummaryPoint.create(
+              MetricData.DoubleSummaryPoint.create(
                   startTime,
                   firstCollect,
                   Labels.of("K", "V"),
@@ -190,16 +159,16 @@ class DoubleValueRecorderSdkTest {
       metricDataList = doubleMeasure.collectAll();
       assertThat(metricDataList).hasSize(1);
       metricData = metricDataList.get(0);
-      assertThat(metricData.getPoints())
+      assertThat(metricData.getDoubleSummaryData().getPoints())
           .containsExactlyInAnyOrder(
-              SummaryPoint.create(
+              DoubleSummaryPoint.create(
                   startTime + SECOND_NANOS,
                   secondCollect,
                   Labels.empty(),
                   1,
                   17.0d,
                   valueAtPercentiles(17d, 17d)),
-              SummaryPoint.create(
+              MetricData.DoubleSummaryPoint.create(
                   startTime + SECOND_NANOS,
                   secondCollect,
                   Labels.of("K", "V"),
@@ -265,9 +234,9 @@ class DoubleValueRecorderSdkTest {
     stressTestBuilder.build().run();
     List<MetricData> metricDataList = doubleMeasure.collectAll();
     assertThat(metricDataList).hasSize(1);
-    assertThat(metricDataList.get(0).getPoints())
+    assertThat(metricDataList.get(0).getDoubleSummaryData().getPoints())
         .containsExactly(
-            SummaryPoint.create(
+            MetricData.DoubleSummaryPoint.create(
                 testClock.now(),
                 testClock.now(),
                 Labels.of("K", "V"),
@@ -304,30 +273,30 @@ class DoubleValueRecorderSdkTest {
     stressTestBuilder.build().run();
     List<MetricData> metricDataList = doubleMeasure.collectAll();
     assertThat(metricDataList).hasSize(1);
-    assertThat(metricDataList.get(0).getPoints())
+    assertThat(metricDataList.get(0).getDoubleSummaryData().getPoints())
         .containsExactly(
-            SummaryPoint.create(
+            MetricData.DoubleSummaryPoint.create(
                 testClock.now(),
                 testClock.now(),
                 Labels.of(keys[0], values[0]),
                 4_000,
                 40_000d,
                 valueAtPercentiles(9.0, 11.0)),
-            SummaryPoint.create(
+            DoubleSummaryPoint.create(
                 testClock.now(),
                 testClock.now(),
                 Labels.of(keys[1], values[1]),
                 4_000,
                 40_000d,
                 valueAtPercentiles(9.0, 11.0)),
-            SummaryPoint.create(
+            MetricData.DoubleSummaryPoint.create(
                 testClock.now(),
                 testClock.now(),
                 Labels.of(keys[2], values[2]),
                 4_000,
                 40_000d,
                 valueAtPercentiles(9.0, 11.0)),
-            SummaryPoint.create(
+            MetricData.DoubleSummaryPoint.create(
                 testClock.now(),
                 testClock.now(),
                 Labels.of(keys[3], values[3]),

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/InstrumentRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/InstrumentRegistryTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongCounterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongCounterSdkTest.java
@@ -61,38 +61,8 @@ class LongCounterSdkTest {
             .setDescription("My very own counter")
             .setUnit("ms")
             .build();
-    List<MetricData> metricDataList = longCounter.collectAll();
-    assertThat(metricDataList).hasSize(1);
-    MetricData metricData = metricDataList.get(0);
-    assertThat(metricData.getName()).isEqualTo("testCounter");
-    assertThat(metricData.getDescription()).isEqualTo("My very own counter");
-    assertThat(metricData.getUnit()).isEqualTo("ms");
-    assertThat(metricData.getType()).isEqualTo(MetricData.Type.LONG_SUM);
-    assertThat(metricData.getResource()).isEqualTo(RESOURCE);
-    assertThat(metricData.getInstrumentationLibraryInfo()).isEqualTo(INSTRUMENTATION_LIBRARY_INFO);
-    assertThat(metricData.getPoints()).isEmpty();
-  }
-
-  @Test
-  void collectMetrics_bound_NoRecords() {
-    LongCounterSdk longCounter =
-        testSdk
-            .longCounterBuilder("testCounter")
-            .setDescription("My very own counter")
-            .setUnit("ms")
-            .build();
     BoundInstrument bound = longCounter.bind(Labels.of("foo", "bar"));
-
-    List<MetricData> metricDataList = longCounter.collectAll();
-    assertThat(metricDataList).hasSize(1);
-    MetricData metricData = metricDataList.get(0);
-    assertThat(metricData.getName()).isEqualTo("testCounter");
-    assertThat(metricData.getDescription()).isEqualTo("My very own counter");
-    assertThat(metricData.getUnit()).isEqualTo("ms");
-    assertThat(metricData.getType()).isEqualTo(MetricData.Type.LONG_SUM);
-    assertThat(metricData.getResource()).isEqualTo(RESOURCE);
-    assertThat(metricData.getInstrumentationLibraryInfo()).isEqualTo(INSTRUMENTATION_LIBRARY_INFO);
-    assertThat(metricData.getPoints()).isEmpty();
+    assertThat(longCounter.collectAll()).isEmpty();
 
     bound.unbind();
   }
@@ -107,8 +77,7 @@ class LongCounterSdkTest {
     MetricData metricData = metricDataList.get(0);
     assertThat(metricData.getResource()).isEqualTo(RESOURCE);
     assertThat(metricData.getInstrumentationLibraryInfo()).isEqualTo(INSTRUMENTATION_LIBRARY_INFO);
-    assertThat(metricData.getPoints()).hasSize(1);
-    assertThat(metricData.getPoints())
+    assertThat(metricData.getLongSumData().getPoints())
         .containsExactly(
             LongPoint.create(testClock.now() - SECOND_NANOS, testClock.now(), Labels.empty(), 12));
   }
@@ -146,8 +115,7 @@ class LongCounterSdkTest {
       List<MetricData> metricDataList = longCounter.collectAll();
       assertThat(metricDataList).hasSize(1);
       MetricData metricData = metricDataList.get(0);
-      assertThat(metricData.getPoints()).hasSize(2);
-      assertThat(metricData.getPoints())
+      assertThat(metricData.getLongSumData().getPoints())
           .containsExactly(
               LongPoint.create(startTime, firstCollect, Labels.of("K", "V"), 555),
               LongPoint.create(startTime, firstCollect, Labels.empty(), 33));
@@ -161,8 +129,7 @@ class LongCounterSdkTest {
       metricDataList = longCounter.collectAll();
       assertThat(metricDataList).hasSize(1);
       metricData = metricDataList.get(0);
-      assertThat(metricData.getPoints()).hasSize(2);
-      assertThat(metricData.getPoints())
+      assertThat(metricData.getLongSumData().getPoints())
           .containsExactly(
               LongPoint.create(startTime, secondCollect, Labels.of("K", "V"), 777),
               LongPoint.create(startTime, secondCollect, Labels.empty(), 44));
@@ -234,7 +201,7 @@ class LongCounterSdkTest {
     stressTestBuilder.build().run();
     List<MetricData> metricDataList = longCounter.collectAll();
     assertThat(metricDataList).hasSize(1);
-    assertThat(metricDataList.get(0).getPoints())
+    assertThat(metricDataList.get(0).getLongSumData().getPoints())
         .containsExactly(
             LongPoint.create(testClock.now(), testClock.now(), Labels.of("K", "V"), 160_000));
   }
@@ -263,7 +230,7 @@ class LongCounterSdkTest {
     stressTestBuilder.build().run();
     List<MetricData> metricDataList = longCounter.collectAll();
     assertThat(metricDataList).hasSize(1);
-    assertThat(metricDataList.get(0).getPoints())
+    assertThat(metricDataList.get(0).getLongSumData().getPoints())
         .containsExactly(
             LongPoint.create(
                 testClock.now(), testClock.now(), Labels.of(keys[0], values[0]), 20_000),

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongSumObserverSdkTest.java
@@ -40,16 +40,7 @@ class LongSumObserverSdkTest {
             .setDescription("My own LongSumObserver")
             .setUnit("ms")
             .build();
-    assertThat(longSumObserver.collectAll())
-        .containsExactly(
-            MetricData.create(
-                RESOURCE,
-                INSTRUMENTATION_LIBRARY_INFO,
-                "testObserver",
-                "My own LongSumObserver",
-                "ms",
-                MetricData.Type.LONG_SUM,
-                Collections.emptyList()));
+    assertThat(longSumObserver.collectAll()).isEmpty();
   }
 
   @Test
@@ -61,16 +52,7 @@ class LongSumObserverSdkTest {
             .setUnit("ms")
             .setUpdater(result -> {})
             .build();
-    assertThat(longSumObserver.collectAll())
-        .containsExactly(
-            MetricData.create(
-                RESOURCE,
-                INSTRUMENTATION_LIBRARY_INFO,
-                "testObserver",
-                "My own LongSumObserver",
-                "ms",
-                MetricData.Type.LONG_SUM,
-                Collections.emptyList()));
+    assertThat(longSumObserver.collectAll()).isEmpty();
   }
 
   @Test
@@ -83,34 +65,38 @@ class LongSumObserverSdkTest {
     testClock.advanceNanos(SECOND_NANOS);
     assertThat(longSumObserver.collectAll())
         .containsExactly(
-            MetricData.create(
+            MetricData.createLongSum(
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 "testObserver",
                 "",
                 "1",
-                MetricData.Type.LONG_SUM,
-                Collections.singletonList(
-                    LongPoint.create(
-                        testClock.now() - SECOND_NANOS,
-                        testClock.now(),
-                        Labels.of("k", "v"),
-                        12))));
+                MetricData.LongSumData.create(
+                    /* isMonotonic= */ true,
+                    MetricData.AggregationTemporality.CUMULATIVE,
+                    Collections.singletonList(
+                        LongPoint.create(
+                            testClock.now() - SECOND_NANOS,
+                            testClock.now(),
+                            Labels.of("k", "v"),
+                            12)))));
     testClock.advanceNanos(SECOND_NANOS);
     assertThat(longSumObserver.collectAll())
         .containsExactly(
-            MetricData.create(
+            MetricData.createLongSum(
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 "testObserver",
                 "",
                 "1",
-                MetricData.Type.LONG_SUM,
-                Collections.singletonList(
-                    LongPoint.create(
-                        testClock.now() - 2 * SECOND_NANOS,
-                        testClock.now(),
-                        Labels.of("k", "v"),
-                        12))));
+                MetricData.LongSumData.create(
+                    /* isMonotonic= */ true,
+                    MetricData.AggregationTemporality.CUMULATIVE,
+                    Collections.singletonList(
+                        LongPoint.create(
+                            testClock.now() - 2 * SECOND_NANOS,
+                            testClock.now(),
+                            Labels.of("k", "v"),
+                            12)))));
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownCounterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownCounterSdkTest.java
@@ -62,15 +62,7 @@ class LongUpDownCounterSdkTest {
             .setUnit("ms")
             .build();
     List<MetricData> metricDataList = longUpDownCounter.collectAll();
-    assertThat(metricDataList).hasSize(1);
-    MetricData metricData = metricDataList.get(0);
-    assertThat(metricData.getName()).isEqualTo("testUpDownCounter");
-    assertThat(metricData.getDescription()).isEqualTo("My very own counter");
-    assertThat(metricData.getUnit()).isEqualTo("ms");
-    assertThat(metricData.getType()).isEqualTo(MetricData.Type.NON_MONOTONIC_LONG_SUM);
-    assertThat(metricData.getResource()).isEqualTo(RESOURCE);
-    assertThat(metricData.getInstrumentationLibraryInfo()).isEqualTo(INSTRUMENTATION_LIBRARY_INFO);
-    assertThat(metricData.getPoints()).isEmpty();
+    assertThat(metricDataList).isEmpty();
   }
 
   @Test
@@ -84,8 +76,7 @@ class LongUpDownCounterSdkTest {
     MetricData metricData = metricDataList.get(0);
     assertThat(metricData.getResource()).isEqualTo(RESOURCE);
     assertThat(metricData.getInstrumentationLibraryInfo()).isEqualTo(INSTRUMENTATION_LIBRARY_INFO);
-    assertThat(metricData.getPoints()).hasSize(1);
-    assertThat(metricData.getPoints())
+    assertThat(metricData.getLongSumData().getPoints())
         .containsExactly(
             LongPoint.create(testClock.now() - SECOND_NANOS, testClock.now(), Labels.empty(), 12));
   }
@@ -126,8 +117,7 @@ class LongUpDownCounterSdkTest {
       List<MetricData> metricDataList = longUpDownCounter.collectAll();
       assertThat(metricDataList).hasSize(1);
       MetricData metricData = metricDataList.get(0);
-      assertThat(metricData.getPoints()).hasSize(2);
-      assertThat(metricData.getPoints())
+      assertThat(metricData.getLongSumData().getPoints())
           .containsExactly(
               LongPoint.create(startTime, firstCollect, Labels.of("K", "V"), 555),
               LongPoint.create(startTime, firstCollect, Labels.empty(), 33));
@@ -141,8 +131,7 @@ class LongUpDownCounterSdkTest {
       metricDataList = longUpDownCounter.collectAll();
       assertThat(metricDataList).hasSize(1);
       metricData = metricDataList.get(0);
-      assertThat(metricData.getPoints()).hasSize(2);
-      assertThat(metricData.getPoints())
+      assertThat(metricData.getLongSumData().getPoints())
           .containsExactly(
               LongPoint.create(startTime, secondCollect, Labels.of("K", "V"), 777),
               LongPoint.create(startTime, secondCollect, Labels.empty(), 44));
@@ -205,7 +194,7 @@ class LongUpDownCounterSdkTest {
     stressTestBuilder.build().run();
     List<MetricData> metricDataList = longUpDownCounter.collectAll();
     assertThat(metricDataList).hasSize(1);
-    assertThat(metricDataList.get(0).getPoints())
+    assertThat(metricDataList.get(0).getLongSumData().getPoints())
         .containsExactly(
             LongPoint.create(testClock.now(), testClock.now(), Labels.of("K", "V"), 160_000));
   }
@@ -236,7 +225,7 @@ class LongUpDownCounterSdkTest {
     stressTestBuilder.build().run();
     List<MetricData> metricDataList = longUpDownCounter.collectAll();
     assertThat(metricDataList).hasSize(1);
-    assertThat(metricDataList.get(0).getPoints())
+    assertThat(metricDataList.get(0).getLongSumData().getPoints())
         .containsExactly(
             LongPoint.create(
                 testClock.now(), testClock.now(), Labels.of(keys[0], values[0]), 20_000),

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownSumObserverSdkTest.java
@@ -40,16 +40,7 @@ class LongUpDownSumObserverSdkTest {
             .setDescription("My own LongUpDownSumObserver")
             .setUnit("ms")
             .build();
-    assertThat(longUpDownSumObserver.collectAll())
-        .containsExactly(
-            MetricData.create(
-                RESOURCE,
-                INSTRUMENTATION_LIBRARY_INFO,
-                "testObserver",
-                "My own LongUpDownSumObserver",
-                "ms",
-                MetricData.Type.NON_MONOTONIC_LONG_SUM,
-                Collections.emptyList()));
+    assertThat(longUpDownSumObserver.collectAll()).isEmpty();
   }
 
   @Test
@@ -61,16 +52,7 @@ class LongUpDownSumObserverSdkTest {
             .setUnit("ms")
             .setUpdater(result -> {})
             .build();
-    assertThat(longUpDownSumObserver.collectAll())
-        .containsExactly(
-            MetricData.create(
-                RESOURCE,
-                INSTRUMENTATION_LIBRARY_INFO,
-                "testObserver",
-                "My own LongUpDownSumObserver",
-                "ms",
-                MetricData.Type.NON_MONOTONIC_LONG_SUM,
-                Collections.emptyList()));
+    assertThat(longUpDownSumObserver.collectAll()).isEmpty();
   }
 
   @Test
@@ -83,34 +65,38 @@ class LongUpDownSumObserverSdkTest {
     testClock.advanceNanos(SECOND_NANOS);
     assertThat(longUpDownSumObserver.collectAll())
         .containsExactly(
-            MetricData.create(
+            MetricData.createLongSum(
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 "testObserver",
                 "",
                 "1",
-                MetricData.Type.NON_MONOTONIC_LONG_SUM,
-                Collections.singletonList(
-                    LongPoint.create(
-                        testClock.now() - SECOND_NANOS,
-                        testClock.now(),
-                        Labels.of("k", "v"),
-                        12))));
+                MetricData.LongSumData.create(
+                    /* isMonotonic= */ false,
+                    MetricData.AggregationTemporality.CUMULATIVE,
+                    Collections.singletonList(
+                        LongPoint.create(
+                            testClock.now() - SECOND_NANOS,
+                            testClock.now(),
+                            Labels.of("k", "v"),
+                            12)))));
     testClock.advanceNanos(SECOND_NANOS);
     assertThat(longUpDownSumObserver.collectAll())
         .containsExactly(
-            MetricData.create(
+            MetricData.createLongSum(
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 "testObserver",
                 "",
                 "1",
-                MetricData.Type.NON_MONOTONIC_LONG_SUM,
-                Collections.singletonList(
-                    LongPoint.create(
-                        testClock.now() - 2 * SECOND_NANOS,
-                        testClock.now(),
-                        Labels.of("k", "v"),
-                        12))));
+                MetricData.LongSumData.create(
+                    /* isMonotonic= */ false,
+                    MetricData.AggregationTemporality.CUMULATIVE,
+                    Collections.singletonList(
+                        LongPoint.create(
+                            testClock.now() - 2 * SECOND_NANOS,
+                            testClock.now(),
+                            Labels.of("k", "v"),
+                            12)))));
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongValueObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongValueObserverSdkTest.java
@@ -40,16 +40,7 @@ class LongValueObserverSdkTest {
             .setDescription("My own LongValueObserver")
             .setUnit("ms")
             .build();
-    assertThat(longValueObserver.collectAll())
-        .containsExactly(
-            MetricData.create(
-                RESOURCE,
-                INSTRUMENTATION_LIBRARY_INFO,
-                "testObserver",
-                "My own LongValueObserver",
-                "ms",
-                MetricData.Type.LONG_GAUGE,
-                Collections.emptyList()));
+    assertThat(longValueObserver.collectAll()).isEmpty();
   }
 
   @Test
@@ -61,16 +52,7 @@ class LongValueObserverSdkTest {
             .setUnit("ms")
             .setUpdater(result -> {})
             .build();
-    assertThat(longValueObserver.collectAll())
-        .containsExactly(
-            MetricData.create(
-                RESOURCE,
-                INSTRUMENTATION_LIBRARY_INFO,
-                "testObserver",
-                "My own LongValueObserver",
-                "ms",
-                MetricData.Type.LONG_GAUGE,
-                Collections.emptyList()));
+    assertThat(longValueObserver.collectAll()).isEmpty();
   }
 
   @Test
@@ -83,34 +65,34 @@ class LongValueObserverSdkTest {
     testClock.advanceNanos(SECOND_NANOS);
     assertThat(longValueObserver.collectAll())
         .containsExactly(
-            MetricData.create(
+            MetricData.createLongGauge(
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 "testObserver",
                 "",
                 "1",
-                MetricData.Type.LONG_GAUGE,
-                Collections.singletonList(
-                    LongPoint.create(
-                        testClock.now() - SECOND_NANOS,
-                        testClock.now(),
-                        Labels.of("k", "v"),
-                        12))));
+                MetricData.LongGaugeData.create(
+                    Collections.singletonList(
+                        LongPoint.create(
+                            testClock.now() - SECOND_NANOS,
+                            testClock.now(),
+                            Labels.of("k", "v"),
+                            12)))));
     testClock.advanceNanos(SECOND_NANOS);
     assertThat(longValueObserver.collectAll())
         .containsExactly(
-            MetricData.create(
+            MetricData.createLongGauge(
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 "testObserver",
                 "",
                 "1",
-                MetricData.Type.LONG_GAUGE,
-                Collections.singletonList(
-                    LongPoint.create(
-                        testClock.now() - SECOND_NANOS,
-                        testClock.now(),
-                        Labels.of("k", "v"),
-                        12))));
+                MetricData.LongGaugeData.create(
+                    Collections.singletonList(
+                        LongPoint.create(
+                            testClock.now() - SECOND_NANOS,
+                            testClock.now(),
+                            Labels.of("k", "v"),
+                            12)))));
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkRegistryTest.java
@@ -82,24 +82,28 @@ class MeterSdkRegistryTest {
 
     assertThat(meterProvider.getMetricProducer().collectAllMetrics())
         .containsExactlyInAnyOrder(
-            MetricData.create(
+            MetricData.createLongSum(
                 Resource.getEmpty(),
                 meterSdk1.getInstrumentationLibraryInfo(),
                 "testLongCounter",
                 "",
                 "1",
-                MetricData.Type.LONG_SUM,
-                Collections.singletonList(
-                    LongPoint.create(testClock.now(), testClock.now(), Labels.empty(), 10))),
-            MetricData.create(
+                MetricData.LongSumData.create(
+                    /* isMonotonic= */ true,
+                    MetricData.AggregationTemporality.CUMULATIVE,
+                    Collections.singletonList(
+                        LongPoint.create(testClock.now(), testClock.now(), Labels.empty(), 10)))),
+            MetricData.createLongSum(
                 Resource.getEmpty(),
                 meterSdk2.getInstrumentationLibraryInfo(),
                 "testLongCounter",
                 "",
                 "1",
-                MetricData.Type.LONG_SUM,
-                Collections.singletonList(
-                    LongPoint.create(testClock.now(), testClock.now(), Labels.empty(), 10))));
+                MetricData.LongSumData.create(
+                    /* isMonotonic= */ true,
+                    MetricData.AggregationTemporality.CUMULATIVE,
+                    Collections.singletonList(
+                        LongPoint.create(testClock.now(), testClock.now(), Labels.empty(), 10)))));
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/MeterSdkTest.java
@@ -18,8 +18,8 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
+import io.opentelemetry.sdk.metrics.data.MetricData.DoubleSummaryPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
-import io.opentelemetry.sdk.metrics.data.MetricData.SummaryPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.ValueAtPercentile;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Arrays;
@@ -405,56 +405,62 @@ class MeterSdkTest {
 
     assertThat(testSdk.collectAll())
         .containsExactlyInAnyOrder(
-            MetricData.create(
+            MetricData.createLongSum(
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 "testLongCounter",
                 "",
                 "1",
-                MetricData.Type.LONG_SUM,
-                Collections.singletonList(
-                    LongPoint.create(testClock.now(), testClock.now(), Labels.empty(), 10))),
-            MetricData.create(
+                MetricData.LongSumData.create(
+                    /* isMonotonic= */ true,
+                    MetricData.AggregationTemporality.CUMULATIVE,
+                    Collections.singletonList(
+                        LongPoint.create(testClock.now(), testClock.now(), Labels.empty(), 10)))),
+            MetricData.createDoubleSum(
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 "testDoubleCounter",
                 "",
                 "1",
-                MetricData.Type.DOUBLE_SUM,
-                Collections.singletonList(
-                    DoublePoint.create(testClock.now(), testClock.now(), Labels.empty(), 10.1))),
-            MetricData.create(
+                MetricData.DoubleSumData.create(
+                    /* isMonotonic= */ true,
+                    MetricData.AggregationTemporality.CUMULATIVE,
+                    Collections.singletonList(
+                        DoublePoint.create(
+                            testClock.now(), testClock.now(), Labels.empty(), 10.1)))),
+            MetricData.createDoubleSummary(
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 "testLongValueRecorder",
                 "",
                 "1",
-                MetricData.Type.SUMMARY,
-                Collections.singletonList(
-                    SummaryPoint.create(
-                        testClock.now(),
-                        testClock.now(),
-                        Labels.empty(),
-                        1,
-                        10,
-                        Arrays.asList(
-                            ValueAtPercentile.create(0, 10), ValueAtPercentile.create(100, 10))))),
-            MetricData.create(
+                MetricData.DoubleSummaryData.create(
+                    Collections.singletonList(
+                        DoubleSummaryPoint.create(
+                            testClock.now(),
+                            testClock.now(),
+                            Labels.empty(),
+                            1,
+                            10,
+                            Arrays.asList(
+                                ValueAtPercentile.create(0, 10),
+                                ValueAtPercentile.create(100, 10)))))),
+            MetricData.createDoubleSummary(
                 RESOURCE,
                 INSTRUMENTATION_LIBRARY_INFO,
                 "testDoubleValueRecorder",
                 "",
                 "1",
-                MetricData.Type.SUMMARY,
-                Collections.singletonList(
-                    SummaryPoint.create(
-                        testClock.now(),
-                        testClock.now(),
-                        Labels.empty(),
-                        1,
-                        10.1d,
-                        Arrays.asList(
-                            ValueAtPercentile.create(0, 10.1d),
-                            ValueAtPercentile.create(100, 10.1d))))));
+                MetricData.DoubleSummaryData.create(
+                    Collections.singletonList(
+                        DoubleSummaryPoint.create(
+                            testClock.now(),
+                            testClock.now(),
+                            Labels.empty(),
+                            1,
+                            10.1d,
+                            Arrays.asList(
+                                ValueAtPercentile.create(0, 10.1d),
+                                ValueAtPercentile.create(100, 10.1d)))))));
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/ViewRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/ViewRegistryTest.java
@@ -12,8 +12,10 @@ import static org.mockito.Mockito.when;
 
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
+import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.view.AggregationConfiguration;
 import io.opentelemetry.sdk.metrics.view.Aggregations;
 import io.opentelemetry.sdk.metrics.view.InstrumentSelector;
@@ -31,7 +33,7 @@ class ViewRegistryTest {
         InstrumentSelector.newBuilder().instrumentType(InstrumentType.COUNTER).build();
     AggregationConfiguration specification =
         AggregationConfiguration.create(
-            Aggregations.count(), AggregationConfiguration.Temporality.CUMULATIVE);
+            Aggregations.count(), MetricData.AggregationTemporality.CUMULATIVE);
 
     viewRegistry.registerView(selector, specification);
 
@@ -54,7 +56,7 @@ class ViewRegistryTest {
 
     AggregationConfiguration specification =
         AggregationConfiguration.create(
-            Aggregations.count(), AggregationConfiguration.Temporality.CUMULATIVE);
+            Aggregations.count(), MetricData.AggregationTemporality.CUMULATIVE);
     InstrumentProcessor expectedInstrumentProcessor =
         InstrumentProcessor.getCumulativeAllLabels(
             descriptor, providerSharedState, meterSharedState, Aggregations.count());
@@ -86,7 +88,7 @@ class ViewRegistryTest {
 
     AggregationConfiguration specification =
         AggregationConfiguration.create(
-            Aggregations.count(), AggregationConfiguration.Temporality.DELTA);
+            Aggregations.count(), MetricData.AggregationTemporality.DELTA);
     InstrumentProcessor expectedInstrumentProcessor =
         InstrumentProcessor.getDeltaAllLabels(
             descriptor, providerSharedState, meterSharedState, Aggregations.count());

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.offset;
 
 import io.opentelemetry.api.common.Labels;
-import io.opentelemetry.sdk.metrics.data.MetricData.SummaryPoint;
+import io.opentelemetry.sdk.metrics.data.MetricData.DoubleSummaryPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.ValueAtPercentile;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,17 +29,20 @@ class DoubleMinMaxSumCountTest {
     aggregator.recordDouble(100);
     assertThat(aggregator.toPoint(0, 100, Labels.empty()))
         .isEqualTo(
-            SummaryPoint.create(0, 100, Labels.empty(), 1, 100, createPercentiles(100d, 100d)));
+            DoubleSummaryPoint.create(
+                0, 100, Labels.empty(), 1, 100, createPercentiles(100d, 100d)));
 
     aggregator.recordDouble(50);
     assertThat(aggregator.toPoint(0, 100, Labels.empty()))
         .isEqualTo(
-            SummaryPoint.create(0, 100, Labels.empty(), 2, 150, createPercentiles(50d, 100d)));
+            DoubleSummaryPoint.create(
+                0, 100, Labels.empty(), 2, 150, createPercentiles(50d, 100d)));
 
     aggregator.recordDouble(-75);
     assertThat(aggregator.toPoint(0, 100, Labels.empty()))
         .isEqualTo(
-            SummaryPoint.create(0, 100, Labels.empty(), 3, 75, createPercentiles(-75d, 100d)));
+            DoubleSummaryPoint.create(
+                0, 100, Labels.empty(), 3, 75, createPercentiles(-75d, 100d)));
   }
 
   @Test
@@ -52,7 +55,8 @@ class DoubleMinMaxSumCountTest {
 
     assertThat(mergedToAggregator.toPoint(0, 100, Labels.empty()))
         .isEqualTo(
-            SummaryPoint.create(0, 100, Labels.empty(), 1, 100, createPercentiles(100d, 100d)));
+            DoubleSummaryPoint.create(
+                0, 100, Labels.empty(), 1, 100, createPercentiles(100d, 100d)));
 
     assertThat(aggregator.toPoint(0, 100, Labels.empty())).isNull();
   }
@@ -97,7 +101,7 @@ class DoubleMinMaxSumCountTest {
     // make sure everything gets merged when all the aggregation is done.
     aggregator.mergeToAndReset(summarizer);
 
-    SummaryPoint actual = (SummaryPoint) summarizer.toPoint(0, 100, Labels.empty());
+    DoubleSummaryPoint actual = (DoubleSummaryPoint) summarizer.toPoint(0, 100, Labels.empty());
     assertThat(actual).isNotNull();
     assertThat(actual.getStartEpochNanos()).isEqualTo(0);
     assertThat(actual.getEpochNanos()).isEqualTo(100);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountTest.java
@@ -8,7 +8,7 @@ package io.opentelemetry.sdk.metrics.aggregator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Labels;
-import io.opentelemetry.sdk.metrics.data.MetricData.SummaryPoint;
+import io.opentelemetry.sdk.metrics.data.MetricData.DoubleSummaryPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.ValueAtPercentile;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,18 +28,20 @@ class LongMinMaxSumCountTest {
     aggregator.recordLong(100);
     assertThat(aggregator.toPoint(0, 100, Labels.empty()))
         .isEqualTo(
-            SummaryPoint.create(
+            DoubleSummaryPoint.create(
                 0, 100, Labels.empty(), 1, 100, createPercentileValues(100L, 100L)));
 
     aggregator.recordLong(50);
     assertThat(aggregator.toPoint(0, 100, Labels.empty()))
         .isEqualTo(
-            SummaryPoint.create(0, 100, Labels.empty(), 2, 150, createPercentileValues(50L, 100L)));
+            DoubleSummaryPoint.create(
+                0, 100, Labels.empty(), 2, 150, createPercentileValues(50L, 100L)));
 
     aggregator.recordLong(-75);
     assertThat(aggregator.toPoint(0, 100, Labels.empty()))
         .isEqualTo(
-            SummaryPoint.create(0, 100, Labels.empty(), 3, 75, createPercentileValues(-75L, 100L)));
+            DoubleSummaryPoint.create(
+                0, 100, Labels.empty(), 3, 75, createPercentileValues(-75L, 100L)));
   }
 
   @Test
@@ -52,7 +54,7 @@ class LongMinMaxSumCountTest {
 
     assertThat(mergedToAggregator.toPoint(0, 100, Labels.empty()))
         .isEqualTo(
-            SummaryPoint.create(
+            DoubleSummaryPoint.create(
                 0, 100, Labels.empty(), 1, 100, createPercentileValues(100L, 100L)));
 
     assertThat(aggregator.toPoint(0, 100, Labels.empty())).isNull();
@@ -100,7 +102,7 @@ class LongMinMaxSumCountTest {
 
     assertThat(summarizer.toPoint(0, 100, Labels.empty()))
         .isEqualTo(
-            SummaryPoint.create(
+            DoubleSummaryPoint.create(
                 0,
                 100,
                 Labels.empty(),

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
@@ -42,14 +42,16 @@ class IntervalMetricReaderTest {
       Collections.singletonList(LongPoint.create(1000, 3000, Labels.empty(), 1234567));
 
   private static final MetricData METRIC_DATA =
-      MetricData.create(
+      MetricData.createDoubleSum(
           Resource.getEmpty(),
           InstrumentationLibraryInfo.create("IntervalMetricReaderTest", null),
           "my metric",
           "my metric description",
           "us",
-          MetricData.Type.LONG_SUM,
-          LONG_POINT_LIST);
+          MetricData.DoubleSumData.create(
+              /* isMonotonic= */ true,
+              MetricData.AggregationTemporality.CUMULATIVE,
+              LONG_POINT_LIST));
 
   @Mock private MetricProducer metricProducer;
 

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/view/CountAggregationTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/view/CountAggregationTest.java
@@ -7,23 +7,42 @@ package io.opentelemetry.sdk.metrics.view;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.api.common.Labels;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.aggregator.NoopAggregator;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link Aggregations#count()}. */
 class CountAggregationTest {
   @Test
-  void getDescriptorType() {
+  void toMetricData() {
     Aggregation count = Aggregations.count();
-    for (InstrumentType type : InstrumentType.values()) {
-      assertThat(count.getDescriptorType(type, InstrumentValueType.DOUBLE))
-          .isEqualTo(MetricData.Type.LONG_SUM);
-      assertThat(count.getDescriptorType(type, InstrumentValueType.LONG))
-          .isEqualTo(MetricData.Type.LONG_SUM);
-    }
+    Aggregator aggregator = count.getAggregatorFactory(InstrumentValueType.LONG).getAggregator();
+    aggregator.recordLong(10);
+
+    MetricData metricData =
+        count.toMetricData(
+            Resource.getDefault(),
+            InstrumentationLibraryInfo.getEmpty(),
+            InstrumentDescriptor.create(
+                "name",
+                "description",
+                "unit",
+                InstrumentType.VALUE_RECORDER,
+                InstrumentValueType.LONG),
+            Collections.singletonMap(Labels.empty(), aggregator),
+            0,
+            100);
+    assertThat(metricData).isNotNull();
+    assertThat(metricData.getUnit()).isEqualTo("1");
+    assertThat(metricData.getType()).isEqualTo(MetricData.Type.LONG_SUM);
   }
 
   @Test
@@ -34,13 +53,5 @@ class CountAggregationTest {
         .isInstanceOf(NoopAggregator.getFactory().getClass());
     assertThat(count.getAggregatorFactory(InstrumentValueType.DOUBLE))
         .isInstanceOf(NoopAggregator.getFactory().getClass());
-  }
-
-  @Test
-  void availableForInstrument() {
-    Aggregation count = Aggregations.count();
-    for (InstrumentType type : InstrumentType.values()) {
-      assertThat(count.availableForInstrument(type)).isTrue();
-    }
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/view/LastValueAggregationTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/view/LastValueAggregationTest.java
@@ -7,34 +7,44 @@ package io.opentelemetry.sdk.metrics.view;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.api.common.Labels;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.aggregator.DoubleLastValueAggregator;
 import io.opentelemetry.sdk.metrics.aggregator.LongLastValueAggregator;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;
-import java.util.EnumSet;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link Aggregations#sum()}. */
 class LastValueAggregationTest {
-  private static final EnumSet<InstrumentType> SUPPORTED_INSTRUMENTS =
-      EnumSet.of(InstrumentType.SUM_OBSERVER, InstrumentType.UP_DOWN_SUM_OBSERVER);
 
   @Test
-  void getDescriptorType_ForSupportedInstruments() {
+  void toMetricData() {
     Aggregation lastValue = Aggregations.lastValue();
-    assertThat(lastValue.getDescriptorType(InstrumentType.SUM_OBSERVER, InstrumentValueType.DOUBLE))
-        .isEqualTo(MetricData.Type.DOUBLE_SUM);
-    assertThat(lastValue.getDescriptorType(InstrumentType.SUM_OBSERVER, InstrumentValueType.LONG))
-        .isEqualTo(MetricData.Type.LONG_SUM);
-    assertThat(
-            lastValue.getDescriptorType(
-                InstrumentType.UP_DOWN_SUM_OBSERVER, InstrumentValueType.DOUBLE))
-        .isEqualTo(MetricData.Type.NON_MONOTONIC_DOUBLE_SUM);
-    assertThat(
-            lastValue.getDescriptorType(
-                InstrumentType.UP_DOWN_SUM_OBSERVER, InstrumentValueType.LONG))
-        .isEqualTo(MetricData.Type.NON_MONOTONIC_LONG_SUM);
+    Aggregator aggregator =
+        lastValue.getAggregatorFactory(InstrumentValueType.LONG).getAggregator();
+    aggregator.recordLong(10);
+
+    MetricData metricData =
+        lastValue.toMetricData(
+            Resource.getDefault(),
+            InstrumentationLibraryInfo.getEmpty(),
+            InstrumentDescriptor.create(
+                "name",
+                "description",
+                "unit",
+                InstrumentType.VALUE_OBSERVER,
+                InstrumentValueType.LONG),
+            Collections.singletonMap(Labels.empty(), aggregator),
+            0,
+            100);
+    assertThat(metricData).isNotNull();
+    assertThat(metricData.getType()).isEqualTo(MetricData.Type.LONG_GAUGE);
   }
 
   @Test
@@ -44,17 +54,5 @@ class LastValueAggregationTest {
         .isInstanceOf(LongLastValueAggregator.getFactory().getClass());
     assertThat(lastValue.getAggregatorFactory(InstrumentValueType.DOUBLE))
         .isInstanceOf(DoubleLastValueAggregator.getFactory().getClass());
-  }
-
-  @Test
-  void availableForInstrument() {
-    Aggregation lastValue = Aggregations.lastValue();
-    for (InstrumentType type : InstrumentType.values()) {
-      if (SUPPORTED_INSTRUMENTS.contains(type)) {
-        assertThat(lastValue.availableForInstrument(type)).isTrue();
-      } else {
-        assertThat(lastValue.availableForInstrument(type)).isFalse();
-      }
-    }
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/view/SumAggregationTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/view/SumAggregationTest.java
@@ -7,40 +7,44 @@ package io.opentelemetry.sdk.metrics.view;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.api.common.Labels;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.aggregator.DoubleSumAggregator;
 import io.opentelemetry.sdk.metrics.aggregator.LongSumAggregator;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link Aggregations#sum()}. */
 class SumAggregationTest {
-  private static final InstrumentType[] MONOTONIC_INSTRUMENTS = {
-    InstrumentType.COUNTER, InstrumentType.SUM_OBSERVER
-  };
-  private static final InstrumentType[] NON_MONOTONIC_INSTRUMENTS = {
-    InstrumentType.UP_DOWN_COUNTER,
-    InstrumentType.UP_DOWN_SUM_OBSERVER,
-    InstrumentType.VALUE_RECORDER,
-    InstrumentType.VALUE_OBSERVER
-  };
 
   @Test
-  void getDescriptorType() {
+  void toMetricData() {
     Aggregation sum = Aggregations.sum();
-    for (InstrumentType type : MONOTONIC_INSTRUMENTS) {
-      assertThat(sum.getDescriptorType(type, InstrumentValueType.DOUBLE))
-          .isEqualTo(MetricData.Type.DOUBLE_SUM);
-      assertThat(sum.getDescriptorType(type, InstrumentValueType.LONG))
-          .isEqualTo(MetricData.Type.LONG_SUM);
-    }
-    for (InstrumentType type : NON_MONOTONIC_INSTRUMENTS) {
-      assertThat(sum.getDescriptorType(type, InstrumentValueType.DOUBLE))
-          .isEqualTo(MetricData.Type.NON_MONOTONIC_DOUBLE_SUM);
-      assertThat(sum.getDescriptorType(type, InstrumentValueType.LONG))
-          .isEqualTo(MetricData.Type.NON_MONOTONIC_LONG_SUM);
-    }
+    Aggregator aggregator = sum.getAggregatorFactory(InstrumentValueType.LONG).getAggregator();
+    aggregator.recordLong(10);
+
+    MetricData metricData =
+        sum.toMetricData(
+            Resource.getDefault(),
+            InstrumentationLibraryInfo.getEmpty(),
+            InstrumentDescriptor.create(
+                "name",
+                "description",
+                "unit",
+                InstrumentType.VALUE_RECORDER,
+                InstrumentValueType.LONG),
+            Collections.singletonMap(Labels.empty(), aggregator),
+            0,
+            100);
+    assertThat(metricData).isNotNull();
+    assertThat(metricData.getType()).isEqualTo(MetricData.Type.LONG_SUM);
+    assertThat(metricData.getLongSumData().getPoints()).hasSize(1);
   }
 
   @Test
@@ -50,13 +54,5 @@ class SumAggregationTest {
         .isInstanceOf(LongSumAggregator.getFactory().getClass());
     assertThat(sum.getAggregatorFactory(InstrumentValueType.DOUBLE))
         .isInstanceOf(DoubleSumAggregator.getFactory().getClass());
-  }
-
-  @Test
-  void availableForInstrument() {
-    Aggregation sum = Aggregations.sum();
-    for (InstrumentType type : InstrumentType.values()) {
-      assertThat(sum.availableForInstrument(type)).isTrue();
-    }
   }
 }

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/exporter/InMemoryMetricExporterTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/exporter/InMemoryMetricExporterTest.java
@@ -26,14 +26,16 @@ class InMemoryMetricExporterTest {
   private static MetricData generateFakeMetric() {
     long startNs = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
     long endNs = startNs + TimeUnit.MILLISECONDS.toNanos(900);
-    return MetricData.create(
+    return MetricData.createLongSum(
         Resource.getEmpty(),
         InstrumentationLibraryInfo.getEmpty(),
         "name",
         "description",
         "1",
-        MetricData.Type.LONG_SUM,
-        Collections.singletonList(LongPoint.create(startNs, endNs, Labels.of("k", "v"), 5)));
+        MetricData.LongSumData.create(
+            /* isMonotonic= */ true,
+            MetricData.AggregationTemporality.CUMULATIVE,
+            Collections.singletonList(LongPoint.create(startNs, endNs, Labels.of("k", "v"), 5))));
   }
 
   @Test


### PR DESCRIPTION
Currently the temporality is not handled correctly, and in all of the cases I am setting it as CUMULATIVE, but in this PR I adding the capability to set temporality from the SDK.

Few fixes in this PR:
* No empty metrics emitted from the SDK. We used to always emit metadata about the metrics without any points even if there were no recordings.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>