### PR TITLE
Fix trace benchmark

### DIFF
--- a/docs/jmh.md
+++ b/docs/jmh.md
@@ -1,0 +1,21 @@
+
+# how to jmh
+
+[jmh] (Java Benchmark Harness) is a tool for running benchmarks and reporting results.
+
+opentelemetry-java has a lot of micro benchmarks. They live inside 
+`jmh` directories in the appropriate module.
+
+The benchmarks are run with a gradle plugin.
+
+To run an entire suite for a module, you can run the jmh gradle task.  
+As an example, here's how you can run the benchmarks for all of 
+the sdk trace module.
+
+```
+`./gradlew :sdk:trace:jmh`
+```
+
+If you just want to run a single benchmark and not the entire suite: 
+
+`./gradlew -PjmhIncludeSingleClass=BatchSpanProcessorBenchmark :sdk:trace:jmh`

--- a/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
+++ b/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
@@ -11,6 +11,8 @@ import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -66,16 +68,27 @@ public class SpanPipelineBenchmark {
 
       collector.start();
 
-      String address = collector.getHost() + ":" + collector.getMappedPort(EXPOSED_PORT);
+      SpanProcessor spanProcessor = makeSpanProcessor(collector);
 
       SdkTracerProvider tracerProvider =
           SdkTracerProvider.builder()
               .setSampler(Sampler.alwaysOn())
-              .addSpanProcessor(getSpanProcessor(address))
+              .addSpanProcessor(spanProcessor)
               .build();
 
       Tracer tracerSdk = tracerProvider.get("PipelineBenchmarkTracer");
       sdkSpanBuilder = (SdkSpanBuilder) tracerSdk.spanBuilder("PipelineBenchmarkSpan");
+    }
+
+    private SpanProcessor makeSpanProcessor(GenericContainer<?> collector) {
+      try {
+        String host = collector.getHost();
+        Integer port = collector.getMappedPort(EXPOSED_PORT);
+        String address = new URL("http", host, port, "").toString();
+        return getSpanProcessor(address);
+      } catch (MalformedURLException e) {
+        throw new IllegalStateException("can't make a url", e);
+      }
     }
 
     @Benchmark


### PR DESCRIPTION
The trace benchmarks were out of date (passing `host:port` instead of `http://host:port` to the SpanProcessor).  This fixes that and adds a doc for how to run the jmh tasks.