### PR TITLE
Make jaeger rate limit sampler only rate limit

### DIFF
--- a/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/RateLimitingSampler.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/RateLimitingSampler.java
@@ -10,7 +10,6 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.internal.SystemClock;
@@ -57,17 +56,6 @@ class RateLimitingSampler implements Sampler {
       SpanKind spanKind,
       Attributes attributes,
       List<LinkData> parentLinks) {
-
-    if (Span.fromContext(parentContext).getSpanContext().isSampled()) {
-      return Sampler.alwaysOn()
-          .shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
-    }
-    for (LinkData parentLink : parentLinks) {
-      if (parentLink.getSpanContext().isSampled()) {
-        return Sampler.alwaysOn()
-            .shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
-      }
-    }
     return this.rateLimiter.checkCredit(1.0) ? onSamplingResult : offSamplingResult;
   }
 

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/RateLimitingSamplerTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/RateLimitingSamplerTest.java
@@ -25,13 +25,7 @@ class RateLimitingSamplerTest {
   private static final SpanKind SPAN_KIND = SpanKind.INTERNAL;
   private static final String TRACE_ID = "12345678876543211234567887654321";
   private static final String PARENT_SPAN_ID = "8765432112345678";
-  private static final Context sampledSpanContext =
-      Context.root()
-          .with(
-              Span.wrap(
-                  SpanContext.create(
-                      TRACE_ID, PARENT_SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault())));
-  private static final Context notSampledSpanContext =
+  private static final Context spanContext =
       Context.root()
           .with(
               Span.wrap(
@@ -39,38 +33,11 @@ class RateLimitingSamplerTest {
                       TRACE_ID, PARENT_SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault())));
 
   @Test
-  void alwaysSampleSampledContext() {
-    RateLimitingSampler sampler = new RateLimitingSampler(1);
-    assertThat(
-            sampler
-                .shouldSample(
-                    sampledSpanContext,
-                    TRACE_ID,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
-        .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
-    assertThat(
-            sampler
-                .shouldSample(
-                    sampledSpanContext,
-                    TRACE_ID,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
-        .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
-  }
-
-  @Test
   void sampleOneTrace() {
     RateLimitingSampler sampler = new RateLimitingSampler(1);
     SamplingResult samplingResult =
         sampler.shouldSample(
-            notSampledSpanContext,
+            spanContext,
             TRACE_ID,
             SPAN_NAME,
             SPAN_KIND,
@@ -80,7 +47,7 @@ class RateLimitingSamplerTest {
     assertThat(
             sampler
                 .shouldSample(
-                    notSampledSpanContext,
+                    spanContext,
                     TRACE_ID,
                     SPAN_NAME,
                     SPAN_KIND,


### PR DESCRIPTION
When we made the remote sampler `Sampler.parentBased` previously, we removed the need for the parent check here. I'm pretty sure we don't need the Links check either but opened https://github.com/open-telemetry/opentelemetry-java/discussions/2874 to confirm. /cc @yurishkuro 