### PR TITLE
Allow setting trusted certificate variable.

### DIFF
--- a/sdk-extensions/autoconfigure/build.gradle
+++ b/sdk-extensions/autoconfigure/build.gradle
@@ -88,7 +88,7 @@ testJaeger {
 testOtlpTls {
     environment("OTEL_RESOURCE_ATTRIBUTES", "service.name=test,cat=meow")
     environment("OTEL_TRACE_EXPORTER", "otlp")
-    environment("OTEL_BSP_SCHEDULE_DELAY_MILLIS", "10")
+    environment("OTEL_BSP_SCHEDULE_DELAY", "10")
 }
 
 testZipkin {

--- a/sdk-extensions/autoconfigure/build.gradle
+++ b/sdk-extensions/autoconfigure/build.gradle
@@ -15,6 +15,7 @@ testSets {
     testInitializeRegistersGlobal
     testJaeger
     testPrometheus
+    testOtlpTls
     testZipkin
 }
 
@@ -36,6 +37,7 @@ dependencies {
             'com.linecorp.armeria:armeria-junit5',
             'com.linecorp.armeria:armeria-grpc'
     testRuntimeOnly 'io.grpc:grpc-netty-shaded'
+    testRuntimeOnly libraries.slf4jsimple
 
     testFullConfigImplementation project(':extensions:trace-propagators')
     testFullConfigImplementation project(':exporters:jaeger')
@@ -45,6 +47,8 @@ dependencies {
     testFullConfigImplementation project(':exporters:prometheus')
     testFullConfigImplementation libraries.prometheus_client_httpserver
     testFullConfigImplementation project(':exporters:zipkin')
+
+    testOtlpTlsImplementation project(':exporters:otlp:all')
 
     testJaegerImplementation project(':exporters:jaeger')
 
@@ -78,6 +82,12 @@ testFullConfig {
 
 testJaeger {
     environment("OTEL_TRACE_EXPORTER", "jaeger")
+    environment("OTEL_BSP_SCHEDULE_DELAY_MILLIS", "10")
+}
+
+testOtlpTls {
+    environment("OTEL_RESOURCE_ATTRIBUTES", "service.name=test,cat=meow")
+    environment("OTEL_TRACE_EXPORTER", "otlp")
     environment("OTEL_BSP_SCHEDULE_DELAY_MILLIS", "10")
 }
 

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ConfigurationException.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ConfigurationException.java
@@ -13,4 +13,8 @@ public final class ConfigurationException extends RuntimeException {
   ConfigurationException(String message) {
     super(message);
   }
+
+  ConfigurationException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/sdk-extensions/autoconfigure/src/testOtlpTls/java/io/opentelemetry/sdk/autoconfigure/OtlpTlsTest.java
+++ b/sdk-extensions/autoconfigure/src/testOtlpTls/java/io/opentelemetry/sdk/autoconfigure/OtlpTlsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import io.grpc.stub.StreamObserver;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
+import java.nio.file.Paths;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class OtlpTlsTest {
+
+  private static final BlockingQueue<ExportTraceServiceRequest> otlpTraceRequests =
+      new LinkedBlockingDeque<>();
+
+  @RegisterExtension
+  @Order(1)
+  public static final SelfSignedCertificateExtension certificate =
+      new SelfSignedCertificateExtension();
+
+  @RegisterExtension
+  @Order(2)
+  public static final ServerExtension server =
+      new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+          sb.service(
+              GrpcService.builder()
+                  // OTLP spans
+                  .addService(
+                      new TraceServiceGrpc.TraceServiceImplBase() {
+                        @Override
+                        public void export(
+                            ExportTraceServiceRequest request,
+                            StreamObserver<ExportTraceServiceResponse> responseObserver) {
+                          otlpTraceRequests.add(request);
+                          responseObserver.onNext(ExportTraceServiceResponse.getDefaultInstance());
+                          responseObserver.onCompleted();
+                        }
+                      })
+                  .useBlockingTaskExecutor(true)
+                  .build());
+
+          sb.tls(certificate.certificateFile(), certificate.privateKeyFile());
+        }
+      };
+
+  @BeforeEach
+  void setUp() {
+    otlpTraceRequests.clear();
+  }
+
+  @Test
+  void configures() {
+    String endpoint = "https://localhost:" + server.httpsPort();
+    System.setProperty("otel.exporter.otlp.endpoint", endpoint);
+    System.setProperty("otel.exporter.otlp.timeout", "10000");
+    System.setProperty(
+        "otel.exporter.otlp.certificate", certificate.certificateFile().getAbsolutePath());
+
+    GlobalOpenTelemetry.get().getTracer("test").spanBuilder("test").startSpan().end();
+
+    await().untilAsserted(() -> assertThat(otlpTraceRequests).hasSize(1));
+  }
+
+  @Test
+  void invalidCertificatePath() {
+    String endpoint = "https://localhost:" + server.httpsPort();
+    System.setProperty("otel.exporter.otlp.endpoint", endpoint);
+    System.setProperty("otel.exporter.otlp.timeout", "10000");
+    System.setProperty("otel.exporter.otlp.certificate", Paths.get("foo", "bar", "baz").toString());
+
+    assertThatThrownBy(OpenTelemetrySdkAutoConfiguration::initialize)
+        .isInstanceOf(ConfigurationException.class);
+  }
+}


### PR DESCRIPTION
I was originally hoping this would solve https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1829 but realized that's about mTLS, not TLS. I don't think the spec defines variables for mTLS yet (technically the current variable is misdocced I guess). But now that I made this change it doesn't hurt to get it in and the variable will likely be renamed in the future.