### PR TITLE
Upload coverage HTML report as action artifact.

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -42,6 +42,11 @@ jobs:
             org.gradle.java.installations.paths=${{ steps.setup-java-8.outputs.path }},${{ steps.setup-java-11.outputs.path }}
       - uses: codecov/codecov-action@v1
         if: ${{ matrix.coverage }}
+      - uses: actions/upload-artifact@v2
+        if: ${{ matrix.coverage }}
+        with:
+          name: coverage-report
+          path: all/build/reports/jacoco/test/html
   publish-snapshots:
     name: Publish snapshots to JFrog
     if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -42,3 +42,8 @@ jobs:
             org.gradle.java.installations.paths=${{ steps.setup-java-8.outputs.path }},${{ steps.setup-java-11.outputs.path }}
       - uses: codecov/codecov-action@v1
         if: ${{ matrix.coverage }}
+      - uses: actions/upload-artifact@v2
+        if: ${{ matrix.coverage }}
+        with:
+          name: coverage-report
+          path: all/build/reports/jacoco/test/html


### PR DESCRIPTION
Lately codecov has been flaky for unknown reasons - it works well for many commits then stops working for many commits. This uploads the HTML report to GitHub Actions so at least there's something to look at.