### PR TITLE
Return Tracer from DefaultTracer.getInstance

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/trace/DefaultTracer.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/DefaultTracer.java
@@ -20,7 +20,7 @@ final class DefaultTracer implements Tracer {
 
   private static final DefaultTracer INSTANCE = new DefaultTracer();
 
-  static DefaultTracer getInstance() {
+  static Tracer getInstance() {
     return INSTANCE;
   }
 

--- a/api/all/src/main/java/io/opentelemetry/api/trace/DefaultTracer.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/DefaultTracer.java
@@ -18,7 +18,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 final class DefaultTracer implements Tracer {
 
-  private static final DefaultTracer INSTANCE = new DefaultTracer();
+  private static final Tracer INSTANCE = new DefaultTracer();
 
   static Tracer getInstance() {
     return INSTANCE;


### PR DESCRIPTION
There don't seem to be anymore instances where public class has method `getInstance` and returns interface. I found this one location where non-public class returns non-public class instead of interface, which is not consistent with our other such cases.

Fixes #2658