### PR TITLE
Cleanup usages of TraceState and TraceFlags

### DIFF
--- a/api/all/src/jmh/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagatorInjectBenchmark.java
+++ b/api/all/src/jmh/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagatorInjectBenchmark.java
@@ -62,9 +62,7 @@ public class W3CTraceContextPropagatorInjectBenchmark {
   }
 
   private static SpanContext createTestSpanContext(String traceId, String spanId) {
-    byte sampledTraceOptions = TraceFlags.getSampled();
-    TraceState traceStateDefault = TraceState.builder().build();
-    return SpanContext.create(traceId, spanId, sampledTraceOptions, traceStateDefault);
+    return SpanContext.create(traceId, spanId, TraceFlags.getSampled(), TraceState.getDefault());
   }
 
   private static List<Context> createContexts(List<SpanContext> spanContexts) {

--- a/api/all/src/main/java/io/opentelemetry/api/trace/TraceState.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/TraceState.java
@@ -39,7 +39,9 @@ public interface TraceState {
   /**
    * Returns the default {@code TraceState} with no entries.
    *
-   * @return the default {@code TraceState}.
+   * <p>This method is equivalent to calling {@code #builder().build()}, but avoids new allocations.
+   *
+   * @return the default {@code TraceState} with no entries.
    */
   static TraceState getDefault() {
     return DefaultTraceState.get();

--- a/api/all/src/main/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagator.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagator.java
@@ -39,7 +39,6 @@ import javax.annotation.concurrent.Immutable;
 public final class W3CTraceContextPropagator implements TextMapPropagator {
   private static final Logger logger = Logger.getLogger(W3CTraceContextPropagator.class.getName());
 
-  private static final TraceState TRACE_STATE_DEFAULT = TraceState.builder().build();
   static final String TRACE_PARENT = "traceparent";
   static final String TRACE_STATE = "tracestate";
   private static final List<String> FIELDS =
@@ -215,7 +214,8 @@ public final class W3CTraceContextPropagator implements TextMapPropagator {
       String spanId = traceparent.substring(SPAN_ID_OFFSET, SPAN_ID_OFFSET + SpanId.getHexLength());
       if (TraceId.isValid(traceId) && SpanId.isValid(spanId)) {
         byte traceFlags = TraceFlags.byteFromHex(traceparent, TRACE_OPTION_OFFSET);
-        return SpanContext.createFromRemoteParent(traceId, spanId, traceFlags, TRACE_STATE_DEFAULT);
+        return SpanContext.createFromRemoteParent(
+            traceId, spanId, traceFlags, TraceState.getDefault());
       }
       return SpanContext.getInvalid();
     } catch (IllegalArgumentException e) {

--- a/api/all/src/test/java/io/opentelemetry/api/trace/SpanContextTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/trace/SpanContextTest.java
@@ -19,7 +19,6 @@ class SpanContextTest {
       TraceState.builder().set("foo", "bar").build();
   private static final TraceState SECOND_TRACE_STATE =
       TraceState.builder().set("foo", "baz").build();
-  private static final TraceState EMPTY_TRACE_STATE = TraceState.builder().build();
   private static final SpanContext first =
       SpanContext.create(FIRST_TRACE_ID, FIRST_SPAN_ID, TraceFlags.getDefault(), FIRST_TRACE_STATE);
   private static final SpanContext second =
@@ -27,7 +26,7 @@ class SpanContextTest {
           SECOND_TRACE_ID, SECOND_SPAN_ID, TraceFlags.getSampled(), SECOND_TRACE_STATE);
   private static final SpanContext remote =
       SpanContext.createFromRemoteParent(
-          SECOND_TRACE_ID, SECOND_SPAN_ID, TraceFlags.getSampled(), EMPTY_TRACE_STATE);
+          SECOND_TRACE_ID, SECOND_SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault());
 
   @Test
   void invalidSpanContext() {
@@ -41,12 +40,18 @@ class SpanContextTest {
     assertThat(SpanContext.getInvalid().isValid()).isFalse();
     assertThat(
             SpanContext.create(
-                    FIRST_TRACE_ID, SpanId.getInvalid(), TraceFlags.getDefault(), EMPTY_TRACE_STATE)
+                    FIRST_TRACE_ID,
+                    SpanId.getInvalid(),
+                    TraceFlags.getDefault(),
+                    TraceState.getDefault())
                 .isValid())
         .isFalse();
     assertThat(
             SpanContext.create(
-                    TraceId.getInvalid(), FIRST_SPAN_ID, TraceFlags.getDefault(), EMPTY_TRACE_STATE)
+                    TraceId.getInvalid(),
+                    FIRST_SPAN_ID,
+                    TraceFlags.getDefault(),
+                    TraceState.getDefault())
                 .isValid())
         .isFalse();
     assertThat(first.isValid()).isTrue();

--- a/api/all/src/test/java/io/opentelemetry/api/trace/TraceStateTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/trace/TraceStateTest.java
@@ -20,12 +20,12 @@ class TraceStateTest {
   private static final String FIRST_VALUE = "value.1";
   private static final String SECOND_VALUE = "value.2";
 
-  private static final TraceState EMPTY = TraceState.builder().build();
-  private final TraceState firstTraceState = EMPTY.toBuilder().set(FIRST_KEY, FIRST_VALUE).build();
+  private final TraceState firstTraceState =
+      TraceState.builder().set(FIRST_KEY, FIRST_VALUE).build();
   private final TraceState secondTraceState =
-      EMPTY.toBuilder().set(SECOND_KEY, SECOND_VALUE).build();
+      TraceState.builder().set(SECOND_KEY, SECOND_VALUE).build();
   private final TraceState multiValueTraceState =
-      EMPTY.toBuilder().set(FIRST_KEY, FIRST_VALUE).set(SECOND_KEY, SECOND_VALUE).build();
+      TraceState.builder().set(FIRST_KEY, FIRST_VALUE).set(SECOND_KEY, SECOND_VALUE).build();
 
   @Test
   void get() {
@@ -38,8 +38,8 @@ class TraceStateTest {
 
   @Test
   void sizeAndEmpty() {
-    assertThat(EMPTY.size()).isZero();
-    assertThat(EMPTY.isEmpty()).isTrue();
+    assertThat(TraceState.getDefault().size()).isZero();
+    assertThat(TraceState.getDefault().isEmpty()).isTrue();
 
     assertThat(firstTraceState.size()).isOne();
     assertThat(firstTraceState.isEmpty()).isFalse();
@@ -78,52 +78,57 @@ class TraceStateTest {
 
   @Test
   void disallowsNullKey() {
-    assertThat(EMPTY.toBuilder().set(null, FIRST_VALUE).build()).isEqualTo(EMPTY);
+    assertThat(TraceState.builder().set(null, FIRST_VALUE).build())
+        .isEqualTo(TraceState.getDefault());
   }
 
   @Test
   void disallowsEmptyKey() {
-    assertThat(EMPTY.toBuilder().set("", FIRST_VALUE).build()).isEqualTo(EMPTY);
+    assertThat(TraceState.builder().set("", FIRST_VALUE).build())
+        .isEqualTo(TraceState.getDefault());
   }
 
   @Test
   void invalidFirstKeyCharacter() {
-    assertThat(EMPTY.toBuilder().set("$_key", FIRST_VALUE).build()).isEqualTo(EMPTY);
+    assertThat(TraceState.builder().set("$_key", FIRST_VALUE).build())
+        .isEqualTo(TraceState.getDefault());
   }
 
   @Test
   void firstKeyCharacterDigitIsAllowed() {
     // note: a digit is only allowed if the key is in the tenant format (with an '@')
-    TraceState result = EMPTY.toBuilder().set("1@tenant", FIRST_VALUE).build();
+    TraceState result = TraceState.builder().set("1@tenant", FIRST_VALUE).build();
     assertThat(result.get("1@tenant")).isEqualTo(FIRST_VALUE);
   }
 
   @Test
   void testValidLongTenantId() {
-    TraceState result = EMPTY.toBuilder().set("12345678901234567890@nr", FIRST_VALUE).build();
+    TraceState result = TraceState.builder().set("12345678901234567890@nr", FIRST_VALUE).build();
     assertThat(result.get("12345678901234567890@nr")).isEqualTo(FIRST_VALUE);
   }
 
   @Test
   void invalidKeyCharacters() {
-    assertThat(EMPTY.toBuilder().set("kEy_1", FIRST_VALUE).build()).isEqualTo(EMPTY);
+    assertThat(TraceState.builder().set("kEy_1", FIRST_VALUE).build())
+        .isEqualTo(TraceState.getDefault());
   }
 
   @Test
   void testValidAtSignVendorNamePrefix() {
-    TraceState result = EMPTY.toBuilder().set("1@nr", FIRST_VALUE).build();
+    TraceState result = TraceState.builder().set("1@nr", FIRST_VALUE).build();
     assertThat(result.get("1@nr")).isEqualTo(FIRST_VALUE);
   }
 
   @Test
   void testVendorIdLongerThan13Characters() {
-    assertThat(EMPTY.toBuilder().set("1@nrabcdefghijkl", FIRST_VALUE).build()).isEqualTo(EMPTY);
+    assertThat(TraceState.builder().set("1@nrabcdefghijkl", FIRST_VALUE).build())
+        .isEqualTo(TraceState.getDefault());
   }
 
   @Test
   void testVendorIdLongerThan13Characters_longTenantId() {
-    assertThat(EMPTY.toBuilder().set("12345678901234567890@nrabcdefghijkl", FIRST_VALUE).build())
-        .isEqualTo(EMPTY);
+    assertThat(TraceState.builder().set("12345678901234567890@nrabcdefghijkl", FIRST_VALUE).build())
+        .isEqualTo(TraceState.getDefault());
   }
 
   @Test
@@ -131,17 +136,20 @@ class TraceStateTest {
     char[] chars = new char[241];
     Arrays.fill(chars, 'a');
     String tenantId = new String(chars);
-    assertThat(EMPTY.toBuilder().set(tenantId + "@nr", FIRST_VALUE).build()).isEqualTo(EMPTY);
+    assertThat(TraceState.builder().set(tenantId + "@nr", FIRST_VALUE).build())
+        .isEqualTo(TraceState.getDefault());
   }
 
   @Test
   void testNonVendorFormatFirstKeyCharacter() {
-    assertThat(EMPTY.toBuilder().set("1acdfrgs", FIRST_VALUE).build()).isEqualTo(EMPTY);
+    assertThat(TraceState.builder().set("1acdfrgs", FIRST_VALUE).build())
+        .isEqualTo(TraceState.getDefault());
   }
 
   @Test
   void testMultipleAtSignNotAllowed() {
-    assertThat(EMPTY.toBuilder().set("1@n@r@", FIRST_VALUE).build()).isEqualTo(EMPTY);
+    assertThat(TraceState.builder().set("1@n@r@", FIRST_VALUE).build())
+        .isEqualTo(TraceState.getDefault());
   }
 
   @Test
@@ -149,7 +157,8 @@ class TraceStateTest {
     char[] chars = new char[257];
     Arrays.fill(chars, 'a');
     String longKey = new String(chars);
-    assertThat(EMPTY.toBuilder().set(longKey, FIRST_VALUE).build()).isEqualTo(EMPTY);
+    assertThat(TraceState.builder().set(longKey, FIRST_VALUE).build())
+        .isEqualTo(TraceState.getDefault());
   }
 
   @Test
@@ -166,28 +175,8 @@ class TraceStateTest {
     stringBuilder.append('*');
     stringBuilder.append('/');
     String allowedKey = stringBuilder.toString();
-    assertThat(EMPTY.toBuilder().set(allowedKey, FIRST_VALUE).build().get(allowedKey))
+    assertThat(TraceState.builder().set(allowedKey, FIRST_VALUE).build().get(allowedKey))
         .isEqualTo(FIRST_VALUE);
-  }
-
-  @Test
-  void disallowsNullValue() {
-    assertThat(EMPTY.toBuilder().set(FIRST_KEY, null).build()).isEqualTo(EMPTY);
-  }
-
-  @Test
-  void valueCannotContainEqual() {
-    assertThat(EMPTY.toBuilder().set(FIRST_KEY, "my_vakue=5").build()).isEqualTo(EMPTY);
-  }
-
-  @Test
-  void valueCannotContainComma() {
-    assertThat(EMPTY.toBuilder().set(FIRST_KEY, "first,second").build()).isEqualTo(EMPTY);
-  }
-
-  @Test
-  void valueCannotContainTrailingSpaces() {
-    assertThat(EMPTY.toBuilder().set(FIRST_KEY, "first ").build()).isEqualTo(EMPTY);
   }
 
   @Test
@@ -195,7 +184,8 @@ class TraceStateTest {
     char[] chars = new char[257];
     Arrays.fill(chars, 'a');
     String longValue = new String(chars);
-    assertThat(EMPTY.toBuilder().set(FIRST_KEY, longValue).build()).isEqualTo(EMPTY);
+    assertThat(TraceState.builder().set(FIRST_KEY, longValue).build())
+        .isEqualTo(TraceState.getDefault());
   }
 
   @Test
@@ -208,17 +198,22 @@ class TraceStateTest {
       stringBuilder.append(c);
     }
     String allowedValue = stringBuilder.toString();
-    assertThat(EMPTY.toBuilder().set(FIRST_KEY, allowedValue).build().get(FIRST_KEY))
+    assertThat(TraceState.builder().set(FIRST_KEY, allowedValue).build().get(FIRST_KEY))
         .isEqualTo(allowedValue);
   }
 
   @Test
   @SuppressWarnings("checkstyle:AvoidEscapedUnicodeCharacters")
-  void notAllowedValueCharacters() {
-    assertThat(TraceState.builder().set("foo", "bar,").build()).isEqualTo(EMPTY);
-    assertThat(TraceState.builder().set("foo", "bar=").build()).isEqualTo(EMPTY);
-    assertThat(TraceState.builder().set("foo", "bar\u0019").build()).isEqualTo(EMPTY);
-    assertThat(TraceState.builder().set("foo", "bar\u007F").build()).isEqualTo(EMPTY);
+  void invalidValues() {
+    assertThat(TraceState.builder().set(FIRST_KEY, null).build())
+        .isEqualTo(TraceState.getDefault());
+    assertThat(TraceState.builder().set("foo", "bar,").build()).isEqualTo(TraceState.getDefault());
+    assertThat(TraceState.builder().set("foo", "bar ").build()).isEqualTo(TraceState.getDefault());
+    assertThat(TraceState.builder().set("foo", "bar=").build()).isEqualTo(TraceState.getDefault());
+    assertThat(TraceState.builder().set("foo", "bar\u0019").build())
+        .isEqualTo(TraceState.getDefault());
+    assertThat(TraceState.builder().set("foo", "bar\u007F").build())
+        .isEqualTo(TraceState.getDefault());
   }
 
   @Test
@@ -253,7 +248,7 @@ class TraceStateTest {
   @Test
   void addSameKey() {
     assertThat(
-            EMPTY.toBuilder()
+            TraceState.builder()
                 .set(FIRST_KEY, SECOND_VALUE) // update the existing entry
                 .set(FIRST_KEY, FIRST_VALUE) // add a new entry
                 .build())
@@ -272,11 +267,11 @@ class TraceStateTest {
   @Test
   void addAndRemoveEntry() {
     assertThat(
-            EMPTY.toBuilder()
+            TraceState.builder()
                 .set(FIRST_KEY, SECOND_VALUE) // update the existing entry
                 .remove(FIRST_KEY) // add a new entry
                 .build())
-        .isEqualTo(EMPTY);
+        .isEqualTo(TraceState.getDefault());
   }
 
   @Test
@@ -288,15 +283,20 @@ class TraceStateTest {
   @Test
   void traceState_EqualsAndHashCode() {
     EqualsTester tester = new EqualsTester();
-    tester.addEqualityGroup(EMPTY, EMPTY);
-    tester.addEqualityGroup(firstTraceState, EMPTY.toBuilder().set(FIRST_KEY, FIRST_VALUE).build());
     tester.addEqualityGroup(
-        secondTraceState, EMPTY.toBuilder().set(SECOND_KEY, SECOND_VALUE).build());
+        TraceState.getDefault(),
+        TraceState.getDefault(),
+        TraceState.getDefault().toBuilder().build(),
+        TraceState.builder().build());
+    tester.addEqualityGroup(
+        firstTraceState, TraceState.builder().set(FIRST_KEY, FIRST_VALUE).build());
+    tester.addEqualityGroup(
+        secondTraceState, TraceState.builder().set(SECOND_KEY, SECOND_VALUE).build());
     tester.testEquals();
   }
 
   @Test
   void traceState_ToString() {
-    assertThat(EMPTY.toString()).isEqualTo("ArrayBasedTraceState{entries=[]}");
+    assertThat(TraceState.getDefault().toString()).isEqualTo("ArrayBasedTraceState{entries=[]}");
   }
 }

--- a/api/all/src/test/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagatorTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagatorTest.java
@@ -28,8 +28,7 @@ import org.junit.jupiter.api.Test;
 /** Unit tests for {@link W3CTraceContextPropagator}. */
 class W3CTraceContextPropagatorTest {
 
-  private static final TraceState TRACE_STATE_DEFAULT = TraceState.builder().build();
-  private static final TraceState TRACE_STATE_NOT_DEFAULT =
+  private static final TraceState TRACE_STATE =
       TraceState.builder().set("foo", "bar").set("bar", "baz").build();
   private static final String TRACE_ID_BASE16 = "ff000000000000000000000000000041";
   private static final String SPAN_ID_BASE16 = "ff00000000000041";
@@ -80,7 +79,7 @@ class W3CTraceContextPropagatorTest {
     Context context =
         withSpanContext(
             SpanContext.create(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TraceState.getDefault()),
             Context.current());
     w3cTraceContextPropagator.inject(
         context,
@@ -112,7 +111,7 @@ class W3CTraceContextPropagatorTest {
     Context context =
         withSpanContext(
             SpanContext.create(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TraceState.getDefault()),
             Context.current());
     w3cTraceContextPropagator.inject(context, carrier, setter);
     assertThat(carrier)
@@ -125,7 +124,7 @@ class W3CTraceContextPropagatorTest {
     Context context =
         withSpanContext(
             SpanContext.create(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE_DEFAULT),
+                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TraceState.getDefault()),
             Context.current());
     w3cTraceContextPropagator.inject(context, carrier, setter);
     assertThat(carrier)
@@ -138,8 +137,7 @@ class W3CTraceContextPropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     Context context =
         withSpanContext(
-            SpanContext.create(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE_NOT_DEFAULT),
+            SpanContext.create(TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE),
             Context.current());
     w3cTraceContextPropagator.inject(context, carrier, setter);
     assertThat(carrier)
@@ -154,7 +152,7 @@ class W3CTraceContextPropagatorTest {
     Context context =
         withSpanContext(
             SpanContext.create(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE_NOT_DEFAULT),
+                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE),
             Context.current());
     w3cTraceContextPropagator.inject(context, carrier, setter);
     assertThat(carrier)
@@ -178,7 +176,7 @@ class W3CTraceContextPropagatorTest {
             getSpanContext(w3cTraceContextPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TraceState.getDefault()));
   }
 
   @Test
@@ -189,7 +187,7 @@ class W3CTraceContextPropagatorTest {
             getSpanContext(w3cTraceContextPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TraceState.getDefault()));
   }
 
   @Test
@@ -211,7 +209,7 @@ class W3CTraceContextPropagatorTest {
             getSpanContext(w3cTraceContextPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TraceState.getDefault()));
   }
 
   @Test
@@ -223,7 +221,7 @@ class W3CTraceContextPropagatorTest {
             getSpanContext(w3cTraceContextPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE_NOT_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE));
   }
 
   @Test
@@ -235,7 +233,7 @@ class W3CTraceContextPropagatorTest {
             getSpanContext(w3cTraceContextPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE_NOT_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE));
   }
 
   @Test
@@ -248,7 +246,7 @@ class W3CTraceContextPropagatorTest {
             getSpanContext(w3cTraceContextPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TraceState.getDefault()));
   }
 
   @Test
@@ -260,7 +258,7 @@ class W3CTraceContextPropagatorTest {
             getSpanContext(w3cTraceContextPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TraceState.getDefault()));
   }
 
   @Test
@@ -272,7 +270,7 @@ class W3CTraceContextPropagatorTest {
             getSpanContext(w3cTraceContextPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE_NOT_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE));
   }
 
   @Test
@@ -401,7 +399,7 @@ class W3CTraceContextPropagatorTest {
                 w3cTraceContextPropagator.extract(Context.current(), invalidHeaders, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TraceState.getDefault()));
   }
 
   @Test
@@ -416,7 +414,7 @@ class W3CTraceContextPropagatorTest {
                 w3cTraceContextPropagator.extract(Context.current(), invalidHeaders, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TraceState.getDefault()));
   }
 
   @Test
@@ -431,7 +429,7 @@ class W3CTraceContextPropagatorTest {
                 w3cTraceContextPropagator.extract(Context.current(), invalidHeaders, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_OPTIONS, TraceState.getDefault()));
   }
 
   @Test
@@ -469,7 +467,7 @@ class W3CTraceContextPropagatorTest {
                 w3cTraceContextPropagator.extract(Context.current(), invalidHeaders, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TraceState.getDefault()));
   }
 
   @Test

--- a/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/AdapterTest.java
+++ b/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/AdapterTest.java
@@ -300,8 +300,7 @@ class AdapterTest {
   }
 
   private static SpanContext createSpanContext(String traceId, String spanId) {
-    return SpanContext.create(
-        traceId, spanId, TraceFlags.getDefault(), TraceState.builder().build());
+    return SpanContext.create(traceId, spanId, TraceFlags.getDefault(), TraceState.getDefault());
   }
 
   @Nullable

--- a/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftSpanExporterTest.java
+++ b/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftSpanExporterTest.java
@@ -48,10 +48,9 @@ class JaegerThriftSpanExporterTest {
   private static final String SPAN_ID = "00000f0000def456";
   private static final String SPAN_ID_2 = "00a0000000aef789";
   private static final SpanContext SPAN_CONTEXT =
-      SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.builder().build());
+      SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault());
   private static final SpanContext SPAN_CONTEXT_2 =
-      SpanContext.create(
-          TRACE_ID, SPAN_ID_2, TraceFlags.getDefault(), TraceState.builder().build());
+      SpanContext.create(TRACE_ID, SPAN_ID_2, TraceFlags.getDefault(), TraceState.getDefault());
 
   private JaegerThriftSpanExporter exporter;
   @Mock private ThriftSender thriftSender;

--- a/exporters/otlp/trace/src/jmh/java/io/opentelemetry/exporter/otlp/trace/RequestMarshalState.java
+++ b/exporters/otlp/trace/src/jmh/java/io/opentelemetry/exporter/otlp/trace/RequestMarshalState.java
@@ -53,10 +53,8 @@ public class RequestMarshalState {
   private static final byte[] SPAN_ID_BYTES =
       new byte[] {(byte) 198, (byte) 245, (byte) 213, (byte) 156, 46, 31, 29, 101};
   private static final String SPAN_ID = SpanId.bytesToHex(SPAN_ID_BYTES);
-
-  private static final TraceState TRACE_STATE = TraceState.builder().build();
   private static final SpanContext SPAN_CONTEXT =
-      SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TRACE_STATE);
+      SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault());
 
   @Param({"16"})
   int numSpans;

--- a/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterTest.java
@@ -254,8 +254,7 @@ class OtlpGrpcSpanExporterTest {
     return TestSpanData.builder()
         .setHasEnded(true)
         .setSpanContext(
-            SpanContext.create(
-                TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.builder().build()))
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()))
         .setName("GET /api/endpoint")
         .setStartEpochNanos(startNs)
         .setEndEpochNanos(endNs)

--- a/extensions/trace-propagators/src/jmh/java/io/opentelemetry/extension/trace/propagation/PropagatorContextInjectBenchmark.java
+++ b/extensions/trace-propagators/src/jmh/java/io/opentelemetry/extension/trace/propagation/PropagatorContextInjectBenchmark.java
@@ -74,8 +74,7 @@ public class PropagatorContextInjectBenchmark {
     }
 
     private static SpanContext createTestSpanContext(String traceId, String spanId) {
-      TraceState traceStateDefault = TraceState.builder().build();
-      return SpanContext.create(traceId, spanId, TraceFlags.getSampled(), traceStateDefault);
+      return SpanContext.create(traceId, spanId, TraceFlags.getSampled(), TraceState.getDefault());
     }
   }
 

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/Common.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/Common.java
@@ -26,8 +26,6 @@ final class Common {
   static final String FALSE_INT = "0";
   static final int MAX_TRACE_ID_LENGTH = TraceId.getHexLength();
   static final int MIN_TRACE_ID_LENGTH = MAX_TRACE_ID_LENGTH / 2;
-  private static final byte SAMPLED = TraceFlags.getSampled();
-  private static final byte NOT_SAMPLED = TraceFlags.getDefault();
 
   private Common() {}
 
@@ -35,8 +33,8 @@ final class Common {
     try {
       byte traceFlags =
           TRUE_INT.equals(sampled) || Boolean.parseBoolean(sampled) // accept either "1" or "true"
-              ? SAMPLED
-              : NOT_SAMPLED;
+              ? TraceFlags.getSampled()
+              : TraceFlags.getDefault();
 
       return SpanContext.createFromRemoteParent(
           StringUtils.padLeft(traceId, MAX_TRACE_ID_LENGTH),

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/JaegerPropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/JaegerPropagator.java
@@ -62,11 +62,7 @@ public final class JaegerPropagator implements TextMapPropagator {
       PARENT_SPAN_ID_OFFSET + PARENT_SPAN_ID_SIZE + PROPAGATION_HEADER_DELIMITER_SIZE;
   private static final int PROPAGATION_HEADER_SIZE = SAMPLED_FLAG_OFFSET + SAMPLED_FLAG_SIZE;
 
-  private static final byte SAMPLED = TraceFlags.getSampled();
-  private static final byte NOT_SAMPLED = TraceFlags.getDefault();
-
   private static final Collection<String> FIELDS = Collections.singletonList(PROPAGATION_HEADER);
-
   private static final JaegerPropagator INSTANCE = new JaegerPropagator();
 
   private JaegerPropagator() {
@@ -243,7 +239,7 @@ public final class JaegerPropagator implements TextMapPropagator {
   private static SpanContext buildSpanContext(String traceId, String spanId, String flags) {
     try {
       int flagsInt = Integer.parseInt(flags);
-      byte traceFlags = ((flagsInt & 1) == 1) ? SAMPLED : NOT_SAMPLED;
+      byte traceFlags = ((flagsInt & 1) == 1) ? TraceFlags.getSampled() : TraceFlags.getDefault();
 
       String otelTraceId = StringUtils.padLeft(traceId, MAX_TRACE_ID_LENGTH);
       String otelSpanId = StringUtils.padLeft(spanId, MAX_SPAN_ID_LENGTH);

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/AwsXrayPropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/AwsXrayPropagatorTest.java
@@ -22,11 +22,8 @@ import org.junit.jupiter.api.Test;
 
 class AwsXrayPropagatorTest {
 
-  private static final String TRACE_ID_BASE16 = "8a3c60f7d188f8fa79d48a391a778fa6";
-  private static final TraceState TRACE_STATE_DEFAULT = TraceState.getDefault();
-
-  private static final String SPAN_ID_BASE16 = "53995c3f42cd8ad8";
-  private static final byte SAMPLED_TRACE_FLAG = TraceFlags.getSampled();
+  private static final String TRACE_ID = "8a3c60f7d188f8fa79d48a391a778fa6";
+  private static final String SPAN_ID = "53995c3f42cd8ad8";
 
   private static final TextMapPropagator.Setter<Map<String, String>> setter = Map::put;
   private static final TextMapPropagator.Getter<Map<String, String>> getter =
@@ -49,8 +46,7 @@ class AwsXrayPropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     xrayPropagator.inject(
         withSpanContext(
-            SpanContext.create(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_FLAG, TRACE_STATE_DEFAULT),
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()),
             Context.current()),
         carrier,
         setter);
@@ -66,8 +62,7 @@ class AwsXrayPropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     xrayPropagator.inject(
         withSpanContext(
-            SpanContext.create(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE_DEFAULT),
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()),
             Context.current()),
         carrier,
         setter);
@@ -84,8 +79,8 @@ class AwsXrayPropagatorTest {
     xrayPropagator.inject(
         withSpanContext(
             SpanContext.create(
-                TRACE_ID_BASE16,
-                SPAN_ID_BASE16,
+                TRACE_ID,
+                SPAN_ID,
                 TraceFlags.getDefault(),
                 TraceState.builder().set("foo", "bar").build()),
             Context.current()),
@@ -118,7 +113,7 @@ class AwsXrayPropagatorTest {
     assertThat(getSpanContext(xrayPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_FLAG, TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -131,7 +126,7 @@ class AwsXrayPropagatorTest {
     assertThat(getSpanContext(xrayPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()));
   }
 
   @Test
@@ -144,7 +139,7 @@ class AwsXrayPropagatorTest {
     assertThat(getSpanContext(xrayPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_FLAG, TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -158,7 +153,7 @@ class AwsXrayPropagatorTest {
     assertThat(getSpanContext(xrayPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID_BASE16, SPAN_ID_BASE16, SAMPLED_TRACE_FLAG, TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/B3PropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/B3PropagatorTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 /** Unit tests for {@link B3Propagator}. */
 class B3PropagatorTest {
 
-  private static final TraceState TRACE_STATE_DEFAULT = TraceState.builder().build();
   private static final String TRACE_ID = "ff000000000000000000000000000041";
   private static final String EXTRA_TRACE_ID = "ff000000000000000000000000000045";
   private static final String TRACE_ID_ALL_ZERO = "00000000000000000000000000000000";
@@ -37,7 +36,6 @@ class B3PropagatorTest {
   private static final String SPAN_ID = "ff00000000000041";
   private static final String EXTRA_SPAN_ID = "ff00000000000045";
   private static final String SPAN_ID_ALL_ZERO = "0000000000000000";
-  private static final byte SAMPLED_TRACE_OPTIONS = TraceFlags.getSampled();
   private static final Setter<Map<String, String>> setter = Map::put;
   private static final Getter<Map<String, String>> getter =
       new Getter<Map<String, String>>() {
@@ -71,7 +69,7 @@ class B3PropagatorTest {
             SpanContext.create(
                 TraceId.getInvalid(),
                 SpanId.getInvalid(),
-                SAMPLED_TRACE_OPTIONS,
+                TraceFlags.getSampled(),
                 TraceState.builder().set("foo", "bar").build()),
             Context.current()),
         carrier,
@@ -84,7 +82,7 @@ class B3PropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     b3Propagator.inject(
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()),
             Context.current()),
         carrier,
         setter);
@@ -98,7 +96,7 @@ class B3PropagatorTest {
     final Map<String, String> carrier = new LinkedHashMap<>();
     b3Propagator.inject(
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()),
             Context.current()),
         null,
         (Setter<Map<String, String>>) (ignored, key, value) -> carrier.put(key, value));
@@ -112,7 +110,7 @@ class B3PropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     b3Propagator.inject(
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT),
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()),
             Context.current()),
         carrier,
         setter);
@@ -139,7 +137,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -152,7 +150,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -165,7 +163,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()));
   }
 
   @Test
@@ -178,7 +176,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                SHORT_TRACE_ID_FULL, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -191,7 +189,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                SHORT_TRACE_ID_FULL, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -204,7 +202,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                SHORT_TRACE_ID_FULL, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()));
   }
 
   @Test
@@ -295,7 +293,7 @@ class B3PropagatorTest {
             SpanContext.create(
                 TraceId.getInvalid(),
                 SpanId.getInvalid(),
-                SAMPLED_TRACE_OPTIONS,
+                TraceFlags.getSampled(),
                 TraceState.builder().set("foo", "bar").build()),
             Context.current()),
         carrier,
@@ -308,7 +306,7 @@ class B3PropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     b3PropagatorSingleHeader.inject(
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()),
             Context.current()),
         carrier,
         setter);
@@ -322,7 +320,7 @@ class B3PropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     b3PropagatorSingleHeader.inject(
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT),
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()),
             Context.current()),
         carrier,
         setter);
@@ -347,7 +345,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -359,7 +357,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -370,7 +368,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -381,7 +379,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -392,7 +390,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()));
   }
 
   @Test
@@ -404,7 +402,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                SHORT_TRACE_ID_FULL, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -417,7 +415,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                SHORT_TRACE_ID_FULL, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -428,7 +426,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                SHORT_TRACE_ID_FULL, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -440,7 +438,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                SHORT_TRACE_ID_FULL, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -452,7 +450,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                SHORT_TRACE_ID_FULL, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()));
   }
 
   @Test
@@ -546,7 +544,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -561,7 +559,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                EXTRA_TRACE_ID, EXTRA_SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                EXTRA_TRACE_ID, EXTRA_SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -611,7 +609,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(context))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
     assertTrue(context.get(DEBUG_CONTEXT_KEY));
   }
 
@@ -626,7 +624,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(context))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
     assertTrue(context.get(DEBUG_CONTEXT_KEY));
   }
 
@@ -642,7 +640,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(context))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
     assertTrue(context.get(DEBUG_CONTEXT_KEY));
   }
 
@@ -658,7 +656,7 @@ class B3PropagatorTest {
     assertThat(getSpanContext(context))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
     assertTrue(context.get(DEBUG_CONTEXT_KEY));
   }
 
@@ -668,7 +666,7 @@ class B3PropagatorTest {
     Context context = Context.current().with(DEBUG_CONTEXT_KEY, true);
     b3Propagator.inject(
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()),
             context),
         carrier,
         setter);
@@ -684,7 +682,7 @@ class B3PropagatorTest {
     Context context = Context.current().with(DEBUG_CONTEXT_KEY, true);
     b3PropagatorSingleHeader.inject(
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()),
             context),
         carrier,
         setter);

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/JaegerPropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/JaegerPropagatorTest.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.api.Test;
 /** Unit tests for {@link io.opentelemetry.extension.trace.propagation.JaegerPropagator}. */
 class JaegerPropagatorTest {
 
-  private static final TraceState TRACE_STATE_DEFAULT = TraceState.builder().build();
   private static final long TRACE_ID_HI = 77L;
   private static final long TRACE_ID_LOW = 22L;
   private static final String TRACE_ID_BASE16 = "000000000000004d0000000000000016";
@@ -51,7 +50,6 @@ class JaegerPropagatorTest {
   private static final long SPAN_ID_LONG = 97321L;
   private static final String SPAN_ID = SpanId.fromLong(SPAN_ID_LONG);
   private static final long DEPRECATED_PARENT_SPAN_LONG = 0L;
-  private static final byte SAMPLED_TRACE_OPTIONS = TraceFlags.getSampled();
   private static final TextMapPropagator.Setter<Map<String, String>> setter = Map::put;
   private static final TextMapPropagator.Getter<Map<String, String>> getter =
       new TextMapPropagator.Getter<Map<String, String>>() {
@@ -85,7 +83,7 @@ class JaegerPropagatorTest {
             SpanContext.create(
                 TraceId.getInvalid(),
                 SpanId.getInvalid(),
-                SAMPLED_TRACE_OPTIONS,
+                TraceFlags.getSampled(),
                 TraceState.builder().set("foo", "bar").build()),
             Context.current()),
         carrier,
@@ -98,7 +96,7 @@ class JaegerPropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     jaegerPropagator.inject(
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()),
             Context.current()),
         carrier,
         setter);
@@ -116,7 +114,7 @@ class JaegerPropagatorTest {
 
     jaegerPropagator.inject(
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()),
             Context.current()),
         null,
         (Setter<Map<String, String>>) (ignored, key, value) -> carrier.put(key, value));
@@ -133,7 +131,7 @@ class JaegerPropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     jaegerPropagator.inject(
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT),
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()),
             Context.current()),
         carrier,
         setter);
@@ -152,7 +150,7 @@ class JaegerPropagatorTest {
             .with(
                 Span.wrap(
                     SpanContext.create(
-                        TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT)))
+                        TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault())))
             .with(Baggage.builder().put("foo", "bar").build());
 
     jaegerPropagator.inject(context, carrier, setter);
@@ -311,7 +309,7 @@ class JaegerPropagatorTest {
     assertThat(getSpanContext(jaegerPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -325,7 +323,7 @@ class JaegerPropagatorTest {
     assertThat(getSpanContext(jaegerPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()));
   }
 
   @Test
@@ -343,7 +341,7 @@ class JaegerPropagatorTest {
     assertThat(getSpanContext(jaegerPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                SHORT_TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -358,7 +356,7 @@ class JaegerPropagatorTest {
     assertThat(getSpanContext(jaegerPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -373,7 +371,7 @@ class JaegerPropagatorTest {
     assertThat(getSpanContext(jaegerPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
     assertThat(fromContext(jaegerPropagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(Baggage.builder().put("foo", "bar").build());
   }

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/OtTracerPropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/OtTracerPropagatorTest.java
@@ -26,13 +26,11 @@ import org.junit.jupiter.api.Test;
 
 class OtTracerPropagatorTest {
 
-  private static final TraceState TRACE_STATE_DEFAULT = TraceState.builder().build();
   private static final String TRACE_ID = "ff000000000000000000000000000041";
   private static final String TRACE_ID_RIGHT_PART = "0000000000000041";
   private static final String SHORT_TRACE_ID = "ff00000000000000";
   private static final String SHORT_TRACE_ID_FULL = "0000000000000000ff00000000000000";
   private static final String SPAN_ID = "ff00000000000041";
-  private static final byte SAMPLED_TRACE_OPTIONS = TraceFlags.getSampled();
   private static final Setter<Map<String, String>> setter = Map::put;
   private static final Getter<Map<String, String>> getter =
       new Getter<Map<String, String>>() {
@@ -65,7 +63,7 @@ class OtTracerPropagatorTest {
             SpanContext.create(
                 TraceId.getInvalid(),
                 SpanId.getInvalid(),
-                SAMPLED_TRACE_OPTIONS,
+                TraceFlags.getSampled(),
                 TraceState.builder().set("foo", "bar").build()),
             Context.current()),
         carrier,
@@ -78,7 +76,7 @@ class OtTracerPropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     propagator.inject(
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()),
             Context.current()),
         carrier,
         setter);
@@ -92,7 +90,7 @@ class OtTracerPropagatorTest {
     final Map<String, String> carrier = new LinkedHashMap<>();
     propagator.inject(
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()),
             Context.current()),
         null,
         (Setter<Map<String, String>>) (ignored, key, value) -> carrier.put(key, value));
@@ -106,7 +104,7 @@ class OtTracerPropagatorTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     propagator.inject(
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT),
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()),
             Context.current()),
         carrier,
         setter);
@@ -121,7 +119,7 @@ class OtTracerPropagatorTest {
     Baggage baggage = Baggage.builder().put("foo", "bar").put("key", "value").build();
     propagator.inject(
         withSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT),
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()),
             Context.current().with(baggage)),
         carrier,
         setter);
@@ -138,8 +136,8 @@ class OtTracerPropagatorTest {
             SpanContext.create(
                 TraceId.getInvalid(),
                 SpanId.getInvalid(),
-                SAMPLED_TRACE_OPTIONS,
-                TRACE_STATE_DEFAULT),
+                TraceFlags.getSampled(),
+                TraceState.getDefault()),
             Context.current().with(baggage)),
         carrier,
         setter);
@@ -164,7 +162,7 @@ class OtTracerPropagatorTest {
     assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -177,7 +175,7 @@ class OtTracerPropagatorTest {
     assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -190,7 +188,7 @@ class OtTracerPropagatorTest {
     assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+                TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()));
   }
 
   @Test
@@ -203,7 +201,7 @@ class OtTracerPropagatorTest {
     assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                SHORT_TRACE_ID_FULL, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -216,7 +214,7 @@ class OtTracerPropagatorTest {
     assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                SHORT_TRACE_ID_FULL, SPAN_ID, SAMPLED_TRACE_OPTIONS, TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
   @Test
@@ -229,7 +227,7 @@ class OtTracerPropagatorTest {
     assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
             SpanContext.createFromRemoteParent(
-                SHORT_TRACE_ID_FULL, SPAN_ID, TraceFlags.getDefault(), TRACE_STATE_DEFAULT));
+                SHORT_TRACE_ID_FULL, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()));
   }
 
   @Test

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/RateLimitingSamplerTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/RateLimitingSamplerTest.java
@@ -27,17 +27,18 @@ class RateLimitingSamplerTest {
   private static final SpanKind SPAN_KIND = SpanKind.INTERNAL;
   private final String traceId = TraceId.fromLongs(150, 150);
   private final String parentSpanId = SpanId.fromLong(250);
-  private final TraceState traceState = TraceState.builder().build();
   private final Context sampledSpanContext =
       Context.root()
           .with(
               Span.wrap(
-                  SpanContext.create(traceId, parentSpanId, TraceFlags.getSampled(), traceState)));
+                  SpanContext.create(
+                      traceId, parentSpanId, TraceFlags.getSampled(), TraceState.getDefault())));
   private final Context notSampledSpanContext =
       Context.root()
           .with(
               Span.wrap(
-                  SpanContext.create(traceId, parentSpanId, TraceFlags.getDefault(), traceState)));
+                  SpanContext.create(
+                      traceId, parentSpanId, TraceFlags.getDefault(), TraceState.getDefault())));
 
   @Test
   void alwaysSampleSampledContext() {

--- a/sdk-extensions/otproto/src/test/java/io/opentelemetry/sdk/extension/otproto/SpanAdapterTest.java
+++ b/sdk-extensions/otproto/src/test/java/io/opentelemetry/sdk/extension/otproto/SpanAdapterTest.java
@@ -45,10 +45,8 @@ class SpanAdapterTest {
   private static final String TRACE_ID = TraceId.bytesToHex(TRACE_ID_BYTES);
   private static final byte[] SPAN_ID_BYTES = new byte[] {0, 0, 0, 0, 4, 3, 2, 1};
   private static final String SPAN_ID = SpanId.bytesToHex(SPAN_ID_BYTES);
-
-  private static final TraceState TRACE_STATE = TraceState.builder().build();
   private static final SpanContext SPAN_CONTEXT =
-      SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TRACE_STATE);
+      SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault());
 
   @Test
   void toProtoSpan() {

--- a/sdk-extensions/zpages/src/test/java/io/opentelemetry/sdk/extension/zpages/TracezSpanProcessorTest.java
+++ b/sdk-extensions/zpages/src/test/java/io/opentelemetry/sdk/extension/zpages/TracezSpanProcessorTest.java
@@ -36,7 +36,7 @@ class TracezSpanProcessorTest {
           TraceId.getInvalid(),
           SpanId.getInvalid(),
           TraceFlags.getSampled(),
-          TraceState.builder().build());
+          TraceState.getDefault());
   private static final SpanContext NOT_SAMPLED_SPAN_CONTEXT = SpanContext.getInvalid();
   private static final StatusData SPAN_STATUS = StatusData.error();
 

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/ParentBasedSamplerTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/ParentBasedSamplerTest.java
@@ -25,28 +25,28 @@ class ParentBasedSamplerTest {
   private final IdGenerator idsGenerator = IdGenerator.random();
   private final String traceId = idsGenerator.generateTraceId();
   private final String parentSpanId = idsGenerator.generateSpanId();
-  private final TraceState traceState = TraceState.builder().build();
   private final SpanContext sampledSpanContext =
-      SpanContext.create(traceId, parentSpanId, TraceFlags.getSampled(), traceState);
+      SpanContext.create(traceId, parentSpanId, TraceFlags.getSampled(), TraceState.getDefault());
   private final Context sampledParentContext = Context.root().with(Span.wrap(sampledSpanContext));
   private final Context notSampledParentContext =
       Context.root()
           .with(
               Span.wrap(
-                  SpanContext.create(traceId, parentSpanId, TraceFlags.getDefault(), traceState)));
+                  SpanContext.create(
+                      traceId, parentSpanId, TraceFlags.getDefault(), TraceState.getDefault())));
   private final Context invalidParentContext = Context.root().with(Span.getInvalid());
   private final Context sampledRemoteParentContext =
       Context.root()
           .with(
               Span.wrap(
                   SpanContext.createFromRemoteParent(
-                      traceId, parentSpanId, TraceFlags.getSampled(), traceState)));
+                      traceId, parentSpanId, TraceFlags.getSampled(), TraceState.getDefault())));
   private final Context notSampledRemoteParentContext =
       Context.root()
           .with(
               Span.wrap(
                   SpanContext.createFromRemoteParent(
-                      traceId, parentSpanId, TraceFlags.getDefault(), traceState)));
+                      traceId, parentSpanId, TraceFlags.getDefault(), TraceState.getDefault())));
 
   @Test
   void alwaysOn() {

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
@@ -57,7 +57,7 @@ class SimpleSpanProcessorTest {
           TraceId.getInvalid(),
           SpanId.getInvalid(),
           TraceFlags.getSampled(),
-          TraceState.builder().build());
+          TraceState.getDefault());
   private static final SpanContext NOT_SAMPLED_SPAN_CONTEXT = SpanContext.getInvalid();
 
   private SpanProcessor simpleSampledSpansProcessor;

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/samplers/AlwaysOffSamplerTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/samplers/AlwaysOffSamplerTest.java
@@ -25,15 +25,15 @@ class AlwaysOffSamplerTest {
   private final IdGenerator idsGenerator = IdGenerator.random();
   private final String traceId = idsGenerator.generateTraceId();
   private final String parentSpanId = idsGenerator.generateSpanId();
-  private final TraceState traceState = TraceState.builder().build();
   private final SpanContext sampledSpanContext =
-      SpanContext.create(traceId, parentSpanId, TraceFlags.getSampled(), traceState);
+      SpanContext.create(traceId, parentSpanId, TraceFlags.getSampled(), TraceState.getDefault());
   private final Context sampledParentContext = Context.root().with(Span.wrap(sampledSpanContext));
   private final Context notSampledParentContext =
       Context.root()
           .with(
               Span.wrap(
-                  SpanContext.create(traceId, parentSpanId, TraceFlags.getDefault(), traceState)));
+                  SpanContext.create(
+                      traceId, parentSpanId, TraceFlags.getDefault(), TraceState.getDefault())));
 
   @Test
   void parentNotSampled() {

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/samplers/AlwaysOnSamplerTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/samplers/AlwaysOnSamplerTest.java
@@ -25,15 +25,15 @@ class AlwaysOnSamplerTest {
   private final IdGenerator idsGenerator = IdGenerator.random();
   private final String traceId = idsGenerator.generateTraceId();
   private final String parentSpanId = idsGenerator.generateSpanId();
-  private final TraceState traceState = TraceState.builder().build();
   private final SpanContext sampledSpanContext =
-      SpanContext.create(traceId, parentSpanId, TraceFlags.getSampled(), traceState);
+      SpanContext.create(traceId, parentSpanId, TraceFlags.getSampled(), TraceState.getDefault());
   private final Context sampledParentContext = Context.root().with(Span.wrap(sampledSpanContext));
   private final Context notSampledParentContext =
       Context.root()
           .with(
               Span.wrap(
-                  SpanContext.create(traceId, parentSpanId, TraceFlags.getDefault(), traceState)));
+                  SpanContext.create(
+                      traceId, parentSpanId, TraceFlags.getDefault(), TraceState.getDefault())));
 
   @Test
   void parentSampled() {

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/samplers/TraceIdRatioBasedSamplerTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/samplers/TraceIdRatioBasedSamplerTest.java
@@ -31,15 +31,15 @@ class TraceIdRatioBasedSamplerTest {
 
   private final String traceId = idsGenerator.generateTraceId();
   private final String parentSpanId = idsGenerator.generateSpanId();
-  private final TraceState traceState = TraceState.builder().build();
   private final SpanContext sampledSpanContext =
-      SpanContext.create(traceId, parentSpanId, TraceFlags.getSampled(), traceState);
+      SpanContext.create(traceId, parentSpanId, TraceFlags.getSampled(), TraceState.getDefault());
   private final Context sampledParentContext = Context.root().with(Span.wrap(sampledSpanContext));
   private final Context notSampledParentContext =
       Context.root()
           .with(
               Span.wrap(
-                  SpanContext.create(traceId, parentSpanId, TraceFlags.getDefault(), traceState)));
+                  SpanContext.create(
+                      traceId, parentSpanId, TraceFlags.getDefault(), TraceState.getDefault())));
   private final Context invalidParentContext = Context.root().with(Span.getInvalid());
   private final LinkData sampledParentLink = LinkData.create(sampledSpanContext);
 


### PR DESCRIPTION
* Avoid calling TraceState.builder().build() and replace it with TraceState.getDefault();
* Avoid storing TraceFalgs.getDefault() and TraceFalgs.getSampler() and use them directly;

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>