### PR TITLE
Remove support for schemaless URLs for gRPC exporters.

### DIFF
--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterBuilder.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterBuilder.java
@@ -14,14 +14,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /** Builder utility for this exporter. */
 public final class JaegerGrpcSpanExporterBuilder {
-
-  private static final Logger logger =
-      Logger.getLogger(JaegerGrpcSpanExporterBuilder.class.getName());
 
   private static final String DEFAULT_ENDPOINT_URL = "http://localhost:14250";
   private static final URI DEFAULT_ENDPOINT = URI.create(DEFAULT_ENDPOINT_URL);
@@ -49,9 +44,6 @@ public final class JaegerGrpcSpanExporterBuilder {
    */
   public JaegerGrpcSpanExporterBuilder setEndpoint(String endpoint) {
     requireNonNull(endpoint, "endpoint");
-    if (!endpoint.contains("://")) {
-      endpoint = "http://" + endpoint;
-    }
 
     URI uri;
     try {
@@ -59,18 +51,13 @@ public final class JaegerGrpcSpanExporterBuilder {
     } catch (URISyntaxException e) {
       throw new IllegalArgumentException("Invalid endpoint, must be a URL: " + endpoint, e);
     }
-    // TODO(anuraaga): Remove after announcing deprecation of schemaless URLs.
-    if (uri.getScheme() != null) {
-      if (!uri.getScheme().equals("http") && !uri.getScheme().equals("https")) {
-        throw new IllegalArgumentException("Invalid scheme, must be http or https: " + endpoint);
-      }
-    } else {
-      logger.log(
-          Level.WARNING,
-          "Endpoints must have a scheme of http:// or https://. Endpoints without schemes will "
-              + "not be permitted in a future version of the SDK.",
-          new Throwable());
+
+    if (uri.getScheme() == null
+        || (!uri.getScheme().equals("http") && !uri.getScheme().equals("https"))) {
+      throw new IllegalArgumentException(
+          "Invalid endpoint, must start with http:// or https://: " + uri);
     }
+
     this.endpoint = uri;
     return this;
   }

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterTest.java
@@ -39,6 +39,7 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.net.InetAddress;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -290,12 +291,16 @@ class JaegerGrpcSpanExporterTest {
     assertThatThrownBy(() -> JaegerGrpcSpanExporter.builder().setEndpoint(null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("endpoint");
-    assertThatThrownBy(() -> JaegerGrpcSpanExporter.builder().setEndpoint(""))
+    assertThatThrownBy(() -> JaegerGrpcSpanExporter.builder().setEndpoint("😺://localhost"))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid endpoint, must be a URL: http://");
+        .hasMessage("Invalid endpoint, must be a URL: 😺://localhost")
+        .hasCauseInstanceOf(URISyntaxException.class);
+    assertThatThrownBy(() -> JaegerGrpcSpanExporter.builder().setEndpoint("localhost"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid endpoint, must start with http:// or https://: localhost");
     assertThatThrownBy(() -> JaegerGrpcSpanExporter.builder().setEndpoint("gopher://localhost"))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid scheme, must be http or https: gopher://localhost");
+        .hasMessage("Invalid endpoint, must start with http:// or https://: gopher://localhost");
   }
 
   static class MockCollectorService extends CollectorServiceGrpc.CollectorServiceImplBase {

--- a/exporters/otlp/metrics/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
+++ b/exporters/otlp/metrics/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
@@ -17,15 +17,10 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /** Builder utility for this exporter. */
 public final class OtlpGrpcMetricExporterBuilder {
-
-  private static final Logger logger =
-      Logger.getLogger(OtlpGrpcMetricExporterBuilder.class.getName());
 
   private static final String DEFAULT_ENDPOINT_URL = "http://localhost:4317";
   private static final URI DEFAULT_ENDPOINT = URI.create(DEFAULT_ENDPOINT_URL);
@@ -75,24 +70,20 @@ public final class OtlpGrpcMetricExporterBuilder {
    */
   public OtlpGrpcMetricExporterBuilder setEndpoint(String endpoint) {
     requireNonNull(endpoint, "endpoint");
-    final URI uri;
+
+    URI uri;
     try {
       uri = new URI(endpoint);
     } catch (URISyntaxException e) {
       throw new IllegalArgumentException("Invalid endpoint, must be a URL: " + endpoint, e);
     }
-    // TODO(anuraaga): Remove after announcing deprecation of schemaless URLs.
-    if (uri.getScheme() != null) {
-      if (!uri.getScheme().equals("http") && !uri.getScheme().equals("https")) {
-        throw new IllegalArgumentException("Invalid scheme, must be http or https: " + endpoint);
-      }
-    } else {
-      logger.log(
-          Level.WARNING,
-          "Endpoints must have a scheme of http:// or https://. Endpoints without schemes will "
-              + "not be permitted in a future version of the SDK.",
-          new Throwable());
+
+    if (uri.getScheme() == null
+        || (!uri.getScheme().equals("http") && !uri.getScheme().equals("https"))) {
+      throw new IllegalArgumentException(
+          "Invalid endpoint, must start with http:// or https://: " + uri);
     }
+
     this.endpoint = uri;
     return this;
   }

--- a/exporters/otlp/metrics/src/test/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterTest.java
+++ b/exporters/otlp/metrics/src/test/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterTest.java
@@ -87,9 +87,12 @@ class OtlpGrpcMetricExporterTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid endpoint, must be a URL: 😺://localhost")
         .hasCauseInstanceOf(URISyntaxException.class);
-    assertThatThrownBy(() -> OtlpGrpcMetricExporter.builder().setEndpoint("ftp://localhost"))
+    assertThatThrownBy(() -> OtlpGrpcMetricExporter.builder().setEndpoint("localhost"))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid scheme, must be http or https: ftp://localhost");
+        .hasMessage("Invalid endpoint, must start with http:// or https://: localhost");
+    assertThatThrownBy(() -> OtlpGrpcMetricExporter.builder().setEndpoint("gopher://localhost"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid endpoint, must start with http:// or https://: gopher://localhost");
   }
 
   @Test

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
@@ -20,16 +20,11 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLException;
 
 /** Builder utility for this exporter. */
 public final class OtlpGrpcSpanExporterBuilder {
-
-  private static final Logger logger =
-      Logger.getLogger(OtlpGrpcSpanExporterBuilder.class.getName());
 
   private static final String DEFAULT_ENDPOINT_URL = "http://localhost:4317";
   private static final URI DEFAULT_ENDPOINT = URI.create(DEFAULT_ENDPOINT_URL);
@@ -79,9 +74,6 @@ public final class OtlpGrpcSpanExporterBuilder {
    */
   public OtlpGrpcSpanExporterBuilder setEndpoint(String endpoint) {
     requireNonNull(endpoint, "endpoint");
-    if (!endpoint.contains("://")) {
-      endpoint = "http://" + endpoint;
-    }
 
     URI uri;
     try {
@@ -89,18 +81,13 @@ public final class OtlpGrpcSpanExporterBuilder {
     } catch (URISyntaxException e) {
       throw new IllegalArgumentException("Invalid endpoint, must be a URL: " + endpoint, e);
     }
-    // TODO(anuraaga): Remove after announcing deprecation of schemaless URLs.
-    if (uri.getScheme() != null) {
-      if (!uri.getScheme().equals("http") && !uri.getScheme().equals("https")) {
-        throw new IllegalArgumentException("Invalid scheme, must be http or https: " + endpoint);
-      }
-    } else {
-      logger.log(
-          Level.WARNING,
-          "Endpoints must have a scheme of http:// or https://. Endpoints without schemes will "
-              + "not be permitted in a future version of the SDK.",
-          new Throwable());
+
+    if (uri.getScheme() == null
+        || (!uri.getScheme().equals("http") && !uri.getScheme().equals("https"))) {
+      throw new IllegalArgumentException(
+          "Invalid endpoint, must start with http:// or https://: " + uri);
     }
+
     this.endpoint = uri;
     return this;
   }

--- a/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterTest.java
@@ -70,11 +70,6 @@ class OtlpGrpcSpanExporterTest {
   }
 
   @Test
-  void legacyEndpointConfig() {
-    OtlpGrpcSpanExporter.builder().setEndpoint("localhost:4317");
-  }
-
-  @Test
   @SuppressWarnings("PreferJavaTimeOverload")
   void invalidConfig() {
     assertThatThrownBy(() -> OtlpGrpcSpanExporter.builder().setTimeout(-1, TimeUnit.MILLISECONDS))
@@ -90,12 +85,15 @@ class OtlpGrpcSpanExporterTest {
     assertThatThrownBy(() -> OtlpGrpcSpanExporter.builder().setEndpoint(null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("endpoint");
-    assertThatThrownBy(() -> OtlpGrpcSpanExporter.builder().setEndpoint(""))
+    assertThatThrownBy(() -> OtlpGrpcSpanExporter.builder().setEndpoint("😺://localhost"))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid endpoint, must be a URL: http://");
+        .hasMessage("Invalid endpoint, must be a URL: 😺://localhost");
+    assertThatThrownBy(() -> OtlpGrpcSpanExporter.builder().setEndpoint("localhost"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid endpoint, must start with http:// or https://: localhost");
     assertThatThrownBy(() -> OtlpGrpcSpanExporter.builder().setEndpoint("gopher://localhost"))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid scheme, must be http or https: gopher://localhost");
+        .hasMessage("Invalid endpoint, must start with http:// or https://: gopher://localhost");
   }
 
   @Test

--- a/sdk-extensions/autoconfigure/src/testJaeger/java/io/opentelemetry/sdk/autoconfigure/JaegerConfigTest.java
+++ b/sdk-extensions/autoconfigure/src/testJaeger/java/io/opentelemetry/sdk/autoconfigure/JaegerConfigTest.java
@@ -57,7 +57,7 @@ class JaegerConfigTest {
 
   @Test
   void configures() {
-    String endpoint = "localhost:" + server.httpPort();
+    String endpoint = "http://localhost:" + server.httpPort();
 
     System.setProperty("otel.exporter.jaeger.endpoint", endpoint);
 


### PR DESCRIPTION
It was already deprecated with warning for OTLP. It wasn't for Jaeger, but I think we can live with it.