### PR TITLE
Add event assertion, full attributes assertion, and fuzzy attribute v…

### DIFF
--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/AttributesAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/AttributesAssert.java
@@ -11,7 +11,9 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.function.Consumer;
 import org.assertj.core.api.AbstractAssert;
 
 /** Assertions for {@link Attributes}. */
@@ -121,6 +123,23 @@ public final class AttributesAssert extends AbstractAssert<AttributesAssert, Att
             "Expected attributes to have key <%s> with value <%s> but was <%s>",
             key, value, actualValue)
         .containsExactlyElementsOf(value);
+    return this;
+  }
+
+  /** Asserts the attributes have the given key with a value satisfying the given condition. */
+  public <T> AttributesAssert hasEntrySatisfying(AttributeKey<T> key, Consumer<T> valueCondition) {
+    isNotNull();
+    assertThat(actual.get(key)).as("value").satisfies(valueCondition);
+    return this;
+  }
+
+  /** Asserts the attributes only contain the given entries. */
+  // NB: SafeVarArgs requires final on the method even if it's on the class.
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  public final AttributesAssert containsOnly(Map.Entry<? extends AttributeKey<?>, ?>... entries) {
+    isNotNull();
+    assertThat(actual.asMap()).containsOnly(entries);
     return this;
   }
 }

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/EventDataAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/EventDataAssert.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.testing.assertj;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.trace.data.EventData;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.assertj.core.api.AbstractAssert;
+
+/** Assertions for {@link EventData}. */
+public final class EventDataAssert extends AbstractAssert<EventDataAssert, EventData> {
+  EventDataAssert(EventData actual) {
+    super(actual, EventDataAssert.class);
+  }
+
+  /** Asserts the event has the given name. */
+  public EventDataAssert hasName(String name) {
+    isNotNull();
+    if (!actual.getName().equals(name)) {
+      failWithActualExpectedAndMessage(
+          actual.getName(),
+          name,
+          "Expected event to have name <%s> but was <%s>",
+          name,
+          actual.getName());
+    }
+    return this;
+  }
+
+  /** Asserts the event has the given timestamp, in nanos. */
+  public EventDataAssert hasTimestamp(long timestampNanos) {
+    isNotNull();
+    if (actual.getEpochNanos() != timestampNanos) {
+      failWithActualExpectedAndMessage(
+          actual.getEpochNanos(),
+          timestampNanos,
+          "Expected event [%s] to have timestamp <%s> nanos but was <%s>",
+          actual.getName(),
+          timestampNanos,
+          actual.getEpochNanos());
+    }
+    return this;
+  }
+
+  /** Asserts the event has the given timestamp. */
+  @SuppressWarnings("PreferJavaTimeOverload")
+  public EventDataAssert hasTimestamp(long timestamp, TimeUnit unit) {
+    return hasTimestamp(unit.toNanos(timestamp));
+  }
+
+  /** Asserts the event has the given timestamp, in nanos. */
+  public EventDataAssert hasTimestamp(Instant timestamp) {
+    return hasTimestamp(TimeUnit.SECONDS.toNanos(timestamp.getEpochSecond()) + timestamp.getNano());
+  }
+
+  /** Asserts the event has the given attributes. */
+  public EventDataAssert hasAttributes(Attributes attributes) {
+    isNotNull();
+    if (!actual.getAttributes().equals(attributes)) {
+      failWithActualExpectedAndMessage(
+          actual.getAttributes(),
+          attributes,
+          "Expected event [%s] to have attributes <%s> but was <%s>",
+          actual.getName(),
+          attributes,
+          actual.getAttributes());
+    }
+    return this;
+  }
+
+  /** Asserts the event has attributes satisfying the given condition. */
+  public EventDataAssert hasAttributesSatisfying(Consumer<Attributes> attributes) {
+    isNotNull();
+    assertThat(actual.getAttributes()).as("attributes").satisfies(attributes);
+    return this;
+  }
+}

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertions.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertions.java
@@ -5,8 +5,15 @@
 
 package io.opentelemetry.sdk.testing.assertj;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 
 /**
@@ -24,6 +31,92 @@ public final class OpenTelemetryAssertions extends Assertions {
   /** Returns an assertion for {@link SpanDataAssert}. */
   public static SpanDataAssert assertThat(SpanData spanData) {
     return new SpanDataAssert(spanData);
+  }
+
+  /** Returns an assertion for {@link EventDataAssert}. */
+  public static EventDataAssert assertThat(EventData eventData) {
+    return new EventDataAssert(eventData);
+  }
+
+  /**
+   * Returns an attribute entry with a String value for use with {@link
+   * AttributesAssert#containsOnly(java.util.Map.Entry[])}.
+   */
+  public static Map.Entry<AttributeKey<String>, String> attributeEntry(String key, String value) {
+    return new AbstractMap.SimpleImmutableEntry<>(AttributeKey.stringKey(key), value);
+  }
+
+  /**
+   * Returns an attribute entry with a boolean value for use with {@link
+   * AttributesAssert#containsOnly(java.util.Map.Entry[])}.
+   */
+  public static Map.Entry<AttributeKey<Boolean>, Boolean> attributeEntry(
+      String key, boolean value) {
+    return new AbstractMap.SimpleImmutableEntry<>(AttributeKey.booleanKey(key), value);
+  }
+
+  /**
+   * Returns an attribute entry with a long value for use with {@link
+   * AttributesAssert#containsOnly(java.util.Map.Entry[])}.
+   */
+  public static Map.Entry<AttributeKey<Long>, Long> attributeEntry(String key, long value) {
+    return new AbstractMap.SimpleImmutableEntry<>(AttributeKey.longKey(key), value);
+  }
+
+  /**
+   * Returns an attribute entry with a double value for use with {@link
+   * AttributesAssert#containsOnly(java.util.Map.Entry[])}.
+   */
+  public static Map.Entry<AttributeKey<Double>, Double> attributeEntry(String key, double value) {
+    return new AbstractMap.SimpleImmutableEntry<>(AttributeKey.doubleKey(key), value);
+  }
+
+  /**
+   * Returns an attribute entry with a String array value for use with {@link
+   * AttributesAssert#containsOnly(java.util.Map.Entry[])}.
+   */
+  public static Map.Entry<AttributeKey<List<String>>, List<String>> attributeEntry(
+      String key, String... value) {
+    return new AbstractMap.SimpleImmutableEntry<>(
+        AttributeKey.stringArrayKey(key), Arrays.asList(value));
+  }
+
+  /**
+   * Returns an attribute entry with a boolean array value for use with {@link
+   * AttributesAssert#containsOnly(java.util.Map.Entry[])}.
+   */
+  public static Map.Entry<AttributeKey<List<Boolean>>, List<Boolean>> attributeEntry(
+      String key, boolean... value) {
+    return new AbstractMap.SimpleImmutableEntry<>(AttributeKey.booleanArrayKey(key), toList(value));
+  }
+
+  /**
+   * Returns an attribute entry with a long array value for use with {@link
+   * AttributesAssert#containsOnly(java.util.Map.Entry[])}.
+   */
+  public static Map.Entry<AttributeKey<List<Long>>, List<Long>> attributeEntry(
+      String key, long... value) {
+    return new AbstractMap.SimpleImmutableEntry<>(
+        AttributeKey.longArrayKey(key), Arrays.stream(value).boxed().collect(Collectors.toList()));
+  }
+
+  /**
+   * Returns an attribute entry with a double array value for use with {@link
+   * AttributesAssert#containsOnly(java.util.Map.Entry[])}.
+   */
+  public static Map.Entry<AttributeKey<List<Double>>, List<Double>> attributeEntry(
+      String key, double... value) {
+    return new AbstractMap.SimpleImmutableEntry<>(
+        AttributeKey.doubleArrayKey(key),
+        Arrays.stream(value).boxed().collect(Collectors.toList()));
+  }
+
+  private static List<Boolean> toList(boolean... values) {
+    Boolean[] boxed = new Boolean[values.length];
+    for (int i = 0; i < values.length; i++) {
+      boxed[i] = values[i];
+    }
+    return Arrays.asList(boxed);
   }
 
   private OpenTelemetryAssertions() {}


### PR DESCRIPTION
…alue assertion.

While comparing parity between the Groovy assertions we use in instrumentation now, I found we need at least

- Event assertion
- Assertion of all attributes (i.e., to assert there are not more attributes than expected)
- Assertion of attribute value as a `Consumer`, e.g., to very an attribute appears to be a thread ID even though we wouldn't assert the actual value