### PR TITLE
Consistent name for Trace/Span ids getters with the specification

### DIFF
--- a/api/all/src/jmh/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagatorBenchmark.java
+++ b/api/all/src/jmh/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagatorBenchmark.java
@@ -76,8 +76,8 @@ public class W3CTraceContextPropagatorBenchmark {
       SpanContext current = Span.fromContext(result).getSpanContext();
       SpanContext clientSpanContext =
           SpanContext.create(
-              current.getTraceId(),
-              current.getSpanId(),
+              current.getTraceIdHex(),
+              current.getSpanIdHex(),
               current.getTraceFlags(),
               current.getTraceState());
       result = Span.wrap(clientSpanContext).storeInContext(result);

--- a/api/all/src/main/java/io/opentelemetry/api/trace/SpanContext.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/SpanContext.java
@@ -70,7 +70,7 @@ public interface SpanContext {
    *
    * @return the trace identifier associated with this {@link SpanContext} as lowercase hex.
    */
-  String getTraceId();
+  String getTraceIdHex();
 
   /**
    * Returns the trace identifier associated with this {@link SpanContext} as 16-byte array.
@@ -78,7 +78,7 @@ public interface SpanContext {
    * @return the trace identifier associated with this {@link SpanContext} as 16-byte array.
    */
   default byte[] getTraceIdBytes() {
-    return TraceId.asBytes(getTraceId());
+    return TraceId.asBytes(getTraceIdHex());
   }
 
   /**
@@ -88,7 +88,7 @@ public interface SpanContext {
    * @return the span identifier associated with this {@link SpanContext} as 16 character lowercase
    *     hex (base16) String.
    */
-  String getSpanId();
+  String getSpanIdHex();
 
   /**
    * Returns the span identifier associated with this {@link SpanContext} as 8-byte array.
@@ -96,7 +96,7 @@ public interface SpanContext {
    * @return the span identifier associated with this {@link SpanContext} as 8-byte array.
    */
   default byte[] getSpanIdBytes() {
-    return SpanId.asBytes(getSpanId());
+    return SpanId.asBytes(getSpanIdHex());
   }
 
   /** Whether the span in this context is sampled. */
@@ -124,7 +124,7 @@ public interface SpanContext {
    * @return {@code true} if this {@code SpanContext} is valid.
    */
   default boolean isValid() {
-    return TraceId.isValid(getTraceId()) && SpanId.isValid(getSpanId());
+    return TraceId.isValid(getTraceIdHex()) && SpanId.isValid(getSpanIdHex());
   }
 
   /**

--- a/api/all/src/main/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagator.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagator.java
@@ -111,14 +111,14 @@ public final class W3CTraceContextPropagator implements TextMapPropagator {
     chars[1] = VERSION.charAt(1);
     chars[2] = TRACEPARENT_DELIMITER;
 
-    String traceId = spanContext.getTraceId();
+    String traceId = spanContext.getTraceIdHex();
     for (int i = 0; i < traceId.length(); i++) {
       chars[TRACE_ID_OFFSET + i] = traceId.charAt(i);
     }
 
     chars[SPAN_ID_OFFSET - 1] = TRACEPARENT_DELIMITER;
 
-    String spanId = spanContext.getSpanId();
+    String spanId = spanContext.getSpanIdHex();
     for (int i = 0; i < spanId.length(); i++) {
       chars[SPAN_ID_OFFSET + i] = spanId.charAt(i);
     }
@@ -177,8 +177,8 @@ public final class W3CTraceContextPropagator implements TextMapPropagator {
     try {
       TraceState traceState = extractTraceState(traceStateHeader);
       return SpanContext.createFromRemoteParent(
-          contextFromParentHeader.getTraceId(),
-          contextFromParentHeader.getSpanId(),
+          contextFromParentHeader.getTraceIdHex(),
+          contextFromParentHeader.getSpanIdHex(),
           contextFromParentHeader.getTraceFlags(),
           traceState);
     } catch (IllegalArgumentException e) {

--- a/api/all/src/test/java/io/opentelemetry/api/trace/SpanContextTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/trace/SpanContextTest.java
@@ -30,8 +30,8 @@ class SpanContextTest {
 
   @Test
   void invalidSpanContext() {
-    assertThat(SpanContext.getInvalid().getTraceId()).isEqualTo(TraceId.getInvalid());
-    assertThat(SpanContext.getInvalid().getSpanId()).isEqualTo(SpanId.getInvalid());
+    assertThat(SpanContext.getInvalid().getTraceIdHex()).isEqualTo(TraceId.getInvalid());
+    assertThat(SpanContext.getInvalid().getSpanIdHex()).isEqualTo(SpanId.getInvalid());
     assertThat(SpanContext.getInvalid().getTraceFlags()).isEqualTo(TraceFlags.getDefault());
   }
 
@@ -60,14 +60,14 @@ class SpanContextTest {
 
   @Test
   void getTraceId() {
-    assertThat(first.getTraceId()).isEqualTo(FIRST_TRACE_ID);
-    assertThat(second.getTraceId()).isEqualTo(SECOND_TRACE_ID);
+    assertThat(first.getTraceIdHex()).isEqualTo(FIRST_TRACE_ID);
+    assertThat(second.getTraceIdHex()).isEqualTo(SECOND_TRACE_ID);
   }
 
   @Test
   void getSpanId() {
-    assertThat(first.getSpanId()).isEqualTo(FIRST_SPAN_ID);
-    assertThat(second.getSpanId()).isEqualTo(SECOND_SPAN_ID);
+    assertThat(first.getSpanIdHex()).isEqualTo(FIRST_SPAN_ID);
+    assertThat(second.getSpanIdHex()).isEqualTo(SECOND_SPAN_ID);
   }
 
   @Test

--- a/exporters/jaeger-thrift/src/main/java/io/opentelemetry/exporter/jaeger/thrift/Adapter.java
+++ b/exporters/jaeger-thrift/src/main/java/io/opentelemetry/exporter/jaeger/thrift/Adapter.java
@@ -232,8 +232,8 @@ final class Adapter {
     // https://github.com/open-telemetry/opentelemetry-java/pull/481/files#r312577862
     return new SpanRef(
         SpanRefType.FOLLOWS_FROM,
-        TraceId.lowPartAsLong(link.getSpanContext().getTraceId()),
-        TraceId.highPartAsLong(link.getSpanContext().getTraceId()),
-        SpanId.asLong(link.getSpanContext().getSpanId()));
+        TraceId.lowPartAsLong(link.getSpanContext().getTraceIdHex()),
+        TraceId.highPartAsLong(link.getSpanContext().getTraceIdHex()),
+        SpanId.asLong(link.getSpanContext().getSpanIdHex()));
   }
 }

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/AwsXrayPropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/AwsXrayPropagator.java
@@ -90,14 +90,14 @@ public final class AwsXrayPropagator implements TextMapPropagator {
 
     SpanContext spanContext = span.getSpanContext();
 
-    String otTraceId = spanContext.getTraceId();
+    String otTraceId = spanContext.getTraceIdHex();
     String xrayTraceId =
         TRACE_ID_VERSION
             + TRACE_ID_DELIMITER
             + otTraceId.substring(0, TRACE_ID_FIRST_PART_LENGTH)
             + TRACE_ID_DELIMITER
             + otTraceId.substring(TRACE_ID_FIRST_PART_LENGTH);
-    String parentId = spanContext.getSpanId();
+    String parentId = spanContext.getSpanIdHex();
     char samplingFlag = spanContext.isSampled() ? IS_SAMPLED : NOT_SAMPLED;
     // TODO: Add OT trace state to the X-Ray trace header
 

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
@@ -31,8 +31,8 @@ final class B3PropagatorInjectorMultipleHeaders implements B3PropagatorInjector 
       sampled = Common.TRUE_INT;
     }
 
-    setter.set(carrier, B3Propagator.TRACE_ID_HEADER, spanContext.getTraceId());
-    setter.set(carrier, B3Propagator.SPAN_ID_HEADER, spanContext.getSpanId());
+    setter.set(carrier, B3Propagator.TRACE_ID_HEADER, spanContext.getTraceIdHex());
+    setter.set(carrier, B3Propagator.SPAN_ID_HEADER, spanContext.getSpanIdHex());
     setter.set(carrier, B3Propagator.SAMPLED_HEADER, sampled);
   }
 }

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorInjectorSingleHeader.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorInjectorSingleHeader.java
@@ -36,11 +36,11 @@ final class B3PropagatorInjectorSingleHeader implements B3PropagatorInjector {
     }
 
     char[] chars = new char[COMBINED_HEADER_SIZE];
-    String traceId = spanContext.getTraceId();
+    String traceId = spanContext.getTraceIdHex();
     traceId.getChars(0, traceId.length(), chars, 0);
     chars[SPAN_ID_OFFSET - 1] = B3Propagator.COMBINED_HEADER_DELIMITER_CHAR;
 
-    String spanId = spanContext.getSpanId();
+    String spanId = spanContext.getSpanIdHex();
     System.arraycopy(spanId.toCharArray(), 0, chars, SPAN_ID_OFFSET, SpanId.getLength());
 
     chars[SAMPLED_FLAG_OFFSET - 1] = B3Propagator.COMBINED_HEADER_DELIMITER_CHAR;

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/JaegerPropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/JaegerPropagator.java
@@ -95,13 +95,13 @@ public final class JaegerPropagator implements TextMapPropagator {
 
     char[] chars = new char[PROPAGATION_HEADER_SIZE];
 
-    String traceId = spanContext.getTraceId();
+    String traceId = spanContext.getTraceIdHex();
     for (int i = 0; i < traceId.length(); i++) {
       chars[i] = traceId.charAt(i);
     }
 
     chars[SPAN_ID_OFFSET - 1] = PROPAGATION_HEADER_DELIMITER;
-    String spanId = spanContext.getSpanId();
+    String spanId = spanContext.getSpanIdHex();
     for (int i = 0; i < spanId.length(); i++) {
       chars[SPAN_ID_OFFSET + i] = spanId.charAt(i);
     }

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/OtTracerPropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/OtTracerPropagator.java
@@ -64,8 +64,8 @@ public final class OtTracerPropagator implements TextMapPropagator {
     // Lightstep trace id MUST be 64-bits therefore OpenTelemetry trace id is truncated to 64-bits
     // by retaining least significant (right-most) bits.
     setter.set(
-        carrier, TRACE_ID_HEADER, spanContext.getTraceId().substring(TraceId.getLength() / 2));
-    setter.set(carrier, SPAN_ID_HEADER, spanContext.getSpanId());
+        carrier, TRACE_ID_HEADER, spanContext.getTraceIdHex().substring(TraceId.getLength() / 2));
+    setter.set(carrier, SPAN_ID_HEADER, spanContext.getSpanIdHex());
     setter.set(carrier, SAMPLED_HEADER, String.valueOf(spanContext.isSampled()));
 
     // Baggage is only injected if there is a valid SpanContext

--- a/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/SpanConverter.java
+++ b/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/SpanConverter.java
@@ -50,8 +50,8 @@ class SpanConverter {
 
   static SpanContext mapSpanContext(io.opentelemetry.api.trace.SpanContext otelSpanContext) {
     return SpanContext.create(
-        TraceId.fromLowerBase16(otelSpanContext.getTraceId()),
-        SpanId.fromLowerBase16(otelSpanContext.getSpanId()),
+        TraceId.fromLowerBase16(otelSpanContext.getTraceIdHex()),
+        SpanId.fromLowerBase16(otelSpanContext.getSpanIdHex()),
         TraceOptions.builder().setIsSampled(otelSpanContext.isSampled()).build(),
         mapTracestate(otelSpanContext.getTraceState()));
   }

--- a/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/InteroperabilityTest.java
+++ b/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/InteroperabilityTest.java
@@ -170,7 +170,7 @@ class InteroperabilityTest {
     assertThat(export1.size()).isEqualTo(1);
     SpanData spanData1 = export1.iterator().next();
     assertThat(spanData1.getName()).isEqualTo("OpenCensusSpan");
-    assertThat(spanData1.getLinks().get(0).getSpanContext().getSpanId())
+    assertThat(spanData1.getLinks().get(0).getSpanContext().getSpanIdHex())
         .isEqualTo(remoteParentSpan.getContext().getSpanId().toLowerBase16());
   }
 
@@ -237,7 +237,7 @@ class InteroperabilityTest {
     assertThat(export3.size()).isEqualTo(1);
     SpanData spanData3 = export3.iterator().next();
     assertThat(spanData3.getName()).isEqualTo("OpenCensusSpan");
-    assertThat(spanData3.getLinks().get(0).getSpanContext().getSpanId())
+    assertThat(spanData3.getLinks().get(0).getSpanContext().getSpanIdHex())
         .isEqualTo(parentLinkSpan.getContext().getSpanId().toLowerBase16());
     assertThat(spanData3.getKind()).isEqualTo(SpanKind.SERVER);
     assertThat(spanData3.getStatus()).isEqualTo(StatusData.ok());

--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/SpanContextShim.java
@@ -60,12 +60,12 @@ final class SpanContextShim extends BaseShimObject implements SpanContext {
 
   @Override
   public String toTraceId() {
-    return context.getTraceId();
+    return context.getTraceIdHex();
   }
 
   @Override
   public String toSpanId() {
-    return context.getSpanId();
+    return context.getSpanIdHex();
   }
 
   @Override

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
@@ -43,8 +43,8 @@ class SpanShimTest {
     SpanContextShim contextShim = (SpanContextShim) spanShim.context();
     assertThat(contextShim).isNotNull();
     assertThat(span.getSpanContext()).isEqualTo(contextShim.getSpanContext());
-    assertThat(span.getSpanContext().getTraceId().toString()).isEqualTo(contextShim.toTraceId());
-    assertThat(span.getSpanContext().getSpanId().toString()).isEqualTo(contextShim.toSpanId());
+    assertThat(span.getSpanContext().getTraceIdHex().toString()).isEqualTo(contextShim.toTraceId());
+    assertThat(span.getSpanContext().getSpanIdHex().toString()).isEqualTo(contextShim.toSpanId());
     assertThat(contextShim.baggageItems().iterator().hasNext()).isFalse();
   }
 

--- a/sdk-extensions/jfr-events/src/main/java/io/opentelemetry/sdk/extension/jfr/ScopeEvent.java
+++ b/sdk-extensions/jfr-events/src/main/java/io/opentelemetry/sdk/extension/jfr/ScopeEvent.java
@@ -24,8 +24,8 @@ class ScopeEvent extends Event {
   private final String spanId;
 
   ScopeEvent(SpanContext spanContext) {
-    this.traceId = spanContext.getTraceId();
-    this.spanId = spanContext.getSpanId();
+    this.traceId = spanContext.getTraceIdHex();
+    this.spanId = spanContext.getSpanIdHex();
   }
 
   @Label("Trace Id")

--- a/sdk-extensions/jfr-events/src/test/java/io/opentelemetry/sdk/extension/jfr/JfrSpanProcessorTest.java
+++ b/sdk-extensions/jfr-events/src/test/java/io/opentelemetry/sdk/extension/jfr/JfrSpanProcessorTest.java
@@ -73,8 +73,8 @@ class JfrSpanProcessorTest {
       events.stream()
           .forEach(
               e -> {
-                assertEquals(span.getSpanContext().getTraceId(), e.getValue("traceId"));
-                assertEquals(span.getSpanContext().getSpanId(), e.getValue("spanId"));
+                assertEquals(span.getSpanContext().getTraceIdHex(), e.getValue("traceId"));
+                assertEquals(span.getSpanContext().getSpanIdHex(), e.getValue("spanId"));
                 assertEquals(OPERATION_NAME, e.getValue("operationName"));
               });
 
@@ -113,8 +113,8 @@ class JfrSpanProcessorTest {
       events.stream()
           .forEach(
               e -> {
-                assertEquals(span.getSpanContext().getTraceId(), e.getValue("traceId"));
-                assertEquals(span.getSpanContext().getSpanId(), e.getValue("spanId"));
+                assertEquals(span.getSpanContext().getTraceIdHex(), e.getValue("traceId"));
+                assertEquals(span.getSpanContext().getSpanIdHex(), e.getValue("spanId"));
                 if ("Span".equals(e.getEventType().getLabel())) {
                   assertEquals(OPERATION_NAME, e.getValue("operationName"));
                 }

--- a/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/TracezSpanProcessor.java
+++ b/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/TracezSpanProcessor.java
@@ -37,7 +37,7 @@ final class TracezSpanProcessor implements SpanProcessor {
 
   @Override
   public void onStart(Context parentContext, ReadWriteSpan span) {
-    runningSpanCache.put(span.getSpanContext().getSpanId(), span);
+    runningSpanCache.put(span.getSpanContext().getSpanIdHex(), span);
   }
 
   @Override
@@ -47,7 +47,7 @@ final class TracezSpanProcessor implements SpanProcessor {
 
   @Override
   public void onEnd(ReadableSpan span) {
-    runningSpanCache.remove(span.getSpanContext().getSpanId());
+    runningSpanCache.remove(span.getSpanContext().getSpanIdHex());
     if (!sampled || span.getSpanContext().isSampled()) {
       completedSpanCache.putIfAbsent(span.getName(), new TracezSpanBuckets());
       completedSpanCache.get(span.getName()).addToBucket(span);

--- a/sdk-extensions/zpages/src/test/java/io/opentelemetry/sdk/extension/zpages/TracezZPageHandlerTest.java
+++ b/sdk-extensions/zpages/src/test/java/io/opentelemetry/sdk/extension/zpages/TracezZPageHandlerTest.java
@@ -270,8 +270,8 @@ class TracezZPageHandlerTest {
     assertThat(output.toString()).contains("<h2>Span Details</h2>");
     assertThat(output.toString()).contains("<b> Span Name: " + RUNNING_SPAN + "</b>");
     assertThat(output.toString()).contains("<b> Number of running: 1");
-    assertThat(output.toString()).contains(runningSpan.getSpanContext().getTraceId());
-    assertThat(output.toString()).contains(runningSpan.getSpanContext().getSpanId());
+    assertThat(output.toString()).contains(runningSpan.getSpanContext().getTraceIdHex());
+    assertThat(output.toString()).contains(runningSpan.getSpanContext().getSpanIdHex());
 
     runningSpan.end();
   }
@@ -294,10 +294,10 @@ class TracezZPageHandlerTest {
     assertThat(output.toString()).contains("<h2>Span Details</h2>");
     assertThat(output.toString()).contains("<b> Span Name: " + LATENCY_SPAN + "</b>");
     assertThat(output.toString()).contains("<b> Number of latency samples: 2");
-    assertThat(output.toString()).contains(latencySpan1.getSpanContext().getTraceId());
-    assertThat(output.toString()).contains(latencySpan1.getSpanContext().getSpanId());
-    assertThat(output.toString()).contains(latencySpan2.getSpanContext().getTraceId());
-    assertThat(output.toString()).contains(latencySpan2.getSpanContext().getSpanId());
+    assertThat(output.toString()).contains(latencySpan1.getSpanContext().getTraceIdHex());
+    assertThat(output.toString()).contains(latencySpan1.getSpanContext().getSpanIdHex());
+    assertThat(output.toString()).contains(latencySpan2.getSpanContext().getTraceIdHex());
+    assertThat(output.toString()).contains(latencySpan2.getSpanContext().getSpanIdHex());
   }
 
   @Test
@@ -318,10 +318,10 @@ class TracezZPageHandlerTest {
     assertThat(output.toString()).contains("<h2>Span Details</h2>");
     assertThat(output.toString()).contains("<b> Span Name: " + ERROR_SPAN + "</b>");
     assertThat(output.toString()).contains("<b> Number of error samples: 2");
-    assertThat(output.toString()).contains(errorSpan1.getSpanContext().getTraceId());
-    assertThat(output.toString()).contains(errorSpan1.getSpanContext().getSpanId());
-    assertThat(output.toString()).contains(errorSpan2.getSpanContext().getTraceId());
-    assertThat(output.toString()).contains(errorSpan2.getSpanContext().getSpanId());
+    assertThat(output.toString()).contains(errorSpan1.getSpanContext().getTraceIdHex());
+    assertThat(output.toString()).contains(errorSpan1.getSpanContext().getSpanIdHex());
+    assertThat(output.toString()).contains(errorSpan2.getSpanContext().getTraceIdHex());
+    assertThat(output.toString()).contains(errorSpan2.getSpanContext().getSpanIdHex());
   }
 
   @Test

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -514,9 +514,9 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
     }
     StringBuilder sb = new StringBuilder();
     sb.append("RecordEventsReadableSpan{traceId=");
-    sb.append(context.getTraceId());
+    sb.append(context.getTraceIdHex());
     sb.append(", spanId=");
-    sb.append(context.getSpanId());
+    sb.append(context.getSpanIdHex());
     sb.append(", parentSpanContext=");
     sb.append(parentSpanContext);
     sb.append(", name=");

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java
@@ -174,7 +174,7 @@ final class SdkSpanBuilder implements SpanBuilder {
       traceId = idGenerator.generateTraceId();
     } else {
       // New child span.
-      traceId = parentSpanContext.getTraceId();
+      traceId = parentSpanContext.getTraceIdHex();
     }
     List<LinkData> immutableLinks =
         links == null ? Collections.emptyList() : Collections.unmodifiableList(links);

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
@@ -31,7 +31,7 @@ public interface SpanData {
    * @return the trace id.
    */
   default String getTraceId() {
-    return getSpanContext().getTraceId();
+    return getSpanContext().getTraceIdHex();
   }
 
   /**
@@ -40,7 +40,7 @@ public interface SpanData {
    * @return the span id.
    */
   default String getSpanId() {
-    return getSpanContext().getSpanId();
+    return getSpanContext().getSpanIdHex();
   }
 
   /** Whether the 'sampled' option set on this span. */
@@ -70,7 +70,7 @@ public interface SpanData {
    * @return the parent {@code SpanId} or an invalid SpanId if this is a root {@code Span}.
    */
   default String getParentSpanId() {
-    return getParentSpanContext().getSpanId();
+    return getParentSpanContext().getSpanIdHex();
   }
 
   /**

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
@@ -631,8 +631,8 @@ class SdkSpanBuilderTest {
     try (Scope ignored = parent.makeCurrent()) {
       Span span = sdkTracer.spanBuilder(SPAN_NAME).setNoParent().startSpan();
       try {
-        assertThat(span.getSpanContext().getTraceId())
-            .isNotEqualTo(parent.getSpanContext().getTraceId());
+        assertThat(span.getSpanContext().getTraceIdHex())
+            .isNotEqualTo(parent.getSpanContext().getTraceIdHex());
         Mockito.verify(mockedSpanProcessor)
             .onStart(Mockito.same(Context.root()), Mockito.same((ReadWriteSpan) span));
         Span spanNoParent =
@@ -643,8 +643,8 @@ class SdkSpanBuilderTest {
                 .setNoParent()
                 .startSpan();
         try {
-          assertThat(span.getSpanContext().getTraceId())
-              .isNotEqualTo(parent.getSpanContext().getTraceId());
+          assertThat(span.getSpanContext().getTraceIdHex())
+              .isNotEqualTo(parent.getSpanContext().getTraceIdHex());
           Mockito.verify(mockedSpanProcessor)
               .onStart(Mockito.same(Context.root()), Mockito.same((ReadWriteSpan) spanNoParent));
         } finally {
@@ -669,10 +669,10 @@ class SdkSpanBuilderTest {
       try {
         Mockito.verify(mockedSpanProcessor)
             .onStart(Mockito.same(parentContext), Mockito.same((ReadWriteSpan) span));
-        assertThat(span.getSpanContext().getTraceId())
-            .isEqualTo(parent.getSpanContext().getTraceId());
+        assertThat(span.getSpanContext().getTraceIdHex())
+            .isEqualTo(parent.getSpanContext().getTraceIdHex());
         assertThat(span.toSpanData().getParentSpanId())
-            .isEqualTo(parent.getSpanContext().getSpanId());
+            .isEqualTo(parent.getSpanContext().getSpanIdHex());
 
         final Context parentContext2 = Context.current().with(parent);
         RecordEventsReadableSpan span2 =
@@ -685,8 +685,8 @@ class SdkSpanBuilderTest {
         try {
           Mockito.verify(mockedSpanProcessor)
               .onStart(Mockito.same(parentContext2), Mockito.same((ReadWriteSpan) span2));
-          assertThat(span2.getSpanContext().getTraceId())
-              .isEqualTo(parent.getSpanContext().getTraceId());
+          assertThat(span2.getSpanContext().getTraceIdHex())
+              .isEqualTo(parent.getSpanContext().getTraceIdHex());
         } finally {
           span2.end();
         }
@@ -710,10 +710,10 @@ class SdkSpanBuilderTest {
       try {
         Mockito.verify(mockedSpanProcessor)
             .onStart(Mockito.same(parentContext), Mockito.same((ReadWriteSpan) span));
-        assertThat(span.getSpanContext().getTraceId())
-            .isEqualTo(parent.getSpanContext().getTraceId());
+        assertThat(span.getSpanContext().getTraceIdHex())
+            .isEqualTo(parent.getSpanContext().getTraceIdHex());
         assertThat(span.toSpanData().getParentSpanId())
-            .isEqualTo(parent.getSpanContext().getSpanId());
+            .isEqualTo(parent.getSpanContext().getSpanIdHex());
       } finally {
         span.end();
       }
@@ -733,10 +733,10 @@ class SdkSpanBuilderTest {
       try {
         Mockito.verify(mockedSpanProcessor)
             .onStart(Mockito.same(context), Mockito.same((ReadWriteSpan) span));
-        assertThat(span.getSpanContext().getTraceId())
-            .isEqualTo(parent.getSpanContext().getTraceId());
+        assertThat(span.getSpanContext().getTraceIdHex())
+            .isEqualTo(parent.getSpanContext().getTraceIdHex());
         assertThat(span.toSpanData().getParentSpanId())
-            .isEqualTo(parent.getSpanContext().getSpanId());
+            .isEqualTo(parent.getSpanContext().getSpanIdHex());
       } finally {
         span.end();
       }
@@ -760,10 +760,10 @@ class SdkSpanBuilderTest {
       try {
         Mockito.verify(mockedSpanProcessor)
             .onStart(Mockito.same(emptyContext), Mockito.same((ReadWriteSpan) span));
-        assertThat(span.getSpanContext().getTraceId())
-            .isNotEqualTo(parent.getSpanContext().getTraceId());
+        assertThat(span.getSpanContext().getTraceIdHex())
+            .isNotEqualTo(parent.getSpanContext().getTraceIdHex());
         assertThat(span.toSpanData().getParentSpanId())
-            .isNotEqualTo(parent.getSpanContext().getSpanId());
+            .isNotEqualTo(parent.getSpanContext().getSpanIdHex());
       } finally {
         span.end();
       }
@@ -782,10 +782,10 @@ class SdkSpanBuilderTest {
       try {
         Mockito.verify(mockedSpanProcessor)
             .onStart(Mockito.same(implicitParent), Mockito.same((ReadWriteSpan) span));
-        assertThat(span.getSpanContext().getTraceId())
-            .isEqualTo(parent.getSpanContext().getTraceId());
+        assertThat(span.getSpanContext().getTraceIdHex())
+            .isEqualTo(parent.getSpanContext().getTraceIdHex());
         assertThat(span.toSpanData().getParentSpanId())
-            .isEqualTo(parent.getSpanContext().getSpanId());
+            .isEqualTo(parent.getSpanContext().getSpanIdHex());
       } finally {
         span.end();
       }
@@ -806,8 +806,8 @@ class SdkSpanBuilderTest {
       Mockito.verify(mockedSpanProcessor)
           .onStart(
               ArgumentMatchers.same(parentContext), ArgumentMatchers.same((ReadWriteSpan) span));
-      assertThat(span.getSpanContext().getTraceId())
-          .isNotEqualTo(parent.getSpanContext().getTraceId());
+      assertThat(span.getSpanContext().getTraceIdHex())
+          .isNotEqualTo(parent.getSpanContext().getTraceIdHex());
       assertThat(SpanId.isValid(span.toSpanData().getParentSpanId())).isFalse();
     } finally {
       span.end();
@@ -903,13 +903,13 @@ class SdkSpanBuilderTest {
     assertThat(span.toSpanData().toString())
         .matches(
             "SpanData\\{spanContext=ImmutableSpanContext\\{"
-                + "traceId=[0-9a-f]{32}, "
-                + "spanId=[0-9a-f]{16}, "
+                + "traceIdHex=[0-9a-f]{32}, "
+                + "spanIdHex=[0-9a-f]{16}, "
                 + "traceFlags=01, "
                 + "traceState=ArrayBasedTraceState\\{entries=\\[]}, remote=false}, "
                 + "parentSpanContext=ImmutableSpanContext\\{"
-                + "traceId=00000000000000000000000000000000, "
-                + "spanId=0000000000000000, "
+                + "traceIdHex=00000000000000000000000000000000, "
+                + "spanIdHex=0000000000000000, "
                 + "traceFlags=00, "
                 + "traceState=ArrayBasedTraceState\\{entries=\\[]}, remote=false}, "
                 + "resource=Resource\\{attributes=\\{service.name=\"unknown_service:java\", "


### PR DESCRIPTION
Updates https://github.com/open-telemetry/opentelemetry-java/issues/2724

See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#retrieving-the-traceid-and-spanid

Not breaking change since methods were just renamed anyway.

There is one more advantage to this, if we ever want to add back the wrapper classes for Trace/Span id we will be able to have nice getters. Related to https://github.com/open-telemetry/opentelemetry-java/issues/2719 and the fact that we may have to add the wrappers to avoid multiple validations, this does not mean that we will do it that way but leaves the option open.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>