### PR TITLE
Stop gap measure to fix api and sdk pom breakage dependency on metrics.

### DIFF
--- a/api/all/build.gradle
+++ b/api/all/build.gradle
@@ -9,6 +9,15 @@ plugins {
 description = 'OpenTelemetry API'
 ext.moduleName = "io.opentelemetry.api"
 
+// Stop gap measure until api no longer depends on api-metrics
+configurations.all {
+    resolutionStrategy {
+        dependencySubstitution {
+            substitute project(':opentelemetry-api-metrics') with module('io.opentelemetry:opentelemetry-api-metrics:0.13.0-alpha')
+        }
+    }
+}
+
 dependencies {
     api project(':opentelemetry-context'),
             project(':opentelemetry-api-baggage'),

--- a/sdk/all/build.gradle
+++ b/sdk/all/build.gradle
@@ -10,6 +10,15 @@ description = 'OpenTelemetry SDK'
 ext.moduleName = "io.opentelemetry.sdk"
 ext.propertiesDir = "build/generated/properties/io/opentelemetry/sdk"
 
+// Stop gap measure until sdk no longer depends on sdk-metrics
+configurations.all {
+    resolutionStrategy {
+        dependencySubstitution {
+            substitute project(':opentelemetry-sdk-metrics') with module('io.opentelemetry:opentelemetry-sdk-metrics:0.13.0-alpha')
+        }
+    }
+}
+
 dependencies {
     api project(':opentelemetry-api'),
             project(':opentelemetry-sdk-common'),


### PR DESCRIPTION
The gradle publishing hacks that put `-alpha` into the version string of the metrics modules missed the poms for the api and sdk modules, as seen here: https://bintray.com/beta/#/open-telemetry/maven/opentelemetry-java/0.13.0?tab=files

This PR is a stop-gap measure that makes the api and sdk modules depend directly on the metrics-api and metrics-sdk (respectively) at the `v0.13.0-alpha` version.  It's not great, but it should work around the current breakage.  This will end up being removed when the api and sdk no longer depend on the metrics modules at all.