### PR TITLE
Make JaegerRemoteSamplerBuilder consistent with other builders.

### DIFF
--- a/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSampler.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSampler.java
@@ -31,15 +31,13 @@ public final class JaegerRemoteSampler implements Sampler {
 
   private static final String WORKER_THREAD_NAME =
       JaegerRemoteSampler.class.getSimpleName() + "_WorkerThread";
-  private static final int DEFAULT_POLLING_INTERVAL_MS = 60000;
-  private static final Sampler INITIAL_SAMPLER = Sampler.traceIdRatioBased(0.001);
 
   private final String serviceName;
   private final SamplingManagerBlockingStub stub;
   private Sampler sampler;
 
   @SuppressWarnings("FutureReturnValueIgnored")
-  private JaegerRemoteSampler(
+  JaegerRemoteSampler(
       String serviceName, ManagedChannel channel, int pollingIntervalMs, Sampler initialSampler) {
     this.serviceName = serviceName;
     this.stub = SamplingManagerGrpc.newBlockingStub(channel);
@@ -115,71 +113,7 @@ public final class JaegerRemoteSampler implements Sampler {
     return this.sampler;
   }
 
-  public static Builder builder() {
-    return new Builder();
-  }
-
-  public static class Builder {
-    private ManagedChannel channel;
-    private String serviceName;
-    private Sampler initialSampler = INITIAL_SAMPLER;
-    private int pollingIntervalMs = DEFAULT_POLLING_INTERVAL_MS;
-
-    /**
-     * Sets the service name to be used by this exporter. Required.
-     *
-     * @param serviceName the service name.
-     * @return this.
-     */
-    public Builder setServiceName(String serviceName) {
-      this.serviceName = serviceName;
-      return this;
-    }
-
-    /**
-     * Sets the managed chanel to use when communicating with the backend. Required.
-     *
-     * @param channel the channel to use.
-     * @return this.
-     */
-    public Builder setChannel(ManagedChannel channel) {
-      this.channel = channel;
-      return this;
-    }
-
-    /**
-     * Sets the polling interval. Optional.
-     *
-     * @param pollingIntervalMs the polling interval in Ms.
-     * @return this.
-     */
-    public Builder withPollingInterval(int pollingIntervalMs) {
-      this.pollingIntervalMs = pollingIntervalMs;
-      return this;
-    }
-
-    /**
-     * Sets the initial sampler that is used before sampling configuration is obtained from the
-     * server. By default probabilistic sampler with is used with probability 0.001. Optional.
-     *
-     * @param initialSampler the initial sampler to use.
-     * @return this.
-     */
-    public Builder withInitialSampler(Sampler initialSampler) {
-      this.initialSampler = initialSampler;
-      return this;
-    }
-
-    /**
-     * Builds the {@link JaegerRemoteSampler}.
-     *
-     * @return the remote sampler instance.
-     */
-    public JaegerRemoteSampler build() {
-      return new JaegerRemoteSampler(
-          this.serviceName, this.channel, this.pollingIntervalMs, this.initialSampler);
-    }
-
-    private Builder() {}
+  public static JaegerRemoteSamplerBuilder builder() {
+    return new JaegerRemoteSamplerBuilder();
   }
 }

--- a/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerBuilder.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerBuilder.java
@@ -118,7 +118,7 @@ public class JaegerRemoteSamplerBuilder {
    *
    * @return the remote sampler instance.
    */
-  public JaegerRemoteSampler build() {
+  public Sampler build() {
     if (channel == null) {
       channel = ManagedChannelBuilder.forTarget(endpoint).usePlaintext().build();
     }

--- a/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerBuilder.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerBuilder.java
@@ -87,38 +87,11 @@ public class JaegerRemoteSamplerBuilder {
   }
 
   /**
-   * Sets the polling interval. Optional.
-   *
-   * @param pollingIntervalMs the polling interval in Ms.
-   * @return this.
-   * @deprecated Use {@link #setPollingInterval(int, TimeUnit)}
-   */
-  @Deprecated
-  public JaegerRemoteSamplerBuilder withPollingInterval(int pollingIntervalMs) {
-    this.pollingIntervalMillis = pollingIntervalMs;
-    return this;
-  }
-
-  /**
-   * Sets the initial sampler that is used before sampling configuration is obtained from the
-   * server. By default probabilistic sampler with is used with probability 0.001. Optional.
-   *
-   * @param initialSampler the initial sampler to use.
-   * @return this.
-   * @deprecated Use {@link #setInitialSampler(Sampler)}
-   */
-  @Deprecated
-  public JaegerRemoteSamplerBuilder withInitialSampler(Sampler initialSampler) {
-    this.initialSampler = initialSampler;
-    return this;
-  }
-
-  /**
    * Builds the {@link JaegerRemoteSampler}.
    *
    * @return the remote sampler instance.
    */
-  public Sampler build() {
+  public JaegerRemoteSampler build() {
     if (channel == null) {
       channel = ManagedChannelBuilder.forTarget(endpoint).usePlaintext().build();
     }

--- a/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerBuilder.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerBuilder.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.extension.trace.jaeger.sampler;
+
+import static java.util.Objects.requireNonNull;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.opentelemetry.api.internal.Utils;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+/** A builder for {@link JaegerRemoteSampler}. */
+public class JaegerRemoteSamplerBuilder {
+  private static final String DEFAULT_ENDPOINT = "localhost:14250";
+  private static final int DEFAULT_POLLING_INTERVAL_MILLIS = 60000;
+  private static final Sampler INITIAL_SAMPLER =
+      Sampler.parentBased(Sampler.traceIdRatioBased(0.001));
+
+  private String endpoint = DEFAULT_ENDPOINT;
+  private ManagedChannel channel;
+  private String serviceName;
+  private Sampler initialSampler = INITIAL_SAMPLER;
+  private int pollingIntervalMillis = DEFAULT_POLLING_INTERVAL_MILLIS;
+
+  /**
+   * Sets the service name to be used by this exporter. Required.
+   *
+   * @param serviceName the service name.
+   * @return this.
+   */
+  public JaegerRemoteSamplerBuilder setServiceName(String serviceName) {
+    requireNonNull(serviceName, "serviceName");
+    this.serviceName = serviceName;
+    return this;
+  }
+
+  /** Sets the Jaeger endpoint to connect to. If unset, defaults to {@value DEFAULT_ENDPOINT}. */
+  public JaegerRemoteSamplerBuilder setEndpoint(String endpoint) {
+    requireNonNull(endpoint, "endpoint");
+    this.endpoint = endpoint;
+    return this;
+  }
+
+  /**
+   * Sets the managed channel to use when communicating with the backend. Takes precedence over
+   * {@link #setEndpoint(String)} if both are called.
+   */
+  public JaegerRemoteSamplerBuilder setChannel(ManagedChannel channel) {
+    requireNonNull(channel, "channel");
+    this.channel = channel;
+    return this;
+  }
+
+  /**
+   * Sets the polling interval for configuration updates. If unset, defaults to {@value
+   * DEFAULT_POLLING_INTERVAL_MILLIS}ms. Must be positive.
+   */
+  public JaegerRemoteSamplerBuilder setPollingInterval(int interval, TimeUnit unit) {
+    requireNonNull(unit, "unit");
+    Utils.checkArgument(interval > 0, "polling interval must be positive");
+    pollingIntervalMillis = (int) unit.toMillis(interval);
+    return this;
+  }
+
+  /**
+   * Sets the polling interval for configuration updates. If unset, defaults to {@value
+   * DEFAULT_POLLING_INTERVAL_MILLIS}ms.
+   */
+  public JaegerRemoteSamplerBuilder setPollingInterval(Duration interval) {
+    requireNonNull(interval, "interval");
+    return setPollingInterval((int) interval.toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * Sets the initial sampler that is used before sampling configuration is obtained. If not set,
+   * defaults to a parent-based ratio-based sampler with a ratio of 0.001.
+   */
+  public JaegerRemoteSamplerBuilder setInitialSampler(Sampler initialSampler) {
+    requireNonNull(initialSampler, "initialSampler");
+    this.initialSampler = initialSampler;
+    return this;
+  }
+
+  /**
+   * Sets the polling interval. Optional.
+   *
+   * @param pollingIntervalMs the polling interval in Ms.
+   * @return this.
+   * @deprecated Use {@link #setPollingInterval(int, TimeUnit)}
+   */
+  @Deprecated
+  public JaegerRemoteSamplerBuilder withPollingInterval(int pollingIntervalMs) {
+    this.pollingIntervalMillis = pollingIntervalMs;
+    return this;
+  }
+
+  /**
+   * Sets the initial sampler that is used before sampling configuration is obtained from the
+   * server. By default probabilistic sampler with is used with probability 0.001. Optional.
+   *
+   * @param initialSampler the initial sampler to use.
+   * @return this.
+   * @deprecated Use {@link #setInitialSampler(Sampler)}
+   */
+  @Deprecated
+  public JaegerRemoteSamplerBuilder withInitialSampler(Sampler initialSampler) {
+    this.initialSampler = initialSampler;
+    return this;
+  }
+
+  /**
+   * Builds the {@link JaegerRemoteSampler}.
+   *
+   * @return the remote sampler instance.
+   */
+  public JaegerRemoteSampler build() {
+    if (channel == null) {
+      channel = ManagedChannelBuilder.forTarget(endpoint).usePlaintext().build();
+    }
+    return new JaegerRemoteSampler(serviceName, channel, pollingIntervalMillis, initialSampler);
+  }
+
+  JaegerRemoteSamplerBuilder() {}
+}

--- a/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerBuilder.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerBuilder.java
@@ -77,7 +77,7 @@ public class JaegerRemoteSamplerBuilder {
   }
 
   /**
-   * Sets the initial sampler that is used before sampling configuration is obtained. If not set,
+   * Sets the initial sampler that is used before sampling configuration is obtained. If unset,
    * defaults to a parent-based ratio-based sampler with a ratio of 0.001.
    */
   public JaegerRemoteSamplerBuilder setInitialSampler(Sampler initialSampler) {

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerIntegrationTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerIntegrationTest.java
@@ -9,7 +9,6 @@ import static io.opentelemetry.sdk.extension.trace.jaeger.sampler.JaegerRemoteSa
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import io.grpc.ManagedChannelBuilder;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.BindMode;
@@ -38,11 +37,9 @@ class JaegerRemoteSamplerIntegrationTest {
 
   @Test
   void remoteSampling_perOperation() {
-    String jaegerHost =
-        String.format("127.0.0.1:%d", jaegerContainer.getMappedPort(COLLECTOR_PORT));
     final JaegerRemoteSampler remoteSampler =
         JaegerRemoteSampler.builder()
-            .setChannel(ManagedChannelBuilder.forTarget(jaegerHost).usePlaintext().build())
+            .setEndpoint("127.0.0.1:" + jaegerContainer.getMappedPort(COLLECTOR_PORT))
             .setServiceName(SERVICE_NAME)
             .build();
 
@@ -55,11 +52,9 @@ class JaegerRemoteSamplerIntegrationTest {
 
   @Test
   void remoteSampling_rateLimiting() {
-    String jaegerHost =
-        String.format("127.0.0.1:%d", jaegerContainer.getMappedPort(COLLECTOR_PORT));
     final JaegerRemoteSampler remoteSampler =
         JaegerRemoteSampler.builder()
-            .setChannel(ManagedChannelBuilder.forTarget(jaegerHost).usePlaintext().build())
+            .setEndpoint("127.0.0.1:" + jaegerContainer.getMappedPort(COLLECTOR_PORT))
             .setServiceName(SERVICE_NAME_RATE_LIMITING)
             .build();
 

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerIntegrationTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerIntegrationTest.java
@@ -38,10 +38,11 @@ class JaegerRemoteSamplerIntegrationTest {
   @Test
   void remoteSampling_perOperation() {
     final JaegerRemoteSampler remoteSampler =
-        JaegerRemoteSampler.builder()
-            .setEndpoint("127.0.0.1:" + jaegerContainer.getMappedPort(COLLECTOR_PORT))
-            .setServiceName(SERVICE_NAME)
-            .build();
+        (JaegerRemoteSampler)
+            JaegerRemoteSampler.builder()
+                .setEndpoint("127.0.0.1:" + jaegerContainer.getMappedPort(COLLECTOR_PORT))
+                .setServiceName(SERVICE_NAME)
+                .build();
 
     await()
         .atMost(Duration.ofSeconds(10))
@@ -53,10 +54,11 @@ class JaegerRemoteSamplerIntegrationTest {
   @Test
   void remoteSampling_rateLimiting() {
     final JaegerRemoteSampler remoteSampler =
-        JaegerRemoteSampler.builder()
-            .setEndpoint("127.0.0.1:" + jaegerContainer.getMappedPort(COLLECTOR_PORT))
-            .setServiceName(SERVICE_NAME_RATE_LIMITING)
-            .build();
+        (JaegerRemoteSampler)
+            JaegerRemoteSampler.builder()
+                .setEndpoint("127.0.0.1:" + jaegerContainer.getMappedPort(COLLECTOR_PORT))
+                .setServiceName(SERVICE_NAME_RATE_LIMITING)
+                .build();
 
     await()
         .atMost(Duration.ofSeconds(10))

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerIntegrationTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerIntegrationTest.java
@@ -38,11 +38,10 @@ class JaegerRemoteSamplerIntegrationTest {
   @Test
   void remoteSampling_perOperation() {
     final JaegerRemoteSampler remoteSampler =
-        (JaegerRemoteSampler)
-            JaegerRemoteSampler.builder()
-                .setEndpoint("127.0.0.1:" + jaegerContainer.getMappedPort(COLLECTOR_PORT))
-                .setServiceName(SERVICE_NAME)
-                .build();
+        JaegerRemoteSampler.builder()
+            .setEndpoint("127.0.0.1:" + jaegerContainer.getMappedPort(COLLECTOR_PORT))
+            .setServiceName(SERVICE_NAME)
+            .build();
 
     await()
         .atMost(Duration.ofSeconds(10))
@@ -54,11 +53,10 @@ class JaegerRemoteSamplerIntegrationTest {
   @Test
   void remoteSampling_rateLimiting() {
     final JaegerRemoteSampler remoteSampler =
-        (JaegerRemoteSampler)
-            JaegerRemoteSampler.builder()
-                .setEndpoint("127.0.0.1:" + jaegerContainer.getMappedPort(COLLECTOR_PORT))
-                .setServiceName(SERVICE_NAME_RATE_LIMITING)
-                .build();
+        JaegerRemoteSampler.builder()
+            .setEndpoint("127.0.0.1:" + jaegerContainer.getMappedPort(COLLECTOR_PORT))
+            .setServiceName(SERVICE_NAME_RATE_LIMITING)
+            .build();
 
     await()
         .atMost(Duration.ofSeconds(10))

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerTest.java
@@ -96,10 +96,11 @@ class JaegerRemoteSamplerTest {
         ArgumentCaptor.forClass(Sampling.SamplingStrategyParameters.class);
 
     JaegerRemoteSampler sampler =
-        JaegerRemoteSampler.builder()
-            .setChannel(inProcessChannel)
-            .setServiceName(SERVICE_NAME)
-            .build();
+        (JaegerRemoteSampler)
+            JaegerRemoteSampler.builder()
+                .setChannel(inProcessChannel)
+                .setServiceName(SERVICE_NAME)
+                .build();
 
     await().atMost(Duration.ofSeconds(10)).until(samplerIsType(sampler, RateLimitingSampler.class));
 
@@ -117,10 +118,11 @@ class JaegerRemoteSamplerTest {
   @Test
   void description() {
     JaegerRemoteSampler sampler =
-        JaegerRemoteSampler.builder()
-            .setChannel(inProcessChannel)
-            .setServiceName(SERVICE_NAME)
-            .build();
+        (JaegerRemoteSampler)
+            JaegerRemoteSampler.builder()
+                .setChannel(inProcessChannel)
+                .setServiceName(SERVICE_NAME)
+                .build();
     assertThat(sampler.getDescription())
         .startsWith("JaegerRemoteSampler{ParentBased{root:TraceIdRatioBased{0.001000}");
 
@@ -134,22 +136,24 @@ class JaegerRemoteSamplerTest {
   @Test
   void initialSampler() {
     JaegerRemoteSampler sampler =
-        JaegerRemoteSampler.builder()
-            .setChannel(inProcessChannel)
-            .setServiceName(SERVICE_NAME)
-            .setInitialSampler(Sampler.alwaysOn())
-            .build();
+        (JaegerRemoteSampler)
+            JaegerRemoteSampler.builder()
+                .setChannel(inProcessChannel)
+                .setServiceName(SERVICE_NAME)
+                .setInitialSampler(Sampler.alwaysOn())
+                .build();
     assertThat(sampler.getDescription()).startsWith("JaegerRemoteSampler{AlwaysOnSampler}");
   }
 
   @Test
   void pollingInterval() throws Exception {
     JaegerRemoteSampler sampler =
-        JaegerRemoteSampler.builder()
-            .setChannel(inProcessChannel)
-            .setServiceName(SERVICE_NAME)
-            .setPollingInterval(1, TimeUnit.MILLISECONDS)
-            .build();
+        (JaegerRemoteSampler)
+            JaegerRemoteSampler.builder()
+                .setChannel(inProcessChannel)
+                .setServiceName(SERVICE_NAME)
+                .setPollingInterval(1, TimeUnit.MILLISECONDS)
+                .build();
 
     // wait until the sampling strategy is retrieved before exiting test method
     await().atMost(Duration.ofSeconds(10)).until(samplerIsType(sampler, RateLimitingSampler.class));
@@ -162,11 +166,12 @@ class JaegerRemoteSamplerTest {
   @Test
   void pollingInterval_duration() throws Exception {
     JaegerRemoteSampler sampler =
-        JaegerRemoteSampler.builder()
-            .setChannel(inProcessChannel)
-            .setServiceName(SERVICE_NAME)
-            .setPollingInterval(Duration.ofMillis(1))
-            .build();
+        (JaegerRemoteSampler)
+            JaegerRemoteSampler.builder()
+                .setChannel(inProcessChannel)
+                .setServiceName(SERVICE_NAME)
+                .setPollingInterval(Duration.ofMillis(1))
+                .build();
 
     // wait until the sampling strategy is retrieved before exiting test method
     await().atMost(Duration.ofSeconds(10)).until(samplerIsType(sampler, RateLimitingSampler.class));

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerTest.java
@@ -96,11 +96,10 @@ class JaegerRemoteSamplerTest {
         ArgumentCaptor.forClass(Sampling.SamplingStrategyParameters.class);
 
     JaegerRemoteSampler sampler =
-        (JaegerRemoteSampler)
-            JaegerRemoteSampler.builder()
-                .setChannel(inProcessChannel)
-                .setServiceName(SERVICE_NAME)
-                .build();
+        JaegerRemoteSampler.builder()
+            .setChannel(inProcessChannel)
+            .setServiceName(SERVICE_NAME)
+            .build();
 
     await().atMost(Duration.ofSeconds(10)).until(samplerIsType(sampler, RateLimitingSampler.class));
 
@@ -118,11 +117,10 @@ class JaegerRemoteSamplerTest {
   @Test
   void description() {
     JaegerRemoteSampler sampler =
-        (JaegerRemoteSampler)
-            JaegerRemoteSampler.builder()
-                .setChannel(inProcessChannel)
-                .setServiceName(SERVICE_NAME)
-                .build();
+        JaegerRemoteSampler.builder()
+            .setChannel(inProcessChannel)
+            .setServiceName(SERVICE_NAME)
+            .build();
     assertThat(sampler.getDescription())
         .startsWith("JaegerRemoteSampler{ParentBased{root:TraceIdRatioBased{0.001000}");
 
@@ -136,24 +134,22 @@ class JaegerRemoteSamplerTest {
   @Test
   void initialSampler() {
     JaegerRemoteSampler sampler =
-        (JaegerRemoteSampler)
-            JaegerRemoteSampler.builder()
-                .setChannel(inProcessChannel)
-                .setServiceName(SERVICE_NAME)
-                .setInitialSampler(Sampler.alwaysOn())
-                .build();
+        JaegerRemoteSampler.builder()
+            .setChannel(inProcessChannel)
+            .setServiceName(SERVICE_NAME)
+            .setInitialSampler(Sampler.alwaysOn())
+            .build();
     assertThat(sampler.getDescription()).startsWith("JaegerRemoteSampler{AlwaysOnSampler}");
   }
 
   @Test
   void pollingInterval() throws Exception {
     JaegerRemoteSampler sampler =
-        (JaegerRemoteSampler)
-            JaegerRemoteSampler.builder()
-                .setChannel(inProcessChannel)
-                .setServiceName(SERVICE_NAME)
-                .setPollingInterval(1, TimeUnit.MILLISECONDS)
-                .build();
+        JaegerRemoteSampler.builder()
+            .setChannel(inProcessChannel)
+            .setServiceName(SERVICE_NAME)
+            .setPollingInterval(1, TimeUnit.MILLISECONDS)
+            .build();
 
     // wait until the sampling strategy is retrieved before exiting test method
     await().atMost(Duration.ofSeconds(10)).until(samplerIsType(sampler, RateLimitingSampler.class));
@@ -166,12 +162,11 @@ class JaegerRemoteSamplerTest {
   @Test
   void pollingInterval_duration() throws Exception {
     JaegerRemoteSampler sampler =
-        (JaegerRemoteSampler)
-            JaegerRemoteSampler.builder()
-                .setChannel(inProcessChannel)
-                .setServiceName(SERVICE_NAME)
-                .setPollingInterval(Duration.ofMillis(1))
-                .build();
+        JaegerRemoteSampler.builder()
+            .setChannel(inProcessChannel)
+            .setServiceName(SERVICE_NAME)
+            .setPollingInterval(Duration.ofMillis(1))
+            .build();
 
     // wait until the sampling strategy is retrieved before exiting test method
     await().atMost(Duration.ofSeconds(10)).until(samplerIsType(sampler, RateLimitingSampler.class));


### PR DESCRIPTION
While I had some mind to mark this module as alpha as well but it's not that much work to make it ready I guess.

- Builder to top level
- setEndpoint similar to other gRPC builders
- setInterval with TimeUnit / Duration instead of only millis
- set, not with
- changed initial sampler default to parent-based since surely it's a better default