### PR TITLE
Have TraceConfig supply itself.

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProviderBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProviderBuilder.java
@@ -66,19 +66,10 @@ public final class SdkTracerProviderBuilder {
   }
 
   /**
-   * Assign an initial {@link TraceConfig} that should be used with this SDK.
-   *
-   * @return this
-   */
-  public SdkTracerProviderBuilder setTraceConfig(TraceConfig traceConfig) {
-    requireNonNull(traceConfig, "traceConfig");
-    this.traceConfigSupplier = () -> traceConfig;
-    return this;
-  }
-
-  /**
    * Assign a {@link Supplier} of {@link TraceConfig}. {@link TraceConfig} will be retrieved each
-   * time a {@link io.opentelemetry.api.trace.Span} is started.
+   * time a {@link io.opentelemetry.api.trace.Span} is started. If you do not need to dynamically
+   * update {@link TraceConfig} you should just set the result of {@link
+   * io.opentelemetry.sdk.trace.config.TraceConfigBuilder#build()} as is.
    *
    * @return this
    */

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.trace.config;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.trace.Span;
+import java.util.function.Supplier;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -61,7 +62,7 @@ import javax.annotation.concurrent.Immutable;
  */
 @AutoValue
 @Immutable
-public abstract class TraceConfig {
+public abstract class TraceConfig implements Supplier<TraceConfig> {
 
   /**
    * Value for attribute length which indicates attributes should not be truncated.
@@ -167,5 +168,10 @@ public abstract class TraceConfig {
         .setMaxNumberOfAttributesPerEvent(getMaxNumberOfAttributesPerEvent())
         .setMaxNumberOfAttributesPerLink(getMaxNumberOfAttributesPerLink())
         .setMaxLengthOfAttributeValues(getMaxLengthOfAttributeValues());
+  }
+
+  @Override
+  public TraceConfig get() {
+    return this;
   }
 }


### PR DESCRIPTION
I don't think we can lose the ability to simply set the result of the traceconfig builder when configuring the SDK since it should be much more common than needing dynamic updates.

This change allows it - I don't know if I like it better than what we have right now though.