### PR TITLE
Call point constructor with the value got instead of getting the value again

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongLastValueAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongLastValueAggregator.java
@@ -47,7 +47,7 @@ public final class LongLastValueAggregator extends AbstractAggregator {
     @Nullable Long currentValue = current.get();
     return currentValue == null
         ? null
-        : LongPoint.create(startEpochNanos, epochNanos, labels, current.get());
+        : LongPoint.create(startEpochNanos, epochNanos, labels, currentValue);
   }
 
   @Override


### PR DESCRIPTION
Not a problem in the Double version where this is implemented correctly.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>