### PR TITLE
[FEEDBACK REQUIRED] Cleanup TraceFlags, make it consistent with ids, but use byte as default

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/trace/BigendianEncoding.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/BigendianEncoding.java
@@ -149,7 +149,7 @@ final class BigendianEncoding {
     return decodeByte(chars.charAt(offset), chars.charAt(offset + 1));
   }
 
-  private static byte decodeByte(char hi, char lo) {
+  static byte decodeByte(char hi, char lo) {
     Utils.checkArgument(lo < ASCII_CHARACTERS && DECODING[lo] != -1, "invalid character " + lo);
     Utils.checkArgument(hi < ASCII_CHARACTERS && DECODING[hi] != -1, "invalid character " + hi);
     int decoded = DECODING[hi] << 4 | DECODING[lo];

--- a/api/all/src/main/java/io/opentelemetry/api/trace/SpanContext.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/SpanContext.java
@@ -96,15 +96,15 @@ public interface SpanContext {
 
   /** Whether the span in this context is sampled. */
   default boolean isSampled() {
-    return (getTraceFlags() & 1) == 1;
+    return TraceFlags.isSampled(getTraceFlags());
   }
 
-  /** The byte-representation of {@link TraceFlags}. */
+  /**
+   * Returns the trace flags associated with this {@link SpanContext} as byte representation.
+   *
+   * @return the trace flags associated with this {@link SpanContext} as byte representation.
+   */
   byte getTraceFlags();
-
-  default void copyTraceFlagsHexTo(char[] dest, int destOffset) {
-    BigendianEncoding.byteToBase16String(getTraceFlags(), dest, destOffset);
-  }
 
   /**
    * Returns the {@code TraceState} associated with this {@code SpanContext}.

--- a/api/all/src/main/java/io/opentelemetry/api/trace/TraceFlags.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/TraceFlags.java
@@ -8,47 +8,104 @@ package io.opentelemetry.api.trace;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * Helper methods for dealing with trace flags options. These options are propagated to all child
- * {@link Span spans}. These determine features such as whether a {@code Span} should be traced. It
- * is implemented as a bitmask.
+ * Helper methods for dealing with trace flags options. A valid trace flags is a byte.
+ *
+ * <p>These options are propagated to all child {@link Span spans}. These determine features such as
+ * whether a {@code Span} should be traced. It is implemented as a bitmask.
+ *
+ * <p>There is another representation that this class helps with:
+ *
+ * <ul>
+ *   <li>Hex: 2 lowercase hex (base16) characters.
+ * </ul>
  */
 @Immutable
 public final class TraceFlags {
   private TraceFlags() {}
 
   // Bit to represent whether trace is sampled or not.
-  private static final byte IS_SAMPLED = 0x1;
-  // the default flags are a 0 byte.
+  private static final byte SAMPLED_BIT = 0x1;
   private static final byte DEFAULT = 0x0;
-
   private static final int SIZE = 1;
-  private static final int HEX_SIZE = 2 * SIZE;
 
-  /** Returns the size in Hex of trace flags. */
-  public static int getHexLength() {
-    return HEX_SIZE;
+  /**
+   * Returns the length of byte representation of the {@code TraceFlags}.
+   *
+   * @return the length of byte representation of the {@code TraceFlags}.
+   */
+  public static int getLength() {
+    return SIZE;
   }
 
   /**
-   * Returns the default byte representation of the flags.
+   * Returns the default (with all flag bits off) byte representation of the {@code TraceFlags}.
    *
-   * @return the default byte representation of the flags.
+   * @return the default (with all flag bits off) byte representation of the {@code TraceFlags}.
    */
   public static byte getDefault() {
     return DEFAULT;
   }
 
   /**
-   * Returns the byte representation of the flags with the sampling bit set to {@code 1}.
+   * Returns the byte representation of the {@code TraceFlags} with the sampling flag bit on.
    *
-   * @return the byte representation of the flags with the sampling bit set to {@code 1}.
+   * @return the byte representation of the {@code TraceFlags} with the sampling flag bit on.
    */
   public static byte getSampled() {
-    return IS_SAMPLED;
+    return SAMPLED_BIT;
   }
 
-  /** Extract the byte representation of the flags from a hex-representation. */
-  public static byte byteFromHex(CharSequence src, int srcOffset) {
-    return BigendianEncoding.byteFromBase16String(src, srcOffset);
+  /**
+   * Returns {@code true} if the sampling bit is on for this byte representation of the {@code
+   * TraceFlags}, otherwise {@code false}.
+   *
+   * @param traceFlags the byte representation of the {@code TraceFlags}.
+   * @return {@code true} if the sampling bit is on for this byte representation of the {@code *
+   *     TraceFlags}, otherwise {@code false}.
+   */
+  public static boolean isSampled(byte traceFlags) {
+    return (traceFlags & SAMPLED_BIT) != 0;
+  }
+
+  /**
+   * Returns the byte representation of the {@code TraceFlags} converted from the given hex (base16)
+   * representation.
+   *
+   * @param first the first lowercase hex (base16) character {@code TraceFlags}.
+   * @param second the second lowercase hex (base16) character {@code TraceFlags}.
+   * @return the byte representation of the {@code TraceFlags}.
+   * @throws NullPointerException if {@code traceFlagsHex} is null.
+   * @throws IllegalArgumentException if not enough characters in the {@code traceFlagsHex}.
+   */
+  public static byte fromHexCharacters(char first, char second) {
+    return BigendianEncoding.decodeByte(first, second);
+  }
+
+  /**
+   * Returns the first lowercase hex (base16) character of the {@code TraceFlags} converted from the
+   * given hex (base16) representation.
+   *
+   * @param traceFlags the byte representation of the {@code TraceFlags}.
+   * @throws IllegalArgumentException if not enough characters in the {@code dest}.
+   */
+  public static char firstHexCharacter(byte traceFlags) {
+    // TODO: Optimize this if we go with this version.
+    char[] dest = new char[2];
+    BigendianEncoding.byteToBase16String(traceFlags, dest, 0);
+    return dest[0];
+  }
+
+  /**
+   * Returns the second lowercase hex (base16) character of the {@code TraceFlags} converted from
+   * the given hex (base16) representation.
+   *
+   * @param traceFlags the byte representation of the {@code TraceFlags}.
+   * @throws IllegalArgumentException if not enough characters in the {@code dest}.
+   */
+  public static char secondHexCharacter(byte traceFlags) {
+    // TODO: Optimize this if we go with this version.
+    char[] dest = new char[2];
+    BigendianEncoding.byteToBase16String(traceFlags, dest, 0);
+    return dest[0];
   }
 }

--- a/api/all/src/main/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagator.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagator.java
@@ -50,7 +50,7 @@ public final class W3CTraceContextPropagator implements TextMapPropagator {
   private static final int TRACEPARENT_DELIMITER_SIZE = 1;
   private static final int TRACE_ID_HEX_SIZE = TraceId.getHexLength();
   private static final int SPAN_ID_HEX_SIZE = SpanId.getHexLength();
-  private static final int TRACE_OPTION_HEX_SIZE = TraceFlags.getHexLength();
+  private static final int TRACE_OPTION_HEX_SIZE = 2 * TraceFlags.getLength();
   private static final int TRACE_ID_OFFSET = VERSION_SIZE + TRACEPARENT_DELIMITER_SIZE;
   private static final int SPAN_ID_OFFSET =
       TRACE_ID_OFFSET + TRACE_ID_HEX_SIZE + TRACEPARENT_DELIMITER_SIZE;
@@ -124,7 +124,8 @@ public final class W3CTraceContextPropagator implements TextMapPropagator {
     }
 
     chars[TRACE_OPTION_OFFSET - 1] = TRACEPARENT_DELIMITER;
-    spanContext.copyTraceFlagsHexTo(chars, TRACE_OPTION_OFFSET);
+    chars[TRACE_OPTION_OFFSET] = TraceFlags.firstHexCharacter(spanContext.getTraceFlags());
+    chars[TRACE_OPTION_OFFSET + 1] = TraceFlags.secondHexCharacter(spanContext.getTraceFlags());
     setter.set(carrier, TRACE_PARENT, new String(chars, 0, TRACEPARENT_HEADER_SIZE));
     TraceState traceState = spanContext.getTraceState();
     if (traceState.isEmpty()) {
@@ -213,7 +214,10 @@ public final class W3CTraceContextPropagator implements TextMapPropagator {
           traceparent.substring(TRACE_ID_OFFSET, TRACE_ID_OFFSET + TraceId.getHexLength());
       String spanId = traceparent.substring(SPAN_ID_OFFSET, SPAN_ID_OFFSET + SpanId.getHexLength());
       if (TraceId.isValid(traceId) && SpanId.isValid(spanId)) {
-        byte traceFlags = TraceFlags.byteFromHex(traceparent, TRACE_OPTION_OFFSET);
+        byte traceFlags =
+            TraceFlags.fromHexCharacters(
+                traceparent.charAt(TRACE_OPTION_OFFSET),
+                traceparent.charAt(TRACE_OPTION_OFFSET + 1));
         return SpanContext.createFromRemoteParent(
             traceId, spanId, traceFlags, TraceState.getDefault());
       }

--- a/api/all/src/test/java/io/opentelemetry/api/trace/TraceFlagsTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/trace/TraceFlagsTest.java
@@ -19,9 +19,9 @@ class TraceFlagsTest {
 
   @Test
   void toByteFromBase16() {
-    assertThat(TraceFlags.byteFromHex("ff", 0)).isEqualTo((byte) 0xff);
-    assertThat(TraceFlags.byteFromHex("01", 0)).isEqualTo((byte) 0x1);
-    assertThat(TraceFlags.byteFromHex("05", 0)).isEqualTo((byte) 0x5);
-    assertThat(TraceFlags.byteFromHex("00", 0)).isEqualTo((byte) 0x0);
+    assertThat(TraceFlags.fromHexCharacters('f', 'f')).isEqualTo((byte) 0xff);
+    assertThat(TraceFlags.fromHexCharacters('0', '1')).isEqualTo((byte) 0x1);
+    assertThat(TraceFlags.fromHexCharacters('0', '5')).isEqualTo((byte) 0x5);
+    assertThat(TraceFlags.fromHexCharacters('0', '0')).isEqualTo((byte) 0x0);
   }
 }


### PR DESCRIPTION
This uses 2 characters to represent the hex TraceFlags.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>

Alternative to https://github.com/open-telemetry/opentelemetry-java/pull/2698 that keeps the default representation as byte for TraceFlags.