### PR TITLE
Add static wrappers for Executor / ExecutorService using current cont…

### DIFF
--- a/context/src/main/java/io/opentelemetry/context/Context.java
+++ b/context/src/main/java/io/opentelemetry/context/Context.java
@@ -109,7 +109,7 @@ public interface Context {
    * dbExecutor = Context.wrapTasks(threadPool)} to ensure calls like {@code dbExecutor.execute(()
    * -> database.query())} have {@link Context} available on the thread executing database queries.
    */
-  static Executor wrapTasks(Executor executor) {
+  static Executor taskWrapping(Executor executor) {
     return command -> executor.execute(Context.current().wrap(command));
   }
 
@@ -125,7 +125,7 @@ public interface Context {
    * dbExecutor.execute(() -> database.query())} have {@link Context} available on the thread
    * executing database queries.
    */
-  static ExecutorService wrapTasks(ExecutorService executorService) {
+  static ExecutorService taskWrapping(ExecutorService executorService) {
     return new CurrentContextExecutorService(executorService);
   }
 

--- a/context/src/main/java/io/opentelemetry/context/Context.java
+++ b/context/src/main/java/io/opentelemetry/context/Context.java
@@ -99,6 +99,19 @@ public interface Context {
     return ArrayBasedContext.root();
   }
 
+  static Executor currentContextWrapping(Executor executor) {
+    return command -> executor.execute(Context.current().wrap(command));
+  }
+
+  /**
+   * Returns an {@link ExecutorService} which delegates to the provided {@code executorService},
+   * wrapping all invocations with the {@linkplain Context#current() current context} at the time of
+   * invocation.
+   */
+  static ExecutorService currentContextWrapping(ExecutorService executorService) {
+    return new CurrentContextExecutorService(executorService);
+  }
+
   /**
    * Returns the value stored in this {@link Context} for the given {@link ContextKey}, or {@code
    * null} if there is no value for the key in this context.

--- a/context/src/main/java/io/opentelemetry/context/Context.java
+++ b/context/src/main/java/io/opentelemetry/context/Context.java
@@ -101,18 +101,31 @@ public interface Context {
 
   /**
    * Returns an {@link Executor} which delegates to the provided {@code executor}, wrapping all
-   * invocations with the {@linkplain Context#current() current context} at the time of invocation.
+   * invocations of {@link Executor#execute(Runnable)} with the {@linkplain Context#current()
+   * current context} at the time of invocation.
+   *
+   * <p>This is generally used to create an {@link Executor} which will forward the {@link Context}
+   * during an invocation to another thread. For example, you may use something like {@code Executor
+   * dbExecutor = Context.wrapTasks(threadPool)} to ensure calls like {@code dbExecutor.execute(()
+   * -> database.query())} have {@link Context} available on the thread executing database queries.
    */
-  static Executor currentContextWrapping(Executor executor) {
+  static Executor wrapTasks(Executor executor) {
     return command -> executor.execute(Context.current().wrap(command));
   }
 
   /**
    * Returns an {@link ExecutorService} which delegates to the provided {@code executorService},
-   * wrapping all invocations with the {@linkplain Context#current() current context} at the time of
-   * invocation.
+   * wrapping all invocations of {@link ExecutorService} methods such as {@link
+   * ExecutorService#execute(Runnable)} or {@link ExecutorService#submit(Runnable)} with the
+   * {@linkplain Context#current() current context} at the time of invocation.
+   *
+   * <p>This is generally used to create an {@link ExecutorService} which will forward the {@link
+   * Context} during an invocation to another thread. For example, you may use something like {@code
+   * ExecutorService dbExecutor = Context.wrapTasks(threadPool)} to ensure calls like {@code
+   * dbExecutor.execute(() -> database.query())} have {@link Context} available on the thread
+   * executing database queries.
    */
-  static ExecutorService currentContextWrapping(ExecutorService executorService) {
+  static ExecutorService wrapTasks(ExecutorService executorService) {
     return new CurrentContextExecutorService(executorService);
   }
 

--- a/context/src/main/java/io/opentelemetry/context/Context.java
+++ b/context/src/main/java/io/opentelemetry/context/Context.java
@@ -99,6 +99,10 @@ public interface Context {
     return ArrayBasedContext.root();
   }
 
+  /**
+   * Returns an {@link Executor} which delegates to the provided {@code executor}, wrapping all
+   * invocations with the {@linkplain Context#current() current context} at the time of invocation.
+   */
   static Executor currentContextWrapping(Executor executor) {
     return command -> executor.execute(Context.current().wrap(command));
   }

--- a/context/src/main/java/io/opentelemetry/context/CurrentContextExecutorService.java
+++ b/context/src/main/java/io/opentelemetry/context/CurrentContextExecutorService.java
@@ -14,61 +14,54 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-class ContextExecutorService extends ForwardingExecutorService {
+class CurrentContextExecutorService extends ForwardingExecutorService {
 
-  private final Context context;
-
-  ContextExecutorService(Context context, ExecutorService delegate) {
+  CurrentContextExecutorService(ExecutorService delegate) {
     super(delegate);
-    this.context = context;
-  }
-
-  final Context context() {
-    return context;
   }
 
   @Override
   public <T> Future<T> submit(Callable<T> task) {
-    return delegate().submit(context.wrap(task));
+    return delegate().submit(Context.current().wrap(task));
   }
 
   @Override
   public <T> Future<T> submit(Runnable task, T result) {
-    return delegate().submit(context.wrap(task), result);
+    return delegate().submit(Context.current().wrap(task), result);
   }
 
   @Override
   public Future<?> submit(Runnable task) {
-    return delegate().submit(context.wrap(task));
+    return delegate().submit(Context.current().wrap(task));
   }
 
   @Override
   public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
       throws InterruptedException {
-    return delegate().invokeAll(wrap(context, tasks));
+    return delegate().invokeAll(wrap(Context.current(), tasks));
   }
 
   @Override
   public <T> List<Future<T>> invokeAll(
       Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
       throws InterruptedException {
-    return delegate().invokeAll(wrap(context, tasks), timeout, unit);
+    return delegate().invokeAll(wrap(Context.current(), tasks), timeout, unit);
   }
 
   @Override
   public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
       throws InterruptedException, ExecutionException {
-    return delegate().invokeAny(wrap(context, tasks));
+    return delegate().invokeAny(wrap(Context.current(), tasks));
   }
 
   @Override
   public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
       throws InterruptedException, ExecutionException, TimeoutException {
-    return delegate().invokeAny(wrap(context, tasks), timeout, unit);
+    return delegate().invokeAny(wrap(Context.current(), tasks), timeout, unit);
   }
 
   @Override
   public void execute(Runnable command) {
-    delegate().execute(context.wrap(command));
+    delegate().execute(Context.current().wrap(command));
   }
 }

--- a/context/src/main/java/io/opentelemetry/context/CurrentContextExecutorService.java
+++ b/context/src/main/java/io/opentelemetry/context/CurrentContextExecutorService.java
@@ -14,7 +14,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-class CurrentContextExecutorService extends ForwardingExecutorService {
+final class CurrentContextExecutorService extends ForwardingExecutorService {
 
   CurrentContextExecutorService(ExecutorService delegate) {
     super(delegate);

--- a/context/src/main/java/io/opentelemetry/context/ForwardingExecutorService.java
+++ b/context/src/main/java/io/opentelemetry/context/ForwardingExecutorService.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.context;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/** A {@link ExecutorService} that implements methods that don't need {@link Context}. */
+abstract class ForwardingExecutorService implements ExecutorService {
+
+  private final ExecutorService delegate;
+
+  protected ForwardingExecutorService(ExecutorService delegate) {
+    this.delegate = delegate;
+  }
+
+  ExecutorService delegate() {
+    return delegate;
+  }
+
+  @Override
+  public final void shutdown() {
+    delegate.shutdown();
+  }
+
+  @Override
+  public final List<Runnable> shutdownNow() {
+    return delegate.shutdownNow();
+  }
+
+  @Override
+  public final boolean isShutdown() {
+    return delegate.isShutdown();
+  }
+
+  @Override
+  public final boolean isTerminated() {
+    return delegate.isTerminated();
+  }
+
+  @Override
+  public final boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return delegate.awaitTermination(timeout, unit);
+  }
+
+  protected static <T> Collection<? extends Callable<T>> wrap(
+      Context context, Collection<? extends Callable<T>> tasks) {
+    List<Callable<T>> wrapped = new ArrayList<>();
+    for (Callable<T> task : tasks) {
+      wrapped.add(context.wrap(task));
+    }
+    return wrapped;
+  }
+}

--- a/context/src/test/java/io/opentelemetry/context/ContextTest.java
+++ b/context/src/test/java/io/opentelemetry/context/ContextTest.java
@@ -219,7 +219,7 @@ class ContextTest {
     assertThat(value).hasValue(null);
 
     try (Scope ignored = CAT.makeCurrent()) {
-      Context.currentContextWrapping(executor).execute(callback);
+      Context.wrapTasks(executor).execute(callback);
       assertThat(value).hasValue("cat");
     }
   }
@@ -372,7 +372,7 @@ class ContextTest {
   class CurrentContextWrappingExecutorService extends WrapExecutorService {
     @Override
     protected ExecutorService wrap(ExecutorService executorService) {
-      return Context.currentContextWrapping(executorService);
+      return Context.wrapTasks(executorService);
     }
 
     private Scope scope;

--- a/context/src/test/java/io/opentelemetry/context/ContextTest.java
+++ b/context/src/test/java/io/opentelemetry/context/ContextTest.java
@@ -217,6 +217,11 @@ class ContextTest {
 
     executor.execute(callback);
     assertThat(value).hasValue(null);
+
+    try (Scope ignored = CAT.makeCurrent()) {
+      Context.currentContextWrapping(executor).execute(callback);
+      assertThat(value).hasValue("cat");
+    }
   }
 
   @Nested
@@ -227,10 +232,14 @@ class ContextTest {
     protected ExecutorService wrapped;
     protected AtomicReference<String> value;
 
+    protected ExecutorService wrap(ExecutorService executorService) {
+      return CAT.wrap(executorService);
+    }
+
     @BeforeAll
     void initExecutor() {
       executor = Executors.newSingleThreadScheduledExecutor();
-      wrapped = CAT.wrap((ExecutorService) executor);
+      wrapped = wrap(executor);
     }
 
     @AfterAll
@@ -355,6 +364,30 @@ class ContextTest {
           .isEqualTo("bar");
       assertThat(value1).hasValue("cat");
       assertThat(value2).hasValue("cat");
+    }
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  class CurrentContextWrappingExecutorService extends WrapExecutorService {
+    @Override
+    protected ExecutorService wrap(ExecutorService executorService) {
+      return Context.currentContextWrapping(executorService);
+    }
+
+    private Scope scope;
+
+    @BeforeEach
+    // Closed in AfterEach
+    @SuppressWarnings("MustBeClosedChecker")
+    void makeCurrent() {
+      scope = CAT.makeCurrent();
+    }
+
+    @AfterEach
+    void close() {
+      scope.close();
+      scope = null;
     }
   }
 

--- a/context/src/test/java/io/opentelemetry/context/ContextTest.java
+++ b/context/src/test/java/io/opentelemetry/context/ContextTest.java
@@ -219,7 +219,7 @@ class ContextTest {
     assertThat(value).hasValue(null);
 
     try (Scope ignored = CAT.makeCurrent()) {
-      Context.wrapTasks(executor).execute(callback);
+      Context.taskWrapping(executor).execute(callback);
       assertThat(value).hasValue("cat");
     }
   }
@@ -372,7 +372,7 @@ class ContextTest {
   class CurrentContextWrappingExecutorService extends WrapExecutorService {
     @Override
     protected ExecutorService wrap(ExecutorService executorService) {
-      return Context.wrapTasks(executorService);
+      return Context.taskWrapping(executorService);
     }
 
     private Scope scope;


### PR DESCRIPTION
…ext at invocation time.

Some asynchronous instrumentation requires registering an `ExecutorService` statically which propagates context from invocations to executions. For example, to properly trace `OkHttpClient` to support `enqueue`, we need to do something like this

```java
client
  .dispatcher(new Dispatcher(Context.currentContextWrapping(new Dispatcher().executorService())))
  .addInterceptor(OkHttpTracing.create(openTelemetry).newInterceptor())
```

I thought of names like `currentContextWrapping`, `wrapWithCurrentContext` but don't know if I like either name so suggestions appreciated.