### PR TITLE
2508: Logging Exporter Example for Trace and Metrics

### DIFF
--- a/examples/logging/build.gradle
+++ b/examples/logging/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id 'java'
+}
+
+description = "OpenTelemetry Examples for logging exporters"
+ext.moduleName = "io.opentelemetry.examples.logging"
+
+dependencies {
+    compile("io.opentelemetry:opentelemetry-api")
+    compile("io.opentelemetry:opentelemetry-api-metrics:${openTelemetryAlphaVersion}")
+    compile("io.opentelemetry:opentelemetry-exporter-logging")
+}

--- a/examples/logging/src/main/java/io/opentelemetry/example/logging/ExampleConfiguration.java
+++ b/examples/logging/src/main/java/io/opentelemetry/example/logging/ExampleConfiguration.java
@@ -42,6 +42,6 @@ public class ExampleConfiguration {
         SdkTracerProvider.builder()
             .addSpanProcessor(SimpleSpanProcessor.create(new LoggingSpanExporter()))
             .build();
-    return OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build();
+    return OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).buildAndRegisterGlobal();
   }
 }

--- a/examples/logging/src/main/java/io/opentelemetry/example/logging/ExampleConfiguration.java
+++ b/examples/logging/src/main/java/io/opentelemetry/example/logging/ExampleConfiguration.java
@@ -24,7 +24,7 @@ public class ExampleConfiguration {
    *
    * @return A ready-to-use {@link OpenTelemetry} instance.
    */
-  public static OpenTelemetry initOpenTelemetry() {
+  public static void initOpenTelemetry() {
     // This will be used to create instruments
     SdkMeterProvider meterProvider = SdkMeterProvider.builder().buildAndRegisterGlobal();
 
@@ -35,13 +35,12 @@ public class ExampleConfiguration {
         .setMetricProducers(Collections.singleton(meterProvider))
         .setExportIntervalMillis(METRIC_EXPORT_INTERVAL_MS)
         .build();
-
     // Tracer provider configured to export spans with SimpleSpanProcessor using
     // the logging exporter.
     SdkTracerProvider tracerProvider =
         SdkTracerProvider.builder()
             .addSpanProcessor(SimpleSpanProcessor.create(new LoggingSpanExporter()))
             .build();
-    return OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build();
+    OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).buildAndRegisterGlobal();
   }
 }

--- a/examples/logging/src/main/java/io/opentelemetry/example/logging/ExampleConfiguration.java
+++ b/examples/logging/src/main/java/io/opentelemetry/example/logging/ExampleConfiguration.java
@@ -1,0 +1,47 @@
+package io.opentelemetry.example.logging;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.exporter.logging.LoggingMetricExporter;
+import io.opentelemetry.exporter.logging.LoggingSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.export.IntervalMetricReader;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import java.util.Collections;
+
+/**
+ * All SDK management takes place here, away from the instrumentation code, which should only access
+ * the OpenTelemetry APIs.
+ */
+public class ExampleConfiguration {
+
+  /** The number of milliseconds between metric exports. */
+  private static final long METRIC_EXPORT_INTERVAL_MS = 800L;
+
+  /**
+   * Initializes an OpenTelemetry SDK with a logging exporter and a SimpleSpanProcessor.
+   *
+   * @return A ready-to-use {@link OpenTelemetry} instance.
+   */
+  public static OpenTelemetry initOpenTelemetry() {
+    // This will be used to create instruments
+    SdkMeterProvider meterProvider = SdkMeterProvider.builder().buildAndRegisterGlobal();
+
+    // Create an instance of IntervalMetricReader and configure it
+    // to read metrics from the meterProvider and export them to the logging exporter
+    IntervalMetricReader.builder()
+        .setMetricExporter(new LoggingMetricExporter())
+        .setMetricProducers(Collections.singleton(meterProvider))
+        .setExportIntervalMillis(METRIC_EXPORT_INTERVAL_MS)
+        .build();
+
+    // Tracer provider configured to export spans with SimpleSpanProcessor using
+    // the logging exporter.
+    SdkTracerProvider tracerProvider =
+        SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(new LoggingSpanExporter()))
+            .build();
+    return OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build();
+  }
+}

--- a/examples/logging/src/main/java/io/opentelemetry/example/logging/ExampleConfiguration.java
+++ b/examples/logging/src/main/java/io/opentelemetry/example/logging/ExampleConfiguration.java
@@ -24,7 +24,7 @@ public class ExampleConfiguration {
    *
    * @return A ready-to-use {@link OpenTelemetry} instance.
    */
-  public static void initOpenTelemetry() {
+  public static OpenTelemetry initOpenTelemetry() {
     // This will be used to create instruments
     SdkMeterProvider meterProvider = SdkMeterProvider.builder().buildAndRegisterGlobal();
 
@@ -35,12 +35,13 @@ public class ExampleConfiguration {
         .setMetricProducers(Collections.singleton(meterProvider))
         .setExportIntervalMillis(METRIC_EXPORT_INTERVAL_MS)
         .build();
+
     // Tracer provider configured to export spans with SimpleSpanProcessor using
     // the logging exporter.
     SdkTracerProvider tracerProvider =
         SdkTracerProvider.builder()
             .addSpanProcessor(SimpleSpanProcessor.create(new LoggingSpanExporter()))
             .build();
-    OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).buildAndRegisterGlobal();
+    return OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build();
   }
 }

--- a/examples/logging/src/main/java/io/opentelemetry/example/logging/LoggingExporterExample.java
+++ b/examples/logging/src/main/java/io/opentelemetry/example/logging/LoggingExporterExample.java
@@ -1,6 +1,6 @@
 package io.opentelemetry.example.logging;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.GlobalMetricsProvider;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.trace.Span;
@@ -16,8 +16,8 @@ public class LoggingExporterExample {
   private final Tracer tracer;
   private final LongCounter counter;
 
-  public LoggingExporterExample() {
-    tracer = GlobalOpenTelemetry.getTracer(INSTRUMENTATION_NAME);
+  public LoggingExporterExample(OpenTelemetry openTelemetry) {
+    tracer = openTelemetry.getTracer(INSTRUMENTATION_NAME);
     counter =
         GlobalMetricsProvider.getMeter(INSTRUMENTATION_NAME)
             .longCounterBuilder("work_done")
@@ -46,10 +46,10 @@ public class LoggingExporterExample {
 
   public static void main(String[] args) {
     // it is important to initialize your SDK as early as possible in your application's lifecycle
-    ExampleConfiguration.initOpenTelemetry();
+    OpenTelemetry oTel = ExampleConfiguration.initOpenTelemetry();
 
     // Start the example
-    LoggingExporterExample example = new LoggingExporterExample();
+    LoggingExporterExample example = new LoggingExporterExample(oTel);
     // Generate a few sample spans
     for (int i = 0; i < 5; i++) {
       example.myWonderfulUseCase();

--- a/examples/logging/src/main/java/io/opentelemetry/example/logging/LoggingExporterExample.java
+++ b/examples/logging/src/main/java/io/opentelemetry/example/logging/LoggingExporterExample.java
@@ -1,6 +1,6 @@
 package io.opentelemetry.example.logging;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.metrics.GlobalMetricsProvider;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.trace.Span;
@@ -16,8 +16,8 @@ public class LoggingExporterExample {
   private final Tracer tracer;
   private final LongCounter counter;
 
-  public LoggingExporterExample(OpenTelemetry openTelemetry) {
-    tracer = openTelemetry.getTracer(INSTRUMENTATION_NAME);
+  public LoggingExporterExample() {
+    tracer = GlobalOpenTelemetry.getTracer(INSTRUMENTATION_NAME);
     counter =
         GlobalMetricsProvider.getMeter(INSTRUMENTATION_NAME)
             .longCounterBuilder("work_done")
@@ -46,10 +46,10 @@ public class LoggingExporterExample {
 
   public static void main(String[] args) {
     // it is important to initialize your SDK as early as possible in your application's lifecycle
-    OpenTelemetry oTel = ExampleConfiguration.initOpenTelemetry();
+    ExampleConfiguration.initOpenTelemetry();
 
     // Start the example
-    LoggingExporterExample example = new LoggingExporterExample(oTel);
+    LoggingExporterExample example = new LoggingExporterExample();
     // Generate a few sample spans
     for (int i = 0; i < 5; i++) {
       example.myWonderfulUseCase();

--- a/examples/logging/src/main/java/io/opentelemetry/example/logging/LoggingExporterExample.java
+++ b/examples/logging/src/main/java/io/opentelemetry/example/logging/LoggingExporterExample.java
@@ -1,0 +1,66 @@
+package io.opentelemetry.example.logging;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.GlobalMetricsProvider;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+
+/**
+ * An example of using {@link io.opentelemetry.exporter.logging.LoggingSpanExporter} and {@link
+ * io.opentelemetry.exporter.logging.LoggingMetricExporter}.
+ */
+public class LoggingExporterExample {
+  private static final String INSTRUMENTATION_NAME = LoggingExporterExample.class.getName();
+
+  private final Tracer tracer;
+  private final LongCounter counter;
+
+  public LoggingExporterExample(OpenTelemetry openTelemetry) {
+    tracer = openTelemetry.getTracer(INSTRUMENTATION_NAME);
+    counter =
+        GlobalMetricsProvider.getMeter(INSTRUMENTATION_NAME)
+            .longCounterBuilder("work_done")
+            .build();
+  }
+
+  public void myWonderfulUseCase() {
+    Span span = this.tracer.spanBuilder("start my wonderful use case").startSpan();
+    span.addEvent("Event 0");
+    doWork();
+    span.addEvent("Event 1");
+    span.end();
+  }
+
+  private void doWork() {
+    Span span = this.tracer.spanBuilder("doWork").startSpan();
+    try {
+      Thread.sleep(1000);
+      counter.add(1);
+    } catch (InterruptedException e) {
+      // do the right thing here
+    } finally {
+      span.end();
+    }
+  }
+
+  public static void main(String[] args) {
+    // it is important to initialize your SDK as early as possible in your application's lifecycle
+    OpenTelemetry oTel = ExampleConfiguration.initOpenTelemetry();
+
+    // Start the example
+    LoggingExporterExample example = new LoggingExporterExample(oTel);
+    // Generate a few sample spans
+    for (int i = 0; i < 5; i++) {
+      example.myWonderfulUseCase();
+    }
+
+    try {
+      // Flush out the metrics that have not yet been exported
+      Thread.sleep(1000L);
+    } catch (InterruptedException e) {
+    }
+
+    System.out.println("Bye");
+  }
+}

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -19,7 +19,8 @@ include ":opentelemetry-examples-grpc",
         ":opentelemetry-examples-prometheus",
         ":opentelemetry-examples-otlp",
         ":opentelemetry-examples-sdk-usage",
-        ":opentelemetry-examples-zipkin"
+        ":opentelemetry-examples-zipkin",
+        ":opentelemetry-examples-logging"
 
 rootProject.children.each {
     it.projectDir = "$rootDir/" + it.name


### PR DESCRIPTION
This PR adds an example to the examples directory showing how to make use of the logging exporters for trace and metrics in a single runnable example. I thought this would help to address #2508 

The jaeger example was used as a basis for this example, altered to make use of the logging exporters