### PR TITLE
Replace max-workers in favor of priority setting, enable local build …

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.parallel=true
-org.gradle.workers.max=2
-org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m
+org.gradle.caching=true
+
+org.gradle.priority=low
+
+# Gradle default is 256m which causes issues with our build - https://docs.gradle.org/current/userguide/build_environment.html#sec:configuring_jvm_memory
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
…caching, and remove unnecessary Xmx

We've been using these settings in instrumentation repo and they seem to work fairly well.

Caching enables the local build cache, so builds don't have to rerun after cleans (btw our CI already uses local build cache).

And we don't need to set Xmx4096 for Gradle's jvmargs since that is only for the wrapper, the Gradle daemon which actually does builds can use a lot of memory.