### PR TITLE
Deprecate StatusData.isUnset

### DIFF
--- a/exporters/jaeger-thrift/src/main/java/io/opentelemetry/exporter/jaeger/thrift/Adapter.java
+++ b/exporters/jaeger-thrift/src/main/java/io/opentelemetry/exporter/jaeger/thrift/Adapter.java
@@ -104,7 +104,7 @@ final class Adapter {
               .setVStr(span.getStatus().getDescription()));
     }
 
-    if (!span.getStatus().isUnset()) {
+    if (span.getStatus().getStatusCode() != StatusCode.UNSET) {
       tags.add(
           new Tag(KEY_SPAN_STATUS_CODE, TagType.STRING)
               .setVStr(span.getStatus().getStatusCode().name()));

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/Adapter.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/Adapter.java
@@ -104,7 +104,7 @@ final class Adapter {
               .build());
     }
 
-    if (!span.getStatus().isUnset()) {
+    if (span.getStatus().getStatusCode() != StatusCode.UNSET) {
       target.addTags(
           Model.KeyValue.newBuilder()
               .setKey(KEY_SPAN_STATUS_CODE)

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
@@ -136,7 +136,7 @@ public final class ZipkinSpanExporter implements SpanExporter {
       spanBuilder.putTag(OTEL_STATUS_CODE, status.getStatusCode().toString());
 
       // add the error tag, if it isn't already in the source span.
-      if (!status.isOk() && spanAttributes.get(STATUS_ERROR) == null) {
+      if (status.getStatusCode() == StatusCode.ERROR && spanAttributes.get(STATUS_ERROR) == null) {
         spanBuilder.putTag(STATUS_ERROR.getKey(), nullToEmpty(status.getDescription()));
       }
     }

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
@@ -12,6 +12,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributeType;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span.Kind;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.ResourceAttributes;
@@ -131,7 +132,7 @@ public final class ZipkinSpanExporter implements SpanExporter {
     StatusData status = spanData.getStatus();
 
     // include status code & error.
-    if (!status.isUnset()) {
+    if (status.getStatusCode() != StatusCode.UNSET) {
       spanBuilder.putTag(OTEL_STATUS_CODE, status.getStatusCode().toString());
 
       // add the error tag, if it isn't already in the source span.

--- a/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/TracezSpanBuckets.java
+++ b/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/TracezSpanBuckets.java
@@ -31,7 +31,7 @@ final class TracezSpanBuckets {
 
   void addToBucket(ReadableSpan span) {
     StatusData status = span.toSpanData().getStatus();
-    if (status.isOk()) {
+    if (status.getStatusCode() != StatusCode.ERROR) {
       latencyBuckets.get(LatencyBoundary.getBoundary(span.getLatencyNanos())).add(span);
       return;
     }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/StatusData.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/StatusData.java
@@ -76,8 +76,8 @@ public interface StatusData {
       case OK:
         return true;
       case ERROR:
-      default:
         return false;
     }
+    return false;
   }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/StatusData.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/StatusData.java
@@ -56,8 +56,10 @@ public interface StatusData {
    * Returns {@code true} if this {@code Status} is UNSET, i.e., not an error.
    *
    * @return {@code true} if this {@code Status} is UNSET.
+   * @deprecated Compare {@link #getStatusCode()} with {@link StatusCode#UNSET}
    */
   // TODO: Consider to remove this in a future PR. Avoid too many changes in the initial PR.
+  @Deprecated
   default boolean isUnset() {
     return StatusCode.UNSET == getStatusCode();
   }
@@ -68,8 +70,14 @@ public interface StatusData {
    *
    * @return {@code true} if this {@code Status} is OK or UNSET.
    */
-  // TODO: Consider to remove this in a future PR. Avoid too many changes in the initial PR.
   default boolean isOk() {
-    return isUnset() || StatusCode.OK == getStatusCode();
+    switch (getStatusCode()) {
+      case UNSET:
+      case OK:
+        return true;
+      case ERROR:
+      default:
+        return false;
+    }
   }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/StatusData.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/StatusData.java
@@ -69,15 +69,10 @@ public interface StatusData {
    * overridden to be ok by an operator.
    *
    * @return {@code true} if this {@code Status} is OK or UNSET.
+   * @deprecated Compare {@link #getStatusCode()} with {@link StatusCode#ERROR}
    */
+  @Deprecated
   default boolean isOk() {
-    switch (getStatusCode()) {
-      case UNSET:
-      case OK:
-        return true;
-      case ERROR:
-        return false;
-    }
-    return false;
+    return isUnset() || StatusCode.OK == getStatusCode();
   }
 }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/data/ImmutableStatusDataTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/data/ImmutableStatusDataTest.java
@@ -25,13 +25,6 @@ class ImmutableStatusDataTest {
   }
 
   @Test
-  void isOk() {
-    assertThat(StatusData.ok().isOk()).isTrue();
-    assertThat(StatusData.unset().isOk()).isTrue();
-    assertThat(StatusData.error().isOk()).isFalse();
-  }
-
-  @Test
   void generateCodeToStatus() {
     StatusCode[] codes = StatusCode.values();
     assertThat(ImmutableStatusData.codeToStatus).hasSize(codes.length);

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/data/ImmutableStatusDataTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/data/ImmutableStatusDataTest.java
@@ -25,6 +25,13 @@ class ImmutableStatusDataTest {
   }
 
   @Test
+  void isOk() {
+    assertThat(StatusData.ok().isOk()).isTrue();
+    assertThat(StatusData.unset().isOk()).isTrue();
+    assertThat(StatusData.error().isOk()).isFalse();
+  }
+
+  @Test
   void generateCodeToStatus() {
     StatusCode[] codes = StatusCode.values();
     assertThat(ImmutableStatusData.codeToStatus).hasSize(codes.length);


### PR DESCRIPTION
There is some inconsistency here. I think there are three options

1. Remove `isUnset` because there is no similar `isError`, and its behavior is different from `isOk` which checks two codes
2. Remove both `isUnset` and `isOk`
3. Add `isError`, change `isOk` to only check OK


I like `isOk` since it's annoying to check two codes to know whether a status is erroneous or not so I've picked the first option. I'm ok with 2 as well. 3 seems silly since it just duplicates the fairly simple code-vs-enum comparison into methods, but it would be more consistent than the current method names.