### PR TITLE
Remove deprecated setServiceName

### DIFF
--- a/exporters/jaeger-thrift/src/main/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftSpanExporterBuilder.java
+++ b/exporters/jaeger-thrift/src/main/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftSpanExporterBuilder.java
@@ -7,14 +7,9 @@ package io.opentelemetry.exporter.jaeger.thrift;
 
 import io.jaegertracing.thrift.internal.senders.HttpSender;
 import io.jaegertracing.thrift.internal.senders.ThriftSender;
-import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 
 /** Builder utility for this exporter. */
 public final class JaegerThriftSpanExporterBuilder {
-
-  private String serviceName =
-      Resource.getDefault().getAttributes().get(ResourceAttributes.SERVICE_NAME);
 
   private String endpoint = JaegerThriftSpanExporter.DEFAULT_ENDPOINT;
   private ThriftSender thriftSender;
@@ -28,21 +23,6 @@ public final class JaegerThriftSpanExporterBuilder {
    */
   public JaegerThriftSpanExporterBuilder setThriftSender(ThriftSender thriftSender) {
     this.thriftSender = thriftSender;
-    return this;
-  }
-
-  /**
-   * Sets the service name to be used by this exporter, if none is found in the Resource associated
-   * with a span.
-   *
-   * @param serviceName the service name.
-   * @return this.
-   * @deprecated The default service name is now extracted from the default Resource. This method
-   *     will be removed in the next release.
-   */
-  @Deprecated
-  public JaegerThriftSpanExporterBuilder setServiceName(String serviceName) {
-    this.serviceName = serviceName;
     return this;
   }
 
@@ -68,7 +48,7 @@ public final class JaegerThriftSpanExporterBuilder {
     if (thriftSender == null) {
       thriftSender = new HttpSender.Builder(endpoint).build();
     }
-    return new JaegerThriftSpanExporter(thriftSender, serviceName);
+    return new JaegerThriftSpanExporter(thriftSender);
   }
 
   JaegerThriftSpanExporterBuilder() {}

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterBuilder.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterBuilder.java
@@ -16,28 +16,11 @@ import java.util.concurrent.TimeUnit;
 /** Builder utility for this exporter. */
 public final class JaegerGrpcSpanExporterBuilder {
   private static final String DEFAULT_ENDPOINT = "localhost:14250";
-  private static final String DEFAULT_SERVICE_NAME = "unknown";
   private static final long DEFAULT_TIMEOUT_SECS = 10;
 
-  private String serviceName = DEFAULT_SERVICE_NAME;
   private String endpoint = DEFAULT_ENDPOINT;
   private ManagedChannel channel;
   private long timeoutNanos = TimeUnit.SECONDS.toNanos(DEFAULT_TIMEOUT_SECS);
-
-  /**
-   * Sets the service name to be used by this exporter, if none is found in the Resource associated
-   * with a span.
-   *
-   * @param serviceName the service name.
-   * @return this.
-   * @deprecated The default service name is now extracted from the default Resource. This method
-   *     will be removed in the next release.
-   */
-  @Deprecated
-  public JaegerGrpcSpanExporterBuilder setServiceName(String serviceName) {
-    this.serviceName = serviceName;
-    return this;
-  }
 
   /**
    * Sets the managed channel to use when communicating with the backend. Takes precedence over
@@ -91,7 +74,7 @@ public final class JaegerGrpcSpanExporterBuilder {
     if (channel == null) {
       channel = ManagedChannelBuilder.forTarget(endpoint).usePlaintext().build();
     }
-    return new JaegerGrpcSpanExporter(serviceName, channel, timeoutNanos);
+    return new JaegerGrpcSpanExporter(channel, timeoutNanos);
   }
 
   JaegerGrpcSpanExporterBuilder() {}

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.exporter.zipkin;
 
-import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import zipkin2.Span;
 import zipkin2.codec.BytesEncoder;
 import zipkin2.codec.SpanBytesEncoder;
@@ -17,32 +15,7 @@ import zipkin2.reporter.okhttp3.OkHttpSender;
 public final class ZipkinSpanExporterBuilder {
   private BytesEncoder<Span> encoder = SpanBytesEncoder.JSON_V2;
   private Sender sender;
-  private String serviceName =
-      Resource.getDefault().getAttributes().get(ResourceAttributes.SERVICE_NAME);
   private String endpoint = ZipkinSpanExporter.DEFAULT_ENDPOINT;
-
-  /**
-   * Label of the remote node in the service graph, such as "favstar". Avoid names with variables or
-   * unique identifiers embedded. Defaults to the service.name specified in the default Resource.
-   *
-   * <p>This is a primary label for trace lookup and aggregation, so it should be intuitive and
-   * consistent. Many use a name from service discovery.
-   *
-   * <p>Note: this value, will be superseded by the value of {@link ResourceAttributes#SERVICE_NAME}
-   * if it has been set in the {@link Resource} associated with the Tracer that created the spans.
-   *
-   * @param serviceName The service name. It defaults to "unknown".
-   * @return this.
-   * @see Resource
-   * @see ResourceAttributes
-   * @deprecated The default service name is now extracted from the default Resource. This method
-   *     will be removed in the next release.
-   */
-  @Deprecated
-  public ZipkinSpanExporterBuilder setServiceName(String serviceName) {
-    this.serviceName = serviceName;
-    return this;
-  }
 
   /**
    * Sets the Zipkin sender. Implements the client side of the span transport. A {@link
@@ -93,6 +66,6 @@ public final class ZipkinSpanExporterBuilder {
     if (sender == null) {
       sender = OkHttpSender.create(endpoint);
     }
-    return new ZipkinSpanExporter(this.encoder, this.sender, this.serviceName);
+    return new ZipkinSpanExporter(this.encoder, this.sender);
   }
 }

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
@@ -20,6 +20,7 @@ import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import java.net.InetAddress;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -129,7 +130,8 @@ public class ZipkinSpanExporterEndToEndHttpTest {
 
     assertThat(zipkinSpans).isNotNull();
     assertThat(zipkinSpans.size()).isEqualTo(1);
-    assertThat(zipkinSpans.get(0)).isEqualTo(buildZipkinSpan());
+    assertThat(zipkinSpans.get(0))
+        .isEqualTo(buildZipkinSpan(zipkinSpanExporter.getLocalAddressForTest()));
   }
 
   private static TestSpanData.Builder buildStandardSpan() {
@@ -153,7 +155,7 @@ public class ZipkinSpanExporterEndToEndHttpTest {
         .setResource(Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, SERVICE_NAME)));
   }
 
-  private static Span buildZipkinSpan() {
+  private static Span buildZipkinSpan(InetAddress localAddress) {
     return Span.newBuilder()
         .traceId(TRACE_ID)
         .parentId(PARENT_SPAN_ID)
@@ -162,7 +164,7 @@ public class ZipkinSpanExporterEndToEndHttpTest {
         .name(SPAN_NAME)
         .timestamp(START_EPOCH_NANOS / 1000)
         .duration((END_EPOCH_NANOS / 1000) - (START_EPOCH_NANOS / 1000))
-        .localEndpoint(Endpoint.newBuilder().serviceName(SERVICE_NAME).build())
+        .localEndpoint(Endpoint.newBuilder().serviceName(SERVICE_NAME).ip(localAddress).build())
         .addAnnotation(RECEIVED_TIMESTAMP_NANOS / 1000, "RECEIVED")
         .addAnnotation(SENT_TIMESTAMP_NANOS / 1000, "SENT")
         .putTag(ZipkinSpanExporter.OTEL_STATUS_CODE, "OK")


### PR DESCRIPTION
Moved the fallback to default resource logic closer to where service name is picked up in Jaeger. And for Zipkin, I think we accidentally lost filling in endpoint, so restoring that is a lot of the change.