### PR TITLE
Use public readProperties instead of protected fromConfigMap to avoid…

### DIFF
--- a/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftSpanExporterTest.java
+++ b/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftSpanExporterTest.java
@@ -21,7 +21,6 @@ import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.common.export.ConfigBuilder;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -30,9 +29,8 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -232,20 +230,11 @@ class JaegerThriftSpanExporterTest {
 
   @Test
   void configTest() {
-    Map<String, String> options = new HashMap<>();
+    Properties options = new Properties();
     String serviceName = "myGreatService";
     options.put("otel.exporter.jaeger.service.name", serviceName);
     JaegerThriftSpanExporter exporter =
-        JaegerThriftSpanExporter.builder()
-            .fromConfigMap(options, ConfigBuilderTest.getNaming())
-            .build();
+        JaegerThriftSpanExporter.builder().readProperties(options).build();
     assertThat(exporter.getProcess().getServiceName()).isEqualTo(serviceName);
-  }
-
-  abstract static class ConfigBuilderTest extends ConfigBuilder<ConfigBuilderTest> {
-
-    public static NamingConvention getNaming() {
-      return NamingConvention.DOT;
-    }
   }
 }

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterTest.java
@@ -27,7 +27,6 @@ import io.opentelemetry.exporter.jaeger.proto.api_v2.CollectorServiceGrpc;
 import io.opentelemetry.exporter.jaeger.proto.api_v2.Model;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.common.export.ConfigBuilder;
 import io.opentelemetry.sdk.extension.otproto.TraceProtoUtils;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.trace.TestSpanData;
@@ -35,10 +34,9 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.SpanData.Status;
 import java.net.InetAddress;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -258,23 +256,15 @@ class JaegerGrpcSpanExporterTest {
 
   @Test
   void configTest() {
-    Map<String, String> options = new HashMap<>();
+    Properties options = new Properties();
     String serviceName = "myGreatService";
     String endpoint = "127.0.0.1:9090";
     options.put("otel.exporter.jaeger.service.name", serviceName);
     options.put("otel.exporter.jaeger.endpoint", endpoint);
     JaegerGrpcSpanExporter exporter =
-        JaegerGrpcSpanExporter.builder()
-            .fromConfigMap(options, ConfigBuilderTest.getNaming())
-            .build();
+        JaegerGrpcSpanExporter.builder().readProperties(options).build();
     assertThat(exporter.getProcessBuilder().getServiceName()).isEqualTo(serviceName);
     assertThat(exporter.getManagedChannel().authority()).isEqualTo(endpoint);
-  }
-
-  abstract static class ConfigBuilderTest extends ConfigBuilder<ConfigBuilderTest> {
-    public static NamingConvention getNaming() {
-      return NamingConvention.DOT;
-    }
   }
 
   static class MockCollectorService extends CollectorServiceGrpc.CollectorServiceImplBase {

--- a/exporters/otlp/metrics/src/test/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterTest.java
+++ b/exporters/otlp/metrics/src/test/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterTest.java
@@ -23,7 +23,6 @@ import io.opentelemetry.proto.collector.metrics.v1.MetricsServiceGrpc;
 import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.common.export.ConfigBuilder;
 import io.opentelemetry.sdk.extension.otproto.MetricAdapter;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
@@ -31,9 +30,8 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
@@ -47,12 +45,6 @@ class OtlpGrpcMetricExporterTest {
   private final String serverName = InProcessServerBuilder.generateName();
   private final ManagedChannel inProcessChannel =
       InProcessChannelBuilder.forName(serverName).directExecutor().build();
-
-  private abstract static class ConfigBuilderTest extends ConfigBuilder<ConfigBuilderTest> {
-    public static NamingConvention getNaming() {
-      return NamingConvention.DOT;
-    }
-  }
 
   private final Closer closer = Closer.create();
 
@@ -75,12 +67,12 @@ class OtlpGrpcMetricExporterTest {
 
   @Test
   void configTest() {
-    Map<String, String> options = new HashMap<>();
+    Properties options = new Properties();
     options.put("otel.exporter.otlp.metric.timeout", "12");
     options.put("otel.exporter.otlp.insecure", "true");
     OtlpGrpcMetricExporterBuilder config = OtlpGrpcMetricExporter.builder();
     OtlpGrpcMetricExporterBuilder spy = Mockito.spy(config);
-    spy.fromConfigMap(options, ConfigBuilderTest.getNaming());
+    spy.readProperties(options);
     verify(spy).setDeadlineMs(12);
     verify(spy).setUseTls(false);
   }

--- a/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterTest.java
@@ -29,7 +29,6 @@ import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.common.export.ConfigBuilder;
 import io.opentelemetry.sdk.extension.otproto.SpanAdapter;
 import io.opentelemetry.sdk.testing.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -37,9 +36,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,12 +45,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class OtlpGrpcSpanExporterTest {
-
-  private abstract static class ConfigBuilderTest extends ConfigBuilder<ConfigBuilderTest> {
-    public static NamingConvention getNaming() {
-      return NamingConvention.DOT;
-    }
-  }
 
   @RegisterExtension
   public static ServerExtension server =
@@ -98,7 +90,7 @@ class OtlpGrpcSpanExporterTest {
 
   @Test
   void configTest() {
-    Map<String, String> options = new HashMap<>();
+    Properties options = new Properties();
     String endpoint = "localhost:" + server.httpPort();
     options.put("otel.exporter.otlp.span.timeout", "5124");
     options.put("otel.exporter.otlp.span.endpoint", endpoint);
@@ -106,10 +98,7 @@ class OtlpGrpcSpanExporterTest {
     options.put(
         "otel.exporter.otlp.span.headers",
         "key=value;key2=value2=;key3=val=ue3; key4 = value4 ;key5= ");
-    OtlpGrpcSpanExporter exporter =
-        OtlpGrpcSpanExporter.builder()
-            .fromConfigMap(options, OtlpGrpcSpanExporterTest.ConfigBuilderTest.getNaming())
-            .build();
+    OtlpGrpcSpanExporter exporter = OtlpGrpcSpanExporter.builder().readProperties(options).build();
 
     assertThat(exporter.getDeadlineMs()).isEqualTo(5124);
     assertThat(

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterTest.java
@@ -29,7 +29,6 @@ import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.api.trace.attributes.SemanticAttributes;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.common.export.ConfigBuilder;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.resources.ResourceAttributes;
 import io.opentelemetry.sdk.testing.trace.TestSpanData;
@@ -38,9 +37,8 @@ import io.opentelemetry.sdk.trace.data.SpanData.Event;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -404,22 +402,16 @@ class ZipkinSpanExporterTest {
         .addAnnotation(1505855799000000L + 459486280L / 1000, "SENT");
   }
 
-  abstract static class ConfigBuilderTest extends ConfigBuilder<ConfigBuilderTest> {
-    public static NamingConvention getNaming() {
-      return NamingConvention.DOT;
-    }
-  }
-
   @Test
   void configTest() {
-    Map<String, String> options = new HashMap<>();
+    Properties options = new Properties();
     String serviceName = "myGreatService";
     String endpoint = "http://127.0.0.1:9090";
     options.put("otel.exporter.zipkin.service.name", serviceName);
     options.put("otel.exporter.zipkin.endpoint", endpoint);
     ZipkinSpanExporterBuilder config = ZipkinSpanExporter.builder();
     ZipkinSpanExporterBuilder spy = Mockito.spy(config);
-    spy.fromConfigMap(options, ConfigBuilderTest.getNaming()).build();
+    spy.readProperties(options);
     Mockito.verify(spy).setServiceName(serviceName);
     Mockito.verify(spy).setEndpoint(endpoint);
   }

--- a/sdk-extensions/async-processor/src/test/java/io/opentelemetry/sdk/extension/trace/export/DisruptorAsyncSpanProcessorTest.java
+++ b/sdk-extensions/async-processor/src/test/java/io/opentelemetry/sdk/extension/trace/export/DisruptorAsyncSpanProcessorTest.java
@@ -9,13 +9,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.common.export.ConfigBuilder;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
@@ -261,15 +259,9 @@ class DisruptorAsyncSpanProcessorTest {
     assertThat(incrementSpanProcessor.getCounterOnShutdown()).isEqualTo(1);
   }
 
-  abstract static class ConfigBuilderTest extends ConfigBuilder<ConfigBuilderTest> {
-    public static NamingConvention getNaming() {
-      return NamingConvention.DOT;
-    }
-  }
-
   @Test
   void configTest() {
-    Map<String, String> options = new HashMap<>();
+    Properties options = new Properties();
     options.put("otel.disruptor.blocking", "false");
     options.put("otel.disruptor.buffer.size", "1234");
     options.put("otel.disruptor.num.retries", "56");
@@ -278,7 +270,7 @@ class DisruptorAsyncSpanProcessorTest {
     DisruptorAsyncSpanProcessor.Builder config =
         DisruptorAsyncSpanProcessor.builder(incrementSpanProcessor);
     DisruptorAsyncSpanProcessor.Builder spy = Mockito.spy(config);
-    spy.fromConfigMap(options, ConfigBuilderTest.getNaming());
+    spy.readProperties(options);
     Mockito.verify(spy).setBlocking(false);
     Mockito.verify(spy).setBufferSize(1234);
   }

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/export/ConfigBuilderTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/export/ConfigBuilderTest.java
@@ -217,7 +217,7 @@ public class ConfigBuilderTest {
     assertThat(ConfigBuilder.getStringProperty("no-key", map)).isNull();
   }
 
-  public static final class ConfigTester extends ConfigBuilder<Map<String, String>> {
+  private static final class ConfigTester extends ConfigBuilder<Map<String, String>> {
 
     public static NamingConvention getNamingDot() {
       return NamingConvention.DOT;

--- a/sdk/metrics/build.gradle
+++ b/sdk/metrics/build.gradle
@@ -19,8 +19,6 @@ dependencies {
     testAnnotationProcessor libraries.auto_value
     testCompileOnly libraries.auto_value_annotation
 
-    testCompile project(path: ':sdk:common', configuration: 'testClasses')
-
     testImplementation libraries.guava
     testImplementation project(':sdk:testing')
     testImplementation libraries.junit_pioneer

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.when;
 import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.common.export.ConfigBuilderTest.ConfigTester;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.Point;
@@ -19,9 +18,8 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -64,11 +62,11 @@ class IntervalMetricReaderTest {
 
   @Test
   void configTest() {
-    Map<String, String> options = new HashMap<>();
+    Properties options = new Properties();
     options.put("otel.imr.export.interval", "12");
     IntervalMetricReader.Builder config = IntervalMetricReader.builder();
     IntervalMetricReader.Builder spy = Mockito.spy(config);
-    spy.fromConfigMap(options, ConfigTester.getNamingDot());
+    spy.readProperties(options);
     Mockito.verify(spy).setExportIntervalMillis(12);
   }
 

--- a/sdk/trace/build.gradle
+++ b/sdk/trace/build.gradle
@@ -21,8 +21,6 @@ dependencies {
     testAnnotationProcessor libraries.auto_value
     testCompileOnly libraries.auto_value_annotation
 
-    testCompile project(path: ':sdk:common', configuration: 'testClasses')
-
     testImplementation libraries.guava
     testImplementation project(':sdk:testing')
     testImplementation libraries.junit_pioneer

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.when;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.common.export.ConfigBuilderTest.ConfigTester;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.TestUtils;
@@ -22,10 +21,8 @@ import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -81,7 +78,7 @@ class BatchSpanProcessorTest {
 
   @Test
   void configTest() {
-    Map<String, String> options = new HashMap<>();
+    Properties options = new Properties();
     options.put("otel.bsp.schedule.delay.millis", "12");
     options.put("otel.bsp.max.queue.size", "34");
     options.put("otel.bsp.max.export.batch.size", "56");
@@ -89,7 +86,7 @@ class BatchSpanProcessorTest {
     options.put("otel.bsp.export.sampled", "false");
     BatchSpanProcessorBuilder config =
         BatchSpanProcessor.builder(new WaitingSpanExporter(0, CompletableResultCode.ofSuccess()))
-            .fromConfigMap(options, ConfigTester.getNamingDot());
+            .readProperties(options);
     assertThat(config.getScheduleDelayMillis()).isEqualTo(12);
     assertThat(config.getMaxQueueSize()).isEqualTo(34);
     assertThat(config.getMaxExportBatchSize()).isEqualTo(56);
@@ -101,7 +98,7 @@ class BatchSpanProcessorTest {
   void configTest_EmptyOptions() {
     BatchSpanProcessorBuilder config =
         BatchSpanProcessor.builder(new WaitingSpanExporter(0, CompletableResultCode.ofSuccess()))
-            .fromConfigMap(Collections.emptyMap(), ConfigTester.getNamingDot());
+            .readProperties(new Properties());
     assertThat(config.getScheduleDelayMillis())
         .isEqualTo(BatchSpanProcessorBuilder.DEFAULT_SCHEDULE_DELAY_MILLIS);
     assertThat(config.getMaxQueueSize())

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
@@ -20,7 +20,6 @@ import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.common.export.ConfigBuilderTest.ConfigTester;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -29,9 +28,7 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessorTest.WaitingSpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -69,19 +66,17 @@ class SimpleSpanProcessorTest {
 
   @Test
   void configTest() {
-    Map<String, String> options = new HashMap<>();
+    Properties options = new Properties();
     options.put("otel.ssp.export.sampled", "false");
     SimpleSpanProcessorBuilder config =
-        SimpleSpanProcessor.builder(spanExporter)
-            .fromConfigMap(options, ConfigTester.getNamingDot());
+        SimpleSpanProcessor.builder(spanExporter).readProperties(options);
     assertThat(config.getExportOnlySampled()).isEqualTo(false);
   }
 
   @Test
   void configTest_EmptyOptions() {
     SimpleSpanProcessorBuilder config =
-        SimpleSpanProcessor.builder(spanExporter)
-            .fromConfigMap(Collections.emptyMap(), ConfigTester.getNamingDot());
+        SimpleSpanProcessor.builder(spanExporter).readProperties(new Properties());
     assertThat(config.getExportOnlySampled())
         .isEqualTo(SimpleSpanProcessorBuilder.DEFAULT_EXPORT_ONLY_SAMPLED);
   }


### PR DESCRIPTION
… annoying pattern of initializing a subclass for testing.