### PR TITLE
2816: Autoconfigure to use SimpleSpanProcessor when logging exporter is used

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
@@ -18,16 +18,9 @@ import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.time.Duration;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.ServiceLoader;
-import java.util.Set;
 
 final class TracerProviderConfiguration {
-
-  /** A set of the exporter names that should use the SimpleSpanProcessor. */
-  private static final Set<String> SPAN_EXPORTER_USING_SIMPLE_SPAN_PROCESSOR =
-      new HashSet<>(Collections.singletonList("logging"));
 
   static SdkTracerProvider configureTracerProvider(Resource resource, ConfigProperties config) {
     SdkTracerProviderBuilder tracerProviderBuilder =
@@ -65,7 +58,7 @@ final class TracerProviderConfiguration {
   // VisibleForTesting
   static SpanProcessor configureSpanProcessor(
       ConfigProperties config, SpanExporter exporter, String exporterName) {
-    if (SPAN_EXPORTER_USING_SIMPLE_SPAN_PROCESSOR.contains(exporterName)) {
+    if (exporterName.equals("logging")) {
       return SimpleSpanProcessor.create(exporter);
     }
     return configureSpanProcessor(config, exporter);

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
@@ -9,8 +9,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.exporter.logging.LoggingSpanExporter;
+import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Collections;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class ConfigurableSpanExporterTest {
@@ -35,5 +40,29 @@ public class ConfigurableSpanExporterTest {
                     "catExporter", ConfigProperties.createForTest(Collections.emptyMap())))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("catExporter");
+  }
+
+  @Test
+  void configureSpanProcessor_simpleSpanProcessor() {
+    String exporterName = "logging";
+    Map<String, String> propMap = Collections.singletonMap("otel.traces.exporter", exporterName);
+    SpanExporter exporter = new LoggingSpanExporter();
+    ConfigProperties properties = ConfigProperties.createForTest(propMap);
+
+    assertThat(
+            TracerProviderConfiguration.configureSpanProcessor(properties, exporter, exporterName))
+        .isInstanceOf(SimpleSpanProcessor.class);
+  }
+
+  @Test
+  void configureSpanProcessor_batchSpanProcessor() {
+    String exporterName = "zipkin";
+    Map<String, String> propMap = Collections.singletonMap("otel.traces.exporter", exporterName);
+    SpanExporter exporter = ZipkinSpanExporter.builder().build();
+    ConfigProperties properties = ConfigProperties.createForTest(propMap);
+
+    assertThat(
+            TracerProviderConfiguration.configureSpanProcessor(properties, exporter, exporterName))
+        .isInstanceOf(BatchSpanProcessor.class);
   }
 }


### PR DESCRIPTION
This PR updates `TracerProviderConfiguration` to use a `SimpleSpanProcessor` whenever the environment variable `otel.traces.exporter` is set to `logging`. Right now on the main branch, an autoconfigured SDK always uses a `BatchSpanProcessor`.


fixes: #2816 


