### PR TITLE
Rename OtTracerPropagator to OtTracePropagator.

### DIFF
--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/Common.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/Common.java
@@ -15,7 +15,7 @@ import java.util.logging.Logger;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * This set of common propagator utils is currently only used by the OtTracerPropagator and the
+ * This set of common propagator utils is currently only used by the OtTracePropagator and the
  * B3Propagator.
  */
 @Immutable

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/OtTracePropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/OtTracePropagator.java
@@ -21,14 +21,15 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * Implementation of the Lightstep propagation protocol. Context is propagated through 3 headers,
- * ot-tracer-traceid, ot-tracer-span-id, and ot-tracer-sampled. Baggage is not supported in this
- * implementation. IDs are sent as hex strings and sampled is sent as true or false. See <a
- * href=https://github.com/lightstep/lightstep-tracer-java-common/blob/master/common/src/main/java/com/lightstep/tracer/shared/TextMapPropagator.java>Lightstep
- * TextMapPropagator</a>.
+ * Implementation of the protocol used by OpenTracing Basic Tracers. Context is propagated through 3
+ * headers, ot-tracer-traceid, ot-tracer-span-id, and ot-tracer-sampled. IDs are sent as hex strings
+ * and sampled is sent as true or false. Baggage values are propagated using the ot-baggage- prefix.
+ * See <a
+ * href=https://github.com/opentracing/basictracer-python/blob/master/basictracer/text_propagator.py>OT
+ * Python Propagation TextMapPropagator</a>.
  */
 @Immutable
-public final class OtTracerPropagator implements TextMapPropagator {
+public final class OtTracePropagator implements TextMapPropagator {
 
   static final String TRACE_ID_HEADER = "ot-tracer-traceid";
   static final String SPAN_ID_HEADER = "ot-tracer-spanid";
@@ -37,13 +38,13 @@ public final class OtTracerPropagator implements TextMapPropagator {
   private static final Collection<String> FIELDS =
       Collections.unmodifiableList(Arrays.asList(TRACE_ID_HEADER, SPAN_ID_HEADER, SAMPLED_HEADER));
 
-  private static final OtTracerPropagator INSTANCE = new OtTracerPropagator();
+  private static final OtTracePropagator INSTANCE = new OtTracePropagator();
 
-  private OtTracerPropagator() {
+  private OtTracePropagator() {
     // singleton
   }
 
-  public static OtTracerPropagator getInstance() {
+  public static OtTracePropagator getInstance() {
     return INSTANCE;
   }
 
@@ -109,7 +110,7 @@ public final class OtTracerPropagator implements TextMapPropagator {
         if (value == null) {
           continue;
         }
-        baggageBuilder.put(key.replace(OtTracerPropagator.PREFIX_BAGGAGE_HEADER, ""), value);
+        baggageBuilder.put(key.replace(OtTracePropagator.PREFIX_BAGGAGE_HEADER, ""), value);
       }
       Baggage baggage = baggageBuilder.build();
       if (!baggage.isEmpty()) {

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/OtTracePropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/OtTracePropagatorTest.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 
-class OtTracerPropagatorTest {
+class OtTracePropagatorTest {
 
   private static final String TRACE_ID = "ff000000000000000000000000000041";
   private static final String TRACE_ID_RIGHT_PART = "0000000000000041";
@@ -45,7 +45,7 @@ class OtTracerPropagatorTest {
           return carrier.get(key);
         }
       };
-  private final OtTracerPropagator propagator = OtTracerPropagator.getInstance();
+  private final OtTracePropagator propagator = OtTracePropagator.getInstance();
 
   private static SpanContext getSpanContext(Context context) {
     return Span.fromContext(context).getSpanContext();
@@ -80,9 +80,9 @@ class OtTracerPropagatorTest {
             Context.current()),
         carrier,
         setter);
-    assertThat(carrier).containsEntry(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_RIGHT_PART);
-    assertThat(carrier).containsEntry(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
-    assertThat(carrier).containsEntry(OtTracerPropagator.SAMPLED_HEADER, "true");
+    assertThat(carrier).containsEntry(OtTracePropagator.TRACE_ID_HEADER, TRACE_ID_RIGHT_PART);
+    assertThat(carrier).containsEntry(OtTracePropagator.SPAN_ID_HEADER, SPAN_ID);
+    assertThat(carrier).containsEntry(OtTracePropagator.SAMPLED_HEADER, "true");
   }
 
   @Test
@@ -94,9 +94,9 @@ class OtTracerPropagatorTest {
             Context.current()),
         null,
         (Setter<Map<String, String>>) (ignored, key, value) -> carrier.put(key, value));
-    assertThat(carrier).containsEntry(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_RIGHT_PART);
-    assertThat(carrier).containsEntry(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
-    assertThat(carrier).containsEntry(OtTracerPropagator.SAMPLED_HEADER, "true");
+    assertThat(carrier).containsEntry(OtTracePropagator.TRACE_ID_HEADER, TRACE_ID_RIGHT_PART);
+    assertThat(carrier).containsEntry(OtTracePropagator.SPAN_ID_HEADER, SPAN_ID);
+    assertThat(carrier).containsEntry(OtTracePropagator.SAMPLED_HEADER, "true");
   }
 
   @Test
@@ -108,9 +108,9 @@ class OtTracerPropagatorTest {
             Context.current()),
         carrier,
         setter);
-    assertThat(carrier).containsEntry(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID_RIGHT_PART);
-    assertThat(carrier).containsEntry(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
-    assertThat(carrier).containsEntry(OtTracerPropagator.SAMPLED_HEADER, "false");
+    assertThat(carrier).containsEntry(OtTracePropagator.TRACE_ID_HEADER, TRACE_ID_RIGHT_PART);
+    assertThat(carrier).containsEntry(OtTracePropagator.SPAN_ID_HEADER, SPAN_ID);
+    assertThat(carrier).containsEntry(OtTracePropagator.SAMPLED_HEADER, "false");
   }
 
   @Test
@@ -123,8 +123,8 @@ class OtTracerPropagatorTest {
             Context.current().with(baggage)),
         carrier,
         setter);
-    assertThat(carrier).containsEntry(OtTracerPropagator.PREFIX_BAGGAGE_HEADER + "foo", "bar");
-    assertThat(carrier).containsEntry(OtTracerPropagator.PREFIX_BAGGAGE_HEADER + "key", "value");
+    assertThat(carrier).containsEntry(OtTracePropagator.PREFIX_BAGGAGE_HEADER + "foo", "bar");
+    assertThat(carrier).containsEntry(OtTracePropagator.PREFIX_BAGGAGE_HEADER + "key", "value");
   }
 
   @Test
@@ -155,9 +155,9 @@ class OtTracerPropagatorTest {
   @Test
   void extract_SampledContext_Int() {
     Map<String, String> carrier = new LinkedHashMap<>();
-    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID);
-    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
-    carrier.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
+    carrier.put(OtTracePropagator.TRACE_ID_HEADER, TRACE_ID);
+    carrier.put(OtTracePropagator.SPAN_ID_HEADER, SPAN_ID);
+    carrier.put(OtTracePropagator.SAMPLED_HEADER, Common.TRUE_INT);
 
     assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
@@ -168,9 +168,9 @@ class OtTracerPropagatorTest {
   @Test
   void extract_SampledContext_Bool() {
     Map<String, String> carrier = new LinkedHashMap<>();
-    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID);
-    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
-    carrier.put(OtTracerPropagator.SAMPLED_HEADER, "true");
+    carrier.put(OtTracePropagator.TRACE_ID_HEADER, TRACE_ID);
+    carrier.put(OtTracePropagator.SPAN_ID_HEADER, SPAN_ID);
+    carrier.put(OtTracePropagator.SAMPLED_HEADER, "true");
 
     assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
@@ -181,9 +181,9 @@ class OtTracerPropagatorTest {
   @Test
   void extract_NotSampledContext() {
     Map<String, String> carrier = new LinkedHashMap<>();
-    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID);
-    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
-    carrier.put(OtTracerPropagator.SAMPLED_HEADER, Common.FALSE_INT);
+    carrier.put(OtTracePropagator.TRACE_ID_HEADER, TRACE_ID);
+    carrier.put(OtTracePropagator.SPAN_ID_HEADER, SPAN_ID);
+    carrier.put(OtTracePropagator.SAMPLED_HEADER, Common.FALSE_INT);
 
     assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
@@ -194,9 +194,9 @@ class OtTracerPropagatorTest {
   @Test
   void extract_SampledContext_Int_Short_TraceId() {
     Map<String, String> carrier = new LinkedHashMap<>();
-    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, SHORT_TRACE_ID);
-    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
-    carrier.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
+    carrier.put(OtTracePropagator.TRACE_ID_HEADER, SHORT_TRACE_ID);
+    carrier.put(OtTracePropagator.SPAN_ID_HEADER, SPAN_ID);
+    carrier.put(OtTracePropagator.SAMPLED_HEADER, Common.TRUE_INT);
 
     assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
@@ -207,9 +207,9 @@ class OtTracerPropagatorTest {
   @Test
   void extract_SampledContext_Bool_Short_TraceId() {
     Map<String, String> carrier = new LinkedHashMap<>();
-    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, SHORT_TRACE_ID);
-    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
-    carrier.put(OtTracerPropagator.SAMPLED_HEADER, "true");
+    carrier.put(OtTracePropagator.TRACE_ID_HEADER, SHORT_TRACE_ID);
+    carrier.put(OtTracePropagator.SPAN_ID_HEADER, SPAN_ID);
+    carrier.put(OtTracePropagator.SAMPLED_HEADER, "true");
 
     assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
@@ -220,9 +220,9 @@ class OtTracerPropagatorTest {
   @Test
   void extract_NotSampledContext_Short_TraceId() {
     Map<String, String> carrier = new LinkedHashMap<>();
-    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, SHORT_TRACE_ID);
-    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
-    carrier.put(OtTracerPropagator.SAMPLED_HEADER, Common.FALSE_INT);
+    carrier.put(OtTracePropagator.TRACE_ID_HEADER, SHORT_TRACE_ID);
+    carrier.put(OtTracePropagator.SPAN_ID_HEADER, SPAN_ID);
+    carrier.put(OtTracePropagator.SAMPLED_HEADER, Common.FALSE_INT);
 
     assertThat(getSpanContext(propagator.extract(Context.current(), carrier, getter)))
         .isEqualTo(
@@ -233,9 +233,9 @@ class OtTracerPropagatorTest {
   @Test
   void extract_InvalidTraceId() {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
-    invalidHeaders.put(OtTracerPropagator.TRACE_ID_HEADER, "abcdefghijklmnopabcdefghijklmnop");
-    invalidHeaders.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
-    invalidHeaders.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
+    invalidHeaders.put(OtTracePropagator.TRACE_ID_HEADER, "abcdefghijklmnopabcdefghijklmnop");
+    invalidHeaders.put(OtTracePropagator.SPAN_ID_HEADER, SPAN_ID);
+    invalidHeaders.put(OtTracePropagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameAs(SpanContext.getInvalid());
   }
@@ -243,9 +243,9 @@ class OtTracerPropagatorTest {
   @Test
   void extract_InvalidTraceId_Size() {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
-    invalidHeaders.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID + "00");
-    invalidHeaders.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
-    invalidHeaders.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
+    invalidHeaders.put(OtTracePropagator.TRACE_ID_HEADER, TRACE_ID + "00");
+    invalidHeaders.put(OtTracePropagator.SPAN_ID_HEADER, SPAN_ID);
+    invalidHeaders.put(OtTracePropagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameAs(SpanContext.getInvalid());
   }
@@ -253,9 +253,9 @@ class OtTracerPropagatorTest {
   @Test
   void extract_InvalidSpanId() {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
-    invalidHeaders.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID);
-    invalidHeaders.put(OtTracerPropagator.SPAN_ID_HEADER, "abcdefghijklmnop");
-    invalidHeaders.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
+    invalidHeaders.put(OtTracePropagator.TRACE_ID_HEADER, TRACE_ID);
+    invalidHeaders.put(OtTracePropagator.SPAN_ID_HEADER, "abcdefghijklmnop");
+    invalidHeaders.put(OtTracePropagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameAs(SpanContext.getInvalid());
   }
@@ -263,9 +263,9 @@ class OtTracerPropagatorTest {
   @Test
   void extract_InvalidSpanId_Size() {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
-    invalidHeaders.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID);
-    invalidHeaders.put(OtTracerPropagator.SPAN_ID_HEADER, "abcdefghijklmnop" + "00");
-    invalidHeaders.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
+    invalidHeaders.put(OtTracePropagator.TRACE_ID_HEADER, TRACE_ID);
+    invalidHeaders.put(OtTracePropagator.SPAN_ID_HEADER, "abcdefghijklmnop" + "00");
+    invalidHeaders.put(OtTracePropagator.SAMPLED_HEADER, Common.TRUE_INT);
     assertThat(getSpanContext(propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameAs(SpanContext.getInvalid());
   }
@@ -280,11 +280,11 @@ class OtTracerPropagatorTest {
   @Test
   void extract_Baggage() {
     Map<String, String> carrier = new LinkedHashMap<>();
-    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, TRACE_ID);
-    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
-    carrier.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
-    carrier.put(OtTracerPropagator.PREFIX_BAGGAGE_HEADER + "foo", "bar");
-    carrier.put(OtTracerPropagator.PREFIX_BAGGAGE_HEADER + "key", "value");
+    carrier.put(OtTracePropagator.TRACE_ID_HEADER, TRACE_ID);
+    carrier.put(OtTracePropagator.SPAN_ID_HEADER, SPAN_ID);
+    carrier.put(OtTracePropagator.SAMPLED_HEADER, Common.TRUE_INT);
+    carrier.put(OtTracePropagator.PREFIX_BAGGAGE_HEADER + "foo", "bar");
+    carrier.put(OtTracePropagator.PREFIX_BAGGAGE_HEADER + "key", "value");
 
     Context context = propagator.extract(Context.current(), carrier, getter);
 
@@ -295,11 +295,11 @@ class OtTracerPropagatorTest {
   @Test
   void extract_Baggage_InvalidContext() {
     Map<String, String> carrier = new LinkedHashMap<>();
-    carrier.put(OtTracerPropagator.TRACE_ID_HEADER, TraceId.getInvalid());
-    carrier.put(OtTracerPropagator.SPAN_ID_HEADER, SPAN_ID);
-    carrier.put(OtTracerPropagator.SAMPLED_HEADER, Common.TRUE_INT);
-    carrier.put(OtTracerPropagator.PREFIX_BAGGAGE_HEADER + "foo", "bar");
-    carrier.put(OtTracerPropagator.PREFIX_BAGGAGE_HEADER + "key", "value");
+    carrier.put(OtTracePropagator.TRACE_ID_HEADER, TraceId.getInvalid());
+    carrier.put(OtTracePropagator.SPAN_ID_HEADER, SPAN_ID);
+    carrier.put(OtTracePropagator.SAMPLED_HEADER, Common.TRUE_INT);
+    carrier.put(OtTracePropagator.PREFIX_BAGGAGE_HEADER + "foo", "bar");
+    carrier.put(OtTracePropagator.PREFIX_BAGGAGE_HEADER + "key", "value");
 
     Context context = propagator.extract(Context.current(), carrier, getter);
 

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/PropagatorConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/PropagatorConfiguration.java
@@ -12,7 +12,7 @@ import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.extension.trace.propagation.AwsXrayPropagator;
 import io.opentelemetry.extension.trace.propagation.B3Propagator;
 import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
-import io.opentelemetry.extension.trace.propagation.OtTracerPropagator;
+import io.opentelemetry.extension.trace.propagation.OtTracePropagator;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -62,8 +62,9 @@ final class PropagatorConfiguration {
         return B3Propagator.builder().injectMultipleHeaders().build();
       case "jaeger":
         return JaegerPropagator.getInstance();
+        // NB: https://github.com/open-telemetry/opentelemetry-specification/pull/1406
       case "ottracer":
-        return OtTracerPropagator.getInstance();
+        return OtTracePropagator.getInstance();
       case "xray":
         return AwsXrayPropagator.getInstance();
       default:

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FullConfigTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FullConfigTest.java
@@ -20,7 +20,7 @@ import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.extension.trace.propagation.AwsXrayPropagator;
 import io.opentelemetry.extension.trace.propagation.B3Propagator;
 import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
-import io.opentelemetry.extension.trace.propagation.OtTracerPropagator;
+import io.opentelemetry.extension.trace.propagation.OtTracePropagator;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
 import io.opentelemetry.proto.collector.metrics.v1.MetricsServiceGrpc;
@@ -122,7 +122,7 @@ class FullConfigTest {
     keys.addAll(W3CBaggagePropagator.getInstance().fields());
     keys.addAll(B3Propagator.getInstance().fields());
     keys.addAll(JaegerPropagator.getInstance().fields());
-    keys.addAll(OtTracerPropagator.getInstance().fields());
+    keys.addAll(OtTracePropagator.getInstance().fields());
     keys.addAll(AwsXrayPropagator.getInstance().fields());
     // Added by TestPropagatorProvider
     keys.add("test");


### PR DESCRIPTION
This is done to match the name in other SIGs and the name it will have in the Specification ([see this](https://github.com/open-telemetry/opentelemetry-specification/pull/1402)).

Updated its small documentation piece as well.