### PR TITLE
Consolidate animalsniffer config to top level.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ import net.ltgt.gradle.errorprone.ErrorPronePlugin
 import org.gradle.api.plugins.JavaPlugin.*
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import ru.vyarus.gradle.plugin.animalsniffer.AnimalSniffer
+import ru.vyarus.gradle.plugin.animalsniffer.AnimalSnifferExtension
 import ru.vyarus.gradle.plugin.animalsniffer.AnimalSnifferPlugin
 import java.time.Duration
 
@@ -363,22 +364,11 @@ subprojects {
 
         plugins.withId("ru.vyarus.animalsniffer") {
             dependencies {
-                add(AnimalSnifferPlugin.SIGNATURE_CONF, "com.toasttab.android:gummy-bears-api-24:0.3.0:coreLib@signature")
+                add(AnimalSnifferPlugin.SIGNATURE_CONF, "com.toasttab.android:gummy-bears-api-19:0.3.0:coreLib@signature")
+            }
 
-                tasks {
-                    withType(AnimalSniffer::class) {
-                        if (name.startsWith("animalsnifferTest")) {
-                            enabled = false
-                        }
-                    }
-
-                    // If JMH enabled ignore animalsniffer.
-                    plugins.withId("me.champeau.gradle.jmh") {
-                        named("animalsnifferJmh") {
-                            enabled = false
-                        }
-                    }
-                }
+            configure<AnimalSnifferExtension> {
+                sourceSets = listOf(the<JavaPluginConvention>().sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME))
             }
         }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -364,7 +364,7 @@ subprojects {
 
         plugins.withId("ru.vyarus.animalsniffer") {
             dependencies {
-                add(AnimalSnifferPlugin.SIGNATURE_CONF, "com.toasttab.android:gummy-bears-api-19:0.3.0:coreLib@signature")
+                add(AnimalSnifferPlugin.SIGNATURE_CONF, "com.toasttab.android:gummy-bears-api-24:0.3.0:coreLib@signature")
             }
 
             configure<AnimalSnifferExtension> {

--- a/exporters/jaeger-thrift/build.gradle
+++ b/exporters/jaeger-thrift/build.gradle
@@ -20,10 +20,3 @@ dependencies {
 
     testImplementation project(':sdk:testing')
 }
-
-animalsniffer {
-    // Don't check sourceSets.jmh and sourceSets.test
-    sourceSets = [
-            sourceSets.main
-    ]
-}

--- a/exporters/jaeger/build.gradle
+++ b/exporters/jaeger/build.gradle
@@ -31,13 +31,6 @@ dependencies {
     testRuntimeOnly "io.grpc:grpc-netty-shaded"
 }
 
-animalsniffer {
-    // Don't check sourceSets.jmh and sourceSets.test
-    sourceSets = [
-            sourceSets.main
-    ]
-}
-
 // IntelliJ complains that the generated classes are not found, ask IntelliJ to include the
 // generated Java directories as source folders.
 idea {

--- a/exporters/logging/build.gradle
+++ b/exporters/logging/build.gradle
@@ -14,10 +14,3 @@ dependencies {
 
     testImplementation project(':sdk:testing')
 }
-
-animalsniffer {
-    // Don't check sourceSets.jmh and sourceSets.test
-    sourceSets = [
-            sourceSets.main
-    ]
-}

--- a/exporters/zipkin/build.gradle
+++ b/exporters/zipkin/build.gradle
@@ -22,10 +22,3 @@ dependencies {
     testImplementation project(':sdk:testing')
     testImplementation "io.zipkin.zipkin2:zipkin-junit"
 }
-
-animalsniffer {
-    // Don't check sourceSets.jmh and sourceSets.test
-    sourceSets = [
-            sourceSets.main
-    ]
-}

--- a/proto/build.gradle
+++ b/proto/build.gradle
@@ -17,13 +17,6 @@ dependencies {
             "io.grpc:grpc-stub"
 }
 
-animalsniffer {
-    // Don't check sourceSets.jmh and sourceSets.test
-    sourceSets = [
-            sourceSets.main
-    ]
-}
-
 def protoVersion = "0.7.0"
 // To generate checksum, download the file and run "shasum -a 256 ~/path/to/vfoo.zip"
 def protoChecksum = "0b581c654b2360485b99c2de3731dd59275b0fe7b91d78e7f6c5efd5997f4c82"

--- a/sdk-extensions/jaeger-remote-sampler/build.gradle
+++ b/sdk-extensions/jaeger-remote-sampler/build.gradle
@@ -25,13 +25,6 @@ dependencies {
     testRuntimeOnly "io.grpc:grpc-netty-shaded"
 }
 
-animalsniffer {
-    // Don't check sourceSets.jmh and sourceSets.test
-    sourceSets = [
-            sourceSets.main
-    ]
-}
-
 // IntelliJ complains that the generated classes are not found, ask IntelliJ to include the
 // generated Java directories as source folders.
 idea {


### PR DESCRIPTION
Instead, simplifies the top level config to use direct sourceset inclusion instead of somewhat fuzzy task name exclusion.