### PR TITLE
Make kotlin stdlib dependencies compileOnly since a user will bring t…

### DIFF
--- a/extensions/kotlin/build.gradle
+++ b/extensions/kotlin/build.gradle
@@ -20,11 +20,12 @@ dependencies {
 
     api project(':api:all')
 
-    api("org.jetbrains.kotlin:kotlin-stdlib-common")
-    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2")
+    compileOnly("org.jetbrains.kotlin:kotlin-stdlib-common")
+    compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2")
 
     testImplementation project(':sdk:testing')
     testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2")
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {


### PR DESCRIPTION
…hem in.

See https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/2206/files#r571379473