### PR TITLE
Exclude jfr-events from coverage report since it doesn't compute cove…

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -70,7 +70,9 @@ tasks.named('jacocoTestReport', JacocoReport) {
                     !it.absolutePath.contains("io/opentelemetry/sdk/extension/trace/jaeger/proto/") &&
                     !it.absolutePath.contains("io/opentelemetry/api/trace/attributes/SemanticAttributes") &&
                     !it.absolutePath.contains("io/opentelemetry/semconv/trace/attributes/SemanticAttributes") &&
-                    !it.absolutePath.contains("AutoValue_")
+                    !it.absolutePath.contains("AutoValue_") &&
+                    // TODO(anuraaga): Remove exclusion after enabling coverage for jfr-events
+                    !it.absolutePath.contains("io/opentelemetry/sdk/extension/jfr")
         })
     }
     additionalSourceDirs(sourcesPath.incoming.artifactView { lenient(true) }.files)


### PR DESCRIPTION
…rage

I'm thinking of enabling Java 15 testing too, to have parity with auto-instrumentation repo. At that point, I think we'd be able to restore this since Java 15 has fixed the JDK bug