### PR TITLE
inject alpha into the version for metrics api and sdk.

### DIFF
--- a/api/metrics/build.gradle
+++ b/api/metrics/build.gradle
@@ -6,6 +6,10 @@ plugins {
     id "ru.vyarus.animalsniffer"
 }
 
+version = "${version}".replaceFirst(/^(\d+)\.(\d+).(\d+)/) { _, major, minor, patch ->
+    "${major}.${minor}.${patch}-alpha"
+}
+
 description = 'OpenTelemetry API'
 ext.moduleName = "io.opentelemetry.api.metrics"
 

--- a/sdk/metrics/build.gradle
+++ b/sdk/metrics/build.gradle
@@ -6,6 +6,10 @@ plugins {
     id "ru.vyarus.animalsniffer"
 }
 
+version = "${version}".replaceFirst(/^(\d+)\.(\d+).(\d+)/) { _, major, minor, patch ->
+    "${major}.${minor}.${patch}-alpha"
+}
+
 description = 'OpenTelemetry SDK Metrics'
 ext.moduleName = "io.opentelemetry.sdk.metrics"
 ext.propertiesDir = "build/generated/properties/io/opentelemetry/sdk/metrics"


### PR DESCRIPTION
Resolves #2266.

After doing a `./gradlew clean build` the jars with alpha look like:

```
$ find . -name '*.jar' | grep alpha
./sdk/metrics/build/libs/opentelemetry-sdk-metrics-0.13.0-alpha-SNAPSHOT.jar
./sdk/metrics/build/libs/opentelemetry-sdk-metrics-0.13.0-alpha-SNAPSHOT-sources.jar
./sdk/metrics/build/libs/opentelemetry-sdk-metrics-0.13.0-alpha-SNAPSHOT-javadoc.jar
./api/metrics/build/libs/opentelemetry-api-metrics-0.13.0-alpha-SNAPSHOT-javadoc.jar
./api/metrics/build/libs/opentelemetry-api-metrics-0.13.0-alpha-SNAPSHOT-sources.jar
./api/metrics/build/libs/opentelemetry-api-metrics-0.13.0-alpha-SNAPSHOT.jar
```