### PR TITLE
Don't fail on timeout / interrupted since the result isn't really don…

### DIFF
--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/CompletableResultCode.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/CompletableResultCode.java
@@ -136,7 +136,9 @@ public final class CompletableResultCode {
   }
 
   /**
-   * Waits for the specified amount of time for this {@link CompletableResultCode} to complete.
+   * Waits up to the specified amount of time for this {@link CompletableResultCode} to complete.
+   * Even after this method returns, the result may not be complete yet - you should always check
+   * {@link #isSuccess()} or {@link #isDone()} after calling this method to determine the result.
    *
    * @return this {@link CompletableResultCode}
    */

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/CompletableResultCode.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/CompletableResultCode.java
@@ -136,8 +136,7 @@ public final class CompletableResultCode {
   }
 
   /**
-   * Waits for the specified amount of time for this {@link CompletableResultCode} to complete. If
-   * it times out or is interrupted, the {@link CompletableResultCode} is failed.
+   * Waits for the specified amount of time for this {@link CompletableResultCode} to complete.
    *
    * @return this {@link CompletableResultCode}
    */
@@ -149,11 +148,10 @@ public final class CompletableResultCode {
     whenComplete(latch::countDown);
     try {
       if (!latch.await(timeout, unit)) {
-        fail();
+        return this;
       }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      fail();
     }
     return this;
   }

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/CompletableResultCodeTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/CompletableResultCodeTest.java
@@ -13,6 +13,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
 class CompletableResultCodeTest {
@@ -163,17 +164,24 @@ class CompletableResultCodeTest {
   void joinTimesOut() {
     CompletableResultCode result = new CompletableResultCode();
     assertThat(result.join(1, TimeUnit.MILLISECONDS).isSuccess()).isFalse();
-    assertThat(result.isDone()).isTrue();
+    assertThat(result.isDone()).isFalse();
   }
 
   @Test
   void joinInterrupted() {
     CompletableResultCode result = new CompletableResultCode();
-    Thread thread = new Thread(() -> result.join(10, TimeUnit.SECONDS));
+    AtomicReference<Boolean> interrupted = new AtomicReference<>();
+    Thread thread =
+        new Thread(
+            () -> {
+              result.join(10, TimeUnit.SECONDS);
+              interrupted.set(Thread.currentThread().isInterrupted());
+            });
     thread.start();
     thread.interrupt();
     // Different thread so wait a bit for result to be propagated.
-    await().untilAsserted(() -> assertThat(result.isDone()).isTrue());
+    await().untilAsserted(() -> assertThat(interrupted).hasValue(true));
     assertThat(result.isSuccess()).isFalse();
+    assertThat(result.isDone()).isFalse();
   }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -111,6 +111,11 @@ public final class BatchSpanProcessor implements SpanProcessor {
     return worker.forceFlush();
   }
 
+  // Visible for testing
+  ArrayList<SpanData> getBatch() {
+    return worker.batch;
+  }
+
   // Worker is a thread that batches multiple spans and calls the registered SpanExporter to export
   // the data.
   private static final class Worker implements Runnable {


### PR DESCRIPTION
…e yet.

If code checks `isSuccess` after join, there will be no change as it still returns `false` before or after this change. If code checks `isDone` after join, now it will more precisely return `false` on timeout - you don't check `isDone` if you don't have code to properly handle the non-done case, so this should be a safe (even beneficial) change.

Fixes #2942 