### PR TITLE
Don't copy events toSpanData if ended.

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -483,6 +483,12 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
       return Collections.emptyList();
     }
 
+    // if the span has ended, then the events are unmodifiable
+    // so we can return them directly and save copying all the data.
+    if (hasEnded) {
+      return Collections.unmodifiableList(events);
+    }
+
     return Collections.unmodifiableList(new ArrayList<>(events));
   }
 

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -196,6 +196,17 @@ class RecordEventsReadableSpanTest {
   }
 
   @Test
+  void toSpanData_immutableEvents_ended() {
+    RecordEventsReadableSpan span = createTestSpan(SpanKind.INTERNAL);
+    span.end();
+    SpanData spanData = span.toSpanData();
+
+    assertThatThrownBy(
+            () -> spanData.getEvents().add(EventData.create(1000, "test", Attributes.empty())))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
   void toSpanData_RootSpan() {
     RecordEventsReadableSpan span = createTestRootSpan();
     try {


### PR DESCRIPTION
We have this check for attributes but seems we can have it for events too.