### PR TITLE
Use health port for jaeger container startup check.

### DIFF
--- a/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftIntegrationTest.java
+++ b/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftIntegrationTest.java
@@ -20,10 +20,9 @@ import okhttp3.Response;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers(disabledWithoutDocker = true)
 class JaegerThriftIntegrationTest {
@@ -33,16 +32,16 @@ class JaegerThriftIntegrationTest {
 
   private static final int QUERY_PORT = 16686;
   private static final int THRIFT_HTTP_PORT = 14268;
-  private static final String JAEGER_VERSION = "1.17";
+  private static final int HEALTH_PORT = 14269;
   private static final String SERVICE_NAME = "E2E-test";
   private static final String JAEGER_URL = "http://localhost";
 
   @Container
   public static GenericContainer<?> jaegerContainer =
-      new GenericContainer<>(DockerImageName.parse("jaegertracing/all-in-one:" + JAEGER_VERSION))
-          .withExposedPorts(THRIFT_HTTP_PORT, QUERY_PORT)
+      new GenericContainer<>("ghcr.io/open-telemetry/java-test-containers:jaeger")
+          .withExposedPorts(THRIFT_HTTP_PORT, QUERY_PORT, HEALTH_PORT)
           .withLogConsumer(outputFrame -> System.out.print(outputFrame.getUtf8String()))
-          .waitingFor(new HttpWaitStrategy().forPath("/"));
+          .waitingFor(Wait.forHttp("/").forPort(HEALTH_PORT));
 
   @Test
   void testJaegerIntegration() {

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerIntegrationTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerIntegrationTest.java
@@ -22,7 +22,7 @@ import okhttp3.Response;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -34,14 +34,15 @@ class JaegerIntegrationTest {
 
   private static final int QUERY_PORT = 16686;
   private static final int COLLECTOR_PORT = 14250;
+  private static final int HEALTH_PORT = 14269;
   private static final String SERVICE_NAME = "E2E-test";
   private static final String JAEGER_URL = "http://localhost";
 
   @Container
   public static GenericContainer<?> jaegerContainer =
-      new GenericContainer<>("open-telemetry-docker-dev.bintray.io/java-test-containers:jaeger")
-          .withExposedPorts(COLLECTOR_PORT, QUERY_PORT)
-          .waitingFor(new HttpWaitStrategy().forPath("/"));
+      new GenericContainer<>("ghcr.io/open-telemetry/java-test-containers:jaeger")
+          .withExposedPorts(COLLECTOR_PORT, QUERY_PORT, HEALTH_PORT)
+          .waitingFor(Wait.forHttp("/").forPort(HEALTH_PORT));
 
   @Test
   void testJaegerIntegration() {

--- a/perf-harness/src/test/java/io/opentelemetry/perf/OtlpPipelineStressTest.java
+++ b/perf-harness/src/test/java/io/opentelemetry/perf/OtlpPipelineStressTest.java
@@ -67,7 +67,7 @@ public class OtlpPipelineStressTest {
   public static GenericContainer<?> collectorContainer =
       new GenericContainer<>(
               DockerImageName.parse(
-                  "open-telemetry-docker-dev.bintray.io/java-test-containers:otel-collector-dev"))
+                  "ghcr.io/open-telemetry/java-test-containers:otel-collector-dev"))
           .withNetwork(network)
           .withNetworkAliases("otel-collector")
           .withExposedPorts(OTLP_RECEIVER_PORT)
@@ -92,8 +92,7 @@ public class OtlpPipelineStressTest {
   @Container
   public static GenericContainer<?> toxiproxyContainer =
       new GenericContainer<>(
-              DockerImageName.parse(
-                  "open-telemetry-docker-dev.bintray.io/java-test-containers:toxiproxy"))
+              DockerImageName.parse("ghcr.io/open-telemetry/java-test-containers:toxiproxy"))
           .withNetwork(network)
           .withNetworkAliases("toxiproxy")
           .withExposedPorts(TOXIPROXY_CONTROL_PORT, COLLECTOR_PROXY_PORT)

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerIntegrationTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerIntegrationTest.java
@@ -14,7 +14,7 @@ import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -23,16 +23,17 @@ class JaegerRemoteSamplerIntegrationTest {
 
   private static final int QUERY_PORT = 16686;
   private static final int COLLECTOR_PORT = 14250;
+  private static final int HEALTH_PORT = 14269;
   private static final String SERVICE_NAME = "E2E-test";
   private static final String SERVICE_NAME_RATE_LIMITING = "bar";
   private static final int RATE = 150;
 
   @Container
   public static GenericContainer<?> jaegerContainer =
-      new GenericContainer<>("open-telemetry-docker-dev.bintray.io/java-test-containers:jaeger")
+      new GenericContainer<>("ghcr.io/open-telemetry/java-test-containers:jaeger")
           .withCommand("--sampling.strategies-file=/sampling.json")
-          .withExposedPorts(COLLECTOR_PORT, QUERY_PORT)
-          .waitingFor(new HttpWaitStrategy().forPath("/"))
+          .withExposedPorts(COLLECTOR_PORT, QUERY_PORT, HEALTH_PORT)
+          .waitingFor(Wait.forHttp("/").forPort(HEALTH_PORT))
           .withClasspathResourceMapping("sampling.json", "/sampling.json", BindMode.READ_ONLY);
 
   @Test


### PR DESCRIPTION
Also migrate images to the ghcr ones I had set up but forgot to apply the change for.

Fixes #1871 (hopefully, will reopen if this doesn't actually fix it)