### PR TITLE
Add SdkMeterProviderBuilder.buildAndRegisterGlobal

### DIFF
--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/GlobalMetricsProvider.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/GlobalMetricsProvider.java
@@ -40,6 +40,16 @@ public class GlobalMetricsProvider {
   }
 
   /**
+   * Sets the {@link MeterProvider} that should be the global instance. Future calls to {@link
+   * #get()} will return the provided {@link MeterProvider} instance. This should be called once as
+   * early as possible in your application initialization logic, often in a {@code static} block in
+   * your main class.
+   */
+  public static void set(MeterProvider meterProvider) {
+    globalMeterProvider.set(meterProvider);
+  }
+
+  /**
    * Gets or creates a named meter instance from the globally registered {@link MeterProvider}.
    *
    * <p>This is a shortcut method for {@code getGlobalMeterProvider().get(instrumentationName)}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProviderBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProviderBuilder.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import io.opentelemetry.api.metrics.GlobalMetricsProvider;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.internal.SystemClock;
 import io.opentelemetry.sdk.resources.Resource;
@@ -47,9 +48,27 @@ public final class SdkMeterProviderBuilder {
   }
 
   /**
-   * Create a new TracerSdkFactory instance.
+   * Returns a new {@link SdkMeterProvider} built with the configuration of this {@link
+   * SdkMeterProviderBuilder} and registers it as the global {@link
+   * io.opentelemetry.api.metrics.MeterProvider}.
    *
-   * @return An initialized TracerSdkFactory.
+   * @see GlobalMetricsProvider
+   */
+  public SdkMeterProvider buildAndRegisterGlobal() {
+    SdkMeterProvider meterProvider = build();
+    GlobalMetricsProvider.set(meterProvider);
+    return meterProvider;
+  }
+
+  /**
+   * Returns a new {@link SdkMeterProvider} built with the configuration of this {@link
+   * SdkMeterProviderBuilder}. This provider is not registered as the global {@link
+   * io.opentelemetry.api.metrics.MeterProvider}. It is recommended that you register one provider
+   * using {@link SdkMeterProviderBuilder#buildAndRegisterGlobal()} for use by instrumentation when
+   * that requires access to a global instance of {@link
+   * io.opentelemetry.api.metrics.MeterProvider}.
+   *
+   * @see GlobalMetricsProvider
    */
   public SdkMeterProvider build() {
     return new SdkMeterProvider(clock, resource);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderBuilderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderBuilderTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.metrics.GlobalMetricsProvider;
+import org.junit.jupiter.api.Test;
+
+class SdkMeterProviderBuilderTest {
+
+  @Test
+  void buildAndRegisterGlobal() {
+    SdkMeterProvider meterProvider = SdkMeterProvider.builder().buildAndRegisterGlobal();
+    try {
+      assertThat(GlobalMetricsProvider.get()).isSameAs(meterProvider);
+    } finally {
+      GlobalMetricsProvider.set(null);
+    }
+  }
+}


### PR DESCRIPTION
For consistency with `OpenTelemetrySdkBuilder` and for use from the autoconfigure wrapper.