### PR TITLE
Move Sdk to be prefix of implementation classes instead of suffix/mid…

### DIFF
--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/OpenTracingShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/OpenTracingShimTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.when;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.propagation.ContextPropagators;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import org.junit.jupiter.api.Test;
 
 class OpenTracingShimTest {
@@ -25,7 +25,7 @@ class OpenTracingShimTest {
   @Test
   void createTracerShim_fromOpenTelemetryInstance() {
     OpenTelemetry openTelemetry = mock(OpenTelemetry.class);
-    TracerSdkProvider sdk = TracerSdkProvider.builder().build();
+    SdkTracerProvider sdk = SdkTracerProvider.builder().build();
     when(openTelemetry.getTracerProvider()).thenReturn(sdk);
     when(openTelemetry.getPropagators()).thenReturn(mock(ContextPropagators.class));
 

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanBuilderShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanBuilderShimTest.java
@@ -10,12 +10,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import org.junit.jupiter.api.Test;
 
 class SpanBuilderShimTest {
 
-  private final TracerSdkProvider tracerSdkFactory = TracerSdkProvider.builder().build();
+  private final SdkTracerProvider tracerSdkFactory = SdkTracerProvider.builder().build();
   private final Tracer tracer = tracerSdkFactory.get("SpanShimTest");
   private final TelemetryInfo telemetryInfo =
       new TelemetryInfo(tracer, OpenTelemetry.getGlobalPropagators());

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 
 class SpanShimTest {
 
-  private final TracerSdkProvider tracerSdkFactory = TracerSdkProvider.builder().build();
+  private final SdkTracerProvider tracerSdkFactory = SdkTracerProvider.builder().build();
   private final Tracer tracer = tracerSdkFactory.get("SpanShimTest");
   private final TelemetryInfo telemetryInfo =
       new TelemetryInfo(tracer, OpenTelemetry.getGlobalPropagators());

--- a/sdk-extensions/logging/src/main/java/io/opentelemetry/sdk/logging/LogProcessor.java
+++ b/sdk-extensions/logging/src/main/java/io/opentelemetry/sdk/logging/LogProcessor.java
@@ -7,14 +7,14 @@ package io.opentelemetry.sdk.logging;
 
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.logging.data.LogRecord;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 
 public interface LogProcessor {
 
   void addLogRecord(LogRecord record);
 
   /**
-   * Called when {@link TracerSdkProvider#shutdown()} is called.
+   * Called when {@link SdkTracerProvider#shutdown()} is called.
    *
    * @return result
    */

--- a/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/TraceConfigzZPageHandler.java
+++ b/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/TraceConfigzZPageHandler.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.sdk.extension.zpages;
 
-import io.opentelemetry.sdk.trace.TracerSdkManagement;
+import io.opentelemetry.sdk.trace.SdkTracerManagement;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.sdk.trace.config.TraceConfigBuilder;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
@@ -35,10 +35,10 @@ final class TraceConfigzZPageHandler extends ZPageHandler {
   // Background color used for zebra striping rows in table
   private static final String ZEBRA_STRIPE_COLOR = "#e6e6e6";
   private static final Logger logger = Logger.getLogger(TraceConfigzZPageHandler.class.getName());
-  private final TracerSdkManagement tracerSdkManagement;
+  private final SdkTracerManagement sdkTracerManagement;
 
-  TraceConfigzZPageHandler(TracerSdkManagement tracerSdkManagement) {
-    this.tracerSdkManagement = tracerSdkManagement;
+  TraceConfigzZPageHandler(SdkTracerManagement sdkTracerManagement) {
+    this.sdkTracerManagement = sdkTracerManagement;
   }
 
   @Override
@@ -211,7 +211,7 @@ final class TraceConfigzZPageHandler extends ZPageHandler {
     emitActiveTableRow(
         /* out= */ out,
         /* paramName= */ "Sampler",
-        /* paramValue=*/ this.tracerSdkManagement
+        /* paramValue=*/ this.sdkTracerManagement
             .getActiveTraceConfig()
             .getSampler()
             .getDescription(),
@@ -221,35 +221,35 @@ final class TraceConfigzZPageHandler extends ZPageHandler {
         /* out= */ out,
         /* paramName= */ "MaxNumOfAttributes",
         /* paramValue=*/ Integer.toString(
-            this.tracerSdkManagement.getActiveTraceConfig().getMaxNumberOfAttributes()),
+            this.sdkTracerManagement.getActiveTraceConfig().getMaxNumberOfAttributes()),
         /* zebraStripeColor= */ ZEBRA_STRIPE_COLOR,
         /* zebraStripe= */ true);
     emitActiveTableRow(
         /* out= */ out,
         /* paramName= */ "MaxNumOfEvents",
         /* paramValue=*/ Integer.toString(
-            this.tracerSdkManagement.getActiveTraceConfig().getMaxNumberOfEvents()),
+            this.sdkTracerManagement.getActiveTraceConfig().getMaxNumberOfEvents()),
         /* zebraStripeColor= */ ZEBRA_STRIPE_COLOR,
         /* zebraStripe= */ false);
     emitActiveTableRow(
         /* out= */ out,
         /* paramName= */ "MaxNumOfLinks",
         /* paramValue=*/ Integer.toString(
-            this.tracerSdkManagement.getActiveTraceConfig().getMaxNumberOfLinks()),
+            this.sdkTracerManagement.getActiveTraceConfig().getMaxNumberOfLinks()),
         /* zebraStripeColor= */ ZEBRA_STRIPE_COLOR,
         /* zebraStripe= */ true);
     emitActiveTableRow(
         /* out= */ out,
         /* paramName= */ "MaxNumOfAttributesPerEvent",
         /* paramValue=*/ Integer.toString(
-            this.tracerSdkManagement.getActiveTraceConfig().getMaxNumberOfAttributesPerEvent()),
+            this.sdkTracerManagement.getActiveTraceConfig().getMaxNumberOfAttributesPerEvent()),
         /* zebraStripeColor= */ ZEBRA_STRIPE_COLOR,
         /* zebraStripe= */ false);
     emitActiveTableRow(
         /* out= */ out,
         /* paramName= */ "MaxNumOfAttributesPerLink",
         /* paramValue=*/ Integer.toString(
-            this.tracerSdkManagement.getActiveTraceConfig().getMaxNumberOfAttributesPerLink()),
+            this.sdkTracerManagement.getActiveTraceConfig().getMaxNumberOfAttributesPerLink()),
         /* zebraStripeColor= */ ZEBRA_STRIPE_COLOR,
         /* zebraStripe=*/ true);
     out.print("</table>");
@@ -370,7 +370,7 @@ final class TraceConfigzZPageHandler extends ZPageHandler {
     }
     if (action.equals(QUERY_STRING_ACTION_CHANGE)) {
       TraceConfigBuilder newConfigBuilder =
-          this.tracerSdkManagement.getActiveTraceConfig().toBuilder();
+          this.sdkTracerManagement.getActiveTraceConfig().toBuilder();
       String samplingProbabilityStr = queryMap.get(QUERY_STRING_SAMPLING_PROBABILITY);
       if (samplingProbabilityStr != null) {
         try {
@@ -435,10 +435,10 @@ final class TraceConfigzZPageHandler extends ZPageHandler {
               "MaxNumOfAttributesPerLink must be of the type integer", e);
         }
       }
-      this.tracerSdkManagement.updateActiveTraceConfig(newConfigBuilder.build());
+      this.sdkTracerManagement.updateActiveTraceConfig(newConfigBuilder.build());
     } else if (action.equals(QUERY_STRING_ACTION_DEFAULT)) {
       TraceConfig defaultConfig = TraceConfig.getDefault().toBuilder().build();
-      this.tracerSdkManagement.updateActiveTraceConfig(defaultConfig);
+      this.sdkTracerManagement.updateActiveTraceConfig(defaultConfig);
     }
   }
 }

--- a/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/ZPageServer.java
+++ b/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/ZPageServer.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.extension.zpages;
 
 import com.sun.net.httpserver.HttpServer;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.trace.TracerSdkManagement;
+import io.opentelemetry.sdk.trace.SdkTracerManagement;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
@@ -55,7 +55,7 @@ public final class ZPageServer {
       TracezSpanProcessor.builder().build();
   private static final TracezDataAggregator tracezDataAggregator =
       new TracezDataAggregator(tracezSpanProcessor);
-  private static final TracerSdkManagement TRACER_SDK_MANAGEMENT =
+  private static final SdkTracerManagement TRACER_SDK_MANAGEMENT =
       OpenTelemetrySdk.getGlobalTracerManagement();
   // Handler for /tracez page
   private static final ZPageHandler tracezZPageHandler =
@@ -74,7 +74,7 @@ public final class ZPageServer {
   @Nullable
   private static HttpServer server;
 
-  /** Function that adds the {@link TracezSpanProcessor} to the {@link TracerSdkManagement}. */
+  /** Function that adds the {@link TracezSpanProcessor} to the {@link SdkTracerManagement}. */
   private static void addTracezSpanProcessor() {
     if (isTracezSpanProcesserAdded.compareAndSet(/* expectedValue=*/ false, /* newValue=*/ true)) {
       TRACER_SDK_MANAGEMENT.addSpanProcessor(tracezSpanProcessor);

--- a/sdk-extensions/zpages/src/test/java/io/opentelemetry/sdk/extension/zpages/SpanBucketTest.java
+++ b/sdk-extensions/zpages/src/test/java/io/opentelemetry/sdk/extension/zpages/SpanBucketTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.trace.ReadableSpan;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -21,8 +21,8 @@ class SpanBucketTest {
   private static final String SPAN_NAME = "span";
   private static final int LATENCY_BUCKET_SIZE = 16;
   private static final int ERROR_BUCKET_SIZE = 8;
-  private final TracerSdkProvider tracerSdkProvider = TracerSdkProvider.builder().build();
-  private final Tracer tracer = tracerSdkProvider.get("SpanBucketTest");
+  private final SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder().build();
+  private final Tracer tracer = sdkTracerProvider.get("SpanBucketTest");
 
   @Test
   void verifyLatencyBucketSizeLimit() {

--- a/sdk-extensions/zpages/src/test/java/io/opentelemetry/sdk/extension/zpages/TraceConfigzZPageHandlerTest.java
+++ b/sdk-extensions/zpages/src/test/java/io/opentelemetry/sdk/extension/zpages/TraceConfigzZPageHandlerTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.trace.TracerSdkManagement;
+import io.opentelemetry.sdk.trace.SdkTracerManagement;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.io.ByteArrayOutputStream;
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link TraceConfigzZPageHandler}. */
 public final class TraceConfigzZPageHandlerTest {
-  private static final TracerSdkManagement TRACER_SDK_MANAGEMENT =
+  private static final SdkTracerManagement TRACER_SDK_MANAGEMENT =
       OpenTelemetrySdk.getGlobalTracerManagement();
   private static final Map<String, String> emptyQueryMap = ImmutableMap.of();
 

--- a/sdk-extensions/zpages/src/test/java/io/opentelemetry/sdk/extension/zpages/TracezDataAggregatorTest.java
+++ b/sdk-extensions/zpages/src/test/java/io/opentelemetry/sdk/extension/zpages/TracezDataAggregatorTest.java
@@ -12,7 +12,7 @@ import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.trace.ReadableSpan;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.List;
 import java.util.Map;
@@ -25,15 +25,15 @@ public final class TracezDataAggregatorTest {
   private static final String SPAN_NAME_ONE = "one";
   private static final String SPAN_NAME_TWO = "two";
   private final TestClock testClock = TestClock.create();
-  private final TracerSdkProvider tracerSdkProvider =
-      TracerSdkProvider.builder().setClock(testClock).build();
-  private final Tracer tracer = tracerSdkProvider.get("TracezDataAggregatorTest");
+  private final SdkTracerProvider sdkTracerProvider =
+      SdkTracerProvider.builder().setClock(testClock).build();
+  private final Tracer tracer = sdkTracerProvider.get("TracezDataAggregatorTest");
   private final TracezSpanProcessor spanProcessor = TracezSpanProcessor.builder().build();
   private final TracezDataAggregator dataAggregator = new TracezDataAggregator(spanProcessor);
 
   @BeforeEach
   void setup() {
-    tracerSdkProvider.addSpanProcessor(spanProcessor);
+    sdkTracerProvider.addSpanProcessor(spanProcessor);
   }
 
   @Test

--- a/sdk-extensions/zpages/src/test/java/io/opentelemetry/sdk/extension/zpages/TracezZPageHandlerTest.java
+++ b/sdk-extensions/zpages/src/test/java/io/opentelemetry/sdk/extension/zpages/TracezZPageHandlerTest.java
@@ -13,7 +13,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.internal.TestClock;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
@@ -38,16 +38,16 @@ class TracezZPageHandlerTest {
   private static final String LATENCY_SPAN = "LatencySpan";
   private static final String ERROR_SPAN = "ErrorSpan";
   private final TestClock testClock = TestClock.create();
-  private final TracerSdkProvider tracerSdkProvider =
-      TracerSdkProvider.builder().setClock(testClock).build();
-  private final Tracer tracer = tracerSdkProvider.get("TracezZPageHandlerTest");
+  private final SdkTracerProvider sdkTracerProvider =
+      SdkTracerProvider.builder().setClock(testClock).build();
+  private final Tracer tracer = sdkTracerProvider.get("TracezZPageHandlerTest");
   private final TracezSpanProcessor spanProcessor = TracezSpanProcessor.builder().build();
   private final TracezDataAggregator dataAggregator = new TracezDataAggregator(spanProcessor);
   private final Map<String, String> emptyQueryMap = ImmutableMap.of();
 
   @BeforeEach
   void setup() {
-    tracerSdkProvider.addSpanProcessor(spanProcessor);
+    sdkTracerProvider.addSpanProcessor(spanProcessor);
   }
 
   @Test

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanAttributeTruncateBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanAttributeTruncateBenchmark.java
@@ -27,7 +27,7 @@ import org.openjdk.jmh.annotations.Warmup;
 public class SpanAttributeTruncateBenchmark {
 
   private final Tracer tracerSdk = OpenTelemetry.getGlobalTracer("benchmarkTracer");
-  private SpanBuilderSdk spanBuilderSdk;
+  private SdkSpanBuilder sdkSpanBuilder;
 
   public final String shortValue = "short";
   public final String longValue = "very_long_attribute_and_then_some_more";
@@ -43,8 +43,8 @@ public class SpanAttributeTruncateBenchmark {
             .setMaxLengthOfAttributeValues(maxLength)
             .build();
     OpenTelemetrySdk.getGlobalTracerManagement().updateActiveTraceConfig(config);
-    spanBuilderSdk =
-        (SpanBuilderSdk)
+    sdkSpanBuilder =
+        (SdkSpanBuilder)
             tracerSdk
                 .spanBuilder("benchmarkSpan")
                 .setSpanKind(Kind.CLIENT)
@@ -66,7 +66,7 @@ public class SpanAttributeTruncateBenchmark {
   @Measurement(iterations = 10, time = 1)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public RecordEventsReadableSpan shortAttributes() {
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilderSdk.startSpan();
+    RecordEventsReadableSpan span = (RecordEventsReadableSpan) sdkSpanBuilder.startSpan();
     for (int i = 0; i < 10; i++) {
       span.setAttribute(String.valueOf(i), shortValue);
     }
@@ -81,7 +81,7 @@ public class SpanAttributeTruncateBenchmark {
   @Measurement(iterations = 10, time = 1)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public RecordEventsReadableSpan longAttributes() {
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilderSdk.startSpan();
+    RecordEventsReadableSpan span = (RecordEventsReadableSpan) sdkSpanBuilder.startSpan();
     for (int i = 0; i < 10; i++) {
       span.setAttribute(String.valueOf(i), longValue);
     }
@@ -96,7 +96,7 @@ public class SpanAttributeTruncateBenchmark {
   @Measurement(iterations = 10, time = 1)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public RecordEventsReadableSpan veryLongAttributes() {
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilderSdk.startSpan();
+    RecordEventsReadableSpan span = (RecordEventsReadableSpan) sdkSpanBuilder.startSpan();
     for (int i = 0; i < 10; i++) {
       span.setAttribute(String.valueOf(i), veryLongValue);
     }

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanBenchmark.java
@@ -25,7 +25,7 @@ import org.openjdk.jmh.annotations.Warmup;
 
 @State(Scope.Benchmark)
 public class SpanBenchmark {
-  private static SpanBuilderSdk spanBuilderSdk;
+  private static SdkSpanBuilder sdkSpanBuilder;
   private final Resource serviceResource =
       Resource.create(
           Attributes.builder()
@@ -36,16 +36,16 @@ public class SpanBenchmark {
 
   @Setup(Level.Trial)
   public final void setup() {
-    TracerSdkProvider tracerProvider =
-        TracerSdkProvider.builder().setResource(serviceResource).build();
+    SdkTracerProvider tracerProvider =
+        SdkTracerProvider.builder().setResource(serviceResource).build();
 
     TraceConfig alwaysOn =
         tracerProvider.getActiveTraceConfig().toBuilder().setSampler(Sampler.alwaysOn()).build();
     tracerProvider.updateActiveTraceConfig(alwaysOn);
 
     Tracer tracerSdk = tracerProvider.get("benchmarkTracer");
-    spanBuilderSdk =
-        (SpanBuilderSdk)
+    sdkSpanBuilder =
+        (SdkSpanBuilder)
             tracerSdk.spanBuilder("benchmarkSpanBuilder").setAttribute("longAttribute", 33L);
   }
 
@@ -90,7 +90,7 @@ public class SpanBenchmark {
   }
 
   private static void doSpanWork() {
-    Span span = spanBuilderSdk.startSpan();
+    Span span = sdkSpanBuilder.startSpan();
     span.addEvent("testEvent");
     span.end();
   }

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
@@ -39,14 +39,14 @@ public class SpanPipelineBenchmark {
         DockerImageName.parse("otel/opentelemetry-collector-dev:latest");
     private static final int EXPOSED_PORT = 5678;
     private static final int HEALTH_CHECK_PORT = 13133;
-    private SpanBuilderSdk spanBuilderSdk;
+    private SdkSpanBuilder sdkSpanBuilder;
 
     protected abstract SpanProcessor getSpanProcessor(String collectorAddress);
 
     protected abstract void runThePipeline();
 
     protected void doWork() {
-      Span span = spanBuilderSdk.startSpan();
+      Span span = sdkSpanBuilder.startSpan();
       for (int i = 0; i < 10; i++) {
         span.setAttribute("benchmarkAttribute_" + i, "benchmarkAttrValue_" + i);
       }
@@ -71,12 +71,12 @@ public class SpanPipelineBenchmark {
       TraceConfig alwaysOn =
           TraceConfig.getDefault().toBuilder().setSampler(Sampler.alwaysOn()).build();
 
-      TracerSdkProvider tracerProvider =
-          TracerSdkProvider.builder().setTraceConfig(alwaysOn).build();
+      SdkTracerProvider tracerProvider =
+          SdkTracerProvider.builder().setTraceConfig(alwaysOn).build();
       tracerProvider.addSpanProcessor(getSpanProcessor(address));
 
       Tracer tracerSdk = tracerProvider.get("PipelineBenchmarkTracer");
-      spanBuilderSdk = (SpanBuilderSdk) tracerSdk.spanBuilder("PipelineBenchmarkSpan");
+      sdkSpanBuilder = (SdkSpanBuilder) tracerSdk.spanBuilder("PipelineBenchmarkSpan");
     }
 
     @Benchmark

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -19,9 +19,9 @@ import io.opentelemetry.sdk.internal.SystemClock;
 import io.opentelemetry.sdk.metrics.MeterSdkProvider;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.IdGenerator;
+import io.opentelemetry.sdk.trace.SdkTracerManagement;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SpanProcessor;
-import io.opentelemetry.sdk.trace.TracerSdkManagement;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,15 +45,15 @@ public final class OpenTelemetrySdk extends DefaultOpenTelemetry {
     return (OpenTelemetrySdk) OpenTelemetry.get();
   }
 
-  /** Returns the global {@link TracerSdkManagement}. */
-  public static TracerSdkManagement getGlobalTracerManagement() {
+  /** Returns the global {@link SdkTracerManagement}. */
+  public static SdkTracerManagement getGlobalTracerManagement() {
     TracerProvider tracerProvider = OpenTelemetry.get().getTracerProvider();
     if (!(tracerProvider instanceof ObfuscatedTracerProvider)) {
       throw new IllegalStateException(
           "Trying to access global TracerSdkManagement but global TracerProvider is not an "
               + "instance created by this SDK.");
     }
-    return (TracerSdkProvider) ((ObfuscatedTracerProvider) tracerProvider).unobfuscate();
+    return (SdkTracerProvider) ((ObfuscatedTracerProvider) tracerProvider).unobfuscate();
   }
 
   /** Returns the global {@link MeterSdkProvider}. */
@@ -87,9 +87,9 @@ public final class OpenTelemetrySdk extends DefaultOpenTelemetry {
     return clock;
   }
 
-  /** Returns the {@link TracerSdkManagement} for this {@link OpenTelemetrySdk}. */
-  public TracerSdkManagement getTracerManagement() {
-    return (TracerSdkProvider) ((ObfuscatedTracerProvider) getTracerProvider()).unobfuscate();
+  /** Returns the {@link SdkTracerManagement} for this {@link OpenTelemetrySdk}. */
+  public SdkTracerManagement getTracerManagement() {
+    return (SdkTracerProvider) ((ObfuscatedTracerProvider) getTracerProvider()).unobfuscate();
   }
 
   /** A builder for configuring an {@link OpenTelemetrySdk}. */
@@ -101,20 +101,20 @@ public final class OpenTelemetrySdk extends DefaultOpenTelemetry {
     private TraceConfig traceConfig;
 
     /**
-     * Sets the {@link TracerSdkProvider} to use. This can be used to configure tracing settings by
-     * returning the instance created by a {@link TracerSdkProvider.Builder}.
+     * Sets the {@link SdkTracerProvider} to use. This can be used to configure tracing settings by
+     * returning the instance created by a {@link SdkTracerProvider.Builder}.
      *
      * <p>If you use this method, it is assumed that you are providing a fully configured
      * TracerSdkProvider, and other settings will be ignored.
      *
-     * <p>Note: the parameter passed in here must be a {@link TracerSdkProvider} instance.
+     * <p>Note: the parameter passed in here must be a {@link SdkTracerProvider} instance.
      *
-     * @param tracerProvider A {@link TracerSdkProvider} to use with this instance.
-     * @see TracerSdkProvider#builder()
+     * @param tracerProvider A {@link SdkTracerProvider} to use with this instance.
+     * @see SdkTracerProvider#builder()
      */
     @Override
     public Builder setTracerProvider(TracerProvider tracerProvider) {
-      if (!(tracerProvider instanceof TracerSdkProvider)) {
+      if (!(tracerProvider instanceof SdkTracerProvider)) {
         throw new IllegalArgumentException(
             "The OpenTelemetrySdk can only be configured with a TracerSdkProvider");
       }
@@ -215,7 +215,7 @@ public final class OpenTelemetrySdk extends DefaultOpenTelemetry {
     @Override
     public OpenTelemetrySdk build() {
       MeterProvider meterProvider = buildMeterProvider();
-      TracerSdkProvider tracerProvider = buildTracerProvider();
+      SdkTracerProvider tracerProvider = buildTracerProvider();
 
       for (SpanProcessor spanProcessor : spanProcessors) {
         tracerProvider.addSpanProcessor(spanProcessor);
@@ -235,12 +235,12 @@ public final class OpenTelemetrySdk extends DefaultOpenTelemetry {
       return sdk;
     }
 
-    private TracerSdkProvider buildTracerProvider() {
+    private SdkTracerProvider buildTracerProvider() {
       TracerProvider tracerProvider = super.tracerProvider;
       if (tracerProvider != null) {
-        return (TracerSdkProvider) tracerProvider;
+        return (SdkTracerProvider) tracerProvider;
       }
-      TracerSdkProvider.Builder tracerProviderBuilder = TracerSdkProvider.builder();
+      SdkTracerProvider.Builder tracerProviderBuilder = SdkTracerProvider.builder();
       if (clock != null) {
         tracerProviderBuilder.setClock(clock);
       }

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -27,8 +27,8 @@ import io.opentelemetry.sdk.internal.SystemClock;
 import io.opentelemetry.sdk.metrics.MeterSdkProvider;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.IdGenerator;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SpanProcessor;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
@@ -41,7 +41,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class OpenTelemetrySdkTest {
 
-  @Mock private TracerSdkProvider tracerProvider;
+  @Mock private SdkTracerProvider tracerProvider;
   @Mock private MeterSdkProvider meterProvider;
   @Mock private ContextPropagators propagators;
   @Mock private Clock clock;
@@ -66,7 +66,7 @@ class OpenTelemetrySdkTest {
 
   @Test
   void testGlobalDefault() {
-    assertThat(((TracerSdkProvider) OpenTelemetrySdk.getGlobalTracerManagement()).get(""))
+    assertThat(((SdkTracerProvider) OpenTelemetrySdk.getGlobalTracerManagement()).get(""))
         .isSameAs(OpenTelemetry.getGlobalTracerProvider().get(""));
     assertThat(OpenTelemetrySdk.getGlobalMeterProvider())
         .isSameAs(OpenTelemetry.getGlobalMeterProvider());
@@ -93,7 +93,7 @@ class OpenTelemetrySdkTest {
             ObfuscatedTracerProvider.class,
             obfuscatedTracerProvider ->
                 assertThat(obfuscatedTracerProvider.unobfuscate())
-                    .isInstanceOf(TracerSdkProvider.class));
+                    .isInstanceOf(SdkTracerProvider.class));
     assertThat(openTelemetry.getMeterProvider()).isInstanceOf(MeterSdkProvider.class);
     assertThat(openTelemetry.getResource()).isEqualTo(Resource.getDefault());
     assertThat(openTelemetry.getClock()).isEqualTo(SystemClock.getInstance());
@@ -133,7 +133,7 @@ class OpenTelemetrySdkTest {
     TracerProvider unobfuscatedTracerProvider =
         ((ObfuscatedTracerProvider) openTelemetry.getTracerProvider()).unobfuscate();
 
-    assertThat(unobfuscatedTracerProvider).isInstanceOf(TracerSdkProvider.class);
+    assertThat(unobfuscatedTracerProvider).isInstanceOf(SdkTracerProvider.class);
     // Since TracerProvider is in a different package, the only alternative to this reflective
     // approach would be to make the fields public for testing which is worse than this.
     assertThat(unobfuscatedTracerProvider)
@@ -216,8 +216,8 @@ class OpenTelemetrySdkTest {
             .setClock(mock(Clock.class))
             .setResource(mock(Resource.class));
 
-    TracerSdkProvider tracerSdkProvider =
-        TracerSdkProvider.builder()
+    SdkTracerProvider sdkTracerProvider =
+        SdkTracerProvider.builder()
             .setClock(mock(Clock.class))
             .setIdGenerator(mock(IdGenerator.class))
             .setResource(mock(Resource.class))
@@ -230,7 +230,7 @@ class OpenTelemetrySdkTest {
             .setResource(mock(Resource.class))
             .build();
 
-    sdkBuilder.setTracerProvider(tracerSdkProvider);
+    sdkBuilder.setTracerProvider(sdkTracerProvider);
     sdkBuilder.setMeterProvider(meterSdkProvider);
     sdkBuilder.setTraceConfig(newConfig);
 

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/junit4/OpenTelemetryRule.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/junit4/OpenTelemetryRule.java
@@ -10,8 +10,8 @@ import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
-import io.opentelemetry.sdk.trace.TracerSdkManagement;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.sdk.trace.SdkTracerManagement;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import java.util.List;
@@ -50,7 +50,7 @@ public class OpenTelemetryRule extends ExternalResource {
   public static OpenTelemetryRule create() {
     InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
 
-    TracerSdkProvider tracerProvider = TracerSdkProvider.builder().build();
+    SdkTracerProvider tracerProvider = SdkTracerProvider.builder().build();
     tracerProvider.addSpanProcessor(SimpleSpanProcessor.builder(spanExporter).build());
 
     OpenTelemetrySdk openTelemetry =
@@ -77,8 +77,8 @@ public class OpenTelemetryRule extends ExternalResource {
     return openTelemetry;
   }
 
-  /** Returns the {@link TracerSdkManagement} created by this extension. */
-  public TracerSdkManagement getTracerManagement() {
+  /** Returns the {@link SdkTracerManagement} created by this extension. */
+  public SdkTracerManagement getTracerManagement() {
     return openTelemetry.getTracerManagement();
   }
 

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtension.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtension.java
@@ -13,8 +13,8 @@ import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.testing.assertj.TracesAssert;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
-import io.opentelemetry.sdk.trace.TracerSdkManagement;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.sdk.trace.SdkTracerManagement;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import java.util.Comparator;
@@ -56,7 +56,7 @@ public class OpenTelemetryExtension
   public static OpenTelemetryExtension create() {
     InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
 
-    TracerSdkProvider tracerProvider = TracerSdkProvider.builder().build();
+    SdkTracerProvider tracerProvider = SdkTracerProvider.builder().build();
     tracerProvider.addSpanProcessor(SimpleSpanProcessor.builder(spanExporter).build());
 
     OpenTelemetrySdk openTelemetry =
@@ -84,8 +84,8 @@ public class OpenTelemetryExtension
     return openTelemetry;
   }
 
-  /** Returns the {@link TracerSdkManagement} created by this extension. */
-  public TracerSdkManagement getTracerManagement() {
+  /** Returns the {@link SdkTracerManagement} created by this extension. */
+  public SdkTracerManagement getTracerManagement() {
     return openTelemetry.getTracerManagement();
   }
 

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/exporter/InMemorySpanExporterTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/exporter/InMemorySpanExporterTest.java
@@ -12,7 +12,7 @@ import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.testing.trace.TestSpanData;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Status;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
@@ -23,13 +23,13 @@ import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link InMemorySpanExporter}. */
 class InMemorySpanExporterTest {
-  private final TracerSdkProvider tracerSdkProvider = TracerSdkProvider.builder().build();
-  private final Tracer tracer = tracerSdkProvider.get("InMemorySpanExporterTest");
+  private final SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder().build();
+  private final Tracer tracer = sdkTracerProvider.get("InMemorySpanExporterTest");
   private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
 
   @BeforeEach
   void setup() {
-    tracerSdkProvider.addSpanProcessor(SimpleSpanProcessor.builder(exporter).build());
+    sdkTracerProvider.addSpanProcessor(SimpleSpanProcessor.builder(exporter).build());
   }
 
   @Test

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/IdGenerator.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/IdGenerator.java
@@ -8,7 +8,7 @@ package io.opentelemetry.sdk.trace;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceId;
 
-/** Interface used by the {@link TracerSdk} to generate new {@link SpanId}s and {@link TraceId}s. */
+/** Interface used by the {@link SdkTracer} to generate new {@link SpanId}s and {@link TraceId}s. */
 public interface IdGenerator {
 
   /**

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java
@@ -35,8 +35,8 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
-/** {@link SpanBuilderSdk} is SDK implementation of {@link SpanBuilder}. */
-final class SpanBuilderSdk implements SpanBuilder {
+/** {@link SdkSpanBuilder} is SDK implementation of {@link SpanBuilder}. */
+final class SdkSpanBuilder implements SpanBuilder {
 
   private final String spanName;
   private final InstrumentationLibraryInfo instrumentationLibraryInfo;
@@ -54,7 +54,7 @@ final class SpanBuilderSdk implements SpanBuilder {
   private long startEpochNanos = 0;
   private boolean isRootSpan;
 
-  SpanBuilderSdk(
+  SdkSpanBuilder(
       String spanName,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
       SpanProcessor spanProcessor,

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java
@@ -9,12 +9,12 @@ import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 
-/** {@link TracerSdk} is SDK implementation of {@link Tracer}. */
-final class TracerSdk implements Tracer {
+/** {@link SdkTracer} is SDK implementation of {@link Tracer}. */
+final class SdkTracer implements Tracer {
   private final TracerSharedState sharedState;
   private final InstrumentationLibraryInfo instrumentationLibraryInfo;
 
-  TracerSdk(TracerSharedState sharedState, InstrumentationLibraryInfo instrumentationLibraryInfo) {
+  SdkTracer(TracerSharedState sharedState, InstrumentationLibraryInfo instrumentationLibraryInfo) {
     this.sharedState = sharedState;
     this.instrumentationLibraryInfo = instrumentationLibraryInfo;
   }
@@ -24,7 +24,7 @@ final class TracerSdk implements Tracer {
     if (sharedState.isStopped()) {
       return Tracer.getDefault().spanBuilder(spanName);
     }
-    return new SpanBuilderSdk(
+    return new SdkSpanBuilder(
         spanName,
         instrumentationLibraryInfo,
         sharedState.getActiveSpanProcessor(),

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerManagement.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerManagement.java
@@ -15,7 +15,7 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
  * "Management" interface for the Tracing SDK. This interface exposes methods for configuring the
  * Tracing SDK, as well as several lifecycle methods.
  */
-public interface TracerSdkManagement {
+public interface SdkTracerManagement {
 
   /**
    * Returns the active {@code TraceConfig}.

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
@@ -26,27 +26,27 @@ import javax.annotation.Nullable;
  * OpenTelemetry}. However, if you need a custom implementation of the factory, you can create one
  * as needed.
  */
-public class TracerSdkProvider implements TracerProvider, TracerSdkManagement {
-  private static final Logger logger = Logger.getLogger(TracerSdkProvider.class.getName());
+public class SdkTracerProvider implements TracerProvider, SdkTracerManagement {
+  private static final Logger logger = Logger.getLogger(SdkTracerProvider.class.getName());
   static final String DEFAULT_TRACER_NAME = "unknown";
   private final TracerSharedState sharedState;
-  private final ComponentRegistry<TracerSdk> tracerSdkComponentRegistry;
+  private final ComponentRegistry<SdkTracer> tracerSdkComponentRegistry;
 
   /**
-   * Returns a new {@link Builder} for {@link TracerSdkProvider}.
+   * Returns a new {@link Builder} for {@link SdkTracerProvider}.
    *
-   * @return a new {@link Builder} for {@link TracerSdkProvider}.
+   * @return a new {@link Builder} for {@link SdkTracerProvider}.
    */
   public static Builder builder() {
     return new Builder();
   }
 
-  private TracerSdkProvider(
+  private SdkTracerProvider(
       Clock clock, IdGenerator idsGenerator, Resource resource, TraceConfig traceConfig) {
     this.sharedState = new TracerSharedState(clock, idsGenerator, resource, traceConfig);
     this.tracerSdkComponentRegistry =
         new ComponentRegistry<>(
-            instrumentationLibraryInfo -> new TracerSdk(sharedState, instrumentationLibraryInfo));
+            instrumentationLibraryInfo -> new SdkTracer(sharedState, instrumentationLibraryInfo));
   }
 
   @Override
@@ -157,8 +157,8 @@ public class TracerSdkProvider implements TracerProvider, TracerSdkManagement {
      *
      * @return An initialized TraceSdkProvider.
      */
-    public TracerSdkProvider build() {
-      return new TracerSdkProvider(clock, idsGenerator, resource, traceConfig);
+    public SdkTracerProvider build() {
+      return new SdkTracerProvider(clock, idsGenerator, resource, traceConfig);
     }
 
     private Builder() {}

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
@@ -7,18 +7,18 @@ package io.opentelemetry.sdk.trace.config;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.sdk.trace.SdkTracerManagement;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import javax.annotation.concurrent.Immutable;
 
 /**
  * Class that holds global trace parameters.
  *
- * <p>Note: To update the TraceConfig associated with a {@link
- * io.opentelemetry.sdk.trace.TracerSdkManagement}, you should use the {@link #toBuilder()} method
- * on the TraceConfig currently assigned to the provider, make the changes desired to the {@link
- * TraceConfigBuilder} instance, then use the {@link
- * io.opentelemetry.sdk.trace.TracerSdkManagement#updateActiveTraceConfig(TraceConfig)} with the
- * resulting TraceConfig instance.
+ * <p>Note: To update the TraceConfig associated with a {@link SdkTracerManagement}, you should use
+ * the {@link #toBuilder()} method on the TraceConfig currently assigned to the provider, make the
+ * changes desired to the {@link TraceConfigBuilder} instance, then use the {@link
+ * SdkTracerManagement#updateActiveTraceConfig(TraceConfig)} with the resulting TraceConfig
+ * instance.
  *
  * <p>Configuration options for {@link TraceConfig} can be read from system properties, environment
  * variables, or {@link java.util.Properties} objects.

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SpanExporter.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SpanExporter.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.trace.export;
 
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.trace.TracerSdkManagement;
+import io.opentelemetry.sdk.trace.SdkTracerManagement;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -75,7 +75,7 @@ public interface SpanExporter {
   CompletableResultCode flush();
 
   /**
-   * Called when {@link TracerSdkManagement#shutdown()} is called, if this {@code SpanExporter} is
+   * Called when {@link SdkTracerManagement#shutdown()} is called, if this {@code SpanExporter} is
    * registered to a {@code TracerSdkManagement} object.
    *
    * @return a {@link CompletableResultCode} which is completed when shutdown completes.

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/package-info.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/package-info.java
@@ -6,6 +6,6 @@
 /**
  * The OpenTelemetry SDK implementation of tracing.
  *
- * @see io.opentelemetry.sdk.trace.TracerSdkProvider
+ * @see io.opentelemetry.sdk.trace.SdkTracerProvider
  */
 package io.opentelemetry.sdk.trace;

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/spi/TracerProviderFactorySdk.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/spi/TracerProviderFactorySdk.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.trace.spi;
 
 import io.opentelemetry.api.trace.TracerProvider;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.spi.trace.TracerProviderFactory;
 
 /** SDK implementation of the TracerProviderFactory for SPI. */
@@ -14,6 +14,6 @@ public final class TracerProviderFactorySdk implements TracerProviderFactory {
 
   @Override
   public TracerProvider create() {
-    return TracerSdkProvider.builder().build();
+    return SdkTracerProvider.builder().build();
   }
 }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
@@ -45,8 +45,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
-/** Unit tests for {@link SpanBuilderSdk}. */
-class SpanBuilderSdkTest {
+/** Unit tests for {@link SdkSpanBuilder}. */
+class SdkSpanBuilderTest {
 
   private static final String SPAN_NAME = "span_name";
   private final SpanContext sampledSpanContext =
@@ -57,8 +57,8 @@ class SpanBuilderSdkTest {
           TraceState.getDefault());
   private final SpanProcessor mockedSpanProcessor = Mockito.mock(SpanProcessor.class);
 
-  private final TracerSdkProvider tracerSdkFactory = TracerSdkProvider.builder().build();
-  private final TracerSdk tracerSdk = (TracerSdk) tracerSdkFactory.get("SpanBuilderSdkTest");
+  private final SdkTracerProvider tracerSdkFactory = SdkTracerProvider.builder().build();
+  private final SdkTracer sdkTracer = (SdkTracer) tracerSdkFactory.get("SpanBuilderSdkTest");
 
   @BeforeEach
   public void setUp() {
@@ -70,19 +70,19 @@ class SpanBuilderSdkTest {
   @Test
   void setSpanKind_null() {
     assertThrows(
-        NullPointerException.class, () -> tracerSdk.spanBuilder(SPAN_NAME).setSpanKind(null));
+        NullPointerException.class, () -> sdkTracer.spanBuilder(SPAN_NAME).setSpanKind(null));
   }
 
   @Test
   void setParent_null() {
     assertThrows(
-        NullPointerException.class, () -> tracerSdk.spanBuilder(SPAN_NAME).setParent(null));
+        NullPointerException.class, () -> sdkTracer.spanBuilder(SPAN_NAME).setParent(null));
   }
 
   @Test
   void addLink() {
     // Verify methods do not crash.
-    SpanBuilder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
+    SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME);
     spanBuilder.addLink(Span.getInvalid().getSpanContext());
     spanBuilder.addLink(Span.getInvalid().getSpanContext(), Attributes.empty());
 
@@ -103,7 +103,7 @@ class SpanBuilderSdkTest {
             .build();
     tracerSdkFactory.updateActiveTraceConfig(traceConfig);
     // Verify methods do not crash.
-    SpanBuilder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
+    SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME);
     for (int i = 0; i < 2 * maxNumberOfLinks; i++) {
       spanBuilder.addLink(sampledSpanContext);
     }
@@ -129,7 +129,7 @@ class SpanBuilderSdkTest {
             .setMaxNumberOfAttributesPerLink(1)
             .build();
     tracerSdkFactory.updateActiveTraceConfig(traceConfig);
-    SpanBuilder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
+    SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME);
     Attributes attributes =
         Attributes.of(
             stringKey("key0"), "str",
@@ -149,7 +149,7 @@ class SpanBuilderSdkTest {
 
   @Test
   void addLink_NoEffectAfterStartSpan() {
-    SpanBuilder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
+    SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME);
     spanBuilder.addLink(sampledSpanContext);
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     try {
@@ -172,27 +172,27 @@ class SpanBuilderSdkTest {
 
   @Test
   void addLinkSpanContext_null() {
-    assertThrows(NullPointerException.class, () -> tracerSdk.spanBuilder(SPAN_NAME).addLink(null));
+    assertThrows(NullPointerException.class, () -> sdkTracer.spanBuilder(SPAN_NAME).addLink(null));
   }
 
   @Test
   void addLinkSpanContextAttributes_nullContext() {
     assertThrows(
         NullPointerException.class,
-        () -> tracerSdk.spanBuilder(SPAN_NAME).addLink(null, Attributes.empty()));
+        () -> sdkTracer.spanBuilder(SPAN_NAME).addLink(null, Attributes.empty()));
   }
 
   @Test
   void addLinkSpanContextAttributes_nullAttributes() {
     assertThrows(
         NullPointerException.class,
-        () -> tracerSdk.spanBuilder(SPAN_NAME).addLink(Span.getInvalid().getSpanContext(), null));
+        () -> sdkTracer.spanBuilder(SPAN_NAME).addLink(Span.getInvalid().getSpanContext(), null));
   }
 
   @Test
   void setAttribute() {
     SpanBuilder spanBuilder =
-        tracerSdk
+        sdkTracer
             .spanBuilder(SPAN_NAME)
             .setAttribute("string", "value")
             .setAttribute("long", 12345L)
@@ -218,7 +218,7 @@ class SpanBuilderSdkTest {
 
   @Test
   void setAttribute_afterEnd() {
-    SpanBuilder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
+    SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME);
     spanBuilder.setAttribute("string", "value");
     spanBuilder.setAttribute("long", 12345L);
     spanBuilder.setAttribute("double", .12345);
@@ -255,7 +255,7 @@ class SpanBuilderSdkTest {
 
   @Test
   void setAttribute_emptyArrayAttributeValue() {
-    SpanBuilder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
+    SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME);
     spanBuilder.setAttribute(stringArrayKey("stringArrayAttribute"), emptyList());
     spanBuilder.setAttribute(booleanArrayKey("boolArrayAttribute"), emptyList());
     spanBuilder.setAttribute(longArrayKey("longArrayAttribute"), emptyList());
@@ -266,7 +266,7 @@ class SpanBuilderSdkTest {
 
   @Test
   void setAttribute_nullStringValue() {
-    SpanBuilder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
+    SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME);
     spanBuilder.setAttribute("emptyString", "");
     spanBuilder.setAttribute("nullString", null);
     spanBuilder.setAttribute(stringKey("nullStringAttributeValue"), null);
@@ -277,7 +277,7 @@ class SpanBuilderSdkTest {
 
   @Test
   void setAttribute_onlyNullStringValue() {
-    SpanBuilder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
+    SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME);
     spanBuilder.setAttribute(stringKey("nullStringAttributeValue"), null);
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     assertThat(span.toSpanData().getAttributes().isEmpty()).isTrue();
@@ -285,7 +285,7 @@ class SpanBuilderSdkTest {
 
   @Test
   void setAttribute_NoEffectAfterStartSpan() {
-    SpanBuilder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
+    SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME);
     spanBuilder.setAttribute("key1", "value1");
     spanBuilder.setAttribute("key2", "value2");
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
@@ -305,7 +305,7 @@ class SpanBuilderSdkTest {
 
   @Test
   void setAttribute_nullAttributeValue() {
-    SpanBuilder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
+    SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME);
     spanBuilder.setAttribute("emptyString", "");
     spanBuilder.setAttribute("nullString", null);
     spanBuilder.setAttribute(stringKey("nullStringAttributeValue"), null);
@@ -323,7 +323,7 @@ class SpanBuilderSdkTest {
 
   @Test
   void setAttribute_nullAttributeValue_afterEnd() {
-    SpanBuilder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
+    SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME);
     spanBuilder.setAttribute("emptyString", "");
     spanBuilder.setAttribute(stringKey("emptyStringAttributeValue"), "");
     spanBuilder.setAttribute("longAttribute", 0L);
@@ -356,7 +356,7 @@ class SpanBuilderSdkTest {
             .setMaxNumberOfAttributes(maxNumberOfAttrs)
             .build();
     tracerSdkFactory.updateActiveTraceConfig(traceConfig);
-    SpanBuilder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
+    SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME);
     for (int i = 0; i < 2 * maxNumberOfAttrs; i++) {
       spanBuilder.setAttribute("key" + i, i);
     }
@@ -380,7 +380,7 @@ class SpanBuilderSdkTest {
             .setMaxLengthOfAttributeValues(10)
             .build();
     tracerSdkFactory.updateActiveTraceConfig(traceConfig);
-    SpanBuilder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
+    SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME);
     spanBuilder.setAttribute("builderStringNull", null);
     spanBuilder.setAttribute("builderStringSmall", "small");
     spanBuilder.setAttribute("builderStringLarge", "very large string that we have to cut");
@@ -429,7 +429,7 @@ class SpanBuilderSdkTest {
             .setSampler(Sampler.traceIdRatioBased(1))
             .build();
     tracerSdkFactory.updateActiveTraceConfig(traceConfig);
-    SpanBuilder spanBuilder = tracerSdk.spanBuilder(SPAN_NAME);
+    SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME);
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     try {
       assertThat(span.toSpanData().getAttributes().size()).isEqualTo(1);
@@ -445,7 +445,7 @@ class SpanBuilderSdkTest {
 
   @Test
   void recordEvents_default() {
-    Span span = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
+    Span span = sdkTracer.spanBuilder(SPAN_NAME).startSpan();
     try {
       assertThat(span.isRecording()).isTrue();
     } finally {
@@ -456,7 +456,7 @@ class SpanBuilderSdkTest {
   @Test
   void kind_default() {
     RecordEventsReadableSpan span =
-        (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).startSpan();
+        (RecordEventsReadableSpan) sdkTracer.spanBuilder(SPAN_NAME).startSpan();
     try {
       assertThat(span.toSpanData().getKind()).isEqualTo(Kind.INTERNAL);
     } finally {
@@ -468,7 +468,7 @@ class SpanBuilderSdkTest {
   void kind() {
     RecordEventsReadableSpan span =
         (RecordEventsReadableSpan)
-            tracerSdk.spanBuilder(SPAN_NAME).setSpanKind(Kind.CONSUMER).startSpan();
+            sdkTracer.spanBuilder(SPAN_NAME).setSpanKind(Kind.CONSUMER).startSpan();
     try {
       assertThat(span.toSpanData().getKind()).isEqualTo(Kind.CONSUMER);
     } finally {
@@ -479,7 +479,7 @@ class SpanBuilderSdkTest {
   @Test
   void sampler() {
     Span span =
-        TestUtils.startSpanWithSampler(tracerSdkFactory, tracerSdk, SPAN_NAME, Sampler.alwaysOff())
+        TestUtils.startSpanWithSampler(tracerSdkFactory, sdkTracer, SPAN_NAME, Sampler.alwaysOff())
             .startSpan();
     try {
       assertThat(span.getSpanContext().isSampled()).isFalse();
@@ -496,7 +496,7 @@ class SpanBuilderSdkTest {
         (RecordEventsReadableSpan)
             TestUtils.startSpanWithSampler(
                     tracerSdkFactory,
-                    tracerSdk,
+                    sdkTracer,
                     SPAN_NAME,
                     new Sampler() {
                       @Override
@@ -544,7 +544,7 @@ class SpanBuilderSdkTest {
         (RecordEventsReadableSpan)
             TestUtils.startSpanWithSampler(
                     tracerSdkFactory,
-                    tracerSdk,
+                    sdkTracer,
                     SPAN_NAME,
                     new Sampler() {
                       @Override
@@ -594,7 +594,7 @@ class SpanBuilderSdkTest {
   void sampledViaParentLinks() {
     Span span =
         TestUtils.startSpanWithSampler(
-                tracerSdkFactory, tracerSdk, SPAN_NAME, Sampler.traceIdRatioBased(0.0))
+                tracerSdkFactory, sdkTracer, SPAN_NAME, Sampler.traceIdRatioBased(0.0))
             .addLink(sampledSpanContext)
             .startSpan();
     try {
@@ -608,16 +608,16 @@ class SpanBuilderSdkTest {
 
   @Test
   void noParent() {
-    Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
+    Span parent = sdkTracer.spanBuilder(SPAN_NAME).startSpan();
     try (Scope ignored = parent.makeCurrent()) {
-      Span span = tracerSdk.spanBuilder(SPAN_NAME).setNoParent().startSpan();
+      Span span = sdkTracer.spanBuilder(SPAN_NAME).setNoParent().startSpan();
       try {
         assertThat(span.getSpanContext().getTraceIdAsHexString())
             .isNotEqualTo(parent.getSpanContext().getTraceIdAsHexString());
         Mockito.verify(mockedSpanProcessor)
             .onStart(Mockito.same(Context.root()), Mockito.same((ReadWriteSpan) span));
         Span spanNoParent =
-            tracerSdk
+            sdkTracer
                 .spanBuilder(SPAN_NAME)
                 .setNoParent()
                 .setParent(Context.current())
@@ -641,12 +641,12 @@ class SpanBuilderSdkTest {
 
   @Test
   void noParent_override() {
-    final Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
+    final Span parent = sdkTracer.spanBuilder(SPAN_NAME).startSpan();
     try {
       final Context parentContext = Context.current().with(parent);
       RecordEventsReadableSpan span =
           (RecordEventsReadableSpan)
-              tracerSdk.spanBuilder(SPAN_NAME).setNoParent().setParent(parentContext).startSpan();
+              sdkTracer.spanBuilder(SPAN_NAME).setNoParent().setParent(parentContext).startSpan();
       try {
         Mockito.verify(mockedSpanProcessor)
             .onStart(Mockito.same(parentContext), Mockito.same((ReadWriteSpan) span));
@@ -658,7 +658,7 @@ class SpanBuilderSdkTest {
         final Context parentContext2 = Context.current().with(parent);
         RecordEventsReadableSpan span2 =
             (RecordEventsReadableSpan)
-                tracerSdk
+                sdkTracer
                     .spanBuilder(SPAN_NAME)
                     .setNoParent()
                     .setParent(parentContext2)
@@ -681,13 +681,13 @@ class SpanBuilderSdkTest {
 
   @Test
   void overrideNoParent_remoteParent() {
-    Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
+    Span parent = sdkTracer.spanBuilder(SPAN_NAME).startSpan();
     try {
 
       final Context parentContext = Context.current().with(parent);
       RecordEventsReadableSpan span =
           (RecordEventsReadableSpan)
-              tracerSdk.spanBuilder(SPAN_NAME).setNoParent().setParent(parentContext).startSpan();
+              sdkTracer.spanBuilder(SPAN_NAME).setNoParent().setParent(parentContext).startSpan();
       try {
         Mockito.verify(mockedSpanProcessor)
             .onStart(Mockito.same(parentContext), Mockito.same((ReadWriteSpan) span));
@@ -705,12 +705,12 @@ class SpanBuilderSdkTest {
 
   @Test
   void parent_fromContext() {
-    final Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
+    final Span parent = sdkTracer.spanBuilder(SPAN_NAME).startSpan();
     final Context context = Context.current().with(parent);
     try {
       final RecordEventsReadableSpan span =
           (RecordEventsReadableSpan)
-              tracerSdk.spanBuilder(SPAN_NAME).setNoParent().setParent(context).startSpan();
+              sdkTracer.spanBuilder(SPAN_NAME).setNoParent().setParent(context).startSpan();
       try {
         Mockito.verify(mockedSpanProcessor)
             .onStart(Mockito.same(context), Mockito.same((ReadWriteSpan) span));
@@ -729,13 +729,13 @@ class SpanBuilderSdkTest {
   @Test
   void parent_fromEmptyContext() {
     Context emptyContext = Context.current();
-    Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
+    Span parent = sdkTracer.spanBuilder(SPAN_NAME).startSpan();
     try {
       RecordEventsReadableSpan span;
       try (Scope scope = parent.makeCurrent()) {
         span =
             (RecordEventsReadableSpan)
-                tracerSdk.spanBuilder(SPAN_NAME).setParent(emptyContext).startSpan();
+                sdkTracer.spanBuilder(SPAN_NAME).setParent(emptyContext).startSpan();
       }
 
       try {
@@ -755,11 +755,11 @@ class SpanBuilderSdkTest {
 
   @Test
   void parentCurrentSpan() {
-    Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
+    Span parent = sdkTracer.spanBuilder(SPAN_NAME).startSpan();
     try (Scope ignored = parent.makeCurrent()) {
       final Context implicitParent = Context.current();
       RecordEventsReadableSpan span =
-          (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).startSpan();
+          (RecordEventsReadableSpan) sdkTracer.spanBuilder(SPAN_NAME).startSpan();
       try {
         Mockito.verify(mockedSpanProcessor)
             .onStart(Mockito.same(implicitParent), Mockito.same((ReadWriteSpan) span));
@@ -782,7 +782,7 @@ class SpanBuilderSdkTest {
     final Context parentContext = Context.current().with(parent);
     RecordEventsReadableSpan span =
         (RecordEventsReadableSpan)
-            tracerSdk.spanBuilder(SPAN_NAME).setParent(parentContext).startSpan();
+            sdkTracer.spanBuilder(SPAN_NAME).setParent(parentContext).startSpan();
     try {
       Mockito.verify(mockedSpanProcessor)
           .onStart(
@@ -799,7 +799,7 @@ class SpanBuilderSdkTest {
   void startTimestamp_numeric() {
     RecordEventsReadableSpan span =
         (RecordEventsReadableSpan)
-            tracerSdk
+            sdkTracer
                 .spanBuilder(SPAN_NAME)
                 .setStartTimestamp(10, TimeUnit.NANOSECONDS)
                 .startSpan();
@@ -811,7 +811,7 @@ class SpanBuilderSdkTest {
   void startTimestamp_instant() {
     RecordEventsReadableSpan span =
         (RecordEventsReadableSpan)
-            tracerSdk
+            sdkTracer
                 .spanBuilder(SPAN_NAME)
                 .setStartTimestamp(Instant.ofEpochMilli(100))
                 .startSpan();
@@ -824,16 +824,16 @@ class SpanBuilderSdkTest {
   void startTimestamp_null() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> tracerSdk.spanBuilder(SPAN_NAME).setStartTimestamp(-1, TimeUnit.NANOSECONDS),
+        () -> sdkTracer.spanBuilder(SPAN_NAME).setStartTimestamp(-1, TimeUnit.NANOSECONDS),
         "Negative startTimestamp");
   }
 
   @Test
   void parent_clockIsSame() {
-    Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
+    Span parent = sdkTracer.spanBuilder(SPAN_NAME).startSpan();
     try (Scope scope = parent.makeCurrent()) {
       RecordEventsReadableSpan span =
-          (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).startSpan();
+          (RecordEventsReadableSpan) sdkTracer.spanBuilder(SPAN_NAME).startSpan();
 
       assertThat(span.getClock()).isSameAs(((RecordEventsReadableSpan) parent).getClock());
     } finally {
@@ -843,10 +843,10 @@ class SpanBuilderSdkTest {
 
   @Test
   void parentCurrentSpan_clockIsSame() {
-    Span parent = tracerSdk.spanBuilder(SPAN_NAME).startSpan();
+    Span parent = sdkTracer.spanBuilder(SPAN_NAME).startSpan();
     try (Scope ignored = parent.makeCurrent()) {
       RecordEventsReadableSpan span =
-          (RecordEventsReadableSpan) tracerSdk.spanBuilder(SPAN_NAME).startSpan();
+          (RecordEventsReadableSpan) sdkTracer.spanBuilder(SPAN_NAME).startSpan();
 
       assertThat(span.getClock()).isSameAs(((RecordEventsReadableSpan) parent).getClock());
     } finally {
@@ -856,15 +856,15 @@ class SpanBuilderSdkTest {
 
   @Test
   void isSampled() {
-    assertThat(SpanBuilderSdk.isSampled(SamplingResult.Decision.DROP)).isFalse();
-    assertThat(SpanBuilderSdk.isSampled(SamplingResult.Decision.RECORD_ONLY)).isFalse();
-    assertThat(SpanBuilderSdk.isSampled(SamplingResult.Decision.RECORD_AND_SAMPLE)).isTrue();
+    assertThat(SdkSpanBuilder.isSampled(SamplingResult.Decision.DROP)).isFalse();
+    assertThat(SdkSpanBuilder.isSampled(SamplingResult.Decision.RECORD_ONLY)).isFalse();
+    assertThat(SdkSpanBuilder.isSampled(SamplingResult.Decision.RECORD_AND_SAMPLE)).isTrue();
   }
 
   @Test
   void isRecording() {
-    assertThat(SpanBuilderSdk.isRecording(SamplingResult.Decision.DROP)).isFalse();
-    assertThat(SpanBuilderSdk.isRecording(SamplingResult.Decision.RECORD_ONLY)).isTrue();
-    assertThat(SpanBuilderSdk.isRecording(SamplingResult.Decision.RECORD_AND_SAMPLE)).isTrue();
+    assertThat(SdkSpanBuilder.isRecording(SamplingResult.Decision.DROP)).isFalse();
+    assertThat(SdkSpanBuilder.isRecording(SamplingResult.Decision.RECORD_ONLY)).isTrue();
+    assertThat(SdkSpanBuilder.isRecording(SamplingResult.Decision.RECORD_AND_SAMPLE)).isTrue();
   }
 }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderTest.java
@@ -27,12 +27,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-/** Unit tests for {@link TracerSdkProvider}. */
+/** Unit tests for {@link SdkTracerProvider}. */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-class TracerSdkProviderTest {
+class SdkTracerProviderTest {
   @Mock private SpanProcessor spanProcessor;
-  private final TracerSdkProvider tracerFactory = TracerSdkProvider.builder().build();
+  private final SdkTracerProvider tracerFactory = SdkTracerProvider.builder().build();
 
   @BeforeEach
   void setUp() {
@@ -44,7 +44,7 @@ class TracerSdkProviderTest {
   @Test
   void builder_HappyPath() {
     assertThat(
-            TracerSdkProvider.builder()
+            SdkTracerProvider.builder()
                 .setClock(mock(Clock.class))
                 .setResource(mock(Resource.class))
                 .setIdGenerator(mock(IdGenerator.class))
@@ -57,21 +57,21 @@ class TracerSdkProviderTest {
   void builder_NullTraceConfig() {
     assertThrows(
         NullPointerException.class,
-        () -> TracerSdkProvider.builder().setTraceConfig(null),
+        () -> SdkTracerProvider.builder().setTraceConfig(null),
         "traceConfig");
   }
 
   @Test
   void builder_NullClock() {
     assertThrows(
-        NullPointerException.class, () -> TracerSdkProvider.builder().setClock(null), "clock");
+        NullPointerException.class, () -> SdkTracerProvider.builder().setClock(null), "clock");
   }
 
   @Test
   void builder_NullResource() {
     assertThrows(
         NullPointerException.class,
-        () -> TracerSdkProvider.builder().setResource(null),
+        () -> SdkTracerProvider.builder().setResource(null),
         "resource");
   }
 
@@ -79,13 +79,13 @@ class TracerSdkProviderTest {
   void builder_NullIdsGenerator() {
     assertThrows(
         NullPointerException.class,
-        () -> TracerSdkProvider.builder().setIdGenerator(null),
+        () -> SdkTracerProvider.builder().setIdGenerator(null),
         "idsGenerator");
   }
 
   @Test
   void defaultGet() {
-    assertThat(tracerFactory.get("test")).isInstanceOf(TracerSdk.class);
+    assertThat(tracerFactory.get("test")).isInstanceOf(SdkTracer.class);
   }
 
   @Test
@@ -104,7 +104,7 @@ class TracerSdkProviderTest {
     InstrumentationLibraryInfo expected =
         InstrumentationLibraryInfo.create("theName", "theVersion");
     Tracer tracer = tracerFactory.get(expected.getName(), expected.getVersion());
-    assertThat(((TracerSdk) tracer).getInstrumentationLibraryInfo()).isEqualTo(expected);
+    assertThat(((SdkTracer) tracer).getInstrumentationLibraryInfo()).isEqualTo(expected);
   }
 
   @Test
@@ -119,10 +119,10 @@ class TracerSdkProviderTest {
   @Test
   void build_traceConfig() {
     TraceConfig initialTraceConfig = mock(TraceConfig.class);
-    TracerSdkProvider tracerSdkProvider =
-        TracerSdkProvider.builder().setTraceConfig(initialTraceConfig).build();
+    SdkTracerProvider sdkTracerProvider =
+        SdkTracerProvider.builder().setTraceConfig(initialTraceConfig).build();
 
-    assertThat(tracerSdkProvider.getActiveTraceConfig()).isSameAs(initialTraceConfig);
+    assertThat(sdkTracerProvider.getActiveTraceConfig()).isSameAs(initialTraceConfig);
   }
 
   @Test
@@ -155,23 +155,23 @@ class TracerSdkProviderTest {
 
   @Test
   void suppliesDefaultTracerForNullName() {
-    TracerSdk tracer = (TracerSdk) tracerFactory.get(null);
+    SdkTracer tracer = (SdkTracer) tracerFactory.get(null);
     assertThat(tracer.getInstrumentationLibraryInfo().getName())
-        .isEqualTo(TracerSdkProvider.DEFAULT_TRACER_NAME);
+        .isEqualTo(SdkTracerProvider.DEFAULT_TRACER_NAME);
 
-    tracer = (TracerSdk) tracerFactory.get(null, null);
+    tracer = (SdkTracer) tracerFactory.get(null, null);
     assertThat(tracer.getInstrumentationLibraryInfo().getName())
-        .isEqualTo(TracerSdkProvider.DEFAULT_TRACER_NAME);
+        .isEqualTo(SdkTracerProvider.DEFAULT_TRACER_NAME);
   }
 
   @Test
   void suppliesDefaultTracerForEmptyName() {
-    TracerSdk tracer = (TracerSdk) tracerFactory.get("");
+    SdkTracer tracer = (SdkTracer) tracerFactory.get("");
     assertThat(tracer.getInstrumentationLibraryInfo().getName())
-        .isEqualTo(TracerSdkProvider.DEFAULT_TRACER_NAME);
+        .isEqualTo(SdkTracerProvider.DEFAULT_TRACER_NAME);
 
-    tracer = (TracerSdk) tracerFactory.get("", "");
+    tracer = (SdkTracer) tracerFactory.get("", "");
     assertThat(tracer.getInstrumentationLibraryInfo().getName())
-        .isEqualTo(TracerSdkProvider.DEFAULT_TRACER_NAME);
+        .isEqualTo(SdkTracerProvider.DEFAULT_TRACER_NAME);
   }
 }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerTest.java
@@ -23,12 +23,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-/** Unit tests for {@link TracerSdk}. */
+/** Unit tests for {@link SdkTracer}. */
 // Need to suppress warnings for MustBeClosed because Android 14 does not support
 // try-with-resources.
 @SuppressWarnings("MustBeClosedChecker")
 @ExtendWith(MockitoExtension.class)
-class TracerSdkTest {
+class SdkTracerTest {
 
   private static final String SPAN_NAME = "span_name";
   private static final String INSTRUMENTATION_LIBRARY_NAME =
@@ -38,15 +38,15 @@ class TracerSdkTest {
       InstrumentationLibraryInfo.create(
           INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION);
   @Mock private Span span;
-  private final TracerSdk tracer =
-      (TracerSdk)
-          TracerSdkProvider.builder()
+  private final SdkTracer tracer =
+      (SdkTracer)
+          SdkTracerProvider.builder()
               .build()
               .get(INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION);
 
   @Test
   void defaultSpanBuilder() {
-    assertThat(tracer.spanBuilder(SPAN_NAME)).isInstanceOf(SpanBuilderSdk.class);
+    assertThat(tracer.spanBuilder(SPAN_NAME)).isInstanceOf(SdkSpanBuilder.class);
   }
 
   @Test
@@ -63,11 +63,11 @@ class TracerSdkTest {
   @Test
   void stressTest() {
     CountingSpanProcessor spanProcessor = new CountingSpanProcessor();
-    TracerSdkProvider tracerSdkProvider = TracerSdkProvider.builder().build();
-    tracerSdkProvider.addSpanProcessor(spanProcessor);
-    TracerSdk tracer =
-        (TracerSdk)
-            tracerSdkProvider.get(INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION);
+    SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder().build();
+    sdkTracerProvider.addSpanProcessor(spanProcessor);
+    SdkTracer tracer =
+        (SdkTracer)
+            sdkTracerProvider.get(INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION);
 
     StressTestRunner.Builder stressTestBuilder =
         StressTestRunner.builder().setTracer(tracer).setSpanProcessor(spanProcessor);
@@ -86,11 +86,11 @@ class TracerSdkTest {
   void stressTest_withBatchSpanProcessor() {
     CountingSpanExporter countingSpanExporter = new CountingSpanExporter();
     SpanProcessor spanProcessor = BatchSpanProcessor.builder(countingSpanExporter).build();
-    TracerSdkProvider tracerSdkProvider = TracerSdkProvider.builder().build();
-    tracerSdkProvider.addSpanProcessor(spanProcessor);
-    TracerSdk tracer =
-        (TracerSdk)
-            tracerSdkProvider.get(INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION);
+    SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder().build();
+    sdkTracerProvider.addSpanProcessor(spanProcessor);
+    SdkTracer tracer =
+        (SdkTracer)
+            sdkTracerProvider.get(INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION);
 
     StressTestRunner.Builder stressTestBuilder =
         StressTestRunner.builder().setTracer(tracer).setSpanProcessor(spanProcessor);
@@ -135,9 +135,9 @@ class TracerSdkTest {
   }
 
   private static class SimpleSpanOperation implements OperationUpdater {
-    private final TracerSdk tracer;
+    private final SdkTracer tracer;
 
-    public SimpleSpanOperation(TracerSdk tracer) {
+    public SimpleSpanOperation(SdkTracer tracer) {
       this.tracer = tracer;
     }
 

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/StressTestRunner.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/StressTestRunner.java
@@ -19,7 +19,7 @@ import javax.annotation.concurrent.Immutable;
 abstract class StressTestRunner {
   abstract ImmutableList<Operation> getOperations();
 
-  abstract TracerSdk getTracer();
+  abstract SdkTracer getTracer();
 
   abstract SpanProcessor getSpanProcessor();
 
@@ -60,7 +60,7 @@ abstract class StressTestRunner {
   @AutoValue.Builder
   abstract static class Builder {
 
-    abstract Builder setTracer(TracerSdk tracerSdk);
+    abstract Builder setTracer(SdkTracer sdkTracer);
 
     abstract ImmutableList.Builder<Operation> operationsBuilder();
 

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/TestUtils.java
@@ -65,9 +65,9 @@ public final class TestUtils {
    * @return A SpanData instance.
    */
   public static SpanBuilder startSpanWithSampler(
-      TracerSdkManagement tracerSdkManagement, Tracer tracer, String spanName, Sampler sampler) {
+      SdkTracerManagement sdkTracerManagement, Tracer tracer, String spanName, Sampler sampler) {
     return startSpanWithSampler(
-        tracerSdkManagement, tracer, spanName, sampler, Collections.emptyMap());
+        sdkTracerManagement, tracer, spanName, sampler, Collections.emptyMap());
   }
 
   /**
@@ -77,13 +77,13 @@ public final class TestUtils {
    * @return A SpanData instance.
    */
   public static SpanBuilder startSpanWithSampler(
-      TracerSdkManagement tracerSdkManagement,
+      SdkTracerManagement sdkTracerManagement,
       Tracer tracer,
       String spanName,
       Sampler sampler,
       Map<String, String> attributes) {
-    TraceConfig originalConfig = tracerSdkManagement.getActiveTraceConfig();
-    tracerSdkManagement.updateActiveTraceConfig(
+    TraceConfig originalConfig = sdkTracerManagement.getActiveTraceConfig();
+    sdkTracerManagement.updateActiveTraceConfig(
         originalConfig.toBuilder().setSampler(sampler).build());
     try {
       SpanBuilder builder = tracer.spanBuilder(spanName);
@@ -91,7 +91,7 @@ public final class TestUtils {
 
       return builder;
     } finally {
-      tracerSdkManagement.updateActiveTraceConfig(originalConfig);
+      sdkTracerManagement.updateActiveTraceConfig(originalConfig);
     }
   }
 }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -15,8 +15,8 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.export.ConfigBuilderTest.ConfigTester;
 import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.TestUtils;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.util.ArrayList;
@@ -45,7 +45,7 @@ class BatchSpanProcessorTest {
   private static final String SPAN_NAME_1 = "MySpanName/1";
   private static final String SPAN_NAME_2 = "MySpanName/2";
   private static final long MAX_SCHEDULE_DELAY_MILLIS = 500;
-  private final TracerSdkProvider tracerSdkFactory = TracerSdkProvider.builder().build();
+  private final SdkTracerProvider tracerSdkFactory = SdkTracerProvider.builder().build();
   private final Tracer tracer = tracerSdkFactory.get("BatchSpanProcessorTest");
   private final BlockingSpanExporter blockingSpanExporter = new BlockingSpanExporter();
   @Mock private SpanExporter mockServiceHandler;

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
@@ -23,8 +23,8 @@ import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.export.ConfigBuilderTest.ConfigTester;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.TestUtils;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessorTest.WaitingSpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
@@ -50,7 +50,7 @@ class SimpleSpanProcessorTest {
   @Mock private ReadableSpan readableSpan;
   @Mock private ReadWriteSpan readWriteSpan;
   @Mock private SpanExporter spanExporter;
-  private final TracerSdkProvider tracerSdkFactory = TracerSdkProvider.builder().build();
+  private final SdkTracerProvider tracerSdkFactory = SdkTracerProvider.builder().build();
   private final Tracer tracer = tracerSdkFactory.get("SimpleSpanProcessor");
   private static final SpanContext SAMPLED_SPAN_CONTEXT =
       SpanContext.create(

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/spi/TracerProviderFactorySdkTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/spi/TracerProviderFactorySdkTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link TracerProviderFactorySdk}. */
@@ -17,7 +17,7 @@ class TracerProviderFactorySdkTest {
 
   @Test
   void testDefault() {
-    Tracer tracerSdk = TracerSdkProvider.builder().build().get("");
+    Tracer tracerSdk = SdkTracerProvider.builder().build().get("");
     assertThat(OpenTelemetry.getGlobalTracerProvider().get("")).isInstanceOf(tracerSdk.getClass());
   }
 }


### PR DESCRIPTION
…fix.

Sending this out to illustrate #2290. No worries if it doesn't seem like nice naming and we can close but figured it's easier to take a look. One observation is that we probably would continue with `OpenTelemetrySdk` instead of `SdkOpenTelemetry` since we use the wording OpenTelemetry SDK so much. While a bit inconsistent, I think it's probably ok.