### PR TITLE
Use BiConsumer instead of custom interface

### DIFF
--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/AsynchronousInstrument.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/AsynchronousInstrument.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.api.metrics;
 
-import io.opentelemetry.api.common.Labels;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -18,15 +17,4 @@ import javax.annotation.concurrent.ThreadSafe;
  * kept.
  */
 @ThreadSafe
-public interface AsynchronousInstrument extends Instrument {
-
-  /** The result pass to the updater. */
-  interface LongResult {
-    void observe(long value, Labels labels);
-  }
-
-  /** The result pass to the updater. */
-  interface DoubleResult {
-    void observe(double value, Labels labels);
-  }
-}
+public interface AsynchronousInstrument extends Instrument {}

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/DefaultMeter.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/DefaultMeter.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.internal.StringUtils;
 import io.opentelemetry.api.internal.Utils;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -430,7 +431,7 @@ final class DefaultMeter implements Meter {
       }
 
       @Override
-      public DoubleSumObserverBuilder setUpdater(Consumer<DoubleResult> updater) {
+      public DoubleSumObserverBuilder setUpdater(Consumer<BiConsumer<Double, Labels>> updater) {
         Objects.requireNonNull(updater, "callback");
         return this;
       }
@@ -457,7 +458,7 @@ final class DefaultMeter implements Meter {
       }
 
       @Override
-      public NoopBuilder setUpdater(Consumer<LongResult> updater) {
+      public NoopBuilder setUpdater(Consumer<BiConsumer<Long, Labels>> updater) {
         Objects.requireNonNull(updater, "callback");
         return this;
       }
@@ -484,7 +485,8 @@ final class DefaultMeter implements Meter {
       }
 
       @Override
-      public DoubleUpDownSumObserverBuilder setUpdater(Consumer<DoubleResult> updater) {
+      public DoubleUpDownSumObserverBuilder setUpdater(
+          Consumer<BiConsumer<Double, Labels>> updater) {
         Objects.requireNonNull(updater, "callback");
         return this;
       }
@@ -511,7 +513,7 @@ final class DefaultMeter implements Meter {
       }
 
       @Override
-      public LongUpDownSumObserverBuilder setUpdater(Consumer<LongResult> updater) {
+      public LongUpDownSumObserverBuilder setUpdater(Consumer<BiConsumer<Long, Labels>> updater) {
         Objects.requireNonNull(updater, "callback");
         return this;
       }
@@ -538,7 +540,7 @@ final class DefaultMeter implements Meter {
       }
 
       @Override
-      public DoubleValueObserverBuilder setUpdater(Consumer<DoubleResult> updater) {
+      public DoubleValueObserverBuilder setUpdater(Consumer<BiConsumer<Double, Labels>> updater) {
         Objects.requireNonNull(updater, "callback");
         return this;
       }
@@ -565,7 +567,7 @@ final class DefaultMeter implements Meter {
       }
 
       @Override
-      public LongValueObserverBuilder setUpdater(Consumer<LongResult> updater) {
+      public LongValueObserverBuilder setUpdater(Consumer<BiConsumer<Long, Labels>> updater) {
         Objects.requireNonNull(updater, "callback");
         return this;
       }

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/DoubleSumObserver.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/DoubleSumObserver.java
@@ -23,24 +23,21 @@ import javax.annotation.concurrent.ThreadSafe;
  * <pre>{@code
  * class YourClass {
  *
+ *   private static final IDLE_LABELS = Labels.of("state", "idle")
+ *   private static final USER_LABELS = Labels.of("state", "user")
  *   private static final Meter meter = OpenTelemetry.getMeterProvider().get("my_library_name");
- *   private static final DoubleSumObserver cpuObserver =
- *       meter.
- *           .doubleSumObserverBuilder("cpu_time")
- *           .setDescription("System CPU usage")
- *           .setUnit("ms")
- *           .build();
  *
  *   void init() {
- *     cpuObserver.setUpdater(
- *         new DoubleSumObserver.Callback<DoubleResult>() {
- *          {@literal @}Override
- *           public void update(DoubleResult result) {
- *             // Get system cpu usage
- *             result.observe(cpuIdle, "state", "idle");
- *             result.observe(cpuUser, "state", "user");
- *           }
- *         });
+ *     meter.
+ *         .doubleSumObserverBuilder("cpu_time")
+ *         .setDescription("System CPU usage")
+ *         .setUnit("ms")
+ *         .setUpdater(result -> {
+ *           // Get system cpu usage
+ *           result.accept(cpuIdle, IDLE_LABELS);
+ *           result.accept(cpuUser, USER_LABELS);
+ *         })
+ *         .build();
  *   }
  * }
  * }</pre>

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/DoubleSumObserverBuilder.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/DoubleSumObserverBuilder.java
@@ -5,11 +5,13 @@
 
 package io.opentelemetry.api.metrics;
 
+import io.opentelemetry.api.common.Labels;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /** Builder class for {@link DoubleSumObserver}. */
 public interface DoubleSumObserverBuilder
-    extends AsynchronousInstrumentBuilder<AsynchronousInstrument.DoubleResult> {
+    extends AsynchronousInstrumentBuilder<BiConsumer<Double, Labels>> {
   @Override
   DoubleSumObserverBuilder setDescription(String description);
 
@@ -17,7 +19,7 @@ public interface DoubleSumObserverBuilder
   DoubleSumObserverBuilder setUnit(String unit);
 
   @Override
-  DoubleSumObserverBuilder setUpdater(Consumer<AsynchronousInstrument.DoubleResult> updater);
+  DoubleSumObserverBuilder setUpdater(Consumer<BiConsumer<Double, Labels>> updater);
 
   @Override
   DoubleSumObserver build();

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/DoubleUpDownSumObserver.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/DoubleUpDownSumObserver.java
@@ -22,25 +22,21 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <pre>{@code
  * class YourClass {
- *
+ *   private static final USED_LABELS = Labels.of("state", "user")
+ *   private static final FREE_LABELS = Labels.of("state", "idle")
  *   private static final Meter meter = OpenTelemetry.getMeterProvider().get("my_library_name");
- *   private static final DoubleUpDownSumObserver memoryObserver =
- *       meter.
- *           .doubleUpDownSumObserverBuilder("memory_usage")
- *           .setDescription("System memory usage")
- *           .setUnit("by")
- *           .build();
  *
  *   void init() {
- *     memoryObserver.setUpdater(
- *         new DoubleUpDownSumObserver.Callback<DoubleResult>() {
- *          {@literal @}Override
- *           public void update(DoubleResult result) {
- *             // Get system memory usage
- *             result.observe(memoryUsed, "state", "used");
- *             result.observe(memoryFree, "state", "free");
- *           }
- *         });
+ *     meter.
+ *         .doubleUpDownSumObserverBuilder("memory_usage")
+ *         .setDescription("System memory usage")
+ *         .setUnit("by")
+ *         .setUpdater(result -> {
+ *           // Get system memory usage
+ *           result.accept(memoryUsed, USED_LABELS);
+ *           result.accept(memoryFree, FREE_LABELS);
+ *         })
+ *         .build();
  *   }
  * }
  * }</pre>

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/DoubleUpDownSumObserverBuilder.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/DoubleUpDownSumObserverBuilder.java
@@ -5,11 +5,13 @@
 
 package io.opentelemetry.api.metrics;
 
+import io.opentelemetry.api.common.Labels;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /** Builder class for {@link DoubleUpDownSumObserver}. */
 public interface DoubleUpDownSumObserverBuilder
-    extends AsynchronousInstrumentBuilder<AsynchronousInstrument.DoubleResult> {
+    extends AsynchronousInstrumentBuilder<BiConsumer<Double, Labels>> {
   @Override
   DoubleUpDownSumObserverBuilder setDescription(String description);
 
@@ -17,7 +19,7 @@ public interface DoubleUpDownSumObserverBuilder
   DoubleUpDownSumObserverBuilder setUnit(String unit);
 
   @Override
-  DoubleUpDownSumObserverBuilder setUpdater(Consumer<AsynchronousInstrument.DoubleResult> updater);
+  DoubleUpDownSumObserverBuilder setUpdater(Consumer<BiConsumer<Double, Labels>> updater);
 
   @Override
   DoubleUpDownSumObserver build();

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/DoubleValueObserver.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/DoubleValueObserver.java
@@ -9,8 +9,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * {@code ValueObserver} is the asynchronous instrument corresponding to ValueRecorder, used to
- * capture values that are treated as individual observations, recorded with the observe(value)
- * method.
+ * capture values that are treated as individual observations.
  *
  * <p>A {@code ValueObserver} is a good choice in situations where a measurement is expensive to
  * compute, such that it would be wasteful to compute on every request.
@@ -21,22 +20,17 @@ import javax.annotation.concurrent.ThreadSafe;
  * class YourClass {
  *
  *   private static final Meter meter = OpenTelemetry.getMeterProvider().get("my_library_name");
- *   private static final DoubleValueObserver cpuObserver =
- *       meter.
- *           .doubleValueObserverBuilder("cpu_temperature")
- *           .setDescription("System CPU temperature")
- *           .setUnit("ms")
- *           .build();
  *
  *   void init() {
- *     cpuObserver.setUpdater(
- *         new DoubleValueObserver.Callback<DoubleResult>() {
- *          {@literal @}Override
- *           public void update(DoubleResult result) {
- *             // Get system cpu temperature
- *             result.observe(cpuTemperature);
- *           }
- *         });
+ *     meter.
+ *         .doubleValueObserverBuilder("cpu_temperature")
+ *         .setDescription("System CPU temperature")
+ *         .setUnit("ms")
+ *         .setUpdater(result -> {
+ *           // Get system cpu temperature
+ *           result.accept(cpuTemperature, Labels.empty());
+ *         })
+ *         .build();
  *   }
  * }
  * }</pre>

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/DoubleValueObserverBuilder.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/DoubleValueObserverBuilder.java
@@ -5,11 +5,13 @@
 
 package io.opentelemetry.api.metrics;
 
+import io.opentelemetry.api.common.Labels;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /** Builder class for {@link DoubleValueObserver}. */
 public interface DoubleValueObserverBuilder
-    extends AsynchronousInstrumentBuilder<AsynchronousInstrument.DoubleResult> {
+    extends AsynchronousInstrumentBuilder<BiConsumer<Double, Labels>> {
   @Override
   DoubleValueObserverBuilder setDescription(String description);
 
@@ -17,7 +19,7 @@ public interface DoubleValueObserverBuilder
   DoubleValueObserverBuilder setUnit(String unit);
 
   @Override
-  DoubleValueObserverBuilder setUpdater(Consumer<AsynchronousInstrument.DoubleResult> updater);
+  DoubleValueObserverBuilder setUpdater(Consumer<BiConsumer<Double, Labels>> updater);
 
   @Override
   DoubleValueObserver build();

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/LongSumObserver.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/LongSumObserver.java
@@ -23,24 +23,21 @@ import javax.annotation.concurrent.ThreadSafe;
  * <pre>{@code
  * class YourClass {
  *
+ *   private static final IDLE_LABELS = Labels.of("state", "idle")
+ *   private static final USER_LABELS = Labels.of("state", "user")
  *   private static final Meter meter = OpenTelemetry.getMeterProvider().get("my_library_name");
- *   private static final LongSumObserver cpuObserver =
- *       meter.
- *           .longSumObserverBuilder("cpu_time")
- *           .setDescription("System CPU usage")
- *           .setUnit("ms")
- *           .build();
  *
  *   void init() {
- *     cpuObserver.setUpdater(
- *         new LongSumObserver.Callback<LongResult>() {
- *          {@literal @}Override
- *           public void update(LongResult result) {
- *             // Get system cpu usage
- *             result.observe(cpuIdle, "state", "idle");
- *             result.observe(cpuUser, "state", "user");
- *           }
- *         });
+ *     meter.
+ *         .longSumObserverBuilder("cpu_time")
+ *         .setDescription("System CPU usage")
+ *         .setUnit("ms")
+ *         .setUpdater(result -> {
+ *           // Get system cpu usage
+ *           result.accept(cpuIdle, IDLE_LABELS);
+ *           result.accept(cpuUser, USER_LABELS);
+ *         })
+ *         .build();
  *   }
  * }
  * }</pre>

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/LongSumObserverBuilder.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/LongSumObserverBuilder.java
@@ -5,11 +5,13 @@
 
 package io.opentelemetry.api.metrics;
 
+import io.opentelemetry.api.common.Labels;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /** Builder class for {@link LongSumObserver}. */
 public interface LongSumObserverBuilder
-    extends AsynchronousInstrumentBuilder<AsynchronousInstrument.LongResult> {
+    extends AsynchronousInstrumentBuilder<BiConsumer<Long, Labels>> {
   @Override
   LongSumObserverBuilder setDescription(String description);
 
@@ -17,7 +19,7 @@ public interface LongSumObserverBuilder
   LongSumObserverBuilder setUnit(String unit);
 
   @Override
-  LongSumObserverBuilder setUpdater(Consumer<AsynchronousInstrument.LongResult> updater);
+  LongSumObserverBuilder setUpdater(Consumer<BiConsumer<Long, Labels>> updater);
 
   @Override
   LongSumObserver build();

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/LongUpDownSumObserver.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/LongUpDownSumObserver.java
@@ -23,24 +23,21 @@ import javax.annotation.concurrent.ThreadSafe;
  * <pre>{@code
  * class YourClass {
  *
+ *   private static final USED_LABELS = Labels.of("state", "user")
+ *   private static final FREE_LABELS = Labels.of("state", "idle")
  *   private static final Meter meter = OpenTelemetry.getMeterProvider().get("my_library_name");
- *   private static final LongUpDownSumObserver memoryObserver =
- *       meter.
- *           .longUpDownSumObserverBuilder("memory_usage")
- *           .setDescription("System memory usage")
- *           .setUnit("by")
- *           .build();
  *
  *   void init() {
- *     memoryObserver.setUpdater(
- *         new LongUpDownSumObserver.Callback<LongResult>() {
- *          {@literal @}Override
- *           public void update(LongResult result) {
- *             // Get system memory usage
- *             result.observe(memoryUsed, "state", "used");
- *             result.observe(memoryFree, "state", "free");
- *           }
- *         });
+ *     meter.
+ *         .longUpDownSumObserverBuilder("memory_usage")
+ *         .setDescription("System memory usage")
+ *         .setUnit("by")
+ *         .setUpdater(result -> {
+ *           // Get system memory usage
+ *           result.accept(memoryUsed, USED_LABELS);
+ *           result.accept(memoryFree, FREE_LABELS);
+ *         })
+ *         .build();
  *   }
  * }
  * }</pre>

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/LongUpDownSumObserverBuilder.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/LongUpDownSumObserverBuilder.java
@@ -5,11 +5,13 @@
 
 package io.opentelemetry.api.metrics;
 
+import io.opentelemetry.api.common.Labels;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /** Builder class for {@link LongUpDownSumObserver}. */
 public interface LongUpDownSumObserverBuilder
-    extends AsynchronousInstrumentBuilder<AsynchronousInstrument.LongResult> {
+    extends AsynchronousInstrumentBuilder<BiConsumer<Long, Labels>> {
   @Override
   LongUpDownSumObserverBuilder setDescription(String description);
 
@@ -17,7 +19,7 @@ public interface LongUpDownSumObserverBuilder
   LongUpDownSumObserverBuilder setUnit(String unit);
 
   @Override
-  LongUpDownSumObserverBuilder setUpdater(Consumer<AsynchronousInstrument.LongResult> updater);
+  LongUpDownSumObserverBuilder setUpdater(Consumer<BiConsumer<Long, Labels>> updater);
 
   @Override
   LongUpDownSumObserver build();

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/LongValueObserver.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/LongValueObserver.java
@@ -9,8 +9,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * {@code ValueObserver} is the asynchronous instrument corresponding to ValueRecorder, used to
- * capture values that are treated as individual observations, recorded with the observe(value)
- * method.
+ * capture values that are treated as individual observations.
  *
  * <p>A {@code ValueObserver} is a good choice in situations where a measurement is expensive to
  * compute, such that it would be wasteful to compute on every request.
@@ -21,22 +20,17 @@ import javax.annotation.concurrent.ThreadSafe;
  * class YourClass {
  *
  *   private static final Meter meter = OpenTelemetry.getMeterProvider().get("my_library_name");
- *   private static final LongValueObserver cpuObserver =
- *       meter.
- *           .longValueObserverBuilder("cpu_fan_speed")
- *           .setDescription("System CPU fan speed")
- *           .setUnit("ms")
- *           .build();
  *
  *   void init() {
- *     cpuObserver.setUpdater(
- *         new LongValueObserver.Callback<LongResult>() {
- *          {@literal @}Override
- *           public void update(LongResult result) {
- *             // Get system cpu fan speed
- *             result.observe(cpuFanSpeed);
- *           }
- *         });
+ *     meter.
+ *         .longValueObserverBuilder("cpu_fan_speed")
+ *         .setDescription("System CPU fan speed")
+ *         .setUnit("ms")
+ *         .setUpdater(result -> {
+ *           // Get system cpu fan speed
+ *           result.accept(cpuFanSpeed, Labels.empty());
+ *         })
+ *         .build();
  *   }
  * }
  * }</pre>

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/LongValueObserverBuilder.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/LongValueObserverBuilder.java
@@ -5,11 +5,13 @@
 
 package io.opentelemetry.api.metrics;
 
+import io.opentelemetry.api.common.Labels;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /** Builder class for {@link LongValueObserver}. */
 public interface LongValueObserverBuilder
-    extends AsynchronousInstrumentBuilder<AsynchronousInstrument.LongResult> {
+    extends AsynchronousInstrumentBuilder<BiConsumer<Long, Labels>> {
   @Override
   LongValueObserverBuilder setDescription(String description);
 
@@ -17,7 +19,7 @@ public interface LongValueObserverBuilder
   LongValueObserverBuilder setUnit(String unit);
 
   @Override
-  LongValueObserverBuilder setUpdater(Consumer<AsynchronousInstrument.LongResult> updater);
+  LongValueObserverBuilder setUpdater(Consumer<BiConsumer<Long, Labels>> updater);
 
   @Override
   LongValueObserver build();

--- a/sdk-extensions/autoconfigure/src/testPrometheus/java/io/opentelemetry/sdk/autoconfigure/PrometheusTest.java
+++ b/sdk-extensions/autoconfigure/src/testPrometheus/java/io/opentelemetry/sdk/autoconfigure/PrometheusTest.java
@@ -38,7 +38,7 @@ class PrometheusTest {
     GlobalMetricsProvider.get()
         .get("test")
         .longValueObserverBuilder("test")
-        .setUpdater(result -> result.observe(2, Labels.empty()))
+        .setUpdater(result -> result.accept(2L, Labels.empty()))
         .build();
 
     WebClient client = WebClient.of("http://127.0.0.1:" + port);

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractDoubleAsynchronousInstrumentBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractDoubleAsynchronousInstrumentBuilder.java
@@ -5,10 +5,11 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import io.opentelemetry.api.metrics.AsynchronousInstrument;
+import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
@@ -17,7 +18,7 @@ abstract class AbstractDoubleAsynchronousInstrumentBuilder<B extends AbstractIns
     extends AbstractInstrument.Builder<B> {
   private final MeterProviderSharedState meterProviderSharedState;
   private final MeterSharedState meterSharedState;
-  @Nullable private Consumer<AsynchronousInstrument.DoubleResult> updater;
+  @Nullable private Consumer<BiConsumer<Double, Labels>> updater;
 
   AbstractDoubleAsynchronousInstrumentBuilder(
       String name,
@@ -30,7 +31,7 @@ abstract class AbstractDoubleAsynchronousInstrumentBuilder<B extends AbstractIns
     this.meterSharedState = meterSharedState;
   }
 
-  public B setUpdater(Consumer<AsynchronousInstrument.DoubleResult> updater) {
+  public B setUpdater(Consumer<BiConsumer<Double, Labels>> updater) {
     this.updater = updater;
     return getThis();
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractLongAsynchronousInstrumentBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractLongAsynchronousInstrumentBuilder.java
@@ -5,10 +5,11 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import io.opentelemetry.api.metrics.AsynchronousInstrument;
+import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
@@ -17,7 +18,7 @@ abstract class AbstractLongAsynchronousInstrumentBuilder<B extends AbstractInstr
     extends AbstractInstrument.Builder<B> {
   private final MeterProviderSharedState meterProviderSharedState;
   private final MeterSharedState meterSharedState;
-  @Nullable private Consumer<AsynchronousInstrument.LongResult> updater;
+  @Nullable private Consumer<BiConsumer<Long, Labels>> updater;
 
   AbstractLongAsynchronousInstrumentBuilder(
       String name,
@@ -30,7 +31,7 @@ abstract class AbstractLongAsynchronousInstrumentBuilder<B extends AbstractInstr
     this.meterSharedState = meterSharedState;
   }
 
-  public B setUpdater(Consumer<AsynchronousInstrument.LongResult> updater) {
+  public B setUpdater(Consumer<BiConsumer<Long, Labels>> updater) {
     this.updater = updater;
     return getThis();
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AsynchronousInstrumentAccumulator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AsynchronousInstrumentAccumulator.java
@@ -5,12 +5,13 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import io.opentelemetry.api.metrics.AsynchronousInstrument;
+import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
@@ -23,7 +24,7 @@ final class AsynchronousInstrumentAccumulator extends AbstractAccumulator {
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState meterSharedState,
       InstrumentDescriptor descriptor,
-      @Nullable Consumer<AsynchronousInstrument.DoubleResult> metricUpdater) {
+      @Nullable Consumer<BiConsumer<Double, Labels>> metricUpdater) {
     Aggregator<T> aggregator =
         getAggregator(meterProviderSharedState, meterSharedState, descriptor);
     InstrumentProcessor<T> instrumentProcessor =
@@ -33,7 +34,7 @@ final class AsynchronousInstrumentAccumulator extends AbstractAccumulator {
       return new AsynchronousInstrumentAccumulator(instrumentProcessor, () -> {});
     }
 
-    AsynchronousInstrument.DoubleResult result =
+    BiConsumer<Double, Labels> result =
         (value, labels) -> instrumentProcessor.batch(labels, aggregator.accumulateDouble(value));
 
     return new AsynchronousInstrumentAccumulator(
@@ -44,7 +45,7 @@ final class AsynchronousInstrumentAccumulator extends AbstractAccumulator {
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState meterSharedState,
       InstrumentDescriptor descriptor,
-      @Nullable Consumer<AsynchronousInstrument.LongResult> metricUpdater) {
+      @Nullable Consumer<BiConsumer<Long, Labels>> metricUpdater) {
     Aggregator<T> aggregator =
         getAggregator(meterProviderSharedState, meterSharedState, descriptor);
     InstrumentProcessor<T> instrumentProcessor =
@@ -54,7 +55,7 @@ final class AsynchronousInstrumentAccumulator extends AbstractAccumulator {
       return new AsynchronousInstrumentAccumulator(instrumentProcessor, () -> {});
     }
 
-    AsynchronousInstrument.LongResult result =
+    BiConsumer<Long, Labels> result =
         (value, labels) -> instrumentProcessor.batch(labels, aggregator.accumulateLong(value));
 
     return new AsynchronousInstrumentAccumulator(

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleSumObserverSdkTest.java
@@ -59,7 +59,7 @@ class DoubleSumObserverSdkTest {
         .doubleSumObserverBuilder("testObserver")
         .setDescription("My own DoubleSumObserver")
         .setUnit("ms")
-        .setUpdater(result -> result.observe(12.1d, Labels.of("k", "v")))
+        .setUpdater(result -> result.accept(12.1d, Labels.of("k", "v")))
         .build();
     testClock.advanceNanos(SECOND_NANOS);
     assertThat(sdkMeterProvider.collectAllMetrics())

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownSumObserverSdkTest.java
@@ -57,7 +57,7 @@ class DoubleUpDownSumObserverSdkTest {
   void collectMetrics_WithOneRecord() {
     sdkMeter
         .doubleUpDownSumObserverBuilder("testObserver")
-        .setUpdater(result -> result.observe(12.1d, Labels.of("k", "v")))
+        .setUpdater(result -> result.accept(12.1d, Labels.of("k", "v")))
         .build();
     testClock.advanceNanos(SECOND_NANOS);
     assertThat(sdkMeterProvider.collectAllMetrics())

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueObserverSdkTest.java
@@ -58,7 +58,7 @@ class DoubleValueObserverSdkTest {
         .doubleValueObserverBuilder("testObserver")
         .setDescription("My own DoubleValueObserver")
         .setUnit("ms")
-        .setUpdater(result -> result.observe(12.1d, Labels.of("k", "v")))
+        .setUpdater(result -> result.accept(12.1d, Labels.of("k", "v")))
         .build();
     testClock.advanceNanos(SECOND_NANOS);
     assertThat(sdkMeterProvider.collectAllMetrics())

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongSumObserverSdkTest.java
@@ -57,7 +57,7 @@ class LongSumObserverSdkTest {
   void collectMetrics_WithOneRecord() {
     sdkMeter
         .longSumObserverBuilder("testObserver")
-        .setUpdater(result -> result.observe(12, Labels.of("k", "v")))
+        .setUpdater(result -> result.accept(12L, Labels.of("k", "v")))
         .build();
     testClock.advanceNanos(SECOND_NANOS);
     assertThat(sdkMeterProvider.collectAllMetrics())

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownSumObserverSdkTest.java
@@ -57,7 +57,7 @@ class LongUpDownSumObserverSdkTest {
   void collectMetrics_WithOneRecord() {
     sdkMeter
         .longUpDownSumObserverBuilder("testObserver")
-        .setUpdater(result -> result.observe(12, Labels.of("k", "v")))
+        .setUpdater(result -> result.accept(12L, Labels.of("k", "v")))
         .build();
     testClock.advanceNanos(SECOND_NANOS);
     assertThat(sdkMeterProvider.collectAllMetrics())

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongValueObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongValueObserverSdkTest.java
@@ -56,7 +56,7 @@ class LongValueObserverSdkTest {
   void collectMetrics_WithOneRecord() {
     sdkMeter
         .longValueObserverBuilder("testObserver")
-        .setUpdater(result -> result.observe(12, Labels.of("k", "v")))
+        .setUpdater(result -> result.accept(12L, Labels.of("k", "v")))
         .build();
     testClock.advanceNanos(SECOND_NANOS);
     assertThat(sdkMeterProvider.collectAllMetrics())

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderTest.java
@@ -388,28 +388,28 @@ public class SdkMeterProviderTest {
   void collectAllAsyncInstruments() {
     sdkMeter
         .longSumObserverBuilder("testLongSumObserver")
-        .setUpdater(longResult -> longResult.observe(10, Labels.empty()))
+        .setUpdater(longResult -> longResult.accept(10L, Labels.empty()))
         .build();
     sdkMeter
         .longUpDownSumObserverBuilder("testLongUpDownSumObserver")
-        .setUpdater(longResult -> longResult.observe(-10, Labels.empty()))
+        .setUpdater(longResult -> longResult.accept(-10L, Labels.empty()))
         .build();
     sdkMeter
         .longValueObserverBuilder("testLongValueObserver")
-        .setUpdater(longResult -> longResult.observe(10, Labels.empty()))
+        .setUpdater(longResult -> longResult.accept(10L, Labels.empty()))
         .build();
 
     sdkMeter
         .doubleSumObserverBuilder("testDoubleSumObserver")
-        .setUpdater(doubleResult -> doubleResult.observe(10.1, Labels.empty()))
+        .setUpdater(doubleResult -> doubleResult.accept(10.1, Labels.empty()))
         .build();
     sdkMeter
         .doubleUpDownSumObserverBuilder("testDoubleUpDownSumObserver")
-        .setUpdater(doubleResult -> doubleResult.observe(-10.1, Labels.empty()))
+        .setUpdater(doubleResult -> doubleResult.accept(-10.1, Labels.empty()))
         .build();
     sdkMeter
         .doubleValueObserverBuilder("testDoubleValueObserver")
-        .setUpdater(doubleResult -> doubleResult.observe(10.1, Labels.empty()))
+        .setUpdater(doubleResult -> doubleResult.accept(10.1, Labels.empty()))
         .build();
 
     assertThat(sdkMeterProvider.collectAllMetrics())
@@ -488,28 +488,28 @@ public class SdkMeterProviderTest {
         sdkMeterProvider, AggregatorFactory.count(AggregationTemporality.CUMULATIVE));
     sdkMeter
         .longSumObserverBuilder("testLongSumObserver")
-        .setUpdater(longResult -> longResult.observe(10, Labels.empty()))
+        .setUpdater(longResult -> longResult.accept(10L, Labels.empty()))
         .build();
     sdkMeter
         .longUpDownSumObserverBuilder("testLongUpDownSumObserver")
-        .setUpdater(longResult -> longResult.observe(-10, Labels.empty()))
+        .setUpdater(longResult -> longResult.accept(-10L, Labels.empty()))
         .build();
     sdkMeter
         .longValueObserverBuilder("testLongValueObserver")
-        .setUpdater(longResult -> longResult.observe(10, Labels.empty()))
+        .setUpdater(longResult -> longResult.accept(10L, Labels.empty()))
         .build();
 
     sdkMeter
         .doubleSumObserverBuilder("testDoubleSumObserver")
-        .setUpdater(doubleResult -> doubleResult.observe(10.1, Labels.empty()))
+        .setUpdater(doubleResult -> doubleResult.accept(10.1, Labels.empty()))
         .build();
     sdkMeter
         .doubleUpDownSumObserverBuilder("testDoubleUpDownSumObserver")
-        .setUpdater(doubleResult -> doubleResult.observe(-10.1, Labels.empty()))
+        .setUpdater(doubleResult -> doubleResult.accept(-10.1, Labels.empty()))
         .build();
     sdkMeter
         .doubleValueObserverBuilder("testDoubleValueObserver")
-        .setUpdater(doubleResult -> doubleResult.observe(10.1, Labels.empty()))
+        .setUpdater(doubleResult -> doubleResult.accept(10.1, Labels.empty()))
         .build();
 
     testClock.advanceNanos(50);

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -152,8 +152,8 @@ public final class BatchSpanProcessor implements SpanProcessor {
           .setUnit("1")
           .setUpdater(
               result ->
-                  result.observe(
-                      queue.size(),
+                  result.accept(
+                      (long) queue.size(),
                       Labels.of(SPAN_PROCESSOR_TYPE_LABEL, SPAN_PROCESSOR_TYPE_VALUE)))
           .build();
       LongCounter processedSpansCounter =


### PR DESCRIPTION
Tried to use ObjDoubleConsumer but then it will be inconsistent with the `add` method on the sync instrument.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>