### PR TITLE
Deprecate trace mutli propagator

### DIFF
--- a/api/context/src/main/java/io/opentelemetry/context/propagation/MultiTextMapPropagator.java
+++ b/api/context/src/main/java/io/opentelemetry/context/propagation/MultiTextMapPropagator.java
@@ -7,6 +7,7 @@ package io.opentelemetry.context.propagation;
 
 import io.opentelemetry.context.Context;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -17,6 +18,10 @@ import javax.annotation.Nullable;
 final class MultiTextMapPropagator implements TextMapPropagator {
   private final TextMapPropagator[] textPropagators;
   private final Collection<String> allFields;
+
+  MultiTextMapPropagator(TextMapPropagator... textPropagators) {
+    this(Arrays.asList(textPropagators));
+  }
 
   MultiTextMapPropagator(List<TextMapPropagator> textPropagators) {
     this.textPropagators = new TextMapPropagator[textPropagators.size()];

--- a/api/context/src/test/java/io/opentelemetry/context/propagation/MultiTextMapPropagatorTest.java
+++ b/api/context/src/test/java/io/opentelemetry/context/propagation/MultiTextMapPropagatorTest.java
@@ -24,6 +24,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("deprecation")
 class MultiTextMapPropagatorTest {
 
   @Mock private TextMapPropagator propagator1;

--- a/api/context/src/test/java/io/opentelemetry/context/propagation/MultiTextMapPropagatorTest.java
+++ b/api/context/src/test/java/io/opentelemetry/context/propagation/MultiTextMapPropagatorTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.context.propagation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.context.Context;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MultiTextMapPropagatorTest {
+
+  @Mock private TextMapPropagator propagator1;
+  @Mock private TextMapPropagator propagator2;
+  @Mock private TextMapPropagator propagator3;
+
+  private static final TextMapPropagator.Getter<Map<String, String>> getter =
+      new TextMapPropagator.Getter<Map<String, String>>() {
+        @Override
+        public Iterable<String> keys(Map<String, String> carrier) {
+          return carrier.keySet();
+        }
+
+        @Nullable
+        @Override
+        public String get(Map<String, String> carrier, String key) {
+          return carrier.get(key);
+        }
+      };
+
+  @Test
+  void addPropagator_null() {
+    assertThrows(
+        NullPointerException.class,
+        () -> new MultiTextMapPropagator((List<TextMapPropagator>) null));
+  }
+
+  @Test
+  void fields() {
+    when(propagator1.fields()).thenReturn(Arrays.asList("foo", "bar"));
+    when(propagator2.fields()).thenReturn(Arrays.asList("hello", "world"));
+    TextMapPropagator prop = new MultiTextMapPropagator(propagator1, propagator2);
+
+    Collection<String> fields = prop.fields();
+    assertThat(fields).containsExactly("foo", "bar", "hello", "world");
+  }
+
+  @Test
+  void fields_duplicates() {
+    when(propagator1.fields()).thenReturn(Arrays.asList("foo", "bar", "foo"));
+    when(propagator2.fields()).thenReturn(Arrays.asList("hello", "world", "world", "bar"));
+    TextMapPropagator prop = new MultiTextMapPropagator(propagator1, propagator2);
+
+    Collection<String> fields = prop.fields();
+    assertThat(fields).containsExactly("foo", "bar", "hello", "world");
+  }
+
+  @Test
+  void fields_readOnly() {
+    when(propagator1.fields()).thenReturn(Arrays.asList("rubber", "baby"));
+    when(propagator2.fields()).thenReturn(Arrays.asList("buggy", "bumpers"));
+    TextMapPropagator prop = new MultiTextMapPropagator(propagator1, propagator2);
+    Collection<String> fields = prop.fields();
+    assertThrows(UnsupportedOperationException.class, () -> fields.add("hi"));
+  }
+
+  @Test
+  void inject_noPropagators() {
+    TextMapPropagator prop = new MultiTextMapPropagator();
+    Map<String, String> carrier = new HashMap<>();
+
+    Context context = Context.current();
+    prop.inject(context, carrier, Map::put);
+    assertThat(carrier).isEmpty();
+    assertThat(prop).isSameAs(NoopTextMapPropagator.getInstance());
+  }
+
+  @Test
+  void inject_allDelegated() {
+    Map<String, String> carrier = new HashMap<>();
+    Context context = mock(Context.class);
+    TextMapPropagator.Setter<Map<String, String>> setter = Map::put;
+
+    TextMapPropagator prop = new MultiTextMapPropagator(propagator1, propagator2, propagator3);
+    prop.inject(context, carrier, setter);
+    verify(propagator1).inject(context, carrier, setter);
+    verify(propagator2).inject(context, carrier, setter);
+    verify(propagator3).inject(context, carrier, setter);
+  }
+
+  @Test
+  void extract_noPropagators() {
+    Map<String, String> carrier = new HashMap<>();
+    Context context = mock(Context.class);
+
+    TextMapPropagator prop = new MultiTextMapPropagator();
+    Context resContext = prop.extract(context, carrier, getter);
+    assertThat(context).isSameAs(resContext);
+  }
+
+  @Test
+  void extract_found_all() {
+    Map<String, String> carrier = new HashMap<>();
+    TextMapPropagator prop = new MultiTextMapPropagator(propagator1, propagator2, propagator3);
+    Context context1 = mock(Context.class);
+    Context context2 = mock(Context.class);
+    Context context3 = mock(Context.class);
+    Context expectedContext = mock(Context.class);
+
+    when(propagator1.extract(context1, carrier, getter)).thenReturn(context2);
+    when(propagator2.extract(context2, carrier, getter)).thenReturn(context3);
+    when(propagator3.extract(context3, carrier, getter)).thenReturn(expectedContext);
+
+    assertThat(prop.extract(context1, carrier, getter)).isEqualTo(expectedContext);
+  }
+
+  @Test
+  void extract_notFound() {
+
+    Map<String, String> carrier = new HashMap<>();
+    Context context = mock(Context.class);
+    when(propagator1.extract(context, carrier, getter)).thenReturn(context);
+    when(propagator2.extract(context, carrier, getter)).thenReturn(context);
+
+    TextMapPropagator prop = new MultiTextMapPropagator(propagator1, propagator2);
+    Context result = prop.extract(context, carrier, getter);
+
+    assertThat(result).isSameAs(context);
+  }
+
+  @Test
+  void createWithOneDelegate() {
+    TextMapPropagator result = new MultiTextMapPropagator(propagator2);
+    assertThat(result).isSameAs(propagator2);
+  }
+}

--- a/api/context/src/test/java/io/opentelemetry/context/propagation/MultiTextMapPropagatorTest.java
+++ b/api/context/src/test/java/io/opentelemetry/context/propagation/MultiTextMapPropagatorTest.java
@@ -81,17 +81,6 @@ class MultiTextMapPropagatorTest {
   }
 
   @Test
-  void inject_noPropagators() {
-    TextMapPropagator prop = new MultiTextMapPropagator();
-    Map<String, String> carrier = new HashMap<>();
-
-    Context context = Context.current();
-    prop.inject(context, carrier, Map::put);
-    assertThat(carrier).isEmpty();
-    assertThat(prop).isSameAs(NoopTextMapPropagator.getInstance());
-  }
-
-  @Test
   void inject_allDelegated() {
     Map<String, String> carrier = new HashMap<>();
     Context context = mock(Context.class);
@@ -142,11 +131,5 @@ class MultiTextMapPropagatorTest {
     Context result = prop.extract(context, carrier, getter);
 
     assertThat(result).isSameAs(context);
-  }
-
-  @Test
-  void createWithOneDelegate() {
-    TextMapPropagator result = new MultiTextMapPropagator(propagator2);
-    assertThat(result).isSameAs(propagator2);
   }
 }

--- a/api/context/src/test/java/io/opentelemetry/context/propagation/MultiTextMapPropagatorTest.java
+++ b/api/context/src/test/java/io/opentelemetry/context/propagation/MultiTextMapPropagatorTest.java
@@ -24,7 +24,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-@SuppressWarnings("deprecation")
+@SuppressWarnings("deprecation") // we're testing deprecated stuff in here.
 class MultiTextMapPropagatorTest {
 
   @Mock private TextMapPropagator propagator1;

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagator.java
@@ -51,6 +51,7 @@ import javax.annotation.concurrent.Immutable;
  *
  * This class is @deprecated and will be removed in 0.14.0. Users should migrate to the
  * MultiTextMapPropagator in the api.
+ * @deprecated Migrate to the MultiTextPropagator in the API.
  */
 @Immutable
 @Deprecated

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagator.java
@@ -51,7 +51,7 @@ import javax.annotation.concurrent.Immutable;
  *
  * This class is @deprecated and will be removed in 0.14.0. Users should migrate to the
  * MultiTextMapPropagator in the api.
- * @deprecated Migrate to the MultiTextPropagator in the API.
+ * @deprecated Use {@link TextMapPropagator#composite}
  */
 @Immutable
 @Deprecated

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagator.java
@@ -48,8 +48,13 @@ import javax.annotation.concurrent.Immutable;
  * Context context = OpenTelemetry.getPropagators().getTextMapPropagator()
  *   .extract(context, carrier, carrierGetter);
  * }</pre>
+ *
+ * This class is deprecated and will be removed in 0.14.0.
+ * Users should migrate to the MultiTextMapPropagator in the api.
+ *
  */
 @Immutable
+@Deprecated
 public final class TraceMultiPropagator implements TextMapPropagator {
 
   /** Returns a {@link TraceMultiPropagator} for the given {@code propagators}. */

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagator.java
@@ -49,9 +49,8 @@ import javax.annotation.concurrent.Immutable;
  *   .extract(context, carrier, carrierGetter);
  * }</pre>
  *
- * This class is deprecated and will be removed in 0.14.0.
- * Users should migrate to the MultiTextMapPropagator in the api.
- *
+ * This class is deprecated and will be removed in 0.14.0. Users should migrate to the
+ * MultiTextMapPropagator in the api.
  */
 @Immutable
 @Deprecated

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagator.java
@@ -49,7 +49,7 @@ import javax.annotation.concurrent.Immutable;
  *   .extract(context, carrier, carrierGetter);
  * }</pre>
  *
- * This class is deprecated and will be removed in 0.14.0. Users should migrate to the
+ * This class is @deprecated and will be removed in 0.14.0. Users should migrate to the
  * MultiTextMapPropagator in the api.
  */
 @Immutable

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagator.java
@@ -49,8 +49,9 @@ import javax.annotation.concurrent.Immutable;
  *   .extract(context, carrier, carrierGetter);
  * }</pre>
  *
- * This class is @deprecated and will be removed in 0.14.0. Users should migrate to the
+ * <p>This class is @deprecated and will be removed in 0.14.0. Users should migrate to the
  * MultiTextMapPropagator in the api.
+ *
  * @deprecated Use {@link TextMapPropagator#composite}
  */
 @Immutable

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagatorTest.java
@@ -30,6 +30,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("deprecation") // the class under test will go away soon
 class TraceMultiPropagatorTest {
   private static final TextMapPropagator PROPAGATOR1 = B3Propagator.getInstance();
   private static final TextMapPropagator PROPAGATOR2 =


### PR DESCRIPTION
This resolves #2244...even if the implementation here doesn't perfectly match what's in that issue.  There were discussions on the previous PR (#2273) and we agreed to deprecate the extension class and remove it in the next release.  Since 0.13.0 went out today, I assumed we could remove it in 0.14.0 but maybe people think 0.15.0 is better?

In any case, I also brought some missing tests over, hopefully coverage goes up slightly.