### PR TITLE
Use archivesBaseName for Implementation-Title

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,13 +147,15 @@ subprojects {
             options.compilerArgs += ["-Xlint:-serial"]
         }
 
-        jar.manifest {
-            attributes('Implementation-Title': name,
-                    'Implementation-Version': version,
-                    'Built-By': System.getProperty('user.name'),
-                    'Built-JDK': System.getProperty('java.version'),
-                    'Source-Compatibility': sourceCompatibility,
-                    'Target-Compatibility': targetCompatibility)
+        afterEvaluate {
+            jar.manifest {
+                attributes('Implementation-Title': archivesBaseName,
+                        'Implementation-Version': version,
+                        'Built-By': System.getProperty('user.name'),
+                        'Built-JDK': System.getProperty('java.version'),
+                        'Source-Compatibility': sourceCompatibility,
+                        'Target-Compatibility': targetCompatibility)
+            }
         }
 
         ext {


### PR DESCRIPTION
When looking around, I realized many Gradle projects don't set this since there's no `addDefaultImplementationEntries` like in Maven. But doesn't hurt.

Fixes #2549 