### PR TITLE
Add setMeterProvider to BSP.

### DIFF
--- a/api/common/src/main/java/io/opentelemetry/api/common/AlphaApi.java
+++ b/api/common/src/main/java/io/opentelemetry/api/common/AlphaApi.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.common;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates the API of the target has not been released for general availability and has no
+ * guarantees regarding compatibility between releases. Its behavior, signature or even existence
+ * might change without a prior notice at any point.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({
+  ElementType.ANNOTATION_TYPE,
+  ElementType.CONSTRUCTOR,
+  ElementType.FIELD,
+  ElementType.METHOD,
+  ElementType.PACKAGE,
+  ElementType.TYPE
+})
+@Documented
+public @interface AlphaApi {}

--- a/sdk/trace/build.gradle
+++ b/sdk/trace/build.gradle
@@ -11,9 +11,14 @@ ext.moduleName = "io.opentelemetry.sdk.trace"
 ext.propertiesDir = "build/generated/properties/io/opentelemetry/sdk/trace"
 
 dependencies {
-    api project(':opentelemetry-api'),
+    api project(':opentelemetry-api-trace'),
             project(':opentelemetry-sdk-common')
 
+    // We do allow enabling metrics for span processors if the user enables it, but we don't want
+    // the user to automatically have metrics on their compile classpath, so we use both
+    // compileOnly and implementation.
+    compileOnly project(':opentelemetry-api-metrics')
+    implementation project(':opentelemetry-api-metrics')
 
     annotationProcessor libraries.auto_value
 

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -140,8 +140,8 @@ public final class BatchSpanProcessor implements SpanProcessor {
 
   /**
    * Sets the {@link MeterProvider} to use to record metrics related to processed spans. By default,
-   * this processor will not record metrics. Call this method with a configured {@link
-   * MeterProvider} to enable recording.
+   * the {@link BatchSpanProcessor} will not record metrics. Call this method with a configured
+   * {@link MeterProvider} to enable recording.
    */
   @AlphaApi
   public void setMeterProvider(MeterProvider meterProvider) {

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.trace.export;
 
 import io.opentelemetry.api.common.AlphaApi;
 import io.opentelemetry.api.common.Labels;
+import io.opentelemetry.api.metrics.GlobalMetricsProvider;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongCounter.BoundLongCounter;
 import io.opentelemetry.api.metrics.Meter;
@@ -140,8 +141,9 @@ public final class BatchSpanProcessor implements SpanProcessor {
 
   /**
    * Sets the {@link MeterProvider} to use to record metrics related to processed spans. By default,
-   * the {@link BatchSpanProcessor} will not record metrics. Call this method with a configured
-   * {@link MeterProvider} to enable recording.
+   * the {@link BatchSpanProcessor} will record metrics using the {@link GlobalMetricsProvider}.
+   * Call this method with a configured {@link MeterProvider} to enable recording metrics if the
+   * {@link GlobalMetricsProvider} is not configured..
    */
   @AlphaApi
   public void setMeterProvider(MeterProvider meterProvider) {
@@ -182,7 +184,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
       this.queue = queue;
       this.batch = new ArrayList<>(this.maxExportBatchSize);
 
-      setMeterProvider(MeterProvider.getDefault());
+      setMeterProvider(GlobalMetricsProvider.get());
     }
 
     private void addSpan(ReadableSpan span) {


### PR DESCRIPTION
I'm playing with the basics for https://github.com/open-telemetry/opentelemetry-java/pull/2262/files#diff-9c65892c78d75723d499d2f433695dfb0eaced043768a3803c1f2a39e201599aR375

Thinking about it led me to #2320 since it seemed a bit strange to be using the metrics API in our code while it's alpha, but I guess we can try the `@AlphaApi` annotation approach. Any thoughts?