### PR TITLE
Make prometheus client API dependency of exporter.

### DIFF
--- a/exporters/prometheus/build.gradle
+++ b/exporters/prometheus/build.gradle
@@ -9,9 +9,8 @@ description = 'OpenTelemetry Prometheus Exporter'
 ext.moduleName = "io.opentelemetry.exporter.prometheus"
 
 dependencies {
-    api project(':sdk:metrics')
-
-    implementation libraries.prometheus_client
+    api project(':sdk:metrics'),
+            libraries.prometheus_client
 
     testImplementation libraries.prometheus_client_common,
             libraries.guava


### PR DESCRIPTION
`PrometheusCollector` extends `Collector` so the prometheus artifact is actually in the public API of the module.