### PR TITLE
prevent workflow 'Publish snapshots to JFrog' in fork repo

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -49,7 +49,7 @@ jobs:
           path: all/build/reports/jacoco/test/html
   publish-snapshots:
     name: Publish snapshots to JFrog
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' && github.repository == 'open-telemetry/opentelemetry-java' }}
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Because  github [enable actions by default](https://github.blog/changelog/2020-12-15-github-actions-environments-environment-protection-rules-and-environment-secrets-beta/) ,every time I sync my repo with upstream, it will run actions ,thgen I get notifications about some jobs fail.

Though I can disable action in settings，but i  think some job will never run in fork repo like ''Publish snapshots to JFrog' .

So i add `if condition` here