### PR TITLE
Use schemed endpoint for jaeger exporter.

### DIFF
--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterTest.java
@@ -286,6 +286,16 @@ class JaegerGrpcSpanExporterTest {
     assertThatThrownBy(() -> JaegerGrpcSpanExporter.builder().setTimeout(null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("timeout");
+
+    assertThatThrownBy(() -> JaegerGrpcSpanExporter.builder().setEndpoint(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("endpoint");
+    assertThatThrownBy(() -> JaegerGrpcSpanExporter.builder().setEndpoint(""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid endpoint, must be a URL: http://");
+    assertThatThrownBy(() -> JaegerGrpcSpanExporter.builder().setEndpoint("gopher://localhost"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid scheme, must be http or https: gopher://localhost");
   }
 
   static class MockCollectorService extends CollectorServiceGrpc.CollectorServiceImplBase {


### PR DESCRIPTION
While looking at https://github.com/open-telemetry/opentelemetry-java-instrumentation/discussions/2266 I noticed that the spec defines endpoint as a schemed URL for Jaeger too, but we don't handle it. This means there's no environment variable for specifying an insecure or secure connection.

https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#jaeger-exporter

I just copied the code from the OTLP exporter, presumably we need to clean these up to remove support for schemaless though.