### PR TITLE
Make AttributeKey compare normally with both type/key.

### DIFF
--- a/api/common/src/main/java/io/opentelemetry/api/common/ArrayBackedAttributes.java
+++ b/api/common/src/main/java/io/opentelemetry/api/common/ArrayBackedAttributes.java
@@ -8,6 +8,7 @@ package io.opentelemetry.api.common;
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.internal.ImmutableKeyValuePairs;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.BiConsumer;
 import javax.annotation.concurrent.Immutable;
@@ -16,6 +17,11 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 abstract class ArrayBackedAttributes extends ImmutableKeyValuePairs<AttributeKey<?>, Object>
     implements Attributes {
+
+  // We only compare the key name, not type, when constructing, to allow deduping keys with the
+  // same name but different type.
+  private static final Comparator<AttributeKey<?>> KEY_COMPARATOR_FOR_CONSTRUCTION =
+      Comparator.comparing(AttributeKey::getKey);
 
   static final Attributes EMPTY = Attributes.builder().build();
 
@@ -53,6 +59,7 @@ abstract class ArrayBackedAttributes extends ImmutableKeyValuePairs<AttributeKey
         data[i] = null;
       }
     }
-    return new AutoValue_ArrayBackedAttributes(sortAndFilter(data, /* filterNullValues= */ true));
+    return new AutoValue_ArrayBackedAttributes(
+        sortAndFilter(data, /* filterNullValues= */ true, KEY_COMPARATOR_FOR_CONSTRUCTION));
   }
 }

--- a/api/common/src/main/java/io/opentelemetry/api/common/AttributeKey.java
+++ b/api/common/src/main/java/io/opentelemetry/api/common/AttributeKey.java
@@ -19,7 +19,7 @@ import javax.annotation.concurrent.Immutable;
  */
 @SuppressWarnings("rawtypes")
 @Immutable
-public interface AttributeKey<T> extends Comparable<AttributeKey> {
+public interface AttributeKey<T> {
   /** Returns the underlying String representation of the key. */
   String getKey();
 

--- a/api/common/src/main/java/io/opentelemetry/api/common/AttributeKeyImpl.java
+++ b/api/common/src/main/java/io/opentelemetry/api/common/AttributeKeyImpl.java
@@ -23,39 +23,4 @@ abstract class AttributeKeyImpl<T> implements AttributeKey<T> {
 
   @Nullable
   abstract String key();
-
-  //////////////////////////////////
-  // IMPORTANT: the equals/hashcode/compareTo *only* include the key, and not the type,
-  // so that de-duping of attributes is based on the key, and not also based on the type.
-  //////////////////////////////////
-
-  @Override
-  public final boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof AttributeKeyImpl)) {
-      return false;
-    }
-
-    AttributeKeyImpl<?> that = (AttributeKeyImpl<?>) o;
-
-    return getKey() != null ? getKey().equals(that.getKey()) : that.getKey() == null;
-  }
-
-  @Override
-  public final int hashCode() {
-    return getKey() != null ? getKey().hashCode() : 0;
-  }
-
-  @Override
-  public int compareTo(AttributeKey o) {
-    if (getKey() == null) {
-      return o.getKey() == null ? 0 : -1;
-    }
-    if (o.getKey() == null) {
-      return 1;
-    }
-    return getKey().compareTo(o.getKey());
-  }
 }

--- a/api/common/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
+++ b/api/common/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
@@ -87,14 +87,14 @@ public abstract class ImmutableKeyValuePairs<K, V> {
   // note: merge sort implementation cribbed from this wikipedia article:
   // https://en.wikipedia.org/wiki/Merge_sort (this is the top-down variant)
   private static void mergeSort(
-      Object[] sourceArray, Object[] workArray, int n, Comparator<?> keyComparatr) {
+      Object[] sourceArray, Object[] workArray, int n, Comparator<?> keyComparator) {
     System.arraycopy(sourceArray, 0, workArray, 0, sourceArray.length);
     splitAndMerge(
         workArray,
         0,
         n,
         sourceArray,
-        keyComparatr); // sort data from workArray[] into sourceArray[]
+        keyComparator); // sort data from workArray[] into sourceArray[]
   }
 
   /**

--- a/api/common/src/test/java/io/opentelemetry/api/common/AttributeKeyTest.java
+++ b/api/common/src/test/java/io/opentelemetry/api/common/AttributeKeyTest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.common;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class AttributeKeyTest {
+
+  @Test
+  @SuppressWarnings("AutoValueSubclassLeaked")
+  void equalsVerifier() {
+    EqualsVerifier.forClass(AutoValue_AttributeKeyImpl.class).verify();
+  }
+}

--- a/api/common/src/test/java/io/opentelemetry/api/common/AttributesTest.java
+++ b/api/common/src/test/java/io/opentelemetry/api/common/AttributesTest.java
@@ -364,4 +364,11 @@ class AttributesTest {
     assertThat(attributes.get(doubleArrayKey("arrayDouble"))).isEqualTo(singletonList(1.0d));
     assertThat(attributes.get(booleanArrayKey("arrayBool"))).isEqualTo(singletonList(true));
   }
+
+  @Test
+  void onlySameTypeCanRetrieveValue() {
+    Attributes attributes = Attributes.of(stringKey("animal"), "cat");
+    assertThat(attributes.get(stringKey("animal"))).isEqualTo("cat");
+    assertThat(attributes.get(longKey("animal"))).isNull();
+  }
 }

--- a/api/common/src/test/java/io/opentelemetry/api/common/AttributesTest.java
+++ b/api/common/src/test/java/io/opentelemetry/api/common/AttributesTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.entry;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
@@ -31,7 +32,7 @@ class AttributesTest {
 
   @Test
   void forEach() {
-    final Map<AttributeKey, Object> entriesSeen = new HashMap<>();
+    final Map<AttributeKey, Object> entriesSeen = new LinkedHashMap<>();
 
     Attributes attributes = Attributes.of(stringKey("key1"), "value1", longKey("key2"), 333L);
 

--- a/api/common/src/test/java/io/opentelemetry/api/common/LabelsTest.java
+++ b/api/common/src/test/java/io/opentelemetry/api/common/LabelsTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
@@ -17,7 +18,7 @@ class LabelsTest {
 
   @Test
   void forEach() {
-    final Map<String, String> entriesSeen = new HashMap<>();
+    final Map<String, String> entriesSeen = new LinkedHashMap<>();
 
     Labels labels =
         Labels.of(

--- a/build.gradle
+++ b/build.gradle
@@ -344,6 +344,7 @@ configure(opentelemetryProjects) {
 
                 // Test dependencies.
                 assertj                     : "org.assertj:assertj-core:3.18.1",
+                equals_verifier              : "nl.jqno.equalsverifier:equalsverifier:3.5",
                 guava_testlib               : "com.google.guava:guava-testlib",
                 junit                       : 'junit:junit:4.13.1',
                 junit_pioneer               : 'org.junit-pioneer:junit-pioneer:1.0.0',
@@ -455,6 +456,7 @@ configure(opentelemetryProjects) {
                 libraries.jsr305
 
         testImplementation libraries.junit_jupiter_api,
+                libraries.equals_verifier,
                 libraries.mockito,
                 libraries.mockito_junit_jupiter,
                 libraries.assertj,


### PR DESCRIPTION
Instead passes a special `Comparator` to sortAndFilter where the old behavior is actually needed. A bit annoying, but all inside an internal class.

Also tried out a testing library I've been wanting to check out :) It was reporting the lack of getType in equals before the change.

Fixes #2282