### PR TITLE
Enable auto-configuration of custom, named span exporters.

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ConfigProperties.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ConfigProperties.java
@@ -46,7 +46,7 @@ public class ConfigProperties {
   }
 
   /**
-   * Get a string-valued configuration property.
+   * Returns a string-valued configuration property.
    *
    * @return null if the property has not been configured.
    */
@@ -56,7 +56,7 @@ public class ConfigProperties {
   }
 
   /**
-   * Get a integer-valued configuration property.
+   * Returns a integer-valued configuration property.
    *
    * @return null if the property has not been configured.
    * @throws NumberFormatException if the property is not a valid integer.
@@ -76,7 +76,7 @@ public class ConfigProperties {
   }
 
   /**
-   * Get a long-valued configuration property.
+   * Returns a long-valued configuration property.
    *
    * @return null if the property has not been configured.
    * @throws NumberFormatException if the property is not a valid long.
@@ -96,7 +96,7 @@ public class ConfigProperties {
   }
 
   /**
-   * Get a double-valued configuration property.
+   * Returns a double-valued configuration property.
    *
    * @return null if the property has not been configured.
    * @throws NumberFormatException if the property is not a valid double.
@@ -116,7 +116,7 @@ public class ConfigProperties {
   }
 
   /**
-   * Get a list-valued configuration property. The format of the original value must be
+   * Returns a list-valued configuration property. The format of the original value must be
    * comma-separated. Empty values will be removed.
    *
    * @return an empty list if the property has not been configured.
@@ -130,7 +130,7 @@ public class ConfigProperties {
   }
 
   /**
-   * Get a map-valued configuration property. The format of the original value must be
+   * Returns a map-valued configuration property. The format of the original value must be
    * comma-separated for each key, with an '=' separating the key and value. For instance, <code>
    * service.name=Greatest Service,host.name=localhost</code> Empty values will be removed.
    *
@@ -156,7 +156,7 @@ public class ConfigProperties {
   }
 
   /**
-   * Get a boolean-valued configuration property. Uses the same rules as {@link
+   * Returns a boolean-valued configuration property. Uses the same rules as {@link
    * Boolean#parseBoolean(String)} for handling the values.
    *
    * @return false if the property has not been configured.

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ConfigProperties.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ConfigProperties.java
@@ -16,7 +16,13 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
-class ConfigProperties {
+/**
+ * Properties to be used for auto-configuration of the OpenTelemetry SDK components. These
+ * properties will be a combination of system properties and environment variables. The properties
+ * for both of these will be normalized to be all lower case, and underscores will be replaced with
+ * periods.
+ */
+public class ConfigProperties {
 
   private final Map<String, String> config;
 
@@ -39,14 +45,25 @@ class ConfigProperties {
     this.config = config;
   }
 
+  /**
+   * Get a string-valued configuration property.
+   *
+   * @return null if the property has not been configured.
+   */
   @Nullable
-  String getString(String name) {
+  public String getString(String name) {
     return config.get(name);
   }
 
+  /**
+   * Get a integer-valued configuration property.
+   *
+   * @return null if the property has not been configured.
+   * @throws NumberFormatException if the property is not a valid integer.
+   */
   @Nullable
   @SuppressWarnings("UnusedException")
-  Integer getInt(String name) {
+  public Integer getInt(String name) {
     String value = config.get(name);
     if (value == null || value.isEmpty()) {
       return null;
@@ -58,9 +75,15 @@ class ConfigProperties {
     }
   }
 
+  /**
+   * Get a long-valued configuration property.
+   *
+   * @return null if the property has not been configured.
+   * @throws NumberFormatException if the property is not a valid long.
+   */
   @Nullable
   @SuppressWarnings("UnusedException")
-  Long getLong(String name) {
+  public Long getLong(String name) {
     String value = config.get(name);
     if (value == null || value.isEmpty()) {
       return null;
@@ -72,9 +95,15 @@ class ConfigProperties {
     }
   }
 
+  /**
+   * Get a double-valued configuration property.
+   *
+   * @return null if the property has not been configured.
+   * @throws NumberFormatException if the property is not a valid double.
+   */
   @Nullable
   @SuppressWarnings("UnusedException")
-  Double getDouble(String name) {
+  public Double getDouble(String name) {
     String value = config.get(name);
     if (value == null || value.isEmpty()) {
       return null;
@@ -86,7 +115,13 @@ class ConfigProperties {
     }
   }
 
-  List<String> getCommaSeparatedValues(String name) {
+  /**
+   * Get a list-valued configuration property. The format of the original value must be
+   * comma-separated. Empty values will be removed.
+   *
+   * @return an empty list if the property has not been configured.
+   */
+  public List<String> getCommaSeparatedValues(String name) {
     String value = config.get(name);
     if (value == null) {
       return Collections.emptyList();
@@ -94,7 +129,14 @@ class ConfigProperties {
     return filterBlanksAndNulls(value.split(","));
   }
 
-  Map<String, String> getCommaSeparatedMap(String name) {
+  /**
+   * Get a map-valued configuration property. The format of the original value must be
+   * comma-separated for each key, with an '=' separating the key and value. For instance, <code>
+   * service.name=Greatest Service,host.name=localhost</code> Empty values will be removed.
+   *
+   * @return an empty list if the property has not been configured.
+   */
+  public Map<String, String> getCommaSeparatedMap(String name) {
     return getCommaSeparatedValues(name).stream()
         .map(keyValuePair -> filterBlanksAndNulls(keyValuePair.split("=", 2)))
         .map(
@@ -113,7 +155,13 @@ class ConfigProperties {
                 Map.Entry::getKey, Map.Entry::getValue, (first, next) -> next, LinkedHashMap::new));
   }
 
-  boolean getBoolean(String name) {
+  /**
+   * Get a boolean-valued configuration property. Uses the same rules as {@link
+   * Boolean#parseBoolean(String)} for handling the values.
+   *
+   * @return false if the property has not been configured.
+   */
+  public boolean getBoolean(String name) {
     return Boolean.parseBoolean(config.get(name));
   }
 

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigurableSpanExporterProvider.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigurableSpanExporterProvider.java
@@ -24,8 +24,9 @@ public interface ConfigurableSpanExporterProvider {
 
   /**
    * Returns the name of this exporter, which can be specified with the {@code otel.trace.exporter}
-   * property to enable it. If the name is the same as any other defined exporter name, it is
-   * undefined which will be used.
+   * property to enable it. The name returned should NOT be the same as any other exporter name.
+   * If the name does conflict with another exporter name, the resulting behavior is undefined and 
+   * it is explicitly unspecified which exporter will actually be used.
    */
   String getName();
 }

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigurableSpanExporterProvider.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigurableSpanExporterProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure.spi;
+
+import io.opentelemetry.sdk.autoconfigure.ConfigProperties;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+
+/**
+ * A service provider interface (SPI) for providing additional exporters that can be used with the
+ * autoconfigured SDK. If the {@code otel.trace.exporter} property contains a value equal to what is
+ * returned by {@link #getName()}, the exporter returned by {@link
+ * #createExporter(ConfigProperties)} will be enabled and added to the SDK.
+ */
+public interface ConfigurableSpanExporterProvider {
+
+  /**
+   * Returns a {@link SpanExporter} that can be registered to OpenTelemetry by providing the
+   * property value specified by {@link #getName()}.
+   */
+  SpanExporter createExporter(ConfigProperties config);
+
+  /**
+   * Returns the name of this exporter, which can be specified with the {@code otel.trace.exporter}
+   * property to enable it. If the name is the same as any other defined exporter name, it is
+   * undefined which will be used.
+   */
+  String getName();
+}

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigurableSpanExporterProvider.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigurableSpanExporterProvider.java
@@ -24,9 +24,9 @@ public interface ConfigurableSpanExporterProvider {
 
   /**
    * Returns the name of this exporter, which can be specified with the {@code otel.trace.exporter}
-   * property to enable it. The name returned should NOT be the same as any other exporter name.
-   * If the name does conflict with another exporter name, the resulting behavior is undefined and 
-   * it is explicitly unspecified which exporter will actually be used.
+   * property to enable it. The name returned should NOT be the same as any other exporter name. If
+   * the name does conflict with another exporter name, the resulting behavior is undefined and it
+   * is explicitly unspecified which exporter will actually be used.
    */
   String getName();
 }

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
@@ -9,7 +9,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
-import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -17,28 +16,15 @@ import org.junit.jupiter.api.Test;
 public class ConfigurableSpanExporterTest {
 
   @Test
-  void configuration_fail() {
-    SpanExporter spanExporter =
-        SpanExporterConfiguration.configureExporter(
-            "testExporter",
-            ConfigProperties.createForTest(ImmutableMap.of("should.always.fail", "true")));
+  void configuration() {
+    ConfigProperties config =
+        ConfigProperties.createForTest(ImmutableMap.of("test.option", "true"));
+    SpanExporter spanExporter = SpanExporterConfiguration.configureExporter("testExporter", config);
 
     assertThat(spanExporter)
-        .isInstanceOf(TestConfigurableSpanExporterProvider.TestSpanExporter.class);
-
-    assertThat(spanExporter.shutdown()).isEqualTo(CompletableResultCode.ofFailure());
-  }
-
-  @Test
-  void configuration_notFail() {
-    SpanExporter spanExporter =
-        SpanExporterConfiguration.configureExporter(
-            "testExporter", ConfigProperties.createForTest(Collections.emptyMap()));
-
-    assertThat(spanExporter)
-        .isInstanceOf(TestConfigurableSpanExporterProvider.TestSpanExporter.class);
-
-    assertThat(spanExporter.shutdown()).isEqualTo(CompletableResultCode.ofSuccess());
+        .isInstanceOf(TestConfigurableSpanExporterProvider.TestSpanExporter.class)
+        .extracting("config")
+        .isSameAs(config);
   }
 
   @Test

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class ConfigurableSpanExporterTest {
+
+  @Test
+  void configuration_fail() {
+    SpanExporter spanExporter =
+        SpanExporterConfiguration.configureExporter(
+            "testExporter",
+            ConfigProperties.createForTest(ImmutableMap.of("should.always.fail", "true")));
+
+    assertThat(spanExporter)
+        .isInstanceOf(TestConfigurableSpanExporterProvider.TestSpanExporter.class);
+
+    assertThat(spanExporter.shutdown()).isEqualTo(CompletableResultCode.ofFailure());
+  }
+
+  @Test
+  void configuration_notFail() {
+    SpanExporter spanExporter =
+        SpanExporterConfiguration.configureExporter(
+            "testExporter", ConfigProperties.createForTest(Collections.emptyMap()));
+
+    assertThat(spanExporter)
+        .isInstanceOf(TestConfigurableSpanExporterProvider.TestSpanExporter.class);
+
+    assertThat(spanExporter.shutdown()).isEqualTo(CompletableResultCode.ofSuccess());
+  }
+
+  @Test
+  void exporterNotFound() {
+    assertThatThrownBy(
+            () ->
+                SpanExporterConfiguration.configureExporter(
+                    "catExporter", ConfigProperties.createForTest(Collections.emptyMap())))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("catExporter");
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/TestConfigurableSpanExporterProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/TestConfigurableSpanExporterProvider.java
@@ -14,7 +14,7 @@ import java.util.Collection;
 public class TestConfigurableSpanExporterProvider implements ConfigurableSpanExporterProvider {
   @Override
   public SpanExporter createExporter(ConfigProperties config) {
-    return new TestSpanExporter(config.getBoolean("should.always.fail"));
+    return new TestSpanExporter(config);
   }
 
   @Override
@@ -24,31 +24,29 @@ public class TestConfigurableSpanExporterProvider implements ConfigurableSpanExp
 
   public static class TestSpanExporter implements SpanExporter {
 
-    private final boolean shouldAlwaysFail;
+    private final ConfigProperties config;
 
-    public TestSpanExporter(boolean shouldAlwaysFail) {
-      this.shouldAlwaysFail = shouldAlwaysFail;
+    public TestSpanExporter(ConfigProperties config) {
+      this.config = config;
     }
 
     @Override
     public CompletableResultCode export(Collection<SpanData> spans) {
-      return shouldAlwaysFail
-          ? CompletableResultCode.ofFailure()
-          : CompletableResultCode.ofSuccess();
+      return CompletableResultCode.ofSuccess();
     }
 
     @Override
     public CompletableResultCode flush() {
-      return shouldAlwaysFail
-          ? CompletableResultCode.ofFailure()
-          : CompletableResultCode.ofSuccess();
+      return CompletableResultCode.ofSuccess();
     }
 
     @Override
     public CompletableResultCode shutdown() {
-      return shouldAlwaysFail
-          ? CompletableResultCode.ofFailure()
-          : CompletableResultCode.ofSuccess();
+      return CompletableResultCode.ofSuccess();
+    }
+
+    public ConfigProperties getConfig() {
+      return config;
     }
   }
 }

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/TestConfigurableSpanExporterProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/TestConfigurableSpanExporterProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurableSpanExporterProvider;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.util.Collection;
+
+public class TestConfigurableSpanExporterProvider implements ConfigurableSpanExporterProvider {
+  @Override
+  public SpanExporter createExporter(ConfigProperties config) {
+    return new TestSpanExporter(config.getBoolean("should.always.fail"));
+  }
+
+  @Override
+  public String getName() {
+    return "testExporter";
+  }
+
+  public static class TestSpanExporter implements SpanExporter {
+
+    private final boolean shouldAlwaysFail;
+
+    public TestSpanExporter(boolean shouldAlwaysFail) {
+      this.shouldAlwaysFail = shouldAlwaysFail;
+    }
+
+    @Override
+    public CompletableResultCode export(Collection<SpanData> spans) {
+      return shouldAlwaysFail
+          ? CompletableResultCode.ofFailure()
+          : CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode flush() {
+      return shouldAlwaysFail
+          ? CompletableResultCode.ofFailure()
+          : CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+      return shouldAlwaysFail
+          ? CompletableResultCode.ofFailure()
+          : CompletableResultCode.ofSuccess();
+    }
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ConfigurableSpanExporterProvider
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ConfigurableSpanExporterProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.sdk.autoconfigure.TestConfigurableSpanExporterProvider


### PR DESCRIPTION
This need was uncovered while working on a custom distribution of the opentelemetry auto-instrumentation agent.

In order for this to work, we really wanted access to the `ConfigProperties` as well, so we could leverage the standardized property handling that it provides.

Alternative approaches would be welcome, but this seems like a pretty clean pattern. In fact, we might want to add the `ConfigProperties` to other auto-configuration SPI methods as well, so we don't have to figure out how to add them later.