### PR TITLE
Reduce usage of errorprone annotations to MustBeClosed.

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.api;
 
-import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
@@ -14,6 +13,7 @@ import java.lang.reflect.Method;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**

--- a/api/context/build.gradle.kts
+++ b/api/context/build.gradle.kts
@@ -34,6 +34,9 @@ dependencies {
 
     add("strictContextEnabledTestImplementation", project(":api:all"))
 
+    // MustBeClosed
+    compileOnly("com.google.errorprone:error_prone_annotations")
+
     testImplementation("org.awaitility:awaitility")
     testImplementation("com.google.guava:guava")
     testImplementation("org.junit-pioneer:junit-pioneer")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -312,7 +312,6 @@ subprojects {
             }
 
             add(COMPILE_ONLY_CONFIGURATION_NAME, "com.google.auto.value:auto-value-annotations")
-            add(COMPILE_ONLY_CONFIGURATION_NAME, "com.google.errorprone:error_prone_annotations")
             add(COMPILE_ONLY_CONFIGURATION_NAME, "com.google.code.findbugs:jsr305")
 
             add(TEST_COMPILE_ONLY_CONFIGURATION_NAME, "com.google.auto.value:auto-value-annotations")

--- a/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/MetricsTestOperationBuilder.java
+++ b/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/MetricsTestOperationBuilder.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import com.google.errorprone.annotations.Immutable;
 import io.opentelemetry.api.metrics.BoundDoubleCounter;
 import io.opentelemetry.api.metrics.BoundDoubleValueRecorder;
 import io.opentelemetry.api.metrics.BoundLongCounter;
@@ -23,6 +22,7 @@ import io.opentelemetry.api.metrics.common.Labels;
  * return a wrapper for both bound and unbound versions of that operation which can then be used in
  * a benchmark.
  */
+@SuppressWarnings("ImmutableEnumChecker")
 public enum MetricsTestOperationBuilder {
   LongCounterAdd(
       meter -> {
@@ -121,7 +121,6 @@ public enum MetricsTestOperationBuilder {
     return this.builder.build(meter);
   }
 
-  @Immutable
   private interface OperationBuilder {
     Operation build(Meter meter);
   }

--- a/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/TestSdk.java
+++ b/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/TestSdk.java
@@ -5,13 +5,13 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import com.google.errorprone.annotations.Immutable;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.SystemClock;
 import io.opentelemetry.sdk.resources.Resource;
 
+@SuppressWarnings("ImmutableEnumChecker")
 public enum TestSdk {
   API_ONLY(
       new SdkBuilder() {
@@ -43,7 +43,6 @@ public enum TestSdk {
     return sdkBuilder.build();
   }
 
-  @Immutable
   private abstract static class SdkBuilder {
     abstract Meter build();
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountAggregator.java
@@ -5,11 +5,11 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
-import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountAggregator.java
@@ -5,11 +5,11 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
-import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe


### PR DESCRIPTION
FWICT, `GuardedBy` is the only annotation that has the problem in #2897. But we can easily avoid it by using the JDK's annotation, which errorprone does support in the same way as its own.

We can't lose the killer `MustBeClosed` so I scoped the annotations down to only the context package to prevent accidentally using the wrong `GuardedBy` in others.

Fixes #2897