### PR TITLE
Fix README tracing and baggage api links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ project.
 This project contains the following top level components:
 
 * [OpenTelemetry API](api/):
-  * [tracing api](api/trace/src/main/java/io/opentelemetry/api/trace/) includes `Tracer`, `Span` and `SpanContext`.
-  * [baggage api](api/baggage/src/main/java/io/opentelemetry/api/baggage/) defines a collection of entries in the form of key-value pairs of data that can be propagated to provide contextual information.
+  * [tracing api](api/all/src/main/java/io/opentelemetry/api/trace/) includes `Tracer`, `Span` and `SpanContext`.
+  * [baggage api](api/all/src/main/java/io/opentelemetry/api/baggage/) defines a collection of entries in the form of key-value pairs of data that can be propagated to provide contextual information.
   * [metrics api](api/metrics/src/main/java/io/opentelemetry/api/metrics/).
   * [context api](api/context/src/main/java/io/opentelemetry/context/).
 * [extensions](extensions/) define additional API extensions, which are not part of the core API.


### PR DESCRIPTION
README seems to have two broken links, this small change fixes them