### PR TITLE
Use bogus endpoint for initialSampler test to prevent flakiness.

### DIFF
--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerTest.java
@@ -138,7 +138,7 @@ class JaegerRemoteSamplerTest {
   void initialSampler() {
     JaegerRemoteSampler sampler =
         JaegerRemoteSampler.builder()
-            .setChannel(inProcessChannel)
+            .setEndpoint("example.com")
             .setServiceName(SERVICE_NAME)
             .setInitialSampler(Sampler.alwaysOn())
             .build();


### PR DESCRIPTION
Right now there's a race if the jaeger lookup actually succeeds before the assertion runs.