### PR TITLE
Metrics are alpha take 2

### DIFF
--- a/api/metrics/build.gradle
+++ b/api/metrics/build.gradle
@@ -6,10 +6,6 @@ plugins {
     id "ru.vyarus.animalsniffer"
 }
 
-version = "${version}".replaceFirst(/^(\d+)\.(\d+).(\d+)/) { _, major, minor, patch ->
-    "${major}.${minor}.${patch}-alpha"
-}
-
 description = 'OpenTelemetry API'
 ext.moduleName = "io.opentelemetry.api.metrics"
 

--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -11,6 +11,7 @@ dependencies {
         parent.childProjects.sort { "$it.value" }
                 .collect { it.value }
                 .findAll { it.name != project.name }
+                .findAll { !it.name.endsWith('-metrics') }
                 .each { project ->
                     api project
                     println project

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,9 @@ subprojects {
         publishing {
             publications {
                 mavenPublication(MavenPublication) {
-                    version version
+                    version project.name.endsWith('-metrics') ? "${version}".replaceFirst(/^(\d+)\.(\d+).(\d+)/) { _, major, minor, patch ->
+                            "${major}.${minor}.${patch}-alpha"
+                        } : version
                     groupId group
 
                     plugins.withId("java-platform") {

--- a/sdk/metrics/build.gradle
+++ b/sdk/metrics/build.gradle
@@ -6,10 +6,6 @@ plugins {
     id "ru.vyarus.animalsniffer"
 }
 
-version = "${version}".replaceFirst(/^(\d+)\.(\d+).(\d+)/) { _, major, minor, patch ->
-    "${major}.${minor}.${patch}-alpha"
-}
-
 description = 'OpenTelemetry SDK Metrics'
 ext.moduleName = "io.opentelemetry.sdk.metrics"
 ext.propertiesDir = "build/generated/properties/io/opentelemetry/sdk/metrics"


### PR DESCRIPTION
This rolls back #2311 and reimplements #2328.

It does feel a bit hacky, but in my testing it does actually include `alpha` in the artifact names, poms, etc...and the bom change omits the metrics artifacts from the bom entirely.