### PR TITLE
Move Sampler to SdkTracerProvider

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
@@ -26,6 +26,11 @@ final class TracerProviderConfiguration {
             .setResource(resource)
             .setTraceConfig(configureTraceConfig(config));
 
+    String sampler = config.getString("otel.trace.sampler");
+    if (sampler != null) {
+      tracerProviderBuilder.setSampler(configureSampler(sampler, config));
+    }
+
     // Run user configuration before setting exporters from environment to allow user span
     // processors to effect export.
     for (SdkTracerProviderConfigurer configurer :
@@ -76,11 +81,6 @@ final class TracerProviderConfiguration {
   // Visible for testing
   static TraceConfig configureTraceConfig(ConfigProperties config) {
     TraceConfigBuilder builder = TraceConfig.builder();
-
-    String sampler = config.getString("otel.trace.sampler");
-    if (sampler != null) {
-      builder.setSampler(configureSampler(sampler, config));
-    }
 
     Integer maxAttrs = config.getInt("otel.span.attribute.count.limit");
     if (maxAttrs != null) {

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
@@ -49,7 +49,7 @@ class TracerProviderConfigurationTest {
         TracerProviderConfiguration.configureTracerProvider(
             resource, ConfigProperties.createForTest(properties));
     try {
-      assertThat(tracerProvider.getActiveTraceConfig().getSampler()).isEqualTo(Sampler.alwaysOff());
+      assertThat(tracerProvider.getSampler()).isEqualTo(Sampler.alwaysOff());
 
       assertThat(tracerProvider)
           .extracting("sharedState")
@@ -148,7 +148,6 @@ class TracerProviderConfigurationTest {
     TraceConfig config =
         TracerProviderConfiguration.configureTraceConfig(
             ConfigProperties.createForTest(properties));
-    assertThat(config.getSampler()).isEqualTo(Sampler.alwaysOff());
     assertThat(config.getMaxNumberOfAttributes()).isEqualTo(5);
     assertThat(config.getMaxNumberOfEvents()).isEqualTo(4);
     assertThat(config.getMaxNumberOfLinks()).isEqualTo(3);

--- a/sdk-extensions/otproto/src/main/java/io/opentelemetry/sdk/extension/otproto/TraceProtoUtils.java
+++ b/sdk-extensions/otproto/src/main/java/io/opentelemetry/sdk/extension/otproto/TraceProtoUtils.java
@@ -8,9 +8,6 @@ package io.opentelemetry.sdk.extension.otproto;
 import com.google.protobuf.ByteString;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceId;
-import io.opentelemetry.proto.trace.v1.ConstantSampler;
-import io.opentelemetry.sdk.trace.config.TraceConfig;
-import io.opentelemetry.sdk.trace.samplers.Sampler;
 
 /** Utilities for converting various objects to protobuf representations. */
 final class TraceProtoUtils {
@@ -22,7 +19,7 @@ final class TraceProtoUtils {
    * @param spanId the spanId to convert.
    * @return a ByteString representation.
    */
-  public static ByteString toProtoSpanId(String spanId) {
+  static ByteString toProtoSpanId(String spanId) {
     return ByteString.copyFrom(SpanId.bytesFromHex(spanId, 0));
   }
 
@@ -32,50 +29,7 @@ final class TraceProtoUtils {
    * @param traceId the traceId to convert.
    * @return a ByteString representation.
    */
-  public static ByteString toProtoTraceId(String traceId) {
+  static ByteString toProtoTraceId(String traceId) {
     return ByteString.copyFrom(TraceId.bytesFromHex(traceId, 0));
-  }
-
-  /**
-   * Returns a {@code TraceConfig} from the given proto.
-   *
-   * @param traceConfigProto proto format {@code TraceConfig}.
-   * @return a {@code TraceConfig}.
-   */
-  public static TraceConfig traceConfigFromProto(
-      io.opentelemetry.proto.trace.v1.TraceConfig traceConfigProto) {
-    return TraceConfig.builder()
-        .setSampler(fromProtoSampler(traceConfigProto))
-        .setMaxNumberOfAttributes((int) traceConfigProto.getMaxNumberOfAttributes())
-        .setMaxNumberOfEvents((int) traceConfigProto.getMaxNumberOfTimedEvents())
-        .setMaxNumberOfLinks((int) traceConfigProto.getMaxNumberOfLinks())
-        .setMaxNumberOfAttributesPerEvent(
-            (int) traceConfigProto.getMaxNumberOfAttributesPerTimedEvent())
-        .setMaxNumberOfAttributesPerLink((int) traceConfigProto.getMaxNumberOfAttributesPerLink())
-        .build();
-  }
-
-  private static Sampler fromProtoSampler(
-      io.opentelemetry.proto.trace.v1.TraceConfig traceConfigProto) {
-    if (traceConfigProto.hasConstantSampler()) {
-      ConstantSampler constantSampler = traceConfigProto.getConstantSampler();
-      switch (constantSampler.getDecision()) {
-        case ALWAYS_ON:
-          return Sampler.alwaysOn();
-        case ALWAYS_OFF:
-          return Sampler.alwaysOff();
-        case ALWAYS_PARENT:
-          // TODO: add support.
-        case UNRECOGNIZED:
-          throw new IllegalArgumentException("unrecognized constant sampling samplingResult");
-      }
-    }
-    if (traceConfigProto.hasTraceIdRatioBased()) {
-      return Sampler.traceIdRatioBased(traceConfigProto.getTraceIdRatioBased().getSamplingRatio());
-    }
-    if (traceConfigProto.hasRateLimitingSampler()) {
-      // TODO: add support for RateLimiting Sampler
-    }
-    throw new IllegalArgumentException("unknown sampler in the trace config proto");
   }
 }

--- a/sdk-extensions/otproto/src/test/java/io/opentelemetry/sdk/extension/otproto/TraceProtoUtilsTest.java
+++ b/sdk-extensions/otproto/src/test/java/io/opentelemetry/sdk/extension/otproto/TraceProtoUtilsTest.java
@@ -10,24 +10,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.protobuf.ByteString;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceId;
-import io.opentelemetry.proto.trace.v1.ConstantSampler;
-import io.opentelemetry.proto.trace.v1.ConstantSampler.ConstantDecision;
-import io.opentelemetry.proto.trace.v1.TraceIdRatioBased;
-import io.opentelemetry.sdk.trace.config.TraceConfig;
-import io.opentelemetry.sdk.trace.samplers.Sampler;
 import org.junit.jupiter.api.Test;
 
 class TraceProtoUtilsTest {
-  private static final io.opentelemetry.proto.trace.v1.TraceConfig TRACE_CONFIG_PROTO =
-      io.opentelemetry.proto.trace.v1.TraceConfig.newBuilder()
-          .setConstantSampler(
-              ConstantSampler.newBuilder().setDecision(ConstantDecision.ALWAYS_ON).build())
-          .setMaxNumberOfAttributes(10)
-          .setMaxNumberOfTimedEvents(9)
-          .setMaxNumberOfLinks(8)
-          .setMaxNumberOfAttributesPerTimedEvent(2)
-          .setMaxNumberOfAttributesPerLink(1)
-          .build();
 
   private static final byte[] TRACE_ID_BYTES =
       new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'a'};
@@ -44,47 +29,5 @@ class TraceProtoUtilsTest {
   void toProtoSpanId() {
     ByteString expected = ByteString.copyFrom(SPAN_ID_BYTES);
     assertThat(TraceProtoUtils.toProtoSpanId(SpanId.bytesToHex(SPAN_ID_BYTES))).isEqualTo(expected);
-  }
-
-  @Test
-  void traceConfigFromProto() {
-    TraceConfig traceConfig = TraceProtoUtils.traceConfigFromProto(TRACE_CONFIG_PROTO);
-    assertThat(traceConfig.getSampler()).isEqualTo(Sampler.alwaysOn());
-    assertThat(traceConfig.getMaxNumberOfAttributes()).isEqualTo(10);
-    assertThat(traceConfig.getMaxNumberOfEvents()).isEqualTo(9);
-    assertThat(traceConfig.getMaxNumberOfLinks()).isEqualTo(8);
-    assertThat(traceConfig.getMaxNumberOfAttributesPerEvent()).isEqualTo(2);
-    assertThat(traceConfig.getMaxNumberOfAttributesPerLink()).isEqualTo(1);
-  }
-
-  @Test
-  void traceConfigFromProto_AlwaysOffSampler() {
-    TraceConfig traceConfig =
-        TraceProtoUtils.traceConfigFromProto(
-            io.opentelemetry.proto.trace.v1.TraceConfig.newBuilder()
-                .setConstantSampler(
-                    ConstantSampler.newBuilder().setDecision(ConstantDecision.ALWAYS_OFF).build())
-                .setMaxNumberOfAttributes(10)
-                .setMaxNumberOfTimedEvents(9)
-                .setMaxNumberOfLinks(8)
-                .setMaxNumberOfAttributesPerTimedEvent(2)
-                .setMaxNumberOfAttributesPerLink(1)
-                .build());
-    assertThat(traceConfig.getSampler()).isEqualTo(Sampler.alwaysOff());
-  }
-
-  @Test
-  void traceConfigFromProto_ProbabilitySampler() {
-    TraceConfig traceConfig =
-        TraceProtoUtils.traceConfigFromProto(
-            io.opentelemetry.proto.trace.v1.TraceConfig.newBuilder()
-                .setTraceIdRatioBased(TraceIdRatioBased.newBuilder().setSamplingRatio(0.1).build())
-                .setMaxNumberOfAttributes(10)
-                .setMaxNumberOfTimedEvents(9)
-                .setMaxNumberOfLinks(8)
-                .setMaxNumberOfAttributesPerTimedEvent(2)
-                .setMaxNumberOfAttributesPerLink(1)
-                .build());
-    assertThat(traceConfig.getSampler()).isEqualTo(Sampler.traceIdRatioBased(0.1));
   }
 }

--- a/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/TraceConfigzZPageHandler.java
+++ b/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/TraceConfigzZPageHandler.java
@@ -121,7 +121,7 @@ final class TraceConfigzZPageHandler extends ZPageHandler {
         /* rowName= */ "SamplingProbability to",
         /* paramName= */ QUERY_STRING_SAMPLING_PROBABILITY,
         /* inputPlaceHolder= */ "[0.0, 1.0]",
-        /* paramDefaultValue= */ TraceConfig.getDefault().getSampler().getDescription(),
+        /* paramDefaultValue= */ "1.0",
         /* zebraStripeColor= */ ZEBRA_STRIPE_COLOR,
         /* zebraStripe= */ false);
     emitChangeTableRow(
@@ -210,7 +210,7 @@ final class TraceConfigzZPageHandler extends ZPageHandler {
     emitActiveTableRow(
         /* out= */ out,
         /* paramName= */ "Sampler",
-        /* paramValue=*/ configSupplier.get().getSampler().getDescription(),
+        /* paramValue=*/ configSupplier.getSampler().getDescription(),
         /* zebraStripeColor= */ ZEBRA_STRIPE_COLOR,
         /* zebraStripe= */ false);
     emitActiveTableRow(
@@ -366,11 +366,11 @@ final class TraceConfigzZPageHandler extends ZPageHandler {
         try {
           double samplingProbability = Double.parseDouble(samplingProbabilityStr);
           if (samplingProbability == 0) {
-            newConfigBuilder.setSampler(Sampler.alwaysOff());
+            configSupplier.setSampler(Sampler.alwaysOff());
           } else if (samplingProbability == 1) {
-            newConfigBuilder.setSampler(Sampler.alwaysOn());
+            configSupplier.setSampler(Sampler.alwaysOn());
           } else {
-            newConfigBuilder.setSampler(Sampler.traceIdRatioBased(samplingProbability));
+            configSupplier.setSampler(Sampler.traceIdRatioBased(samplingProbability));
           }
         } catch (NumberFormatException e) {
           throw new IllegalArgumentException("SamplingProbability must be of the type double", e);

--- a/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/TraceConfigzZPageHandler.java
+++ b/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/TraceConfigzZPageHandler.java
@@ -365,13 +365,7 @@ final class TraceConfigzZPageHandler extends ZPageHandler {
       if (samplingProbabilityStr != null) {
         try {
           double samplingProbability = Double.parseDouble(samplingProbabilityStr);
-          if (samplingProbability == 0) {
-            configSupplier.setSampler(Sampler.alwaysOff());
-          } else if (samplingProbability == 1) {
-            configSupplier.setSampler(Sampler.alwaysOn());
-          } else {
-            configSupplier.setSampler(Sampler.traceIdRatioBased(samplingProbability));
-          }
+          configSupplier.setSampler(Sampler.traceIdRatioBased(samplingProbability));
         } catch (NumberFormatException e) {
           throw new IllegalArgumentException("SamplingProbability must be of the type double", e);
         }

--- a/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/TracezTraceConfigSupplier.java
+++ b/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/TracezTraceConfigSupplier.java
@@ -21,7 +21,7 @@ final class TracezTraceConfigSupplier implements Supplier<TraceConfig>, Sampler 
   private volatile TraceConfig activeTraceConfig;
 
   TracezTraceConfigSupplier() {
-    sampler = Sampler.parentBased(Sampler.alwaysOn());
+    sampler = Sampler.traceIdRatioBased(1.0);
     activeTraceConfig = TraceConfig.getDefault();
   }
 

--- a/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/TracezTraceConfigSupplier.java
+++ b/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/TracezTraceConfigSupplier.java
@@ -5,14 +5,23 @@
 
 package io.opentelemetry.sdk.extension.zpages;
 
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+import java.util.List;
 import java.util.function.Supplier;
 
-final class TracezTraceConfigSupplier implements Supplier<TraceConfig> {
+final class TracezTraceConfigSupplier implements Supplier<TraceConfig>, Sampler {
 
+  private volatile Sampler sampler;
   private volatile TraceConfig activeTraceConfig;
 
   TracezTraceConfigSupplier() {
+    sampler = Sampler.parentBased(Sampler.alwaysOn());
     activeTraceConfig = TraceConfig.getDefault();
   }
 
@@ -21,7 +30,31 @@ final class TracezTraceConfigSupplier implements Supplier<TraceConfig> {
     return activeTraceConfig;
   }
 
+  Sampler getSampler() {
+    return sampler;
+  }
+
+  void setSampler(Sampler sampler) {
+    this.sampler = sampler;
+  }
+
   void setActiveTraceConfig(TraceConfig traceConfig) {
     activeTraceConfig = traceConfig;
+  }
+
+  @Override
+  public SamplingResult shouldSample(
+      Context parentContext,
+      String traceId,
+      String name,
+      Span.Kind spanKind,
+      Attributes attributes,
+      List<LinkData> parentLinks) {
+    return sampler.shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
+  }
+
+  @Override
+  public String getDescription() {
+    return sampler.getDescription();
   }
 }

--- a/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/ZPageServer.java
+++ b/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/ZPageServer.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.extension.zpages;
 import com.sun.net.httpserver.HttpServer;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
@@ -18,10 +19,11 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A collection of HTML pages to display stats and trace data and allow library configuration
- * control. To use, add {@linkplain ZPageServer#getSpanProcessor() the z-pages span processor} and
- * {@linkplain ZPageServer#getTracezTraceConfigSupplier() the z-pages dynamic trace config} to a
- * {@link io.opentelemetry.sdk.trace.SdkTracerProviderBuilder}. Currently all tracers can only be
- * made visible to a singleton {@link ZPageServer}.
+ * control. To use, add {@linkplain ZPageServer#getSpanProcessor() the z-pages span processor},
+ * {@linkplain ZPageServer#getTracezTraceConfigSupplier() the z-pages dynamic trace config} and
+ * {@linkplain ZPageServer#getTracezSampler() the z-pages dynamic sampler} to a {@link
+ * io.opentelemetry.sdk.trace.SdkTracerProviderBuilder}. Currently all tracers can only be made
+ * visible to a singleton {@link ZPageServer}.
  *
  * <p>Example usage with private {@link HttpServer}
  *
@@ -32,6 +34,7 @@ import javax.annotation.concurrent.ThreadSafe;
  *         .setTracerProvider(SdkTracerProvider.builder()
  *             .addSpanProcessor(ZPageServer.getSpanProcessor())
  *             .setTraceConfigSupplier(ZPageServer.getTraceConfigSupplier())
+ *             .setSampler(ZPageServer.getSampler())
  *             .build();
  *         .build();
  *
@@ -50,6 +53,7 @@ import javax.annotation.concurrent.ThreadSafe;
  *         .setTracerProvider(SdkTracerProvider.builder()
  *             .addSpanProcessor(ZPageServer.getSpanProcessor())
  *             .setTraceConfigSupplier(ZPageServer.getTraceConfigSupplier())
+ *             .setSampler(ZPageServer.getSampler())
  *             .build();
  *         .build();
  *
@@ -92,6 +96,11 @@ public final class ZPageServer {
 
   /** Returns a supplier of {@link TraceConfig} which can be reconfigured using zpages. */
   public static Supplier<TraceConfig> getTracezTraceConfigSupplier() {
+    return tracezTraceConfigSupplier;
+  }
+
+  /** Returns a {@link Sampler} which can be reconfigured using zpages. */
+  public static Sampler getTracezSampler() {
     return tracezTraceConfigSupplier;
   }
 

--- a/sdk-extensions/zpages/src/test/java/io/opentelemetry/sdk/extension/zpages/TraceConfigzZPageHandlerTest.java
+++ b/sdk-extensions/zpages/src/test/java/io/opentelemetry/sdk/extension/zpages/TraceConfigzZPageHandlerTest.java
@@ -42,8 +42,7 @@ class TraceConfigzZPageHandlerTest {
 
     assertThat(output.toString()).contains("SamplingProbability to");
     assertThat(output.toString()).contains("name=" + querySamplingProbability);
-    assertThat(output.toString())
-        .contains("(" + TraceConfig.getDefault().getSampler().getDescription() + ")");
+    assertThat(output.toString()).contains("(1.0)");
     assertThat(output.toString()).contains("MaxNumberOfAttributes to");
     assertThat(output.toString()).contains("name=" + queryMaxNumOfAttributes);
     assertThat(output.toString())
@@ -83,7 +82,7 @@ class TraceConfigzZPageHandlerTest {
 
     assertThat(output.toString()).contains("Sampler");
     assertThat(output.toString())
-        .contains(">" + configSupplier.get().getSampler().getDescription() + "<");
+        .contains(">" + configSupplier.getSampler().getDescription() + "<");
     assertThat(output.toString()).contains("MaxNumberOfAttributes");
     assertThat(output.toString())
         .contains(">" + Integer.toString(configSupplier.get().getMaxNumberOfAttributes()) + "<");
@@ -135,7 +134,7 @@ class TraceConfigzZPageHandlerTest {
     traceConfigzZPageHandler.processRequest("POST", queryMap, output);
     traceConfigzZPageHandler.emitHtml(queryMap, output);
 
-    assertThat(configSupplier.get().getSampler().getDescription())
+    assertThat(configSupplier.getSampler().getDescription())
         .isEqualTo(
             Sampler.traceIdRatioBased(Double.parseDouble(newSamplingProbability)).getDescription());
     assertThat(configSupplier.get().getMaxNumberOfAttributes())
@@ -161,8 +160,8 @@ class TraceConfigzZPageHandlerTest {
     traceConfigzZPageHandler.processRequest("POST", queryMap, output);
     traceConfigzZPageHandler.emitHtml(queryMap, output);
 
-    assertThat(configSupplier.get().getSampler().getDescription())
-        .isEqualTo(TraceConfig.getDefault().getSampler().getDescription());
+    assertThat(configSupplier.getSampler().getDescription())
+        .isEqualTo(Sampler.parentBased(Sampler.alwaysOn()).getDescription());
     assertThat(configSupplier.get().getMaxNumberOfAttributes())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfAttributes());
     assertThat(configSupplier.get().getMaxNumberOfEvents())
@@ -186,8 +185,8 @@ class TraceConfigzZPageHandlerTest {
     traceConfigzZPageHandler.processRequest("POST", queryMap, output);
     traceConfigzZPageHandler.emitHtml(queryMap, output);
 
-    assertThat(configSupplier.get().getSampler().getDescription())
-        .isEqualTo(TraceConfig.getDefault().getSampler().getDescription());
+    assertThat(configSupplier.getSampler().getDescription())
+        .isEqualTo(Sampler.parentBased(Sampler.alwaysOn()).getDescription());
     assertThat(configSupplier.get().getMaxNumberOfAttributes())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfAttributes());
     assertThat(configSupplier.get().getMaxNumberOfEvents())
@@ -320,8 +319,8 @@ class TraceConfigzZPageHandlerTest {
     // GET request, Should not apply changes
     traceConfigzZPageHandler.emitHtml(queryMap, output);
 
-    assertThat(configSupplier.get().getSampler().getDescription())
-        .isEqualTo(TraceConfig.getDefault().getSampler().getDescription());
+    assertThat(configSupplier.getSampler().getDescription())
+        .isEqualTo(Sampler.parentBased(Sampler.alwaysOn()).getDescription());
     assertThat(configSupplier.get().getMaxNumberOfAttributes())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfAttributes());
     assertThat(configSupplier.get().getMaxNumberOfEvents())
@@ -337,7 +336,7 @@ class TraceConfigzZPageHandlerTest {
     traceConfigzZPageHandler.processRequest("POST", queryMap, output);
     traceConfigzZPageHandler.emitHtml(queryMap, output);
 
-    assertThat(configSupplier.get().getSampler().getDescription())
+    assertThat(configSupplier.getSampler().getDescription())
         .isEqualTo(
             Sampler.traceIdRatioBased(Double.parseDouble(newSamplingProbability)).getDescription());
     assertThat(configSupplier.get().getMaxNumberOfAttributes())

--- a/sdk-extensions/zpages/src/test/java/io/opentelemetry/sdk/extension/zpages/TraceConfigzZPageHandlerTest.java
+++ b/sdk-extensions/zpages/src/test/java/io/opentelemetry/sdk/extension/zpages/TraceConfigzZPageHandlerTest.java
@@ -161,7 +161,7 @@ class TraceConfigzZPageHandlerTest {
     traceConfigzZPageHandler.emitHtml(queryMap, output);
 
     assertThat(configSupplier.getSampler().getDescription())
-        .isEqualTo(Sampler.parentBased(Sampler.alwaysOn()).getDescription());
+        .isEqualTo(Sampler.traceIdRatioBased(1.0).getDescription());
     assertThat(configSupplier.get().getMaxNumberOfAttributes())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfAttributes());
     assertThat(configSupplier.get().getMaxNumberOfEvents())
@@ -186,7 +186,7 @@ class TraceConfigzZPageHandlerTest {
     traceConfigzZPageHandler.emitHtml(queryMap, output);
 
     assertThat(configSupplier.getSampler().getDescription())
-        .isEqualTo(Sampler.parentBased(Sampler.alwaysOn()).getDescription());
+        .isEqualTo(Sampler.traceIdRatioBased(1.0).getDescription());
     assertThat(configSupplier.get().getMaxNumberOfAttributes())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfAttributes());
     assertThat(configSupplier.get().getMaxNumberOfEvents())
@@ -320,7 +320,7 @@ class TraceConfigzZPageHandlerTest {
     traceConfigzZPageHandler.emitHtml(queryMap, output);
 
     assertThat(configSupplier.getSampler().getDescription())
-        .isEqualTo(Sampler.parentBased(Sampler.alwaysOn()).getDescription());
+        .isEqualTo(Sampler.traceIdRatioBased(1.0).getDescription());
     assertThat(configSupplier.get().getMaxNumberOfAttributes())
         .isEqualTo(TraceConfig.getDefault().getMaxNumberOfAttributes());
     assertThat(configSupplier.get().getMaxNumberOfEvents())

--- a/sdk-extensions/zpages/src/test/java/io/opentelemetry/sdk/extension/zpages/ZPageServerTest.java
+++ b/sdk-extensions/zpages/src/test/java/io/opentelemetry/sdk/extension/zpages/ZPageServerTest.java
@@ -21,4 +21,9 @@ class ZPageServerTest {
     assertThat(ZPageServer.getTracezTraceConfigSupplier())
         .isInstanceOf(TracezTraceConfigSupplier.class);
   }
+
+  @Test
+  void testSampler() {
+    assertThat(ZPageServer.getTracezSampler()).isInstanceOf(TracezTraceConfigSupplier.class);
+  }
 }

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -129,17 +129,13 @@ class OpenTelemetrySdkTest {
   // Demonstrates how clear or confusing is SDK configuration
   @Test
   void fullOpenTelemetrySdkConfigurationDemo() {
-    TraceConfig currentConfig = TraceConfig.getDefault();
-    TraceConfig newConfig =
-        currentConfig.toBuilder()
-            .setSampler(mock(Sampler.class))
-            .setMaxLengthOfAttributeValues(128)
-            .build();
+    TraceConfig newConfig = TraceConfig.builder().setMaxLengthOfAttributeValues(128).build();
 
     OpenTelemetrySdkBuilder sdkBuilder =
         OpenTelemetrySdk.builder()
             .setTracerProvider(
                 SdkTracerProvider.builder()
+                    .setSampler(mock(Sampler.class))
                     .addSpanProcessor(SimpleSpanProcessor.create(mock(SpanExporter.class)))
                     .addSpanProcessor(SimpleSpanProcessor.create(mock(SpanExporter.class)))
                     .setClock(mock(Clock.class))
@@ -173,7 +169,7 @@ class OpenTelemetrySdkTest {
         .setTracerProvider(
             SdkTracerProvider.builder()
                 .addSpanProcessor(SimpleSpanProcessor.create(mock(SpanExporter.class)))
-                .setTraceConfig(TraceConfig.builder().setSampler(mock(Sampler.class)).build())
+                .setSampler(mock(Sampler.class))
                 .build())
         .setPropagators(ContextPropagators.create(mock(TextMapPropagator.class)))
         .build();
@@ -182,7 +178,7 @@ class OpenTelemetrySdkTest {
         .setTracerProvider(
             SdkTracerProvider.builder()
                 .addSpanProcessor(SimpleSpanProcessor.create(mock(SpanExporter.class)))
-                .setTraceConfig(TraceConfig.builder().setSampler(mock(Sampler.class)).build())
+                .setSampler(mock(Sampler.class))
                 .setIdGenerator(mock(IdGenerator.class))
                 .build())
         .setPropagators(ContextPropagators.create(mock(TextMapPropagator.class)))

--- a/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/SpanBenchmark.java
+++ b/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/SpanBenchmark.java
@@ -9,7 +9,6 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -36,9 +35,11 @@ public class SpanBenchmark {
 
   @Setup(Level.Trial)
   public final void setup() {
-    TraceConfig alwaysOn = TraceConfig.builder().setSampler(Sampler.alwaysOn()).build();
     SdkTracerProvider tracerProvider =
-        SdkTracerProvider.builder().setResource(serviceResource).setTraceConfig(alwaysOn).build();
+        SdkTracerProvider.builder()
+            .setResource(serviceResource)
+            .setSampler(Sampler.alwaysOn())
+            .build();
 
     Tracer tracerSdk = tracerProvider.get("benchmarkTracer");
     sdkSpanBuilder =

--- a/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
+++ b/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
@@ -8,7 +8,6 @@ package io.opentelemetry.sdk.trace;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
-import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
@@ -69,11 +68,9 @@ public class SpanPipelineBenchmark {
 
       String address = collector.getHost() + ":" + collector.getMappedPort(EXPOSED_PORT);
 
-      TraceConfig alwaysOn = TraceConfig.builder().setSampler(Sampler.alwaysOn()).build();
-
       SdkTracerProvider tracerProvider =
           SdkTracerProvider.builder()
-              .setTraceConfig(alwaysOn)
+              .setSampler(Sampler.alwaysOn())
               .addSpanProcessor(getSpanProcessor(address))
               .build();
 

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java
@@ -30,13 +30,7 @@ final class SdkTracer implements Tracer {
       return Tracer.getDefault().spanBuilder(spanName);
     }
     return new SdkSpanBuilder(
-        spanName,
-        instrumentationLibraryInfo,
-        sharedState.getActiveSpanProcessor(),
-        sharedState.getActiveTraceConfig(),
-        sharedState.getResource(),
-        sharedState.getIdGenerator(),
-        sharedState.getClock());
+        spanName, instrumentationLibraryInfo, sharedState, sharedState.getActiveTraceConfig());
   }
 
   /**

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
@@ -13,6 +13,7 @@ import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.internal.ComponentRegistry;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.io.Closeable;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -49,9 +50,11 @@ public final class SdkTracerProvider implements TracerProvider, SdkTracerManagem
       IdGenerator idsGenerator,
       Resource resource,
       Supplier<TraceConfig> traceConfigSupplier,
+      Sampler sampler,
       List<SpanProcessor> spanProcessors) {
     this.sharedState =
-        new TracerSharedState(clock, idsGenerator, resource, traceConfigSupplier, spanProcessors);
+        new TracerSharedState(
+            clock, idsGenerator, resource, traceConfigSupplier, sampler, spanProcessors);
     this.tracerSdkComponentRegistry =
         new ComponentRegistry<>(
             instrumentationLibraryInfo -> new SdkTracer(sharedState, instrumentationLibraryInfo));
@@ -76,6 +79,11 @@ public final class SdkTracerProvider implements TracerProvider, SdkTracerManagem
   @Override
   public TraceConfig getActiveTraceConfig() {
     return sharedState.getActiveTraceConfig();
+  }
+
+  /** Returns the configured {@link Sampler}. */
+  public Sampler getSampler() {
+    return sharedState.getSampler();
   }
 
   /**

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProviderBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProviderBuilder.java
@@ -11,18 +11,22 @@ import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.internal.SystemClock;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
 /** Builder of {@link SdkTracerProvider}. */
 public final class SdkTracerProviderBuilder {
+  private static final Sampler DEFAULT_SAMPLER = Sampler.parentBased(Sampler.alwaysOn());
+
   private final List<SpanProcessor> spanProcessors = new ArrayList<>();
 
   private Clock clock = SystemClock.getInstance();
   private IdGenerator idsGenerator = IdGenerator.random();
   private Resource resource = Resource.getDefault();
   private Supplier<TraceConfig> traceConfigSupplier = TraceConfig::getDefault;
+  private Sampler sampler = DEFAULT_SAMPLER;
 
   /**
    * Assign a {@link Clock}.
@@ -84,6 +88,13 @@ public final class SdkTracerProviderBuilder {
     return this;
   }
 
+  /** Assign a {@link Sampler} to use for sampling traces. */
+  public SdkTracerProviderBuilder setSampler(Sampler sampler) {
+    requireNonNull(sampler);
+    this.sampler = sampler;
+    return this;
+  }
+
   /**
    * Add a SpanProcessor to the span pipeline that will be built.
    *
@@ -101,7 +112,7 @@ public final class SdkTracerProviderBuilder {
    */
   public SdkTracerProvider build() {
     return new SdkTracerProvider(
-        clock, idsGenerator, resource, traceConfigSupplier, spanProcessors);
+        clock, idsGenerator, resource, traceConfigSupplier, sampler, spanProcessors);
   }
 
   SdkTracerProviderBuilder() {}

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProviderBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProviderBuilder.java
@@ -90,7 +90,7 @@ public final class SdkTracerProviderBuilder {
 
   /** Assign a {@link Sampler} to use for sampling traces. */
   public SdkTracerProviderBuilder setSampler(Sampler sampler) {
-    requireNonNull(sampler);
+    requireNonNull(sampler, "sampler");
     this.sampler = sampler;
     return this;
   }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/TracerSharedState.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/TracerSharedState.java
@@ -9,6 +9,7 @@ import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.util.List;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -22,6 +23,7 @@ final class TracerSharedState {
   private final Resource resource;
 
   private final Supplier<TraceConfig> traceConfigSupplier;
+  private final Sampler sampler;
   private final SpanProcessor activeSpanProcessor;
 
   @GuardedBy("lock")
@@ -33,11 +35,13 @@ final class TracerSharedState {
       IdGenerator idGenerator,
       Resource resource,
       Supplier<TraceConfig> traceConfigSupplier,
+      Sampler sampler,
       List<SpanProcessor> spanProcessors) {
     this.clock = clock;
     this.idGenerator = idGenerator;
     this.resource = resource;
     this.traceConfigSupplier = traceConfigSupplier;
+    this.sampler = sampler;
     activeSpanProcessor = SpanProcessor.composite(spanProcessors);
   }
 
@@ -60,6 +64,11 @@ final class TracerSharedState {
    */
   TraceConfig getActiveTraceConfig() {
     return traceConfigSupplier.get();
+  }
+
+  /** Returns the configured {@link Sampler}. */
+  Sampler getSampler() {
+    return sampler;
   }
 
   /**

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
@@ -7,7 +7,6 @@ package io.opentelemetry.sdk.trace.config;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.sdk.trace.samplers.Sampler;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -91,7 +90,6 @@ public abstract class TraceConfig {
   }
 
   static TraceConfig create(
-      Sampler sampler,
       int maxNumAttributes,
       int maxNumEvents,
       int maxNumLinks,
@@ -99,7 +97,6 @@ public abstract class TraceConfig {
       int maxNumAttributesPerLink,
       int maxAttributeLength) {
     return new AutoValue_TraceConfig(
-        sampler,
         maxNumAttributes,
         maxNumEvents,
         maxNumLinks,
@@ -107,13 +104,6 @@ public abstract class TraceConfig {
         maxNumAttributesPerLink,
         maxAttributeLength);
   }
-
-  /**
-   * Returns the global default {@code Sampler} which is used when constructing a new {@code Span}.
-   *
-   * @return the global default {@code Sampler}.
-   */
-  public abstract Sampler getSampler();
 
   /**
    * Returns the global default max number of attributes per {@link Span}.
@@ -171,7 +161,6 @@ public abstract class TraceConfig {
    */
   public TraceConfigBuilder toBuilder() {
     return new TraceConfigBuilder()
-        .setSampler(getSampler())
         .setMaxNumberOfAttributes(getMaxNumberOfAttributes())
         .setMaxNumberOfEvents(getMaxNumberOfEvents())
         .setMaxNumberOfLinks(getMaxNumberOfLinks())

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfigBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfigBuilder.java
@@ -5,15 +5,11 @@
 
 package io.opentelemetry.sdk.trace.config;
 
-import static java.util.Objects.requireNonNull;
-
 import io.opentelemetry.api.internal.Utils;
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.sdk.trace.samplers.Sampler;
 
 /** Builder for {@link TraceConfig}. */
 public final class TraceConfigBuilder {
-  private static final Sampler DEFAULT_SAMPLER = Sampler.parentBased(Sampler.alwaysOn());
   private static final int DEFAULT_SPAN_MAX_NUM_ATTRIBUTES = 1000;
   private static final int DEFAULT_SPAN_MAX_NUM_EVENTS = 1000;
   private static final int DEFAULT_SPAN_MAX_NUM_LINKS = 1000;
@@ -21,7 +17,6 @@ public final class TraceConfigBuilder {
   private static final int DEFAULT_SPAN_MAX_NUM_ATTRIBUTES_PER_LINK = 32;
   private static final int DEFAULT_MAX_ATTRIBUTE_LENGTH = TraceConfig.UNLIMITED_ATTRIBUTE_LENGTH;
 
-  private Sampler sampler = DEFAULT_SAMPLER;
   private int maxNumAttributes = DEFAULT_SPAN_MAX_NUM_ATTRIBUTES;
   private int maxNumEvents = DEFAULT_SPAN_MAX_NUM_EVENTS;
   private int maxNumLinks = DEFAULT_SPAN_MAX_NUM_LINKS;
@@ -30,39 +25,6 @@ public final class TraceConfigBuilder {
   private int maxAttributeLength = DEFAULT_MAX_ATTRIBUTE_LENGTH;
 
   TraceConfigBuilder() {}
-
-  /**
-   * Sets the global default {@code Sampler}. It must be not {@code null} otherwise {@link #build()}
-   * will throw an exception.
-   *
-   * @param sampler the global default {@code Sampler}.
-   * @return this.
-   */
-  public TraceConfigBuilder setSampler(Sampler sampler) {
-    requireNonNull(sampler, "sampler");
-    this.sampler = sampler;
-    return this;
-  }
-
-  /**
-   * Sets the global default {@code Sampler}. It must be not {@code null} otherwise {@link #build()}
-   * will throw an exception.
-   *
-   * @param samplerRatio the global default ratio used to make decisions on {@link Span} sampling.
-   * @return this.
-   */
-  public TraceConfigBuilder setTraceIdRatioBased(double samplerRatio) {
-    Utils.checkArgument(samplerRatio >= 0, "samplerRatio must be greater than or equal to 0.");
-    Utils.checkArgument(samplerRatio <= 1, "samplerRatio must be lesser than or equal to 1.");
-    if (samplerRatio == 1) {
-      setSampler(Sampler.parentBased(Sampler.alwaysOn()));
-    } else if (samplerRatio == 0) {
-      setSampler(Sampler.alwaysOff());
-    } else {
-      setSampler(Sampler.parentBased(Sampler.traceIdRatioBased(samplerRatio)));
-    }
-    return this;
-  }
 
   /**
    * Sets the global default max number of attributes per {@link Span}.
@@ -156,7 +118,6 @@ public final class TraceConfigBuilder {
    */
   public TraceConfig build() {
     return TraceConfig.create(
-        sampler,
         maxNumAttributes,
         maxNumEvents,
         maxNumLinks,

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderTest.java
@@ -74,6 +74,13 @@ class SdkTracerProviderTest {
   }
 
   @Test
+  void builder_configureSampler_null() {
+    assertThatThrownBy(() -> SdkTracerProvider.builder().setSampler(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("sampler");
+  }
+
+  @Test
   void builder_serviceNameProvided() {
     Resource resource =
         Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, "mySpecialService"));

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderTest.java
@@ -18,6 +18,7 @@ import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,6 +59,18 @@ class SdkTracerProviderTest {
     assertThat(tracerProvider)
         .extracting("sharedState")
         .hasFieldOrPropertyWithValue("resource", resourceWithDefaults);
+  }
+
+  @Test
+  void builder_defaultSampler() {
+    assertThat(SdkTracerProvider.builder().build().getSampler())
+        .isEqualTo(Sampler.parentBased(Sampler.alwaysOn()));
+  }
+
+  @Test
+  void builder_configureSampler() {
+    assertThat(SdkTracerProvider.builder().setSampler(Sampler.alwaysOff()).build().getSampler())
+        .isEqualTo(Sampler.alwaysOff());
   }
 
   @Test

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/config/TraceConfigTest.java
@@ -6,17 +6,13 @@
 package io.opentelemetry.sdk.trace.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.opentelemetry.sdk.trace.samplers.Sampler;
 import org.junit.jupiter.api.Test;
 
 class TraceConfigTest {
 
   @Test
   void defaultTraceConfig() {
-    assertThat(TraceConfig.getDefault().getSampler().getDescription())
-        .isEqualTo(Sampler.parentBased(Sampler.alwaysOn()).getDescription());
     assertThat(TraceConfig.getDefault().getMaxNumberOfAttributes()).isEqualTo(1000);
     assertThat(TraceConfig.getDefault().getMaxNumberOfEvents()).isEqualTo(1000);
     assertThat(TraceConfig.getDefault().getMaxNumberOfLinks()).isEqualTo(1000);
@@ -25,79 +21,15 @@ class TraceConfigTest {
   }
 
   @Test
-  void updateTraceConfig_NullSampler() {
-    assertThatThrownBy(() -> TraceConfig.builder().setSampler(null))
-        .isInstanceOf(NullPointerException.class);
-  }
-
-  @Test
-  void updateTraceConfig_NonPositiveMaxNumberOfAttributes() {
-    assertThatThrownBy(() -> TraceConfig.builder().setMaxNumberOfAttributes(0))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  void updateTraceConfig_NonPositiveMaxNumberOfEvents() {
-    assertThatThrownBy(() -> TraceConfig.builder().setMaxNumberOfEvents(0))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  void updateTraceConfig_NonPositiveMaxNumberOfLinks() {
-    assertThatThrownBy(() -> TraceConfig.builder().setMaxNumberOfLinks(0))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  void updateTraceConfig_NonPositiveMaxNumberOfAttributesPerEvent() {
-    assertThatThrownBy(() -> TraceConfig.builder().setMaxNumberOfAttributesPerEvent(0))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  void updateTraceConfig_NonPositiveMaxNumberOfAttributesPerLink() {
-    assertThatThrownBy(() -> TraceConfig.builder().setMaxNumberOfAttributesPerLink(0))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  void updateTraceConfig_InvalidTraceIdRatioBased() {
-    assertThatThrownBy(() -> TraceConfig.builder().setTraceIdRatioBased(2))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  void updateTraceConfig_NegativeTraceIdRatioBased() {
-    assertThatThrownBy(() -> TraceConfig.builder().setTraceIdRatioBased(-1))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  void updateTraceConfig_OffTraceIdRatioBased() {
-    TraceConfig traceConfig = TraceConfig.builder().setTraceIdRatioBased(0).build();
-    assertThat(traceConfig.getSampler()).isSameAs(Sampler.alwaysOff());
-  }
-
-  @Test
-  void updateTraceConfig_OnTraceIdRatioBased() {
-    TraceConfig traceConfig = TraceConfig.builder().setTraceIdRatioBased(1).build();
-
-    Sampler sampler = traceConfig.getSampler();
-    assertThat(sampler).isEqualTo(Sampler.parentBased(Sampler.alwaysOn()));
-  }
-
-  @Test
   void updateTraceConfig_All() {
     TraceConfig traceConfig =
         TraceConfig.builder()
-            .setSampler(Sampler.alwaysOff())
             .setMaxNumberOfAttributes(8)
             .setMaxNumberOfEvents(10)
             .setMaxNumberOfLinks(11)
             .setMaxNumberOfAttributesPerEvent(1)
             .setMaxNumberOfAttributesPerLink(2)
             .build();
-    assertThat(traceConfig.getSampler()).isEqualTo(Sampler.alwaysOff());
     assertThat(traceConfig.getMaxNumberOfAttributes()).isEqualTo(8);
     assertThat(traceConfig.getMaxNumberOfEvents()).isEqualTo(10);
     assertThat(traceConfig.getMaxNumberOfLinks()).isEqualTo(11);


### PR DESCRIPTION
For #2022

Didn't bother with deprecating since it seems complicated to do here.

Given how often our unit tests set samplers, and rarely they set limits, there does seem to be a nice win here.

/cc @iNikem 