### PR TITLE
Expose zipkin as an API dependency.

### DIFF
--- a/exporters/zipkin/build.gradle
+++ b/exporters/zipkin/build.gradle
@@ -13,10 +13,11 @@ dependencies {
 
     api project(':sdk:all')
 
+    api "io.zipkin.reporter2:zipkin-reporter"
+
     annotationProcessor "com.google.auto.value:auto-value"
 
-    implementation "io.zipkin.reporter2:zipkin-reporter",
-            "io.zipkin.reporter2:zipkin-sender-okhttp3"
+    implementation "io.zipkin.reporter2:zipkin-sender-okhttp3"
 
     testImplementation project(':sdk:testing')
     testImplementation "com.google.guava:guava",


### PR DESCRIPTION
We have `Sender` and `BytesEncoder` in our builder API