### PR TITLE
Keep reference to leaked scope to make sure GC detection doesn't kick…

### DIFF
--- a/context/src/strictContextEnabledTest/java/io/opentelemetry/context/StrictContextStorageTest.java
+++ b/context/src/strictContextEnabledTest/java/io/opentelemetry/context/StrictContextStorageTest.java
@@ -141,7 +141,8 @@ class StrictContextStorageTest {
 
   @SuppressWarnings("ReturnValueIgnored")
   void decorator_close_withLeakedScope(Supplier<Scope> method, String methodName) throws Exception {
-    Thread thread = new Thread(method::get);
+    AtomicReference<Scope> scope = new AtomicReference<>();
+    Thread thread = new Thread(() -> scope.set(method.get()));
     thread.setName("t1");
     thread.start();
     thread.join();


### PR DESCRIPTION
… in first.

This test is meant to check the behavior if a scope is kept but not closed, `garbageCollectedScope` already exists for the GC case. But there seems to be a race that can cause the GC check to trigger and cause this test to fail (though no idea why we might have started seeing it more often recently).