### PR TITLE
Don't use singleton in resource test

### DIFF
--- a/sdk-extensions/resources/src/test/java/io/opentelemetry/sdk/extension/resources/ProcessRuntimeResourceTest.java
+++ b/sdk-extensions/resources/src/test/java/io/opentelemetry/sdk/extension/resources/ProcessRuntimeResourceTest.java
@@ -19,7 +19,7 @@ class ProcessRuntimeResourceTest {
   @Test
   void shouldCreateRuntimeAttributes() {
     // when
-    Attributes attributes = ProcessRuntimeResource.get().getAttributes();
+    Attributes attributes = ProcessRuntimeResource.buildResource().getAttributes();
 
     // then
     assertThat(attributes.get(ResourceAttributes.PROCESS_RUNTIME_NAME)).isNotBlank();


### PR DESCRIPTION
If the other test ran first, the singleton would already be initialized with an empty value. Presumably something changed that is causing test order to be different (or more random) than before causing test failures.