### PR TITLE
Remove sampling probability attribute when was not accepted to spec.

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/ImmutableSamplingResult.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/ImmutableSamplingResult.java
@@ -5,10 +5,7 @@
 
 package io.opentelemetry.sdk.trace.samplers;
 
-import static io.opentelemetry.api.common.AttributeKey.doubleKey;
-
 import com.google.auto.value.AutoValue;
-import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import javax.annotation.concurrent.Immutable;
 
@@ -24,17 +21,6 @@ abstract class ImmutableSamplingResult implements SamplingResult {
 
   static final SamplingResult EMPTY_RECORDED_SAMPLING_RESULT =
       ImmutableSamplingResult.createWithoutAttributes(SamplingResult.Decision.RECORD_ONLY);
-
-  /**
-   * Probability value used by a probability-based Span sampling strategy.
-   *
-   * <p>Note: This will need to be updated if a specification for this value is merged which changes
-   * this proposed value. Also, once it's in the spec, we should move it somewhere more visible.
-   *
-   * <p>See https://github.com/open-telemetry/opentelemetry-specification/pull/570
-   */
-  // Visible for tests.
-  static final AttributeKey<Double> SAMPLING_PROBABILITY = doubleKey("sampling.probability");
 
   static SamplingResult createSamplingResult(Decision decision, Attributes attributes) {
     return new AutoValue_ImmutableSamplingResult(decision, attributes);

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/ImmutableSamplingResult.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/ImmutableSamplingResult.java
@@ -40,11 +40,6 @@ abstract class ImmutableSamplingResult implements SamplingResult {
     return new AutoValue_ImmutableSamplingResult(decision, attributes);
   }
 
-  static SamplingResult createWithProbability(Decision decision, double probability) {
-    return new AutoValue_ImmutableSamplingResult(
-        decision, Attributes.of(ImmutableSamplingResult.SAMPLING_PROBABILITY, probability));
-  }
-
   private static SamplingResult createWithoutAttributes(Decision decision) {
     return new AutoValue_ImmutableSamplingResult(decision, Attributes.empty());
   }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/TraceIdRatioBasedSampler.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/TraceIdRatioBasedSampler.java
@@ -46,9 +46,8 @@ abstract class TraceIdRatioBasedSampler implements Sampler {
     return new AutoValue_TraceIdRatioBasedSampler(
         ratio,
         idUpperBound,
-        ImmutableSamplingResult.createWithProbability(
-            SamplingResult.Decision.RECORD_AND_SAMPLE, ratio),
-        ImmutableSamplingResult.createWithProbability(SamplingResult.Decision.DROP, ratio));
+        SamplingResult.create(SamplingResult.Decision.RECORD_AND_SAMPLE),
+        SamplingResult.create(SamplingResult.Decision.DROP));
   }
 
   abstract double getRatio();

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/samplers/TraceIdRatioBasedSamplerTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/samplers/TraceIdRatioBasedSamplerTest.java
@@ -176,8 +176,6 @@ class TraceIdRatioBasedSamplerTest {
             Attributes.empty(),
             Collections.emptyList());
     assertThat(samplingResult1.getDecision()).isEqualTo(SamplingResult.Decision.DROP);
-    assertThat(samplingResult1.getAttributes())
-        .isEqualTo(Attributes.of(ImmutableSamplingResult.SAMPLING_PROBABILITY, 0.0001));
     // This traceId will be sampled by the Probability Sampler because the last 8 bytes as long
     // is less than probability * Long.MAX_VALUE;
     String sampledTraceId =
@@ -209,8 +207,6 @@ class TraceIdRatioBasedSamplerTest {
             Attributes.empty(),
             Collections.emptyList());
     assertThat(samplingResult2.getDecision()).isEqualTo(SamplingResult.Decision.RECORD_AND_SAMPLE);
-    assertThat(samplingResult1.getAttributes())
-        .isEqualTo(Attributes.of(ImmutableSamplingResult.SAMPLING_PROBABILITY, 0.0001));
   }
 
   // Applies the given sampler to NUM_SAMPLE_TRIES random traceId.


### PR DESCRIPTION
If anyone is relying on this currently, it's not too difficult to use a custom sampler implementation until the spec is updated.

Fixes #2420 