### PR TITLE
Deprecate BatchSpanProcessor.setExportOnlySampled

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBuilder.java
@@ -46,7 +46,12 @@ public final class BatchSpanProcessorBuilder {
    * @param exportOnlySampled if {@code true} report only sampled spans.
    * @return this.
    * @see BatchSpanProcessorBuilder#DEFAULT_EXPORT_ONLY_SAMPLED
+   * @deprecated Will be removed without replacement, all spans with a sampling result of {@link
+   *     io.opentelemetry.sdk.trace.samplers.SamplingResult.Decision#RECORD_AND_SAMPLE} will be
+   *     exported while spans with a result of {@link
+   *     io.opentelemetry.sdk.trace.samplers.SamplingResult.Decision#RECORD_ONLY} will not.
    */
+  @Deprecated
   public BatchSpanProcessorBuilder setExportOnlySampled(boolean exportOnlySampled) {
     this.exportOnlySampled = exportOnlySampled;
     return this;

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -423,7 +423,6 @@ class BatchSpanProcessorTest {
             .addSpanProcessor(
                 BatchSpanProcessor.builder(waitingSpanExporter)
                     .setScheduleDelay(MAX_SCHEDULE_DELAY_MILLIS, TimeUnit.MILLISECONDS)
-                    .setExportOnlySampled(true)
                     .build())
             .setTraceConfig(traceConfig::get)
             .build();


### PR DESCRIPTION
Had already removed from SimpleSpanProcessor but not here yet.