### PR TITLE
Add code-of-conduct file.

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,3 @@
+# OpenTelemetry Community Code of Conduct
+
+Please refer to our [OpenTelemetry Community Code of Conduct](https://github.com/open-telemetry/community/blob/main/code-of-conduct.md)


### PR DESCRIPTION
Followed same pattern as Kubernetes projects, which link to the community repo, which links to CNCF

https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/code-of-conduct.md