### PR TITLE
Remove the documentation about explicit exceptions thrown when TraceFlags are invalid

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/trace/TraceFlags.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/TraceFlags.java
@@ -47,12 +47,11 @@ public interface TraceFlags {
   /**
    * Returns the {@link TraceFlags} converted from the given lowercase hex (base16) representation.
    *
+   * <p>This may throw runtime exceptions if the input is invalid.
+   *
    * @param src the buffer where the hex (base16) representation of the {@link TraceFlags} is.
    * @param srcOffset the offset int buffer.
    * @return the {@link TraceFlags} converted from the given lowercase hex (base16) representation.
-   * @throws NullPointerException if {@code src} is null.
-   * @throws IndexOutOfBoundsException if {@code src} is too short.
-   * @throws IllegalArgumentException if invalid characters in the {@code src}.
    */
   static TraceFlags fromHex(CharSequence src, int srcOffset) {
     return ImmutableTraceFlags.fromHex(src, srcOffset);


### PR DESCRIPTION
The correct behavior here is not yet known, so remove the documentation that implies a strict contract around the parsing of TraceFlags from hex inputs.