### PR TITLE
Consistent naming for SPI classes

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/spi/SdkMeterProviderFactory.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/spi/SdkMeterProviderFactory.java
@@ -5,17 +5,11 @@
 
 package io.opentelemetry.sdk.metrics.spi;
 
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.spi.metrics.MeterProviderFactory;
 
-/**
- * {@code MeterProvider} provider implementation for {@link MeterProviderFactory}.
- *
- * <p>This class is not intended to be used in application code and it is used only by {@link
- * OpenTelemetry}.
- */
-public final class MeterProviderFactorySdk implements MeterProviderFactory {
+/** SDK implementation of the {@link MeterProviderFactory} for SPI. */
+public final class SdkMeterProviderFactory implements MeterProviderFactory {
 
   @Override
   public SdkMeterProvider create() {

--- a/sdk/metrics/src/main/resources/META-INF/services/io.opentelemetry.spi.metrics.MeterProviderFactory
+++ b/sdk/metrics/src/main/resources/META-INF/services/io.opentelemetry.spi.metrics.MeterProviderFactory
@@ -1,1 +1,1 @@
-io.opentelemetry.sdk.metrics.spi.MeterProviderFactorySdk
+io.opentelemetry.sdk.metrics.spi.SdkMeterProviderFactory

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/spi/SdkMeterProviderFactoryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/spi/SdkMeterProviderFactoryTest.java
@@ -11,8 +11,8 @@ import io.opentelemetry.api.metrics.GlobalMetricsProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link MeterProviderFactorySdk}. */
-class MeterProviderFactorySdkTest {
+/** Unit tests for {@link SdkMeterProviderFactory}. */
+class SdkMeterProviderFactoryTest {
   @Test
   void testDefault() {
     assertThat(GlobalMetricsProvider.get()).isInstanceOf(SdkMeterProvider.class);

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/spi/SdkTracerProviderFactory.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/spi/SdkTracerProviderFactory.java
@@ -9,8 +9,8 @@ import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.spi.trace.TracerProviderFactory;
 
-/** SDK implementation of the TracerProviderFactory for SPI. */
-public final class TracerProviderFactorySdk implements TracerProviderFactory {
+/** SDK implementation of the {@link TracerProviderFactory} for SPI. */
+public final class SdkTracerProviderFactory implements TracerProviderFactory {
 
   @Override
   public TracerProvider create() {

--- a/sdk/trace/src/main/resources/META-INF/services/io.opentelemetry.spi.trace.TracerProviderFactory
+++ b/sdk/trace/src/main/resources/META-INF/services/io.opentelemetry.spi.trace.TracerProviderFactory
@@ -1,1 +1,1 @@
-io.opentelemetry.sdk.trace.spi.TracerProviderFactorySdk
+io.opentelemetry.sdk.trace.spi.SdkTracerProviderFactory

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/spi/SdkTracerProviderFactoryTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/spi/SdkTracerProviderFactoryTest.java
@@ -12,8 +12,8 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link TracerProviderFactorySdk}. */
-class TracerProviderFactorySdkTest {
+/** Unit tests for {@link SdkTracerProviderFactory}. */
+class SdkTracerProviderFactoryTest {
 
   @Test
   void testDefault() {


### PR DESCRIPTION
Follow the java convention to name Factories, ${CLASS_NAME}Factory.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>