### PR TITLE
Target Android API 21 with animalsniffer and disable it for metrics f…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -372,7 +372,7 @@ subprojects {
 
         plugins.withId("ru.vyarus.animalsniffer") {
             dependencies {
-                add(AnimalSnifferPlugin.SIGNATURE_CONF, "com.toasttab.android:gummy-bears-api-24:0.3.0:coreLib@signature")
+                add(AnimalSnifferPlugin.SIGNATURE_CONF, "com.toasttab.android:gummy-bears-api-21:0.3.0:coreLib@signature")
             }
 
             configure<AnimalSnifferExtension> {

--- a/sdk/metrics/build.gradle.kts
+++ b/sdk/metrics/build.gradle.kts
@@ -3,7 +3,10 @@ plugins {
     id("maven-publish")
 
     id("me.champeau.gradle.jmh")
-    id("ru.vyarus.animalsniffer")
+
+    // TODO(anuraaga): Enable animalsniffer by the time we are getting ready to release a stable
+    // version. Long/DoubleAdder are not part of Android API 21 which is our current target.
+    // id("ru.vyarus.animalsniffer")
 }
 
 description = "OpenTelemetry SDK Metrics"


### PR DESCRIPTION
…or now since it's unstable.

This aligns our target with okhttp, which we consider a library to follow for best practices for supporting Android. We can always raise the version later if we feel it's appropriate, or maybe we'll figure out a workaround, but for now it makes sense to keep the baseline lower as all of our stable artifacts are already compatible with it.

Fixes #2808 