### PR TITLE
Migrate to guava JRE version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,7 +165,7 @@ subprojects {
             errorProneJavacVersion = '9+181-r4173-1'
             findBugsJsr305Version = '3.0.2'
             grpcVersion = '1.34.1'
-            guavaVersion = '30.1-android'
+            guavaVersion = '30.1-jre'
             jacksonVersion = '2.12.0'
             jmhVersion = '1.26'
             junitVersion = '5.7.0'

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/CompletableResultCodeTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/CompletableResultCodeTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import com.google.common.util.concurrent.Uninterruptibles;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -149,7 +150,7 @@ class CompletableResultCodeTest {
     CompletableResultCode result = new CompletableResultCode();
     new Thread(
             () -> {
-              Uninterruptibles.sleepUninterruptibly(50, TimeUnit.MILLISECONDS);
+              Uninterruptibles.sleepUninterruptibly(Duration.ofMillis(50));
               result.succeed();
             })
         .start();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/StressTestRunner.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/StressTestRunner.java
@@ -8,10 +8,10 @@ package io.opentelemetry.sdk.metrics;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Uninterruptibles;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.concurrent.Immutable;
 
 @AutoValue
@@ -32,8 +32,7 @@ abstract class StressTestRunner {
             () -> {
               // While workers still work, do collections.
               while (countDownLatch.getCount() != 0) {
-                Uninterruptibles.sleepUninterruptibly(
-                    getCollectionIntervalMs(), TimeUnit.MILLISECONDS);
+                Uninterruptibles.sleepUninterruptibly(Duration.ofMillis(getCollectionIntervalMs()));
               }
             });
     List<Thread> operationThreads = new ArrayList<>(numThreads);
@@ -44,7 +43,7 @@ abstract class StressTestRunner {
                 for (int i = 0; i < operation.getNumOperations(); i++) {
                   operation.getUpdater().update();
                   Uninterruptibles.sleepUninterruptibly(
-                      operation.getOperationDelayMs(), TimeUnit.MILLISECONDS);
+                      Duration.ofMillis(operation.getOperationDelayMs()));
                 }
                 countDownLatch.countDown();
               }));

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/StressTestRunner.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/StressTestRunner.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.trace;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Uninterruptibles;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -35,7 +36,7 @@ abstract class StressTestRunner {
                 for (int i = 0; i < operation.getNumOperations(); i++) {
                   operation.getUpdater().update();
                   Uninterruptibles.sleepUninterruptibly(
-                      operation.getOperationDelayMs(), TimeUnit.MILLISECONDS);
+                      Duration.ofMillis(operation.getOperationDelayMs()));
                 }
                 countDownLatch.countDown();
               }));


### PR DESCRIPTION
We only use guava in tests now, so we can use JRE version which has less chance of conflicts with other libraries.