### PR TITLE
Minor cleanups to zipkin exporter.

### DIFF
--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
@@ -77,9 +77,7 @@ public final class ZipkinSpanExporter implements SpanExporter {
       }
     } catch (Exception e) {
       // don't crash the caller if there was a problem reading nics.
-      if (logger.isLoggable(Level.FINE)) {
-        logger.log(Level.FINE, "error reading nics", e);
-      }
+      logger.log(Level.FINE, "error reading nics", e);
     }
     return null;
   }

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
@@ -11,7 +11,6 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributeType;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -155,23 +154,18 @@ public final class ZipkinSpanExporter implements SpanExporter {
 
   @Nullable
   private static Span.Kind toSpanKind(SpanData spanData) {
-    // This is a hack because the Span API did not have SpanKind.
-    if (spanData.getKind() == SpanKind.SERVER) {
-      return Span.Kind.SERVER;
+    switch (spanData.getKind()) {
+      case SERVER:
+        return Span.Kind.SERVER;
+      case CLIENT:
+        return Span.Kind.CLIENT;
+      case PRODUCER:
+        return Span.Kind.PRODUCER;
+      case CONSUMER:
+        return Span.Kind.CONSUMER;
+      case INTERNAL:
+        return null;
     }
-
-    // This is a hack because the Span API did not have SpanKind.
-    if (spanData.getKind() == SpanKind.CLIENT || spanData.getName().startsWith("Sent.")) {
-      return Span.Kind.CLIENT;
-    }
-
-    if (spanData.getKind() == SpanKind.PRODUCER) {
-      return Span.Kind.PRODUCER;
-    }
-    if (spanData.getKind() == SpanKind.CONSUMER) {
-      return Span.Kind.CONSUMER;
-    }
-
     return null;
   }
 
@@ -179,7 +173,7 @@ public final class ZipkinSpanExporter implements SpanExporter {
     return NANOSECONDS.toMicros(epochNanos);
   }
 
-  private static <T> String valueToString(AttributeKey<?> key, Object attributeValue) {
+  private static String valueToString(AttributeKey<?> key, Object attributeValue) {
     AttributeType type = key.getType();
     switch (type) {
       case STRING:

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterTest.java
@@ -170,6 +170,23 @@ class ZipkinSpanExporterTest {
   }
 
   @Test
+  void generateSpan_defaultResourceServiceName() {
+    SpanData data = buildStandardSpan().setResource(Resource.getEmpty()).build();
+
+    Endpoint expectedEndpoint =
+        Endpoint.newBuilder()
+            .serviceName(Resource.getDefault().getAttributes().get(ResourceAttributes.SERVICE_NAME))
+            .ip(exporter.getLocalAddressForTest())
+            .build();
+    Span expectedZipkinSpan =
+        buildZipkinSpan(Span.Kind.SERVER).toBuilder()
+            .localEndpoint(expectedEndpoint)
+            .putTag(ZipkinSpanExporter.OTEL_STATUS_CODE, "OK")
+            .build();
+    assertThat(exporter.generateSpan(data)).isEqualTo(expectedZipkinSpan);
+  }
+
+  @Test
   void generateSpan_WithAttributes() {
     Attributes attributes =
         Attributes.builder()


### PR DESCRIPTION
There seem to be some opencensus-specific hacks still left over.

Only randomly went through the code since it showed up in codecov report of unrelated diff - apparently the `// don't crash the caller if there was a problem reading nics.` sometimes and sometimes doesn't throw on CI :O