### PR TITLE
Don't throw on null in propagator implementations.

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagator.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagator.java
@@ -41,6 +41,9 @@ public final class W3CBaggagePropagator implements TextMapPropagator {
 
   @Override
   public <C> void inject(Context context, C carrier, TextMapSetter<C> setter) {
+    if (context == null || setter == null) {
+      return;
+    }
     Baggage baggage = Baggage.fromContext(context);
     if (baggage.isEmpty()) {
       return;
@@ -63,6 +66,13 @@ public final class W3CBaggagePropagator implements TextMapPropagator {
 
   @Override
   public <C> Context extract(Context context, @Nullable C carrier, TextMapGetter<C> getter) {
+    if (context == null) {
+      return Context.root();
+    }
+    if (getter == null) {
+      return context;
+    }
+
     String baggageHeader = getter.get(carrier, FIELD);
     if (baggageHeader == null) {
       return context;

--- a/api/all/src/main/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagator.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagator.java
@@ -23,7 +23,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -100,8 +99,9 @@ public final class W3CTraceContextPropagator implements TextMapPropagator {
 
   @Override
   public <C> void inject(Context context, @Nullable C carrier, TextMapSetter<C> setter) {
-    Objects.requireNonNull(context, "context");
-    Objects.requireNonNull(setter, "setter");
+    if (context == null || setter == null) {
+      return;
+    }
 
     SpanContext spanContext = Span.fromContext(context).getSpanContext();
     if (!spanContext.isValid()) {
@@ -148,8 +148,12 @@ public final class W3CTraceContextPropagator implements TextMapPropagator {
 
   @Override
   public <C> Context extract(Context context, @Nullable C carrier, TextMapGetter<C> getter) {
-    Objects.requireNonNull(context, "context");
-    Objects.requireNonNull(getter, "getter");
+    if (context == null) {
+      return Context.root();
+    }
+    if (getter == null) {
+      return context;
+    }
 
     SpanContext spanContext = extractImpl(carrier, getter);
     if (!spanContext.isValid()) {

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
@@ -13,7 +13,9 @@ import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.baggage.BaggageEntryMetadata;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
@@ -155,6 +157,19 @@ class W3CBaggagePropagatorTest {
   }
 
   @Test
+  void extract_nullContext() {
+    assertThat(W3CBaggagePropagator.getInstance().extract(null, Collections.emptyMap(), getter))
+        .isSameAs(Context.root());
+  }
+
+  @Test
+  void extract_nullGetter() {
+    Context context = Context.current().with(Baggage.builder().put("cat", "meow").build());
+    assertThat(W3CBaggagePropagator.getInstance().extract(context, Collections.emptyMap(), null))
+        .isSameAs(context);
+  }
+
+  @Test
   void inject_noBaggage() {
     W3CBaggagePropagator propagator = W3CBaggagePropagator.getInstance();
     Map<String, String> carrier = new HashMap<>();
@@ -185,5 +200,20 @@ class W3CBaggagePropagatorTest {
         .containsExactlyInAnyOrderEntriesOf(
             singletonMap(
                 "baggage", "meta=meta-value;somemetadata; someother=foo,nometa=nometa-value"));
+  }
+
+  @Test
+  void inject_nullContext() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    W3CBaggagePropagator.getInstance().inject(null, carrier, Map::put);
+    assertThat(carrier).isEmpty();
+  }
+
+  @Test
+  void inject_nullSetter() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    Context context = Context.current().with(Baggage.builder().put("cat", "meow").build());
+    W3CBaggagePropagator.getInstance().inject(context, carrier, null);
+    assertThat(carrier).isEmpty();
   }
 }

--- a/api/all/src/test/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagatorTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagatorTest.java
@@ -162,6 +162,25 @@ class W3CTraceContextPropagatorTest {
   }
 
   @Test
+  void inject_nullContext() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    w3cTraceContextPropagator.inject(null, carrier, setter);
+    assertThat(carrier).isEmpty();
+  }
+
+  @Test
+  void inject_nullSetter() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    Context context =
+        withSpanContext(
+            SpanContext.create(
+                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TRACE_STATE),
+            Context.current());
+    w3cTraceContextPropagator.inject(context, carrier, null);
+    assertThat(carrier).isEmpty();
+  }
+
+  @Test
   void extract_Nothing() {
     // Context remains untouched.
     assertThat(w3cTraceContextPropagator.extract(Context.current(), Collections.emptyMap(), getter))
@@ -490,5 +509,22 @@ class W3CTraceContextPropagatorTest {
             getSpanContext(
                 w3cTraceContextPropagator.extract(Context.current(), emptyHeaders, getter)))
         .isSameAs(SpanContext.getInvalid());
+  }
+
+  @Test
+  void extract_nullContext() {
+    assertThat(w3cTraceContextPropagator.extract(null, Collections.emptyMap(), getter))
+        .isSameAs(Context.root());
+  }
+
+  @Test
+  void extract_nullGetter() {
+    Context context =
+        withSpanContext(
+            SpanContext.create(
+                TRACE_ID_BASE16, SPAN_ID_BASE16, TraceFlags.getDefault(), TraceState.getDefault()),
+            Context.current());
+    assertThat(w3cTraceContextPropagator.extract(context, Collections.emptyMap(), null))
+        .isSameAs(context);
   }
 }

--- a/extensions/aws/src/test/java/io/opentelemetry/extension/aws/AwsXrayPropagatorTest.java
+++ b/extensions/aws/src/test/java/io/opentelemetry/extension/aws/AwsXrayPropagatorTest.java
@@ -96,6 +96,24 @@ class AwsXrayPropagatorTest {
   }
 
   @Test
+  void inject_nullContext() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    xrayPropagator.inject(null, carrier, setter);
+    assertThat(carrier).isEmpty();
+  }
+
+  @Test
+  void inject_nullSetter() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    Context context =
+        withSpanContext(
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()),
+            Context.current());
+    xrayPropagator.inject(context, carrier, null);
+    assertThat(carrier).isEmpty();
+  }
+
+  @Test
   void extract_Nothing() {
     // Context remains untouched.
     assertThat(
@@ -241,6 +259,21 @@ class AwsXrayPropagatorTest {
 
     assertThat(getSpanContext(xrayPropagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameAs(SpanContext.getInvalid());
+  }
+
+  @Test
+  void extract_nullContext() {
+    assertThat(xrayPropagator.extract(null, Collections.emptyMap(), getter))
+        .isSameAs(Context.root());
+  }
+
+  @Test
+  void extract_nullGetter() {
+    Context context =
+        withSpanContext(
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()),
+            Context.current());
+    assertThat(xrayPropagator.extract(context, Collections.emptyMap(), null)).isSameAs(context);
   }
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorExtractor.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorExtractor.java
@@ -8,10 +8,11 @@ package io.opentelemetry.extension.trace.propagation;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
 interface B3PropagatorExtractor {
 
-  <C> Optional<Context> extract(Context context, C carrier, TextMapGetter<C> getter);
+  <C> Optional<Context> extract(Context context, @Nullable C carrier, TextMapGetter<C> getter);
 }

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorExtractorMultipleHeaders.java
@@ -8,9 +8,9 @@ package io.opentelemetry.extension.trace.propagation;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
@@ -19,14 +19,19 @@ final class B3PropagatorExtractorMultipleHeaders implements B3PropagatorExtracto
       Logger.getLogger(B3PropagatorExtractorMultipleHeaders.class.getName());
 
   @Override
-  public <C> Optional<Context> extract(Context context, C carrier, TextMapGetter<C> getter) {
-    Objects.requireNonNull(carrier, "carrier");
-    Objects.requireNonNull(getter, "getter");
+  public <C> Optional<Context> extract(
+      Context context, @Nullable C carrier, TextMapGetter<C> getter) {
+    if (context == null) {
+      return Optional.of(Context.root());
+    }
+    if (getter == null) {
+      return Optional.of(context);
+    }
     return extractSpanContextFromMultipleHeaders(context, carrier, getter);
   }
 
   private static <C> Optional<Context> extractSpanContextFromMultipleHeaders(
-      Context context, C carrier, TextMapGetter<C> getter) {
+      Context context, @Nullable C carrier, TextMapGetter<C> getter) {
     String traceId = getter.get(carrier, B3Propagator.TRACE_ID_HEADER);
     if (!Common.isTraceIdValid(traceId)) {
       logger.fine(

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorExtractorSingleHeader.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorExtractorSingleHeader.java
@@ -8,9 +8,9 @@ package io.opentelemetry.extension.trace.propagation;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
@@ -19,14 +19,19 @@ final class B3PropagatorExtractorSingleHeader implements B3PropagatorExtractor {
       Logger.getLogger(B3PropagatorExtractorSingleHeader.class.getName());
 
   @Override
-  public <C> Optional<Context> extract(Context context, C carrier, TextMapGetter<C> getter) {
-    Objects.requireNonNull(carrier, "carrier");
-    Objects.requireNonNull(getter, "getter");
+  public <C> Optional<Context> extract(
+      Context context, @Nullable C carrier, TextMapGetter<C> getter) {
+    if (context == null) {
+      return Optional.of(Context.root());
+    }
+    if (getter == null) {
+      return Optional.of(context);
+    }
     return extractSpanContextFromSingleHeader(context, carrier, getter);
   }
 
   private static <C> Optional<Context> extractSpanContextFromSingleHeader(
-      Context context, C carrier, TextMapGetter<C> getter) {
+      Context context, @Nullable C carrier, TextMapGetter<C> getter) {
     String value = getter.get(carrier, B3Propagator.COMBINED_HEADER);
     if (StringUtils.isNullOrEmpty(value)) {
       return Optional.empty();

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorInjector.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorInjector.java
@@ -7,9 +7,10 @@ package io.opentelemetry.extension.trace.propagation;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapSetter;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
 interface B3PropagatorInjector {
-  <C> void inject(Context context, C carrier, TextMapSetter<C> setter);
+  <C> void inject(Context context, @Nullable C carrier, TextMapSetter<C> setter);
 }

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
@@ -9,15 +9,19 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapSetter;
-import java.util.Objects;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
 final class B3PropagatorInjectorMultipleHeaders implements B3PropagatorInjector {
   @Override
-  public <C> void inject(Context context, C carrier, TextMapSetter<C> setter) {
-    Objects.requireNonNull(context, "context");
-    Objects.requireNonNull(setter, "setter");
+  public <C> void inject(Context context, @Nullable C carrier, TextMapSetter<C> setter) {
+    if (context == null) {
+      return;
+    }
+    if (setter == null) {
+      return;
+    }
 
     SpanContext spanContext = Span.fromContext(context).getSpanContext();
     if (!spanContext.isValid()) {

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorInjectorSingleHeader.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorInjectorSingleHeader.java
@@ -11,7 +11,7 @@ import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapSetter;
-import java.util.Objects;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
@@ -26,9 +26,13 @@ final class B3PropagatorInjectorSingleHeader implements B3PropagatorInjector {
   private static final int COMBINED_HEADER_SIZE = SAMPLED_FLAG_OFFSET + SAMPLED_FLAG_SIZE;
 
   @Override
-  public <C> void inject(Context context, C carrier, TextMapSetter<C> setter) {
-    Objects.requireNonNull(context, "context");
-    Objects.requireNonNull(setter, "setter");
+  public <C> void inject(Context context, @Nullable C carrier, TextMapSetter<C> setter) {
+    if (context == null) {
+      return;
+    }
+    if (setter == null) {
+      return;
+    }
 
     SpanContext spanContext = Span.fromContext(context).getSpanContext();
     if (!spanContext.isValid()) {

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/OtTracePropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/OtTracePropagator.java
@@ -56,7 +56,7 @@ public final class OtTracePropagator implements TextMapPropagator {
   }
 
   @Override
-  public <C> void inject(Context context, C carrier, TextMapSetter<C> setter) {
+  public <C> void inject(Context context, @Nullable C carrier, TextMapSetter<C> setter) {
     if (context == null || setter == null) {
       return;
     }
@@ -83,8 +83,10 @@ public final class OtTracePropagator implements TextMapPropagator {
 
   @Override
   public <C> Context extract(Context context, @Nullable C carrier, TextMapGetter<C> getter) {
-    if (context == null || getter == null) {
-      // TODO Other propagators throw exceptions here
+    if (context == null) {
+      return Context.root();
+    }
+    if (getter == null) {
       return context;
     }
     String incomingTraceId = getter.get(carrier, TRACE_ID_HEADER);

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/B3PropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/B3PropagatorTest.java
@@ -120,6 +120,28 @@ class B3PropagatorTest {
   }
 
   @Test
+  void inject_nullContext() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    b3Propagator.inject(null, carrier, setter);
+    assertThat(carrier).isEmpty();
+    b3PropagatorSingleHeader.inject(null, carrier, setter);
+    assertThat(carrier).isEmpty();
+  }
+
+  @Test
+  void inject_nullSetter() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    Context context =
+        withSpanContext(
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()),
+            Context.current());
+    b3Propagator.inject(context, carrier, null);
+    assertThat(carrier).isEmpty();
+    b3PropagatorSingleHeader.inject(context, carrier, null);
+    assertThat(carrier).isEmpty();
+  }
+
+  @Test
   void extract_Nothing() {
     // Context remains untouched.
     assertThat(
@@ -573,6 +595,24 @@ class B3PropagatorTest {
 
     assertThat(getSpanContext(b3Propagator.extract(Context.current(), invalidHeaders, getter)))
         .isSameAs(SpanContext.getInvalid());
+  }
+
+  @Test
+  void extract_nullContext() {
+    assertThat(b3Propagator.extract(null, Collections.emptyMap(), getter)).isSameAs(Context.root());
+    assertThat(b3PropagatorSingleHeader.extract(null, Collections.emptyMap(), getter))
+        .isSameAs(Context.root());
+  }
+
+  @Test
+  void extract_nullGetter() {
+    Context context =
+        withSpanContext(
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()),
+            Context.current());
+    assertThat(b3Propagator.extract(context, Collections.emptyMap(), null)).isSameAs(context);
+    assertThat(b3PropagatorSingleHeader.extract(context, Collections.emptyMap(), null))
+        .isSameAs(context);
   }
 
   @Test

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/JaegerPropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/JaegerPropagatorTest.java
@@ -173,6 +173,24 @@ class JaegerPropagatorTest {
   }
 
   @Test
+  void inject_nullContext() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    jaegerPropagator.inject(null, carrier, setter);
+    assertThat(carrier).isEmpty();
+  }
+
+  @Test
+  void inject_nullSetter() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    Context context =
+        withSpanContext(
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()),
+            Context.current());
+    jaegerPropagator.inject(context, carrier, null);
+    assertThat(carrier).isEmpty();
+  }
+
+  @Test
   void extract_Nothing() {
     // Context remains untouched.
     assertThat(
@@ -427,6 +445,21 @@ class JaegerPropagatorTest {
                 .put("meta", "meta-value")
                 .put("foo", "bar")
                 .build());
+  }
+
+  @Test
+  void extract_nullContext() {
+    assertThat(jaegerPropagator.extract(null, Collections.emptyMap(), getter))
+        .isSameAs(Context.root());
+  }
+
+  @Test
+  void extract_nullGetter() {
+    Context context =
+        withSpanContext(
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()),
+            Context.current());
+    assertThat(jaegerPropagator.extract(context, Collections.emptyMap(), null)).isSameAs(context);
   }
 
   private static String generateTraceIdHeaderValue(

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/OtTracePropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/OtTracePropagatorTest.java
@@ -145,6 +145,24 @@ class OtTracePropagatorTest {
   }
 
   @Test
+  void inject_nullContext() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    propagator.inject(null, carrier, setter);
+    assertThat(carrier).isEmpty();
+  }
+
+  @Test
+  void inject_nullSetter() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    Context context =
+        withSpanContext(
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()),
+            Context.current());
+    propagator.inject(context, carrier, null);
+    assertThat(carrier).isEmpty();
+  }
+
+  @Test
   void extract_Nothing() {
     // Context remains untouched.
     assertThat(
@@ -304,5 +322,19 @@ class OtTracePropagatorTest {
     Context context = propagator.extract(Context.current(), carrier, getter);
 
     assertThat(Baggage.fromContext(context).isEmpty()).isTrue();
+  }
+
+  @Test
+  void extract_nullContext() {
+    assertThat(propagator.extract(null, Collections.emptyMap(), getter)).isSameAs(Context.root());
+  }
+
+  @Test
+  void extract_nullGetter() {
+    Context context =
+        withSpanContext(
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()),
+            Context.current());
+    assertThat(propagator.extract(context, Collections.emptyMap(), null)).isSameAs(context);
   }
 }


### PR DESCRIPTION
While it's not quite as bad as other parts of the API throwing since adding propagators is explicit, we still want to prevent exceptions in apps as per the otel's error handling rules.

Started looking into these files as part of #2736 and realized that it doesn't seem so bad to just remove the `@Nullable` given all these checks anyways.