### PR TITLE
Simplify TraceFlags fromHex, less checks to perform

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/trace/ImmutableTraceFlags.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/ImmutableTraceFlags.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.api.trace;
 
-import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
@@ -16,17 +15,9 @@ final class ImmutableTraceFlags implements TraceFlags {
 
   static final ImmutableTraceFlags DEFAULT = fromByte((byte) 0x00);
   static final ImmutableTraceFlags SAMPLED = fromByte(SAMPLED_BIT);
-  static final int HEX_LENGTH = 2;
 
   private final String hexRep;
   private final byte byteRep;
-
-  // Implementation of the TraceFlags.fromHex().
-  static ImmutableTraceFlags fromHex(CharSequence src, int srcOffset) {
-    Objects.requireNonNull(src, "src");
-    return fromByte(
-        BigendianEncoding.byteFromBase16(src.charAt(srcOffset), src.charAt(srcOffset + 1)));
-  }
 
   // Implementation of the TraceFlags.fromByte().
   static ImmutableTraceFlags fromByte(byte traceFlagsByte) {

--- a/api/all/src/main/java/io/opentelemetry/api/trace/TraceFlags.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/TraceFlags.java
@@ -16,15 +16,6 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public interface TraceFlags {
   /**
-   * Returns the length of the lowercase hex (base16) representation of the {@link TraceFlags}.
-   *
-   * @return the length of the lowercase hex (base16) representation of the {@link TraceFlags}.
-   */
-  static int getLength() {
-    return ImmutableTraceFlags.HEX_LENGTH;
-  }
-
-  /**
    * Returns the default (with all flag bits off) byte representation of the {@link TraceFlags}.
    *
    * @return the default (with all flag bits off) byte representation of the {@link TraceFlags}.
@@ -45,17 +36,15 @@ public interface TraceFlags {
   }
 
   /**
-   * Returns the {@link TraceFlags} converted from the given lowercase hex (base16) representation.
+   * Returns the {@link TraceFlags} converted from the given two lowercase hex characters.
    *
-   * @param src the buffer where the hex (base16) representation of the {@link TraceFlags} is.
-   * @param srcOffset the offset int buffer.
+   * @param first the first hex character.
+   * @param second the second hex character.
    * @return the {@link TraceFlags} converted from the given lowercase hex (base16) representation.
-   * @throws NullPointerException if {@code src} is null.
-   * @throws IndexOutOfBoundsException if {@code src} is too short.
-   * @throws IllegalArgumentException if invalid characters in the {@code src}.
+   * @throws IllegalArgumentException if invalid lowercase hex characters.
    */
-  static TraceFlags fromHex(CharSequence src, int srcOffset) {
-    return ImmutableTraceFlags.fromHex(src, srcOffset);
+  static TraceFlags fromHex(char first, char second) {
+    return fromByte(BigendianEncoding.byteFromBase16(first, second));
   }
 
   /**

--- a/api/all/src/main/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagator.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagator.java
@@ -50,7 +50,7 @@ public final class W3CTraceContextPropagator implements TextMapPropagator {
   private static final int TRACEPARENT_DELIMITER_SIZE = 1;
   private static final int TRACE_ID_HEX_SIZE = TraceId.getLength();
   private static final int SPAN_ID_HEX_SIZE = SpanId.getLength();
-  private static final int TRACE_OPTION_HEX_SIZE = TraceFlags.getLength();
+  private static final int TRACE_OPTION_HEX_SIZE = 2;
   private static final int TRACE_ID_OFFSET = VERSION_SIZE + TRACEPARENT_DELIMITER_SIZE;
   private static final int SPAN_ID_OFFSET =
       TRACE_ID_OFFSET + TRACE_ID_HEX_SIZE + TRACEPARENT_DELIMITER_SIZE;
@@ -215,7 +215,10 @@ public final class W3CTraceContextPropagator implements TextMapPropagator {
           traceparent.substring(TRACE_ID_OFFSET, TRACE_ID_OFFSET + TraceId.getLength());
       String spanId = traceparent.substring(SPAN_ID_OFFSET, SPAN_ID_OFFSET + SpanId.getLength());
       if (TraceId.isValid(traceId) && SpanId.isValid(spanId)) {
-        TraceFlags traceFlags = TraceFlags.fromHex(traceparent, TRACE_OPTION_OFFSET);
+        TraceFlags traceFlags =
+            TraceFlags.fromHex(
+                traceparent.charAt(TRACE_OPTION_OFFSET),
+                traceparent.charAt(TRACE_OPTION_OFFSET + 1));
         return SpanContext.createFromRemoteParent(
             traceId, spanId, traceFlags, TraceState.getDefault());
       }

--- a/api/all/src/test/java/io/opentelemetry/api/trace/TraceFlagsTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/trace/TraceFlagsTest.java
@@ -33,7 +33,7 @@ class TraceFlagsTest {
       if (hex.length() == 1) {
         hex = "0" + hex;
       }
-      assertThat(TraceFlags.fromHex(hex, 0).asHex()).isEqualTo(hex);
+      assertThat(TraceFlags.fromHex(hex.charAt(0), hex.charAt(1)).asHex()).isEqualTo(hex);
     }
   }
 


### PR DESCRIPTION
getLength is no longer needed because fromHex cleary shows how many characters are needed.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>