### PR TITLE
Convert the examples to not use the GlobalOpenTelemetry instance.

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -14,7 +14,7 @@ subprojects {
 
     ext {
         opentelemetryVersion = "0.13.1"
-        grpcVersion = '1.30.2'
+        grpcVersion = '1.34.1'
         protobufVersion = '3.11.4'
         protocVersion = protobufVersion
     }

--- a/examples/grpc/src/main/java/io/opentelemetry/example/grpc/HelloWorldClient.java
+++ b/examples/grpc/src/main/java/io/opentelemetry/example/grpc/HelloWorldClient.java
@@ -16,7 +16,6 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.StatusRuntimeException;
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
@@ -41,13 +40,14 @@ public class HelloWorldClient {
   private final Integer serverPort;
   private final GreeterGrpc.GreeterBlockingStub blockingStub;
 
-  OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
+  private static final OpenTelemetry openTelemetry = initTracing();
+
   // OTel API
-  Tracer tracer = openTelemetry.getTracer("io.opentelemetry.example.HelloWorldClient");
+  private Tracer tracer = openTelemetry.getTracer("io.opentelemetry.example.HelloWorldClient");
   // Share context via text headers
-  TextMapPropagator textFormat = openTelemetry.getPropagators().getTextMapPropagator();
+  private TextMapPropagator textFormat = openTelemetry.getPropagators().getTextMapPropagator();
   // Inject context into the gRPC request metadata
-  TextMapPropagator.Setter<Metadata> setter =
+  private TextMapPropagator.Setter<Metadata> setter =
       (carrier, key, value) ->
           carrier.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value);
 
@@ -116,7 +116,7 @@ public class HelloWorldClient {
     }
   }
 
-  private static void initTracing() {
+  private static OpenTelemetry initTracing() {
     // install the W3C Trace Context propagator
     // Get the tracer management instance
     SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder().build();
@@ -124,13 +124,10 @@ public class HelloWorldClient {
     LoggingSpanExporter exporter = new LoggingSpanExporter();
     sdkTracerProvider.addSpanProcessor(SimpleSpanProcessor.builder(exporter).build());
 
-    OpenTelemetrySdk openTelemetrySdk =
-        OpenTelemetrySdk.builder()
-            .setTracerProvider(sdkTracerProvider)
-            .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
-            .build();
-
-    GlobalOpenTelemetry.set(openTelemetrySdk);
+    return OpenTelemetrySdk.builder()
+        .setTracerProvider(sdkTracerProvider)
+        .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+        .build();
   }
 
   /**
@@ -138,7 +135,6 @@ public class HelloWorldClient {
    * greeting.
    */
   public static void main(String[] args) throws Exception {
-    initTracing();
     // Access a service running on the local machine on port 50051
     HelloWorldClient client = new HelloWorldClient("localhost", 50051);
     try {

--- a/examples/grpc/src/main/java/io/opentelemetry/example/grpc/HelloWorldClient.java
+++ b/examples/grpc/src/main/java/io/opentelemetry/example/grpc/HelloWorldClient.java
@@ -40,7 +40,7 @@ public class HelloWorldClient {
   private final Integer serverPort;
   private final GreeterGrpc.GreeterBlockingStub blockingStub;
 
-  private static final OpenTelemetry openTelemetry = initTracing();
+  private static final OpenTelemetry openTelemetry = initOpenTelemetry();
 
   // OTel API
   private Tracer tracer = openTelemetry.getTracer("io.opentelemetry.example.HelloWorldClient");
@@ -116,7 +116,7 @@ public class HelloWorldClient {
     }
   }
 
-  private static OpenTelemetry initTracing() {
+  private static OpenTelemetry initOpenTelemetry() {
     // install the W3C Trace Context propagator
     // Get the tracer management instance
     SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder().build();

--- a/examples/grpc/src/main/java/io/opentelemetry/example/grpc/HelloWorldClientStream.java
+++ b/examples/grpc/src/main/java/io/opentelemetry/example/grpc/HelloWorldClientStream.java
@@ -47,7 +47,7 @@ public class HelloWorldClientStream {
   // Export spans as log entries
   private static final LoggingSpanExporter exporter = new LoggingSpanExporter();
   // OTel API
-  private static final OpenTelemetry openTelemetry = initTracing(exporter);
+  private static final OpenTelemetry openTelemetry = initOpenTelemetry(exporter);
 
   private final Tracer tracer =
       openTelemetry.getTracer("io.opentelemetry.example.HelloWorldClient");
@@ -162,7 +162,7 @@ public class HelloWorldClientStream {
     }
   }
 
-  private static OpenTelemetry initTracing(LoggingSpanExporter exporter) {
+  private static OpenTelemetry initOpenTelemetry(LoggingSpanExporter exporter) {
     // install the W3C Trace Context propagator
     // Get the tracer management instance
     SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder().build();

--- a/examples/grpc/src/main/java/io/opentelemetry/example/grpc/HelloWorldClientStream.java
+++ b/examples/grpc/src/main/java/io/opentelemetry/example/grpc/HelloWorldClientStream.java
@@ -49,11 +49,11 @@ public class HelloWorldClientStream {
   // OTel API
   private static final OpenTelemetry openTelemetry = initTracing(exporter);
 
-  private final Tracer tracer = openTelemetry
-      .getTracer("io.opentelemetry.example.HelloWorldClient");
+  private final Tracer tracer =
+      openTelemetry.getTracer("io.opentelemetry.example.HelloWorldClient");
   // Share context via text headers
-  private final TextMapPropagator textFormat = openTelemetry.getPropagators()
-      .getTextMapPropagator();
+  private final TextMapPropagator textFormat =
+      openTelemetry.getPropagators().getTextMapPropagator();
   // Inject context into the gRPC request metadata
   private final TextMapPropagator.Setter<Metadata> setter =
       (carrier, key, value) ->

--- a/examples/grpc/src/main/java/io/opentelemetry/example/grpc/HelloWorldServer.java
+++ b/examples/grpc/src/main/java/io/opentelemetry/example/grpc/HelloWorldServer.java
@@ -36,7 +36,7 @@ public class HelloWorldServer {
 
   private static final int PORT = 50051;
   private static final LoggingSpanExporter exporter = new LoggingSpanExporter();
-  private static final OpenTelemetry openTelemetry = initTracing(exporter);
+  private static final OpenTelemetry openTelemetry = initOpenTelemetry(exporter);
 
   private Server server;
 
@@ -166,7 +166,7 @@ public class HelloWorldServer {
     }
   }
 
-  private static OpenTelemetry initTracing(LoggingSpanExporter exporter) {
+  private static OpenTelemetry initOpenTelemetry(LoggingSpanExporter exporter) {
     SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder().build();
     // Set to process the the spans by the LogExporter
     sdkTracerProvider.addSpanProcessor(SimpleSpanProcessor.builder(exporter).build());

--- a/examples/http/src/main/java/io/opentelemetry/example/http/HttpClient.java
+++ b/examples/http/src/main/java/io/opentelemetry/example/http/HttpClient.java
@@ -31,7 +31,7 @@ public class HttpClient {
 
   // OTel API
   private static final LoggingSpanExporter loggingExporter = new LoggingSpanExporter();
-  private static final OpenTelemetry openTelemetry = initTracing(loggingExporter);
+  private static final OpenTelemetry openTelemetry = initOpenTelemetry(loggingExporter);
   private static final Tracer tracer =
       openTelemetry.getTracer("io.opentelemetry.example.http.HttpClient");
   // Export traces to log
@@ -39,7 +39,7 @@ public class HttpClient {
   private static final TextMapPropagator.Setter<HttpURLConnection> setter =
       URLConnection::setRequestProperty;
 
-  private static OpenTelemetry initTracing(LoggingSpanExporter loggingExporter) {
+  private static OpenTelemetry initOpenTelemetry(LoggingSpanExporter loggingExporter) {
     // install the W3C Trace Context propagator
     // Get the tracer management instance
     SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder().build();

--- a/examples/http/src/main/java/io/opentelemetry/example/http/HttpClient.java
+++ b/examples/http/src/main/java/io/opentelemetry/example/http/HttpClient.java
@@ -5,11 +5,11 @@
 
 package io.opentelemetry.example.http;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.attributes.SemanticAttributes;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
@@ -30,28 +30,26 @@ import java.nio.charset.Charset;
 public class HttpClient {
 
   // OTel API
-  private static final Tracer tracer =
-      OpenTelemetry.getGlobalTracer("io.opentelemetry.example.http.HttpClient");
-  // Export traces to log
   private static final LoggingSpanExporter loggingExporter = new LoggingSpanExporter();
+  private static final OpenTelemetry openTelemetry = initTracing(loggingExporter);
+  private static final Tracer tracer =
+      openTelemetry.getTracer("io.opentelemetry.example.http.HttpClient");
+  // Export traces to log
   // Inject the span context into the request
   private static final TextMapPropagator.Setter<HttpURLConnection> setter =
       URLConnection::setRequestProperty;
 
-  private static void initTracing() {
+  private static OpenTelemetry initTracing(LoggingSpanExporter loggingExporter) {
     // install the W3C Trace Context propagator
     // Get the tracer management instance
     SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder().build();
     // Set to process the the spans by the LogExporter
     sdkTracerProvider.addSpanProcessor(SimpleSpanProcessor.builder(loggingExporter).build());
 
-    OpenTelemetrySdk openTelemetrySdk =
-        OpenTelemetrySdk.builder()
-            .setTracerProvider(sdkTracerProvider)
-            .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
-            .build();
-
-    GlobalOpenTelemetry.set(openTelemetrySdk);
+    return OpenTelemetrySdk.builder()
+        .setTracerProvider(sdkTracerProvider)
+        .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+        .build();
   }
 
   private void makeRequest() throws IOException {
@@ -66,9 +64,8 @@ public class HttpClient {
     // See: https://github.com/open-telemetry/opentelemetry-specification/issues/270
     Span span = tracer.spanBuilder("/").setSpanKind(Span.Kind.CLIENT).startSpan();
     try (Scope scope = span.makeCurrent()) {
-      // TODO provide semantic convention attributes to Span.Builder
+      span.setAttribute(SemanticAttributes.HTTP_METHOD, "GET");
       span.setAttribute("component", "http");
-      span.setAttribute("http.method", "GET");
       /*
        Only one of the following is required:
          - http.url
@@ -76,10 +73,10 @@ public class HttpClient {
          - http.scheme, peer.hostname, peer.port, http.target
          - http.scheme, peer.ip, peer.port, http.target
       */
-      span.setAttribute("http.url", url.toString());
+      span.setAttribute(SemanticAttributes.HTTP_URL, url.toString());
 
       // Inject the request with the current Context/Span.
-      GlobalOpenTelemetry.getPropagators()
+      openTelemetry.getPropagators()
           .getTextMapPropagator()
           .inject(Context.current(), con, setter);
 
@@ -113,7 +110,6 @@ public class HttpClient {
    * @param args It is not required.
    */
   public static void main(String[] args) {
-    initTracing();
     HttpClient httpClient = new HttpClient();
 
     // Perform request every 5s

--- a/examples/http/src/main/java/io/opentelemetry/example/http/HttpClient.java
+++ b/examples/http/src/main/java/io/opentelemetry/example/http/HttpClient.java
@@ -76,9 +76,7 @@ public class HttpClient {
       span.setAttribute(SemanticAttributes.HTTP_URL, url.toString());
 
       // Inject the request with the current Context/Span.
-      openTelemetry.getPropagators()
-          .getTextMapPropagator()
-          .inject(Context.current(), con, setter);
+      openTelemetry.getPropagators().getTextMapPropagator().inject(Context.current(), con, setter);
 
       try {
         // Process the request

--- a/examples/http/src/main/java/io/opentelemetry/example/http/HttpServer.java
+++ b/examples/http/src/main/java/io/opentelemetry/example/http/HttpServer.java
@@ -33,7 +33,6 @@ public class HttpServer {
   private static final Tracer tracer =
       openTelemetry.getTracer("io.opentelemetry.example.http.HttpServer");
 
-
   private static final int port = 8080;
   private final com.sun.net.httpserver.HttpServer server;
 
@@ -85,7 +84,8 @@ public class HttpServer {
     public void handle(HttpExchange exchange) throws IOException {
       // Extract the context from the HTTP request
       Context context =
-          openTelemetry.getPropagators()
+          openTelemetry
+              .getPropagators()
               .getTextMapPropagator()
               .extract(Context.current(), exchange, getter);
 

--- a/examples/http/src/main/java/io/opentelemetry/example/http/HttpServer.java
+++ b/examples/http/src/main/java/io/opentelemetry/example/http/HttpServer.java
@@ -29,7 +29,7 @@ import java.nio.charset.Charset;
 
 public class HttpServer {
   // OTel API
-  private static final OpenTelemetry openTelemetry = initTracing(new LoggingSpanExporter());
+  private static final OpenTelemetry openTelemetry = initOpenTelemetry(new LoggingSpanExporter());
   private static final Tracer tracer =
       openTelemetry.getTracer("io.opentelemetry.example.http.HttpServer");
 
@@ -65,7 +65,7 @@ public class HttpServer {
     System.out.println("Server ready on http://127.0.0.1:" + port);
   }
 
-  private static OpenTelemetry initTracing(LoggingSpanExporter loggingExporter) {
+  private static OpenTelemetry initOpenTelemetry(LoggingSpanExporter loggingExporter) {
     // install the W3C Trace Context propagator
     // Get the tracer management instance
     SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder().build();

--- a/examples/jaeger/src/main/java/io/opentelemetry/example/jaeger/JaegerExample.java
+++ b/examples/jaeger/src/main/java/io/opentelemetry/example/jaeger/JaegerExample.java
@@ -16,12 +16,12 @@ public class JaegerExample {
   private final Tracer tracer;
 
   public JaegerExample(String ip, int port) {
-    OpenTelemetrySdk sdk = setupTracing(ip, port);
+    OpenTelemetrySdk sdk = initOpenTelemetry(ip, port);
     this.sdkTracerManagement = sdk.getTracerManagement();
     tracer = sdk.getTracer("io.opentelemetry.example.JaegerExample");
   }
 
-  private OpenTelemetrySdk setupTracing(String ip, int port) {
+  private OpenTelemetrySdk initOpenTelemetry(String ip, int port) {
     // Create a channel towards Jaeger end point
     ManagedChannel jaegerChannel =
         ManagedChannelBuilder.forAddress(ip, port).usePlaintext().build();
@@ -78,7 +78,7 @@ public class JaegerExample {
 
     // Start the example
     JaegerExample example = new JaegerExample(ip, port);
-    example.setupTracing(ip, port);
+    example.initOpenTelemetry(ip, port);
     // generate a few sample spans
     for (int i = 0; i < 10; i++) {
       example.myWonderfulUseCase();

--- a/examples/jaeger/src/main/java/io/opentelemetry/example/jaeger/JaegerExample.java
+++ b/examples/jaeger/src/main/java/io/opentelemetry/example/jaeger/JaegerExample.java
@@ -36,7 +36,8 @@ public class JaegerExample {
 
     // Set to process the spans by the Jaeger Exporter
     OpenTelemetrySdk openTelemetry = OpenTelemetrySdk.builder().build();
-    openTelemetry.getTracerManagement()
+    openTelemetry
+        .getTracerManagement()
         .addSpanProcessor(SimpleSpanProcessor.builder(jaegerExporter).build());
     return openTelemetry;
   }
@@ -61,7 +62,8 @@ public class JaegerExample {
 
   // graceful shutdown
   public void shutdown() {
-    //note: this doesn't wait for everything to get cleaned up. We need an SDK update to enable that.
+    // note: this doesn't wait for everything to get cleaned up. We need an SDK update to enable
+    // that.
     sdkTracerManagement.shutdown();
   }
 

--- a/examples/jaeger/src/main/java/io/opentelemetry/example/jaeger/JaegerExample.java
+++ b/examples/jaeger/src/main/java/io/opentelemetry/example/jaeger/JaegerExample.java
@@ -2,29 +2,26 @@ package io.opentelemetry.example.jaeger;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.trace.SdkTracerManagement;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 
 public class JaegerExample {
 
-  // Jaeger Endpoint URL and PORT
-  private final String ip; // = "jaeger";
-  private final int port; // = 14250;
-
   // OTel API
-  private final Tracer tracer =
-      OpenTelemetry.getGlobalTracer("io.opentelemetry.example.JaegerExample");
+  private final SdkTracerManagement sdkTracerManagement;
+  private final Tracer tracer;
 
   public JaegerExample(String ip, int port) {
-    this.ip = ip;
-    this.port = port;
+    OpenTelemetrySdk sdk = setupTracing(ip, port);
+    this.sdkTracerManagement = sdk.getTracerManagement();
+    tracer = sdk.getTracer("io.opentelemetry.example.JaegerExample");
   }
 
-  private void setupJaegerExporter() {
+  private OpenTelemetrySdk setupTracing(String ip, int port) {
     // Create a channel towards Jaeger end point
     ManagedChannel jaegerChannel =
         ManagedChannelBuilder.forAddress(ip, port).usePlaintext().build();
@@ -38,8 +35,10 @@ public class JaegerExample {
             .build();
 
     // Set to process the spans by the Jaeger Exporter
-    OpenTelemetrySdk.getGlobalTracerManagement()
+    OpenTelemetrySdk openTelemetry = OpenTelemetrySdk.builder().build();
+    openTelemetry.getTracerManagement()
         .addSpanProcessor(SimpleSpanProcessor.builder(jaegerExporter).build());
+    return openTelemetry;
   }
 
   private void myWonderfulUseCase() {
@@ -62,7 +61,8 @@ public class JaegerExample {
 
   // graceful shutdown
   public void shutdown() {
-    OpenTelemetrySdk.getGlobalTracerManagement().shutdown();
+    //note: this doesn't wait for everything to get cleaned up. We need an SDK update to enable that.
+    sdkTracerManagement.shutdown();
   }
 
   public static void main(String[] args) {
@@ -76,7 +76,7 @@ public class JaegerExample {
 
     // Start the example
     JaegerExample example = new JaegerExample(ip, port);
-    example.setupJaegerExporter();
+    example.setupTracing(ip, port);
     // generate a few sample spans
     for (int i = 0; i < 10; i++) {
       example.myWonderfulUseCase();

--- a/examples/metrics/src/main/java/io/opentelemetry/example/metrics/DoubleCounterExample.java
+++ b/examples/metrics/src/main/java/io/opentelemetry/example/metrics/DoubleCounterExample.java
@@ -1,6 +1,7 @@
 package io.opentelemetry.example.metrics;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.DefaultOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.metrics.DoubleCounter;
 import io.opentelemetry.api.metrics.GlobalMetricsProvider;
@@ -20,11 +21,11 @@ import javax.swing.filechooser.FileSystemView;
  * extensions.
  */
 public class DoubleCounterExample {
-
+  private static final OpenTelemetry openTelemetry = DefaultOpenTelemetry.builder().build();
   private static final Tracer tracer =
-      GlobalOpenTelemetry.getTracer("io.opentelemetry.example.metrics", "0.5");
+      openTelemetry.getTracer("io.opentelemetry.example.metrics", "0.31.1");
   private static final Meter sampleMeter =
-      GlobalMetricsProvider.get().get("io.opentelemetry.example.metrics", "0.5");
+      GlobalMetricsProvider.get().get("io.opentelemetry.example.metrics", "0.13.1");
   private static final File directoryToCountIn =
       FileSystemView.getFileSystemView().getHomeDirectory();
   private static final DoubleCounter diskSpaceCounter =

--- a/examples/metrics/src/main/java/io/opentelemetry/example/metrics/DoubleCounterExample.java
+++ b/examples/metrics/src/main/java/io/opentelemetry/example/metrics/DoubleCounterExample.java
@@ -23,7 +23,7 @@ import javax.swing.filechooser.FileSystemView;
 public class DoubleCounterExample {
   private static final OpenTelemetry openTelemetry = DefaultOpenTelemetry.builder().build();
   private static final Tracer tracer =
-      openTelemetry.getTracer("io.opentelemetry.example.metrics", "0.31.1");
+      openTelemetry.getTracer("io.opentelemetry.example.metrics", "0.13.1");
   private static final Meter sampleMeter =
       GlobalMetricsProvider.get().get("io.opentelemetry.example.metrics", "0.13.1");
   private static final File directoryToCountIn =

--- a/examples/metrics/src/main/java/io/opentelemetry/example/metrics/LongCounterExample.java
+++ b/examples/metrics/src/main/java/io/opentelemetry/example/metrics/LongCounterExample.java
@@ -1,6 +1,7 @@
 package io.opentelemetry.example.metrics;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.DefaultOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.metrics.GlobalMetricsProvider;
 import io.opentelemetry.api.metrics.LongCounter;
@@ -19,11 +20,12 @@ import javax.swing.filechooser.FileSystemView;
  * directories.
  */
 public class LongCounterExample {
-
+  private static final OpenTelemetry openTelemetry = DefaultOpenTelemetry.builder().build();
   private static final Tracer tracer =
-      GlobalOpenTelemetry.getTracer("io.opentelemetry.example.metrics", "0.5");
+      openTelemetry.getTracer("io.opentelemetry.example.metrics", "0.13.1");
+
   private static final Meter sampleMeter =
-      GlobalMetricsProvider.getMeter("io.opentelemetry.example.metrics", "0.5");
+      GlobalMetricsProvider.getMeter("io.opentelemetry.example.metrics", "0.13.1");
   private static final LongCounter directoryCounter =
       sampleMeter
           .longCounterBuilder("directories_search_count")

--- a/examples/metrics/src/main/java/io/opentelemetry/example/metrics/LongValueObserverExample.java
+++ b/examples/metrics/src/main/java/io/opentelemetry/example/metrics/LongValueObserverExample.java
@@ -2,6 +2,7 @@ package io.opentelemetry.example.metrics;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Labels;
+import io.opentelemetry.api.metrics.GlobalMetricsProvider;
 import io.opentelemetry.api.metrics.LongValueObserver;
 import io.opentelemetry.api.metrics.Meter;
 
@@ -13,7 +14,7 @@ import io.opentelemetry.api.metrics.Meter;
 public class LongValueObserverExample {
 
   public static void main(String[] args) {
-    Meter sampleMeter = OpenTelemetry.getGlobalMeter("io.opentelemetry.example.metrics", "0.5");
+    Meter sampleMeter = GlobalMetricsProvider.getMeter("io.opentelemetry.example.metrics", "0.13.1");
     LongValueObserver observer =
         sampleMeter
             .longValueObserverBuilder("jvm.memory.total")

--- a/examples/metrics/src/main/java/io/opentelemetry/example/metrics/LongValueObserverExample.java
+++ b/examples/metrics/src/main/java/io/opentelemetry/example/metrics/LongValueObserverExample.java
@@ -1,6 +1,5 @@
 package io.opentelemetry.example.metrics;
 
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.metrics.GlobalMetricsProvider;
 import io.opentelemetry.api.metrics.LongValueObserver;
@@ -14,7 +13,8 @@ import io.opentelemetry.api.metrics.Meter;
 public class LongValueObserverExample {
 
   public static void main(String[] args) {
-    Meter sampleMeter = GlobalMetricsProvider.getMeter("io.opentelemetry.example.metrics", "0.13.1");
+    Meter sampleMeter =
+        GlobalMetricsProvider.getMeter("io.opentelemetry.example.metrics", "0.13.1");
     LongValueObserver observer =
         sampleMeter
             .longValueObserverBuilder("jvm.memory.total")

--- a/examples/otlp/src/main/java/io/opentelemetry/example/otlp/OtlpExporterExample.java
+++ b/examples/otlp/src/main/java/io/opentelemetry/example/otlp/OtlpExporterExample.java
@@ -6,15 +6,19 @@
 package io.opentelemetry.example.otlp;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.GlobalMetricsProvider;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.export.IntervalMetricReader;
+import io.opentelemetry.sdk.trace.SdkTracerManagement;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import java.util.Collections;
 
@@ -26,6 +30,18 @@ import java.util.Collections;
  * of this module.
  */
 public class OtlpExporterExample {
+  private static SdkTracerManagement tracerManagement;
+
+  private static OpenTelemetry initTracing() {
+    OtlpGrpcSpanExporter spanExporter = OtlpGrpcSpanExporter.getDefault();
+    BatchSpanProcessor spanProcessor =
+        BatchSpanProcessor.builder(spanExporter).setScheduleDelayMillis(100).build();
+
+    OpenTelemetrySdk openTelemetrySdk = OpenTelemetrySdk.builder().build();
+    openTelemetrySdk.getTracerManagement().addSpanProcessor(spanProcessor);
+    tracerManagement = openTelemetrySdk.getTracerManagement();
+    return openTelemetrySdk;
+  }
 
   public static void main(String[] args) throws InterruptedException {
     // this will make sure that a proper service.name attribute is set on all the spans/metrics.
@@ -34,24 +50,26 @@ public class OtlpExporterExample {
     System.setProperty("otel.resource.attributes", "service.name=OtlpExporterExample");
 
     // set up the span exporter and wire it into the SDK
-    OtlpGrpcSpanExporter spanExporter = OtlpGrpcSpanExporter.getDefault();
-    BatchSpanProcessor spanProcessor =
-        BatchSpanProcessor.builder(spanExporter).setScheduleDelayMillis(100).build();
-    OpenTelemetrySdk.getGlobalTracerManagement().addSpanProcessor(spanProcessor);
+    OpenTelemetry openTelemetry = initTracing();
+    Tracer tracer = openTelemetry.getTracer("io.opentelemetry.example");
 
     // set up the metric exporter and wire it into the SDK and a timed reader.
     OtlpGrpcMetricExporter metricExporter = OtlpGrpcMetricExporter.getDefault();
+
+    //note: currently metrics is alpha and the configuration story is still unfolding. This will
+    // definitely change in the future.
+    MeterProvider meterProvider = GlobalMetricsProvider.get();
+    SdkMeterProvider sdkMeterProvider = (SdkMeterProvider) meterProvider;
     IntervalMetricReader intervalMetricReader =
         IntervalMetricReader.builder()
             .setMetricExporter(metricExporter)
             .setMetricProducers(
                 Collections.singleton(
-                    OpenTelemetrySdk.getGlobalMeterProvider().getMetricProducer()))
+                    sdkMeterProvider.getMetricProducer()))
             .setExportIntervalMillis(500)
             .build();
 
-    Tracer tracer = OpenTelemetry.getGlobalTracer("io.opentelemetry.example");
-    Meter meter = OpenTelemetry.getGlobalMeter("io.opentelemetry.example");
+    Meter meter = meterProvider.get("io.opentelemetry.example");
     LongCounter counter = meter.longCounterBuilder("example_counter").build();
 
     for (int i = 0; i < 10; i++) {
@@ -69,7 +87,7 @@ public class OtlpExporterExample {
     // sleep for a bit to let everything settle
     Thread.sleep(2000);
 
-    OpenTelemetrySdk.getGlobalTracerManagement().shutdown();
+    tracerManagement.shutdown();
     intervalMetricReader.shutdown();
   }
 }

--- a/examples/otlp/src/main/java/io/opentelemetry/example/otlp/OtlpExporterExample.java
+++ b/examples/otlp/src/main/java/io/opentelemetry/example/otlp/OtlpExporterExample.java
@@ -56,16 +56,14 @@ public class OtlpExporterExample {
     // set up the metric exporter and wire it into the SDK and a timed reader.
     OtlpGrpcMetricExporter metricExporter = OtlpGrpcMetricExporter.getDefault();
 
-    //note: currently metrics is alpha and the configuration story is still unfolding. This will
+    // note: currently metrics is alpha and the configuration story is still unfolding. This will
     // definitely change in the future.
     MeterProvider meterProvider = GlobalMetricsProvider.get();
     SdkMeterProvider sdkMeterProvider = (SdkMeterProvider) meterProvider;
     IntervalMetricReader intervalMetricReader =
         IntervalMetricReader.builder()
             .setMetricExporter(metricExporter)
-            .setMetricProducers(
-                Collections.singleton(
-                    sdkMeterProvider.getMetricProducer()))
+            .setMetricProducers(Collections.singleton(sdkMeterProvider.getMetricProducer()))
             .setExportIntervalMillis(500)
             .build();
 

--- a/examples/otlp/src/main/java/io/opentelemetry/example/otlp/OtlpExporterExample.java
+++ b/examples/otlp/src/main/java/io/opentelemetry/example/otlp/OtlpExporterExample.java
@@ -32,7 +32,7 @@ import java.util.Collections;
 public class OtlpExporterExample {
   private static SdkTracerManagement tracerManagement;
 
-  private static OpenTelemetry initTracing() {
+  private static OpenTelemetry initOpenTelemetry() {
     OtlpGrpcSpanExporter spanExporter = OtlpGrpcSpanExporter.getDefault();
     BatchSpanProcessor spanProcessor =
         BatchSpanProcessor.builder(spanExporter).setScheduleDelayMillis(100).build();
@@ -50,7 +50,7 @@ public class OtlpExporterExample {
     System.setProperty("otel.resource.attributes", "service.name=OtlpExporterExample");
 
     // set up the span exporter and wire it into the SDK
-    OpenTelemetry openTelemetry = initTracing();
+    OpenTelemetry openTelemetry = initOpenTelemetry();
     Tracer tracer = openTelemetry.getTracer("io.opentelemetry.example");
 
     // set up the metric exporter and wire it into the SDK and a timed reader.

--- a/examples/prometheus/src/main/java/io/opentelemetry/example/prometheus/PrometheusExample.java
+++ b/examples/prometheus/src/main/java/io/opentelemetry/example/prometheus/PrometheusExample.java
@@ -22,12 +22,11 @@ import java.util.concurrent.ThreadLocalRandom;
 public class PrometheusExample {
 
   private final MeterProvider meterSdkProvider = GlobalMetricsProvider.get();
-  private final Meter meter = meterSdkProvider.get("PrometheusExample", "0.7");
+  private final Meter meter = meterSdkProvider.get("PrometheusExample", "0.13.1");
   private final HTTPServer server;
   private long incomingMessageCount;
 
   public PrometheusExample(int port) throws IOException {
-
     LongValueObserver observer =
         meter
             .longValueObserverBuilder("incoming.messages")

--- a/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureSpanProcessorExample.java
+++ b/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureSpanProcessorExample.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.sdk.example;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -17,15 +16,14 @@ import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 /** This example shows how to instantiate different Span Processors. */
 public class ConfigureSpanProcessorExample {
 
-  static LoggingSpanExporter exporter = new LoggingSpanExporter();
-
-  // Get the Tracer Provider
-  static SdkTracerManagement tracerProvider = OpenTelemetrySdk.getGlobalTracerManagement();
+  private static final LoggingSpanExporter exporter = new LoggingSpanExporter();
+  private static final OpenTelemetrySdk openTelemetry = OpenTelemetrySdk.builder().build();
+  // Get the Tracer Management interface
+  private static final SdkTracerManagement tracerManagement = openTelemetry.getTracerManagement();
   // Acquire a tracer
-  static Tracer tracer = GlobalOpenTelemetry.getTracer("ConfigureSpanProcessorExample");
+  private static final Tracer tracer = openTelemetry.getTracer("ConfigureSpanProcessorExample");
 
   public static void main(String[] args) {
-
     // Example how to configure the default SpanProcessors.
     defaultSpanProcessors();
     // After this method, the following SpanProcessors are registered:
@@ -42,7 +40,7 @@ public class ConfigureSpanProcessorExample {
     // When exiting, it is recommended to call the shutdown method. This method calls `shutdown` on
     // all configured SpanProcessors. This way, the configured exporters can release all resources
     // and terminate their job sending the remaining traces to their back end.
-    tracerProvider.shutdown();
+    tracerManagement.shutdown();
   }
 
   private static void defaultSpanProcessors() {
@@ -56,7 +54,7 @@ public class ConfigureSpanProcessorExample {
     // Configure the simple spans processor. This span processor exports span immediately after they
     // are ended.
     SimpleSpanProcessor simpleSpansProcessor = SimpleSpanProcessor.builder(exporter).build();
-    tracerProvider.addSpanProcessor(simpleSpansProcessor);
+    tracerManagement.addSpanProcessor(simpleSpansProcessor);
 
     // Configure the batch spans processor. This span processor exports span in batches.
     BatchSpanProcessor batchSpansProcessor =
@@ -69,12 +67,12 @@ public class ConfigureSpanProcessorExample {
             // interrupted
             .setScheduleDelayMillis(5000) // set time between two different exports
             .build();
-    tracerProvider.addSpanProcessor(batchSpansProcessor);
+    tracerManagement.addSpanProcessor(batchSpansProcessor);
 
     // Configure the composite span processor. A Composite SpanProcessor accepts a list of Span
     // Processors.
     SpanProcessor multiSpanProcessor =
         SpanProcessor.composite(simpleSpansProcessor, batchSpansProcessor);
-    tracerProvider.addSpanProcessor(multiSpanProcessor);
+    tracerManagement.addSpanProcessor(multiSpanProcessor);
   }
 }

--- a/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureTraceExample.java
+++ b/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureTraceExample.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.sdk.example;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Span.Kind;
@@ -24,8 +24,10 @@ import java.util.List;
 class ConfigureTraceExample {
 
   // Configure a tracer for these examples
-  static SdkTracerManagement tracerManagement = OpenTelemetrySdk.getGlobalTracerManagement();
-  static Tracer tracer = GlobalOpenTelemetry.getTracer("ConfigureTraceExample");
+  private static final OpenTelemetry openTelemetry = OpenTelemetrySdk.builder().build();
+  private static final SdkTracerManagement tracerManagement = ((OpenTelemetrySdk) openTelemetry)
+      .getTracerManagement();
+  private static final Tracer tracer = openTelemetry.getTracer("ConfigureTraceExample");
 
   static {
     tracerManagement.addSpanProcessor(
@@ -33,8 +35,7 @@ class ConfigureTraceExample {
   }
 
   public static void main(String[] args) {
-
-    // TraceConfig handles the global tracing configuration
+    // TraceConfig handles the tracing configuration
     printTraceConfig();
 
     // OpenTelemetry has a maximum of 32 Attributes by default for Spans, Links, and Events.

--- a/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureTraceExample.java
+++ b/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureTraceExample.java
@@ -25,8 +25,8 @@ class ConfigureTraceExample {
 
   // Configure a tracer for these examples
   private static final OpenTelemetry openTelemetry = OpenTelemetrySdk.builder().build();
-  private static final SdkTracerManagement tracerManagement = ((OpenTelemetrySdk) openTelemetry)
-      .getTracerManagement();
+  private static final SdkTracerManagement tracerManagement =
+      ((OpenTelemetrySdk) openTelemetry).getTracerManagement();
   private static final Tracer tracer = openTelemetry.getTracer("ConfigureTraceExample");
 
   static {

--- a/examples/zipkin/src/main/java/io/opentelemetry/example/zipkin/ZipkinExample.java
+++ b/examples/zipkin/src/main/java/io/opentelemetry/example/zipkin/ZipkinExample.java
@@ -19,10 +19,10 @@ public class ZipkinExample {
   // Name of the service
   private static final String SERVICE_NAME = "myExampleService";
 
-  //SDK Tracer Management interface
+  // SDK Tracer Management interface
   private SdkTracerManagement sdkTracerManagement;
 
-  //The Tracer we'll use for the example
+  // The Tracer we'll use for the example
   private Tracer tracer;
 
   public ZipkinExample(String ip, int port) {

--- a/examples/zipkin/src/main/java/io/opentelemetry/example/zipkin/ZipkinExample.java
+++ b/examples/zipkin/src/main/java/io/opentelemetry/example/zipkin/ZipkinExample.java
@@ -1,10 +1,10 @@
 package io.opentelemetry.example.zipkin;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.trace.SdkTracerManagement;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 
 public class ZipkinExample {
@@ -14,14 +14,16 @@ public class ZipkinExample {
   private int port; // port of the zipkin backend server
 
   // Zipkin API Endpoints for uploading spans
-  private static final String ENDPOINT_V1_SPANS = "/api/v1/spans";
   private static final String ENDPOINT_V2_SPANS = "/api/v2/spans";
 
   // Name of the service
   private static final String SERVICE_NAME = "myExampleService";
 
-  private final Tracer tracer =
-      GlobalOpenTelemetry.getTracer("io.opentelemetry.example.ZipkinExample");
+  //SDK Tracer Management interface
+  private SdkTracerManagement sdkTracerManagement;
+
+  //The Tracer we'll use for the example
+  private Tracer tracer;
 
   public ZipkinExample(String ip, int port) {
     this.ip = ip;
@@ -30,7 +32,9 @@ public class ZipkinExample {
 
   // This method adds SimpleSpanProcessor initialized with ZipkinSpanExporter to the
   // TracerSdkProvider
-  public void setupZipkinExporter() {
+  private void setupZipkinExporter() {
+    OpenTelemetrySdk sdk = OpenTelemetrySdk.builder().build();
+
     String httpUrl = String.format("http://%s:%s", ip, port);
     ZipkinSpanExporter zipkinExporter =
         ZipkinSpanExporter.builder()
@@ -38,9 +42,12 @@ public class ZipkinExample {
             .setServiceName(SERVICE_NAME)
             .build();
 
+    // save the management interface so we can shut it down at the end of the example.
+    this.sdkTracerManagement = sdk.getTracerManagement();
     // Set to process the spans by the Zipkin Exporter
-    OpenTelemetrySdk.getGlobalTracerManagement()
-        .addSpanProcessor(SimpleSpanProcessor.builder(zipkinExporter).build());
+    sdkTracerManagement.addSpanProcessor(SimpleSpanProcessor.builder(zipkinExporter).build());
+
+    tracer = sdk.getTracer("io.opentelemetry.example.ZipkinExample");
   }
 
   // This method instruments doWork() method
@@ -66,7 +73,7 @@ public class ZipkinExample {
 
   // graceful shutdown
   public void shutdown() {
-    OpenTelemetrySdk.getGlobalTracerManagement().shutdown();
+    sdkTracerManagement.shutdown();
   }
 
   public static void main(String[] args) {


### PR DESCRIPTION
I think there is probably still work to be done on cleaning up the story in these examples, since SDK and API usage tends to be mixed together in unfortunate ways.