### PR TITLE
Set autoconfigure release to alpha.

### DIFF
--- a/sdk-extensions/autoconfigure/gradle.properties
+++ b/sdk-extensions/autoconfigure/gradle.properties
@@ -1,0 +1,1 @@
+otel.release=alpha


### PR DESCRIPTION
Had meant to do this since it depends on metrics, and SDK environment variables still somewhat fluxing.