### PR TITLE
Ignore classpath error when otlp is set as metrics exporter but is no…

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
@@ -58,7 +58,7 @@ final class MetricExporterConfiguration {
           "OTLP Metrics Exporter",
           "opentelemetry-exporter-otlp-metrics");
     } catch (ConfigurationException e) {
-      // Squash this for now, once metrics is stable and included in the `exporter-otlp` artifact
+      // Squash this for now, until metrics are stable and included in the `exporter-otlp` artifact
       // by default,
       return null;
     }

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
@@ -17,6 +17,7 @@ import io.prometheus.client.exporter.HTTPServer;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Collections;
+import javax.annotation.Nullable;
 
 final class MetricExporterConfiguration {
 
@@ -48,12 +49,19 @@ final class MetricExporterConfiguration {
   }
 
   // Visible for testing
+  @Nullable
   static OtlpGrpcMetricExporter configureOtlpMetrics(
       ConfigProperties config, SdkMeterProvider meterProvider) {
-    ClasspathUtil.checkClassExists(
-        "io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter",
-        "OTLP Metrics Exporter",
-        "opentelemetry-exporter-otlp-metrics");
+    try {
+      ClasspathUtil.checkClassExists(
+          "io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter",
+          "OTLP Metrics Exporter",
+          "opentelemetry-exporter-otlp-metrics");
+    } catch (ConfigurationException e) {
+      // Squash this for now, once metrics is stable and included in the `exporter-otlp` artifact
+      // by default,
+      return null;
+    }
     OtlpGrpcMetricExporterBuilder builder = OtlpGrpcMetricExporter.builder();
 
     String endpoint = config.getString("otel.exporter.otlp.endpoint");

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfiguration.java
@@ -67,7 +67,7 @@ final class SpanExporterConfiguration {
     ClasspathUtil.checkClassExists(
         "io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter",
         "OTLP Trace Exporter",
-        "opentelemetry-exporter-otlp-trace");
+        "opentelemetry-exporter-otlp");
     OtlpGrpcSpanExporterBuilder builder = OtlpGrpcSpanExporter.builder();
 
     String endpoint = config.getString("otel.exporter.otlp.endpoint");

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/NotOnClasspathTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/NotOnClasspathTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.autoconfigure;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
@@ -21,7 +22,7 @@ class NotOnClasspathTest {
     assertThatThrownBy(() -> SpanExporterConfiguration.configureExporter("otlp", EMPTY))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining(
-            "OTLP Trace Exporter enabled but opentelemetry-exporter-otlp-trace not found on "
+            "OTLP Trace Exporter enabled but opentelemetry-exporter-otlp not found on "
                 + "classpath");
   }
 
@@ -65,14 +66,11 @@ class NotOnClasspathTest {
 
   @Test
   void otlpMetrics() {
-    assertThatThrownBy(
+    assertThatCode(
             () ->
                 MetricExporterConfiguration.configureExporter(
                     "otlp", EMPTY, SdkMeterProvider.builder().build()))
-        .isInstanceOf(ConfigurationException.class)
-        .hasMessageContaining(
-            "OTLP Metrics Exporter enabled but opentelemetry-exporter-otlp-metrics not found on "
-                + "classpath");
+        .doesNotThrowAnyException();
   }
 
   @Test


### PR DESCRIPTION
…t on the classpath since the default value is otlp but metrics is alpha.

Also changes error message to encourage users to use `-otlp`, not `-otlp-trace` artifact which I think we prefer.

Fixes #2941