### PR TITLE
Mark public classes as final in the exporters directory

### DIFF
--- a/exporters/jaeger-thrift/src/main/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftSpanExporter.java
+++ b/exporters/jaeger-thrift/src/main/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftSpanExporter.java
@@ -31,9 +31,8 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class JaegerThriftSpanExporter implements SpanExporter {
 
-  public static final String DEFAULT_HOST_NAME = "unknown";
-  public static final String DEFAULT_ENDPOINT = "http://localhost:14268/api/traces";
-  public static final String DEFAULT_SERVICE_NAME = DEFAULT_HOST_NAME;
+  private static final String DEFAULT_HOST_NAME = "unknown";
+  static final String DEFAULT_ENDPOINT = "http://localhost:14268/api/traces";
 
   private static final Logger logger = Logger.getLogger(JaegerThriftSpanExporter.class.getName());
   private static final String CLIENT_VERSION_KEY = "jaeger.version";

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporter.java
@@ -25,7 +25,7 @@ import org.curioswitch.common.protobuf.json.MessageMarshaller;
  * A {@link MetricExporter} which writes {@linkplain MetricData spans} to a {@link Logger} in OTLP
  * JSON format. Each log line will include a single {@link ResourceMetrics}.
  */
-public class OtlpJsonLoggingMetricExporter implements MetricExporter {
+public final class OtlpJsonLoggingMetricExporter implements MetricExporter {
 
   private static final MessageMarshaller marshaller =
       MessageMarshaller.builder()

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporter.java
@@ -23,7 +23,7 @@ import org.curioswitch.common.protobuf.json.MessageMarshaller;
  * A {@link SpanExporter} which writes {@linkplain SpanData spans} to a {@link Logger} in OTLP JSON
  * format. Each log line will include a single {@link ResourceSpans}.
  */
-public class OtlpJsonLoggingSpanExporter implements SpanExporter {
+public final class OtlpJsonLoggingSpanExporter implements SpanExporter {
 
   private static final MessageMarshaller marshaller =
       MessageMarshaller.builder()


### PR DESCRIPTION
Also avoids exporting some internal properties in the Jaeger exporter

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>