### PR TITLE
Add Context.toString

### DIFF
--- a/api/context/src/main/java/io/opentelemetry/context/ArrayBasedContext.java
+++ b/api/context/src/main/java/io/opentelemetry/context/ArrayBasedContext.java
@@ -81,4 +81,18 @@ final class ArrayBasedContext implements Context {
     newEntries[newEntries.length - 1] = value;
     return new ArrayBasedContext(newEntries);
   }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder("{");
+    for (int i = 0; i < entries.length; i += 2) {
+      sb.append(entries[i]).append('=').append(entries[i + 1]).append(", ");
+    }
+    // get rid of that last pesky comma
+    if (sb.length() > 1) {
+      sb.setLength(sb.length() - 2);
+    }
+    sb.append('}');
+    return sb.toString();
+  }
 }

--- a/api/context/src/test/java/io/opentelemetry/context/ContextTest.java
+++ b/api/context/src/test/java/io/opentelemetry/context/ContextTest.java
@@ -479,6 +479,14 @@ class ContextTest {
   }
 
   @Test
+  void string() {
+    assertThat(Context.root()).hasToString("{}");
+    assertThat(Context.root().with(ANIMAL, "cat")).hasToString("{animal=cat}");
+    assertThat(Context.root().with(ANIMAL, "cat").with(BAG, 10))
+        .hasToString("{animal=cat, bag=10}");
+  }
+
+  @Test
   void hashcodeCollidingKeys() {
     Context context = Context.root();
     HashCollidingKey cheese = new HashCollidingKey();


### PR DESCRIPTION
It's difficult to debug context issues, such as IntelliJ debugger view or the error messages from `StringContextStorage`, without a toString on Context.