### PR TITLE
Rename AwsXRayPropagator to AwsXrayPropagator

### DIFF
--- a/extensions/trace-propagators/src/jmh/java/io/opentelemetry/extension/trace/propagation/PropagatorContextExtractBenchmark.java
+++ b/extensions/trace-propagators/src/jmh/java/io/opentelemetry/extension/trace/propagation/PropagatorContextExtractBenchmark.java
@@ -271,19 +271,19 @@ public class PropagatorContextExtractBenchmark {
     private static final List<Map<String, String>> traceHeaders =
         Arrays.asList(
             Collections.singletonMap(
-                AwsXRayPropagator.TRACE_HEADER_KEY,
+                AwsXrayPropagator.TRACE_HEADER_KEY,
                 "Root=1-8a3c60f7-d188f8fa79d48a391a778fa6;Parent=53995c3f42cd8ad8;Sampled=1"),
             Collections.singletonMap(
-                AwsXRayPropagator.TRACE_HEADER_KEY,
+                AwsXrayPropagator.TRACE_HEADER_KEY,
                 "Root=1-8a3c60f7-d188f8fa79d48a391a778fa6;Parent=53995c3f42cd8ad8;Sampled=0"),
             Collections.singletonMap(
-                AwsXRayPropagator.TRACE_HEADER_KEY,
+                AwsXrayPropagator.TRACE_HEADER_KEY,
                 "Parent=53995c3f42cd8ad8;Sampled=1;Root=1-8a3c60f7-d188f8fa79d48a391a778fa6"),
             Collections.singletonMap(
-                AwsXRayPropagator.TRACE_HEADER_KEY,
+                AwsXrayPropagator.TRACE_HEADER_KEY,
                 "Root=1-57ff426a-80c11c39b0c928905eb0828d;Parent=53995c3f42cd8ad8;Sampled=1"),
             Collections.singletonMap(
-                AwsXRayPropagator.TRACE_HEADER_KEY,
+                AwsXrayPropagator.TRACE_HEADER_KEY,
                 "Root=1-57ff426a-80c11c39b0c928905eb0828d;Parent=12345c3f42cd8ad8;Sampled=0"));
 
     private final TextMapPropagator.Getter<Map<String, String>> getter =
@@ -299,7 +299,7 @@ public class PropagatorContextExtractBenchmark {
           }
         };
 
-    private final AwsXRayPropagator xrayPropagator = AwsXRayPropagator.getInstance();
+    private final AwsXrayPropagator xrayPropagator = AwsXrayPropagator.getInstance();
 
     @Override
     protected Context doExtract() {

--- a/extensions/trace-propagators/src/jmh/java/io/opentelemetry/extension/trace/propagation/PropagatorContextInjectBenchmark.java
+++ b/extensions/trace-propagators/src/jmh/java/io/opentelemetry/extension/trace/propagation/PropagatorContextInjectBenchmark.java
@@ -137,7 +137,7 @@ public class PropagatorContextInjectBenchmark {
 
   /** Benchmark for injecting trace context into AWS X-Ray headers. */
   public static class AwsXRayPropagatorInjectBenchmark extends AbstractContextInjectBenchmark {
-    private final AwsXRayPropagator xrayPropagator = AwsXRayPropagator.getInstance();
+    private final AwsXrayPropagator xrayPropagator = AwsXrayPropagator.getInstance();
     private final TextMapPropagator.Setter<Map<String, String>> setter =
         new TextMapPropagator.Setter<Map<String, String>>() {
           @Override

--- a/extensions/trace-propagators/src/jmh/java/io/opentelemetry/extension/trace/propagation/PropagatorContextInjectBenchmark.java
+++ b/extensions/trace-propagators/src/jmh/java/io/opentelemetry/extension/trace/propagation/PropagatorContextInjectBenchmark.java
@@ -136,7 +136,7 @@ public class PropagatorContextInjectBenchmark {
   }
 
   /** Benchmark for injecting trace context into AWS X-Ray headers. */
-  public static class AwsXRayPropagatorInjectBenchmark extends AbstractContextInjectBenchmark {
+  public static class AwsXrayPropagatorInjectBenchmark extends AbstractContextInjectBenchmark {
     private final AwsXrayPropagator xrayPropagator = AwsXrayPropagator.getInstance();
     private final TextMapPropagator.Setter<Map<String, String>> setter =
         new TextMapPropagator.Setter<Map<String, String>>() {

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/AwsXrayPropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/AwsXrayPropagator.java
@@ -30,8 +30,8 @@ import javax.annotation.Nullable;
  * OpenTelemetry.setPropagators(
  *   DefaultContextPropagators
  *     .builder()
- *     .addTextMapPropagator(W3CTraceContextPropagator.getDefaultInstance())
- *     .addTextMapPropagator(AWSXrayPropagator.getDefaultInstance())
+ *     .addTextMapPropagator(W3CTraceContextPropagator.getInstance())
+ *     .addTextMapPropagator(AWSXrayPropagator.getInstance())
  *     .build());
  * }</pre>
  */

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/AwsXrayPropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/AwsXrayPropagator.java
@@ -30,17 +30,17 @@ import javax.annotation.Nullable;
  * OpenTelemetry.setPropagators(
  *   DefaultContextPropagators
  *     .builder()
- *     .addTextMapPropagator(new HttpTraceContext())
- *     .addTextMapPropagator(new AWSXRayPropagator())
+ *     .addTextMapPropagator(W3CTraceContextPropagator.getDefaultInstance())
+ *     .addTextMapPropagator(AWSXrayPropagator.getDefaultInstance())
  *     .build());
  * }</pre>
  */
-public final class AwsXRayPropagator implements TextMapPropagator {
+public final class AwsXrayPropagator implements TextMapPropagator {
 
   // Visible for testing
   static final String TRACE_HEADER_KEY = "X-Amzn-Trace-Id";
 
-  private static final Logger logger = Logger.getLogger(AwsXRayPropagator.class.getName());
+  private static final Logger logger = Logger.getLogger(AwsXrayPropagator.class.getName());
 
   private static final char TRACE_HEADER_DELIMITER = ';';
   private static final char KV_DELIMITER = '=';
@@ -63,13 +63,13 @@ public final class AwsXRayPropagator implements TextMapPropagator {
 
   private static final Collection<String> FIELDS = Collections.singletonList(TRACE_HEADER_KEY);
 
-  private static final AwsXRayPropagator INSTANCE = new AwsXRayPropagator();
+  private static final AwsXrayPropagator INSTANCE = new AwsXrayPropagator();
 
-  private AwsXRayPropagator() {
+  private AwsXrayPropagator() {
     // singleton
   }
 
-  public static AwsXRayPropagator getInstance() {
+  public static AwsXrayPropagator getInstance() {
     return INSTANCE;
   }
 

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/AwsXrayPropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/AwsXrayPropagatorTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.extension.trace.propagation;
 
-import static io.opentelemetry.extension.trace.propagation.AwsXRayPropagator.TRACE_HEADER_KEY;
+import static io.opentelemetry.extension.trace.propagation.AwsXrayPropagator.TRACE_HEADER_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.Span;
@@ -20,7 +20,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 
-class AwsXRayPropagatorTest {
+class AwsXrayPropagatorTest {
 
   private static final String TRACE_ID_BASE16 = "8a3c60f7d188f8fa79d48a391a778fa6";
   private static final TraceState TRACE_STATE_DEFAULT = TraceState.getDefault();
@@ -42,7 +42,7 @@ class AwsXRayPropagatorTest {
           return carrier.get(key);
         }
       };
-  private final AwsXRayPropagator xrayPropagator = AwsXRayPropagator.getInstance();
+  private final AwsXrayPropagator xrayPropagator = AwsXrayPropagator.getInstance();
 
   @Test
   void inject_SampledContext() {


### PR DESCRIPTION
Currently the id generator and propagator do not consistently spell xray which has been a bit strange. Now they do.