### PR TITLE
Migrate AWS mock server tests to junit5.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -285,6 +285,7 @@ configure(opentelemetryProjects) {
     }
 
     ext {
+        armeriaVersion = '1.3.0'
         autoValueVersion = '1.7.4'
         errorProneVersion = '2.4.0'
         errorProneJavacVersion = '9+181-r4173-1'
@@ -304,12 +305,13 @@ configure(opentelemetryProjects) {
         zipkinVersion = '2.18.3'
 
         boms = [
-                grpc           : "io.grpc:grpc-bom:${grpcVersion}",
-                guava          : "com.google.guava:guava-bom:${guavaVersion}",
-                jackson        : "com.fasterxml.jackson:jackson-bom:2.11.3",
-                junit          : "org.junit:junit-bom:${junitVersion}",
-                protobuf       : "com.google.protobuf:protobuf-bom:${protobufVersion}",
-                zipkin_reporter: "io.zipkin.reporter2:zipkin-reporter-bom:${zipkinReporterVersion}"
+                "com.linecorp.armeria:armeria-bom:${armeriaVersion}",
+                "io.grpc:grpc-bom:${grpcVersion}",
+                "com.google.guava:guava-bom:${guavaVersion}",
+                "com.fasterxml.jackson:jackson-bom:2.11.3",
+                "org.junit:junit-bom:${junitVersion}",
+                "com.google.protobuf:protobuf-bom:${protobufVersion}",
+                "io.zipkin.reporter2:zipkin-reporter-bom:${zipkinReporterVersion}"
         ]
 
         libraries = [
@@ -437,12 +439,9 @@ configure(opentelemetryProjects) {
         configurations.all {
             // Kotlin compiler classpaths don't support BOM nor need it.
             if (it.name.endsWith('Classpath') && !it.name.startsWith('kotlin')) {
-                add(it.name, enforcedPlatform(boms.grpc))
-                add(it.name, enforcedPlatform(boms.guava))
-                add(it.name, enforcedPlatform(boms.jackson))
-                add(it.name, enforcedPlatform(boms.junit))
-                add(it.name, enforcedPlatform(boms.protobuf))
-                add(it.name, enforcedPlatform(boms.zipkin_reporter))
+                boms.each {bom ->
+                    add(it.name, enforcedPlatform(bom))
+                }
             }
         }
 

--- a/exporters/jaeger/build.gradle
+++ b/exporters/jaeger/build.gradle
@@ -29,7 +29,9 @@ dependencies {
 
     // Protobuf plugin seems to erroneously use the non-classpath configurations for resolving
     // dependencies.
-    testImplementation enforcedPlatform(boms.jackson)
+    boms.each {
+        testImplementation enforcedPlatform(it)
+    }
 
     testRuntime "io.grpc:grpc-netty-shaded:${grpcVersion}"
 

--- a/proto/build.gradle
+++ b/proto/build.gradle
@@ -13,8 +13,9 @@ ext.moduleName = 'io.opentelemetry.proto'
 dependencies {
     // Protobuf plugin seems to erroneously use the non-classpath configurations for resolving
     // dependencies.
-    implementation enforcedPlatform(boms.grpc)
-    implementation enforcedPlatform(boms.protobuf)
+    boms.each {
+        implementation enforcedPlatform(it)
+    }
 
     api libraries.protobuf,
             libraries.grpc_api,

--- a/sdk-extensions/aws/build.gradle
+++ b/sdk-extensions/aws/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
-    testImplementation 'com.github.tomakehurst:wiremock-jre8:2.27.2',
+    testImplementation 'com.linecorp.armeria:armeria-junit5',
             libraries.guava,
             libraries.junit
 }

--- a/sdk-extensions/aws/src/test/java/io/opentelemetry/sdk/extension/aws/resource/JdkHttpClientTest.java
+++ b/sdk-extensions/aws/src/test/java/io/opentelemetry/sdk/extension/aws/resource/JdkHttpClientTest.java
@@ -5,47 +5,41 @@
 
 package io.opentelemetry.sdk.extension.aws.resource;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.any;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import com.google.common.collect.ImmutableMap;
-import java.io.IOException;
+import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.testing.junit5.server.mock.MockWebServerExtension;
 import java.util.Map;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class JdkHttpClientTest {
+class JdkHttpClientTest {
 
-  @ClassRule
-  public static WireMockClassRule server = new WireMockClassRule(wireMockConfig().dynamicPort());
+  @RegisterExtension public static MockWebServerExtension server = new MockWebServerExtension();
 
   @Test
-  public void testFetchString() throws IOException {
-    stubFor(any(urlPathEqualTo("/path")).willReturn(ok("expected result")));
+  void testFetchString() {
+    server.enqueue(HttpResponse.of("expected result"));
 
     Map<String, String> requestPropertyMap = ImmutableMap.of("key1", "value1", "key2", "value2");
-    String urlStr = String.format("http://localhost:%s%s", server.port(), "/path");
+    String urlStr = String.format("http://localhost:%s%s", server.httpPort(), "/path");
     JdkHttpClient jdkHttpClient = new JdkHttpClient();
     String result = jdkHttpClient.fetchString("GET", urlStr, requestPropertyMap, null);
 
     assertThat(result).isEqualTo("expected result");
-    verify(getRequestedFor(urlEqualTo("/path")).withHeader("key1", equalTo("value1")));
-    verify(getRequestedFor(urlEqualTo("/path")).withHeader("key2", equalTo("value2")));
+
+    AggregatedHttpRequest request1 = server.takeRequest().request();
+    assertThat(request1.path()).isEqualTo("/path");
+    assertThat(request1.headers().get("key1")).isEqualTo("value1");
+    assertThat(request1.headers().get("key2")).isEqualTo("value2");
   }
 
   @Test
-  public void testFailedFetchString() {
+  void testFailedFetchString() {
     Map<String, String> requestPropertyMap = ImmutableMap.of("key1", "value1", "key2", "value2");
-    String urlStr = String.format("http://localhost:%s%s", server.port(), "/path");
+    String urlStr = String.format("http://localhost:%s%s", server.httpPort(), "/path");
     JdkHttpClient jdkHttpClient = new JdkHttpClient();
     String result = jdkHttpClient.fetchString("GET", urlStr, requestPropertyMap, null);
     assertThat(result).isEmpty();


### PR DESCRIPTION
Switches wiremock with armeria which supports junit5.