### PR TITLE
Remove OpenTelemetryBuilder interface, every implementation will have it's own builder

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/DefaultOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/DefaultOpenTelemetry.java
@@ -5,14 +5,10 @@
 
 package io.opentelemetry.api;
 
-import static java.util.Objects.requireNonNull;
-
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.spi.OpenTelemetryFactory;
-import io.opentelemetry.spi.metrics.MeterProviderFactory;
-import io.opentelemetry.spi.trace.TracerProviderFactory;
 import java.util.ServiceLoader;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -45,8 +41,13 @@ public class DefaultOpenTelemetry implements OpenTelemetry {
     globalOpenTelemetry = openTelemetry;
   }
 
-  static Builder builder() {
-    return new Builder();
+  /**
+   * Returns a builder for the {@link DefaultOpenTelemetry}.
+   *
+   * @return a builder for the {@link DefaultOpenTelemetry}.
+   */
+  public static DefaultOpenTelemetryBuilder builder() {
+    return new DefaultOpenTelemetryBuilder();
   }
 
   @Nullable private static volatile OpenTelemetry globalOpenTelemetry;
@@ -93,7 +94,7 @@ public class DefaultOpenTelemetry implements OpenTelemetry {
    * @throws IllegalStateException if a specified provider is not found
    */
   @Nullable
-  private static <T> T loadSpi(Class<T> providerClass) {
+  static <T> T loadSpi(Class<T> providerClass) {
     String specifiedProvider = System.getProperty(providerClass.getName());
     ServiceLoader<T> providers = ServiceLoader.load(providerClass);
     for (T provider : providers) {
@@ -111,58 +112,5 @@ public class DefaultOpenTelemetry implements OpenTelemetry {
   // for testing
   static void reset() {
     globalOpenTelemetry = null;
-  }
-
-  protected static class Builder implements OpenTelemetryBuilder<Builder> {
-    protected ContextPropagators propagators = ContextPropagators.noop();
-
-    protected TracerProvider tracerProvider;
-    protected MeterProvider meterProvider;
-
-    @Override
-    public Builder setTracerProvider(TracerProvider tracerProvider) {
-      requireNonNull(tracerProvider, "tracerProvider");
-      this.tracerProvider = tracerProvider;
-      return this;
-    }
-
-    @Override
-    public Builder setMeterProvider(MeterProvider meterProvider) {
-      requireNonNull(meterProvider, "meterProvider");
-      this.meterProvider = meterProvider;
-      return this;
-    }
-
-    @Override
-    public Builder setPropagators(ContextPropagators propagators) {
-      requireNonNull(propagators, "propagators");
-      this.propagators = propagators;
-      return this;
-    }
-
-    @Override
-    public OpenTelemetry build() {
-      MeterProvider meterProvider = this.meterProvider;
-      if (meterProvider == null) {
-        MeterProviderFactory meterProviderFactory = loadSpi(MeterProviderFactory.class);
-        if (meterProviderFactory != null) {
-          meterProvider = meterProviderFactory.create();
-        } else {
-          meterProvider = MeterProvider.getDefault();
-        }
-      }
-
-      TracerProvider tracerProvider = this.tracerProvider;
-      if (tracerProvider == null) {
-        TracerProviderFactory tracerProviderFactory = loadSpi(TracerProviderFactory.class);
-        if (tracerProviderFactory != null) {
-          tracerProvider = tracerProviderFactory.create();
-        } else {
-          tracerProvider = TracerProvider.getDefault();
-        }
-      }
-
-      return new DefaultOpenTelemetry(tracerProvider, meterProvider, propagators);
-    }
   }
 }

--- a/api/all/src/main/java/io/opentelemetry/api/DefaultOpenTelemetryBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/DefaultOpenTelemetryBuilder.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api;
+
+import static java.util.Objects.requireNonNull;
+
+import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.api.trace.TracerProvider;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.spi.metrics.MeterProviderFactory;
+import io.opentelemetry.spi.trace.TracerProviderFactory;
+
+/** Builder class for {@link DefaultOpenTelemetry}. */
+@SuppressWarnings("deprecation")
+public class DefaultOpenTelemetryBuilder
+    implements OpenTelemetryBuilder<DefaultOpenTelemetryBuilder> {
+  protected ContextPropagators propagators = ContextPropagators.noop();
+
+  protected TracerProvider tracerProvider;
+  protected MeterProvider meterProvider;
+
+  @Override
+  public DefaultOpenTelemetryBuilder setTracerProvider(TracerProvider tracerProvider) {
+    requireNonNull(tracerProvider, "tracerProvider");
+    this.tracerProvider = tracerProvider;
+    return this;
+  }
+
+  @Override
+  public DefaultOpenTelemetryBuilder setMeterProvider(MeterProvider meterProvider) {
+    requireNonNull(meterProvider, "meterProvider");
+    this.meterProvider = meterProvider;
+    return this;
+  }
+
+  @Override
+  public DefaultOpenTelemetryBuilder setPropagators(ContextPropagators propagators) {
+    requireNonNull(propagators, "propagators");
+    this.propagators = propagators;
+    return this;
+  }
+
+  @Override
+  public OpenTelemetry build() {
+    MeterProvider meterProvider = this.meterProvider;
+    if (meterProvider == null) {
+      MeterProviderFactory meterProviderFactory =
+          DefaultOpenTelemetry.loadSpi(MeterProviderFactory.class);
+      if (meterProviderFactory != null) {
+        meterProvider = meterProviderFactory.create();
+      } else {
+        meterProvider = MeterProvider.getDefault();
+      }
+    }
+
+    TracerProvider tracerProvider = this.tracerProvider;
+    if (tracerProvider == null) {
+      TracerProviderFactory tracerProviderFactory =
+          DefaultOpenTelemetry.loadSpi(TracerProviderFactory.class);
+      if (tracerProviderFactory != null) {
+        tracerProvider = tracerProviderFactory.create();
+      } else {
+        tracerProvider = TracerProvider.getDefault();
+      }
+    }
+
+    return new DefaultOpenTelemetry(tracerProvider, meterProvider, propagators);
+  }
+}

--- a/api/all/src/main/java/io/opentelemetry/api/OpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/OpenTelemetry.java
@@ -205,8 +205,13 @@ public interface OpenTelemetry {
   /** Returns the {@link ContextPropagators} for this {@link OpenTelemetry}. */
   ContextPropagators getPropagators();
 
-  /** Returns a new {@link OpenTelemetryBuilder}. */
+  /**
+   * Returns a new {@link OpenTelemetryBuilder}.
+   *
+   * @deprecated use {@link DefaultOpenTelemetry#builder()}.
+   */
+  @Deprecated
   static OpenTelemetryBuilder<?> builder() {
-    return new DefaultOpenTelemetry.Builder();
+    return new DefaultOpenTelemetryBuilder();
   }
 }

--- a/api/all/src/main/java/io/opentelemetry/api/OpenTelemetryBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/OpenTelemetryBuilder.java
@@ -12,7 +12,10 @@ import io.opentelemetry.context.propagation.ContextPropagators;
 /**
  * A builder of an implementation of the OpenTelemetry API. Generally used to reconfigure SDK
  * implementations.
+ *
+ * @deprecated use the {@link DefaultOpenTelemetryBuilder} instead.
  */
+@Deprecated
 public interface OpenTelemetryBuilder<T extends OpenTelemetryBuilder<T>> {
 
   /** Sets the {@link TracerProvider} to use. */

--- a/api/all/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
@@ -74,7 +74,7 @@ class OpenTelemetryTest {
     TracerProvider tracerProvider = mock(TracerProvider.class);
     ContextPropagators contextPropagators = mock(ContextPropagators.class);
     OpenTelemetry openTelemetry =
-        OpenTelemetry.builder()
+        DefaultOpenTelemetry.builder()
             .setMeterProvider(meterProvider)
             .setTracerProvider(tracerProvider)
             .setPropagators(contextPropagators)
@@ -193,12 +193,12 @@ class OpenTelemetryTest {
     Tracer tracer1 = mock(Tracer.class);
     when(provider1.get("foo")).thenReturn(tracer1);
     when(provider1.get("foo", "1.0")).thenReturn(tracer1);
-    OpenTelemetry otel1 = OpenTelemetry.builder().setTracerProvider(provider1).build();
+    OpenTelemetry otel1 = DefaultOpenTelemetry.builder().setTracerProvider(provider1).build();
     TracerProvider provider2 = mock(TracerProvider.class);
     Tracer tracer2 = mock(Tracer.class);
     when(provider2.get("foo")).thenReturn(tracer2);
     when(provider2.get("foo", "1.0")).thenReturn(tracer2);
-    OpenTelemetry otel2 = OpenTelemetry.builder().setTracerProvider(provider2).build();
+    OpenTelemetry otel2 = DefaultOpenTelemetry.builder().setTracerProvider(provider2).build();
 
     assertThat(otel1.getTracer("foo")).isSameAs(tracer1);
     assertThat(otel1.getTracer("foo", "1.0")).isSameAs(tracer1);
@@ -212,12 +212,12 @@ class OpenTelemetryTest {
     Meter meter1 = mock(Meter.class);
     when(provider1.get("foo")).thenReturn(meter1);
     when(provider1.get("foo", "1.0")).thenReturn(meter1);
-    OpenTelemetry otel1 = OpenTelemetry.builder().setMeterProvider(provider1).build();
+    OpenTelemetry otel1 = DefaultOpenTelemetry.builder().setMeterProvider(provider1).build();
     MeterProvider provider2 = mock(MeterProvider.class);
     Meter meter2 = mock(Meter.class);
     when(provider2.get("foo")).thenReturn(meter2);
     when(provider2.get("foo", "1.0")).thenReturn(meter2);
-    OpenTelemetry otel2 = OpenTelemetry.builder().setMeterProvider(provider2).build();
+    OpenTelemetry otel2 = DefaultOpenTelemetry.builder().setMeterProvider(provider2).build();
 
     assertThat(otel1.getMeter("foo")).isSameAs(meter1);
     assertThat(otel1.getMeter("foo", "1.0")).isSameAs(meter1);
@@ -228,9 +228,9 @@ class OpenTelemetryTest {
   @Test
   void independentNonGlobalPropagators() {
     ContextPropagators propagators1 = mock(ContextPropagators.class);
-    OpenTelemetry otel1 = OpenTelemetry.builder().setPropagators(propagators1).build();
+    OpenTelemetry otel1 = DefaultOpenTelemetry.builder().setPropagators(propagators1).build();
     ContextPropagators propagators2 = mock(ContextPropagators.class);
-    OpenTelemetry otel2 = OpenTelemetry.builder().setPropagators(propagators2).build();
+    OpenTelemetry otel2 = DefaultOpenTelemetry.builder().setPropagators(propagators2).build();
 
     assertThat(otel1.getPropagators()).isSameAs(propagators1);
     assertThat(otel2.getPropagators()).isSameAs(propagators2);

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk;
 import static java.util.Objects.requireNonNull;
 
 import io.opentelemetry.api.DefaultOpenTelemetry;
+import io.opentelemetry.api.DefaultOpenTelemetryBuilder;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.trace.Tracer;
@@ -92,7 +93,7 @@ public final class OpenTelemetrySdk extends DefaultOpenTelemetry {
   }
 
   /** A builder for configuring an {@link OpenTelemetrySdk}. */
-  public static class Builder extends DefaultOpenTelemetry.Builder {
+  public static class Builder extends DefaultOpenTelemetryBuilder {
     private Clock clock;
     private Resource resource;
     private final List<SpanProcessor> spanProcessors = new ArrayList<>();

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import io.opentelemetry.api.DefaultOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.MeterProvider;
@@ -55,7 +56,7 @@ class OpenTelemetrySdkTest {
     OpenTelemetry previous = OpenTelemetry.get();
     assertThatCode(OpenTelemetrySdk::getGlobalTracerManagement).doesNotThrowAnyException();
     try {
-      OpenTelemetry.set(OpenTelemetry.builder().setTracerProvider(tracerProvider).build());
+      OpenTelemetry.set(DefaultOpenTelemetry.builder().setTracerProvider(tracerProvider).build());
       assertThatThrownBy(OpenTelemetrySdk::getGlobalTracerManagement)
           .isInstanceOf(IllegalStateException.class);
     } finally {


### PR DESCRIPTION
This PR also fixes the DefaultOpenTelemetry builder to be it's own class and not a sub-class.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>