### PR TITLE
Change the SdkTracerManagement shutdown method to return CompletableResultCode

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerManagement.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerManagement.java
@@ -64,8 +64,11 @@ public interface SdkTracerManagement {
    * <p>After this is called, further attempts at re-using or reconfiguring this instance will
    * result in undefined behavior. It should be considered a terminal operation for the SDK
    * implementation.
+   *
+   * @return a {@link CompletableResultCode} which is completed when all the span processors have
+   *     been shut down.
    */
-  void shutdown();
+  CompletableResultCode shutdown();
 
   /**
    * Requests the active span processor to process all span events that have not yet been processed

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
@@ -86,12 +86,12 @@ public final class SdkTracerProvider implements TracerProvider, SdkTracerManagem
   }
 
   @Override
-  public void shutdown() {
+  public CompletableResultCode shutdown() {
     if (sharedState.isStopped()) {
       logger.log(Level.WARNING, "Calling shutdown() multiple times.");
-      return;
+      return CompletableResultCode.ofSuccess();
     }
-    sharedState.stop();
+    return sharedState.stop();
   }
 
   @Override

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
@@ -91,7 +91,7 @@ public final class SdkTracerProvider implements TracerProvider, SdkTracerManagem
       logger.log(Level.WARNING, "Calling shutdown() multiple times.");
       return CompletableResultCode.ofSuccess();
     }
-    return sharedState.stop();
+    return sharedState.shutdown();
   }
 
   @Override

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/TracerSharedState.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/TracerSharedState.java
@@ -29,7 +29,7 @@ final class TracerSharedState {
 
   @GuardedBy("lock")
   @Nullable
-  private volatile CompletableResultCode isStopped = null;
+  private volatile CompletableResultCode shutdownResult = null;
 
   @GuardedBy("lock")
   private final List<SpanProcessor> registeredSpanProcessors;
@@ -106,7 +106,7 @@ final class TracerSharedState {
    */
   boolean isStopped() {
     synchronized (lock) {
-      return isStopped != null && isStopped.isSuccess();
+      return shutdownResult != null && shutdownResult.isSuccess();
     }
   }
 
@@ -116,13 +116,13 @@ final class TracerSharedState {
    * @return a {@link CompletableResultCode} that will be completed when the span processor is shut
    *     down.
    */
-  CompletableResultCode stop() {
+  CompletableResultCode shutdown() {
     synchronized (lock) {
-      if (isStopped != null) {
-        return isStopped;
+      if (shutdownResult != null) {
+        return shutdownResult;
       }
-      isStopped = activeSpanProcessor.shutdown();
-      return isStopped;
+      shutdownResult = activeSpanProcessor.shutdown();
+      return shutdownResult;
     }
   }
 }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.trace.export;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.api.trace.Span;
@@ -32,12 +33,8 @@ import javax.annotation.concurrent.GuardedBy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 class BatchSpanProcessorTest {
 
   private static final String SPAN_NAME_1 = "MySpanName/1";
@@ -45,8 +42,6 @@ class BatchSpanProcessorTest {
   private static final long MAX_SCHEDULE_DELAY_MILLIS = 500;
   private SdkTracerProvider sdkTracerProvider;
   private final BlockingSpanExporter blockingSpanExporter = new BlockingSpanExporter();
-
-  @Mock private SpanExporter mockSpanExporter;
 
   @AfterEach
   void cleanup() {
@@ -289,6 +284,7 @@ class BatchSpanProcessorTest {
 
   @Test
   void exporterThrowsException() {
+    SpanExporter mockSpanExporter = mock(SpanExporter.class);
     WaitingSpanExporter waitingSpanExporter =
         new WaitingSpanExporter(1, CompletableResultCode.ofSuccess());
     doThrow(new IllegalArgumentException("No export for you."))
@@ -453,6 +449,7 @@ class BatchSpanProcessorTest {
 
   @Test
   void shutdownPropagatesSuccess() {
+    SpanExporter mockSpanExporter = mock(SpanExporter.class);
     when(mockSpanExporter.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
     BatchSpanProcessor processor = BatchSpanProcessor.builder(mockSpanExporter).build();
     CompletableResultCode result = processor.shutdown();
@@ -462,6 +459,7 @@ class BatchSpanProcessorTest {
 
   @Test
   void shutdownPropagatesFailure() {
+    SpanExporter mockSpanExporter = mock(SpanExporter.class);
     when(mockSpanExporter.shutdown()).thenReturn(CompletableResultCode.ofFailure());
     BatchSpanProcessor processor = BatchSpanProcessor.builder(mockSpanExporter).build();
     CompletableResultCode result = processor.shutdown();


### PR DESCRIPTION
This makes the shutdown method more consistent across the SDK.