### PR TITLE
Deprecate OpenTelemetry SPI.

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/DefaultOpenTelemetryBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/DefaultOpenTelemetryBuilder.java
@@ -9,9 +9,9 @@ import static java.util.Objects.requireNonNull;
 
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
-import io.opentelemetry.spi.trace.TracerProviderFactory;
 
 /** Builder class for {@link DefaultOpenTelemetry}. */
+@SuppressWarnings("deprecation") // Remove after deleting OpenTelemetry SPI
 public final class DefaultOpenTelemetryBuilder {
   private ContextPropagators propagators = ContextPropagators.noop();
   private TracerProvider tracerProvider;
@@ -55,7 +55,8 @@ public final class DefaultOpenTelemetryBuilder {
   public OpenTelemetry build() {
     TracerProvider tracerProvider = this.tracerProvider;
     if (tracerProvider == null) {
-      TracerProviderFactory tracerProviderFactory = Utils.loadSpi(TracerProviderFactory.class);
+      io.opentelemetry.spi.trace.TracerProviderFactory tracerProviderFactory =
+          Utils.loadSpi(io.opentelemetry.spi.trace.TracerProviderFactory.class);
       if (tracerProviderFactory != null) {
         tracerProvider = tracerProviderFactory.create();
       } else {

--- a/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
@@ -8,8 +8,6 @@ package io.opentelemetry.api;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
-import io.opentelemetry.spi.OpenTelemetryFactory;
-import io.opentelemetry.spi.trace.TracerProviderFactory;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.logging.Level;
@@ -20,11 +18,6 @@ import javax.annotation.Nullable;
  * A global singleton for the entrypoint to telemetry functionality for tracing, metrics and
  * baggage.
  *
- * <p>The global singleton can be retrieved by {@link #get()}. The default for the returned {@link
- * OpenTelemetry}, if none has been set via {@link #set(OpenTelemetry)}, will be created with any
- * {@link OpenTelemetryFactory}, or {@link TracerProviderFactory} found on the classpath, or
- * otherwise will be default, with no-op behavior.
- *
  * <p>If using the OpenTelemetry SDK, you may want to instantiate the {@link OpenTelemetry} to
  * provide configuration, for example of {@code Resource} or {@code Sampler}. See {@code
  * OpenTelemetrySdk} and {@code OpenTelemetrySdk.builder} for information on how to construct the
@@ -33,6 +26,7 @@ import javax.annotation.Nullable;
  * @see TracerProvider
  * @see ContextPropagators
  */
+@SuppressWarnings("deprecation") // Remove after deleting OpenTelemetry SPI
 public final class GlobalOpenTelemetry {
 
   private static final Logger logger = Logger.getLogger(GlobalOpenTelemetry.class.getName());
@@ -44,10 +38,7 @@ public final class GlobalOpenTelemetry {
   private GlobalOpenTelemetry() {}
 
   /**
-   * Returns the registered global {@link OpenTelemetry}. If no call to {@link #set(OpenTelemetry)}
-   * has been made so far, a default {@link OpenTelemetry} composed of functionality any {@link
-   * OpenTelemetryFactory}, or {@link TracerProviderFactory} found on the classpath, or otherwise
-   * will be default, with no-op behavior.
+   * Returns the registered global {@link OpenTelemetry}.
    *
    * @throws IllegalStateException if a provider has been specified by system property using the
    *     interface FQCN but the specified provider cannot be found.
@@ -63,7 +54,8 @@ public final class GlobalOpenTelemetry {
             return autoConfigured;
           }
 
-          OpenTelemetryFactory openTelemetryFactory = Utils.loadSpi(OpenTelemetryFactory.class);
+          io.opentelemetry.spi.OpenTelemetryFactory openTelemetryFactory =
+              Utils.loadSpi(io.opentelemetry.spi.OpenTelemetryFactory.class);
           if (openTelemetryFactory != null) {
             set(openTelemetryFactory.create());
           } else {

--- a/api/all/src/main/java/io/opentelemetry/spi/OpenTelemetryFactory.java
+++ b/api/all/src/main/java/io/opentelemetry/spi/OpenTelemetryFactory.java
@@ -14,7 +14,12 @@ import io.opentelemetry.api.OpenTelemetry;
  *
  * <p>A specific implementation can be selected by setting the system property {@code
  * io.opentelemetry.spi.OpenTelemetryFactory} with the value of the fully qualified class name.
+ *
+ * @deprecated Use {@link io.opentelemetry.api.DefaultOpenTelemetry#builder} to initialize
+ *     OpenTelemetry with a custom provider, or {@code OpenTelemetrySdk#builder} or {@code
+ *     opentelemetry-sdk-extension-autoconfigure} to configure the default SDK.
  */
+@Deprecated
 public interface OpenTelemetryFactory {
 
   /** Returns a new {@link OpenTelemetry} instance. */

--- a/api/all/src/main/java/io/opentelemetry/spi/trace/TracerProviderFactory.java
+++ b/api/all/src/main/java/io/opentelemetry/spi/trace/TracerProviderFactory.java
@@ -18,8 +18,12 @@ import javax.annotation.concurrent.ThreadSafe;
  * io.opentelemetry.trace.spi.TracerProviderFactory} with value of fully qualified class name.
  *
  * @see OpenTelemetry
+ * @deprecated Use {@link io.opentelemetry.api.DefaultOpenTelemetry#builder} to initialize
+ *     OpenTelemetry with a custom provider, or {@code OpenTelemetrySdk#builder} or {@code
+ *     opentelemetry-sdk-extension-autoconfigure} to configure the default SDK.
  */
 @ThreadSafe
+@Deprecated
 public interface TracerProviderFactory {
 
   /**

--- a/api/all/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
@@ -14,7 +14,6 @@ import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
-import io.opentelemetry.spi.trace.TracerProviderFactory;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -25,6 +24,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("deprecation") // Remove after deleting OpenTelemetry SPI
 class OpenTelemetryTest {
 
   @BeforeAll
@@ -35,7 +35,7 @@ class OpenTelemetryTest {
   @AfterEach
   void after() {
     GlobalOpenTelemetry.reset();
-    System.clearProperty(TracerProviderFactory.class.getName());
+    System.clearProperty(io.opentelemetry.spi.trace.TracerProviderFactory.class.getName());
   }
 
   @Test
@@ -66,7 +66,7 @@ class OpenTelemetryTest {
   void testTracerLoadArbitrary() throws IOException {
     File serviceFile =
         createService(
-            TracerProviderFactory.class,
+            io.opentelemetry.spi.trace.TracerProviderFactory.class,
             FirstTracerProviderFactory.class,
             SecondTracerProviderFactory.class);
     try {
@@ -85,11 +85,12 @@ class OpenTelemetryTest {
   void testTracerSystemProperty() throws IOException {
     File serviceFile =
         createService(
-            TracerProviderFactory.class,
+            io.opentelemetry.spi.trace.TracerProviderFactory.class,
             FirstTracerProviderFactory.class,
             SecondTracerProviderFactory.class);
     System.setProperty(
-        TracerProviderFactory.class.getName(), SecondTracerProviderFactory.class.getName());
+        io.opentelemetry.spi.trace.TracerProviderFactory.class.getName(),
+        SecondTracerProviderFactory.class.getName());
     try {
       assertThat(GlobalOpenTelemetry.getTracerProvider().get(""))
           .isInstanceOf(SecondTracerProviderFactory.class);
@@ -100,7 +101,8 @@ class OpenTelemetryTest {
 
   @Test
   void testTracerNotFound() {
-    System.setProperty(TracerProviderFactory.class.getName(), "io.does.not.exists");
+    System.setProperty(
+        io.opentelemetry.spi.trace.TracerProviderFactory.class.getName(), "io.does.not.exists");
     assertThatThrownBy(() -> GlobalOpenTelemetry.getTracer("testTracer"))
         .isInstanceOf(IllegalStateException.class);
   }
@@ -169,7 +171,7 @@ class OpenTelemetryTest {
   }
 
   public static class FirstTracerProviderFactory
-      implements Tracer, TracerProvider, TracerProviderFactory {
+      implements Tracer, TracerProvider, io.opentelemetry.spi.trace.TracerProviderFactory {
 
     @Override
     public Tracer get(String instrumentationName) {

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,10 @@ subprojects {
             it.options.errorprone.disable("AutoValueImmutableFields")
             // "-Xep:AutoValueImmutableFields:OFF"
 
+            // Fully qualified names may be necessary when deprecating a class to avoid
+            // deprecation warning.
+            it.options.errorprone.disable("UnnecessarilyFullyQualified")
+
             it.options.encoding = "UTF-8"
 
             // Ignore warnings for protobuf and jmh generated files.

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdkFactory.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdkFactory.java
@@ -6,13 +6,13 @@
 package io.opentelemetry.sdk;
 
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.spi.OpenTelemetryFactory;
 
 /**
  * Factory SPI implementation to register a {@link OpenTelemetrySdk} as the default {@link
  * OpenTelemetry}.
  */
-public final class OpenTelemetrySdkFactory implements OpenTelemetryFactory {
+@SuppressWarnings("deprecation") // Remove after deleting OpenTelemetry SPI
+public final class OpenTelemetrySdkFactory implements io.opentelemetry.spi.OpenTelemetryFactory {
   @Override
   public OpenTelemetry create() {
     return OpenTelemetrySdk.builder().build();

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/spi/SdkTracerProviderFactory.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/spi/SdkTracerProviderFactory.java
@@ -7,10 +7,11 @@ package io.opentelemetry.sdk.trace.spi;
 
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
-import io.opentelemetry.spi.trace.TracerProviderFactory;
 
-/** SDK implementation of the {@link TracerProviderFactory} for SPI. */
-public final class SdkTracerProviderFactory implements TracerProviderFactory {
+/** SDK implementation of tracing. */
+@SuppressWarnings("deprecation") // Remove after deleting OpenTelemetry SPI
+public final class SdkTracerProviderFactory
+    implements io.opentelemetry.spi.trace.TracerProviderFactory {
 
   @Override
   public TracerProvider create() {


### PR DESCRIPTION
We have autoconfigure module for SDK customization and would like to see patterns related to custom SDKs before SPIing to much initially.

Hopefully this helps with #2022 