### PR TITLE
Prevent ImmutableBaggage.isKeyValid from allowing non-zero-length strings that contain nothing but spaces and/or tabs (#2948)

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/baggage/ImmutableBaggage.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/ImmutableBaggage.java
@@ -94,7 +94,7 @@ final class ImmutableBaggage extends ImmutableKeyValuePairs<String, BaggageEntry
    * @return whether the name is valid.
    */
   private static boolean isKeyValid(String name) {
-    return name != null && !name.isEmpty() && StringUtils.isPrintableString(name);
+    return name != null && !name.trim().isEmpty() && StringUtils.isPrintableString(name);
   }
 
   /**

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/ImmutableBaggageTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/ImmutableBaggageTest.java
@@ -94,6 +94,14 @@ class ImmutableBaggageTest {
   }
 
   @Test
+  void put_nonZeroLengthEmptyKey() {
+    BaggageBuilder builder = ONE_ENTRY.toBuilder();
+    Baggage built = builder.build();
+    builder.put(" ", V2, TMD);
+    assertThat(builder.build()).isEqualTo(built);
+  }
+
+  @Test
   void put_nullMetadata() {
     BaggageBuilder builder = ONE_ENTRY.toBuilder();
     Baggage built = builder.build();


### PR DESCRIPTION
Prevent ImmutableBaggage.isKeyValid from allowing non-zero-length strings that contain nothing but spaces and/or tabs (#2948)