### PR TITLE
Make MetricExporter shutdown method returns CompletableResultCode.

### DIFF
--- a/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/LoggingMetricExporter.java
+++ b/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/LoggingMetricExporter.java
@@ -44,8 +44,9 @@ public final class LoggingMetricExporter implements MetricExporter {
   }
 
   @Override
-  public void shutdown() {
+  public CompletableResultCode shutdown() {
     // no-op
     this.flush();
+    return CompletableResultCode.ofSuccess();
   }
 }

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporter/otlp/OtlpGrpcMetricExporter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporter/otlp/OtlpGrpcMetricExporter.java
@@ -153,11 +153,12 @@ public final class OtlpGrpcMetricExporter implements MetricExporter {
    * cancelled. The channel is forcefully closed after a timeout.
    */
   @Override
-  public void shutdown() {
+  public CompletableResultCode shutdown() {
     try {
       managedChannel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
     } catch (InterruptedException e) {
       logger.log(Level.WARNING, "Failed to shutdown the gRPC channel", e);
     }
+    return CompletableResultCode.ofSuccess();
   }
 }

--- a/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/FakeMetricExporter.java
+++ b/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/FakeMetricExporter.java
@@ -76,5 +76,7 @@ class FakeMetricExporter implements MetricExporter {
   }
 
   @Override
-  public void shutdown() {}
+  public CompletableResultCode shutdown() {
+    return CompletableResultCode.ofSuccess();
+  }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/MetricExporter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/MetricExporter.java
@@ -36,6 +36,10 @@ public interface MetricExporter {
    */
   CompletableResultCode flush();
 
-  /** Called when the associated IntervalMetricReader is shutdown. */
-  void shutdown();
+  /**
+   * Called when the associated IntervalMetricReader is shutdown.
+   *
+   * @return a {@link CompletableResultCode} which is completed when shutdown completes.
+   */
+  CompletableResultCode shutdown();
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
@@ -166,8 +166,9 @@ class IntervalMetricReaderTest {
     }
 
     @Override
-    public void shutdown() {
+    public CompletableResultCode shutdown() {
       hasShutdown.set(true);
+      return CompletableResultCode.ofSuccess();
     }
 
     /**

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/exporter/InMemoryMetricExporter.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/exporter/InMemoryMetricExporter.java
@@ -119,8 +119,9 @@ public final class InMemoryMetricExporter implements MetricExporter {
    * CompletableResultCode.ofFailure()}
    */
   @Override
-  public void shutdown() {
+  public CompletableResultCode shutdown() {
     isStopped = true;
     finishedMetricItems.clear();
+    return CompletableResultCode.ofSuccess();
   }
 }


### PR DESCRIPTION
closes [https://github.com/open-telemetry/opentelemetry-java/issues/2316](https://github.com/open-telemetry/opentelemetry-java/issues/2316)