### PR TITLE
Set the opentelemetry-bom archive name explicitly to fix publishing issue

### DIFF
--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -5,6 +5,7 @@ plugins {
 
 description = 'OpenTelemetry Bill of Materials'
 group = "io.opentelemetry"
+archivesBaseName = "opentelemetry-bom"
 
 afterEvaluate {
     dependencies {


### PR DESCRIPTION
Fixes #2511 

We'll want to cherrypick this for a patch release.