### PR TITLE
Move OTLP adapters to otproto module for use outside of gRPC exporters.

### DIFF
--- a/exporters/otlp/src/main/java/io/opentelemetry/exporter/otlp/OtlpGrpcMetricExporter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporter/otlp/OtlpGrpcMetricExporter.java
@@ -14,6 +14,7 @@ import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
 import io.opentelemetry.proto.collector.metrics.v1.MetricsServiceGrpc;
 import io.opentelemetry.proto.collector.metrics.v1.MetricsServiceGrpc.MetricsServiceFutureStub;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.extension.otproto.MetricAdapter;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.util.Collection;

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporter/otlp/OtlpGrpcMetricExporterBuilder.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporter/otlp/OtlpGrpcMetricExporterBuilder.java
@@ -13,6 +13,7 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
 import io.grpc.stub.MetadataUtils;
 import io.opentelemetry.sdk.common.export.ConfigBuilder;
+import io.opentelemetry.sdk.extension.otproto.CommonProperties;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporter/otlp/OtlpGrpcSpanExporter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporter/otlp/OtlpGrpcSpanExporter.java
@@ -18,6 +18,7 @@ import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
 import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc.TraceServiceFutureStub;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.extension.otproto.SpanAdapter;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Collection;

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporter/otlp/OtlpGrpcSpanExporterBuilder.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporter/otlp/OtlpGrpcSpanExporterBuilder.java
@@ -13,6 +13,7 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
 import io.grpc.stub.MetadataUtils;
 import io.opentelemetry.sdk.common.export.ConfigBuilder;
+import io.opentelemetry.sdk.extension.otproto.CommonProperties;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporter/otlp/package-info.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporter/otlp/package-info.java
@@ -9,12 +9,12 @@
  * <h2>Contents</h2>
  *
  * <ul>
- *   <li>{@link io.opentelemetry.exporter.otlp.CommonAdapter}
- *   <li>{@link io.opentelemetry.exporter.otlp.MetricAdapter}
+ *   <li>{@link io.opentelemetry.sdk.extension.otproto.CommonAdapter}
+ *   <li>{@link io.opentelemetry.sdk.extension.otproto.MetricAdapter}
  *   <li>{@link io.opentelemetry.exporter.otlp.OtlpGrpcMetricExporter}
  *   <li>{@link io.opentelemetry.exporter.otlp.OtlpGrpcSpanExporter}
- *   <li>{@link io.opentelemetry.exporter.otlp.ResourceAdapter}
- *   <li>{@link io.opentelemetry.exporter.otlp.SpanAdapter}
+ *   <li>{@link io.opentelemetry.sdk.extension.otproto.ResourceAdapter}
+ *   <li>{@link io.opentelemetry.sdk.extension.otproto.SpanAdapter}
  * </ul>
  *
  * <p>Configuration options for {@link io.opentelemetry.exporter.otlp.OtlpGrpcMetricExporter} and

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporter/otlp/OtlpGrpcMetricExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporter/otlp/OtlpGrpcMetricExporterTest.java
@@ -25,6 +25,7 @@ import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.common.export.ConfigBuilder;
+import io.opentelemetry.sdk.extension.otproto.MetricAdapter;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
 import io.opentelemetry.sdk.resources.Resource;

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporter/otlp/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporter/otlp/OtlpGrpcSpanExporterTest.java
@@ -22,6 +22,7 @@ import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.extension.otproto.SpanAdapter;
 import io.opentelemetry.sdk.testing.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.io.IOException;

--- a/sdk-extensions/otproto/README.md
+++ b/sdk-extensions/otproto/README.md
@@ -2,8 +2,8 @@
 
 [![Javadocs][javadoc-image]][javadoc-url]
 
-This module contains code to helps with conversions from OpenTelemetry proto objects to API or SDK
-objects (e.g. SpanId, TraceId, TraceConfig etc.).
+This module contains code to helps with conversions betewen OpenTelemetry proto objects and API or 
+SDK objects (e.g. SpanId, TraceId, TraceConfig, SpanData etc.).
 
 [javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-sdk-contrib-otproto.svg
 [javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-contrib-otproto

--- a/sdk-extensions/otproto/build.gradle
+++ b/sdk-extensions/otproto/build.gradle
@@ -16,6 +16,8 @@ dependencies {
     implementation libraries.protobuf,
             libraries.protobuf_util
 
+    testImplementation project(':opentelemetry-sdk-testing')
+
     testImplementation "io.grpc:grpc-testing:${grpcVersion}"
     testRuntime "io.grpc:grpc-netty-shaded:${grpcVersion}"
 

--- a/sdk-extensions/otproto/src/main/java/io/opentelemetry/sdk/extension/otproto/CommonAdapter.java
+++ b/sdk-extensions/otproto/src/main/java/io/opentelemetry/sdk/extension/otproto/CommonAdapter.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.exporter.otlp;
+package io.opentelemetry.sdk.extension.otproto;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.proto.common.v1.AnyValue;

--- a/sdk-extensions/otproto/src/main/java/io/opentelemetry/sdk/extension/otproto/CommonProperties.java
+++ b/sdk-extensions/otproto/src/main/java/io/opentelemetry/sdk/extension/otproto/CommonProperties.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.exporter.otlp;
+package io.opentelemetry.sdk.extension.otproto;
 
 public class CommonProperties {
   public static final String KEY_TIMEOUT = "otel.exporter.otlp.timeout";

--- a/sdk-extensions/otproto/src/main/java/io/opentelemetry/sdk/extension/otproto/MetricAdapter.java
+++ b/sdk-extensions/otproto/src/main/java/io/opentelemetry/sdk/extension/otproto/MetricAdapter.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.exporter.otlp;
+package io.opentelemetry.sdk.extension.otproto;
 
 import static io.opentelemetry.proto.metrics.v1.AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE;
 import static io.opentelemetry.proto.metrics.v1.AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA;
@@ -33,9 +33,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-final class MetricAdapter {
+/** Converter from SDK {@link MetricData} to OTLP {@link ResourceMetrics}. */
+public final class MetricAdapter {
 
-  static List<ResourceMetrics> toProtoResourceMetrics(Collection<MetricData> metricData) {
+  /** Converts the provided {@link MetricData} to {@link ResourceMetrics}. */
+  public static List<ResourceMetrics> toProtoResourceMetrics(Collection<MetricData> metricData) {
     Map<Resource, Map<InstrumentationLibraryInfo, List<Metric>>> resourceAndLibraryMap =
         groupByResourceAndLibrary(metricData);
     List<ResourceMetrics> resourceMetrics = new ArrayList<>(resourceAndLibraryMap.size());

--- a/sdk-extensions/otproto/src/main/java/io/opentelemetry/sdk/extension/otproto/ResourceAdapter.java
+++ b/sdk-extensions/otproto/src/main/java/io/opentelemetry/sdk/extension/otproto/ResourceAdapter.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.exporter.otlp;
+package io.opentelemetry.sdk.extension.otproto;
 
 import io.opentelemetry.proto.resource.v1.Resource;
 

--- a/sdk-extensions/otproto/src/main/java/io/opentelemetry/sdk/extension/otproto/SpanAdapter.java
+++ b/sdk-extensions/otproto/src/main/java/io/opentelemetry/sdk/extension/otproto/SpanAdapter.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.exporter.otlp;
+package io.opentelemetry.sdk.extension.otproto;
 
 import static io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT;
 import static io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CONSUMER;
@@ -22,7 +22,6 @@ import io.opentelemetry.proto.trace.v1.Span;
 import io.opentelemetry.proto.trace.v1.Span.SpanKind;
 import io.opentelemetry.proto.trace.v1.Status;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.extension.otproto.TraceProtoUtils;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Event;
@@ -32,8 +31,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-final class SpanAdapter {
-  static List<ResourceSpans> toProtoResourceSpans(Collection<SpanData> spanDataList) {
+/** Converter from SDK {@link SpanData} to OTLP {@link ResourceSpans}. */
+public final class SpanAdapter {
+
+  /** Converts the provided {@link SpanData} to {@link ResourceSpans}. */
+  public static List<ResourceSpans> toProtoResourceSpans(Collection<SpanData> spanDataList) {
     Map<Resource, Map<InstrumentationLibraryInfo, List<Span>>> resourceAndLibraryMap =
         groupByResourceAndLibrary(spanDataList);
     List<ResourceSpans> resourceSpans = new ArrayList<>(resourceAndLibraryMap.size());

--- a/sdk-extensions/otproto/src/main/java/io/opentelemetry/sdk/extension/otproto/package-info.java
+++ b/sdk-extensions/otproto/src/main/java/io/opentelemetry/sdk/extension/otproto/package-info.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/** Utilities for working with the OTLP format for traces. */
+/** Utilities for working with the OTLP format. */
 @ParametersAreNonnullByDefault
 package io.opentelemetry.sdk.extension.otproto;
 

--- a/sdk-extensions/otproto/src/test/java/io/opentelemetry/sdk/extension/otproto/CommonAdapterTest.java
+++ b/sdk-extensions/otproto/src/test/java/io/opentelemetry/sdk/extension/otproto/CommonAdapterTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.exporter.otlp;
+package io.opentelemetry.sdk.extension.otproto;
 
 import static io.opentelemetry.api.common.AttributeKey.booleanArrayKey;
 import static io.opentelemetry.api.common.AttributeKey.booleanKey;
@@ -23,7 +23,6 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link CommonAdapter}. */
 class CommonAdapterTest {
   @Test
   void toProtoAttribute_Bool() {

--- a/sdk-extensions/otproto/src/test/java/io/opentelemetry/sdk/extension/otproto/MetricAdapterTest.java
+++ b/sdk-extensions/otproto/src/test/java/io/opentelemetry/sdk/extension/otproto/MetricAdapterTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.exporter.otlp;
+package io.opentelemetry.sdk.extension.otproto;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.proto.metrics.v1.AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE;
@@ -36,7 +36,6 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link MetricAdapter}. */
 class MetricAdapterTest {
   @Test
   void toProtoLabels() {

--- a/sdk-extensions/otproto/src/test/java/io/opentelemetry/sdk/extension/otproto/ResourceAdapterTest.java
+++ b/sdk-extensions/otproto/src/test/java/io/opentelemetry/sdk/extension/otproto/ResourceAdapterTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.exporter.otlp;
+package io.opentelemetry.sdk.extension.otproto;
 
 import static io.opentelemetry.api.common.AttributeKey.booleanKey;
 import static io.opentelemetry.api.common.AttributeKey.doubleKey;
@@ -17,7 +17,6 @@ import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.sdk.resources.Resource;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link ResourceAdapter}. */
 class ResourceAdapterTest {
   @Test
   void toProtoResource() {

--- a/sdk-extensions/otproto/src/test/java/io/opentelemetry/sdk/extension/otproto/SpanAdapterTest.java
+++ b/sdk-extensions/otproto/src/test/java/io/opentelemetry/sdk/extension/otproto/SpanAdapterTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.exporter.otlp;
+package io.opentelemetry.sdk.extension.otproto;
 
 import static io.opentelemetry.api.common.AttributeKey.booleanKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
@@ -39,7 +39,6 @@ import io.opentelemetry.sdk.trace.data.SpanData.Link;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link SpanAdapter}. */
 class SpanAdapterTest {
   private static final byte[] TRACE_ID_BYTES =
       new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4};

--- a/sdk-extensions/otproto/src/test/java/io/opentelemetry/sdk/extension/otproto/TraceProtoUtilsTest.java
+++ b/sdk-extensions/otproto/src/test/java/io/opentelemetry/sdk/extension/otproto/TraceProtoUtilsTest.java
@@ -17,7 +17,6 @@ import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link TraceProtoUtils}. */
 class TraceProtoUtilsTest {
   private static final io.opentelemetry.proto.trace.v1.TraceConfig TRACE_CONFIG_PROTO =
       io.opentelemetry.proto.trace.v1.TraceConfig.newBuilder()


### PR DESCRIPTION
In #2295 we are thinking of using these outside the gRPC exporter artifacts. And we probably will want to provide HTTP exporters eventually as well, so we need these conversions to live outside. `otproto` seems designed for it based on the README.