### PR TITLE
Returns invalid traceflags for a bad string parse instead of throwing…

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/trace/ImmutableSpanContext.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/ImmutableSpanContext.java
@@ -38,7 +38,7 @@ abstract class ImmutableSpanContext implements SpanContext {
       TraceFlags traceFlags,
       TraceState traceState,
       boolean remote) {
-    if (SpanId.isValid(spanIdHex) && TraceId.isValid(traceIdHex)) {
+    if (SpanId.isValid(spanIdHex) && TraceId.isValid(traceIdHex) && traceFlags.isValid()) {
       return createInternal(
           traceIdHex, spanIdHex, traceFlags, traceState, remote, /* valid= */ true);
     }

--- a/api/all/src/main/java/io/opentelemetry/api/trace/SpanContext.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/SpanContext.java
@@ -135,7 +135,9 @@ public interface SpanContext {
    * @return {@code true} if this {@code SpanContext} is valid.
    */
   default boolean isValid() {
-    return TraceId.isValid(getTraceId()) && SpanId.isValid(getSpanId());
+    return TraceId.isValid(getTraceId())
+        && SpanId.isValid(getSpanId())
+        && getTraceFlags().isValid();
   }
 
   /**

--- a/api/all/src/main/java/io/opentelemetry/api/trace/TraceFlags.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/TraceFlags.java
@@ -46,13 +46,12 @@ public interface TraceFlags {
 
   /**
    * Returns the {@link TraceFlags} converted from the given lowercase hex (base16) representation.
+   * If the input cannot be parsed, a {@link TraceFlags} will be returned where {@link
+   * TraceFlags#isValid()} returns {@code false}.
    *
    * @param src the buffer where the hex (base16) representation of the {@link TraceFlags} is.
    * @param srcOffset the offset int buffer.
    * @return the {@link TraceFlags} converted from the given lowercase hex (base16) representation.
-   * @throws NullPointerException if {@code src} is null.
-   * @throws IndexOutOfBoundsException if {@code src} is too short.
-   * @throws IllegalArgumentException if invalid characters in the {@code src}.
    */
   static TraceFlags fromHex(CharSequence src, int srcOffset) {
     return ImmutableTraceFlags.fromHex(src, srcOffset);
@@ -90,4 +89,10 @@ public interface TraceFlags {
    * @return the byte representation of the {@link TraceFlags}.
    */
   byte asByte();
+
+  /**
+   * Returns whether this {@link TraceFlags} is valid. An invalid {@link TraceFlags} should
+   * generally be discarded.
+   */
+  boolean isValid();
 }

--- a/api/all/src/main/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagator.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagator.java
@@ -207,26 +207,19 @@ public final class W3CTraceContextPropagator implements TextMapPropagator {
       return SpanContext.getInvalid();
     }
 
-    try {
-      String version = traceparent.substring(0, 2);
-      if (!VALID_VERSIONS.contains(version)) {
-        return SpanContext.getInvalid();
-      }
-      if (version.equals(VERSION_00) && traceparent.length() > TRACEPARENT_HEADER_SIZE) {
-        return SpanContext.getInvalid();
-      }
-
-      String traceId =
-          traceparent.substring(TRACE_ID_OFFSET, TRACE_ID_OFFSET + TraceId.getLength());
-      String spanId = traceparent.substring(SPAN_ID_OFFSET, SPAN_ID_OFFSET + SpanId.getLength());
-
-      TraceFlags traceFlags = TraceFlags.fromHex(traceparent, TRACE_OPTION_OFFSET);
-      return SpanContext.createFromRemoteParent(
-          traceId, spanId, traceFlags, TraceState.getDefault());
-    } catch (IllegalArgumentException e) {
-      logger.fine("Unparseable traceparent header. Returning INVALID span context.");
+    String version = traceparent.substring(0, 2);
+    if (!VALID_VERSIONS.contains(version)) {
       return SpanContext.getInvalid();
     }
+    if (version.equals(VERSION_00) && traceparent.length() > TRACEPARENT_HEADER_SIZE) {
+      return SpanContext.getInvalid();
+    }
+
+    String traceId = traceparent.substring(TRACE_ID_OFFSET, TRACE_ID_OFFSET + TraceId.getLength());
+    String spanId = traceparent.substring(SPAN_ID_OFFSET, SPAN_ID_OFFSET + SpanId.getLength());
+
+    TraceFlags traceFlags = TraceFlags.fromHex(traceparent, TRACE_OPTION_OFFSET);
+    return SpanContext.createFromRemoteParent(traceId, spanId, traceFlags, TraceState.getDefault());
   }
 
   private static TraceState extractTraceState(String traceStateHeader) {

--- a/api/all/src/test/java/io/opentelemetry/api/trace/SpanContextTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/trace/SpanContextTest.java
@@ -56,6 +56,14 @@ class SpanContextTest {
         .isFalse();
     assertThat(first.isValid()).isTrue();
     assertThat(second.isValid()).isTrue();
+    assertThat(
+            SpanContext.create(
+                    FIRST_TRACE_ID,
+                    FIRST_SPAN_ID,
+                    TraceFlags.fromHex("abc", 3),
+                    TraceState.getDefault())
+                .isValid())
+        .isFalse();
   }
 
   @Test

--- a/api/all/src/test/java/io/opentelemetry/api/trace/TraceFlagsTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/trace/TraceFlagsTest.java
@@ -38,6 +38,13 @@ class TraceFlagsTest {
   }
 
   @Test
+  void toFromHex_Invalid() {
+    assertThat(TraceFlags.fromHex(null, 0).isValid()).isFalse();
+    assertThat(TraceFlags.fromHex("hex", 0).isValid()).isFalse();
+    assertThat(TraceFlags.fromHex("aa", 1).isValid()).isFalse();
+  }
+
+  @Test
   void toFromByte() {
     for (int i = 0; i < 256; i++) {
       assertThat(TraceFlags.fromByte((byte) i).asByte()).isEqualTo((byte) i);


### PR DESCRIPTION
… an exception.

Supercedes #2869 

This removes the one and only place in the API that still declares it throws an exception. It avoids returning `null`, as in #2869, to reduce the chance of problems with usage of the API, an invalid traceflags should be handled by a propagator. But in the chance it's not handled, it will act as an empty traceflags and not cause crashes.

This is a behavior change which I agree with @bogdandrutu we need to make now or never since, i.e. a propagator that relied on the exceptions to handle invalid would not do so anymore if we removed them later. As `TraceFlags` presumably has no real use case outside of the w3c propagator, I'm comfortable with squeezing this into the release but open to thoughts.