### PR TITLE
Use super wildcards for forEach consumer.

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/baggage/Baggage.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/Baggage.java
@@ -79,7 +79,7 @@ public interface Baggage extends ImplicitContextKeyed {
   }
 
   /** Iterates over all the entries in this {@link Baggage}. */
-  void forEach(BiConsumer<String, BaggageEntry> consumer);
+  void forEach(BiConsumer<? super String, ? super BaggageEntry> consumer);
 
   /** Returns a read-only view of this {@link Baggage} as a {@link Map}. */
   Map<String, BaggageEntry> asMap();

--- a/api/all/src/main/java/io/opentelemetry/api/common/Attributes.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/Attributes.java
@@ -36,7 +36,7 @@ public interface Attributes {
   <T> T get(AttributeKey<T> key);
 
   /** Iterates over all the key-value pairs of attributes contained by this instance. */
-  void forEach(BiConsumer<AttributeKey<?>, Object> consumer);
+  void forEach(BiConsumer<? super AttributeKey<?>, ? super Object> consumer);
 
   /** The number of attributes contained in this. */
   int size();

--- a/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
@@ -81,7 +81,7 @@ public abstract class ImmutableKeyValuePairs<K, V> {
 
   /** Iterates over all the key-value pairs of labels contained by this instance. */
   @SuppressWarnings("unchecked")
-  public final void forEach(BiConsumer<K, V> consumer) {
+  public final void forEach(BiConsumer<? super K, ? super V> consumer) {
     if (consumer == null) {
       return;
     }

--- a/api/all/src/main/java/io/opentelemetry/api/trace/ArrayBasedTraceState.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/ArrayBasedTraceState.java
@@ -44,7 +44,7 @@ abstract class ArrayBasedTraceState implements TraceState {
   }
 
   @Override
-  public void forEach(BiConsumer<String, String> consumer) {
+  public void forEach(BiConsumer<? super String, ? super String> consumer) {
     List<String> entries = getEntries();
     for (int i = 0; i < entries.size(); i += 2) {
       consumer.accept(entries.get(i), entries.get(i + 1));

--- a/api/all/src/main/java/io/opentelemetry/api/trace/TraceState.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/TraceState.java
@@ -70,7 +70,7 @@ public interface TraceState {
   boolean isEmpty();
 
   /** Iterates over all the key-value entries contained in this {@link TraceState}. */
-  void forEach(BiConsumer<String, String> consumer);
+  void forEach(BiConsumer<? super String, ? super String> consumer);
 
   /** Returns a read-only view of this {@link TraceState} as a {@link Map}. */
   Map<String, String> asMap();

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/common/Labels.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/common/Labels.java
@@ -102,7 +102,7 @@ public interface Labels {
   }
 
   /** Iterates over all the key-value pairs of labels contained by this instance. */
-  void forEach(BiConsumer<String, String> consumer);
+  void forEach(BiConsumer<? super String, ? super String> consumer);
 
   /** The number of key-value pairs of labels in this instance. */
   int size();

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/AttributesMap.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/AttributesMap.java
@@ -69,7 +69,7 @@ final class AttributesMap implements Attributes {
   @Override
   public void forEach(BiConsumer<? super AttributeKey<?>, ? super Object> consumer) {
     for (Map.Entry<AttributeKey<?>, Object> entry : data.entrySet()) {
-      AttributeKey key = entry.getKey();
+      AttributeKey<?> key = entry.getKey();
       Object value = entry.getValue();
       consumer.accept((AttributeKey<?>) key, value);
     }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/AttributesMap.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/AttributesMap.java
@@ -67,11 +67,11 @@ final class AttributesMap implements Attributes {
 
   @SuppressWarnings({"rawtypes", "unchecked"})
   @Override
-  public void forEach(BiConsumer<AttributeKey<?>, Object> consumer) {
+  public void forEach(BiConsumer<? super AttributeKey<?>, ? super Object> consumer) {
     for (Map.Entry<AttributeKey<?>, Object> entry : data.entrySet()) {
       AttributeKey key = entry.getKey();
       Object value = entry.getValue();
-      consumer.accept(key, value);
+      consumer.accept((AttributeKey<?>) key, value);
     }
   }
 


### PR DESCRIPTION
I randomly noticed that our `forEach` didn't follow the pattern of Java of consumers accepting `? super`. I'm not sure how big of a deal this is in practice since our types aren't extendible - but it does mean we wouldn't ever be able to do `AttributesMap extends HashMap` which is what I was trying in the first place to run into this.

I believe this is ABI compatible because generics are erased - it's the reason that I couldn't extend HashMap. But appreciate a second opinion. It's API compatible because the bounds are made less, not more, restrictive.