### PR TITLE
Change aggregator to use generics for Accumulation

### DIFF
--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountBenchmark.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
+import io.opentelemetry.sdk.metrics.aggregation.MinMaxSumCountAccumulation;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
@@ -20,7 +21,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @State(Scope.Benchmark)
 public class DoubleMinMaxSumCountBenchmark {
 
-  private Aggregator aggregator;
+  private Aggregator<MinMaxSumCountAccumulation> aggregator;
 
   @Setup(Level.Trial)
   public final void setup() {

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountBenchmark.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
+import io.opentelemetry.sdk.metrics.aggregation.MinMaxSumCountAccumulation;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
@@ -20,7 +21,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @State(Scope.Benchmark)
 public class LongMinMaxSumCountBenchmark {
 
-  private Aggregator aggregator;
+  private Aggregator<MinMaxSumCountAccumulation> aggregator;
 
   @Setup(Level.Trial)
   public final void setup() {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractSynchronousInstrument.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractSynchronousInstrument.java
@@ -25,7 +25,7 @@ abstract class AbstractSynchronousInstrument extends AbstractInstrument {
     return accumulator.collectAll();
   }
 
-  Aggregator acquireHandle(Labels labels) {
+  Aggregator<?> acquireHandle(Labels labels) {
     return accumulator.bind(labels);
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleCounterSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleCounterSdk.java
@@ -21,7 +21,7 @@ final class DoubleCounterSdk extends AbstractSynchronousInstrument implements Do
 
   @Override
   public void add(double increment, Labels labels) {
-    Aggregator aggregator = acquireHandle(labels);
+    Aggregator<?> aggregator = acquireHandle(labels);
     try {
       if (increment < 0) {
         throw new IllegalArgumentException("Counters can only increase");
@@ -43,9 +43,9 @@ final class DoubleCounterSdk extends AbstractSynchronousInstrument implements Do
   }
 
   static final class BoundInstrument implements DoubleCounter.BoundDoubleCounter {
-    private final Aggregator aggregator;
+    private final Aggregator<?> aggregator;
 
-    BoundInstrument(Aggregator aggregator) {
+    BoundInstrument(Aggregator<?> aggregator) {
       this.aggregator = aggregator;
     }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleUpDownCounterSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleUpDownCounterSdk.java
@@ -22,7 +22,7 @@ final class DoubleUpDownCounterSdk extends AbstractSynchronousInstrument
 
   @Override
   public void add(double increment, Labels labels) {
-    Aggregator aggregator = acquireHandle(labels);
+    Aggregator<?> aggregator = acquireHandle(labels);
     try {
       aggregator.recordDouble(increment);
     } finally {
@@ -41,9 +41,9 @@ final class DoubleUpDownCounterSdk extends AbstractSynchronousInstrument
   }
 
   static final class BoundInstrument implements BoundDoubleUpDownCounter {
-    private final Aggregator aggregator;
+    private final Aggregator<?> aggregator;
 
-    BoundInstrument(Aggregator aggregator) {
+    BoundInstrument(Aggregator<?> aggregator) {
       this.aggregator = aggregator;
     }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdk.java
@@ -22,7 +22,7 @@ final class DoubleValueRecorderSdk extends AbstractSynchronousInstrument
 
   @Override
   public void record(double value, Labels labels) {
-    Aggregator aggregator = acquireHandle(labels);
+    Aggregator<?> aggregator = acquireHandle(labels);
     try {
       aggregator.recordDouble(value);
     } finally {
@@ -41,9 +41,9 @@ final class DoubleValueRecorderSdk extends AbstractSynchronousInstrument
   }
 
   static final class BoundInstrument implements BoundDoubleValueRecorder {
-    private final Aggregator aggregator;
+    private final Aggregator<?> aggregator;
 
-    BoundInstrument(Aggregator aggregator) {
+    BoundInstrument(Aggregator<?> aggregator) {
       this.aggregator = aggregator;
     }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/InstrumentProcessor.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/InstrumentProcessor.java
@@ -36,7 +36,7 @@ final class InstrumentProcessor {
   private final Resource resource;
   private final InstrumentationLibraryInfo instrumentationLibraryInfo;
   private final Clock clock;
-  private final AggregatorFactory aggregatorFactory;
+  private final AggregatorFactory<?> aggregatorFactory;
   private Map<Labels, Accumulation> accumulationMap;
   private long startEpochNanos;
   private final boolean delta;
@@ -102,7 +102,7 @@ final class InstrumentProcessor {
    *
    * @return the {@link Aggregator} used to aggregate individual events.
    */
-  Aggregator getAggregator() {
+  Aggregator<?> getAggregator() {
     return aggregatorFactory.getAggregator();
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongCounterSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongCounterSdk.java
@@ -21,7 +21,7 @@ final class LongCounterSdk extends AbstractSynchronousInstrument implements Long
 
   @Override
   public void add(long increment, Labels labels) {
-    Aggregator aggregator = acquireHandle(labels);
+    Aggregator<?> aggregator = acquireHandle(labels);
     try {
       if (increment < 0) {
         throw new IllegalArgumentException("Counters can only increase");
@@ -43,9 +43,9 @@ final class LongCounterSdk extends AbstractSynchronousInstrument implements Long
   }
 
   static final class BoundInstrument implements LongCounter.BoundLongCounter {
-    private final Aggregator aggregator;
+    private final Aggregator<?> aggregator;
 
-    BoundInstrument(Aggregator aggregator) {
+    BoundInstrument(Aggregator<?> aggregator) {
       this.aggregator = aggregator;
     }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongUpDownCounterSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongUpDownCounterSdk.java
@@ -22,7 +22,7 @@ final class LongUpDownCounterSdk extends AbstractSynchronousInstrument
 
   @Override
   public void add(long increment, Labels labels) {
-    Aggregator aggregator = acquireHandle(labels);
+    Aggregator<?> aggregator = acquireHandle(labels);
     try {
       aggregator.recordLong(increment);
     } finally {
@@ -41,9 +41,9 @@ final class LongUpDownCounterSdk extends AbstractSynchronousInstrument
   }
 
   static final class BoundInstrument implements BoundLongUpDownCounter {
-    private final Aggregator aggregator;
+    private final Aggregator<?> aggregator;
 
-    BoundInstrument(Aggregator aggregator) {
+    BoundInstrument(Aggregator<?> aggregator) {
       this.aggregator = aggregator;
     }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdk.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/LongValueRecorderSdk.java
@@ -22,7 +22,7 @@ final class LongValueRecorderSdk extends AbstractSynchronousInstrument
 
   @Override
   public void record(long value, Labels labels) {
-    Aggregator aggregator = acquireHandle(labels);
+    Aggregator<?> aggregator = acquireHandle(labels);
     try {
       aggregator.recordLong(value);
     } finally {
@@ -41,9 +41,9 @@ final class LongValueRecorderSdk extends AbstractSynchronousInstrument
   }
 
   static final class BoundInstrument implements BoundLongValueRecorder {
-    private final Aggregator aggregator;
+    private final Aggregator<?> aggregator;
 
-    BoundInstrument(Aggregator aggregator) {
+    BoundInstrument(Aggregator<?> aggregator) {
       this.aggregator = aggregator;
     }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/ViewRegistry.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/ViewRegistry.java
@@ -90,7 +90,6 @@ final class ViewRegistry {
       InstrumentDescriptor descriptor) {
 
     AggregationConfiguration specification = chooseAggregation(descriptor);
-
     Aggregation aggregation =
         specification.getAggregationFactory().create(descriptor.getValueType());
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregation/Aggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregation/Aggregation.java
@@ -29,7 +29,7 @@ public interface Aggregation {
    *
    * @return the {@code AggregationFactory}.
    */
-  AggregatorFactory getAggregatorFactory();
+  AggregatorFactory<?> getAggregatorFactory();
 
   /**
    * Returns the result of the merge of the given {@link Accumulation}s.

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregation/CountAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregation/CountAggregation.java
@@ -23,7 +23,7 @@ final class CountAggregation implements Aggregation {
   private CountAggregation() {}
 
   @Override
-  public AggregatorFactory getAggregatorFactory() {
+  public AggregatorFactory<?> getAggregatorFactory() {
     return CountAggregator.getFactory();
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregation/LastValueAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregation/LastValueAggregation.java
@@ -24,14 +24,14 @@ final class LastValueAggregation implements Aggregation {
   static final LastValueAggregation DOUBLE_INSTANCE =
       new LastValueAggregation(DoubleLastValueAggregator.getFactory());
 
-  private final AggregatorFactory aggregatorFactory;
+  private final AggregatorFactory<?> aggregatorFactory;
 
-  private LastValueAggregation(AggregatorFactory aggregatorFactory) {
+  private LastValueAggregation(AggregatorFactory<?> aggregatorFactory) {
     this.aggregatorFactory = aggregatorFactory;
   }
 
   @Override
-  public AggregatorFactory getAggregatorFactory() {
+  public AggregatorFactory<?> getAggregatorFactory() {
     return aggregatorFactory;
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregation/MinMaxSumCountAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregation/MinMaxSumCountAggregation.java
@@ -24,14 +24,14 @@ final class MinMaxSumCountAggregation implements Aggregation {
   static final MinMaxSumCountAggregation DOUBLE_INSTANCE =
       new MinMaxSumCountAggregation(DoubleMinMaxSumCountAggregator.getFactory());
 
-  private final AggregatorFactory aggregatorFactory;
+  private final AggregatorFactory<?> aggregatorFactory;
 
-  private MinMaxSumCountAggregation(AggregatorFactory aggregatorFactory) {
+  private MinMaxSumCountAggregation(AggregatorFactory<?> aggregatorFactory) {
     this.aggregatorFactory = aggregatorFactory;
   }
 
   @Override
-  public AggregatorFactory getAggregatorFactory() {
+  public AggregatorFactory<?> getAggregatorFactory() {
     return aggregatorFactory;
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregation/SumAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregation/SumAggregation.java
@@ -24,14 +24,14 @@ final class SumAggregation implements Aggregation {
   static final SumAggregation DOUBLE_INSTANCE =
       new SumAggregation(DoubleSumAggregator.getFactory());
 
-  private final AggregatorFactory aggregatorFactory;
+  private final AggregatorFactory<?> aggregatorFactory;
 
-  private SumAggregation(AggregatorFactory aggregatorFactory) {
+  private SumAggregation(AggregatorFactory<?> aggregatorFactory) {
     this.aggregatorFactory = aggregatorFactory;
   }
 
   @Override
-  public AggregatorFactory getAggregatorFactory() {
+  public AggregatorFactory<?> getAggregatorFactory() {
     return aggregatorFactory;
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/Aggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/Aggregator.java
@@ -18,7 +18,7 @@ import javax.annotation.Nullable;
  * used to keep the state of mapping ('1' is used for unmapped and '0' is for mapped) and the rest
  * of the bits are used for reference (usage) counting.
  */
-public abstract class Aggregator {
+public abstract class Aggregator<T extends Accumulation> {
   // Atomically counts the number of references (usages) while also keeping a state of
   // mapped/unmapped into a registry map.
   private final AtomicLong refCountMapped;
@@ -70,7 +70,7 @@ public abstract class Aggregator {
    * {@code Aggregator}.
    */
   @Nullable
-  public final Accumulation accumulateThenReset() {
+  public final T accumulateThenReset() {
     if (!hasRecordings) {
       return null;
     }
@@ -79,7 +79,7 @@ public abstract class Aggregator {
   }
 
   /** Implementation of the {@code accumulateThenReset}. */
-  protected abstract Accumulation doAccumulateThenReset();
+  protected abstract T doAccumulateThenReset();
 
   /**
    * Updates the current aggregator with a newly recorded {@code long} value.

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/AggregatorFactory.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/AggregatorFactory.java
@@ -5,16 +5,17 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
+import io.opentelemetry.sdk.metrics.aggregation.Accumulation;
 import javax.annotation.concurrent.Immutable;
 
 /** Factory class for {@link Aggregator}. */
 @Immutable
-public interface AggregatorFactory {
+public interface AggregatorFactory<T extends Accumulation> {
 
   /**
    * Returns a new {@link Aggregator}.
    *
    * @return a new {@link Aggregator}.
    */
-  Aggregator getAggregator();
+  Aggregator<T> getAggregator();
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/CountAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/CountAggregator.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
-import io.opentelemetry.sdk.metrics.aggregation.Accumulation;
 import io.opentelemetry.sdk.metrics.aggregation.LongAccumulation;
 import java.util.concurrent.atomic.LongAdder;
 
-public final class CountAggregator extends Aggregator {
-  private static final AggregatorFactory AGGREGATOR_FACTORY = CountAggregator::new;
+public final class CountAggregator extends Aggregator<LongAccumulation> {
+  private static final AggregatorFactory<LongAccumulation> AGGREGATOR_FACTORY =
+      CountAggregator::new;
 
   private final LongAdder current;
 
@@ -23,7 +23,7 @@ public final class CountAggregator extends Aggregator {
    *
    * @return an {@link AggregatorFactory} that produces {@link CountAggregator} instances.
    */
-  public static AggregatorFactory getFactory() {
+  public static AggregatorFactory<LongAccumulation> getFactory() {
     return AGGREGATOR_FACTORY;
   }
 
@@ -38,7 +38,7 @@ public final class CountAggregator extends Aggregator {
   }
 
   @Override
-  protected Accumulation doAccumulateThenReset() {
+  protected LongAccumulation doAccumulateThenReset() {
     return LongAccumulation.create(current.sumThenReset());
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleLastValueAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleLastValueAggregator.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
-import io.opentelemetry.sdk.metrics.aggregation.Accumulation;
 import io.opentelemetry.sdk.metrics.aggregation.DoubleAccumulation;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
@@ -18,10 +17,11 @@ import javax.annotation.Nullable;
  * problem because LastValueAggregator is currently only available for Observers which record all
  * values once.
  */
-public final class DoubleLastValueAggregator extends Aggregator {
+public final class DoubleLastValueAggregator extends Aggregator<DoubleAccumulation> {
 
   @Nullable private static final Double DEFAULT_VALUE = null;
-  private static final AggregatorFactory AGGREGATOR_FACTORY = DoubleLastValueAggregator::new;
+  private static final AggregatorFactory<DoubleAccumulation> AGGREGATOR_FACTORY =
+      DoubleLastValueAggregator::new;
 
   private final AtomicReference<Double> current = new AtomicReference<>(DEFAULT_VALUE);
 
@@ -30,12 +30,12 @@ public final class DoubleLastValueAggregator extends Aggregator {
    *
    * @return an {@link AggregatorFactory} that produces {@link DoubleLastValueAggregator} instances.
    */
-  public static AggregatorFactory getFactory() {
+  public static AggregatorFactory<DoubleAccumulation> getFactory() {
     return AGGREGATOR_FACTORY;
   }
 
   @Override
-  protected Accumulation doAccumulateThenReset() {
+  protected DoubleAccumulation doAccumulateThenReset() {
     return DoubleAccumulation.create(this.current.getAndSet(DEFAULT_VALUE));
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountAggregator.java
@@ -6,15 +6,15 @@
 package io.opentelemetry.sdk.metrics.aggregator;
 
 import com.google.errorprone.annotations.concurrent.GuardedBy;
-import io.opentelemetry.sdk.metrics.aggregation.Accumulation;
 import io.opentelemetry.sdk.metrics.aggregation.MinMaxSumCountAccumulation;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
-public final class DoubleMinMaxSumCountAggregator extends Aggregator {
+public final class DoubleMinMaxSumCountAggregator extends Aggregator<MinMaxSumCountAccumulation> {
 
-  private static final AggregatorFactory AGGREGATOR_FACTORY = DoubleMinMaxSumCountAggregator::new;
+  private static final AggregatorFactory<MinMaxSumCountAccumulation> AGGREGATOR_FACTORY =
+      DoubleMinMaxSumCountAggregator::new;
 
   private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
@@ -23,17 +23,17 @@ public final class DoubleMinMaxSumCountAggregator extends Aggregator {
   @GuardedBy("lock")
   private final DoubleState current = new DoubleState();
 
-  public static AggregatorFactory getFactory() {
+  public static AggregatorFactory<MinMaxSumCountAccumulation> getFactory() {
     return AGGREGATOR_FACTORY;
   }
 
   private DoubleMinMaxSumCountAggregator() {}
 
   @Override
-  protected Accumulation doAccumulateThenReset() {
+  protected MinMaxSumCountAccumulation doAccumulateThenReset() {
     lock.writeLock().lock();
     try {
-      Accumulation toReturn =
+      MinMaxSumCountAccumulation toReturn =
           MinMaxSumCountAccumulation.create(current.count, current.sum, current.min, current.max);
       current.reset();
       return toReturn;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleSumAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleSumAggregator.java
@@ -5,13 +5,13 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
-import io.opentelemetry.sdk.metrics.aggregation.Accumulation;
 import io.opentelemetry.sdk.metrics.aggregation.DoubleAccumulation;
 import java.util.concurrent.atomic.DoubleAdder;
 
-public final class DoubleSumAggregator extends Aggregator {
+public final class DoubleSumAggregator extends Aggregator<DoubleAccumulation> {
 
-  private static final AggregatorFactory AGGREGATOR_FACTORY = DoubleSumAggregator::new;
+  private static final AggregatorFactory<DoubleAccumulation> AGGREGATOR_FACTORY =
+      DoubleSumAggregator::new;
 
   private final DoubleAdder current = new DoubleAdder();
 
@@ -20,12 +20,12 @@ public final class DoubleSumAggregator extends Aggregator {
    *
    * @return an {@link AggregatorFactory} that produces {@link DoubleSumAggregator} instances.
    */
-  public static AggregatorFactory getFactory() {
+  public static AggregatorFactory<DoubleAccumulation> getFactory() {
     return AGGREGATOR_FACTORY;
   }
 
   @Override
-  protected Accumulation doAccumulateThenReset() {
+  protected DoubleAccumulation doAccumulateThenReset() {
     return DoubleAccumulation.create(this.current.sumThenReset());
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongLastValueAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongLastValueAggregator.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
-import io.opentelemetry.sdk.metrics.aggregation.Accumulation;
 import io.opentelemetry.sdk.metrics.aggregation.LongAccumulation;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
@@ -18,10 +17,10 @@ import javax.annotation.Nullable;
  * problem because LastValueAggregator is currently only available for Observers which record all
  * values once.
  */
-public final class LongLastValueAggregator extends Aggregator {
-
+public final class LongLastValueAggregator extends Aggregator<LongAccumulation> {
   @Nullable private static final Long DEFAULT_VALUE = null;
-  private static final AggregatorFactory AGGREGATOR_FACTORY = LongLastValueAggregator::new;
+  private static final AggregatorFactory<LongAccumulation> AGGREGATOR_FACTORY =
+      LongLastValueAggregator::new;
 
   private final AtomicReference<Long> current = new AtomicReference<>(DEFAULT_VALUE);
 
@@ -30,12 +29,12 @@ public final class LongLastValueAggregator extends Aggregator {
    *
    * @return an {@link AggregatorFactory} that produces {@link LongLastValueAggregator} instances.
    */
-  public static AggregatorFactory getFactory() {
+  public static AggregatorFactory<LongAccumulation> getFactory() {
     return AGGREGATOR_FACTORY;
   }
 
   @Override
-  protected Accumulation doAccumulateThenReset() {
+  protected LongAccumulation doAccumulateThenReset() {
     return LongAccumulation.create(this.current.getAndSet(DEFAULT_VALUE));
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountAggregator.java
@@ -6,15 +6,14 @@
 package io.opentelemetry.sdk.metrics.aggregator;
 
 import com.google.errorprone.annotations.concurrent.GuardedBy;
-import io.opentelemetry.sdk.metrics.aggregation.Accumulation;
 import io.opentelemetry.sdk.metrics.aggregation.MinMaxSumCountAccumulation;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
-public final class LongMinMaxSumCountAggregator extends Aggregator {
-
-  private static final AggregatorFactory AGGREGATOR_FACTORY = LongMinMaxSumCountAggregator::new;
+public final class LongMinMaxSumCountAggregator extends Aggregator<MinMaxSumCountAccumulation> {
+  private static final AggregatorFactory<MinMaxSumCountAccumulation> AGGREGATOR_FACTORY =
+      LongMinMaxSumCountAggregator::new;
 
   private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
@@ -25,15 +24,15 @@ public final class LongMinMaxSumCountAggregator extends Aggregator {
 
   private LongMinMaxSumCountAggregator() {}
 
-  public static AggregatorFactory getFactory() {
+  public static AggregatorFactory<MinMaxSumCountAccumulation> getFactory() {
     return AGGREGATOR_FACTORY;
   }
 
   @Override
-  protected Accumulation doAccumulateThenReset() {
+  protected MinMaxSumCountAccumulation doAccumulateThenReset() {
     lock.writeLock().lock();
     try {
-      Accumulation toReturn =
+      MinMaxSumCountAccumulation toReturn =
           MinMaxSumCountAccumulation.create(current.count, current.sum, current.min, current.max);
       current.reset();
       return toReturn;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongSumAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongSumAggregator.java
@@ -5,13 +5,12 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
-import io.opentelemetry.sdk.metrics.aggregation.Accumulation;
 import io.opentelemetry.sdk.metrics.aggregation.LongAccumulation;
 import java.util.concurrent.atomic.LongAdder;
 
-public final class LongSumAggregator extends Aggregator {
-
-  private static final AggregatorFactory AGGREGATOR_FACTORY = LongSumAggregator::new;
+public final class LongSumAggregator extends Aggregator<LongAccumulation> {
+  private static final AggregatorFactory<LongAccumulation> AGGREGATOR_FACTORY =
+      LongSumAggregator::new;
 
   private final LongAdder current = new LongAdder();
 
@@ -20,12 +19,12 @@ public final class LongSumAggregator extends Aggregator {
    *
    * @return an {@link AggregatorFactory} that produces {@link LongSumAggregator} instances.
    */
-  public static AggregatorFactory getFactory() {
+  public static AggregatorFactory<LongAccumulation> getFactory() {
     return AGGREGATOR_FACTORY;
   }
 
   @Override
-  protected Accumulation doAccumulateThenReset() {
+  protected LongAccumulation doAccumulateThenReset() {
     return LongAccumulation.create(this.current.sumThenReset());
   }
 

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SynchronousInstrumentAccumulatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SynchronousInstrumentAccumulatorTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
-import io.opentelemetry.sdk.metrics.aggregation.Aggregations;
+import io.opentelemetry.sdk.metrics.aggregation.AggregationFactory;
 import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
@@ -32,13 +32,16 @@ public class SynchronousInstrumentAccumulatorTest {
     SynchronousInstrumentAccumulator accumulator =
         new SynchronousInstrumentAccumulator(
             InstrumentProcessor.getCumulativeAllLabels(
-                DESCRIPTOR, providerSharedState, meterSharedState, Aggregations.count()));
-    Aggregator aggregator = accumulator.bind(Labels.of("K", "V"));
-    Aggregator duplicateAggregator = accumulator.bind(Labels.of("K", "V"));
+                DESCRIPTOR,
+                providerSharedState,
+                meterSharedState,
+                AggregationFactory.count().create(DESCRIPTOR.getValueType())));
+    Aggregator<?> aggregator = accumulator.bind(Labels.of("K", "V"));
+    Aggregator<?> duplicateAggregator = accumulator.bind(Labels.of("K", "V"));
     try {
       assertThat(duplicateAggregator).isSameAs(aggregator);
       accumulator.collectAll();
-      Aggregator anotherDuplicateAggregator = accumulator.bind(Labels.of("K", "V"));
+      Aggregator<?> anotherDuplicateAggregator = accumulator.bind(Labels.of("K", "V"));
       try {
         assertThat(anotherDuplicateAggregator).isSameAs(aggregator);
       } finally {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregation/CountAggregationTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregation/CountAggregationTest.java
@@ -19,12 +19,11 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link AggregationFactory#count()}. */
 class CountAggregationTest {
   @Test
   void toMetricData() {
     Aggregation count = AggregationFactory.count().create(InstrumentValueType.LONG);
-    Aggregator aggregator = count.getAggregatorFactory().getAggregator();
+    Aggregator<?> aggregator = count.getAggregatorFactory().getAggregator();
     aggregator.recordLong(10);
 
     MetricData metricData =

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregation/LastValueAggregationTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregation/LastValueAggregationTest.java
@@ -20,13 +20,12 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link AggregationFactory#lastValue()}. */
 class LastValueAggregationTest {
 
   @Test
   void toMetricData() {
     Aggregation lastValue = AggregationFactory.lastValue().create(InstrumentValueType.LONG);
-    Aggregator aggregator = lastValue.getAggregatorFactory().getAggregator();
+    Aggregator<?> aggregator = lastValue.getAggregatorFactory().getAggregator();
     aggregator.recordLong(10);
 
     MetricData metricData =

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregation/MinMaxSumCountAggregationTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregation/MinMaxSumCountAggregationTest.java
@@ -20,14 +20,13 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link AggregationFactory#minMaxSumCount()}. */
 class MinMaxSumCountAggregationTest {
 
   @Test
   void toMetricData() {
     Aggregation minMaxSumCount =
         AggregationFactory.minMaxSumCount().create(InstrumentValueType.LONG);
-    Aggregator aggregator = minMaxSumCount.getAggregatorFactory().getAggregator();
+    Aggregator<?> aggregator = minMaxSumCount.getAggregatorFactory().getAggregator();
     aggregator.recordLong(10);
 
     MetricData metricData =

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregation/SumAggregationTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregation/SumAggregationTest.java
@@ -26,7 +26,7 @@ class SumAggregationTest {
   @Test
   void toMetricData() {
     Aggregation sum = AggregationFactory.sum().create(InstrumentValueType.LONG);
-    Aggregator aggregator = sum.getAggregatorFactory().getAggregator();
+    Aggregator<?> aggregator = sum.getAggregatorFactory().getAggregator();
     aggregator.recordLong(10);
 
     MetricData metricData =

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/AggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/AggregatorTest.java
@@ -91,7 +91,7 @@ public class AggregatorTest {
     assertThat(testAggregator.recordedDouble.get()).isEqualTo(0);
   }
 
-  private static class TestAggregator extends Aggregator {
+  private static class TestAggregator extends Aggregator<Accumulation> {
     final AtomicLong recordedLong = new AtomicLong();
     final AtomicDouble recordedDouble = new AtomicDouble();
 

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/CountAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/CountAggregatorTest.java
@@ -14,13 +14,13 @@ import org.junit.jupiter.api.Test;
 class CountAggregatorTest {
   @Test
   void factoryAggregation() {
-    AggregatorFactory factory = CountAggregator.getFactory();
+    AggregatorFactory<LongAccumulation> factory = CountAggregator.getFactory();
     assertThat(factory.getAggregator()).isInstanceOf(CountAggregator.class);
   }
 
   @Test
   void recordLongOperations() {
-    Aggregator aggregator = CountAggregator.getFactory().getAggregator();
+    Aggregator<LongAccumulation> aggregator = CountAggregator.getFactory().getAggregator();
     aggregator.recordLong(12);
     aggregator.recordLong(12);
     assertThat(aggregator.accumulateThenReset()).isEqualTo(LongAccumulation.create(2));
@@ -28,7 +28,7 @@ class CountAggregatorTest {
 
   @Test
   void recordDoubleOperations() {
-    Aggregator aggregator = CountAggregator.getFactory().getAggregator();
+    Aggregator<LongAccumulation> aggregator = CountAggregator.getFactory().getAggregator();
     aggregator.recordDouble(12.3);
     aggregator.recordDouble(12.3);
     assertThat(aggregator.accumulateThenReset()).isEqualTo(LongAccumulation.create(2));

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleLastValueAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleLastValueAggregatorTest.java
@@ -14,19 +14,21 @@ import org.junit.jupiter.api.Test;
 class DoubleLastValueAggregatorTest {
   @Test
   void factoryAggregation() {
-    AggregatorFactory factory = DoubleLastValueAggregator.getFactory();
+    AggregatorFactory<DoubleAccumulation> factory = DoubleLastValueAggregator.getFactory();
     assertThat(factory.getAggregator()).isInstanceOf(DoubleLastValueAggregator.class);
   }
 
   @Test
   void toPoint() {
-    Aggregator aggregator = DoubleLastValueAggregator.getFactory().getAggregator();
+    Aggregator<DoubleAccumulation> aggregator =
+        DoubleLastValueAggregator.getFactory().getAggregator();
     assertThat(aggregator.accumulateThenReset()).isNull();
   }
 
   @Test
   void multipleRecords() {
-    Aggregator aggregator = DoubleLastValueAggregator.getFactory().getAggregator();
+    Aggregator<DoubleAccumulation> aggregator =
+        DoubleLastValueAggregator.getFactory().getAggregator();
     aggregator.recordDouble(12.1);
     assertThat(aggregator.accumulateThenReset()).isEqualTo(DoubleAccumulation.create(12.1));
     aggregator.recordDouble(13.1);
@@ -36,7 +38,8 @@ class DoubleLastValueAggregatorTest {
 
   @Test
   void toAccumulationAndReset() {
-    Aggregator aggregator = DoubleLastValueAggregator.getFactory().getAggregator();
+    Aggregator<DoubleAccumulation> aggregator =
+        DoubleLastValueAggregator.getFactory().getAggregator();
     aggregator.recordDouble(13.1);
     assertThat(aggregator.accumulateThenReset()).isEqualTo(DoubleAccumulation.create(13.1));
     assertThat(aggregator.accumulateThenReset()).isNull();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountAggregatorTest.java
@@ -23,13 +23,15 @@ import org.junit.jupiter.api.Test;
 class DoubleMinMaxSumCountAggregatorTest {
   @Test
   void factoryAggregation() {
-    AggregatorFactory factory = DoubleMinMaxSumCountAggregator.getFactory();
+    AggregatorFactory<MinMaxSumCountAccumulation> factory =
+        DoubleMinMaxSumCountAggregator.getFactory();
     assertThat(factory.getAggregator()).isInstanceOf(DoubleMinMaxSumCountAggregator.class);
   }
 
   @Test
   void testRecordings() {
-    Aggregator aggregator = DoubleMinMaxSumCountAggregator.getFactory().getAggregator();
+    Aggregator<MinMaxSumCountAccumulation> aggregator =
+        DoubleMinMaxSumCountAggregator.getFactory().getAggregator();
 
     aggregator.recordDouble(100);
     assertThat(aggregator.accumulateThenReset())
@@ -46,7 +48,8 @@ class DoubleMinMaxSumCountAggregatorTest {
 
   @Test
   void toAccumulationAndReset() {
-    Aggregator aggregator = DoubleMinMaxSumCountAggregator.getFactory().getAggregator();
+    Aggregator<MinMaxSumCountAccumulation> aggregator =
+        DoubleMinMaxSumCountAggregator.getFactory().getAggregator();
     assertThat(aggregator.accumulateThenReset()).isNull();
 
     aggregator.recordDouble(100);
@@ -62,7 +65,8 @@ class DoubleMinMaxSumCountAggregatorTest {
 
   @Test
   void testMultithreadedUpdates() throws Exception {
-    final Aggregator aggregator = DoubleMinMaxSumCountAggregator.getFactory().getAggregator();
+    final Aggregator<MinMaxSumCountAccumulation> aggregator =
+        DoubleMinMaxSumCountAggregator.getFactory().getAggregator();
     final Summary summarizer = new Summary();
     int numberOfThreads = 10;
     final double[] updates = new double[] {1, 2, 3, 5, 7, 11, 13, 17, 19, 23};

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleSumAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleSumAggregatorTest.java
@@ -14,19 +14,19 @@ import org.junit.jupiter.api.Test;
 class DoubleSumAggregatorTest {
   @Test
   void factoryAggregation() {
-    AggregatorFactory factory = DoubleSumAggregator.getFactory();
+    AggregatorFactory<DoubleAccumulation> factory = DoubleSumAggregator.getFactory();
     assertThat(factory.getAggregator()).isInstanceOf(DoubleSumAggregator.class);
   }
 
   @Test
   void toPoint() {
-    Aggregator aggregator = DoubleSumAggregator.getFactory().getAggregator();
+    Aggregator<DoubleAccumulation> aggregator = DoubleSumAggregator.getFactory().getAggregator();
     assertThat(aggregator.accumulateThenReset()).isNull();
   }
 
   @Test
   void multipleRecords() {
-    Aggregator aggregator = DoubleSumAggregator.getFactory().getAggregator();
+    Aggregator<DoubleAccumulation> aggregator = DoubleSumAggregator.getFactory().getAggregator();
     aggregator.recordDouble(12.1);
     aggregator.recordDouble(12.1);
     aggregator.recordDouble(12.1);
@@ -37,7 +37,7 @@ class DoubleSumAggregatorTest {
 
   @Test
   void multipleRecords_WithNegatives() {
-    Aggregator aggregator = DoubleSumAggregator.getFactory().getAggregator();
+    Aggregator<DoubleAccumulation> aggregator = DoubleSumAggregator.getFactory().getAggregator();
     aggregator.recordDouble(12);
     aggregator.recordDouble(12);
     aggregator.recordDouble(-23);
@@ -49,7 +49,7 @@ class DoubleSumAggregatorTest {
 
   @Test
   void toAccumulationAndReset() {
-    Aggregator aggregator = DoubleSumAggregator.getFactory().getAggregator();
+    Aggregator<DoubleAccumulation> aggregator = DoubleSumAggregator.getFactory().getAggregator();
     aggregator.recordDouble(13);
     aggregator.recordDouble(12);
     assertThat(aggregator.accumulateThenReset()).isEqualTo(DoubleAccumulation.create(25));

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongLastValueAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongLastValueAggregatorTest.java
@@ -14,19 +14,19 @@ import org.junit.jupiter.api.Test;
 class LongLastValueAggregatorTest {
   @Test
   void factoryAggregation() {
-    AggregatorFactory factory = LongLastValueAggregator.getFactory();
+    AggregatorFactory<LongAccumulation> factory = LongLastValueAggregator.getFactory();
     assertThat(factory.getAggregator()).isInstanceOf(LongLastValueAggregator.class);
   }
 
   @Test
   void toPoint() {
-    Aggregator aggregator = LongLastValueAggregator.getFactory().getAggregator();
+    Aggregator<LongAccumulation> aggregator = LongLastValueAggregator.getFactory().getAggregator();
     assertThat(aggregator.accumulateThenReset()).isNull();
   }
 
   @Test
   void multipleRecords() {
-    Aggregator aggregator = LongLastValueAggregator.getFactory().getAggregator();
+    Aggregator<LongAccumulation> aggregator = LongLastValueAggregator.getFactory().getAggregator();
     aggregator.recordLong(12);
     assertThat(aggregator.accumulateThenReset()).isEqualTo(LongAccumulation.create(12));
     aggregator.recordLong(13);
@@ -36,7 +36,7 @@ class LongLastValueAggregatorTest {
 
   @Test
   void toAccumulationAndReset() {
-    Aggregator aggregator = LongLastValueAggregator.getFactory().getAggregator();
+    Aggregator<LongAccumulation> aggregator = LongLastValueAggregator.getFactory().getAggregator();
     aggregator.recordLong(13);
     assertThat(aggregator.accumulateThenReset()).isEqualTo(LongAccumulation.create(13));
     assertThat(aggregator.accumulateThenReset()).isNull();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountAggregatorTest.java
@@ -23,13 +23,15 @@ import org.junit.jupiter.api.Test;
 class LongMinMaxSumCountAggregatorTest {
   @Test
   void factoryAggregation() {
-    AggregatorFactory factory = LongMinMaxSumCountAggregator.getFactory();
+    AggregatorFactory<MinMaxSumCountAccumulation> factory =
+        LongMinMaxSumCountAggregator.getFactory();
     assertThat(factory.getAggregator()).isInstanceOf(LongMinMaxSumCountAggregator.class);
   }
 
   @Test
   void testRecordings() {
-    Aggregator aggregator = LongMinMaxSumCountAggregator.getFactory().getAggregator();
+    Aggregator<MinMaxSumCountAccumulation> aggregator =
+        LongMinMaxSumCountAggregator.getFactory().getAggregator();
     aggregator.recordLong(100);
     assertThat(aggregator.accumulateThenReset())
         .isEqualTo(MinMaxSumCountAccumulation.create(1, 100, 100, 100));
@@ -43,7 +45,8 @@ class LongMinMaxSumCountAggregatorTest {
 
   @Test
   void toAccumulationAndReset() {
-    Aggregator aggregator = LongMinMaxSumCountAggregator.getFactory().getAggregator();
+    Aggregator<MinMaxSumCountAccumulation> aggregator =
+        LongMinMaxSumCountAggregator.getFactory().getAggregator();
     assertThat(aggregator.accumulateThenReset()).isNull();
 
     aggregator.recordLong(100);
@@ -59,7 +62,8 @@ class LongMinMaxSumCountAggregatorTest {
 
   @Test
   void testMultithreadedUpdates() throws Exception {
-    final Aggregator aggregator = LongMinMaxSumCountAggregator.getFactory().getAggregator();
+    final Aggregator<MinMaxSumCountAccumulation> aggregator =
+        LongMinMaxSumCountAggregator.getFactory().getAggregator();
     final Summary summarizer = new Summary();
     int numberOfThreads = 10;
     final long[] updates = new long[] {1, 2, 3, 5, 7, 11, 13, 17, 19, 23};

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongSumAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongSumAggregatorTest.java
@@ -14,13 +14,13 @@ import org.junit.jupiter.api.Test;
 class LongSumAggregatorTest {
   @Test
   void factoryAggregation() {
-    AggregatorFactory factory = LongSumAggregator.getFactory();
+    AggregatorFactory<LongAccumulation> factory = LongSumAggregator.getFactory();
     assertThat(factory.getAggregator()).isInstanceOf(LongSumAggregator.class);
   }
 
   @Test
   void multipleRecords() {
-    Aggregator aggregator = LongSumAggregator.getFactory().getAggregator();
+    Aggregator<LongAccumulation> aggregator = LongSumAggregator.getFactory().getAggregator();
     aggregator.recordLong(12);
     aggregator.recordLong(12);
     aggregator.recordLong(12);
@@ -32,7 +32,7 @@ class LongSumAggregatorTest {
 
   @Test
   void multipleRecords_WithNegatives() {
-    Aggregator aggregator = LongSumAggregator.getFactory().getAggregator();
+    Aggregator<LongAccumulation> aggregator = LongSumAggregator.getFactory().getAggregator();
     aggregator.recordLong(12);
     aggregator.recordLong(12);
     aggregator.recordLong(-23);
@@ -45,7 +45,7 @@ class LongSumAggregatorTest {
 
   @Test
   void toAccumulationAndReset() {
-    Aggregator aggregator = LongSumAggregator.getFactory().getAggregator();
+    Aggregator<LongAccumulation> aggregator = LongSumAggregator.getFactory().getAggregator();
     aggregator.recordLong(13);
     aggregator.recordLong(12);
     assertThat(aggregator.accumulateThenReset()).isEqualTo(LongAccumulation.create(25));


### PR DESCRIPTION
Followup PR will propagate the Accumulation type to the Aggregation to avoid type cast in merge.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>