### PR TITLE
Use shadow plugin to generate bundled jars.

### DIFF
--- a/.github/workflows/pr-examples-build.yml
+++ b/.github/workflows/pr-examples-build.yml
@@ -38,4 +38,4 @@ jobs:
           remote-build-cache-proxy-enabled: false
           arguments: clean check shadowJar
           build-root-directory: examples
-      - run: java -cp examples/sdk-usage/build/libs/opentelemetry-examples-sdk-usage-all-0.1.0-SNAPSHOT.jar io.opentelemetry.sdk.example.ConfigureSpanProcessorExample
+      - run: java -cp examples/sdk-usage/build/libs/opentelemetry-examples-sdk-usage-0.1.0-SNAPSHOT-all.jar io.opentelemetry.sdk.example.ConfigureSpanProcessorExample

--- a/.github/workflows/pr-examples-build.yml
+++ b/.github/workflows/pr-examples-build.yml
@@ -36,6 +36,6 @@ jobs:
       - uses: burrunan/gradle-cache-action@v1.6
         with:
           remote-build-cache-proxy-enabled: false
-          arguments: clean check fatJar
+          arguments: clean check shadowJar
           build-root-directory: examples
       - run: java -cp examples/sdk-usage/build/libs/opentelemetry-examples-sdk-usage-all-0.1.0-SNAPSHOT.jar io.opentelemetry.sdk.example.ConfigureSpanProcessorExample

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "com.diffplug.spotless"
+    id "com.github.johnrengelman.shadow" apply false
 }
 
 subprojects {
@@ -8,6 +9,7 @@ subprojects {
     apply plugin: 'java-library'
     apply plugin: 'idea'
     apply plugin: 'com.diffplug.spotless'
+    apply plugin: 'com.github.johnrengelman.shadow'
 
     group = "io.opentelemetry"
     version = "0.1.0-SNAPSHOT"
@@ -37,12 +39,5 @@ subprojects {
         java {
             googleJavaFormat("1.9")
         }
-    }
-
-    //create a single Jar with all dependencies
-    task fatJar(type: Jar) {
-        archiveBaseName = project.name + '-all'
-        from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
-        with jar
     }
 }

--- a/examples/grpc/README.md
+++ b/examples/grpc/README.md
@@ -15,17 +15,17 @@ and create a **Child Span**.
 
 ## 1 - Compile 
 ```shell script
-../gradlew fatJar
+../gradlew shadowJar
 ```
 
 ## 2 - Start the Server
 ```shell script
-java -cp ./build/libs/opentelemetry-examples-grpc-all-0.1.0-SNAPSHOT.jar io.opentelemetry.example.grpc.HelloWorldServer
+java -cp ./build/libs/opentelemetry-examples-grpc-0.1.0-SNAPSHOT-all.jar io.opentelemetry.example.grpc.HelloWorldServer
 ```
  
 ## 3 - Start the normal Client
 ```shell script
-java -cp ./build/libs/opentelemetry-examples-grpc-all-0.1.0-SNAPSHOT.jar io.opentelemetry.example.grpc.HelloWorldClient
+java -cp ./build/libs/opentelemetry-examples-grpc-0.1.0-SNAPSHOT-all.jar io.opentelemetry.example.grpc.HelloWorldClient
 ```
 
 ## 4 - Start the streamed Client

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -16,15 +16,15 @@ and create a **Child Span** with attached a **Span Event**.
 
 ## 1 - Compile 
 ```shell script
-../gradlew fatJar
+../gradlew shadowJar
 ```
 
 ## 2 - Start the Server
 ```shell script
-java -cp ./build/libs/opentelemetry-examples-http-all-0.1.0-SNAPSHOT.jar io.opentelemetry.example.http.HttpServer
+java -cp ./build/libs/opentelemetry-examples-http-0.1.0-SNAPSHOT-all.jar io.opentelemetry.example.http.HttpServer
 ```
  
 ## 3 - Start the Client
 ```shell script
-java -cp ./build/libs/opentelemetry-examples-http-all-0.1.0-SNAPSHOT.jar io.opentelemetry.example.http.HttpClient
+java -cp ./build/libs/opentelemetry-examples-http-0.1.0-SNAPSHOT-all.jar io.opentelemetry.example.http.HttpClient
 ```

--- a/examples/jaeger/README.md
+++ b/examples/jaeger/README.md
@@ -13,7 +13,7 @@ to instrument a simple application using Jaeger as trace exporter.
 
 ## 1 - Compile 
 ```shell script
-../gradlew fatJar
+../gradlew shadowJar
 ```
 ## 2 - Run Jaeger
 
@@ -27,7 +27,7 @@ docker run --rm -it --name jaeger\
 
 ## 3 - Start the Application
 ```shell script
-java -cp build/libs/opentelemetry-examples-jaeger-all-0.1.0-SNAPSHOT.jar io.opentelemetry.example.jaeger.JaegerExample localhost 14250
+java -cp build/libs/opentelemetry-examples-jaeger-0.1.0-SNAPSHOT-all.jar io.opentelemetry.example.jaeger.JaegerExample localhost 14250
 ```
 ## 4 - Open the Jaeger UI
 

--- a/examples/prometheus/README.md
+++ b/examples/prometheus/README.md
@@ -13,7 +13,7 @@ These are collected by a Prometheus instance which is configured to pull these m
 
 ## 1 - Compile 
 ```shell script
-../gradlew fatJar
+../gradlew shadowJar
 ```
 ## 2 - Run Prometheus
 
@@ -31,7 +31,7 @@ docker run --network="host" --rm -it \
 
 ## 3 - Start the Application
 ```shell script
-java -cp build/libs/opentelemetry-examples-prometheus-all-0.1.0-SNAPSHOT.jar io.opentelemetry.example.prometheus.PrometheusExample 19090
+java -cp build/libs/opentelemetry-examples-prometheus-0.1.0-SNAPSHOT-all.jar io.opentelemetry.example.prometheus.PrometheusExample 19090
 ```
 ## 4 - Open the Prometheus UI
 

--- a/examples/sdk-usage/README.md
+++ b/examples/sdk-usage/README.md
@@ -9,15 +9,15 @@ This is a simple example that demonstrates how to use and configure the OpenTele
 ## Compile
 Compile with 
 ```shell script
-../gradlew fatJar
+../gradlew shadowJar
 ```
 
 ## Run
 
 The following commands are used to run the examples.
 ```shell script
-java -cp build/libs/opentelemetry-examples-sdk-usage-all-0.1.0-SNAPSHOT.jar io.opentelemetry.sdk.example.ConfigureTraceExample
+java -cp build/libs/opentelemetry-examples-sdk-usage-0.1.0-SNAPSHOT-all.jar io.opentelemetry.sdk.example.ConfigureTraceExample
 ```
 ```shell script
-java -cp build/libs/opentelemetry-examples-sdk-usage-all-0.1.0-SNAPSHOT.jar io.opentelemetry.sdk.example.ConfigureSpanProcessorExample
+java -cp build/libs/opentelemetry-examples-sdk-usage-0.1.0-SNAPSHOT-all.jar io.opentelemetry.sdk.example.ConfigureSpanProcessorExample
 ```

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -1,6 +1,7 @@
 pluginManagement {
     plugins {
         id "com.diffplug.spotless" version "5.6.1"
+        id "com.github.johnrengelman.shadow" version "6.1.0"
         id 'com.google.protobuf' version '0.8.8'
     }
 

--- a/examples/zipkin/README.md
+++ b/examples/zipkin/README.md
@@ -11,7 +11,7 @@ to instrument a simple application using Zipkin as trace exporter.
 
 ## 1 - Compile 
 ```shell script
-../gradlew fatJar
+../gradlew shadowJar
 ```
 ## 2 - Run Zipkin
 
@@ -23,7 +23,7 @@ docker run --rm -it --name zipkin \
 
 ## 3 - Start the Application
 ```shell script
-java -cp build/libs/opentelemetry-examples-zipkin-all-0.1.0-SNAPSHOT.jar io.opentelemetry.example.zipkin.ZipkinExample localhost 9411
+java -cp build/libs/opentelemetry-examples-zipkin-0.1.0-SNAPSHOT-all.jar io.opentelemetry.example.zipkin.ZipkinExample localhost 9411
 ```
 ## 4 - Open the Zipkin UI
 

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -1,16 +1,11 @@
 plugins {
     id "java"
+
+    id "com.github.johnrengelman.shadow"
 }
 
 description = 'OpenTelemetry Integration Tests'
 ext.moduleName = "io.opentelemetry.integration.tests"
-
-// create a single Jar with all dependencies
-task fatJar(type: Jar) {
-    baseName = project.name + '-all'
-    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
-    with jar
-}
 
 dependencies {
     implementation project(':sdk:all'),
@@ -24,8 +19,8 @@ dependencies {
             "com.squareup.okhttp3:okhttp"
 
     tasks.withType(Test) {
-        dependsOn fatJar
-        systemProperty 'archive.name', fatJar.outputs.files[0].path
+        dependsOn shadowJar
+        systemProperty 'archive.name', shadowJar.archiveFile.get().asFile.absolutePath
     }
 }
 

--- a/integration-tests/tracecontext/build.gradle
+++ b/integration-tests/tracecontext/build.gradle
@@ -1,19 +1,18 @@
 plugins {
     id 'java'
+
+    id "com.github.johnrengelman.shadow"
 }
 
 description = 'OpenTelemetry W3C Context Propagation Integration Tests'
 ext.moduleName = "io.opentelemetry.tracecontext.integration.tests"
 
+shadowJar {
+    archiveFileName = 'tracecontext-tests.jar'
 
-// create a single Jar with all dependencies
-task fatJar(type: Jar) {
     manifest {
         attributes 'Main-Class': 'io.opentelemetry.Application'
     }
-    archiveName = 'tracecontext-tests.jar'
-    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
-    with jar
 }
 
 dependencies {

--- a/integration-tests/tracecontext/tracecontext-integration-test.sh
+++ b/integration-tests/tracecontext/tracecontext-integration-test.sh
@@ -9,7 +9,7 @@ git clone https://github.com/w3c/trace-context ./target/trace-context
 cd ./target/trace-context && git checkout $TRACECONTEXT_GIT_TAG && cd -
 pip3 install setuptools;
 pip3 install aiohttp;
-../../gradlew fatJar
+../../gradlew shadowJar
 java -jar build/libs/tracecontext-tests.jar 1>&2 &
 EXAMPLE_SERVER_PID=$!
 # give the app server a little time to start up. Not adding some sort

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ pluginManagement {
     plugins {
         id "com.diffplug.spotless" version "5.9.0"
         id "com.github.ben-manes.versions" version "0.36.0"
+        id "com.github.johnrengelman.shadow" version "6.1.0"
         id "com.google.protobuf" version "0.8.14"
         id "de.marcphilipp.nexus-publish" version "0.4.0"
         id "de.undercouch.download" version "4.1.1"


### PR DESCRIPTION
Since that's its job, so less configuration on our side. Removes use of a potentially non-inclusive term too.