### PR TITLE
Add an internal GuardedBy annotation to enable our own error prone ch…

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.api;
 
+import io.opentelemetry.api.internal.GuardedBy;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
@@ -13,7 +14,6 @@ import java.lang.reflect.Method;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**

--- a/api/all/src/main/java/io/opentelemetry/api/internal/GuardedBy.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/GuardedBy.java
@@ -34,11 +34,11 @@ import java.lang.annotation.Target;
  *
  * <p>This annotation is similar to {@link javax.annotation.concurrent.GuardedBy} but has {@link
  * RetentionPolicy#SOURCE} so it is not in published artifacts. We only apply this to private
- * fields, so there is no reason to publish them and we avoid requiring end users to have to depend
+ * members, so there is no reason to publish them and we avoid requiring end users to have to depend
  * on the annotations in their own build. See the original <a
  * href="https://github.com/open-telemetry/opentelemetry-java/issues/2897">issue</a> for more info.
  */
-@Target(ElementType.FIELD)
+@Target({ElementType.FIELD, ElementType.METHOD})
 @Retention(RetentionPolicy.SOURCE)
 public @interface GuardedBy {
   /** The name of the object guarding the target. */

--- a/api/all/src/main/java/io/opentelemetry/api/internal/GuardedBy.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/GuardedBy.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.internal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The field or method to which this annotation is applied can only be accessed when holding a
+ * particular lock, which may be a built-in (synchronization) lock, or may be an explicit {@link
+ * java.util.concurrent.locks.Lock}.
+ *
+ * <p>The argument determines which lock guards the annotated field or method:
+ *
+ * <ul>
+ *   <li>this : The string literal "this" means that this field is guarded by the class in which it
+ *       is defined.
+ *   <li>class-name.this : For inner classes, it may be necessary to disambiguate 'this'; the
+ *       class-name.this designation allows you to specify which 'this' reference is intended
+ *   <li>itself : For reference fields only; the object to which the field refers.
+ *   <li>field-name : The lock object is referenced by the (instance or static) field specified by
+ *       field-name.
+ *   <li>class-name.field-name : The lock object is reference by the static field specified by
+ *       class-name.field-name.
+ *   <li>method-name() : The lock object is returned by calling the named nil-ary method.
+ *   <li>class-name.class : The Class object for the specified class should be used as the lock
+ *       object.
+ * </ul>
+ *
+ * <p>This annotation is similar to {@link javax.annotation.concurrent.GuardedBy} but has {@link
+ * RetentionPolicy#SOURCE} so it is not in published artifacts. We only apply this to private
+ * fields, so there is no reason to publish them and we avoid requiring end users to have to depend
+ * on the annotations in their own build. See the original <a
+ * href="https://github.com/open-telemetry/opentelemetry-java/issues/2897">issue</a> for more info.
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.SOURCE)
+public @interface GuardedBy {
+  /** The name of the object guarding the target. */
+  String value();
+}

--- a/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/ZPageServer.java
+++ b/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/ZPageServer.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.extension.zpages;
 
 import com.sun.net.httpserver.HttpServer;
+import io.opentelemetry.api.internal.GuardedBy;
 import io.opentelemetry.sdk.trace.SpanLimits;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
@@ -14,7 +15,6 @@ import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/CompletableResultCode.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/CompletableResultCode.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.common;
 
+import io.opentelemetry.api.internal.GuardedBy;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -13,7 +14,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.GuardedBy;
 
 /**
  * This class models JDK 8's CompletableFuture to afford migration should Open Telemetry's SDK

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/TestClock.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/TestClock.java
@@ -5,9 +5,9 @@
 
 package io.opentelemetry.sdk.internal;
 
+import io.opentelemetry.api.internal.GuardedBy;
 import io.opentelemetry.sdk.common.Clock;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 /** A mutable {@link Clock} that allows the time to be set for testing. */

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleHistogramAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleHistogramAggregator.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
+import io.opentelemetry.api.internal.GuardedBy;
 import io.opentelemetry.api.metrics.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
@@ -18,7 +19,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
-import javax.annotation.concurrent.GuardedBy;
 
 final class DoubleHistogramAggregator extends AbstractAggregator<HistogramAccumulation> {
   private final double[] boundaries;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountAggregator.java
@@ -5,11 +5,11 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
+import io.opentelemetry.api.internal.GuardedBy;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountAggregator.java
@@ -5,11 +5,11 @@
 
 package io.opentelemetry.sdk.metrics.aggregator;
 
+import io.opentelemetry.api.internal.GuardedBy;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.trace;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.internal.GuardedBy;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
@@ -32,7 +33,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 /** Implementation for the {@link Span} class that records trace events. */

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
+import io.opentelemetry.api.internal.GuardedBy;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.common.CompletableResultCode;
@@ -33,7 +34,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.GuardedBy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
…ecker without affecting downstream.

We only ever apply the annotation to private members, never anything public, and I don't foresee this ever changing given how difficult an API would be if it required locking by the caller. So we can avoid having to leak all of our annotations to a user's classpath by just reimplementing this one, using `SOURCE` retention.

Fixes #2897 