### PR TITLE
For async instrument tests call the public metric producer method, instead of passing timestamp

### DIFF
--- a/perf-harness/src/test/java/io/opentelemetry/perf/OtlpPipelineStressTest.java
+++ b/perf-harness/src/test/java/io/opentelemetry/perf/OtlpPipelineStressTest.java
@@ -250,7 +250,7 @@ public class OtlpPipelineStressTest {
     intervalMetricReader =
         IntervalMetricReader.builder()
             .setMetricExporter(metricExporter)
-            .setMetricProducers(Collections.singleton(meterProvider.getMetricProducer()))
+            .setMetricProducers(Collections.singleton(meterProvider))
             .setExportIntervalMillis(1000)
             .build();
 

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
@@ -80,7 +80,7 @@ final class MetricExporterConfiguration {
 
     IntervalMetricReaderBuilder readerBuilder =
         IntervalMetricReader.builder()
-            .setMetricProducers(Collections.singleton(meterProvider.getMetricProducer()))
+            .setMetricProducers(Collections.singleton(meterProvider))
             .setMetricExporter(exporter);
     Long exportIntervalMillis = config.getLong("otel.imr.export.interval");
     if (exportIntervalMillis != null) {
@@ -98,9 +98,7 @@ final class MetricExporterConfiguration {
         "io.opentelemetry.exporter.prometheus.PrometheusCollector",
         "Prometheus Metrics Server",
         "opentelemetry-exporter-prometheus");
-    PrometheusCollector.builder()
-        .setMetricProducer(meterProvider.getMetricProducer())
-        .buildAndRegister();
+    PrometheusCollector.builder().setMetricProducer(meterProvider).buildAndRegister();
     Integer port = config.getInt("otel.exporter.prometheus.port");
     if (port == null) {
       port = 9464;

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorDroppedSpansBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorDroppedSpansBenchmark.java
@@ -52,8 +52,7 @@ public class BatchSpanProcessorDroppedSpansBenchmark {
 
   @State(Scope.Benchmark)
   public static class BenchmarkState {
-    private final MetricProducer metricProducer =
-        ((SdkMeterProvider) GlobalMetricsProvider.get()).getMetricProducer();
+    private final MetricProducer metricProducer = ((SdkMeterProvider) GlobalMetricsProvider.get());
     private BatchSpanProcessor processor;
     private Tracer tracer;
     private Collection<MetricData> allMetrics;

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleSumObserverSdkTest.java
@@ -32,38 +32,35 @@ class DoubleSumObserverSdkTest {
 
   @Test
   void collectMetrics_NoCallback() {
-    DoubleSumObserverSdk doubleSumObserver =
-        sdkMeter
-            .doubleSumObserverBuilder("testObserver")
-            .setDescription("My own DoubleSumObserver")
-            .setUnit("ms")
-            .build();
-    assertThat(doubleSumObserver.collectAll(testClock.now())).isEmpty();
+    sdkMeter
+        .doubleSumObserverBuilder("testObserver")
+        .setDescription("My own DoubleSumObserver")
+        .setUnit("ms")
+        .build();
+    assertThat(sdkMeterProvider.collectAllMetrics()).isEmpty();
   }
 
   @Test
   void collectMetrics_NoRecords() {
-    DoubleSumObserverSdk doubleSumObserver =
-        sdkMeter
-            .doubleSumObserverBuilder("testObserver")
-            .setDescription("My own DoubleSumObserver")
-            .setUnit("ms")
-            .setUpdater(result -> {})
-            .build();
-    assertThat(doubleSumObserver.collectAll(testClock.now())).isEmpty();
+    sdkMeter
+        .doubleSumObserverBuilder("testObserver")
+        .setDescription("My own DoubleSumObserver")
+        .setUnit("ms")
+        .setUpdater(result -> {})
+        .build();
+    assertThat(sdkMeterProvider.collectAllMetrics()).isEmpty();
   }
 
   @Test
   void collectMetrics_WithOneRecord() {
-    DoubleSumObserverSdk doubleSumObserver =
-        sdkMeter
-            .doubleSumObserverBuilder("testObserver")
-            .setDescription("My own DoubleSumObserver")
-            .setUnit("ms")
-            .setUpdater(result -> result.observe(12.1d, Labels.of("k", "v")))
-            .build();
+    sdkMeter
+        .doubleSumObserverBuilder("testObserver")
+        .setDescription("My own DoubleSumObserver")
+        .setUnit("ms")
+        .setUpdater(result -> result.observe(12.1d, Labels.of("k", "v")))
+        .build();
     testClock.advanceNanos(SECOND_NANOS);
-    assertThat(doubleSumObserver.collectAll(testClock.now()))
+    assertThat(sdkMeterProvider.collectAllMetrics())
         .containsExactly(
             MetricData.createDoubleSum(
                 RESOURCE,
@@ -81,7 +78,7 @@ class DoubleSumObserverSdkTest {
                             Labels.of("k", "v"),
                             12.1d)))));
     testClock.advanceNanos(SECOND_NANOS);
-    assertThat(doubleSumObserver.collectAll(testClock.now()))
+    assertThat(sdkMeterProvider.collectAllMetrics())
         .containsExactly(
             MetricData.createDoubleSum(
                 RESOURCE,

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownSumObserverSdkTest.java
@@ -32,36 +32,33 @@ class DoubleUpDownSumObserverSdkTest {
 
   @Test
   void collectMetrics_NoCallback() {
-    DoubleUpDownSumObserverSdk doubleUpDownSumObserver =
-        sdkMeter
-            .doubleUpDownSumObserverBuilder("testObserver")
-            .setDescription("My own DoubleUpDownSumObserver")
-            .setUnit("ms")
-            .build();
-    assertThat(doubleUpDownSumObserver.collectAll(testClock.now())).isEmpty();
+    sdkMeter
+        .doubleUpDownSumObserverBuilder("testObserver")
+        .setDescription("My own DoubleUpDownSumObserver")
+        .setUnit("ms")
+        .build();
+    assertThat(sdkMeterProvider.collectAllMetrics()).isEmpty();
   }
 
   @Test
   void collectMetrics_NoRecords() {
-    DoubleUpDownSumObserverSdk doubleUpDownSumObserver =
-        sdkMeter
-            .doubleUpDownSumObserverBuilder("testObserver")
-            .setDescription("My own DoubleUpDownSumObserver")
-            .setUnit("ms")
-            .setUpdater(result -> {})
-            .build();
-    assertThat(doubleUpDownSumObserver.collectAll(testClock.now())).isEmpty();
+    sdkMeter
+        .doubleUpDownSumObserverBuilder("testObserver")
+        .setDescription("My own DoubleUpDownSumObserver")
+        .setUnit("ms")
+        .setUpdater(result -> {})
+        .build();
+    assertThat(sdkMeterProvider.collectAllMetrics()).isEmpty();
   }
 
   @Test
   void collectMetrics_WithOneRecord() {
-    DoubleUpDownSumObserverSdk doubleUpDownSumObserver =
-        sdkMeter
-            .doubleUpDownSumObserverBuilder("testObserver")
-            .setUpdater(result -> result.observe(12.1d, Labels.of("k", "v")))
-            .build();
+    sdkMeter
+        .doubleUpDownSumObserverBuilder("testObserver")
+        .setUpdater(result -> result.observe(12.1d, Labels.of("k", "v")))
+        .build();
     testClock.advanceNanos(SECOND_NANOS);
-    assertThat(doubleUpDownSumObserver.collectAll(testClock.now()))
+    assertThat(sdkMeterProvider.collectAllMetrics())
         .containsExactly(
             MetricData.createDoubleSum(
                 RESOURCE,
@@ -79,7 +76,7 @@ class DoubleUpDownSumObserverSdkTest {
                             Labels.of("k", "v"),
                             12.1d)))));
     testClock.advanceNanos(SECOND_NANOS);
-    assertThat(doubleUpDownSumObserver.collectAll(testClock.now()))
+    assertThat(sdkMeterProvider.collectAllMetrics())
         .containsExactly(
             MetricData.createDoubleSum(
                 RESOURCE,

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueObserverSdkTest.java
@@ -32,38 +32,35 @@ class DoubleValueObserverSdkTest {
 
   @Test
   void collectMetrics_NoCallback() {
-    DoubleValueObserverSdk doubleValueObserver =
-        sdkMeter
-            .doubleValueObserverBuilder("testObserver")
-            .setDescription("My own DoubleValueObserver")
-            .setUnit("ms")
-            .build();
-    assertThat(doubleValueObserver.collectAll(testClock.now())).isEmpty();
+    sdkMeter
+        .doubleValueObserverBuilder("testObserver")
+        .setDescription("My own DoubleValueObserver")
+        .setUnit("ms")
+        .build();
+    assertThat(sdkMeterProvider.collectAllMetrics()).isEmpty();
   }
 
   @Test
   void collectMetrics_NoRecords() {
-    DoubleValueObserverSdk doubleValueObserver =
-        sdkMeter
-            .doubleValueObserverBuilder("testObserver")
-            .setDescription("My own DoubleValueObserver")
-            .setUnit("ms")
-            .setUpdater(result -> {})
-            .build();
-    assertThat(doubleValueObserver.collectAll(testClock.now())).isEmpty();
+    sdkMeter
+        .doubleValueObserverBuilder("testObserver")
+        .setDescription("My own DoubleValueObserver")
+        .setUnit("ms")
+        .setUpdater(result -> {})
+        .build();
+    assertThat(sdkMeterProvider.collectAllMetrics()).isEmpty();
   }
 
   @Test
   void collectMetrics_WithOneRecord() {
-    DoubleValueObserverSdk doubleValueObserver =
-        sdkMeter
-            .doubleValueObserverBuilder("testObserver")
-            .setDescription("My own DoubleValueObserver")
-            .setUnit("ms")
-            .setUpdater(result -> result.observe(12.1d, Labels.of("k", "v")))
-            .build();
+    sdkMeter
+        .doubleValueObserverBuilder("testObserver")
+        .setDescription("My own DoubleValueObserver")
+        .setUnit("ms")
+        .setUpdater(result -> result.observe(12.1d, Labels.of("k", "v")))
+        .build();
     testClock.advanceNanos(SECOND_NANOS);
-    assertThat(doubleValueObserver.collectAll(testClock.now()))
+    assertThat(sdkMeterProvider.collectAllMetrics())
         .containsExactly(
             MetricData.createDoubleGauge(
                 RESOURCE,
@@ -79,7 +76,7 @@ class DoubleValueObserverSdkTest {
                             Labels.of("k", "v"),
                             12.1d)))));
     testClock.advanceNanos(SECOND_NANOS);
-    assertThat(doubleValueObserver.collectAll(testClock.now()))
+    assertThat(sdkMeterProvider.collectAllMetrics())
         .containsExactly(
             MetricData.createDoubleGauge(
                 RESOURCE,

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongSumObserverSdkTest.java
@@ -32,36 +32,33 @@ class LongSumObserverSdkTest {
 
   @Test
   void collectMetrics_NoCallback() {
-    LongSumObserverSdk longSumObserver =
-        sdkMeter
-            .longSumObserverBuilder("testObserver")
-            .setDescription("My own LongSumObserver")
-            .setUnit("ms")
-            .build();
-    assertThat(longSumObserver.collectAll(testClock.now())).isEmpty();
+    sdkMeter
+        .longSumObserverBuilder("testObserver")
+        .setDescription("My own LongSumObserver")
+        .setUnit("ms")
+        .build();
+    assertThat(sdkMeterProvider.collectAllMetrics()).isEmpty();
   }
 
   @Test
   void collectMetrics_NoRecords() {
-    LongSumObserverSdk longSumObserver =
-        sdkMeter
-            .longSumObserverBuilder("testObserver")
-            .setDescription("My own LongSumObserver")
-            .setUnit("ms")
-            .setUpdater(result -> {})
-            .build();
-    assertThat(longSumObserver.collectAll(testClock.now())).isEmpty();
+    sdkMeter
+        .longSumObserverBuilder("testObserver")
+        .setDescription("My own LongSumObserver")
+        .setUnit("ms")
+        .setUpdater(result -> {})
+        .build();
+    assertThat(sdkMeterProvider.collectAllMetrics()).isEmpty();
   }
 
   @Test
   void collectMetrics_WithOneRecord() {
-    LongSumObserverSdk longSumObserver =
-        sdkMeter
-            .longSumObserverBuilder("testObserver")
-            .setUpdater(result -> result.observe(12, Labels.of("k", "v")))
-            .build();
+    sdkMeter
+        .longSumObserverBuilder("testObserver")
+        .setUpdater(result -> result.observe(12, Labels.of("k", "v")))
+        .build();
     testClock.advanceNanos(SECOND_NANOS);
-    assertThat(longSumObserver.collectAll(testClock.now()))
+    assertThat(sdkMeterProvider.collectAllMetrics())
         .containsExactly(
             MetricData.createLongSum(
                 RESOURCE,
@@ -79,7 +76,7 @@ class LongSumObserverSdkTest {
                             Labels.of("k", "v"),
                             12)))));
     testClock.advanceNanos(SECOND_NANOS);
-    assertThat(longSumObserver.collectAll(testClock.now()))
+    assertThat(sdkMeterProvider.collectAllMetrics())
         .containsExactly(
             MetricData.createLongSum(
                 RESOURCE,

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownSumObserverSdkTest.java
@@ -32,36 +32,33 @@ class LongUpDownSumObserverSdkTest {
 
   @Test
   void collectMetrics_NoCallback() {
-    LongUpDownSumObserverSdk longUpDownSumObserver =
-        sdkMeter
-            .longUpDownSumObserverBuilder("testObserver")
-            .setDescription("My own LongUpDownSumObserver")
-            .setUnit("ms")
-            .build();
-    assertThat(longUpDownSumObserver.collectAll(testClock.now())).isEmpty();
+    sdkMeter
+        .longUpDownSumObserverBuilder("testObserver")
+        .setDescription("My own LongUpDownSumObserver")
+        .setUnit("ms")
+        .build();
+    assertThat(sdkMeterProvider.collectAllMetrics()).isEmpty();
   }
 
   @Test
   void collectMetrics_NoRecords() {
-    LongUpDownSumObserverSdk longUpDownSumObserver =
-        sdkMeter
-            .longUpDownSumObserverBuilder("testObserver")
-            .setDescription("My own LongUpDownSumObserver")
-            .setUnit("ms")
-            .setUpdater(result -> {})
-            .build();
-    assertThat(longUpDownSumObserver.collectAll(testClock.now())).isEmpty();
+    sdkMeter
+        .longUpDownSumObserverBuilder("testObserver")
+        .setDescription("My own LongUpDownSumObserver")
+        .setUnit("ms")
+        .setUpdater(result -> {})
+        .build();
+    assertThat(sdkMeterProvider.collectAllMetrics()).isEmpty();
   }
 
   @Test
   void collectMetrics_WithOneRecord() {
-    LongUpDownSumObserverSdk longUpDownSumObserver =
-        sdkMeter
-            .longUpDownSumObserverBuilder("testObserver")
-            .setUpdater(result -> result.observe(12, Labels.of("k", "v")))
-            .build();
+    sdkMeter
+        .longUpDownSumObserverBuilder("testObserver")
+        .setUpdater(result -> result.observe(12, Labels.of("k", "v")))
+        .build();
     testClock.advanceNanos(SECOND_NANOS);
-    assertThat(longUpDownSumObserver.collectAll(testClock.now()))
+    assertThat(sdkMeterProvider.collectAllMetrics())
         .containsExactly(
             MetricData.createLongSum(
                 RESOURCE,
@@ -79,7 +76,7 @@ class LongUpDownSumObserverSdkTest {
                             Labels.of("k", "v"),
                             12)))));
     testClock.advanceNanos(SECOND_NANOS);
-    assertThat(longUpDownSumObserver.collectAll(testClock.now()))
+    assertThat(sdkMeterProvider.collectAllMetrics())
         .containsExactly(
             MetricData.createLongSum(
                 RESOURCE,

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongValueObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongValueObserverSdkTest.java
@@ -32,36 +32,33 @@ class LongValueObserverSdkTest {
 
   @Test
   void collectMetrics_NoCallback() {
-    LongValueObserverSdk longValueObserver =
-        sdkMeter
-            .longValueObserverBuilder("testObserver")
-            .setDescription("My own LongValueObserver")
-            .setUnit("ms")
-            .build();
-    assertThat(longValueObserver.collectAll(testClock.now())).isEmpty();
+    sdkMeter
+        .longValueObserverBuilder("testObserver")
+        .setDescription("My own LongValueObserver")
+        .setUnit("ms")
+        .build();
+    assertThat(sdkMeterProvider.collectAllMetrics()).isEmpty();
   }
 
   @Test
   void collectMetrics_NoRecords() {
-    LongValueObserverSdk longValueObserver =
-        sdkMeter
-            .longValueObserverBuilder("testObserver")
-            .setDescription("My own LongValueObserver")
-            .setUnit("ms")
-            .setUpdater(result -> {})
-            .build();
-    assertThat(longValueObserver.collectAll(testClock.now())).isEmpty();
+    sdkMeter
+        .longValueObserverBuilder("testObserver")
+        .setDescription("My own LongValueObserver")
+        .setUnit("ms")
+        .setUpdater(result -> {})
+        .build();
+    assertThat(sdkMeterProvider.collectAllMetrics()).isEmpty();
   }
 
   @Test
   void collectMetrics_WithOneRecord() {
-    LongValueObserverSdk longValueObserver =
-        sdkMeter
-            .longValueObserverBuilder("testObserver")
-            .setUpdater(result -> result.observe(12, Labels.of("k", "v")))
-            .build();
+    sdkMeter
+        .longValueObserverBuilder("testObserver")
+        .setUpdater(result -> result.observe(12, Labels.of("k", "v")))
+        .build();
     testClock.advanceNanos(SECOND_NANOS);
-    assertThat(longValueObserver.collectAll(testClock.now()))
+    assertThat(sdkMeterProvider.collectAllMetrics())
         .containsExactly(
             MetricData.createLongGauge(
                 RESOURCE,
@@ -77,7 +74,7 @@ class LongValueObserverSdkTest {
                             Labels.of("k", "v"),
                             12)))));
     testClock.advanceNanos(SECOND_NANOS);
-    assertThat(longValueObserver.collectAll(testClock.now()))
+    assertThat(sdkMeterProvider.collectAllMetrics())
         .containsExactly(
             MetricData.createLongGauge(
                 RESOURCE,

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterRegistryTest.java
@@ -82,7 +82,7 @@ class SdkMeterRegistryTest {
     LongCounterSdk longCounter2 = sdkMeter2.longCounterBuilder("testLongCounter").build();
     longCounter2.add(10, Labels.empty());
 
-    assertThat(meterProvider.getMetricProducer().collectAllMetrics())
+    assertThat(meterProvider.collectAllMetrics())
         .containsExactlyInAnyOrder(
             MetricData.createLongSum(
                 Resource.getEmpty(),


### PR DESCRIPTION
Depends on https://github.com/open-telemetry/opentelemetry-java/pull/2489