### PR TITLE
Migrate assertThrows -> assertThatThrownBy

### DIFF
--- a/api/all/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -101,7 +101,8 @@ class OpenTelemetryTest {
   @Test
   void testTracerNotFound() {
     System.setProperty(TracerProviderFactory.class.getName(), "io.does.not.exists");
-    assertThrows(IllegalStateException.class, () -> GlobalOpenTelemetry.getTracer("testTracer"));
+    assertThatThrownBy(() -> GlobalOpenTelemetry.getTracer("testTracer"))
+        .isInstanceOf(IllegalStateException.class);
   }
 
   @Test

--- a/api/baggage/src/test/java/io/opentelemetry/api/baggage/ImmutableBaggageTest.java
+++ b/api/baggage/src/test/java/io/opentelemetry/api/baggage/ImmutableBaggageTest.java
@@ -6,8 +6,8 @@
 package io.opentelemetry.api.baggage;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.testing.EqualsTester;
 import io.opentelemetry.context.Context;
@@ -127,7 +127,8 @@ class ImmutableBaggageTest {
 
   @Test
   void setParent_nullContext() {
-    assertThrows(NullPointerException.class, () -> Baggage.builder().setParent(null));
+    assertThatThrownBy(() -> Baggage.builder().setParent(null))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test

--- a/api/common/src/test/java/io/opentelemetry/api/internal/UtilsTest.java
+++ b/api/common/src/test/java/io/opentelemetry/api/internal/UtilsTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.api.internal;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
@@ -15,9 +15,8 @@ class UtilsTest {
   @Test
   void checkArgument() {
     Utils.checkArgument(true, TEST_MESSAGE);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> Utils.checkArgument(false, TEST_MESSAGE),
-        TEST_MESSAGE);
+    assertThatThrownBy(() -> Utils.checkArgument(false, TEST_MESSAGE))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(TEST_MESSAGE);
   }
 }

--- a/api/context/src/test/java/io/opentelemetry/context/propagation/DefaultPropagatorsTest.java
+++ b/api/context/src/test/java/io/opentelemetry/context/propagation/DefaultPropagatorsTest.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.context.propagation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
@@ -21,7 +21,8 @@ class DefaultPropagatorsTest {
 
   @Test
   void addTextMapPropagatorNull() {
-    assertThrows(NullPointerException.class, () -> ContextPropagators.create(null));
+    assertThatThrownBy(() -> ContextPropagators.create(null))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test

--- a/api/metrics/src/test/java/io/opentelemetry/api/metrics/BatchRecorderTest.java
+++ b/api/metrics/src/test/java/io/opentelemetry/api/metrics/BatchRecorderTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.api.metrics;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,61 +14,58 @@ class BatchRecorderTest {
 
   @Test
   void testNewBatchRecorder_WrongNumberOfLabels() {
-    assertThrows(IllegalArgumentException.class, () -> meter.newBatchRecorder("key"), "key/value");
+    assertThatThrownBy(() -> meter.newBatchRecorder("key"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("key/value");
   }
 
   @Test
   void testNewBatchRecorder_NullLabelKey() {
-    assertThrows(
-        NullPointerException.class, () -> meter.newBatchRecorder(null, "value"), "null keys");
+    assertThatThrownBy(() -> meter.newBatchRecorder(null, "value"))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("null keys");
   }
 
   @Test
   void preventNull_MeasureLong() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.newBatchRecorder().put((LongValueRecorder) null, 5L).record(),
-        "valueRecorder");
+    assertThatThrownBy(() -> meter.newBatchRecorder().put((LongValueRecorder) null, 5L).record())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("valueRecorder");
   }
 
   @Test
   void preventNull_MeasureDouble() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.newBatchRecorder().put((DoubleValueRecorder) null, 5L).record(),
-        "valueRecorder");
+    assertThatThrownBy(() -> meter.newBatchRecorder().put((DoubleValueRecorder) null, 5L).record())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("valueRecorder");
   }
 
   @Test
   void preventNull_LongCounter() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.newBatchRecorder().put((LongCounter) null, 5L).record(),
-        "counter");
+    assertThatThrownBy(() -> meter.newBatchRecorder().put((LongCounter) null, 5L).record())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("counter");
   }
 
   @Test
   void preventNull_DoubleCounter() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.newBatchRecorder().put((DoubleCounter) null, 5L).record(),
-        "counter");
+    assertThatThrownBy(() -> meter.newBatchRecorder().put((DoubleCounter) null, 5L).record())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("counter");
   }
 
   @Test
   void preventNull_LongUpDownCounter() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.newBatchRecorder().put((LongUpDownCounter) null, 5L).record(),
-        "upDownCounter");
+    assertThatThrownBy(() -> meter.newBatchRecorder().put((LongUpDownCounter) null, 5L).record())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("upDownCounter");
   }
 
   @Test
   void preventNull_DoubleUpDownCounter() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.newBatchRecorder().put((DoubleUpDownCounter) null, 5L).record(),
-        "upDownCounter");
+    assertThatThrownBy(() -> meter.newBatchRecorder().put((DoubleUpDownCounter) null, 5L).record())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("upDownCounter");
   }
 
   @Test
@@ -89,18 +86,18 @@ class BatchRecorderTest {
   @Test
   void negativeValue_DoubleCounter() {
     BatchRecorder batchRecorder = meter.newBatchRecorder();
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> batchRecorder.put(meter.doubleCounterBuilder("doubleCounter").build(), -77.556d),
-        "Counters can only increase");
+    assertThatThrownBy(
+            () -> batchRecorder.put(meter.doubleCounterBuilder("doubleCounter").build(), -77.556d))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Counters can only increase");
   }
 
   @Test
   void negativeValue_LongCounter() {
     BatchRecorder batchRecorder = meter.newBatchRecorder();
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> batchRecorder.put(meter.longCounterBuilder("longCounter").build(), -44L),
-        "Counters can only increase");
+    assertThatThrownBy(
+            () -> batchRecorder.put(meter.longCounterBuilder("longCounter").build(), -44L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Counters can only increase");
   }
 }

--- a/api/metrics/src/test/java/io/opentelemetry/api/metrics/DoubleCounterTest.java
+++ b/api/metrics/src/test/java/io/opentelemetry/api/metrics/DoubleCounterTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.api.metrics;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.internal.StringUtils;
@@ -22,23 +22,23 @@ class DoubleCounterTest {
 
   @Test
   void preventNull_Name() {
-    assertThrows(NullPointerException.class, () -> meter.doubleCounterBuilder(null), "name");
+    assertThatThrownBy(() -> meter.doubleCounterBuilder(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("name");
   }
 
   @Test
   void preventEmpty_Name() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.doubleCounterBuilder("").build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.doubleCounterBuilder("").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNonPrintableName() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.doubleCounterBuilder("\2").build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.doubleCounterBuilder("\2").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
@@ -46,34 +46,30 @@ class DoubleCounterTest {
     char[] chars = new char[StringUtils.METRIC_NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.doubleCounterBuilder(longName).build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.doubleCounterBuilder(longName).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNull_Description() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleCounterBuilder("metric").setDescription(null).build(),
-        "description");
+    assertThatThrownBy(() -> meter.doubleCounterBuilder("metric").setDescription(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("description");
   }
 
   @Test
   void preventNull_Unit() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleCounterBuilder("metric").setUnit(null).build(),
-        "unit");
+    assertThatThrownBy(() -> meter.doubleCounterBuilder("metric").setUnit(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("unit");
   }
 
   @Test
   void add_preventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleCounterBuilder("metric").build().add(1.0, null),
-        "labels");
+    assertThatThrownBy(() -> meter.doubleCounterBuilder("metric").build().add(1.0, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test
@@ -88,18 +84,16 @@ class DoubleCounterTest {
   void add_PreventNegativeValue() {
     DoubleCounter doubleCounter =
         meter.doubleCounterBuilder(NAME).setDescription(DESCRIPTION).setUnit(UNIT).build();
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> doubleCounter.add(-1.0, Labels.empty()),
-        "Counters can only increase");
+    assertThatThrownBy(() -> doubleCounter.add(-1.0, Labels.empty()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Counters can only increase");
   }
 
   @Test
   void bound_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleCounterBuilder("metric").build().bind(null),
-        "labels");
+    assertThatThrownBy(() -> meter.doubleCounterBuilder("metric").build().bind(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test
@@ -117,8 +111,9 @@ class DoubleCounterTest {
         meter.doubleCounterBuilder(NAME).setDescription(DESCRIPTION).setUnit(UNIT).build();
     BoundDoubleCounter bound = doubleCounter.bind(Labels.empty());
     try {
-      assertThrows(
-          IllegalArgumentException.class, () -> bound.add(-1.0), "Counters can only increase");
+      assertThatThrownBy(() -> bound.add(-1.0))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Counters can only increase");
     } finally {
       bound.unbind();
     }

--- a/api/metrics/src/test/java/io/opentelemetry/api/metrics/DoubleSumObserverTest.java
+++ b/api/metrics/src/test/java/io/opentelemetry/api/metrics/DoubleSumObserverTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.api.metrics;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.internal.StringUtils;
 import java.util.Arrays;
@@ -19,21 +19,22 @@ class DoubleSumObserverTest {
 
   @Test
   void preventNull_Name() {
-    assertThrows(NullPointerException.class, () -> meter.doubleSumObserverBuilder(null), "name");
+    assertThatThrownBy(() -> meter.doubleSumObserverBuilder(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("name");
   }
 
   @Test
   void preventEmpty_Name() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.doubleSumObserverBuilder("").build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.doubleSumObserverBuilder("").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNonPrintableName() {
-    assertThrows(
-        IllegalArgumentException.class, () -> meter.doubleSumObserverBuilder("\2").build());
+    assertThatThrownBy(() -> meter.doubleSumObserverBuilder("\2").build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -41,34 +42,30 @@ class DoubleSumObserverTest {
     char[] chars = new char[StringUtils.METRIC_NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.doubleSumObserverBuilder(longName).build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.doubleSumObserverBuilder(longName).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNull_Description() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleSumObserverBuilder("metric").setDescription(null).build(),
-        "description");
+    assertThatThrownBy(() -> meter.doubleSumObserverBuilder("metric").setDescription(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("description");
   }
 
   @Test
   void preventNull_Unit() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleSumObserverBuilder("metric").setUnit(null).build(),
-        "unit");
+    assertThatThrownBy(() -> meter.doubleSumObserverBuilder("metric").setUnit(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("unit");
   }
 
   @Test
   void preventNull_Callback() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleSumObserverBuilder("metric").setUpdater(null).build(),
-        "callback");
+    assertThatThrownBy(() -> meter.doubleSumObserverBuilder("metric").setUpdater(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("callback");
   }
 
   @Test

--- a/api/metrics/src/test/java/io/opentelemetry/api/metrics/DoubleUpDownCounterTest.java
+++ b/api/metrics/src/test/java/io/opentelemetry/api/metrics/DoubleUpDownCounterTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.api.metrics;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.internal.StringUtils;
@@ -22,23 +22,23 @@ class DoubleUpDownCounterTest {
 
   @Test
   void preventNull_Name() {
-    assertThrows(NullPointerException.class, () -> meter.doubleUpDownCounterBuilder(null), "name");
+    assertThatThrownBy(() -> meter.doubleUpDownCounterBuilder(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("name");
   }
 
   @Test
   void preventEmpty_Name() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.doubleUpDownCounterBuilder("").build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.doubleUpDownCounterBuilder("").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNonPrintableName() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.doubleUpDownCounterBuilder("\2").build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.doubleUpDownCounterBuilder("\2").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
@@ -46,34 +46,31 @@ class DoubleUpDownCounterTest {
     char[] chars = new char[StringUtils.METRIC_NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.doubleUpDownCounterBuilder(longName).build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.doubleUpDownCounterBuilder(longName).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNull_Description() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleUpDownCounterBuilder("metric").setDescription(null).build(),
-        "description");
+    assertThatThrownBy(
+            () -> meter.doubleUpDownCounterBuilder("metric").setDescription(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("description");
   }
 
   @Test
   void preventNull_Unit() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleUpDownCounterBuilder("metric").setUnit(null).build(),
-        "unit");
+    assertThatThrownBy(() -> meter.doubleUpDownCounterBuilder("metric").setUnit(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("unit");
   }
 
   @Test
   void add_preventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleUpDownCounterBuilder("metric").build().bind(null),
-        "labels");
+    assertThatThrownBy(() -> meter.doubleUpDownCounterBuilder("metric").build().bind(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test
@@ -88,10 +85,9 @@ class DoubleUpDownCounterTest {
 
   @Test
   void bound_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleUpDownCounterBuilder("metric").build().bind(null),
-        "labels");
+    assertThatThrownBy(() -> meter.doubleUpDownCounterBuilder("metric").build().bind(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test

--- a/api/metrics/src/test/java/io/opentelemetry/api/metrics/DoubleUpDownSumObserverTest.java
+++ b/api/metrics/src/test/java/io/opentelemetry/api/metrics/DoubleUpDownSumObserverTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.api.metrics;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.internal.StringUtils;
 import java.util.Arrays;
@@ -20,22 +20,22 @@ class DoubleUpDownSumObserverTest {
 
   @Test
   void preventNull_Name() {
-    assertThrows(
-        NullPointerException.class, () -> meter.doubleUpDownSumObserverBuilder(null), "name");
+    assertThatThrownBy(() -> meter.doubleUpDownSumObserverBuilder(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("name");
   }
 
   @Test
   void preventEmpty_Name() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.doubleUpDownSumObserverBuilder("").build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.doubleUpDownSumObserverBuilder("").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNonPrintableName() {
-    assertThrows(
-        IllegalArgumentException.class, () -> meter.doubleUpDownSumObserverBuilder("\2").build());
+    assertThatThrownBy(() -> meter.doubleUpDownSumObserverBuilder("\2").build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -43,34 +43,32 @@ class DoubleUpDownSumObserverTest {
     char[] chars = new char[StringUtils.METRIC_NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.doubleUpDownSumObserverBuilder(longName).build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.doubleUpDownSumObserverBuilder(longName).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNull_Description() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleUpDownSumObserverBuilder("metric").setDescription(null).build(),
-        "description");
+    assertThatThrownBy(
+            () -> meter.doubleUpDownSumObserverBuilder("metric").setDescription(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("description");
   }
 
   @Test
   void preventNull_Unit() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleUpDownSumObserverBuilder("metric").setUnit(null).build(),
-        "unit");
+    assertThatThrownBy(() -> meter.doubleUpDownSumObserverBuilder("metric").setUnit(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("unit");
   }
 
   @Test
   void preventNull_Callback() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleUpDownSumObserverBuilder("metric").setUpdater(null).build(),
-        "callback");
+    assertThatThrownBy(
+            () -> meter.doubleUpDownSumObserverBuilder("metric").setUpdater(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("callback");
   }
 
   @Test

--- a/api/metrics/src/test/java/io/opentelemetry/api/metrics/DoubleValueObserverTest.java
+++ b/api/metrics/src/test/java/io/opentelemetry/api/metrics/DoubleValueObserverTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.api.metrics;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.internal.StringUtils;
 import java.util.Arrays;
@@ -20,21 +20,22 @@ class DoubleValueObserverTest {
 
   @Test
   void preventNull_Name() {
-    assertThrows(NullPointerException.class, () -> meter.doubleValueObserverBuilder(null), "name");
+    assertThatThrownBy(() -> meter.doubleValueObserverBuilder(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("name");
   }
 
   @Test
   void preventEmpty_Name() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.doubleValueObserverBuilder("").build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.doubleValueObserverBuilder("").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNonPrintableName() {
-    assertThrows(
-        IllegalArgumentException.class, () -> meter.doubleValueObserverBuilder("\2").build());
+    assertThatThrownBy(() -> meter.doubleValueObserverBuilder("\2").build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -42,34 +43,31 @@ class DoubleValueObserverTest {
     char[] chars = new char[StringUtils.METRIC_NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.doubleValueObserverBuilder(longName).build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.doubleValueObserverBuilder(longName).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNull_Description() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleValueObserverBuilder("metric").setDescription(null).build(),
-        "description");
+    assertThatThrownBy(
+            () -> meter.doubleValueObserverBuilder("metric").setDescription(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("description");
   }
 
   @Test
   void preventNull_Unit() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleValueObserverBuilder("metric").setUnit(null).build(),
-        "unit");
+    assertThatThrownBy(() -> meter.doubleValueObserverBuilder("metric").setUnit(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("unit");
   }
 
   @Test
   void preventNull_Callback() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleValueObserverBuilder("metric").setUpdater(null).build(),
-        "callback");
+    assertThatThrownBy(() -> meter.doubleValueObserverBuilder("metric").setUpdater(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("callback");
   }
 
   @Test

--- a/api/metrics/src/test/java/io/opentelemetry/api/metrics/DoubleValueRecorderTest.java
+++ b/api/metrics/src/test/java/io/opentelemetry/api/metrics/DoubleValueRecorderTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.api.metrics;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.metrics.DoubleValueRecorder.BoundDoubleValueRecorder;
@@ -21,23 +21,23 @@ class DoubleValueRecorderTest {
 
   @Test
   void preventNull_Name() {
-    assertThrows(NullPointerException.class, () -> meter.doubleValueRecorderBuilder(null), "name");
+    assertThatThrownBy(() -> meter.doubleValueRecorderBuilder(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("name");
   }
 
   @Test
   void preventEmpty_Name() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.doubleValueRecorderBuilder("").build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.doubleValueRecorderBuilder("").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNonPrintableName() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.doubleValueRecorderBuilder("\2").build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.doubleValueRecorderBuilder("\2").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
@@ -45,34 +45,31 @@ class DoubleValueRecorderTest {
     char[] chars = new char[256];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.doubleValueRecorderBuilder(longName).build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.doubleValueRecorderBuilder(longName).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNull_Description() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleValueRecorderBuilder("metric").setDescription(null).build(),
-        "description");
+    assertThatThrownBy(
+            () -> meter.doubleValueRecorderBuilder("metric").setDescription(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("description");
   }
 
   @Test
   void preventNull_Unit() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleValueRecorderBuilder("metric").setUnit(null).build(),
-        "unit");
+    assertThatThrownBy(() -> meter.doubleValueRecorderBuilder("metric").setUnit(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("unit");
   }
 
   @Test
   void record_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleValueRecorderBuilder("metric").build().record(1.0, null),
-        "labels");
+    assertThatThrownBy(() -> meter.doubleValueRecorderBuilder("metric").build().record(1.0, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test
@@ -87,10 +84,9 @@ class DoubleValueRecorderTest {
 
   @Test
   void bound_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.doubleValueRecorderBuilder("metric").build().bind(null),
-        "labels");
+    assertThatThrownBy(() -> meter.doubleValueRecorderBuilder("metric").build().bind(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test

--- a/api/metrics/src/test/java/io/opentelemetry/api/metrics/LongCounterTest.java
+++ b/api/metrics/src/test/java/io/opentelemetry/api/metrics/LongCounterTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.api.metrics;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.internal.StringUtils;
@@ -22,23 +22,23 @@ class LongCounterTest {
 
   @Test
   void preventNull_Name() {
-    assertThrows(NullPointerException.class, () -> meter.longCounterBuilder(null), "name");
+    assertThatThrownBy(() -> meter.longCounterBuilder(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("name");
   }
 
   @Test
   void preventEmpty_Name() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.longCounterBuilder("").build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.longCounterBuilder("").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNonPrintableName() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.longCounterBuilder("\2").build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.longCounterBuilder("\2").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
@@ -46,34 +46,30 @@ class LongCounterTest {
     char[] chars = new char[StringUtils.METRIC_NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.longCounterBuilder(longName).build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.longCounterBuilder(longName).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNull_Description() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longCounterBuilder("metric").setDescription(null).build(),
-        "description");
+    assertThatThrownBy(() -> meter.longCounterBuilder("metric").setDescription(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("description");
   }
 
   @Test
   void preventNull_Unit() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longCounterBuilder("metric").setUnit(null).build(),
-        "unit");
+    assertThatThrownBy(() -> meter.longCounterBuilder("metric").setUnit(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("unit");
   }
 
   @Test
   void add_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longCounterBuilder("metric").build().add(1, null),
-        "labels");
+    assertThatThrownBy(() -> meter.longCounterBuilder("metric").build().add(1, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test
@@ -88,18 +84,16 @@ class LongCounterTest {
   void add_PreventNegativeValue() {
     LongCounter longCounter =
         meter.longCounterBuilder(NAME).setDescription(DESCRIPTION).setUnit(UNIT).build();
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> longCounter.add(-1, Labels.empty()),
-        "Counters can only increase");
+    assertThatThrownBy(() -> longCounter.add(-1, Labels.empty()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Counters can only increase");
   }
 
   @Test
   void bound_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longCounterBuilder("metric").build().bind(null),
-        "labels");
+    assertThatThrownBy(() -> meter.longCounterBuilder("metric").build().bind(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test
@@ -117,8 +111,9 @@ class LongCounterTest {
         meter.longCounterBuilder(NAME).setDescription(DESCRIPTION).setUnit(UNIT).build();
     BoundLongCounter bound = longCounter.bind(Labels.empty());
     try {
-      assertThrows(
-          IllegalArgumentException.class, () -> bound.add(-1), "Counters can only increase");
+      assertThatThrownBy(() -> bound.add(-1))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Counters can only increase");
     } finally {
       bound.unbind();
     }

--- a/api/metrics/src/test/java/io/opentelemetry/api/metrics/LongSumObserverTest.java
+++ b/api/metrics/src/test/java/io/opentelemetry/api/metrics/LongSumObserverTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.api.metrics;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.internal.StringUtils;
 import java.util.Arrays;
@@ -20,23 +20,23 @@ class LongSumObserverTest {
 
   @Test
   void preventNull_Name() {
-    assertThrows(NullPointerException.class, () -> meter.longSumObserverBuilder(null), "name");
+    assertThatThrownBy(() -> meter.longSumObserverBuilder(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("name");
   }
 
   @Test
   void preventEmpty_Name() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.longSumObserverBuilder("").build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.longSumObserverBuilder("").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNonPrintableName() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.longSumObserverBuilder("\2").build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.longSumObserverBuilder("\2").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
@@ -44,34 +44,30 @@ class LongSumObserverTest {
     char[] chars = new char[StringUtils.METRIC_NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.longSumObserverBuilder(longName).build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.longSumObserverBuilder(longName).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNull_Description() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longSumObserverBuilder("metric").setDescription(null).build(),
-        "description");
+    assertThatThrownBy(() -> meter.longSumObserverBuilder("metric").setDescription(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("description");
   }
 
   @Test
   void preventNull_Unit() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longSumObserverBuilder("metric").setUnit(null).build(),
-        "unit");
+    assertThatThrownBy(() -> meter.longSumObserverBuilder("metric").setUnit(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("unit");
   }
 
   @Test
   void preventNull_Callback() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longSumObserverBuilder("metric").setUpdater(null).build(),
-        "callback");
+    assertThatThrownBy(() -> meter.longSumObserverBuilder("metric").setUpdater(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("callback");
   }
 
   @Test

--- a/api/metrics/src/test/java/io/opentelemetry/api/metrics/LongUpDownCounterTest.java
+++ b/api/metrics/src/test/java/io/opentelemetry/api/metrics/LongUpDownCounterTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.api.metrics;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.internal.StringUtils;
@@ -22,23 +22,23 @@ class LongUpDownCounterTest {
 
   @Test
   void preventNull_Name() {
-    assertThrows(NullPointerException.class, () -> meter.longUpDownCounterBuilder(null), "name");
+    assertThatThrownBy(() -> meter.longUpDownCounterBuilder(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("name");
   }
 
   @Test
   void preventEmpty_Name() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.longUpDownCounterBuilder("").build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.longUpDownCounterBuilder("").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNonPrintableName() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.longUpDownCounterBuilder("\2").build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.longUpDownCounterBuilder("\2").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
@@ -46,34 +46,30 @@ class LongUpDownCounterTest {
     char[] chars = new char[StringUtils.METRIC_NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.longUpDownCounterBuilder(longName).build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.longUpDownCounterBuilder(longName).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNull_Description() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longUpDownCounterBuilder("metric").setDescription(null).build(),
-        "description");
+    assertThatThrownBy(() -> meter.longUpDownCounterBuilder("metric").setDescription(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("description");
   }
 
   @Test
   void preventNull_Unit() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longUpDownCounterBuilder("metric").setUnit(null).build(),
-        "unit");
+    assertThatThrownBy(() -> meter.longUpDownCounterBuilder("metric").setUnit(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("unit");
   }
 
   @Test
   void add_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longUpDownCounterBuilder("metric").build().add(1, null),
-        "labels");
+    assertThatThrownBy(() -> meter.longUpDownCounterBuilder("metric").build().add(1, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test
@@ -88,10 +84,9 @@ class LongUpDownCounterTest {
 
   @Test
   void bound_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longUpDownCounterBuilder("metric").build().bind(null),
-        "labels");
+    assertThatThrownBy(() -> meter.longUpDownCounterBuilder("metric").build().bind(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test

--- a/api/metrics/src/test/java/io/opentelemetry/api/metrics/LongUpDownSumObserverTest.java
+++ b/api/metrics/src/test/java/io/opentelemetry/api/metrics/LongUpDownSumObserverTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.api.metrics;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.internal.StringUtils;
 import java.util.Arrays;
@@ -20,24 +20,23 @@ class LongUpDownSumObserverTest {
 
   @Test
   void preventNull_Name() {
-    assertThrows(
-        NullPointerException.class, () -> meter.longUpDownSumObserverBuilder(null), "name");
+    assertThatThrownBy(() -> meter.longUpDownSumObserverBuilder(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("name");
   }
 
   @Test
   void preventEmpty_Name() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.longUpDownSumObserverBuilder("").build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.longUpDownSumObserverBuilder("").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNonPrintableName() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.longUpDownSumObserverBuilder("\2").build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.longUpDownSumObserverBuilder("\2").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
@@ -45,34 +44,31 @@ class LongUpDownSumObserverTest {
     char[] chars = new char[StringUtils.METRIC_NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.longUpDownSumObserverBuilder(longName).build(),
-        DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.longUpDownSumObserverBuilder(longName).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(DefaultMeter.ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNull_Description() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longUpDownSumObserverBuilder("metric").setDescription(null).build(),
-        "description");
+    assertThatThrownBy(
+            () -> meter.longUpDownSumObserverBuilder("metric").setDescription(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("description");
   }
 
   @Test
   void preventNull_Unit() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longUpDownSumObserverBuilder("metric").setUnit(null).build(),
-        "unit");
+    assertThatThrownBy(() -> meter.longUpDownSumObserverBuilder("metric").setUnit(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("unit");
   }
 
   @Test
   void preventNull_Callback() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longUpDownSumObserverBuilder("metric").setUpdater(null).build(),
-        "callback");
+    assertThatThrownBy(() -> meter.longUpDownSumObserverBuilder("metric").setUpdater(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("callback");
   }
 
   @Test

--- a/api/metrics/src/test/java/io/opentelemetry/api/metrics/LongValueObserverTest.java
+++ b/api/metrics/src/test/java/io/opentelemetry/api/metrics/LongValueObserverTest.java
@@ -8,7 +8,7 @@ package io.opentelemetry.api.metrics;
 import static io.opentelemetry.api.internal.StringUtils.METRIC_NAME_MAX_LENGTH;
 import static io.opentelemetry.api.metrics.DefaultMeter.ERROR_MESSAGE_INVALID_NAME;
 import static java.util.Arrays.fill;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,23 +22,23 @@ class LongValueObserverTest {
 
   @Test
   void preventNull_Name() {
-    assertThrows(NullPointerException.class, () -> meter.longValueObserverBuilder(null), "name");
+    assertThatThrownBy(() -> meter.longValueObserverBuilder(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("name");
   }
 
   @Test
   void preventEmpty_Name() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.longValueObserverBuilder("").build(),
-        ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.longValueObserverBuilder("").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNonPrintableName() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.longValueObserverBuilder("\2").build(),
-        ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.longValueObserverBuilder("\2").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
@@ -46,34 +46,30 @@ class LongValueObserverTest {
     char[] chars = new char[METRIC_NAME_MAX_LENGTH + 1];
     fill(chars, 'a');
     String longName = String.valueOf(chars);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.longValueObserverBuilder(longName).build(),
-        ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.longValueObserverBuilder(longName).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNull_Description() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longValueObserverBuilder("metric").setDescription(null).build(),
-        "description");
+    assertThatThrownBy(() -> meter.longValueObserverBuilder("metric").setDescription(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("description");
   }
 
   @Test
   void preventNull_Unit() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longValueObserverBuilder("metric").setUnit(null).build(),
-        "unit");
+    assertThatThrownBy(() -> meter.longValueObserverBuilder("metric").setUnit(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("unit");
   }
 
   @Test
   void preventNull_Callback() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longValueObserverBuilder("metric").setUpdater(null).build(),
-        "callback");
+    assertThatThrownBy(() -> meter.longValueObserverBuilder("metric").setUpdater(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("callback");
   }
 
   @Test

--- a/api/metrics/src/test/java/io/opentelemetry/api/metrics/LongValueRecorderTest.java
+++ b/api/metrics/src/test/java/io/opentelemetry/api/metrics/LongValueRecorderTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.api.metrics;
 
 import static io.opentelemetry.api.metrics.DefaultMeter.ERROR_MESSAGE_INVALID_NAME;
 import static java.util.Arrays.fill;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.metrics.LongValueRecorder.BoundLongValueRecorder;
@@ -23,23 +23,23 @@ public final class LongValueRecorderTest {
 
   @Test
   void preventNull_Name() {
-    assertThrows(NullPointerException.class, () -> meter.longValueRecorderBuilder(null), "name");
+    assertThatThrownBy(() -> meter.longValueRecorderBuilder(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("name");
   }
 
   @Test
   void preventEmpty_Name() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.longValueRecorderBuilder("").build(),
-        ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.longValueRecorderBuilder("").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNonPrintableMeasureName() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.longValueRecorderBuilder("\2").build(),
-        ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.longValueRecorderBuilder("\2").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
@@ -47,34 +47,30 @@ public final class LongValueRecorderTest {
     char[] chars = new char[256];
     fill(chars, 'a');
     String longName = String.valueOf(chars);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> meter.longValueRecorderBuilder(longName).build(),
-        ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> meter.longValueRecorderBuilder(longName).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNull_Description() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longValueRecorderBuilder("metric").setDescription(null).build(),
-        "description");
+    assertThatThrownBy(() -> meter.longValueRecorderBuilder("metric").setDescription(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("description");
   }
 
   @Test
   void preventNull_Unit() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longValueRecorderBuilder("metric").setUnit(null).build(),
-        "unit");
+    assertThatThrownBy(() -> meter.longValueRecorderBuilder("metric").setUnit(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("unit");
   }
 
   @Test
   void record_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longValueRecorderBuilder("metric").build().record(1, null),
-        "labels");
+    assertThatThrownBy(() -> meter.longValueRecorderBuilder("metric").build().record(1, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test
@@ -89,10 +85,9 @@ public final class LongValueRecorderTest {
 
   @Test
   void bound_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> meter.longValueRecorderBuilder("metric").build().bind(null),
-        "labels");
+    assertThatThrownBy(() -> meter.longValueRecorderBuilder("metric").build().bind(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test

--- a/api/trace/src/test/java/io/opentelemetry/api/trace/BigendianEncodingTest.java
+++ b/api/trace/src/test/java/io/opentelemetry/api/trace/BigendianEncodingTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.api.trace;
 
 import static java.nio.CharBuffer.wrap;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.CharBuffer;
 import org.junit.jupiter.api.Test;
@@ -56,10 +56,10 @@ class BigendianEncodingTest {
   @Test
   void longToByteArray_Fails() {
     // These contain bytes not in the decoding.
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> BigendianEncoding.longToByteArray(123, new byte[BigendianEncoding.LONG_BYTES], 1),
-        "array too small");
+    assertThatThrownBy(
+            () -> BigendianEncoding.longToByteArray(123, new byte[BigendianEncoding.LONG_BYTES], 1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("array too small");
   }
 
   @Test
@@ -81,10 +81,10 @@ class BigendianEncodingTest {
   @Test
   void longFromByteArray_ArrayToSmall() {
     // These contain bytes not in the decoding.
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> BigendianEncoding.longFromByteArray(new byte[BigendianEncoding.LONG_BYTES], 1),
-        "array too small");
+    assertThatThrownBy(
+            () -> BigendianEncoding.longFromByteArray(new byte[BigendianEncoding.LONG_BYTES], 1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("array too small");
   }
 
   @Test
@@ -127,21 +127,20 @@ class BigendianEncodingTest {
   @Test
   void longFromBase16String_InputTooSmall() {
     // Valid base16 strings always have an even length.
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            BigendianEncoding.longFromBase16String(
-                wrap(new char[BigendianEncoding.LONG_BASE16]), 1),
-        "chars too small");
+    assertThatThrownBy(
+            () ->
+                BigendianEncoding.longFromBase16String(
+                    wrap(new char[BigendianEncoding.LONG_BASE16]), 1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("chars too small");
   }
 
   @Test
   void longFromBase16String_UnrecognizedCharacters() {
     // These contain bytes not in the decoding.
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> BigendianEncoding.longFromBase16String("0123456789gbcdef", 0),
-        "invalid character g");
+    assertThatThrownBy(() -> BigendianEncoding.longFromBase16String("0123456789gbcdef", 0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("invalid character g");
   }
 
   @Test

--- a/api/trace/src/test/java/io/opentelemetry/api/trace/DefaultTracerTest.java
+++ b/api/trace/src/test/java/io/opentelemetry/api/trace/DefaultTracerTest.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.api.trace;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.context.Context;
 import org.junit.jupiter.api.Test;
@@ -30,7 +30,8 @@ class DefaultTracerTest {
 
   @Test
   void spanBuilderWithName_NullName() {
-    assertThrows(NullPointerException.class, () -> defaultTracer.spanBuilder(null));
+    assertThatThrownBy(() -> defaultTracer.spanBuilder(null))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test
@@ -66,8 +67,8 @@ class DefaultTracerTest {
 
   @Test
   void testSpanContextPropagation_nullContext() {
-    assertThrows(
-        NullPointerException.class, () -> defaultTracer.spanBuilder(SPAN_NAME).setParent(null));
+    assertThatThrownBy(() -> defaultTracer.spanBuilder(SPAN_NAME).setParent(null))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test

--- a/api/trace/src/test/java/io/opentelemetry/api/trace/SpanBuilderTest.java
+++ b/api/trace/src/test/java/io/opentelemetry/api/trace/SpanBuilderTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.api.trace;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span.Kind;
@@ -42,15 +42,14 @@ class SpanBuilderTest {
   @Test
   void setParent_NullContext() {
     SpanBuilder spanBuilder = tracer.spanBuilder("MySpanName");
-    assertThrows(NullPointerException.class, () -> spanBuilder.setParent(null));
+    assertThatThrownBy(() -> spanBuilder.setParent(null)).isInstanceOf(NullPointerException.class);
   }
 
   @Test
   void setStartTimestamp_Negative() {
     SpanBuilder spanBuilder = tracer.spanBuilder("MySpanName");
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> spanBuilder.setStartTimestamp(-1, TimeUnit.NANOSECONDS),
-        "Negative startTimestamp");
+    assertThatThrownBy(() -> spanBuilder.setStartTimestamp(-1, TimeUnit.NANOSECONDS))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Negative startTimestamp");
   }
 }

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/StringUtilsTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/StringUtilsTest.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.extension.trace.propagation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +27,8 @@ class StringUtilsTest {
 
   @Test
   void padLeft_throws_for_null_value() {
-    assertThrows(NullPointerException.class, () -> StringUtils.padLeft(null, 10));
+    assertThatThrownBy(() -> StringUtils.padLeft(null, 10))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/TraceMultiPropagatorTest.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.extension.trace.propagation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -60,8 +60,8 @@ class TraceMultiPropagatorTest {
 
   @Test
   void addPropagator_null() {
-    assertThrows(
-        NullPointerException.class, () -> TraceMultiPropagator.create((TextMapPropagator) null));
+    assertThatThrownBy(() -> TraceMultiPropagator.create((TextMapPropagator) null))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test
@@ -92,7 +92,7 @@ class TraceMultiPropagatorTest {
             new EmptyPropagator("foo", "bar"), new EmptyPropagator("hello", "world"));
 
     Collection<String> fields = prop.fields();
-    assertThrows(UnsupportedOperationException.class, () -> fields.add("hi"));
+    assertThatThrownBy(() -> fields.add("hi")).isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test

--- a/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/OpenTelemetryBinaryFormatImplTest.java
+++ b/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/OpenTelemetryBinaryFormatImplTest.java
@@ -5,8 +5,8 @@
 
 package io.opentelemetry.opencensusshim;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.SpanId;
@@ -57,7 +57,9 @@ class OpenTelemetryBinaryFormatImplTest {
 
   @Test
   void toBinaryValue_NullSpanContext() {
-    assertThrows(NullPointerException.class, () -> binaryFormat.toByteArray(null), "spanContext");
+    assertThatThrownBy(() -> binaryFormat.toByteArray(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("spanContext");
   }
 
   @Test
@@ -76,56 +78,59 @@ class OpenTelemetryBinaryFormatImplTest {
 
   @Test
   void fromBinaryValue_NullInput() {
-    assertThrows(NullPointerException.class, () -> binaryFormat.toByteArray(null), "spanContext");
+    assertThatThrownBy(() -> binaryFormat.toByteArray(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("spanContext");
   }
 
   @Test
   void fromBinaryValue_EmptyInput() {
-    assertThrows(
-        SpanContextParseException.class,
-        () -> binaryFormat.fromByteArray(new byte[0]),
-        "Unsupported version.");
+    assertThatThrownBy(() -> binaryFormat.fromByteArray(new byte[0]))
+        .isInstanceOf(SpanContextParseException.class)
+        .hasMessage("Unsupported version.");
   }
 
   @Test
   void fromBinaryValue_UnsupportedVersionId() {
-    assertThrows(
-        SpanContextParseException.class,
-        () ->
-            binaryFormat.fromByteArray(
-                new byte[] {
-                  66, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 97, 98, 99,
-                  100, 101, 102, 103, 104, 1
-                }),
-        "Unsupported version.");
+    assertThatThrownBy(
+            () ->
+                binaryFormat.fromByteArray(
+                    new byte[] {
+                      66, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 97, 98,
+                      99, 100, 101, 102, 103, 104, 1
+                    }))
+        .isInstanceOf(SpanContextParseException.class)
+        .hasMessage("Unsupported version.");
   }
 
   @Test
   void fromBinaryValue_UnsupportedFieldIdFirst() {
-    assertThrows(
-        SpanContextParseException.class,
-        () ->
-            binaryFormat.fromByteArray(
-                new byte[] {
-                  0, 4, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 1, 97, 98,
-                  99, 100, 101, 102, 103, 104, 2, 1
-                }),
-        "Invalid input: expected trace ID at offset "
-            + OpenTelemetryBinaryFormatImpl.TRACE_ID_FIELD_ID_OFFSET);
+    assertThatThrownBy(
+            () ->
+                binaryFormat.fromByteArray(
+                    new byte[] {
+                      0, 4, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 1, 97,
+                      98, 99, 100, 101, 102, 103, 104, 2, 1
+                    }))
+        .isInstanceOf(SpanContextParseException.class)
+        .hasMessage(
+            "Invalid input: expected trace ID at offset "
+                + OpenTelemetryBinaryFormatImpl.TRACE_ID_FIELD_ID_OFFSET);
   }
 
   @Test
   void fromBinaryValue_UnsupportedFieldIdSecond() {
-    assertThrows(
-        SpanContextParseException.class,
-        () ->
-            binaryFormat.fromByteArray(
-                new byte[] {
-                  0, 0, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 3, 97, 98,
-                  99, 100, 101, 102, 103, 104, 2, 1
-                }),
-        "Invalid input: expected span ID at offset "
-            + OpenTelemetryBinaryFormatImpl.SPAN_ID_FIELD_ID_OFFSET);
+    assertThatThrownBy(
+            () ->
+                binaryFormat.fromByteArray(
+                    new byte[] {
+                      0, 0, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 3, 97,
+                      98, 99, 100, 101, 102, 103, 104, 2, 1
+                    }))
+        .isInstanceOf(SpanContextParseException.class)
+        .hasMessage(
+            "Invalid input: expected span ID at offset "
+                + OpenTelemetryBinaryFormatImpl.SPAN_ID_FIELD_ID_OFFSET);
   }
 
   @Test
@@ -143,33 +148,33 @@ class OpenTelemetryBinaryFormatImplTest {
 
   @Test
   void fromBinaryValue_ShorterTraceId() {
-    assertThrows(
-        SpanContextParseException.class,
-        () ->
-            binaryFormat.fromByteArray(
-                new byte[] {0, 0, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76}),
-        "Invalid input: truncated");
+    assertThatThrownBy(
+            () ->
+                binaryFormat.fromByteArray(
+                    new byte[] {0, 0, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76}))
+        .isInstanceOf(SpanContextParseException.class)
+        .hasMessage("Invalid input: truncated");
   }
 
   @Test
   void fromBinaryValue_ShorterSpanId() {
-    assertThrows(
-        SpanContextParseException.class,
-        () -> binaryFormat.fromByteArray(new byte[] {0, 1, 97, 98, 99, 100, 101, 102, 103}),
-        "Invalid input: truncated");
+    assertThatThrownBy(
+            () -> binaryFormat.fromByteArray(new byte[] {0, 1, 97, 98, 99, 100, 101, 102, 103}))
+        .isInstanceOf(SpanContextParseException.class)
+        .hasMessage("Invalid input: truncated");
   }
 
   @Test
   void fromBinaryValue_ShorterTraceOptions() {
-    assertThrows(
-        SpanContextParseException.class,
-        () ->
-            binaryFormat.fromByteArray(
-                new byte[] {
-                  0, 0, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 1, 97, 98,
-                  99, 100, 101, 102, 103, 104, 2
-                }),
-        "Invalid input: truncated");
+    assertThatThrownBy(
+            () ->
+                binaryFormat.fromByteArray(
+                    new byte[] {
+                      0, 0, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 1, 97,
+                      98, 99, 100, 101, 102, 103, 104, 2
+                    }))
+        .isInstanceOf(SpanContextParseException.class)
+        .hasMessage("Invalid input: truncated");
   }
 
   @Test

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfo.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfo.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.sdk.common;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.trace.Tracer;
 import javax.annotation.Nullable;
@@ -28,6 +30,7 @@ public abstract class InstrumentationLibraryInfo {
    * @return the new instance
    */
   public static InstrumentationLibraryInfo create(String name, @Nullable String version) {
+    requireNonNull(name, "name");
     return new AutoValue_InstrumentationLibraryInfo(name, version);
   }
 

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfoTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfoTest.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
@@ -21,7 +21,8 @@ class InstrumentationLibraryInfoTest {
 
   @Test
   void nullName() {
-    assertThrows(
-        NullPointerException.class, () -> InstrumentationLibraryInfo.create(null, "1.0.0"), "name");
+    assertThatThrownBy(() -> InstrumentationLibraryInfo.create(null, "1.0.0"))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("name");
   }
 }

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/internal/ComponentRegistryTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/internal/ComponentRegistryTest.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import org.junit.jupiter.api.Test;
@@ -21,7 +21,9 @@ class ComponentRegistryTest {
 
   @Test
   void libraryName_MustNotBeNull() {
-    assertThrows(NullPointerException.class, () -> registry.get(null, "version"), "name");
+    assertThatThrownBy(() -> registry.get(null, "version"))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("name");
   }
 
   @Test

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/resources/ResourcesConfigTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/resources/ResourcesConfigTest.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.resources;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Test;
@@ -21,9 +21,10 @@ class ResourcesConfigTest {
 
   @Test
   void updateResourcesConfig_NullDisabledResourceProviders() {
-    assertThrows(
-        NullPointerException.class,
-        () -> ResourcesConfig.getDefault().toBuilder().setDisabledResourceProviders(null).build());
+    assertThatThrownBy(
+            () ->
+                ResourcesConfig.getDefault().toBuilder().setDisabledResourceProviders(null).build())
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.metrics;
 
 import static io.opentelemetry.sdk.metrics.AbstractInstrument.Builder.ERROR_MESSAGE_INVALID_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.internal.StringUtils;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
@@ -28,12 +28,16 @@ class AbstractInstrumentBuilderTest {
 
   @Test
   void preventNull_Name() {
-    assertThrows(NullPointerException.class, () -> new TestInstrumentBuilder(null).build(), "name");
+    assertThatThrownBy(() -> new TestInstrumentBuilder(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("name");
   }
 
   @Test
   void preventEmpty_Name() {
-    assertThrows(IllegalArgumentException.class, () -> new TestInstrumentBuilder(""), "Name");
+    assertThatThrownBy(() -> new TestInstrumentBuilder(""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Name");
   }
 
   @Test
@@ -42,15 +46,15 @@ class AbstractInstrumentBuilderTest {
     new TestInstrumentBuilder("METRIC_name");
     new TestInstrumentBuilder("metric.name_01");
     new TestInstrumentBuilder("metric_name.01");
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> new TestInstrumentBuilder("01.metric_name_01"),
-        "Name");
+    assertThatThrownBy(() -> new TestInstrumentBuilder("01.metric_name_01"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Name");
   }
 
   @Test
   void preventNonPrintableName() {
-    assertThrows(IllegalArgumentException.class, () -> new TestInstrumentBuilder("\2").build());
+    assertThatThrownBy(() -> new TestInstrumentBuilder("\2").build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -58,26 +62,23 @@ class AbstractInstrumentBuilderTest {
     char[] chars = new char[StringUtils.METRIC_NAME_MAX_LENGTH + 1];
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> new TestInstrumentBuilder(longName).build(),
-        ERROR_MESSAGE_INVALID_NAME);
+    assertThatThrownBy(() -> new TestInstrumentBuilder(longName).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(ERROR_MESSAGE_INVALID_NAME);
   }
 
   @Test
   void preventNull_Description() {
-    assertThrows(
-        NullPointerException.class,
-        () -> new TestInstrumentBuilder(NAME).setDescription(null).build(),
-        "description");
+    assertThatThrownBy(() -> new TestInstrumentBuilder(NAME).setDescription(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("description");
   }
 
   @Test
   void preventNull_Unit() {
-    assertThrows(
-        NullPointerException.class,
-        () -> new TestInstrumentBuilder(NAME).setUnit(null).build(),
-        "unit");
+    assertThatThrownBy(() -> new TestInstrumentBuilder(NAME).setUnit(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("unit");
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/BatchRecorderSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/BatchRecorderSdkTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.metrics;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.Labels;
@@ -37,10 +37,9 @@ class BatchRecorderSdkTest {
 
   @Test
   void batchRecorder_badLabelSet() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.newBatchRecorder("key").record(),
-        "key/value");
+    assertThatThrownBy(() -> testSdk.newBatchRecorder("key").record())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("key/value");
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleCounterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleCounterSdkTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.metrics;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.Labels;
@@ -38,18 +38,16 @@ class DoubleCounterSdkTest {
 
   @Test
   void add_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> testSdk.doubleCounterBuilder("testCounter").build().add(1.0, null),
-        "labels");
+    assertThatThrownBy(() -> testSdk.doubleCounterBuilder("testCounter").build().add(1.0, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test
   void bound_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> testSdk.doubleCounterBuilder("testCounter").build().bind(null),
-        "labels");
+    assertThatThrownBy(() -> testSdk.doubleCounterBuilder("testCounter").build().bind(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test
@@ -181,15 +179,16 @@ class DoubleCounterSdkTest {
   void doubleCounterAdd_Monotonicity() {
     DoubleCounterSdk doubleCounter = testSdk.doubleCounterBuilder("testCounter").build();
 
-    assertThrows(IllegalArgumentException.class, () -> doubleCounter.add(-45.77d, Labels.empty()));
+    assertThatThrownBy(() -> doubleCounter.add(-45.77d, Labels.empty()))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void boundDoubleCounterAdd_Monotonicity() {
     DoubleCounterSdk doubleCounter = testSdk.doubleCounterBuilder("testCounter").build();
 
-    assertThrows(
-        IllegalArgumentException.class, () -> doubleCounter.bind(Labels.empty()).add(-9.3));
+    assertThatThrownBy(() -> doubleCounter.bind(Labels.empty()).add(-9.3))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownCounterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownCounterSdkTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.metrics;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.Labels;
@@ -39,18 +39,18 @@ class DoubleUpDownCounterSdkTest {
 
   @Test
   void add_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> testSdk.doubleUpDownCounterBuilder("testUpDownCounter").build().add(1.0, null),
-        "labels");
+    assertThatThrownBy(
+            () -> testSdk.doubleUpDownCounterBuilder("testUpDownCounter").build().add(1.0, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test
   void bound_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> testSdk.doubleUpDownCounterBuilder("testUpDownCounter").build().bind(null),
-        "labels");
+    assertThatThrownBy(
+            () -> testSdk.doubleUpDownCounterBuilder("testUpDownCounter").build().bind(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdkTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.metrics;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.Labels;
@@ -42,18 +42,17 @@ class DoubleValueRecorderSdkTest {
 
   @Test
   void record_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> testSdk.doubleValueRecorderBuilder("testRecorder").build().record(1.0, null),
-        "labels");
+    assertThatThrownBy(
+            () -> testSdk.doubleValueRecorderBuilder("testRecorder").build().record(1.0, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test
   void bound_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> testSdk.doubleValueRecorderBuilder("testRecorder").build().bind(null),
-        "labels");
+    assertThatThrownBy(() -> testSdk.doubleValueRecorderBuilder("testRecorder").build().bind(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/InstrumentRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/InstrumentRegistryTest.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
@@ -50,13 +50,13 @@ class InstrumentRegistryTest {
     assertThat(meterSharedState.getInstrumentRegistry().register(testInstrument))
         .isSameAs(testInstrument);
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            meterSharedState
-                .getInstrumentRegistry()
-                .register(new TestInstrument(OTHER_INSTRUMENT_DESCRIPTOR)),
-        "Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(
+            () ->
+                meterSharedState
+                    .getInstrumentRegistry()
+                    .register(new TestInstrument(OTHER_INSTRUMENT_DESCRIPTOR)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
   }
 
   @Test
@@ -67,13 +67,13 @@ class InstrumentRegistryTest {
     assertThat(meterSharedState.getInstrumentRegistry().register(testInstrument))
         .isSameAs(testInstrument);
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            meterSharedState
-                .getInstrumentRegistry()
-                .register(new OtherTestInstrument(INSTRUMENT_DESCRIPTOR)),
-        "Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(
+            () ->
+                meterSharedState
+                    .getInstrumentRegistry()
+                    .register(new OtherTestInstrument(INSTRUMENT_DESCRIPTOR)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
   }
 
   private static final class TestInstrument extends AbstractInstrument {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongCounterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongCounterSdkTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.metrics;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.Labels;
@@ -39,18 +39,16 @@ class LongCounterSdkTest {
 
   @Test
   void add_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> testSdk.longCounterBuilder("testCounter").build().add(1, null),
-        "labels");
+    assertThatThrownBy(() -> testSdk.longCounterBuilder("testCounter").build().add(1, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test
   void bound_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> testSdk.longCounterBuilder("testCounter").build().bind(null),
-        "labels");
+    assertThatThrownBy(() -> testSdk.longCounterBuilder("testCounter").build().bind(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test
@@ -172,14 +170,16 @@ class LongCounterSdkTest {
   void longCounterAdd_MonotonicityCheck() {
     LongCounterSdk longCounter = testSdk.longCounterBuilder("testCounter").build();
 
-    assertThrows(IllegalArgumentException.class, () -> longCounter.add(-45, Labels.empty()));
+    assertThatThrownBy(() -> longCounter.add(-45, Labels.empty()))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void boundLongCounterAdd_MonotonicityCheck() {
     LongCounterSdk longCounter = testSdk.longCounterBuilder("testCounter").build();
 
-    assertThrows(IllegalArgumentException.class, () -> longCounter.bind(Labels.empty()).add(-9));
+    assertThatThrownBy(() -> longCounter.bind(Labels.empty()).add(-9))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownCounterSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownCounterSdkTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.metrics;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.Labels;
@@ -39,18 +39,17 @@ class LongUpDownCounterSdkTest {
 
   @Test
   void add_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> testSdk.longUpDownCounterBuilder("testCounter").build().add(1, null),
-        "labels");
+    assertThatThrownBy(() -> testSdk.longUpDownCounterBuilder("testCounter").build().add(1, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test
   void bound_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> testSdk.longUpDownCounterBuilder("testUpDownCounter").build().bind(null),
-        "labels");
+    assertThatThrownBy(
+            () -> testSdk.longUpDownCounterBuilder("testUpDownCounter").build().bind(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdkTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.metrics;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.Labels;
@@ -42,18 +42,17 @@ class LongValueRecorderSdkTest {
 
   @Test
   void record_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> testSdk.longValueRecorderBuilder("testRecorder").build().record(1, null),
-        "labels");
+    assertThatThrownBy(
+            () -> testSdk.longValueRecorderBuilder("testRecorder").build().record(1, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test
   void bound_PreventNullLabels() {
-    assertThrows(
-        NullPointerException.class,
-        () -> testSdk.longValueRecorderBuilder("testRecorder").build().bind(null),
-        "labels");
+    assertThatThrownBy(() -> testSdk.longValueRecorderBuilder("testRecorder").build().bind(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("labels");
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterRegistryTest.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import io.opentelemetry.api.common.Labels;
@@ -37,14 +37,16 @@ class SdkMeterRegistryTest {
 
   @Test
   void builder_NullClock() {
-    assertThrows(
-        NullPointerException.class, () -> SdkMeterProvider.builder().setClock(null), "clock");
+    assertThatThrownBy(() -> SdkMeterProvider.builder().setClock(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("clock");
   }
 
   @Test
   void builder_NullResource() {
-    assertThrows(
-        NullPointerException.class, () -> SdkMeterProvider.builder().setResource(null), "resource");
+    assertThatThrownBy(() -> SdkMeterProvider.builder().setResource(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("resource");
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.metrics;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.Labels;
@@ -56,14 +56,12 @@ class SdkMeterTest {
                 .build())
         .isSameAs(longCounter);
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.longCounterBuilder("testLongCounter").build(),
-        "Instrument with same name and different descriptor already created.");
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.longCounterBuilder("testLongCounter".toUpperCase()).build(),
-        "Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(() -> testSdk.longCounterBuilder("testLongCounter").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(() -> testSdk.longCounterBuilder("testLongCounter".toUpperCase()).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
   }
 
   @Test
@@ -84,14 +82,13 @@ class SdkMeterTest {
                 .build())
         .isSameAs(longUpDownCounter);
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.longUpDownCounterBuilder("testLongUpDownCounter").build(),
-        "Instrument with same name and different descriptor already created.");
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.longUpDownCounterBuilder("testLongUpDownCounter".toUpperCase()).build(),
-        "Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(() -> testSdk.longUpDownCounterBuilder("testLongUpDownCounter").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(
+            () -> testSdk.longUpDownCounterBuilder("testLongUpDownCounter".toUpperCase()).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
   }
 
   @Test
@@ -112,14 +109,13 @@ class SdkMeterTest {
                 .build())
         .isSameAs(longValueRecorder);
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.longValueRecorderBuilder("testLongValueRecorder").build(),
-        "Instrument with same name and different descriptor already created.");
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.longValueRecorderBuilder("testLongValueRecorder".toUpperCase()).build(),
-        "Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(() -> testSdk.longValueRecorderBuilder("testLongValueRecorder").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(
+            () -> testSdk.longValueRecorderBuilder("testLongValueRecorder".toUpperCase()).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
   }
 
   @Test
@@ -140,14 +136,13 @@ class SdkMeterTest {
                 .build())
         .isSameAs(longValueObserver);
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.longValueObserverBuilder("longValueObserver").build(),
-        "Instrument with same name and different descriptor already created.");
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.longValueObserverBuilder("longValueObserver".toUpperCase()).build(),
-        "Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(() -> testSdk.longValueObserverBuilder("longValueObserver").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(
+            () -> testSdk.longValueObserverBuilder("longValueObserver".toUpperCase()).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
   }
 
   @Test
@@ -168,15 +163,14 @@ class SdkMeterTest {
                 .build())
         .isSameAs(longObserver);
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.longSumObserverBuilder("testLongSumObserver").build(),
-        "Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(() -> testSdk.longSumObserverBuilder("testLongSumObserver").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.longSumObserverBuilder("testLongSumObserver".toUpperCase()).build(),
-        "Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(
+            () -> testSdk.longSumObserverBuilder("testLongSumObserver".toUpperCase()).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
   }
 
   @Test
@@ -197,16 +191,18 @@ class SdkMeterTest {
                 .build())
         .isSameAs(longObserver);
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.longUpDownSumObserverBuilder("testLongUpDownSumObserver").build(),
-        "Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(
+            () -> testSdk.longUpDownSumObserverBuilder("testLongUpDownSumObserver").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            testSdk.longUpDownSumObserverBuilder("testLongUpDownSumObserver".toUpperCase()).build(),
-        "Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(
+            () ->
+                testSdk
+                    .longUpDownSumObserverBuilder("testLongUpDownSumObserver".toUpperCase())
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
   }
 
   @Test
@@ -227,14 +223,13 @@ class SdkMeterTest {
                 .build())
         .isSameAs(doubleCounter);
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.doubleCounterBuilder("testDoubleCounter").build(),
-        "Instrument with same name and different descriptor already created.");
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.doubleCounterBuilder("testDoubleCounter".toUpperCase()).build(),
-        "Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(() -> testSdk.doubleCounterBuilder("testDoubleCounter").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(
+            () -> testSdk.doubleCounterBuilder("testDoubleCounter".toUpperCase()).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
   }
 
   @Test
@@ -255,14 +250,14 @@ class SdkMeterTest {
                 .build())
         .isSameAs(doubleUpDownCounter);
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.doubleUpDownCounterBuilder("testDoubleUpDownCounter").build(),
-        "Instrument with same name and different descriptor already created.");
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.doubleUpDownCounterBuilder("testDoubleUpDownCounter".toUpperCase()).build(),
-        "Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(() -> testSdk.doubleUpDownCounterBuilder("testDoubleUpDownCounter").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(
+            () ->
+                testSdk.doubleUpDownCounterBuilder("testDoubleUpDownCounter".toUpperCase()).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
   }
 
   @Test
@@ -283,14 +278,14 @@ class SdkMeterTest {
                 .build())
         .isSameAs(doubleValueRecorder);
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.doubleValueRecorderBuilder("testDoubleValueRecorder").build(),
-        "Instrument with same name and different descriptor already created.");
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.doubleValueRecorderBuilder("testDoubleValueRecorder".toUpperCase()).build(),
-        "Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(() -> testSdk.doubleValueRecorderBuilder("testDoubleValueRecorder").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(
+            () ->
+                testSdk.doubleValueRecorderBuilder("testDoubleValueRecorder".toUpperCase()).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
   }
 
   @Test
@@ -311,14 +306,13 @@ class SdkMeterTest {
                 .build())
         .isSameAs(doubleObserver);
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.doubleSumObserverBuilder("testDoubleSumObserver").build(),
-        "Instrument with same name and different descriptor already created.");
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.doubleSumObserverBuilder("testDoubleSumObserver".toUpperCase()).build(),
-        "Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(() -> testSdk.doubleSumObserverBuilder("testDoubleSumObserver").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(
+            () -> testSdk.doubleSumObserverBuilder("testDoubleSumObserver".toUpperCase()).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
   }
 
   @Test
@@ -339,17 +333,17 @@ class SdkMeterTest {
                 .build())
         .isSameAs(doubleObserver);
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.doubleUpDownSumObserverBuilder("testDoubleUpDownSumObserver").build(),
-        "Instrument with same name and different descriptor already created.");
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            testSdk
-                .doubleUpDownSumObserverBuilder("testDoubleUpDownSumObserver".toUpperCase())
-                .build(),
-        "Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(
+            () -> testSdk.doubleUpDownSumObserverBuilder("testDoubleUpDownSumObserver").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(
+            () ->
+                testSdk
+                    .doubleUpDownSumObserverBuilder("testDoubleUpDownSumObserver".toUpperCase())
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
   }
 
   @Test
@@ -370,14 +364,13 @@ class SdkMeterTest {
                 .build())
         .isSameAs(doubleValueObserver);
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.doubleValueObserverBuilder("doubleValueObserver").build(),
-        "Instrument with same name and different descriptor already created.");
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> testSdk.doubleValueObserverBuilder("doubleValueObserver".toUpperCase()).build(),
-        "Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(() -> testSdk.doubleValueObserverBuilder("doubleValueObserver").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
+    assertThatThrownBy(
+            () -> testSdk.doubleValueObserverBuilder("doubleValueObserver".toUpperCase()).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument with same name and different descriptor already created.");
   }
 
   @Test

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/trace/TestSpanDataTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/trace/TestSpanDataTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.testing.trace;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span.Kind;
@@ -44,16 +44,17 @@ class TestSpanDataTest {
   void unmodifiableLinks() {
     SpanData spanData = createSpanDataWithMutableCollections();
 
-    assertThrows(UnsupportedOperationException.class, () -> spanData.getLinks().add(emptyLink()));
+    assertThatThrownBy(() -> spanData.getLinks().add(emptyLink()))
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test
   void unmodifiableTimedEvents() {
     SpanData spanData = createSpanDataWithMutableCollections();
 
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> spanData.getEvents().add(Event.create(1234, "foo", Attributes.empty())));
+    assertThatThrownBy(
+            () -> spanData.getEvents().add(Event.create(1234, "foo", Attributes.empty())))
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProviderBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProviderBuilder.java
@@ -5,13 +5,14 @@
 
 package io.opentelemetry.sdk.trace;
 
+import static java.util.Objects.requireNonNull;
+
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.internal.SystemClock;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 /** Builder of {@link SdkTracerProvider}. */
 public final class SdkTracerProviderBuilder {
@@ -29,7 +30,7 @@ public final class SdkTracerProviderBuilder {
    * @return this
    */
   public SdkTracerProviderBuilder setClock(Clock clock) {
-    Objects.requireNonNull(clock, "clock");
+    requireNonNull(clock, "clock");
     this.clock = clock;
     return this;
   }
@@ -42,7 +43,7 @@ public final class SdkTracerProviderBuilder {
    * @return this
    */
   public SdkTracerProviderBuilder setIdGenerator(IdGenerator idGenerator) {
-    Objects.requireNonNull(idGenerator, "idGenerator");
+    requireNonNull(idGenerator, "idGenerator");
     this.idsGenerator = idGenerator;
     return this;
   }
@@ -54,7 +55,7 @@ public final class SdkTracerProviderBuilder {
    * @return this
    */
   public SdkTracerProviderBuilder setResource(Resource resource) {
-    Objects.requireNonNull(resource, "resource");
+    requireNonNull(resource, "resource");
     this.resource = resource;
     return this;
   }
@@ -65,8 +66,8 @@ public final class SdkTracerProviderBuilder {
    * @return this
    */
   public SdkTracerProviderBuilder setTraceConfig(TraceConfig traceConfig) {
+    requireNonNull(traceConfig, "traceConfig");
     this.traceConfig = traceConfig;
-    Objects.requireNonNull(traceConfig);
     return this;
   }
 

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -14,7 +14,7 @@ import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -182,9 +182,8 @@ class RecordEventsReadableSpanTest {
     RecordEventsReadableSpan span = createTestSpan(Kind.INTERNAL);
     SpanData spanData = span.toSpanData();
 
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> spanData.getLinks().add(Link.create(SpanContext.getInvalid())));
+    assertThatThrownBy(() -> spanData.getLinks().add(Link.create(SpanContext.getInvalid())))
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test
@@ -192,9 +191,9 @@ class RecordEventsReadableSpanTest {
     RecordEventsReadableSpan span = createTestSpan(Kind.INTERNAL);
     SpanData spanData = span.toSpanData();
 
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> spanData.getEvents().add(Event.create(1000, "test", Attributes.empty())));
+    assertThatThrownBy(
+            () -> spanData.getEvents().add(Event.create(1000, "test", Attributes.empty())))
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
@@ -15,7 +15,7 @@ import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -72,14 +72,14 @@ class SdkSpanBuilderTest {
 
   @Test
   void setSpanKind_null() {
-    assertThrows(
-        NullPointerException.class, () -> sdkTracer.spanBuilder(SPAN_NAME).setSpanKind(null));
+    assertThatThrownBy(() -> sdkTracer.spanBuilder(SPAN_NAME).setSpanKind(null))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test
   void setParent_null() {
-    assertThrows(
-        NullPointerException.class, () -> sdkTracer.spanBuilder(SPAN_NAME).setParent(null));
+    assertThatThrownBy(() -> sdkTracer.spanBuilder(SPAN_NAME).setParent(null))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test
@@ -175,21 +175,22 @@ class SdkSpanBuilderTest {
 
   @Test
   void addLinkSpanContext_null() {
-    assertThrows(NullPointerException.class, () -> sdkTracer.spanBuilder(SPAN_NAME).addLink(null));
+    assertThatThrownBy(() -> sdkTracer.spanBuilder(SPAN_NAME).addLink(null))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test
   void addLinkSpanContextAttributes_nullContext() {
-    assertThrows(
-        NullPointerException.class,
-        () -> sdkTracer.spanBuilder(SPAN_NAME).addLink(null, Attributes.empty()));
+    assertThatThrownBy(() -> sdkTracer.spanBuilder(SPAN_NAME).addLink(null, Attributes.empty()))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test
   void addLinkSpanContextAttributes_nullAttributes() {
-    assertThrows(
-        NullPointerException.class,
-        () -> sdkTracer.spanBuilder(SPAN_NAME).addLink(Span.getInvalid().getSpanContext(), null));
+    assertThatThrownBy(
+            () ->
+                sdkTracer.spanBuilder(SPAN_NAME).addLink(Span.getInvalid().getSpanContext(), null))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test
@@ -825,10 +826,10 @@ class SdkSpanBuilderTest {
 
   @Test
   void startTimestamp_null() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> sdkTracer.spanBuilder(SPAN_NAME).setStartTimestamp(-1, TimeUnit.NANOSECONDS),
-        "Negative startTimestamp");
+    assertThatThrownBy(
+            () -> sdkTracer.spanBuilder(SPAN_NAME).setStartTimestamp(-1, TimeUnit.NANOSECONDS))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Negative startTimestamp");
   }
 
   @Test

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderTest.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.trace;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -55,32 +55,30 @@ class SdkTracerProviderTest {
 
   @Test
   void builder_NullTraceConfig() {
-    assertThrows(
-        NullPointerException.class,
-        () -> SdkTracerProvider.builder().setTraceConfig(null),
-        "traceConfig");
+    assertThatThrownBy(() -> SdkTracerProvider.builder().setTraceConfig(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("traceConfig");
   }
 
   @Test
   void builder_NullClock() {
-    assertThrows(
-        NullPointerException.class, () -> SdkTracerProvider.builder().setClock(null), "clock");
+    assertThatThrownBy(() -> SdkTracerProvider.builder().setClock(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("clock");
   }
 
   @Test
   void builder_NullResource() {
-    assertThrows(
-        NullPointerException.class,
-        () -> SdkTracerProvider.builder().setResource(null),
-        "resource");
+    assertThatThrownBy(() -> SdkTracerProvider.builder().setResource(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("resource");
   }
 
   @Test
   void builder_NullIdsGenerator() {
-    assertThrows(
-        NullPointerException.class,
-        () -> SdkTracerProvider.builder().setIdGenerator(null),
-        "idsGenerator");
+    assertThatThrownBy(() -> SdkTracerProvider.builder().setIdGenerator(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("idGenerator");
   }
 
   @Test

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigSystemPropertiesTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigSystemPropertiesTest.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.trace.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import org.junit.jupiter.api.AfterEach;
@@ -50,48 +50,42 @@ public class TraceConfigSystemPropertiesTest {
   @Test
   void updateTraceConfig_InvalidSamplerProbability() {
     System.setProperty("otel.config.sampler.probability", "-1");
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> TraceConfig.getDefault().toBuilder().readSystemProperties().build());
+    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().readSystemProperties().build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_NonPositiveMaxNumberOfAttributes() {
     System.setProperty("otel.span.attribute.count.limit", "-5");
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> TraceConfig.getDefault().toBuilder().readSystemProperties().build());
+    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().readSystemProperties().build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_NonPositiveMaxNumberOfEvents() {
     System.setProperty("otel.span.event.count.limit", "-6");
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> TraceConfig.getDefault().toBuilder().readSystemProperties().build());
+    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().readSystemProperties().build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_NonPositiveMaxNumberOfLinks() {
     System.setProperty("otel.span.link.count.limit", "-9");
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> TraceConfig.getDefault().toBuilder().readSystemProperties().build());
+    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().readSystemProperties().build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_NonPositiveMaxNumberOfAttributesPerEvent() {
     System.setProperty("otel.config.max.event.attrs", "-7");
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> TraceConfig.getDefault().toBuilder().readSystemProperties().build());
+    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().readSystemProperties().build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_NonPositiveMaxNumberOfAttributesPerLink() {
     System.setProperty("otel.config.max.link.attrs", "-10");
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> TraceConfig.getDefault().toBuilder().readSystemProperties().build());
+    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().readSystemProperties().build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.trace.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import org.junit.jupiter.api.Test;
@@ -26,57 +26,52 @@ class TraceConfigTest {
 
   @Test
   void updateTraceConfig_NullSampler() {
-    assertThrows(
-        NullPointerException.class, () -> TraceConfig.getDefault().toBuilder().setSampler(null));
+    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().setSampler(null))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test
   void updateTraceConfig_NonPositiveMaxNumberOfAttributes() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> TraceConfig.getDefault().toBuilder().setMaxNumberOfAttributes(0));
+    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().setMaxNumberOfAttributes(0))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_NonPositiveMaxNumberOfEvents() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> TraceConfig.getDefault().toBuilder().setMaxNumberOfEvents(0));
+    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().setMaxNumberOfEvents(0))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_NonPositiveMaxNumberOfLinks() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> TraceConfig.getDefault().toBuilder().setMaxNumberOfLinks(0));
+    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().setMaxNumberOfLinks(0))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_NonPositiveMaxNumberOfAttributesPerEvent() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> TraceConfig.getDefault().toBuilder().setMaxNumberOfAttributesPerEvent(0));
+    assertThatThrownBy(
+            () -> TraceConfig.getDefault().toBuilder().setMaxNumberOfAttributesPerEvent(0))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_NonPositiveMaxNumberOfAttributesPerLink() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> TraceConfig.getDefault().toBuilder().setMaxNumberOfAttributesPerLink(0));
+    assertThatThrownBy(
+            () -> TraceConfig.getDefault().toBuilder().setMaxNumberOfAttributesPerLink(0))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_InvalidTraceIdRatioBased() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> TraceConfig.getDefault().toBuilder().setTraceIdRatioBased(2));
+    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().setTraceIdRatioBased(2))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_NegativeTraceIdRatioBased() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> TraceConfig.getDefault().toBuilder().setTraceIdRatioBased(-1));
+    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().setTraceIdRatioBased(-1))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test


### PR DESCRIPTION
This makes all the assertions consistently assertj. It also restores asserting on the exception message. During JUnit5 migration, I misinterpreted the `message` parameter to `assertThrows` as a check on the message, but it isn't - the correct way would have been to assert on the returned `Throwable` instead.

This PR is 1) Structural replace 2) Fix failing tests due to drift in exception message assertions mostly by changing `hasMessage` to `hasMessageContaining`