### PR TITLE
Improve ImmutableKeyValuePairs dedup, do everything inplace

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/baggage/ImmutableBaggage.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/ImmutableBaggage.java
@@ -64,7 +64,7 @@ final class ImmutableBaggage extends ImmutableKeyValuePairs<String, BaggageEntry
     }
 
     Builder(List<Object> data) {
-      this.data = new ArrayList<>(data);
+      this.data = data;
     }
 
     @Override


### PR DESCRIPTION
This change will reduce the number of allocations by 2 for the case where all entries are valid,
and by 1 when entries are filtered in the dedup.

**Benchmarks Before:**

<img width="1502" alt="Screen Shot 2021-02-09 at 12 18 11 PM" src="https://user-images.githubusercontent.com/1373887/107423278-fc166500-6ad0-11eb-9369-2aeea9aca0cc.png">

<img width="1471" alt="Screen Shot 2021-02-09 at 12 19 31 PM" src="https://user-images.githubusercontent.com/1373887/107423395-18b29d00-6ad1-11eb-9cf2-c4747441ea90.png">

**Benchmarks After:**

<img width="1411" alt="Screen Shot 2021-02-09 at 3 02 20 PM" src="https://user-images.githubusercontent.com/1373887/107440017-d183d680-6ae7-11eb-9e9e-e74a245a7648.png">

<img width="1409" alt="Screen Shot 2021-02-09 at 3 02 48 PM" src="https://user-images.githubusercontent.com/1373887/107440058-e7919700-6ae7-11eb-92c4-4709d30763ec.png">


Updates https://github.com/open-telemetry/opentelemetry-java/issues/2765

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>