### PR TITLE
add environment variables to ConfigProperties last

### DIFF
--- a/sdk-extensions/autoconfigure/build.gradle.kts
+++ b/sdk-extensions/autoconfigure/build.gradle.kts
@@ -117,12 +117,12 @@ tasks {
 
     val testResourceDisabledByProperty by existing(Test::class) {
         jvmArgs("-Dotel.java.disabled.resource-providers=io.opentelemetry.sdk.extension.resources.OsResourceProvider,io.opentelemetry.sdk.extension.resources.ProcessResourceProvider")
-        // Properties win, this is ignored.
-        environment("OTEL_JAVA_DISABLED_RESOURCE_PROVIDERS", "io.opentelemetry.sdk.extension.resources.ProcessRuntimeResourceProvider")
     }
 
     val testResourceDisabledByEnv by existing(Test::class) {
         environment("OTEL_JAVA_DISABLED_RESOURCE_PROVIDERS", "io.opentelemetry.sdk.extension.resources.OsResourceProvider,io.opentelemetry.sdk.extension.resources.ProcessResourceProvider")
+        // Environment variables win, this is ignored.
+        jvmArgs("-Dotel.java.disabled.resource-providers=io.opentelemetry.sdk.extension.resources.OsResourceProvider")
     }
 
     val check by existing {

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ConfigProperties.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ConfigProperties.java
@@ -40,8 +40,8 @@ public final class ConfigProperties {
   private ConfigProperties(Map<?, ?> systemProperties, Map<String, String> environmentVariables) {
     Map<String, String> config = new HashMap<>();
     systemProperties.forEach(
-            (key, value) ->
-                    config.put(((String) key).toLowerCase(Locale.ROOT).replace('-', '.'), (String) value));
+        (key, value) ->
+            config.put(((String) key).toLowerCase(Locale.ROOT).replace('-', '.'), (String) value));
     environmentVariables.forEach(
         (name, value) -> config.put(name.toLowerCase(Locale.ROOT).replace('_', '.'), value));
 

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ConfigProperties.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ConfigProperties.java
@@ -39,11 +39,11 @@ public final class ConfigProperties {
 
   private ConfigProperties(Map<?, ?> systemProperties, Map<String, String> environmentVariables) {
     Map<String, String> config = new HashMap<>();
+    systemProperties.forEach(
+            (key, value) ->
+                    config.put(((String) key).toLowerCase(Locale.ROOT).replace('-', '.'), (String) value));
     environmentVariables.forEach(
         (name, value) -> config.put(name.toLowerCase(Locale.ROOT).replace('_', '.'), value));
-    systemProperties.forEach(
-        (key, value) ->
-            config.put(((String) key).toLowerCase(Locale.ROOT).replace('-', '.'), (String) value));
 
     this.config = config;
   }

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySdkAutoConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySdkAutoConfiguration.java
@@ -25,7 +25,7 @@ public final class OpenTelemetrySdkAutoConfiguration {
   private static final Resource RESOURCE = buildResource();
 
   /** Returns the automatically configured {@link Resource}. */
-  public static Resource getResource() {
+  public static Resource  getResource() {
     return RESOURCE;
   }
 


### PR DESCRIPTION
switching env variables with system properties gives them precedence and allows for more general configurability