### PR TITLE
Make StrictContextStorage closeable.

### DIFF
--- a/api/context/src/main/java/io/opentelemetry/context/StrictContextStorage.java
+++ b/api/context/src/main/java/io/opentelemetry/context/StrictContextStorage.java
@@ -33,37 +33,11 @@ import java.util.stream.Collectors;
 
 /**
  * A {@link ContextStorage} which keeps track of opened and closed {@link Scope}s, reporting caller
- * information if a {@link Scope} is closed incorrectly or not at all. This is useful in
- * instrumentation tests to check whether any scopes leaked.
+ * information if a {@link Scope} is closed incorrectly or not at all.
  *
- * <pre>{@code
- * > class MyInstrumentationTest {
- * >   private static ContextStorage previousStorage;
- * >   private static StrictContextStorage strictStorage;
- * >
- * >   @BeforeAll
- * >   static void setUp() {
- * >     previousStorage = ContextStorage.get()
- * >     strictStorage = StrictContextStorage.create(previousStorage);
- * >     ContextStorage.set(strictStorage);
- * >   }
- * >
- * >   @AfterEach
- * >   void checkScopes() {
- * >     strictStorage.ensureAllClosed();
- * >   }
- * >
- * >   @AfterAll
- * >   static void tearDown() {
- * >     ContextStorage.set(previousStorage);
- * >   }
- * >
- * >   @Test
- * >   void badTest() {
- * >     Context.root().makeCurrent();
- * >   }
- * > }
- * }</pre>
+ * <p>Calling {@link StrictContextStorage#close()} will check at the moment it's called whether
+ * there are any scopes that have been opened but not closed yet. This could be called at the end of
+ * a unit test to ensure the tested code cleaned up scopes correctly.
  */
 final class StrictContextStorage implements ContextStorage, AutoCloseable {
 

--- a/api/context/src/main/java/io/opentelemetry/context/StrictContextStorage.java
+++ b/api/context/src/main/java/io/opentelemetry/context/StrictContextStorage.java
@@ -65,7 +65,7 @@ import java.util.stream.Collectors;
  * > }
  * }</pre>
  */
-final class StrictContextStorage implements ContextStorage {
+final class StrictContextStorage implements ContextStorage, AutoCloseable {
 
   /**
    * Returns a new {@link StrictContextStorage} which delegates to the provided {@link
@@ -153,8 +153,8 @@ final class StrictContextStorage implements ContextStorage {
    * @throws AssertionError if any scopes were left unclosed.
    */
   // AssertionError to ensure test runners render the stack trace
-  // Visible for testing
-  void ensureAllClosed() {
+  @Override
+  public void close() {
     pendingScopes.expungeStaleEntries();
     List<CallerStackTrace> leaked = pendingScopes.drainPendingCallers();
     if (!leaked.isEmpty()) {

--- a/api/context/src/strictContextEnabledTest/java/io/opentelemetry/context/StrictContextStorageTest.java
+++ b/api/context/src/strictContextEnabledTest/java/io/opentelemetry/context/StrictContextStorageTest.java
@@ -68,7 +68,7 @@ class StrictContextStorageTest {
       try (Scope ws2 = Context.current().with(ANIMAL, "dog").makeCurrent()) {}
     }
 
-    ((StrictContextStorage) ContextStorage.get()).ensureAllClosed(); // doesn't error
+    ((StrictContextStorage) ContextStorage.get()).close(); // doesn't error
   }
 
   static final class BusinessClass {
@@ -146,7 +146,7 @@ class StrictContextStorageTest {
     thread.start();
     thread.join();
 
-    assertThatThrownBy(() -> ((StrictContextStorage) ContextStorage.get()).ensureAllClosed())
+    assertThatThrownBy(() -> ((StrictContextStorage) ContextStorage.get()).close())
         .isInstanceOf(AssertionError.class)
         .satisfies(
             t -> assertThat(t.getMessage()).matches("Thread \\[t1\\] opened a scope of .* here:"))
@@ -162,7 +162,7 @@ class StrictContextStorageTest {
   void multipleLeaks() {
     Scope scope1 = Context.current().with(ANIMAL, "cat").makeCurrent();
     Scope scope2 = Context.current().with(ANIMAL, "dog").makeCurrent();
-    assertThatThrownBy(() -> ((StrictContextStorage) ContextStorage.get()).ensureAllClosed())
+    assertThatThrownBy(() -> ((StrictContextStorage) ContextStorage.get()).close())
         .isInstanceOf(AssertionError.class);
   }
 


### PR DESCRIPTION
This doesn't make `StrictContextStorage` public but at least allows instrumentation tests to do something like this if they want.

```java
@AfterEach
void tearDown() {
  ((AutoCloseable) ContextStorage.get()).close();
}
```

@mateuszrzeszutek has been looking into activating strict context storage in our tests and we do need some way to call this.