### PR TITLE
[BREAKING CHANGE] Remove not very used `isSampled` method from SpanData

### DIFF
--- a/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/TracezZPageHandler.java
+++ b/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/TracezZPageHandler.java
@@ -298,7 +298,7 @@ final class TracezZPageHandler extends ZPageHandler {
         "<td class=\"border-left-dark\"><pre class=\"no-margin wrap-text\"><b>"
             + "TraceId: <b style=\"color:%s;\">%s</b> "
             + " | SpanId: %s | ParentSpanId: %s</b></pre></td>",
-        span.isSampled() ? SAMPLED_TRACE_ID_COLOR : NOT_SAMPLED_TRACE_ID_COLOR,
+        span.getSpanContext().isSampled() ? SAMPLED_TRACE_ID_COLOR : NOT_SAMPLED_TRACE_ID_COLOR,
         span.getTraceId(),
         span.getSpanId(),
         span.getParentSpanId());

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SpanDataAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SpanDataAssert.java
@@ -63,7 +63,7 @@ public class SpanDataAssert extends AbstractAssert<SpanDataAssert, SpanData> {
   /** Asserts the span is sampled. */
   public SpanDataAssert isSampled() {
     isNotNull();
-    if (!actual.isSampled()) {
+    if (!actual.getSpanContext().isSampled()) {
       failWithMessage("Expected span [%s] to be sampled but was not.", actual.getName());
     }
     return this;
@@ -72,7 +72,7 @@ public class SpanDataAssert extends AbstractAssert<SpanDataAssert, SpanData> {
   /** Asserts the span is not sampled. */
   public SpanDataAssert isNotSampled() {
     isNotNull();
-    if (actual.isSampled()) {
+    if (actual.getSpanContext().isSampled()) {
       failWithMessage("Expected span [%s] to not be sampled but it was.", actual.getName());
     }
     return this;

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
@@ -43,11 +43,6 @@ public interface SpanData {
     return getSpanContext().getSpanId();
   }
 
-  /** Whether the 'sampled' option set on this span. */
-  default boolean isSampled() {
-    return getSpanContext().isSampled();
-  }
-
   /**
    * Gets the {@code TraceState} for this span.
    *

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -926,7 +926,7 @@ class RecordEventsReadableSpanTest {
         StatusData.unset(),
         /* hasEnded= */ true);
     assertThat(result.getTotalRecordedLinks()).isEqualTo(1);
-    assertThat(result.isSampled()).isEqualTo(false);
+    assertThat(result.getSpanContext().isSampled()).isEqualTo(false);
   }
 
   @Test


### PR DESCRIPTION
It will always be possible to add it back if this becomes a problem for our users.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>