### PR TITLE
Set the default traceidratio to 1.0 when it is not specified

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
@@ -121,9 +121,7 @@ final class TracerProviderConfiguration {
         {
           Double ratio = config.getDouble("otel.trace.sampler.arg");
           if (ratio == null) {
-            throw new ConfigurationException(
-                "otel.trace.sampler=traceidratio but otel.trace.sampler.arg is not provided. "
-                    + "Set otel.trace.sampler.arg to a value in the range [0.0, 1.0].");
+            ratio = 1.0d;
           }
           return Sampler.traceIdRatioBased(ratio);
         }
@@ -135,10 +133,7 @@ final class TracerProviderConfiguration {
         {
           Double ratio = config.getDouble("otel.trace.sampler.arg");
           if (ratio == null) {
-            throw new ConfigurationException(
-                "otel.trace.sampler=parentbased_traceidratio but otel.trace.sampler.arg is not "
-                    + "provided. Set otel.trace.sampler.arg to a value in the "
-                    + "range [0.0, 1.0].");
+            ratio = 1.0d;
           }
           return Sampler.parentBased(Sampler.traceIdRatioBased(ratio));
         }

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
@@ -167,9 +167,8 @@ class TracerProviderConfigurationTest {
                 ConfigProperties.createForTest(
                     Collections.singletonMap("otel.trace.sampler.arg", "0.5"))))
         .isEqualTo(Sampler.traceIdRatioBased(0.5));
-    assertThatThrownBy(() -> TracerProviderConfiguration.configureSampler("traceidratio", EMPTY))
-        .isInstanceOf(ConfigurationException.class)
-        .hasMessageContaining("otel.trace.sampler.arg is not provided");
+    assertThat(TracerProviderConfiguration.configureSampler("traceidratio", EMPTY))
+        .isEqualTo(Sampler.traceIdRatioBased(1.0d));
     assertThat(TracerProviderConfiguration.configureSampler("parentbased_always_on", EMPTY))
         .isEqualTo(Sampler.parentBased(Sampler.alwaysOn()));
     assertThat(TracerProviderConfiguration.configureSampler("parentbased_always_off", EMPTY))
@@ -180,10 +179,8 @@ class TracerProviderConfigurationTest {
                 ConfigProperties.createForTest(
                     Collections.singletonMap("otel.trace.sampler.arg", "0.4"))))
         .isEqualTo(Sampler.parentBased(Sampler.traceIdRatioBased(0.4)));
-    assertThatThrownBy(
-            () -> TracerProviderConfiguration.configureSampler("parentbased_traceidratio", EMPTY))
-        .isInstanceOf(ConfigurationException.class)
-        .hasMessageContaining("otel.trace.sampler.arg is not provided");
+    assertThat(TracerProviderConfiguration.configureSampler("parentbased_traceidratio", EMPTY))
+        .isEqualTo(Sampler.parentBased(Sampler.traceIdRatioBased(1.0d)));
 
     assertThatThrownBy(() -> TracerProviderConfiguration.configureSampler("catsampler", EMPTY))
         .isInstanceOf(ConfigurationException.class)


### PR DESCRIPTION
See this spec update: https://github.com/open-telemetry/opentelemetry-specification/pull/1322