### PR TITLE
Update the check in the tracer to see if the SDK has been shut down.

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java
@@ -26,7 +26,7 @@ final class SdkTracer implements Tracer {
     if (spanName == null || spanName.trim().isEmpty()) {
       spanName = FALLBACK_SPAN_NAME;
     }
-    if (sharedState.isStopped()) {
+    if (sharedState.hasBeenShutdown()) {
       return Tracer.getDefault().spanBuilder(spanName);
     }
     return new SdkSpanBuilder(

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
@@ -101,7 +101,7 @@ public final class SdkTracerProvider implements TracerProvider, Closeable {
    *     been shut down.
    */
   public CompletableResultCode shutdown() {
-    if (sharedState.isStopped()) {
+    if (sharedState.hasBeenShutdown()) {
       logger.log(Level.WARNING, "Calling shutdown() multiple times.");
       return CompletableResultCode.ofSuccess();
     }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/TracerSharedState.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/TracerSharedState.java
@@ -81,18 +81,20 @@ final class TracerSharedState {
   }
 
   /**
-   * Returns {@code true} if tracing is stopped.
+   * Returns {@code true} if tracing has been shut down.
    *
-   * @return {@code true} if tracing is stopped.
+   * @return {@code true} if tracing has been shut down.
    */
-  boolean isStopped() {
+  boolean hasBeenShutdown() {
+    // todo: do we really need a lock around this check? This is on the hot path of tracing.
     synchronized (lock) {
-      return shutdownResult != null && shutdownResult.isSuccess();
+      return shutdownResult != null;
     }
   }
 
   /**
-   * Stops tracing, including shutting down processors and set to {@code true} {@link #isStopped()}.
+   * Stops tracing, including shutting down processors and set to {@code true} {@link
+   * #hasBeenShutdown()}.
    *
    * @return a {@link CompletableResultCode} that will be completed when the span processor is shut
    *     down.

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/TracerSharedState.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/TracerSharedState.java
@@ -13,7 +13,6 @@ import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.util.List;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.GuardedBy;
 
 // Represents the shared state/config between all Tracers created by the same TracerProvider.
 final class TracerSharedState {
@@ -26,9 +25,7 @@ final class TracerSharedState {
   private final Sampler sampler;
   private final SpanProcessor activeSpanProcessor;
 
-  @GuardedBy("lock")
-  @Nullable
-  private volatile CompletableResultCode shutdownResult = null;
+  @Nullable private volatile CompletableResultCode shutdownResult = null;
 
   TracerSharedState(
       Clock clock,
@@ -86,10 +83,7 @@ final class TracerSharedState {
    * @return {@code true} if tracing has been shut down.
    */
   boolean hasBeenShutdown() {
-    // todo: do we really need a lock around this check? This is on the hot path of tracing.
-    synchronized (lock) {
-      return shutdownResult != null;
-    }
+    return shutdownResult != null;
   }
 
   /**


### PR DESCRIPTION
This changes the logic so that we only need to have called shutdown on the TracerSharedState, not that it has successfully shut down. Otherwise, a failed shutdown would continue to produce spans when it shouldn't be.