### PR TITLE
Reduce usage of GlobalOpenTelemetry

### DIFF
--- a/extensions/kotlin/src/test/kotlin/io/opentelemetry/extension/kotlin/KotlinCoroutinesTest.kt
+++ b/extensions/kotlin/src/test/kotlin/io/opentelemetry/extension/kotlin/KotlinCoroutinesTest.kt
@@ -1,17 +1,22 @@
 package io.opentelemetry.extension.kotlin
 
-import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.ContextKey
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
 import kotlinx.coroutines.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class KotlinCoroutinesTest {
 
     companion object {
         private val ANIMAL: ContextKey<String> = ContextKey.named("animal")
+
+        @JvmField
+        @RegisterExtension
+        val otelTesting = OpenTelemetryExtension.create()
     }
 
     @Test
@@ -37,7 +42,8 @@ class KotlinCoroutinesTest {
 
     @Test
     fun runWithSpan() {
-        val span = GlobalOpenTelemetry.getTracer("test").spanBuilder("test").startSpan()
+        val span = otelTesting.openTelemetry.getTracer("test").spanBuilder("test")
+                .startSpan()
         assertThat(Span.current()).isEqualTo(Span.getInvalid())
         runBlocking(Dispatchers.Default + span.asContextElement()) {
             assertThat(Span.current()).isEqualTo(span)

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanBuilderShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanBuilderShimTest.java
@@ -8,8 +8,8 @@ package io.opentelemetry.opentracingshim;
 import static io.opentelemetry.opentracingshim.TestUtils.getBaggageMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import org.junit.jupiter.api.Test;
 
@@ -17,8 +17,7 @@ class SpanBuilderShimTest {
 
   private final SdkTracerProvider tracerSdkFactory = SdkTracerProvider.builder().build();
   private final Tracer tracer = tracerSdkFactory.get("SpanShimTest");
-  private final TelemetryInfo telemetryInfo =
-      new TelemetryInfo(tracer, GlobalOpenTelemetry.getPropagators());
+  private final TelemetryInfo telemetryInfo = new TelemetryInfo(tracer, ContextPropagators.noop());
 
   private static final String SPAN_NAME = "Span";
 

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
@@ -8,9 +8,9 @@ package io.opentelemetry.opentracingshim;
 import static io.opentelemetry.opentracingshim.TestUtils.getBaggageMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
@@ -21,8 +21,7 @@ class SpanShimTest {
 
   private final SdkTracerProvider tracerSdkFactory = SdkTracerProvider.builder().build();
   private final Tracer tracer = tracerSdkFactory.get("SpanShimTest");
-  private final TelemetryInfo telemetryInfo =
-      new TelemetryInfo(tracer, GlobalOpenTelemetry.getPropagators());
+  private final TelemetryInfo telemetryInfo = new TelemetryInfo(tracer, ContextPropagators.noop());
   private Span span;
 
   private static final String SPAN_NAME = "Span";

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/TracerShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/TracerShimTest.java
@@ -7,7 +7,8 @@ package io.opentelemetry.opentracingshim;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
@@ -23,8 +24,11 @@ import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 class TracerShimTest {
+
+  @RegisterExtension public OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
 
   TracerShim tracerShim;
 
@@ -33,8 +37,8 @@ class TracerShimTest {
     tracerShim =
         new TracerShim(
             new TelemetryInfo(
-                GlobalOpenTelemetry.getTracer("opentracingshim"),
-                GlobalOpenTelemetry.getPropagators()));
+                otelTesting.getOpenTelemetry().getTracer("opentracingshim"),
+                ContextPropagators.noop()));
   }
 
   @Test

--- a/sdk-extensions/jfr-events/src/test/java/io/opentelemetry/sdk/extension/jfr/JfrSpanProcessorTest.java
+++ b/sdk-extensions/jfr-events/src/test/java/io/opentelemetry/sdk/extension/jfr/JfrSpanProcessorTest.java
@@ -7,12 +7,10 @@ package io.opentelemetry.sdk.extension.jfr;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.ContextStorage;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -21,25 +19,31 @@ import java.util.List;
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordingFile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class JfrSpanProcessorTest {
 
   private static final String OPERATION_NAME = "Test Span";
-  private final Tracer tracer;
+
+  private SdkTracerProvider sdkTracerProvider;
+  private Tracer tracer;
+
+  @BeforeEach
+  void setUp() {
+    sdkTracerProvider =
+        SdkTracerProvider.builder().addSpanProcessor(new JfrSpanProcessor()).build();
+    tracer = sdkTracerProvider.get("JfrSpanProcessorTest");
+  }
+
+  @AfterEach
+  void tearDown() {
+    sdkTracerProvider.shutdown();
+  }
 
   static {
     ContextStorage.addWrapper(JfrContextStorageWrapper::new);
-    GlobalOpenTelemetry.set(
-        OpenTelemetrySdk.builder()
-            .setTracerProvider(
-                SdkTracerProvider.builder().addSpanProcessor(new JfrSpanProcessor()).build())
-            .build());
-  }
-
-  /** Simple test to validate JFR events for Span and Scope. */
-  public JfrSpanProcessorTest() {
-    tracer = GlobalOpenTelemetry.getTracer("JfrSpanProcessorTest");
   }
 
   /**

--- a/sdk-extensions/zpages/src/jmh/java/io/opentelemetry/sdk/extension/zpages/TracezSpanBucketsBenchmark.java
+++ b/sdk-extensions/zpages/src/jmh/java/io/opentelemetry/sdk/extension/zpages/TracezSpanBucketsBenchmark.java
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.sdk.extension.zpages;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
@@ -32,7 +32,7 @@ public class TracezSpanBucketsBenchmark {
   @Setup(Level.Trial)
   public final void setup() {
     bucket = new TracezSpanBuckets();
-    Tracer tracer = GlobalOpenTelemetry.getTracer("TracezZPageBenchmark");
+    Tracer tracer = SdkTracerProvider.builder().build().get("TracezZPageBenchmark");
     Span span = tracer.spanBuilder(spanName).startSpan();
     span.end();
     readableSpan = (ReadableSpan) span;

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBenchmark.java
@@ -6,11 +6,11 @@
 package io.opentelemetry.sdk.trace.export;
 
 import com.google.common.collect.ImmutableList;
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.Collection;
 import java.util.List;
@@ -79,7 +79,7 @@ public class BatchSpanProcessorBenchmark {
     processor = BatchSpanProcessor.builder(exporter).build();
 
     ImmutableList.Builder<Span> spans = ImmutableList.builderWithExpectedSize(spanCount);
-    Tracer tracer = GlobalOpenTelemetry.getTracerProvider().get("benchmarkTracer");
+    Tracer tracer = SdkTracerProvider.builder().build().get("benchmarkTracer");
     for (int i = 0; i < spanCount; i++) {
       spans.add(tracer.spanBuilder("span").startSpan());
     }

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorDroppedSpansBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorDroppedSpansBenchmark.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.sdk.trace.export;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.metrics.GlobalMetricsProvider;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.common.CompletableResultCode;
@@ -15,6 +14,7 @@ import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.Point;
 import io.opentelemetry.sdk.metrics.export.MetricProducer;
 import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -66,7 +66,7 @@ public class BatchSpanProcessorDroppedSpansBenchmark {
       SpanExporter exporter = new DelayingSpanExporter();
       processor = BatchSpanProcessor.builder(exporter).build();
 
-      tracer = GlobalOpenTelemetry.getTracerProvider().get("benchmarkTracer");
+      tracer = SdkTracerProvider.builder().build().get("benchmarkTracer");
     }
 
     @TearDown(Level.Trial)

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorFlushBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorFlushBenchmark.java
@@ -6,11 +6,11 @@
 package io.opentelemetry.sdk.trace.export;
 
 import com.google.common.collect.ImmutableList;
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.Collection;
 import java.util.List;
@@ -79,7 +79,7 @@ public class BatchSpanProcessorFlushBenchmark {
     processor = BatchSpanProcessor.builder(exporter).build();
 
     ImmutableList.Builder<Span> spans = ImmutableList.builderWithExpectedSize(spanCount);
-    Tracer tracer = GlobalOpenTelemetry.getTracerProvider().get("benchmarkTracer");
+    Tracer tracer = SdkTracerProvider.builder().build().get("benchmarkTracer");
     for (int i = 0; i < spanCount; i++) {
       spans.add(tracer.spanBuilder("span").startSpan());
     }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/testbed/clientserver/Client.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/testbed/clientserver/Client.java
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.sdk.trace.testbed.clientserver;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Span.Kind;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -30,9 +30,7 @@ final class Client {
     span.setAttribute("component", "example-client");
 
     try (Scope ignored = span.makeCurrent()) {
-      GlobalOpenTelemetry.getPropagators()
-          .getTextMapPropagator()
-          .inject(Context.current(), message, Message::put);
+      W3CTraceContextPropagator.getInstance().inject(Context.current(), message, Message::put);
       queue.put(message);
     } finally {
       span.end();

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/testbed/clientserver/Server.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/testbed/clientserver/Server.java
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.sdk.trace.testbed.clientserver;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Span.Kind;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapPropagator.Getter;
@@ -27,8 +27,7 @@ final class Server extends Thread {
 
   private void process(Message message) {
     Context context =
-        GlobalOpenTelemetry.getPropagators()
-            .getTextMapPropagator()
+        W3CTraceContextPropagator.getInstance()
             .extract(
                 Context.current(),
                 message,


### PR DESCRIPTION
Mostly to make the tests more readable rather than relying on what happens to be in the global at the time (possibly mutated in another test in the package).