### PR TITLE
Add TraceConfig.builder()

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
@@ -84,7 +84,7 @@ final class TracerProviderConfiguration {
 
   // Visible for testing
   static TraceConfig configureTraceConfig(ConfigProperties config) {
-    TraceConfigBuilder builder = TraceConfig.getDefault().toBuilder();
+    TraceConfigBuilder builder = TraceConfig.builder();
 
     String sampler = config.getString("otel.trace.sampler");
     if (sampler != null) {

--- a/sdk-extensions/otproto/src/main/java/io/opentelemetry/sdk/extension/otproto/TraceProtoUtils.java
+++ b/sdk-extensions/otproto/src/main/java/io/opentelemetry/sdk/extension/otproto/TraceProtoUtils.java
@@ -44,7 +44,7 @@ public final class TraceProtoUtils {
    */
   public static TraceConfig traceConfigFromProto(
       io.opentelemetry.proto.trace.v1.TraceConfig traceConfigProto) {
-    return TraceConfig.getDefault().toBuilder()
+    return TraceConfig.builder()
         .setSampler(fromProtoSampler(traceConfigProto))
         .setMaxNumberOfAttributes((int) traceConfigProto.getMaxNumberOfAttributes())
         .setMaxNumberOfEvents((int) traceConfigProto.getMaxNumberOfTimedEvents())

--- a/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/TraceConfigzZPageHandler.java
+++ b/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/TraceConfigzZPageHandler.java
@@ -427,7 +427,7 @@ final class TraceConfigzZPageHandler extends ZPageHandler {
       }
       configSupplier.setActiveTraceConfig(newConfigBuilder.build());
     } else if (action.equals(QUERY_STRING_ACTION_DEFAULT)) {
-      TraceConfig defaultConfig = TraceConfig.getDefault().toBuilder().build();
+      TraceConfig defaultConfig = TraceConfig.builder().build();
       configSupplier.setActiveTraceConfig(defaultConfig);
     }
   }

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanAttributeTruncateBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanAttributeTruncateBenchmark.java
@@ -37,10 +37,7 @@ public class SpanAttributeTruncateBenchmark {
   public final void setup() {
     Tracer tracer =
         SdkTracerProvider.builder()
-            .setTraceConfig(
-                TraceConfig.getDefault().toBuilder()
-                    .setMaxLengthOfAttributeValues(maxLength)
-                    .build())
+            .setTraceConfig(TraceConfig.builder().setMaxLengthOfAttributeValues(maxLength).build())
             .build()
             .get("benchmarkTracer");
     sdkSpanBuilder =

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanBenchmark.java
@@ -37,8 +37,7 @@ public class SpanBenchmark {
   @Setup(Level.Trial)
   public final void setup() {
 
-    TraceConfig alwaysOn =
-        TraceConfig.getDefault().toBuilder().setSampler(Sampler.alwaysOn()).build();
+    TraceConfig alwaysOn = TraceConfig.builder().setSampler(Sampler.alwaysOn()).build();
     SdkTracerProvider tracerProvider =
         SdkTracerProvider.builder().setResource(serviceResource).setTraceConfig(alwaysOn).build();
 

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
@@ -68,8 +68,7 @@ public class SpanPipelineBenchmark {
 
       String address = collector.getHost() + ":" + collector.getMappedPort(EXPOSED_PORT);
 
-      TraceConfig alwaysOn =
-          TraceConfig.getDefault().toBuilder().setSampler(Sampler.alwaysOn()).build();
+      TraceConfig alwaysOn = TraceConfig.builder().setSampler(Sampler.alwaysOn()).build();
 
       SdkTracerProvider tracerProvider =
           SdkTracerProvider.builder()

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -187,8 +187,7 @@ class OpenTelemetrySdkTest {
         .setTracerProvider(
             SdkTracerProvider.builder()
                 .addSpanProcessor(SimpleSpanProcessor.create(mock(SpanExporter.class)))
-                .setTraceConfig(
-                    TraceConfig.getDefault().toBuilder().setSampler(mock(Sampler.class)).build())
+                .setTraceConfig(TraceConfig.builder().setSampler(mock(Sampler.class)).build())
                 .build())
         .setPropagators(ContextPropagators.create(mock(TextMapPropagator.class)))
         .build();
@@ -197,8 +196,7 @@ class OpenTelemetrySdkTest {
         .setTracerProvider(
             SdkTracerProvider.builder()
                 .addSpanProcessor(SimpleSpanProcessor.create(mock(SpanExporter.class)))
-                .setTraceConfig(
-                    TraceConfig.getDefault().toBuilder().setSampler(mock(Sampler.class)).build())
+                .setTraceConfig(TraceConfig.builder().setSampler(mock(Sampler.class)).build())
                 .setIdGenerator(mock(IdGenerator.class))
                 .build())
         .setPropagators(ContextPropagators.create(mock(TextMapPropagator.class)))

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
@@ -85,6 +85,11 @@ public abstract class TraceConfig {
     return DEFAULT;
   }
 
+  /** Returns a new {@link TraceConfigBuilder} to construct a {@link TraceConfig}. */
+  public static TraceConfigBuilder builder() {
+    return new TraceConfigBuilder();
+  }
+
   static TraceConfig create(
       Sampler sampler,
       int maxNumAttributes,

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -532,9 +532,7 @@ class RecordEventsReadableSpanTest {
   void droppingAttributes() {
     final int maxNumberOfAttributes = 8;
     TraceConfig traceConfig =
-        TraceConfig.getDefault().toBuilder()
-            .setMaxNumberOfAttributes(maxNumberOfAttributes)
-            .build();
+        TraceConfig.builder().setMaxNumberOfAttributes(maxNumberOfAttributes).build();
     RecordEventsReadableSpan span = createTestSpan(traceConfig);
     try {
       for (int i = 0; i < 2 * maxNumberOfAttributes; i++) {
@@ -569,9 +567,7 @@ class RecordEventsReadableSpanTest {
   void droppingAndAddingAttributes() {
     final int maxNumberOfAttributes = 8;
     TraceConfig traceConfig =
-        TraceConfig.getDefault().toBuilder()
-            .setMaxNumberOfAttributes(maxNumberOfAttributes)
-            .build();
+        TraceConfig.builder().setMaxNumberOfAttributes(maxNumberOfAttributes).build();
     RecordEventsReadableSpan span = createTestSpan(traceConfig);
     try {
       for (int i = 0; i < 2 * maxNumberOfAttributes; i++) {
@@ -605,8 +601,7 @@ class RecordEventsReadableSpanTest {
   @Test
   void droppingEvents() {
     final int maxNumberOfEvents = 8;
-    TraceConfig traceConfig =
-        TraceConfig.getDefault().toBuilder().setMaxNumberOfEvents(maxNumberOfEvents).build();
+    TraceConfig traceConfig = TraceConfig.builder().setMaxNumberOfEvents(maxNumberOfEvents).build();
     RecordEventsReadableSpan span = createTestSpan(traceConfig);
     try {
       for (int i = 0; i < 2 * maxNumberOfEvents; i++) {

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
@@ -100,8 +100,7 @@ class SdkSpanBuilderTest {
   @Test
   void truncateLink() {
     final int maxNumberOfLinks = 8;
-    TraceConfig traceConfig =
-        TraceConfig.getDefault().toBuilder().setMaxNumberOfLinks(maxNumberOfLinks).build();
+    TraceConfig traceConfig = TraceConfig.builder().setMaxNumberOfLinks(maxNumberOfLinks).build();
     TracerProvider tracerProvider = SdkTracerProvider.builder().setTraceConfig(traceConfig).build();
     // Verify methods do not crash.
     SpanBuilder spanBuilder = tracerProvider.get("test").spanBuilder(SPAN_NAME);
@@ -124,8 +123,7 @@ class SdkSpanBuilderTest {
 
   @Test
   void truncateLinkAttributes() {
-    TraceConfig traceConfig =
-        TraceConfig.getDefault().toBuilder().setMaxNumberOfAttributesPerLink(1).build();
+    TraceConfig traceConfig = TraceConfig.builder().setMaxNumberOfAttributesPerLink(1).build();
     TracerProvider tracerProvider = SdkTracerProvider.builder().setTraceConfig(traceConfig).build();
     // Verify methods do not crash.
     SpanBuilder spanBuilder = tracerProvider.get("test").spanBuilder(SPAN_NAME);
@@ -351,7 +349,7 @@ class SdkSpanBuilderTest {
   void droppingAttributes() {
     final int maxNumberOfAttrs = 8;
     TraceConfig traceConfig =
-        TraceConfig.getDefault().toBuilder().setMaxNumberOfAttributes(maxNumberOfAttrs).build();
+        TraceConfig.builder().setMaxNumberOfAttributes(maxNumberOfAttrs).build();
     TracerProvider tracerProvider = SdkTracerProvider.builder().setTraceConfig(traceConfig).build();
     // Verify methods do not crash.
     SpanBuilder spanBuilder = tracerProvider.get("test").spanBuilder(SPAN_NAME);
@@ -372,8 +370,7 @@ class SdkSpanBuilderTest {
 
   @Test
   public void tooLargeAttributeValuesAreTruncated() {
-    TraceConfig traceConfig =
-        TraceConfig.getDefault().toBuilder().setMaxLengthOfAttributeValues(10).build();
+    TraceConfig traceConfig = TraceConfig.builder().setMaxLengthOfAttributeValues(10).build();
     TracerProvider tracerProvider = SdkTracerProvider.builder().setTraceConfig(traceConfig).build();
     // Verify methods do not crash.
     SpanBuilder spanBuilder = tracerProvider.get("test").spanBuilder(SPAN_NAME);
@@ -420,7 +417,7 @@ class SdkSpanBuilderTest {
   @Test
   void addAttributes_OnlyViaSampler() {
     TraceConfig traceConfig =
-        TraceConfig.getDefault().toBuilder()
+        TraceConfig.builder()
             .setSampler(
                 new Sampler() {
                   @Override
@@ -488,8 +485,7 @@ class SdkSpanBuilderTest {
   void sampler() {
     Span span =
         SdkTracerProvider.builder()
-            .setTraceConfig(
-                TraceConfig.getDefault().toBuilder().setSampler(Sampler.alwaysOff()).build())
+            .setTraceConfig(TraceConfig.builder().setSampler(Sampler.alwaysOff()).build())
             .build()
             .get("test")
             .spanBuilder(SPAN_NAME)
@@ -509,7 +505,7 @@ class SdkSpanBuilderTest {
         (RecordEventsReadableSpan)
             SdkTracerProvider.builder()
                 .setTraceConfig(
-                    TraceConfig.getDefault().toBuilder()
+                    TraceConfig.builder()
                         .setSampler(
                             new Sampler() {
                               @Override
@@ -562,7 +558,7 @@ class SdkSpanBuilderTest {
         (RecordEventsReadableSpan)
             SdkTracerProvider.builder()
                 .setTraceConfig(
-                    TraceConfig.getDefault().toBuilder()
+                    TraceConfig.builder()
                         .setSampler(
                             new Sampler() {
                               @Override
@@ -620,8 +616,7 @@ class SdkSpanBuilderTest {
   void sampledViaParentLinks() {
     Span span =
         SdkTracerProvider.builder()
-            .setTraceConfig(
-                TraceConfig.getDefault().toBuilder().setSampler(Sampler.alwaysOff()).build())
+            .setTraceConfig(TraceConfig.builder().setSampler(Sampler.alwaysOff()).build())
             .build()
             .get("test")
             .spanBuilder(SPAN_NAME)

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderTest.java
@@ -118,8 +118,7 @@ class SdkTracerProviderTest {
   @SuppressWarnings("deprecation") // Testing the deprecated method
   void updateActiveTraceConfig() {
     assertThat(tracerFactory.getActiveTraceConfig()).isEqualTo(TraceConfig.getDefault());
-    TraceConfig newConfig =
-        TraceConfig.getDefault().toBuilder().setSampler(Sampler.alwaysOff()).build();
+    TraceConfig newConfig = TraceConfig.builder().setSampler(Sampler.alwaysOff()).build();
     tracerFactory.updateActiveTraceConfig(newConfig);
     assertThat(tracerFactory.getActiveTraceConfig()).isEqualTo(newConfig);
   }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigSystemPropertiesTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigSystemPropertiesTest.java
@@ -33,10 +33,7 @@ public class TraceConfigSystemPropertiesTest {
     System.setProperty("otel.config.max.event.attrs", "7");
     System.setProperty("otel.config.max.link.attrs", "11");
     TraceConfig traceConfig =
-        TraceConfig.getDefault().toBuilder()
-            .readEnvironmentVariables()
-            .readSystemProperties()
-            .build();
+        TraceConfig.builder().readEnvironmentVariables().readSystemProperties().build();
     // this is not a useful assertion. How can we do better?
     assertThat(traceConfig.getSampler())
         .isEqualTo(Sampler.parentBased(Sampler.traceIdRatioBased(0.3)));
@@ -50,42 +47,42 @@ public class TraceConfigSystemPropertiesTest {
   @Test
   void updateTraceConfig_InvalidSamplerProbability() {
     System.setProperty("otel.config.sampler.probability", "-1");
-    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().readSystemProperties().build())
+    assertThatThrownBy(() -> TraceConfig.builder().readSystemProperties().build())
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_NonPositiveMaxNumberOfAttributes() {
     System.setProperty("otel.span.attribute.count.limit", "-5");
-    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().readSystemProperties().build())
+    assertThatThrownBy(() -> TraceConfig.builder().readSystemProperties().build())
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_NonPositiveMaxNumberOfEvents() {
     System.setProperty("otel.span.event.count.limit", "-6");
-    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().readSystemProperties().build())
+    assertThatThrownBy(() -> TraceConfig.builder().readSystemProperties().build())
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_NonPositiveMaxNumberOfLinks() {
     System.setProperty("otel.span.link.count.limit", "-9");
-    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().readSystemProperties().build())
+    assertThatThrownBy(() -> TraceConfig.builder().readSystemProperties().build())
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_NonPositiveMaxNumberOfAttributesPerEvent() {
     System.setProperty("otel.config.max.event.attrs", "-7");
-    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().readSystemProperties().build())
+    assertThatThrownBy(() -> TraceConfig.builder().readSystemProperties().build())
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_NonPositiveMaxNumberOfAttributesPerLink() {
     System.setProperty("otel.config.max.link.attrs", "-10");
-    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().readSystemProperties().build())
+    assertThatThrownBy(() -> TraceConfig.builder().readSystemProperties().build())
         .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
@@ -26,63 +26,61 @@ class TraceConfigTest {
 
   @Test
   void updateTraceConfig_NullSampler() {
-    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().setSampler(null))
+    assertThatThrownBy(() -> TraceConfig.builder().setSampler(null))
         .isInstanceOf(NullPointerException.class);
   }
 
   @Test
   void updateTraceConfig_NonPositiveMaxNumberOfAttributes() {
-    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().setMaxNumberOfAttributes(0))
+    assertThatThrownBy(() -> TraceConfig.builder().setMaxNumberOfAttributes(0))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_NonPositiveMaxNumberOfEvents() {
-    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().setMaxNumberOfEvents(0))
+    assertThatThrownBy(() -> TraceConfig.builder().setMaxNumberOfEvents(0))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_NonPositiveMaxNumberOfLinks() {
-    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().setMaxNumberOfLinks(0))
+    assertThatThrownBy(() -> TraceConfig.builder().setMaxNumberOfLinks(0))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_NonPositiveMaxNumberOfAttributesPerEvent() {
-    assertThatThrownBy(
-            () -> TraceConfig.getDefault().toBuilder().setMaxNumberOfAttributesPerEvent(0))
+    assertThatThrownBy(() -> TraceConfig.builder().setMaxNumberOfAttributesPerEvent(0))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_NonPositiveMaxNumberOfAttributesPerLink() {
-    assertThatThrownBy(
-            () -> TraceConfig.getDefault().toBuilder().setMaxNumberOfAttributesPerLink(0))
+    assertThatThrownBy(() -> TraceConfig.builder().setMaxNumberOfAttributesPerLink(0))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_InvalidTraceIdRatioBased() {
-    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().setTraceIdRatioBased(2))
+    assertThatThrownBy(() -> TraceConfig.builder().setTraceIdRatioBased(2))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_NegativeTraceIdRatioBased() {
-    assertThatThrownBy(() -> TraceConfig.getDefault().toBuilder().setTraceIdRatioBased(-1))
+    assertThatThrownBy(() -> TraceConfig.builder().setTraceIdRatioBased(-1))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void updateTraceConfig_OffTraceIdRatioBased() {
-    TraceConfig traceConfig = TraceConfig.getDefault().toBuilder().setTraceIdRatioBased(0).build();
+    TraceConfig traceConfig = TraceConfig.builder().setTraceIdRatioBased(0).build();
     assertThat(traceConfig.getSampler()).isSameAs(Sampler.alwaysOff());
   }
 
   @Test
   void updateTraceConfig_OnTraceIdRatioBased() {
-    TraceConfig traceConfig = TraceConfig.getDefault().toBuilder().setTraceIdRatioBased(1).build();
+    TraceConfig traceConfig = TraceConfig.builder().setTraceIdRatioBased(1).build();
 
     Sampler sampler = traceConfig.getSampler();
     assertThat(sampler).isEqualTo(Sampler.parentBased(Sampler.alwaysOn()));
@@ -91,7 +89,7 @@ class TraceConfigTest {
   @Test
   void updateTraceConfig_All() {
     TraceConfig traceConfig =
-        TraceConfig.getDefault().toBuilder()
+        TraceConfig.builder()
             .setSampler(Sampler.alwaysOff())
             .setMaxNumberOfAttributes(8)
             .setMaxNumberOfEvents(10)

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -357,8 +357,7 @@ class BatchSpanProcessorTest {
     WaitingSpanExporter waitingSpanExporter =
         new WaitingSpanExporter(1, CompletableResultCode.ofSuccess());
     AtomicReference<TraceConfig> traceConfig =
-        new AtomicReference<>(
-            TraceConfig.getDefault().toBuilder().setSampler(Sampler.alwaysOff()).build());
+        new AtomicReference<>(TraceConfig.builder().setSampler(Sampler.alwaysOff()).build());
     sdkTracerProvider =
         SdkTracerProvider.builder()
             .addSpanProcessor(
@@ -388,7 +387,7 @@ class BatchSpanProcessorTest {
         new WaitingSpanExporter(1, CompletableResultCode.ofSuccess());
     AtomicReference<TraceConfig> traceConfig =
         new AtomicReference<>(
-            TraceConfig.getDefault().toBuilder()
+            TraceConfig.builder()
                 .setSampler(
                     new Sampler() {
                       @Override

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
@@ -141,8 +141,7 @@ class SimpleSpanProcessorTest {
     WaitingSpanExporter waitingSpanExporter =
         new WaitingSpanExporter(1, CompletableResultCode.ofSuccess());
     AtomicReference<TraceConfig> traceConfig =
-        new AtomicReference<>(
-            TraceConfig.getDefault().toBuilder().setSampler(Sampler.alwaysOff()).build());
+        new AtomicReference<>(TraceConfig.builder().setSampler(Sampler.alwaysOff()).build());
     SdkTracerProvider sdkTracerProvider =
         SdkTracerProvider.builder()
             .addSpanProcessor(


### PR DESCRIPTION
Now that `updateTraceConfig` is deprecated, I think we do want this to avoid the tedium / lack of discoverability of `getDefault().toBuilder()`