### PR TITLE
Avoids triggering GH action workflow on non-code changes

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - "docs/**"
+      - "examples/**"
+      - "**.md"
 
 jobs:
   build:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - "docs/**"
+      - "examples/**"
+      - "**.md"
 
 jobs:
   build:


### PR DESCRIPTION
I noticed that we are running some GH action workflows on changes including changes in README, docs and examples which is not necessary at all.

GitHub actions supports path filters which we can use to avoid running CI on changes in markdown or text files. This PR utilizes that to filter docs, examples and README (with other markdown files) in `master-build` and `pr-build` workflows. 

References for this PR:
- https://github.community/t/using-on-push-tags-ignore-and-paths-ignore-together/16931
- https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
- hypertrace/hypertrace-service#48
- https://github.com/openshift/gatekeeper/blob/1fb8db0b4d81cd366a56808f950c3d6f8719f658/.github/workflows/workflow.yaml
