### PR TITLE
Allow updates that may require additional POM updates on minor updates.

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -41,8 +41,8 @@ new artifact which requires adding the new artifact to dependency declarations.
 
 As a user, if you always depend on the latest version of the BOM for a given `MAJOR` version, and
 you do not use classes in the `internal` package (which you MUST NOT do), you can be assured that
-your app will always function and have the latest features of OpenTelemetry without needing any
-changes to code.
+your app will always function and have access tothe latest features of OpenTelemetry without needing 
+any changes to code.
 
 ## API vs SDK
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -35,9 +35,14 @@ Backwards incompatible changes to `internal` packages are expected. Versions of 
 are expected to be aligned by using BOMs we publish. We will always provide BOMs to allow alignment
 of versions.
 
+Changes may be made that require changes to the an app's dependency declarations aside from just
+incrementing the version on `MINOR` version updates. For example, code may be separated out to a
+new artifact which requires adding the new artifact to dependency declarations.
+
 As a user, if you always depend on the latest version of the BOM for a given `MAJOR` version, and
 you do not use classes in the `internal` package (which you MUST NOT do), you can be assured that
-your app will always function and have the latest features of OpenTelemetry.
+your app will always function and have the latest features of OpenTelemetry without needing any
+changes to code.
 
 ## API vs SDK
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -41,7 +41,7 @@ new artifact which requires adding the new artifact to dependency declarations.
 
 As a user, if you always depend on the latest version of the BOM for a given `MAJOR` version, and
 you do not use classes in the `internal` package (which you MUST NOT do), you can be assured that
-your app will always function and have access tothe latest features of OpenTelemetry without needing 
+your app will always function and have access to the latest features of OpenTelemetry without needing 
 any changes to code.
 
 ## API vs SDK


### PR DESCRIPTION
I think these are generally allowed by semver since a user needs to update the POM anyways when updating, but we want to make sure they don't need to update code / retest everything.