### PR TITLE
Restore Trace/SpanId.fromBytes

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/trace/BigendianEncoding.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/BigendianEncoding.java
@@ -82,6 +82,12 @@ final class BigendianEncoding {
     return result;
   }
 
+  static void bytesToBase16(byte[] bytes, char[] dest) {
+    for (int i = 0; i < bytes.length; i++) {
+      byteToBase16(bytes[i], dest, i * 2);
+    }
+  }
+
   /**
    * Encodes the specified byte, and returns the encoded {@code String}.
    *

--- a/api/all/src/main/java/io/opentelemetry/api/trace/SpanId.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/SpanId.java
@@ -60,11 +60,32 @@ public final class SpanId {
 
   /**
    * Returns the lowercase hex (base16) representation of the {@code SpanId} converted from the
+   * given bytes representation.
+   *
+   * @param spanIdBytes the bytes (8-byte array) representation of the {@code SpanId}.
+   * @return the lowercase hex (base16) representation of the {@code SpanId}.
+   * @throws NullPointerException if {@code spanIdBytes} is null.
+   * @throws IndexOutOfBoundsException if {@code spanIdBytes} too short.
+   */
+  public static String fromBytes(byte[] spanIdBytes) {
+    if (spanIdBytes == null) {
+      return INVALID;
+    }
+    char[] result = getTemporaryBuffer();
+    BigendianEncoding.bytesToBase16(spanIdBytes, result);
+    return new String(result);
+  }
+
+  /**
+   * Returns the lowercase hex (base16) representation of the {@code SpanId} converted from the
    * given {@code long} value representation.
    *
    * <p>There is no restriction on the specified values, other than the already established validity
    * rules applying to {@code SpanId}. Specifying 0 for the long value will effectively return
    * {@link #getInvalid()}.
+   *
+   * <p>This is equivalent to calling {@link #fromBytes(byte[])} with the specified value stored as
+   * big-endian.
    *
    * @param id the higher part of the {@code TraceId}.
    * @return the lowercase hex (base16) representation of the {@code SpanId}.

--- a/api/all/src/main/java/io/opentelemetry/api/trace/TraceId.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/TraceId.java
@@ -64,12 +64,33 @@ public final class TraceId {
   }
 
   /**
+   * Returns the lowercase hex (base16) representation of the {@code TraceId} converted from the
+   * given bytes representation.
+   *
+   * @param traceIdBytes the bytes (16-byte array) representation of the {@code TraceId}.
+   * @return the lowercase hex (base16) representation of the {@code TraceId}.
+   * @throws NullPointerException if {@code traceIdBytes} is null.
+   * @throws IndexOutOfBoundsException if {@code traceIdBytes} too short.
+   */
+  public static String fromBytes(byte[] traceIdBytes) {
+    if (traceIdBytes == null) {
+      return INVALID;
+    }
+    char[] result = getTemporaryBuffer();
+    BigendianEncoding.bytesToBase16(traceIdBytes, result);
+    return new String(result);
+  }
+
+  /**
    * Returns the bytes (16-byte array) representation of the {@code TraceId} converted from the
    * given two {@code long} values representing the lower and higher parts.
    *
    * <p>There is no restriction on the specified values, other than the already established validity
    * rules applying to {@code TraceId}. Specifying 0 for both values will effectively return {@link
    * #getInvalid()}.
+   *
+   * <p>This is equivalent to calling {@link #fromBytes(byte[])} with the specified values stored as
+   * big-endian.
    *
    * @param traceIdLongHighPart the higher part of the long values representation of the {@code
    *     TraceId}.

--- a/api/all/src/test/java/io/opentelemetry/api/trace/SpanIdTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/trace/SpanIdTest.java
@@ -33,4 +33,13 @@ class SpanIdTest {
     assertThat(SpanId.fromLong(0x61)).isEqualTo(first);
     assertThat(SpanId.fromLong(0xff00000000000041L)).isEqualTo(second);
   }
+
+  @Test
+  void fromBytes() {
+    assertThat(SpanId.fromBytes(null)).isEqualTo(SpanId.getInvalid());
+
+    String spanId = "090a0b0c0d0e0f00";
+    assertThat(SpanId.fromBytes(BigendianEncoding.bytesFromBase16(spanId, SpanId.getLength())))
+        .isEqualTo(spanId);
+  }
 }

--- a/api/all/src/test/java/io/opentelemetry/api/trace/TraceIdTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/trace/TraceIdTest.java
@@ -49,4 +49,13 @@ class TraceIdTest {
     assertThat(TraceId.fromLongs(0xff01020304050600L, 0xff0a0b0c0d0e0f00L))
         .isEqualTo("ff01020304050600ff0a0b0c0d0e0f00");
   }
+
+  @Test
+  void fromBytes() {
+    assertThat(TraceId.fromBytes(null)).isEqualTo(TraceId.getInvalid());
+
+    String traceId = "0102030405060708090a0b0c0d0e0f00";
+    assertThat(TraceId.fromBytes(BigendianEncoding.bytesFromBase16(traceId, TraceId.getLength())))
+        .isEqualTo(traceId);
+  }
 }

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/AdapterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/AdapterTest.java
@@ -15,13 +15,14 @@ import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.io.BaseEncoding;
 import com.google.protobuf.util.Durations;
 import com.google.protobuf.util.Timestamps;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.exporter.jaeger.proto.api_v2.Model;
 import io.opentelemetry.sdk.resources.Resource;
@@ -41,7 +42,6 @@ import org.junit.jupiter.api.Test;
 /** Unit tests for {@link Adapter}. */
 class AdapterTest {
 
-  private static final BaseEncoding hex = BaseEncoding.base16().lowerCase();
   private static final String LINK_TRACE_ID = "00000000000000000000000000cba123";
   private static final String LINK_SPAN_ID = "0000000000fed456";
   private static final String TRACE_ID = "00000000000000000000000000abc123";
@@ -73,8 +73,9 @@ class AdapterTest {
 
     // test
     Model.Span jaegerSpan = Adapter.toJaeger(span);
-    assertThat(hex.encode(jaegerSpan.getTraceId().toByteArray())).isEqualTo(span.getTraceId());
-    assertThat(hex.encode(jaegerSpan.getSpanId().toByteArray())).isEqualTo(span.getSpanId());
+    assertThat(TraceId.fromBytes(jaegerSpan.getTraceId().toByteArray()))
+        .isEqualTo(span.getTraceId());
+    assertThat(SpanId.fromBytes(jaegerSpan.getSpanId().toByteArray())).isEqualTo(span.getSpanId());
     assertThat(jaegerSpan.getOperationName()).isEqualTo("GET /api/endpoint");
     assertThat(jaegerSpan.getStartTime()).isEqualTo(Timestamps.fromMillis(startMs));
     assertThat(Durations.toMillis(jaegerSpan.getDuration())).isEqualTo(duration);
@@ -215,8 +216,8 @@ class AdapterTest {
     Model.SpanRef spanRef = Adapter.toSpanRef(link);
 
     // verify
-    assertThat(hex.encode(spanRef.getSpanId().toByteArray())).isEqualTo(SPAN_ID);
-    assertThat(hex.encode(spanRef.getTraceId().toByteArray())).isEqualTo(TRACE_ID);
+    assertThat(SpanId.fromBytes(spanRef.getSpanId().toByteArray())).isEqualTo(SPAN_ID);
+    assertThat(TraceId.fromBytes(spanRef.getTraceId().toByteArray())).isEqualTo(TRACE_ID);
     assertThat(spanRef.getRefType()).isEqualTo(Model.SpanRefType.FOLLOWS_FROM);
   }
 
@@ -329,8 +330,8 @@ class AdapterTest {
     boolean found = false;
     for (Model.SpanRef spanRef : jaegerSpan.getReferencesList()) {
       if (Model.SpanRefType.FOLLOWS_FROM.equals(spanRef.getRefType())) {
-        assertThat(hex.encode(spanRef.getTraceId().toByteArray())).isEqualTo(LINK_TRACE_ID);
-        assertThat(hex.encode(spanRef.getSpanId().toByteArray())).isEqualTo(LINK_SPAN_ID);
+        assertThat(TraceId.fromBytes(spanRef.getTraceId().toByteArray())).isEqualTo(LINK_TRACE_ID);
+        assertThat(SpanId.fromBytes(spanRef.getSpanId().toByteArray())).isEqualTo(LINK_SPAN_ID);
         found = true;
       }
     }
@@ -341,8 +342,8 @@ class AdapterTest {
     boolean found = false;
     for (Model.SpanRef spanRef : jaegerSpan.getReferencesList()) {
       if (Model.SpanRefType.CHILD_OF.equals(spanRef.getRefType())) {
-        assertThat(hex.encode(spanRef.getTraceId().toByteArray())).isEqualTo(TRACE_ID);
-        assertThat(hex.encode(spanRef.getSpanId().toByteArray())).isEqualTo(PARENT_SPAN_ID);
+        assertThat(TraceId.fromBytes(spanRef.getTraceId().toByteArray())).isEqualTo(TRACE_ID);
+        assertThat(SpanId.fromBytes(spanRef.getSpanId().toByteArray())).isEqualTo(PARENT_SPAN_ID);
         found = true;
       }
     }

--- a/exporters/otlp/trace/src/jmh/java/io/opentelemetry/exporter/otlp/trace/RequestMarshalState.java
+++ b/exporters/otlp/trace/src/jmh/java/io/opentelemetry/exporter/otlp/trace/RequestMarshalState.java
@@ -8,8 +8,10 @@ package io.opentelemetry.exporter.otlp.trace;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
@@ -45,8 +47,12 @@ public class RequestMarshalState {
 
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create("name", null);
-  private static final String TRACE_ID = "7b2e170db4df2d593ddb4ddf2ddf2d59";
-  private static final String SPAN_ID = "170d3ddb4d23e81f";
+  private static final byte[] TRACE_ID_BYTES =
+      new byte[] {123, 46, 23, 78, 12, 5, (byte) 180, (byte) 223, 45, 89, 71, 61, 62, 29, 34, 54};
+  private static final String TRACE_ID = TraceId.fromBytes(TRACE_ID_BYTES);
+  private static final byte[] SPAN_ID_BYTES =
+      new byte[] {(byte) 198, (byte) 245, (byte) 213, (byte) 156, 46, 31, 29, 101};
+  private static final String SPAN_ID = SpanId.fromBytes(SPAN_ID_BYTES);
   private static final SpanContext SPAN_CONTEXT =
       SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault());
 

--- a/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/TraceMarshalerTest.java
+++ b/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/TraceMarshalerTest.java
@@ -11,8 +11,10 @@ import com.google.protobuf.CodedOutputStream;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -50,8 +52,11 @@ class TraceMarshalerTest {
 
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create("name", null);
-  private static final String TRACE_ID = "00000000000000000000000001020304";
-  private static final String SPAN_ID = "0000000004030201";
+  private static final byte[] TRACE_ID_BYTES =
+      new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4};
+  private static final String TRACE_ID = TraceId.fromBytes(TRACE_ID_BYTES);
+  private static final byte[] SPAN_ID_BYTES = new byte[] {0, 0, 0, 0, 4, 3, 2, 1};
+  private static final String SPAN_ID = SpanId.fromBytes(SPAN_ID_BYTES);
 
   private static final SpanContext SPAN_CONTEXT =
       SpanContext.create(

--- a/sdk-extensions/otproto/src/test/java/io/opentelemetry/sdk/extension/otproto/SpanAdapterTest.java
+++ b/sdk-extensions/otproto/src/test/java/io/opentelemetry/sdk/extension/otproto/SpanAdapterTest.java
@@ -22,9 +22,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.protobuf.ByteString;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
@@ -40,9 +42,9 @@ import org.junit.jupiter.api.Test;
 class SpanAdapterTest {
   private static final byte[] TRACE_ID_BYTES =
       new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4};
-  private static final String TRACE_ID = "00000000000000000000000001020304";
+  private static final String TRACE_ID = TraceId.fromBytes(TRACE_ID_BYTES);
   private static final byte[] SPAN_ID_BYTES = new byte[] {0, 0, 0, 0, 4, 3, 2, 1};
-  private static final String SPAN_ID = "0000000004030201";
+  private static final String SPAN_ID = SpanId.fromBytes(SPAN_ID_BYTES);
   private static final SpanContext SPAN_CONTEXT =
       SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault());
 

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/samplers/TraceIdRatioBasedSamplerTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/samplers/TraceIdRatioBasedSamplerTest.java
@@ -13,6 +13,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.IdGenerator;
@@ -147,7 +148,26 @@ class TraceIdRatioBasedSamplerTest {
     final Sampler defaultProbability = Sampler.traceIdRatioBased(0.0001);
     // This traceId will not be sampled by the Probability Sampler because the last 8 bytes as long
     // is not less than probability * Long.MAX_VALUE;
-    String notSampledTraceId = "00000000000000008fffffffffffffff";
+    String notSampledTraceId =
+        TraceId.fromBytes(
+            new byte[] {
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              (byte) 0x8F,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF
+            });
     SamplingResult samplingResult1 =
         defaultProbability.shouldSample(
             invalidParentContext,
@@ -159,7 +179,26 @@ class TraceIdRatioBasedSamplerTest {
     assertThat(samplingResult1.getDecision()).isEqualTo(SamplingDecision.DROP);
     // This traceId will be sampled by the Probability Sampler because the last 8 bytes as long
     // is less than probability * Long.MAX_VALUE;
-    String sampledTraceId = "0000ffffffffffff0000000000000000";
+    String sampledTraceId =
+        TraceId.fromBytes(
+            new byte[] {
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0
+            });
     SamplingResult samplingResult2 =
         defaultProbability.shouldSample(
             invalidParentContext,


### PR DESCRIPTION
This reverts commit d6fea3a70af466f1ef358ab3126a667a9607fd5e.

There currently isn't any way to get an ID from OTLP, which is often used in integration tests. Insrumentation repo used these methods and for now I've inlined everything down through BigEndianEncoding, but I think we need to provide this.