### PR TITLE
Register global in autoconfigure

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
@@ -52,7 +52,6 @@ public final class GlobalOpenTelemetry {
 
           OpenTelemetry autoConfigured = maybeAutoConfigure();
           if (autoConfigured != null) {
-            set(autoConfigured);
             return autoConfigured;
           }
 

--- a/sdk-extensions/autoconfigure/build.gradle
+++ b/sdk-extensions/autoconfigure/build.gradle
@@ -12,6 +12,7 @@ ext.moduleName = "io.opentelemetry.sdk.autoconfigure"
 testSets {
     testConfigError
     testFullConfig
+    testInitializeRegistersGlobal
     testJaeger
     testPrometheus
     testZipkin

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySdkAutoConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySdkAutoConfiguration.java
@@ -38,7 +38,7 @@ public final class OpenTelemetrySdkAutoConfiguration {
     return OpenTelemetrySdk.builder()
         .setTracerProvider(tracerProvider)
         .setPropagators(propagators)
-        .build();
+        .buildAndRegisterGlobal();
   }
 
   private static void configureMeterProvider(Resource resource, ConfigProperties config) {

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FullConfigTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FullConfigTest.java
@@ -115,7 +115,6 @@ class FullConfigTest {
     System.setProperty("otel.exporter.otlp.endpoint", endpoint);
     System.setProperty("otel.exporter.otlp.timeout", "10000");
 
-    OpenTelemetrySdkAutoConfiguration.initialize();
     Collection<String> fields =
         GlobalOpenTelemetry.get().getPropagators().getTextMapPropagator().fields();
     List<String> keys = new ArrayList<>();

--- a/sdk-extensions/autoconfigure/src/testInitializeRegistersGlobal/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySdkAutoConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testInitializeRegistersGlobal/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySdkAutoConfigurationTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.sdk.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sdk-extensions/autoconfigure/src/testInitializeRegistersGlobal/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySdkAutoConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testInitializeRegistersGlobal/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySdkAutoConfigurationTest.java
@@ -1,0 +1,16 @@
+package io.opentelemetry.sdk.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import org.junit.jupiter.api.Test;
+
+class OpenTelemetrySdkAutoConfigurationTest {
+
+  @Test
+  void initializeAndGet() {
+    OpenTelemetrySdk sdk = OpenTelemetrySdkAutoConfiguration.initialize();
+    assertThat(GlobalOpenTelemetry.get()).isSameAs(sdk);
+  }
+}


### PR DESCRIPTION
Currently calling initialize explicitly does not register the global, meaning a subsequent call to get the global actually reinitializes the SDK by calling initialize again. This isn't intended nor efficient/safe.