### PR TITLE
Document expected behavior for null params

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/trace/Span.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/Span.java
@@ -22,6 +22,12 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <p>Spans are created by the {@link SpanBuilder#startSpan} method.
  *
+ * <p>When inserting attributes, {@code null} keys and values are prohibited, and in that case the
+ * behavior is undefined.
+ *
+ * <p>When adding events, {@code null} names, attributes, units and timestamps, and in that case the
+ * behavior is undefined.
+ *
  * <p>{@code Span} <b>must</b> be ended by calling {@link #end()}.
  */
 @ThreadSafe
@@ -274,7 +280,8 @@ public interface Span extends ImplicitContextKeyed {
    * <p>Only the value of the last call will be recorded, and implementations are free to ignore
    * previous calls.
    *
-   * @param statusCode the {@link StatusCode} to set.
+   * @param statusCode the {@link StatusCode} to set. {@code null} is prohibited, and in that case
+   *     the behavior is undefined.
    * @return this.
    */
   default Span setStatus(StatusCode statusCode) {
@@ -290,8 +297,10 @@ public interface Span extends ImplicitContextKeyed {
    * <p>Only the value of the last call will be recorded, and implementations are free to ignore
    * previous calls.
    *
-   * @param statusCode the {@link StatusCode} to set.
-   * @param description the description of the {@code Status}.
+   * @param statusCode the {@link StatusCode} to set. {@code null} is prohibited, and in that case
+   *     the behavior is undefined.
+   * @param description the description of the {@code Status}. {@code null} is prohibited, and in
+   *     that case the behavior is undefined.
    * @return this.
    */
   Span setStatus(StatusCode statusCode, String description);
@@ -303,7 +312,8 @@ public interface Span extends ImplicitContextKeyed {
    * this function. You should record this attribute manually using {@link
    * #recordException(Throwable, Attributes)} if you know that an exception is escaping.
    *
-   * @param exception the {@link Throwable} to record.
+   * @param exception the {@link Throwable} to record. {@code null} is prohibited, and in that case
+   *     the behavior is undefined.
    * @return this.
    */
   default Span recordException(Throwable exception) {
@@ -313,8 +323,10 @@ public interface Span extends ImplicitContextKeyed {
   /**
    * Records information about the {@link Throwable} to the {@link Span}.
    *
-   * @param exception the {@link Throwable} to record.
-   * @param additionalAttributes the additional {@link Attributes} to record.
+   * @param exception the {@link Throwable} to record. {@code null} is prohibited, and in that case
+   *     the behavior is undefined.
+   * @param additionalAttributes the additional {@link Attributes} to record. {@code null} is
+   *     prohibited, and in that case the behavior is undefined.
    * @return this.
    */
   Span recordException(Throwable exception, Attributes additionalAttributes);
@@ -327,7 +339,8 @@ public interface Span extends ImplicitContextKeyed {
    * <p>Upon this update, any sampling behavior based on {@code Span} name will depend on the
    * implementation.
    *
-   * @param name the {@code Span} name.
+   * @param name the {@code Span} name. {@code null} is prohibited, and in that case the behavior is
+   *     undefined.
    * @return this.
    */
   Span updateName(String name);
@@ -351,7 +364,8 @@ public interface Span extends ImplicitContextKeyed {
    *
    * @param timestamp the explicit timestamp from the epoch, for this {@code Span}. {@code 0}
    *     indicates current time should be used.
-   * @param unit the unit of the timestamp
+   * @param unit the unit of the timestamp. {@code null} is prohibited, and in that case the
+   *     behavior is undefined.
    */
   void end(long timestamp, TimeUnit unit);
 
@@ -364,7 +378,7 @@ public interface Span extends ImplicitContextKeyed {
    * <p>Use this method for specifying explicit end options, such as end {@code Timestamp}. When no
    * explicit values are required, use {@link #end()}.
    *
-   * @param timestamp the explicit timestamp from the epoch, for this {@code Span}. {@code 0}
+   * @param timestamp the explicit timestamp from the epoch, for this {@code Span}. {@code null}
    *     indicates current time should be used.
    */
   default void end(Instant timestamp) {

--- a/api/all/src/main/java/io/opentelemetry/api/trace/SpanBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/SpanBuilder.java
@@ -101,6 +101,12 @@ import java.util.concurrent.TimeUnit;
  * }
  * }</pre>
  *
+ * <p>When inserting attributes, {@code null} keys and values are prohibited, and in that case the
+ * behavior is undefined.
+ *
+ * <p>When adding links, {@code null} span contexts and attributes are prohibited, and in that case
+ * the behavior is undefined.
+ *
  * <p>see {@link SpanBuilder#startSpan} for usage examples.
  */
 public interface SpanBuilder {
@@ -140,7 +146,6 @@ public interface SpanBuilder {
    *
    * @param spanContext the context of the linked {@code Span}.
    * @return this.
-   * @throws NullPointerException if {@code spanContext} is {@code null}.
    */
   SpanBuilder addLink(SpanContext spanContext);
 
@@ -154,8 +159,6 @@ public interface SpanBuilder {
    * @param spanContext the context of the linked {@code Span}.
    * @param attributes the attributes of the {@code Link}.
    * @return this.
-   * @throws NullPointerException if {@code spanContext} is {@code null}.
-   * @throws NullPointerException if {@code attributes} is {@code null}.
    */
   SpanBuilder addLink(SpanContext spanContext, Attributes attributes);
 
@@ -172,7 +175,6 @@ public interface SpanBuilder {
    * @param key the key for this attribute.
    * @param value the value for this attribute.
    * @return this.
-   * @throws NullPointerException if {@code key} is {@code null}.
    */
   SpanBuilder setAttribute(String key, String value);
 
@@ -186,7 +188,6 @@ public interface SpanBuilder {
    * @param key the key for this attribute.
    * @param value the value for this attribute.
    * @return this.
-   * @throws NullPointerException if {@code key} is {@code null}.
    */
   SpanBuilder setAttribute(String key, long value);
 
@@ -200,7 +201,6 @@ public interface SpanBuilder {
    * @param key the key for this attribute.
    * @param value the value for this attribute.
    * @return this.
-   * @throws NullPointerException if {@code key} is {@code null}.
    */
   SpanBuilder setAttribute(String key, double value);
 
@@ -214,7 +214,6 @@ public interface SpanBuilder {
    * @param key the key for this attribute.
    * @param value the value for this attribute.
    * @return this.
-   * @throws NullPointerException if {@code key} is {@code null}.
    */
   SpanBuilder setAttribute(String key, boolean value);
 
@@ -227,8 +226,6 @@ public interface SpanBuilder {
    * @param key the key for this attribute.
    * @param value the value for this attribute.
    * @return this.
-   * @throws NullPointerException if {@code key} is {@code null}.
-   * @throws NullPointerException if {@code value} is {@code null}.
    */
   <T> SpanBuilder setAttribute(AttributeKey<T> key, T value);
 
@@ -236,7 +233,8 @@ public interface SpanBuilder {
    * Sets the {@link SpanKind} for the newly created {@code Span}. If not called, the implementation
    * will provide a default value {@link SpanKind#INTERNAL}.
    *
-   * @param spanKind the kind of the newly created {@code Span}.
+   * @param spanKind the kind of the newly created {@code Span}. {@code null} is prohibited, and in
+   *     that case the behavior is undefined.
    * @return this.
    */
   SpanBuilder setSpanKind(SpanKind spanKind);
@@ -252,7 +250,8 @@ public interface SpanBuilder {
    *
    * @param startTimestamp the explicit start timestamp from the epoch of the newly created {@code
    *     Span}.
-   * @param unit the unit of the timestamp.
+   * @param unit the unit of the timestamp. {@code null} is prohibited, and in that case the
+   *     behavior is undefined.
    * @return this.
    */
   SpanBuilder setStartTimestamp(long startTimestamp, TimeUnit unit);
@@ -265,16 +264,16 @@ public interface SpanBuilder {
    *
    * <p>Important this is NOT equivalent with System.nanoTime().
    *
-   * @param startTimestamp the explicit start timestamp from the epoch of the newly created {@code
-   *     Span}.
+   * @param timestamp the explicit start timestamp from the epoch of the newly created {@code Span}.
+   *     {@code null} indicates calling time of {@link #startSpan()} should be used.
    * @return this.
    */
-  default SpanBuilder setStartTimestamp(Instant startTimestamp) {
-    if (startTimestamp == null) {
+  default SpanBuilder setStartTimestamp(Instant timestamp) {
+    if (timestamp == null) {
       return this;
     }
     return setStartTimestamp(
-        SECONDS.toNanos(startTimestamp.getEpochSecond()) + startTimestamp.getNano(), NANOSECONDS);
+        SECONDS.toNanos(timestamp.getEpochSecond()) + timestamp.getNano(), NANOSECONDS);
   }
 
   /**
@@ -291,7 +290,7 @@ public interface SpanBuilder {
    *
    * <pre>{@code
    * class MyClass {
-   *   private static final Tracer tracer = OpenTelemetry.get().getTracer("com.example.rpc");
+   *   private static final Tracer tracer = GlobalOpenTelemetry.get().getTracer("com.example.rpc");
    *
    *   void doWork(Span parent) {
    *     Span childSpan = tracer.spanBuilder("MyChildSpan")

--- a/api/all/src/main/java/io/opentelemetry/api/trace/Tracer.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/Tracer.java
@@ -63,9 +63,9 @@ public interface Tracer {
    *
    * <p>See {@link SpanBuilder} for usage examples.
    *
-   * @param spanName The name of the returned Span.
+   * @param spanName The name of the returned Span. {@code null} is prohibited, and in that case the
+   *     behavior is undefined.
    * @return a {@code Span.Builder} to create and start a new {@code Span}.
-   * @throws NullPointerException if {@code spanName} is {@code null}.
    */
   SpanBuilder spanBuilder(String spanName);
 }


### PR DESCRIPTION
This follows the way how Java documents null params for interfaces. The API needs to document the possible behaviors not what happens in our SDK (like adding throws annotations). If we want to ensure that no implementation can throw an exception (which I think we shouldn't) we can change the text to say that.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>