### PR TITLE
Move sort and dedup to constructor of ImmutableKeyValuePairs

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/baggage/ImmutableBaggage.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/ImmutableBaggage.java
@@ -21,7 +21,7 @@ final class ImmutableBaggage extends ImmutableKeyValuePairs<String, BaggageEntry
 
   private static final Baggage EMPTY = new ImmutableBaggage.Builder().build();
 
-  ImmutableBaggage(List<Object> data) {
+  private ImmutableBaggage(Object[] data) {
     super(data);
   }
 
@@ -48,7 +48,7 @@ final class ImmutableBaggage extends ImmutableKeyValuePairs<String, BaggageEntry
   }
 
   private static Baggage sortAndFilterToBaggage(Object[] data) {
-    return new ImmutableBaggage(sortAndFilter(data));
+    return new ImmutableBaggage(data);
   }
 
   // TODO: Migrate to AutoValue.Builder

--- a/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedAttributes.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedAttributes.java
@@ -8,7 +8,6 @@ package io.opentelemetry.api.common;
 import io.opentelemetry.api.internal.ImmutableKeyValuePairs;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
@@ -22,8 +21,8 @@ final class ArrayBackedAttributes extends ImmutableKeyValuePairs<AttributeKey<?>
 
   static final Attributes EMPTY = Attributes.builder().build();
 
-  ArrayBackedAttributes(List<Object> data) {
-    super(data);
+  private ArrayBackedAttributes(Object[] data, Comparator<AttributeKey<?>> keyComparator) {
+    super(data, keyComparator);
   }
 
   @Override
@@ -46,6 +45,6 @@ final class ArrayBackedAttributes extends ImmutableKeyValuePairs<AttributeKey<?>
         data[i] = null;
       }
     }
-    return new ArrayBackedAttributes(sortAndFilter(data, KEY_COMPARATOR_FOR_CONSTRUCTION));
+    return new ArrayBackedAttributes(data, KEY_COMPARATOR_FOR_CONSTRUCTION);
   }
 }

--- a/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
@@ -22,8 +22,8 @@ import javax.annotation.concurrent.Immutable;
  * <p>Key-value pairs are dropped for {@code null} or empty keys.
  *
  * <p>Note: for subclasses of this, null keys will be removed, but if your key has another concept
- * of being "empty", you'll need to remove them before calling {@link #sortAndFilter(Object[])},
- * assuming you don't want the "empty" keys to be kept in your collection.
+ * of being "empty", you'll need to remove them before calling the constructor, assuming you don't
+ * want the "empty" keys to be kept in your collection.
  *
  * @param <V> The type of the values contained in this.
  */
@@ -31,8 +31,24 @@ import javax.annotation.concurrent.Immutable;
 public abstract class ImmutableKeyValuePairs<K, V> {
   private final List<Object> data;
 
-  protected ImmutableKeyValuePairs(List<Object> data) {
+  private ImmutableKeyValuePairs(List<Object> data) {
     this.data = data;
+  }
+
+  /**
+   * Sorts and dedupes the key/value pairs in {@code data}. {@code null} values will be removed.
+   * Keys must be {@link Comparable}.
+   */
+  protected ImmutableKeyValuePairs(Object[] data) {
+    this(sortAndFilter(data, Comparator.naturalOrder()));
+  }
+
+  /**
+   * Sorts and dedupes the key/value pairs in {@code data}. {@code null} values will be removed.
+   * Keys will be compared with the given {@link Comparator}.
+   */
+  protected ImmutableKeyValuePairs(Object[] data, Comparator<?> keyComparator) {
+    this(sortAndFilter(data, keyComparator));
   }
 
   protected final List<Object> data() {
@@ -73,17 +89,9 @@ public abstract class ImmutableKeyValuePairs<K, V> {
 
   /**
    * Sorts and dedupes the key/value pairs in {@code data}. {@code null} values will be removed.
-   * Keys must be {@link Comparable}.
-   */
-  protected static List<Object> sortAndFilter(Object[] data) {
-    return sortAndFilter(data, Comparator.naturalOrder());
-  }
-
-  /**
-   * Sorts and dedupes the key/value pairs in {@code data}. {@code null} values will be removed.
    * Keys will be compared with the given {@link Comparator}.
    */
-  protected static List<Object> sortAndFilter(Object[] data, Comparator<?> keyComparator) {
+  private static List<Object> sortAndFilter(Object[] data, Comparator<?> keyComparator) {
     checkArgument(
         data.length % 2 == 0, "You must provide an even number of key/value pair arguments.");
 

--- a/api/all/src/test/java/io/opentelemetry/api/internal/ImmutableKeyValuePairsTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/internal/ImmutableKeyValuePairsTest.java
@@ -7,47 +7,44 @@ package io.opentelemetry.api.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class ImmutableKeyValuePairsTest {
 
   @Test
   void get() {
-    assertThat(new TestPairs(Collections.emptyList()).get("one")).isNull();
-    assertThat(new TestPairs(Arrays.asList("one", 55)).get("one")).isEqualTo(55);
-    assertThat(new TestPairs(Arrays.asList("one", 55)).get("two")).isNull();
-    assertThat(new TestPairs(Arrays.asList("one", 55, "two", "b")).get("one")).isEqualTo(55);
-    assertThat(new TestPairs(Arrays.asList("one", 55, "two", "b")).get("two")).isEqualTo("b");
-    assertThat(new TestPairs(Arrays.asList("one", 55, "two", "b")).get("three")).isNull();
+    assertThat(new TestPairs(new Object[0]).get("one")).isNull();
+    assertThat(new TestPairs(new Object[] {"one", 55}).get("one")).isEqualTo(55);
+    assertThat(new TestPairs(new Object[] {"one", 55}).get("two")).isNull();
+    assertThat(new TestPairs(new Object[] {"one", 55, "two", "b"}).get("one")).isEqualTo(55);
+    assertThat(new TestPairs(new Object[] {"one", 55, "two", "b"}).get("two")).isEqualTo("b");
+    assertThat(new TestPairs(new Object[] {"one", 55, "two", "b"}).get("three")).isNull();
   }
 
   @Test
   void size() {
-    assertThat(new TestPairs(Collections.emptyList()).size()).isEqualTo(0);
-    assertThat(new TestPairs(Arrays.asList("one", 55)).size()).isEqualTo(1);
-    assertThat(new TestPairs(Arrays.asList("one", 55, "two", "b")).size()).isEqualTo(2);
+    assertThat(new TestPairs(new Object[0]).size()).isEqualTo(0);
+    assertThat(new TestPairs(new Object[] {"one", 55}).size()).isEqualTo(1);
+    assertThat(new TestPairs(new Object[] {"one", 55, "two", "b"}).size()).isEqualTo(2);
   }
 
   @Test
   void isEmpty() {
-    assertThat(new TestPairs(Collections.emptyList()).isEmpty()).isTrue();
-    assertThat(new TestPairs(Arrays.asList("one", 55)).isEmpty()).isFalse();
-    assertThat(new TestPairs(Arrays.asList("one", 55, "two", "b")).isEmpty()).isFalse();
+    assertThat(new TestPairs(new Object[0]).isEmpty()).isTrue();
+    assertThat(new TestPairs(new Object[] {"one", 55}).isEmpty()).isFalse();
+    assertThat(new TestPairs(new Object[] {"one", 55, "two", "b"}).isEmpty()).isFalse();
   }
 
   @Test
   void toStringIsHumanReadable() {
-    assertThat(new TestPairs(Collections.emptyList()).toString()).isEqualTo("{}");
-    assertThat(new TestPairs(Arrays.asList("one", 55)).toString()).isEqualTo("{one=55}");
-    assertThat(new TestPairs(Arrays.asList("one", 55, "two", "b")).toString())
+    assertThat(new TestPairs(new Object[0]).toString()).isEqualTo("{}");
+    assertThat(new TestPairs(new Object[] {"one", 55}).toString()).isEqualTo("{one=55}");
+    assertThat(new TestPairs(new Object[] {"one", 55, "two", "b"}).toString())
         .isEqualTo("{one=55, two=\"b\"}");
   }
 
   static class TestPairs extends ImmutableKeyValuePairs<String, Object> {
-    TestPairs(List<Object> data) {
+    TestPairs(Object[] data) {
       super(data);
     }
   }

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/common/ArrayBackedLabels.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/common/ArrayBackedLabels.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.api.metrics.common;
 
 import io.opentelemetry.api.internal.ImmutableKeyValuePairs;
-import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
@@ -17,12 +16,12 @@ final class ArrayBackedLabels extends ImmutableKeyValuePairs<String, String> imp
     return EMPTY;
   }
 
-  ArrayBackedLabels(List<Object> data) {
+  private ArrayBackedLabels(Object[] data) {
     super(data);
   }
 
   static Labels sortAndFilterToLabels(Object... data) {
-    return new ArrayBackedLabels(sortAndFilter(data));
+    return new ArrayBackedLabels(data);
   }
 
   @Override


### PR DESCRIPTION
This will allow us to store internally an array and size or other combination that makes sense for performance.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>