### PR TITLE
[Breaking Change] Rename getEmpty() to empty()

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/trace/ArrayBasedTraceStateBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/ArrayBasedTraceStateBuilder.java
@@ -27,7 +27,7 @@ final class ArrayBasedTraceStateBuilder implements TraceStateBuilder {
   private final ArrayBasedTraceState parent;
   @Nullable private List<String> entries;
 
-  static TraceState getEmpty() {
+  static TraceState empty() {
     return EMPTY;
   }
 

--- a/api/all/src/main/java/io/opentelemetry/api/trace/TraceState.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/TraceState.java
@@ -44,7 +44,7 @@ public interface TraceState {
    * @return the default {@code TraceState} with no entries.
    */
   static TraceState getDefault() {
-    return ArrayBasedTraceStateBuilder.getEmpty();
+    return ArrayBasedTraceStateBuilder.empty();
   }
 
   /** Returns an empty {@code TraceStateBuilder}. */

--- a/exporters/otlp/metrics/src/test/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterTest.java
+++ b/exporters/otlp/metrics/src/test/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterTest.java
@@ -256,8 +256,8 @@ class OtlpGrpcMetricExporterTest {
     long startNs = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
     long endNs = startNs + TimeUnit.MILLISECONDS.toNanos(900);
     return MetricData.createLongSum(
-        Resource.getEmpty(),
-        InstrumentationLibraryInfo.getEmpty(),
+        Resource.empty(),
+        InstrumentationLibraryInfo.empty(),
         "name",
         "description",
         "1",

--- a/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/TraceMarshalerTest.java
+++ b/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/TraceMarshalerTest.java
@@ -121,7 +121,7 @@ class TraceMarshalerTest {
             testSpanDataWithInstrumentationLibrary(InstrumentationLibraryInfo.create("name", "")),
             testSpanDataWithInstrumentationLibrary(
                 InstrumentationLibraryInfo.create("name", "version")),
-            testSpanDataWithInstrumentationLibrary(InstrumentationLibraryInfo.getEmpty()),
+            testSpanDataWithInstrumentationLibrary(InstrumentationLibraryInfo.empty()),
             testSpanDataWithInstrumentationLibrary(InstrumentationLibraryInfo.create("", ""))));
   }
 

--- a/sdk-extensions/otproto/src/test/java/io/opentelemetry/sdk/extension/otproto/MetricAdapterTest.java
+++ b/sdk-extensions/otproto/src/test/java/io/opentelemetry/sdk/extension/otproto/MetricAdapterTest.java
@@ -211,8 +211,8 @@ class MetricAdapterTest {
     assertThat(
             MetricAdapter.toProtoMetric(
                 MetricData.createLongSum(
-                    Resource.getEmpty(),
-                    InstrumentationLibraryInfo.getEmpty(),
+                    Resource.empty(),
+                    InstrumentationLibraryInfo.empty(),
                     "name",
                     "description",
                     "1",
@@ -246,8 +246,8 @@ class MetricAdapterTest {
     assertThat(
             MetricAdapter.toProtoMetric(
                 MetricData.createDoubleSum(
-                    Resource.getEmpty(),
-                    InstrumentationLibraryInfo.getEmpty(),
+                    Resource.empty(),
+                    InstrumentationLibraryInfo.empty(),
                     "name",
                     "description",
                     "1",
@@ -286,8 +286,8 @@ class MetricAdapterTest {
     assertThat(
             MetricAdapter.toProtoMetric(
                 MetricData.createLongSum(
-                    Resource.getEmpty(),
-                    InstrumentationLibraryInfo.getEmpty(),
+                    Resource.empty(),
+                    InstrumentationLibraryInfo.empty(),
                     "name",
                     "description",
                     "1",
@@ -321,8 +321,8 @@ class MetricAdapterTest {
     assertThat(
             MetricAdapter.toProtoMetric(
                 MetricData.createDoubleSum(
-                    Resource.getEmpty(),
-                    InstrumentationLibraryInfo.getEmpty(),
+                    Resource.empty(),
+                    InstrumentationLibraryInfo.empty(),
                     "name",
                     "description",
                     "1",
@@ -361,8 +361,8 @@ class MetricAdapterTest {
     assertThat(
             MetricAdapter.toProtoMetric(
                 MetricData.createLongGauge(
-                    Resource.getEmpty(),
-                    InstrumentationLibraryInfo.getEmpty(),
+                    Resource.empty(),
+                    InstrumentationLibraryInfo.empty(),
                     "name",
                     "description",
                     "1",
@@ -392,8 +392,8 @@ class MetricAdapterTest {
     assertThat(
             MetricAdapter.toProtoMetric(
                 MetricData.createDoubleGauge(
-                    Resource.getEmpty(),
-                    InstrumentationLibraryInfo.getEmpty(),
+                    Resource.empty(),
+                    InstrumentationLibraryInfo.empty(),
                     "name",
                     "description",
                     "1",
@@ -428,8 +428,8 @@ class MetricAdapterTest {
     assertThat(
             MetricAdapter.toProtoMetric(
                 MetricData.createDoubleSummary(
-                    Resource.getEmpty(),
-                    InstrumentationLibraryInfo.getEmpty(),
+                    Resource.empty(),
+                    InstrumentationLibraryInfo.empty(),
                     "name",
                     "description",
                     "1",
@@ -529,7 +529,7 @@ class MetricAdapterTest {
                             Collections.singletonList(
                                 DoublePointData.create(123, 456, Labels.of("k", "v"), 5.0)))),
                     MetricData.createDoubleSum(
-                        Resource.getEmpty(),
+                        Resource.empty(),
                         instrumentationLibraryInfo,
                         "name",
                         "description",
@@ -540,8 +540,8 @@ class MetricAdapterTest {
                             Collections.singletonList(
                                 DoublePointData.create(123, 456, Labels.of("k", "v"), 5.0)))),
                     MetricData.createDoubleSum(
-                        Resource.getEmpty(),
-                        InstrumentationLibraryInfo.getEmpty(),
+                        Resource.empty(),
+                        InstrumentationLibraryInfo.empty(),
                         "name",
                         "description",
                         "1",

--- a/sdk-extensions/otproto/src/test/java/io/opentelemetry/sdk/extension/otproto/ResourceAdapterTest.java
+++ b/sdk-extensions/otproto/src/test/java/io/opentelemetry/sdk/extension/otproto/ResourceAdapterTest.java
@@ -54,7 +54,7 @@ class ResourceAdapterTest {
 
   @Test
   void toProtoResource_Empty() {
-    assertThat(ResourceAdapter.toProtoResource(Resource.getEmpty()))
+    assertThat(ResourceAdapter.toProtoResource(Resource.empty()))
         .isEqualTo(io.opentelemetry.proto.resource.v1.Resource.newBuilder().build());
   }
 }

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -140,7 +140,7 @@ class OpenTelemetrySdkTest {
                     .addSpanProcessor(SimpleSpanProcessor.create(mock(SpanExporter.class)))
                     .setClock(mock(Clock.class))
                     .setIdGenerator(mock(IdGenerator.class))
-                    .setResource(Resource.getEmpty())
+                    .setResource(Resource.empty())
                     .setSpanLimits(newConfig)
                     .build());
 

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfo.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfo.java
@@ -39,7 +39,7 @@ public abstract class InstrumentationLibraryInfo {
    *
    * @return an "empty" {@code InstrumentationLibraryInfo}.
    */
-  public static InstrumentationLibraryInfo getEmpty() {
+  public static InstrumentationLibraryInfo empty() {
     return EMPTY;
   }
 

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/resources/Resource.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/resources/Resource.java
@@ -118,7 +118,7 @@ public abstract class Resource {
    *
    * @return an empty {@code Resource}.
    */
-  public static Resource getEmpty() {
+  public static Resource empty() {
     return EMPTY;
   }
 

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfoTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfoTest.java
@@ -15,8 +15,8 @@ class InstrumentationLibraryInfoTest {
 
   @Test
   void emptyLibraryInfo() {
-    assertThat(InstrumentationLibraryInfo.getEmpty().getName()).isEmpty();
-    assertThat(InstrumentationLibraryInfo.getEmpty().getVersion()).isNull();
+    assertThat(InstrumentationLibraryInfo.empty().getName()).isEmpty();
+    assertThat(InstrumentationLibraryInfo.empty().getVersion()).isNull();
   }
 
   @Test

--- a/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/TestSdk.java
+++ b/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/TestSdk.java
@@ -24,7 +24,7 @@ public enum TestSdk {
         @Override
         Meter build() {
           MeterProviderSharedState meterProviderSharedState =
-              MeterProviderSharedState.create(SystemClock.getInstance(), Resource.getEmpty());
+              MeterProviderSharedState.create(SystemClock.getInstance(), Resource.empty());
           InstrumentationLibraryInfo instrumentationLibraryInfo =
               InstrumentationLibraryInfo.create("io.opentelemetry.sdk.metrics", null);
 

--- a/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountBenchmark.java
+++ b/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountBenchmark.java
@@ -28,7 +28,7 @@ public class DoubleMinMaxSumCountBenchmark {
       AggregatorFactory.minMaxSumCount()
           .create(
               Resource.getDefault(),
-              InstrumentationLibraryInfo.getEmpty(),
+              InstrumentationLibraryInfo.empty(),
               InstrumentDescriptor.create(
                   "name",
                   "description",

--- a/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountBenchmark.java
+++ b/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountBenchmark.java
@@ -28,7 +28,7 @@ public class LongMinMaxSumCountBenchmark {
       AggregatorFactory.minMaxSumCount()
           .create(
               Resource.getDefault(),
-              InstrumentationLibraryInfo.getEmpty(),
+              InstrumentationLibraryInfo.empty(),
               InstrumentDescriptor.create(
                   "name",
                   "description",

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/InstrumentRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/InstrumentRegistryTest.java
@@ -28,8 +28,7 @@ class InstrumentRegistryTest {
 
   @Test
   void register() {
-    MeterSharedState meterSharedState =
-        MeterSharedState.create(InstrumentationLibraryInfo.getEmpty());
+    MeterSharedState meterSharedState = MeterSharedState.create(InstrumentationLibraryInfo.empty());
     TestInstrument testInstrument = new TestInstrument(INSTRUMENT_DESCRIPTOR);
     assertThat(meterSharedState.getInstrumentRegistry().register(testInstrument))
         .isSameAs(testInstrument);
@@ -44,8 +43,7 @@ class InstrumentRegistryTest {
 
   @Test
   void register_OtherDescriptor() {
-    MeterSharedState meterSharedState =
-        MeterSharedState.create(InstrumentationLibraryInfo.getEmpty());
+    MeterSharedState meterSharedState = MeterSharedState.create(InstrumentationLibraryInfo.empty());
     TestInstrument testInstrument = new TestInstrument(INSTRUMENT_DESCRIPTOR);
     assertThat(meterSharedState.getInstrumentRegistry().register(testInstrument))
         .isSameAs(testInstrument);
@@ -61,8 +59,7 @@ class InstrumentRegistryTest {
 
   @Test
   void register_OtherInstance() {
-    MeterSharedState meterSharedState =
-        MeterSharedState.create(InstrumentationLibraryInfo.getEmpty());
+    MeterSharedState meterSharedState = MeterSharedState.create(InstrumentationLibraryInfo.empty());
     TestInstrument testInstrument = new TestInstrument(INSTRUMENT_DESCRIPTOR);
     assertThat(meterSharedState.getInstrumentRegistry().register(testInstrument))
         .isSameAs(testInstrument);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterRegistryTest.java
@@ -25,14 +25,14 @@ import org.junit.jupiter.api.Test;
 class SdkMeterRegistryTest {
   private final TestClock testClock = TestClock.create();
   private final SdkMeterProvider meterProvider =
-      SdkMeterProvider.builder().setClock(testClock).setResource(Resource.getEmpty()).build();
+      SdkMeterProvider.builder().setClock(testClock).setResource(Resource.empty()).build();
 
   @Test
   void builder_HappyPath() {
     assertThat(
             SdkMeterProvider.builder()
                 .setClock(mock(Clock.class))
-                .setResource(Resource.getEmpty())
+                .setResource(Resource.empty())
                 .build())
         .isNotNull();
   }
@@ -87,7 +87,7 @@ class SdkMeterRegistryTest {
     assertThat(meterProvider.collectAllMetrics())
         .containsExactlyInAnyOrder(
             MetricData.createLongSum(
-                Resource.getEmpty(),
+                Resource.empty(),
                 sdkMeter1.getInstrumentationLibraryInfo(),
                 "testLongCounter",
                 "",
@@ -99,7 +99,7 @@ class SdkMeterRegistryTest {
                         LongPointData.create(
                             testClock.now(), testClock.now(), Labels.empty(), 10)))),
             MetricData.createLongSum(
-                Resource.getEmpty(),
+                Resource.empty(),
                 sdkMeter2.getInstrumentationLibraryInfo(),
                 "testLongCounter",
                 "",

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SynchronousInstrumentAccumulatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SynchronousInstrumentAccumulatorTest.java
@@ -26,8 +26,7 @@ public class SynchronousInstrumentAccumulatorTest {
   private final TestClock testClock = TestClock.create();
   private final Aggregator<Long> aggregator =
       AggregatorFactory.lastValue()
-          .create(
-              Resource.getEmpty(), InstrumentationLibraryInfo.create("test", "1.0"), DESCRIPTOR);
+          .create(Resource.empty(), InstrumentationLibraryInfo.create("test", "1.0"), DESCRIPTOR);
 
   @Test
   void sameAggregator_ForSameLabelSet() {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/AggregatorFactoryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/AggregatorFactoryTest.java
@@ -22,7 +22,7 @@ class AggregatorFactoryTest {
     assertThat(
             count.create(
                 Resource.getDefault(),
-                InstrumentationLibraryInfo.getEmpty(),
+                InstrumentationLibraryInfo.empty(),
                 InstrumentDescriptor.create(
                     "name",
                     "description",
@@ -33,7 +33,7 @@ class AggregatorFactoryTest {
     assertThat(
             count.create(
                 Resource.getDefault(),
-                InstrumentationLibraryInfo.getEmpty(),
+                InstrumentationLibraryInfo.empty(),
                 InstrumentDescriptor.create(
                     "name",
                     "description",
@@ -49,7 +49,7 @@ class AggregatorFactoryTest {
     assertThat(
             lastValue.create(
                 Resource.getDefault(),
-                InstrumentationLibraryInfo.getEmpty(),
+                InstrumentationLibraryInfo.empty(),
                 InstrumentDescriptor.create(
                     "name",
                     "description",
@@ -60,7 +60,7 @@ class AggregatorFactoryTest {
     assertThat(
             lastValue.create(
                 Resource.getDefault(),
-                InstrumentationLibraryInfo.getEmpty(),
+                InstrumentationLibraryInfo.empty(),
                 InstrumentDescriptor.create(
                     "name",
                     "description",
@@ -76,7 +76,7 @@ class AggregatorFactoryTest {
     assertThat(
             minMaxSumCount.create(
                 Resource.getDefault(),
-                InstrumentationLibraryInfo.getEmpty(),
+                InstrumentationLibraryInfo.empty(),
                 InstrumentDescriptor.create(
                     "name",
                     "description",
@@ -87,7 +87,7 @@ class AggregatorFactoryTest {
     assertThat(
             minMaxSumCount.create(
                 Resource.getDefault(),
-                InstrumentationLibraryInfo.getEmpty(),
+                InstrumentationLibraryInfo.empty(),
                 InstrumentDescriptor.create(
                     "name",
                     "description",
@@ -103,7 +103,7 @@ class AggregatorFactoryTest {
     assertThat(
             sum.create(
                 Resource.getDefault(),
-                InstrumentationLibraryInfo.getEmpty(),
+                InstrumentationLibraryInfo.empty(),
                 InstrumentDescriptor.create(
                     "name",
                     "description",
@@ -114,7 +114,7 @@ class AggregatorFactoryTest {
     assertThat(
             sum.create(
                 Resource.getDefault(),
-                InstrumentationLibraryInfo.getEmpty(),
+                InstrumentationLibraryInfo.empty(),
                 InstrumentDescriptor.create(
                     "name",
                     "description",

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/CountAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/CountAggregatorTest.java
@@ -25,7 +25,7 @@ class CountAggregatorTest {
   private static final CountAggregator cumulativeAggregator =
       new CountAggregator(
           Resource.getDefault(),
-          InstrumentationLibraryInfo.getEmpty(),
+          InstrumentationLibraryInfo.empty(),
           InstrumentDescriptor.create(
               "name",
               "description",
@@ -36,7 +36,7 @@ class CountAggregatorTest {
   private static final CountAggregator deltaAggregator =
       new CountAggregator(
           Resource.getDefault(),
-          InstrumentationLibraryInfo.getEmpty(),
+          InstrumentationLibraryInfo.empty(),
           InstrumentDescriptor.create(
               "name",
               "description",
@@ -87,7 +87,7 @@ class CountAggregatorTest {
         .isEqualTo(
             MetricData.createLongSum(
                 Resource.getDefault(),
-                InstrumentationLibraryInfo.getEmpty(),
+                InstrumentationLibraryInfo.empty(),
                 "name",
                 "description",
                 "1",
@@ -112,7 +112,7 @@ class CountAggregatorTest {
         .isEqualTo(
             MetricData.createLongSum(
                 Resource.getDefault(),
-                InstrumentationLibraryInfo.getEmpty(),
+                InstrumentationLibraryInfo.empty(),
                 "name",
                 "description",
                 "1",

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleLastValueAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleLastValueAggregatorTest.java
@@ -24,7 +24,7 @@ class DoubleLastValueAggregatorTest {
   private static final DoubleLastValueAggregator aggregator =
       new DoubleLastValueAggregator(
           Resource.getDefault(),
-          InstrumentationLibraryInfo.getEmpty(),
+          InstrumentationLibraryInfo.empty(),
           InstrumentDescriptor.create(
               "name",
               "description",
@@ -76,7 +76,7 @@ class DoubleLastValueAggregatorTest {
         .isEqualTo(
             MetricData.createDoubleGauge(
                 Resource.getDefault(),
-                InstrumentationLibraryInfo.getEmpty(),
+                InstrumentationLibraryInfo.empty(),
                 "name",
                 "description",
                 "unit",

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountAggregatorTest.java
@@ -29,7 +29,7 @@ class DoubleMinMaxSumCountAggregatorTest {
   private static final DoubleMinMaxSumCountAggregator aggregator =
       new DoubleMinMaxSumCountAggregator(
           Resource.getDefault(),
-          InstrumentationLibraryInfo.getEmpty(),
+          InstrumentationLibraryInfo.empty(),
           InstrumentDescriptor.create(
               "name",
               "description",

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleSumAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleSumAggregatorTest.java
@@ -25,7 +25,7 @@ class DoubleSumAggregatorTest {
   private static final DoubleSumAggregator aggregator =
       new DoubleSumAggregator(
           Resource.getDefault(),
-          InstrumentationLibraryInfo.getEmpty(),
+          InstrumentationLibraryInfo.empty(),
           InstrumentDescriptor.create(
               "name", "description", "unit", InstrumentType.COUNTER, InstrumentValueType.DOUBLE),
           /* stateful= */ true);
@@ -89,7 +89,7 @@ class DoubleSumAggregatorTest {
         .isEqualTo(
             MetricData.createDoubleSum(
                 Resource.getDefault(),
-                InstrumentationLibraryInfo.getEmpty(),
+                InstrumentationLibraryInfo.empty(),
                 "name",
                 "description",
                 "unit",

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongLastValueAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongLastValueAggregatorTest.java
@@ -24,7 +24,7 @@ class LongLastValueAggregatorTest {
   private static final LongLastValueAggregator aggregator =
       new LongLastValueAggregator(
           Resource.getDefault(),
-          InstrumentationLibraryInfo.getEmpty(),
+          InstrumentationLibraryInfo.empty(),
           InstrumentDescriptor.create(
               "name",
               "description",
@@ -76,7 +76,7 @@ class LongLastValueAggregatorTest {
         .isEqualTo(
             MetricData.createLongGauge(
                 Resource.getDefault(),
-                InstrumentationLibraryInfo.getEmpty(),
+                InstrumentationLibraryInfo.empty(),
                 "name",
                 "description",
                 "unit",

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountAggregatorTest.java
@@ -29,7 +29,7 @@ class LongMinMaxSumCountAggregatorTest {
   private static final LongMinMaxSumCountAggregator aggregator =
       new LongMinMaxSumCountAggregator(
           Resource.getDefault(),
-          InstrumentationLibraryInfo.getEmpty(),
+          InstrumentationLibraryInfo.empty(),
           InstrumentDescriptor.create(
               "name",
               "description",

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongSumAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongSumAggregatorTest.java
@@ -25,7 +25,7 @@ class LongSumAggregatorTest {
   private static final LongSumAggregator aggregator =
       new LongSumAggregator(
           Resource.getDefault(),
-          InstrumentationLibraryInfo.getEmpty(),
+          InstrumentationLibraryInfo.empty(),
           InstrumentDescriptor.create(
               "name", "description", "unit", InstrumentType.COUNTER, InstrumentValueType.LONG),
           /* stateful= */ true);
@@ -91,7 +91,7 @@ class LongSumAggregatorTest {
         .isEqualTo(
             MetricData.createLongSum(
                 Resource.getDefault(),
-                InstrumentationLibraryInfo.getEmpty(),
+                InstrumentationLibraryInfo.empty(),
                 "name",
                 "description",
                 "unit",

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/MetricDataTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/MetricDataTest.java
@@ -45,8 +45,8 @@ class MetricDataTest {
   void metricData_Getters() {
     MetricData metricData =
         MetricData.createDoubleGauge(
-            Resource.getEmpty(),
-            InstrumentationLibraryInfo.getEmpty(),
+            Resource.empty(),
+            InstrumentationLibraryInfo.empty(),
             "metric_name",
             "metric_description",
             "ms",
@@ -55,9 +55,9 @@ class MetricDataTest {
     assertThat(metricData.getDescription()).isEqualTo("metric_description");
     assertThat(metricData.getUnit()).isEqualTo("ms");
     assertThat(metricData.getType()).isEqualTo(MetricDataType.DOUBLE_GAUGE);
-    assertThat(metricData.getResource()).isEqualTo(Resource.getEmpty());
+    assertThat(metricData.getResource()).isEqualTo(Resource.empty());
     assertThat(metricData.getInstrumentationLibraryInfo())
-        .isEqualTo(InstrumentationLibraryInfo.getEmpty());
+        .isEqualTo(InstrumentationLibraryInfo.empty());
     assertThat(metricData.isEmpty()).isTrue();
   }
 
@@ -70,8 +70,8 @@ class MetricDataTest {
     assertThat(LONG_POINT.getValue()).isEqualTo(LONG_VALUE);
     MetricData metricData =
         MetricData.createLongGauge(
-            Resource.getEmpty(),
-            InstrumentationLibraryInfo.getEmpty(),
+            Resource.empty(),
+            InstrumentationLibraryInfo.empty(),
             "metric_name",
             "metric_description",
             "ms",
@@ -80,8 +80,8 @@ class MetricDataTest {
     assertThat(metricData.getLongGaugeData().getPoints()).containsExactly(LONG_POINT);
     metricData =
         MetricData.createLongSum(
-            Resource.getEmpty(),
-            InstrumentationLibraryInfo.getEmpty(),
+            Resource.empty(),
+            InstrumentationLibraryInfo.empty(),
             "metric_name",
             "metric_description",
             "ms",
@@ -102,8 +102,8 @@ class MetricDataTest {
     assertThat(DOUBLE_POINT.getValue()).isEqualTo(DOUBLE_VALUE);
     MetricData metricData =
         MetricData.createDoubleGauge(
-            Resource.getEmpty(),
-            InstrumentationLibraryInfo.getEmpty(),
+            Resource.empty(),
+            InstrumentationLibraryInfo.empty(),
             "metric_name",
             "metric_description",
             "ms",
@@ -112,8 +112,8 @@ class MetricDataTest {
     assertThat(metricData.getDoubleGaugeData().getPoints()).containsExactly(DOUBLE_POINT);
     metricData =
         MetricData.createDoubleSum(
-            Resource.getEmpty(),
-            InstrumentationLibraryInfo.getEmpty(),
+            Resource.empty(),
+            InstrumentationLibraryInfo.empty(),
             "metric_name",
             "metric_description",
             "ms",
@@ -137,8 +137,8 @@ class MetricDataTest {
         .isEqualTo(Arrays.asList(MINIMUM_VALUE, MAXIMUM_VALUE));
     MetricData metricData =
         MetricData.createDoubleSummary(
-            Resource.getEmpty(),
-            InstrumentationLibraryInfo.getEmpty(),
+            Resource.empty(),
+            InstrumentationLibraryInfo.empty(),
             "metric_name",
             "metric_description",
             "ms",
@@ -150,8 +150,8 @@ class MetricDataTest {
   void metricData_GetDefault() {
     MetricData metricData =
         MetricData.createDoubleSummary(
-            Resource.getEmpty(),
-            InstrumentationLibraryInfo.getEmpty(),
+            Resource.empty(),
+            InstrumentationLibraryInfo.empty(),
             "metric_name",
             "metric_description",
             "ms",
@@ -164,8 +164,8 @@ class MetricDataTest {
 
     metricData =
         MetricData.createDoubleGauge(
-            Resource.getEmpty(),
-            InstrumentationLibraryInfo.getEmpty(),
+            Resource.empty(),
+            InstrumentationLibraryInfo.empty(),
             "metric_name",
             "metric_description",
             "ms",

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
@@ -42,7 +42,7 @@ class IntervalMetricReaderTest {
 
   private static final MetricData METRIC_DATA =
       MetricData.createLongSum(
-          Resource.getEmpty(),
+          Resource.empty(),
           InstrumentationLibraryInfo.create("IntervalMetricReaderTest", null),
           "my metric",
           "my metric description",

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/trace/TestSpanData.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/trace/TestSpanData.java
@@ -37,13 +37,13 @@ public abstract class TestSpanData implements SpanData {
     return new AutoValue_TestSpanData.Builder()
         .setSpanContext(SpanContext.getInvalid())
         .setParentSpanContext(SpanContext.getInvalid())
-        .setInstrumentationLibraryInfo(InstrumentationLibraryInfo.getEmpty())
+        .setInstrumentationLibraryInfo(InstrumentationLibraryInfo.empty())
         .setLinks(Collections.emptyList())
         .setTotalRecordedLinks(0)
         .setAttributes(Attributes.empty())
         .setEvents(Collections.emptyList())
         .setTotalRecordedEvents(0)
-        .setResource(Resource.getEmpty())
+        .setResource(Resource.empty())
         .setTotalAttributeCount(0);
   }
 

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertionsTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertionsTest.java
@@ -159,12 +159,11 @@ class OpenTelemetryAssertionsTest {
         .isInstanceOf(AssertionError.class);
     assertThatThrownBy(() -> assertThat(SPAN1).hasParentSpanId("foo"))
         .isInstanceOf(AssertionError.class);
-    assertThatThrownBy(() -> assertThat(SPAN1).hasResource(Resource.getEmpty()))
+    assertThatThrownBy(() -> assertThat(SPAN1).hasResource(Resource.empty()))
         .isInstanceOf(AssertionError.class);
     assertThatThrownBy(
             () ->
-                assertThat(SPAN1)
-                    .hasInstrumentationLibraryInfo(InstrumentationLibraryInfo.getEmpty()))
+                assertThat(SPAN1).hasInstrumentationLibraryInfo(InstrumentationLibraryInfo.empty()))
         .isInstanceOf(AssertionError.class);
     assertThatThrownBy(() -> assertThat(SPAN1).hasName("foo")).isInstanceOf(AssertionError.class);
     assertThatThrownBy(() -> assertThat(SPAN1).hasKind(SpanKind.SERVER))

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/exporter/InMemoryMetricExporterTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/exporter/InMemoryMetricExporterTest.java
@@ -29,8 +29,8 @@ class InMemoryMetricExporterTest {
     long startNs = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
     long endNs = startNs + TimeUnit.MILLISECONDS.toNanos(900);
     return MetricData.createLongSum(
-        Resource.getEmpty(),
-        InstrumentationLibraryInfo.getEmpty(),
+        Resource.empty(),
+        InstrumentationLibraryInfo.empty(),
         "name",
         "description",
         "1",

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/trace/TestSpanDataTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/trace/TestSpanDataTest.java
@@ -36,7 +36,7 @@ class TestSpanDataTest {
     assertThat(spanData.getEvents()).isEqualTo(emptyList());
     assertThat(spanData.getLinks()).isEqualTo(emptyList());
     assertThat(spanData.getInstrumentationLibraryInfo())
-        .isSameAs(InstrumentationLibraryInfo.getEmpty());
+        .isSameAs(InstrumentationLibraryInfo.empty());
   }
 
   @Test

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -70,7 +70,7 @@ class RecordEventsReadableSpanTest {
   private final String parentSpanId = idsGenerator.generateSpanId();
   private final SpanContext spanContext =
       SpanContext.create(traceId, spanId, TraceFlags.getDefault(), TraceState.getDefault());
-  private final Resource resource = Resource.getEmpty();
+  private final Resource resource = Resource.empty();
   private final InstrumentationLibraryInfo instrumentationLibraryInfo =
       InstrumentationLibraryInfo.create("theName", null);
   private final Map<AttributeKey, Object> attributes = new HashMap<>();


### PR DESCRIPTION
Provisionally resolves #2786 

Do not merge unless we agree to make this change before 1.0.0