### PR TITLE
[BREAKING CHANGE] Remove not very used `getTraceState` method from SpanData

### DIFF
--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SpanDataAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SpanDataAssert.java
@@ -81,14 +81,14 @@ public class SpanDataAssert extends AbstractAssert<SpanDataAssert, SpanData> {
   /** Asserts the span has the given {@link TraceState}. */
   public SpanDataAssert hasTraceState(TraceState traceState) {
     isNotNull();
-    if (!actual.getTraceState().equals(traceState)) {
+    if (!actual.getSpanContext().getTraceState().equals(traceState)) {
       failWithActualExpectedAndMessage(
-          actual.getTraceState(),
+          actual.getSpanContext().getTraceState(),
           traceState,
           "Expected span [%s] to have trace state <%s> but was <%s>",
           actual.getName(),
           traceState,
-          actual.getTraceState());
+          actual.getSpanContext().getTraceState());
     }
     return this;
   }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
@@ -8,7 +8,6 @@ package io.opentelemetry.sdk.trace.data;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SpanLimits;
@@ -46,15 +45,6 @@ public interface SpanData {
   /** Whether the 'sampled' option set on this span. */
   default boolean isSampled() {
     return getSpanContext().isSampled();
-  }
-
-  /**
-   * Gets the {@code TraceState} for this span.
-   *
-   * @return the {@code TraceState} for this span.
-   */
-  default TraceState getTraceState() {
-    return getSpanContext().getTraceState();
   }
 
   /**

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -839,7 +839,7 @@ class RecordEventsReadableSpanTest {
     assertThat(spanData.getTraceId()).isEqualTo(traceId);
     assertThat(spanData.getSpanId()).isEqualTo(spanId);
     assertThat(spanData.getParentSpanId()).isEqualTo(parentSpanId);
-    assertThat(spanData.getTraceState()).isEqualTo(TraceState.getDefault());
+    assertThat(spanData.getSpanContext().getTraceState()).isEqualTo(TraceState.getDefault());
     assertThat(spanData.getResource()).isEqualTo(resource);
     assertThat(spanData.getInstrumentationLibraryInfo()).isEqualTo(instrumentationLibraryInfo);
     assertThat(spanData.getName()).isEqualTo(spanName);

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
@@ -545,7 +545,8 @@ class SdkSpanBuilderTest {
     try {
       assertThat(span.getSpanContext().isSampled()).isTrue();
       assertThat(span.toSpanData().getAttributes().get(samplerAttributeKey)).isNotNull();
-      assertThat(span.toSpanData().getTraceState()).isEqualTo(TraceState.getDefault());
+      assertThat(span.toSpanData().getSpanContext().getTraceState())
+          .isEqualTo(TraceState.getDefault());
     } finally {
       span.end();
     }
@@ -599,7 +600,7 @@ class SdkSpanBuilderTest {
     try {
       assertThat(span.getSpanContext().isSampled()).isTrue();
       assertThat(span.toSpanData().getAttributes().get(samplerAttributeKey)).isNotNull();
-      assertThat(span.toSpanData().getTraceState())
+      assertThat(span.toSpanData().getSpanContext().getTraceState())
           .isEqualTo(TraceState.builder().set("newkey", "newValue").build());
     } finally {
       span.end();


### PR DESCRIPTION
It will always be possible to add it back if this becomes a problem for our users.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>