### PR TITLE
Span.Kind is a part of annotation API and should be declared as such.

### DIFF
--- a/extensions/annotations/build.gradle
+++ b/extensions/annotations/build.gradle
@@ -9,6 +9,5 @@ description = 'OpenTelemetry Extension Annotations'
 ext.moduleName = "io.opentelemetry.extension.annotations"
 
 dependencies {
-    implementation project(':opentelemetry-api')
-
-    }
+    api project(':opentelemetry-api')
+}


### PR DESCRIPTION
If someone only uses `@WithSpan` annotation and declares `o.opentelemetry:opentelemetry-extension-annotations` as the only dependency, he will get these warnings on compilation:

```
warning: unknown enum constant Kind.INTERNAL
  reason: class file for io.opentelemetry.api.trace.Span not found
```

According to [this](https://stackoverflow.com/questions/51368530/suppress-unknown-enum-constant-warning-for-enums-used-in-class-retention-annot) this is because `WithSpan` uses `Span.Kind` in its API. But in gradle it is declared as `implementation` dependency. Declaring it as `api` dependency should fix the problem.