### PR TITLE
remove the `millis` from the BSP config options

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
@@ -50,7 +50,7 @@ final class TracerProviderConfiguration {
   static BatchSpanProcessor configureSpanProcessor(ConfigProperties config, SpanExporter exporter) {
     BatchSpanProcessorBuilder builder = BatchSpanProcessor.builder(exporter);
 
-    Long scheduleDelayMillis = config.getLong("otel.bsp.schedule.delay.millis");
+    Long scheduleDelayMillis = config.getLong("otel.bsp.schedule.delay");
     if (scheduleDelayMillis != null) {
       builder.setScheduleDelay(Duration.ofMillis(scheduleDelayMillis));
     }
@@ -65,7 +65,7 @@ final class TracerProviderConfiguration {
       builder.setMaxExportBatchSize(maxExportBatch);
     }
 
-    Integer timeout = config.getInt("otel.bsp.export.timeout.millis");
+    Integer timeout = config.getInt("otel.bsp.export.timeout");
     if (timeout != null) {
       builder.setExporterTimeout(Duration.ofMillis(timeout));
     }

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
@@ -39,7 +39,7 @@ class TracerProviderConfigurationTest {
   @Test
   void configureTracerProvider() {
     Map<String, String> properties = new HashMap<>();
-    properties.put("otel.bsp.schedule.delay.millis", "100000");
+    properties.put("otel.bsp.schedule.delay", "100000");
     properties.put("otel.trace.sampler", "always_off");
 
     Resource resource = Resource.create(Attributes.builder().put("cat", "meow").build());
@@ -97,10 +97,10 @@ class TracerProviderConfigurationTest {
   @Test
   void configureSpanProcessor_configured() {
     Map<String, String> properties = new HashMap<>();
-    properties.put("otel.bsp.schedule.delay.millis", "100000");
+    properties.put("otel.bsp.schedule.delay", "100000");
     properties.put("otel.bsp.max.queue.size", "2");
     properties.put("otel.bsp.max.export.batch.size", "3");
-    properties.put("otel.bsp.export.timeout.millis", "4");
+    properties.put("otel.bsp.export.timeout", "4");
 
     BatchSpanProcessor processor =
         TracerProviderConfiguration.configureSpanProcessor(


### PR DESCRIPTION
see this spec change:  https://github.com/open-telemetry/opentelemetry-specification/pull/1325