### PR TITLE
Properly shutdown tracer providers synchronously via close()

### DIFF
--- a/examples/http/src/main/java/io/opentelemetry/example/http/ExampleConfiguration.java
+++ b/examples/http/src/main/java/io/opentelemetry/example/http/ExampleConfiguration.java
@@ -37,7 +37,7 @@ class ExampleConfiguration {
             .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
             .build();
 
-    Runtime.getRuntime().addShutdownHook(new Thread(sdkTracerProvider::shutdown));
+    Runtime.getRuntime().addShutdownHook(new Thread(sdkTracerProvider::close));
     return sdk;
   }
 }

--- a/examples/jaeger/src/main/java/io/opentelemetry/example/jaeger/ExampleConfiguration.java
+++ b/examples/jaeger/src/main/java/io/opentelemetry/example/jaeger/ExampleConfiguration.java
@@ -54,7 +54,7 @@ class ExampleConfiguration {
         OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build();
 
     // it's always a good idea to shut down the SDK cleanly at JVM exit.
-    Runtime.getRuntime().addShutdownHook(new Thread(tracerProvider::shutdown));
+    Runtime.getRuntime().addShutdownHook(new Thread(tracerProvider::close));
 
     return openTelemetry;
   }

--- a/examples/otlp/src/main/java/io/opentelemetry/example/otlp/ExampleConfiguration.java
+++ b/examples/otlp/src/main/java/io/opentelemetry/example/otlp/ExampleConfiguration.java
@@ -45,7 +45,7 @@ public class ExampleConfiguration {
     OpenTelemetrySdk openTelemetrySdk =
         OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).buildAndRegisterGlobal();
 
-    Runtime.getRuntime().addShutdownHook(new Thread(tracerProvider::shutdown));
+    Runtime.getRuntime().addShutdownHook(new Thread(tracerProvider::close));
 
     return openTelemetrySdk;
   }

--- a/examples/zipkin/src/main/java/io/opentelemetry/example/zipkin/ExampleConfiguration.java
+++ b/examples/zipkin/src/main/java/io/opentelemetry/example/zipkin/ExampleConfiguration.java
@@ -13,7 +13,6 @@ import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
-import java.util.concurrent.TimeUnit;
 
 /**
  * All SDK management takes place here, away from the instrumentation code, which should only access

--- a/examples/zipkin/src/main/java/io/opentelemetry/example/zipkin/ExampleConfiguration.java
+++ b/examples/zipkin/src/main/java/io/opentelemetry/example/zipkin/ExampleConfiguration.java
@@ -13,6 +13,7 @@ import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import java.util.concurrent.TimeUnit;
 
 /**
  * All SDK management takes place here, away from the instrumentation code, which should only access
@@ -44,7 +45,7 @@ public class ExampleConfiguration {
         OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).buildAndRegisterGlobal();
 
     // add a shutdown hook to shut down the SDK
-    Runtime.getRuntime().addShutdownHook(new Thread(tracerProvider::shutdown));
+    Runtime.getRuntime().addShutdownHook(new Thread(tracerProvider::close));
 
     // return the configured instance so it can be used for instrumentation.
     return openTelemetry;

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
@@ -48,7 +48,7 @@ final class TracerProviderConfiguration {
     }
 
     SdkTracerProvider tracerProvider = tracerProviderBuilder.build();
-    Runtime.getRuntime().addShutdownHook(new Thread(tracerProvider::shutdown));
+    Runtime.getRuntime().addShutdownHook(new Thread(tracerProvider::close));
     return tracerProvider;
   }
 


### PR DESCRIPTION
Resolves #2825

I updated the examples, as well, since they were also not doing it correctly.