### PR TITLE
Add CodeQL security scans

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,28 +33,12 @@ jobs:
           languages: java
 
       # Build the code
-      # - uses: actions/checkout@v2
-      #   with:
-      #     fetch-depth: 0
-      # - id: setup-java-8
-      #   name: Setup Java 8
-      #   uses: actions/setup-java@v1
-      #   with:
-      #     java-version: 8
-      #     java-package: jre
       - name: Setup Java 11
         uses: actions/setup-java@v1
         with:
           java-version: 11
 
       - run: ./gradlew build --stacktrace jacocoTestReport
-      # - uses: burrunan/gradle-cache-action@v1.6
-      #   with:
-      #     remote-build-cache-proxy-enabled: false
-      #     arguments: build --stacktrace jacocoTestReport
-      #     properties: |
-      #       testAdditionalJavaVersions=true
-      #       org.gradle.java.installations.paths=${{ steps.setup-java-8.outputs.path }},${{ steps.setup-java-11.outputs.path }}
 
       # Perform Analysis
       - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,7 +40,6 @@ jobs:
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v1
-      # - run: ./gradlew build --stacktrace jacocoTestReport
 
       # Perform Analysis
       - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,27 +33,28 @@ jobs:
           languages: java
 
       # Build the code
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - id: setup-java-8
-        name: Setup Java 8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 8
-          java-package: jre
-      - id: setup-java-11
-        name: Setup Java 11
+      # - uses: actions/checkout@v2
+      #   with:
+      #     fetch-depth: 0
+      # - id: setup-java-8
+      #   name: Setup Java 8
+      #   uses: actions/setup-java@v1
+      #   with:
+      #     java-version: 8
+      #     java-package: jre
+      - name: Setup Java 11
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - uses: burrunan/gradle-cache-action@v1.6
-        with:
-          remote-build-cache-proxy-enabled: false
-          arguments: build --stacktrace jacocoTestReport
-          properties: |
-            testAdditionalJavaVersions=true
-            org.gradle.java.installations.paths=${{ steps.setup-java-8.outputs.path }},${{ steps.setup-java-11.outputs.path }}
+
+      - run: ./gradlew build --stacktrace jacocoTestReport
+      # - uses: burrunan/gradle-cache-action@v1.6
+      #   with:
+      #     remote-build-cache-proxy-enabled: false
+      #     arguments: build --stacktrace jacocoTestReport
+      #     properties: |
+      #       testAdditionalJavaVersions=true
+      #       org.gradle.java.installations.paths=${{ steps.setup-java-8.outputs.path }},${{ steps.setup-java-11.outputs.path }}
 
       # Perform Analysis
       - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,9 @@ jobs:
         with:
           java-version: 11
 
-      - run: ./gradlew build --stacktrace jacocoTestReport
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
+      # - run: ./gradlew build --stacktrace jacocoTestReport
 
       # Perform Analysis
       - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,10 +1,6 @@
 name: "Code Scanning - Action"
 
 on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
   workflow_dispatch:
   schedule:
     #        ┌───────────── minute (0 - 59)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,15 +3,6 @@ name: "Code Scanning - Action"
 on:
   workflow_dispatch:
   schedule:
-    #        ┌───────────── minute (0 - 59)
-    #        │  ┌───────────── hour (0 - 23)
-    #        │  │ ┌───────────── day of the month (1 - 31)
-    #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
-    #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
-    #        │  │ │ │ │
-    #        │  │ │ │ │
-    #        │  │ │ │ │
-    #        *  * * * *
     - cron: '30 1 * * *'
 
 jobs:
@@ -22,13 +13,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1
         with:
           languages: java
 
-      # Build the code
       - name: Setup Java 11
         uses: actions/setup-java@v1
         with:
@@ -37,6 +26,5 @@ jobs:
       - name: Autobuild
         uses: github/codeql-action/autobuild@v1
 
-      # Perform Analysis
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,39 @@
+name: "Code Scanning - Action"
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+  schedule:
+    #        ┌───────────── minute (0 - 59)
+    #        │  ┌───────────── hour (0 - 23)
+    #        │  │ ┌───────────── day of the month (1 - 31)
+    #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        *  * * * *
+    - cron: '30 1 * * *'
+
+jobs:
+  CodeQL-Build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: java
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,8 +32,29 @@ jobs:
         with:
           languages: java
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+      # Build the code
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - id: setup-java-8
+        name: Setup Java 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+          java-package: jre
+      - id: setup-java-11
+        name: Setup Java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: burrunan/gradle-cache-action@v1.6
+        with:
+          remote-build-cache-proxy-enabled: false
+          arguments: build --stacktrace jacocoTestReport
+          properties: |
+            testAdditionalJavaVersions=true
+            org.gradle.java.installations.paths=${{ steps.setup-java-8.outputs.path }},${{ steps.setup-java-11.outputs.path }}
 
+      # Perform Analysis
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
## Motivation
Follow up to issue https://github.com/open-telemetry/oteps/issues/144

[CodeQL](https://github.com/github/codeql-action) is GitHub's static analysis engine which scans repos for security vulnerabilities. As the project grows and we near GA it might be useful to have a workflow which checks for security vulnerabilities with every PR so we can ensure every incremental change is following best development practices. Also passing basic security checks will also make sure that there aren't any glaring issues for our users.
## Changes
* This PR adds [CodeQL](https://github.com/github/codeql-action) security checks to the repo
* After every run the workflow uploads the results to GitHub. Details on the run and security alerts will show up in the `security` tab of this repo.

**Workflow Triggers**
* daily cron job at 1:30am
* workflow_dispatch (in case maintainers want to trigger a security check manually)

cc- @alolita