### PR TITLE
Rename disabled resources property to be consistent with agent.

### DIFF
--- a/sdk/common/build.gradle.kts
+++ b/sdk/common/build.gradle.kts
@@ -89,12 +89,12 @@ tasks {
 
     named<Test>("testResourceDisabledByProperty") {
         jvmArgs("-Dotel.java.disabled.resource-providers=io.opentelemetry.sdk.extension.resources.OsResource,io.opentelemetry.sdk.extension.resources.ProcessResource")
+        // Properties win, this is ignored.
+        environment("OTEL_JAVA_DISABLED_RESOURCE_PROVIDERS", "io.opentelemetry.sdk.extension.resources.ProcessRuntimeResource")
     }
 
     named<Test>("testResourceDisabledByEnv") {
         environment("OTEL_JAVA_DISABLED_RESOURCE_PROVIDERS", "io.opentelemetry.sdk.extension.resources.OsResource,io.opentelemetry.sdk.extension.resources.ProcessResource")
-        // Environment variable wins, this is ignored.
-        jvmArgs("-Dotel.java.disabled.resource-providers=io.opentelemetry.sdk.extension.resources.ProcessRuntimeResource")
 
     }
 }

--- a/sdk/common/build.gradle.kts
+++ b/sdk/common/build.gradle.kts
@@ -3,12 +3,18 @@ plugins {
     id("maven-publish")
 
     id("ru.vyarus.animalsniffer")
+    id("org.unbroken-dome.test-sets")
 }
 
 description = "OpenTelemetry SDK Common"
 extra["moduleName"] = "io.opentelemetry.sdk.common"
 
 val mrJarVersions = listOf(9)
+
+testSets {
+    create("testResourceDisabledByProperty")
+    create("testResourceDisabledByEnv")
+}
 
 dependencies {
     api(project(":api:all"))
@@ -19,6 +25,7 @@ dependencies {
     testAnnotationProcessor("com.google.auto.value:auto-value")
 
     testImplementation(project(":sdk:testing"))
+    testImplementation(project(":sdk-extensions:resources"))
     testImplementation("com.google.guava:guava-testlib")
 }
 
@@ -78,5 +85,16 @@ tasks {
         manifest.attributes(
                 "Multi-Release" to "true"
         )
+    }
+
+    named<Test>("testResourceDisabledByProperty") {
+        jvmArgs("-Dotel.java.disabled.resource-providers=io.opentelemetry.sdk.extension.resources.OsResource,io.opentelemetry.sdk.extension.resources.ProcessResource")
+    }
+
+    named<Test>("testResourceDisabledByEnv") {
+        environment("OTEL_JAVA_DISABLED_RESOURCE_PROVIDERS", "io.opentelemetry.sdk.extension.resources.OsResource,io.opentelemetry.sdk.extension.resources.ProcessResource")
+        // Environment variable wins, this is ignored.
+        jvmArgs("-Dotel.java.disabled.resource-providers=io.opentelemetry.sdk.extension.resources.ProcessRuntimeResource")
+
     }
 }

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/resources/Resource.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/resources/Resource.java
@@ -40,7 +40,7 @@ import javax.annotation.concurrent.Immutable;
 public abstract class Resource {
 
   private static final String OTEL_JAVA_DISABLED_RESOURCES_PROVIDERS_PROPERTY_KEY =
-      "otel.java.disabled.resource_providers";
+      "otel.java.disabled.resource-providers";
 
   private static final String OTEL_JAVA_DISABLED_RESOURCES_PROVIDERS_ENV_KEY =
       "OTEL_JAVA_DISABLED_RESOURCE_PROVIDERS";

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/resources/Resource.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/resources/Resource.java
@@ -90,10 +90,10 @@ public abstract class Resource {
 
   private static Resource readResourceFromProviders() {
     String disabledResourceProvidersConfig =
-        System.getenv(OTEL_JAVA_DISABLED_RESOURCES_PROVIDERS_ENV_KEY);
+        System.getProperty(OTEL_JAVA_DISABLED_RESOURCES_PROVIDERS_PROPERTY_KEY, "");
     if (disabledResourceProvidersConfig == null) {
       disabledResourceProvidersConfig =
-          System.getProperty(OTEL_JAVA_DISABLED_RESOURCES_PROVIDERS_PROPERTY_KEY, "");
+          System.getenv(OTEL_JAVA_DISABLED_RESOURCES_PROVIDERS_ENV_KEY);
     }
     Set<String> disabledResourceProviders =
         Arrays.stream(disabledResourceProvidersConfig.split(","))

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/resources/ResourceProvidersTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/resources/ResourceProvidersTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.resources;
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import org.junit.jupiter.api.Test;
 
 class ResourceProvidersTest {
@@ -19,5 +20,9 @@ class ResourceProvidersTest {
     long providerAttribute = resource.getAttributes().get(longKey("providerAttribute"));
     assertThat(providerAttribute).isNotNull();
     assertThat(providerAttribute).isEqualTo(42);
+
+    assertThat(resource.getAttributes().get(ResourceAttributes.OS_TYPE)).isNotNull();
+    assertThat(resource.getAttributes().get(ResourceAttributes.PROCESS_PID)).isNotNull();
+    assertThat(resource.getAttributes().get(ResourceAttributes.PROCESS_RUNTIME_NAME)).isNotNull();
   }
 }

--- a/sdk/common/src/testResourceDisabledByEnv/java/io/opentelemetry/sdk/resources/ResourceDisabledByEnvTest.java
+++ b/sdk/common/src/testResourceDisabledByEnv/java/io/opentelemetry/sdk/resources/ResourceDisabledByEnvTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import org.junit.jupiter.api.Test;
+
+class ResourceDisabledByEnvTest {
+
+  @Test
+  void osAndProcessDisabled() {
+    Resource resource = Resource.getDefault();
+
+    assertThat(resource.getAttributes().get(ResourceAttributes.OS_TYPE)).isNull();
+    assertThat(resource.getAttributes().get(ResourceAttributes.PROCESS_PID)).isNull();
+    assertThat(resource.getAttributes().get(ResourceAttributes.PROCESS_RUNTIME_NAME)).isNotNull();
+  }
+}

--- a/sdk/common/src/testResourceDisabledByProperty/java/io/opentelemetry/sdk/resources/ResourceDisabledByPropertyTest.java
+++ b/sdk/common/src/testResourceDisabledByProperty/java/io/opentelemetry/sdk/resources/ResourceDisabledByPropertyTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import org.junit.jupiter.api.Test;
+
+class ResourceDisabledByPropertyTest {
+
+  @Test
+  void osAndProcessDisabled() {
+    Resource resource = Resource.getDefault();
+
+    assertThat(resource.getAttributes().get(ResourceAttributes.OS_TYPE)).isNull();
+    assertThat(resource.getAttributes().get(ResourceAttributes.PROCESS_PID)).isNull();
+    assertThat(resource.getAttributes().get(ResourceAttributes.PROCESS_RUNTIME_NAME)).isNotNull();
+  }
+}


### PR DESCRIPTION
Lacking anything in the spec, this follows the rule of do what agent is doing right now. 

It's a small external configuration change which I think is within the scope of RC.

Fixes #2526