### PR TITLE
Don't require commit SHAs.

### DIFF
--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -8,8 +8,8 @@ on:
         description: The version to tag the release with, e.g., 1.2.1, 1.2.2
         required: true
       commits:
-        description: Comma separated list of commit shas to cherrypick
-        required: true
+        description: Comma separated list of commit shas to cherrypick, leave blank if changes have already been merged into the release branch
+        required: false
 
 jobs:
   prepare-release-branch:


### PR DESCRIPTION
Because changes might already exist in the release branch.