### PR TITLE
[Breaking Change] Rename API getDefault to noop!

### DIFF
--- a/api/all/src/jmh/java/io/opentelemetry/api/trace/DefaultTracerBenchmarks.java
+++ b/api/all/src/jmh/java/io/opentelemetry/api/trace/DefaultTracerBenchmarks.java
@@ -22,7 +22,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @State(Scope.Thread)
 public class DefaultTracerBenchmarks {
 
-  private final Tracer tracer = Tracer.getDefault();
+  private final Tracer tracer = DefaultTracer.getInstance();
   @Nullable private Span span = null;
 
   /** Benchmark the full span lifecycle. */

--- a/api/all/src/main/java/io/opentelemetry/api/DefaultOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/DefaultOpenTelemetry.java
@@ -33,7 +33,7 @@ final class DefaultOpenTelemetry implements OpenTelemetry {
 
   @Override
   public TracerProvider getTracerProvider() {
-    return TracerProvider.getDefault();
+    return TracerProvider.noop();
   }
 
   @Override

--- a/api/all/src/main/java/io/opentelemetry/api/DefaultOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/DefaultOpenTelemetry.java
@@ -17,11 +17,11 @@ import javax.annotation.concurrent.ThreadSafe;
 final class DefaultOpenTelemetry implements OpenTelemetry {
   private static final OpenTelemetry NO_OP = new DefaultOpenTelemetry(ContextPropagators.noop());
 
-  static OpenTelemetry noop() {
+  static OpenTelemetry getNoop() {
     return NO_OP;
   }
 
-  static OpenTelemetry propagating(ContextPropagators propagators) {
+  static OpenTelemetry getPropagating(ContextPropagators propagators) {
     return new DefaultOpenTelemetry(propagators);
   }
 

--- a/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
@@ -57,8 +57,8 @@ public final class GlobalOpenTelemetry {
             return autoConfigured;
           }
 
-          set(OpenTelemetry.getDefault());
-          return OpenTelemetry.getDefault();
+          set(OpenTelemetry.noop());
+          return OpenTelemetry.noop();
         }
       }
     }

--- a/api/all/src/main/java/io/opentelemetry/api/OpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/OpenTelemetry.java
@@ -21,8 +21,8 @@ import io.opentelemetry.context.propagation.ContextPropagators;
  * @see ContextPropagators
  */
 public interface OpenTelemetry {
-  /** Returns a default, completely no-op {@link OpenTelemetry}. */
-  static OpenTelemetry getDefault() {
+  /** Returns a completely no-op {@link OpenTelemetry}. */
+  static OpenTelemetry noop() {
     return DefaultOpenTelemetry.noop();
   }
 
@@ -31,7 +31,7 @@ public interface OpenTelemetry {
    * io.opentelemetry.context.Context} using the provided {@link ContextPropagators} and is no-op
    * otherwise.
    */
-  static OpenTelemetry getPropagating(ContextPropagators propagators) {
+  static OpenTelemetry propagating(ContextPropagators propagators) {
     return DefaultOpenTelemetry.propagating(propagators);
   }
 

--- a/api/all/src/main/java/io/opentelemetry/api/OpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/OpenTelemetry.java
@@ -23,7 +23,7 @@ import io.opentelemetry.context.propagation.ContextPropagators;
 public interface OpenTelemetry {
   /** Returns a completely no-op {@link OpenTelemetry}. */
   static OpenTelemetry noop() {
-    return DefaultOpenTelemetry.noop();
+    return DefaultOpenTelemetry.getNoop();
   }
 
   /**
@@ -32,7 +32,7 @@ public interface OpenTelemetry {
    * otherwise.
    */
   static OpenTelemetry propagating(ContextPropagators propagators) {
-    return DefaultOpenTelemetry.propagating(propagators);
+    return DefaultOpenTelemetry.getPropagating(propagators);
   }
 
   /** Returns the {@link TracerProvider} for this {@link OpenTelemetry}. */

--- a/api/all/src/main/java/io/opentelemetry/api/trace/DefaultTracerProvider.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/DefaultTracerProvider.java
@@ -23,7 +23,7 @@ class DefaultTracerProvider implements TracerProvider {
 
   @Override
   public Tracer get(String instrumentationName, String instrumentationVersion) {
-    return Tracer.getDefault();
+    return DefaultTracer.getInstance();
   }
 
   private DefaultTracerProvider() {}

--- a/api/all/src/main/java/io/opentelemetry/api/trace/Tracer.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/Tracer.java
@@ -59,14 +59,6 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface Tracer {
 
   /**
-   * Returns a no-op {@link Tracer} that only creates no-op {@link Span}s which do not record nor
-   * are emitted.
-   */
-  static Tracer getDefault() {
-    return DefaultTracer.getInstance();
-  }
-
-  /**
    * Returns a {@link SpanBuilder} to create and start a new {@link Span}.
    *
    * <p>See {@link SpanBuilder} for usage examples.

--- a/api/all/src/main/java/io/opentelemetry/api/trace/TracerProvider.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/TracerProvider.java
@@ -20,7 +20,7 @@ public interface TracerProvider {
    * Returns a no-op {@link TracerProvider} which only creates no-op {@link Span}s which do not
    * record nor are emitted.
    */
-  static TracerProvider getDefault() {
+  static TracerProvider noop() {
     return DefaultTracerProvider.getInstance();
   }
 

--- a/api/all/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
@@ -29,23 +29,22 @@ class OpenTelemetryTest {
 
   @Test
   void testDefault() {
-    assertThat(OpenTelemetry.getDefault().getTracerProvider())
-        .isSameAs(TracerProvider.getDefault());
-    assertThat(OpenTelemetry.getDefault().getPropagators()).isSameAs(ContextPropagators.noop());
+    assertThat(OpenTelemetry.noop().getTracerProvider()).isSameAs(TracerProvider.noop());
+    assertThat(OpenTelemetry.noop().getPropagators()).isSameAs(ContextPropagators.noop());
   }
 
   @Test
   void propagating() {
     ContextPropagators contextPropagators = mock(ContextPropagators.class);
-    OpenTelemetry openTelemetry = OpenTelemetry.getPropagating(contextPropagators);
+    OpenTelemetry openTelemetry = OpenTelemetry.propagating(contextPropagators);
 
-    assertThat(openTelemetry.getTracerProvider()).isSameAs(TracerProvider.getDefault());
+    assertThat(openTelemetry.getTracerProvider()).isSameAs(TracerProvider.noop());
     assertThat(openTelemetry.getPropagators()).isSameAs(contextPropagators);
   }
 
   @Test
   void testGlobalBeforeSet() {
-    assertThat(GlobalOpenTelemetry.getTracerProvider()).isSameAs(TracerProvider.getDefault());
+    assertThat(GlobalOpenTelemetry.getTracerProvider()).isSameAs(TracerProvider.noop());
     assertThat(GlobalOpenTelemetry.getTracerProvider())
         .isSameAs(GlobalOpenTelemetry.getTracerProvider());
     assertThat(GlobalOpenTelemetry.getPropagators()).isSameAs(GlobalOpenTelemetry.getPropagators());
@@ -54,9 +53,9 @@ class OpenTelemetryTest {
   @Test
   void independentNonGlobalPropagators() {
     ContextPropagators propagators1 = mock(ContextPropagators.class);
-    OpenTelemetry otel1 = OpenTelemetry.getPropagating(propagators1);
+    OpenTelemetry otel1 = OpenTelemetry.propagating(propagators1);
     ContextPropagators propagators2 = mock(ContextPropagators.class);
-    OpenTelemetry otel2 = OpenTelemetry.getPropagating(propagators2);
+    OpenTelemetry otel2 = OpenTelemetry.propagating(propagators2);
 
     assertThat(otel1.getPropagators()).isSameAs(propagators1);
     assertThat(otel2.getPropagators()).isSameAs(propagators2);
@@ -65,7 +64,7 @@ class OpenTelemetryTest {
   @Test
   void setThenSet() {
     setOpenTelemetry();
-    assertThatThrownBy(() -> GlobalOpenTelemetry.set(OpenTelemetry.getDefault()))
+    assertThatThrownBy(() -> GlobalOpenTelemetry.set(OpenTelemetry.noop()))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("GlobalOpenTelemetry.set has already been called")
         .hasStackTraceContaining("setOpenTelemetry");
@@ -74,14 +73,14 @@ class OpenTelemetryTest {
   @Test
   void getThenSet() {
     assertThat(getOpenTelemetry()).isInstanceOf(DefaultOpenTelemetry.class);
-    assertThatThrownBy(() -> GlobalOpenTelemetry.set(OpenTelemetry.getDefault()))
+    assertThatThrownBy(() -> GlobalOpenTelemetry.set(OpenTelemetry.noop()))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("GlobalOpenTelemetry.set has already been called")
         .hasStackTraceContaining("getOpenTelemetry");
   }
 
   private static void setOpenTelemetry() {
-    GlobalOpenTelemetry.set(OpenTelemetry.getDefault());
+    GlobalOpenTelemetry.set(OpenTelemetry.noop());
   }
 
   private static OpenTelemetry getOpenTelemetry() {

--- a/api/all/src/test/java/io/opentelemetry/api/trace/DefaultTracerProviderTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/trace/DefaultTracerProviderTest.java
@@ -13,7 +13,7 @@ class DefaultTracerProviderTest {
 
   @Test
   void returnsDefaultTracer() {
-    assertThat(TracerProvider.getDefault().get("test")).isInstanceOf(DefaultTracer.class);
-    assertThat(TracerProvider.getDefault().get("test", "1.0")).isInstanceOf(DefaultTracer.class);
+    assertThat(TracerProvider.noop().get("test")).isInstanceOf(DefaultTracer.class);
+    assertThat(TracerProvider.noop().get("test", "1.0")).isInstanceOf(DefaultTracer.class);
   }
 }

--- a/api/all/src/test/java/io/opentelemetry/api/trace/DefaultTracerTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/trace/DefaultTracerTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 // try-with-resources.
 @SuppressWarnings("MustBeClosedChecker")
 class DefaultTracerTest {
-  private static final Tracer defaultTracer = Tracer.getDefault();
+  private static final Tracer defaultTracer = DefaultTracer.getInstance();
   private static final String SPAN_NAME = "MySpanName";
   private static final SpanContext spanContext =
       SpanContext.create(

--- a/api/all/src/test/java/io/opentelemetry/api/trace/SpanBuilderTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/trace/SpanBuilderTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link SpanBuilder}. */
 class SpanBuilderTest {
-  private final Tracer tracer = Tracer.getDefault();
+  private final Tracer tracer = DefaultTracer.getInstance();
 
   @Test
   void doNotCrash_NoopImplementation() {

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/DefaultMeterProvider.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/DefaultMeterProvider.java
@@ -23,7 +23,7 @@ final class DefaultMeterProvider implements MeterProvider {
 
   @Override
   public Meter get(String instrumentationName, String instrumentationVersion) {
-    return Meter.getDefault();
+    return DefaultMeter.getInstance();
   }
 
   private DefaultMeterProvider() {}

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/GlobalMetricsProvider.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/GlobalMetricsProvider.java
@@ -23,7 +23,7 @@ public class GlobalMetricsProvider {
     if (meterProvider == null) {
       synchronized (mutex) {
         if (globalMeterProvider.get() == null) {
-          return MeterProvider.getDefault();
+          return MeterProvider.noop();
         }
       }
     }

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/Meter.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/Meter.java
@@ -26,14 +26,6 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface Meter {
 
   /**
-   * Returns a {@link Meter} that only creates no-op {@link Instrument}s that neither record nor are
-   * emitted.
-   */
-  static Meter getDefault() {
-    return DefaultMeter.getInstance();
-  }
-
-  /**
    * Returns a builder for a {@link DoubleCounter}.
    *
    * @param name the name of the instrument. Should be a ASCII string with a length no greater than

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/MeterProvider.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/MeterProvider.java
@@ -20,7 +20,7 @@ public interface MeterProvider {
    * Returns a {@link MeterProvider} that only creates no-op {@link Instrument}s that neither record
    * nor are emitted.
    */
-  static MeterProvider getDefault() {
+  static MeterProvider noop() {
     return DefaultMeterProvider.getInstance();
   }
 

--- a/api/metrics/src/test/java/io/opentelemetry/api/metrics/BatchRecorderTest.java
+++ b/api/metrics/src/test/java/io/opentelemetry/api/metrics/BatchRecorderTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.api.Test;
 
 class BatchRecorderTest {
-  private static final Meter meter = Meter.getDefault();
+  private static final Meter meter = DefaultMeter.getInstance();
 
   @Test
   void testNewBatchRecorder_WrongNumberOfLabels() {

--- a/api/metrics/src/test/java/io/opentelemetry/api/metrics/DefaultMeterTest.java
+++ b/api/metrics/src/test/java/io/opentelemetry/api/metrics/DefaultMeterTest.java
@@ -12,8 +12,8 @@ import org.junit.jupiter.api.Test;
 class DefaultMeterTest {
   @Test
   void expectDefaultMeter() {
-    assertThat(MeterProvider.getDefault().get("test")).isInstanceOf(DefaultMeter.class);
-    assertThat(MeterProvider.getDefault().get("test")).isSameAs(Meter.getDefault());
-    assertThat(MeterProvider.getDefault().get("test", "0.1.0")).isSameAs(Meter.getDefault());
+    assertThat(MeterProvider.noop().get("test")).isInstanceOf(DefaultMeter.class);
+    assertThat(MeterProvider.noop().get("test")).isSameAs(DefaultMeter.getInstance());
+    assertThat(MeterProvider.noop().get("test", "0.1.0")).isSameAs(DefaultMeter.getInstance());
   }
 }

--- a/integration-tests/tracecontext/src/main/java/io/opentelemetry/Application.java
+++ b/integration-tests/tracecontext/src/main/java/io/opentelemetry/Application.java
@@ -34,7 +34,7 @@ public class Application {
 
   static {
     openTelemetry =
-        OpenTelemetry.getPropagating(
+        OpenTelemetry.propagating(
             ContextPropagators.create(W3CTraceContextPropagator.getInstance()));
   }
 

--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/NoopSpanBuilderShim.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/NoopSpanBuilderShim.java
@@ -6,12 +6,17 @@
 package io.opentelemetry.opentracingshim;
 
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerProvider;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer.SpanBuilder;
 import io.opentracing.tag.Tag;
 
 final class NoopSpanBuilderShim extends BaseShimObject implements SpanBuilder {
+
+  private static final Tracer TRACER =
+      TracerProvider.noop().get("io.opentelemetry.opentracingshim");
+
   private final String spanName;
 
   public NoopSpanBuilderShim(TelemetryInfo telemetryInfo, String spanName) {
@@ -66,6 +71,6 @@ final class NoopSpanBuilderShim extends BaseShimObject implements SpanBuilder {
 
   @Override
   public Span start() {
-    return new SpanShim(telemetryInfo, Tracer.getDefault().spanBuilder(spanName).startSpan());
+    return new SpanShim(telemetryInfo, TRACER.spanBuilder(spanName).startSpan());
   }
 }

--- a/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/TestSdk.java
+++ b/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/TestSdk.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.metrics;
 
 import com.google.errorprone.annotations.Immutable;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.SystemClock;
 import io.opentelemetry.sdk.resources.Resource;
@@ -16,7 +17,7 @@ public enum TestSdk {
       new SdkBuilder() {
         @Override
         Meter build() {
-          return Meter.getDefault();
+          return MeterProvider.noop().get("io.opentelemetry.sdk.metrics");
         }
       }),
   SDK(

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.trace;
 
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 
 /** {@link SdkTracer} is SDK implementation of {@link Tracer}. */
@@ -27,7 +28,9 @@ final class SdkTracer implements Tracer {
       spanName = FALLBACK_SPAN_NAME;
     }
     if (sharedState.hasBeenShutdown()) {
-      return Tracer.getDefault().spanBuilder(spanName);
+      return TracerProvider.noop()
+          .get(instrumentationLibraryInfo.getName(), instrumentationLibraryInfo.getVersion())
+          .spanBuilder(spanName);
     }
     return new SdkSpanBuilder(
         spanName, instrumentationLibraryInfo, sharedState, sharedState.getSpanLimits());


### PR DESCRIPTION
Removes `Tracer.getDefault` and `Meter.getDefault` since they're easy to get from the providers.