### PR TITLE
Remove Memoized for byte arrays. Byte-arrays are not immutable

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/trace/ImmutableSpanContext.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/ImmutableSpanContext.java
@@ -33,18 +33,6 @@ abstract class ImmutableSpanContext implements SpanContext {
 
   @Override
   @Memoized
-  public byte[] getTraceIdBytes() {
-    return SpanContext.super.getTraceIdBytes();
-  }
-
-  @Override
-  @Memoized
-  public byte[] getSpanIdBytes() {
-    return SpanContext.super.getSpanIdBytes();
-  }
-
-  @Override
-  @Memoized
   public boolean isValid() {
     return SpanContext.super.isValid();
   }


### PR DESCRIPTION
Updates https://github.com/open-telemetry/opentelemetry-java/issues/2623

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>