### PR TITLE
Fix unit test for kotlin context propagation.

### DIFF
--- a/extensions/kotlin/src/test/kotlin/io/opentelemetry/extension/kotlin/KotlinCoroutinesTest.kt
+++ b/extensions/kotlin/src/test/kotlin/io/opentelemetry/extension/kotlin/KotlinCoroutinesTest.kt
@@ -33,10 +33,10 @@ class KotlinCoroutinesTest {
 
             assertThat(Context.current().get(ANIMAL)).isEqualTo("cat")
 
-            GlobalScope.launch {
+            async(Dispatchers.IO) {
                 // Child coroutine inherits context automatically.
                 assertThat(Context.current().get(ANIMAL)).isEqualTo("cat")
-            }
+            }.await()
         }
     }
 

--- a/extensions/kotlin/src/test/kotlin/io/opentelemetry/extension/kotlin/KotlinCoroutinesTest.kt
+++ b/extensions/kotlin/src/test/kotlin/io/opentelemetry/extension/kotlin/KotlinCoroutinesTest.kt
@@ -37,6 +37,11 @@ class KotlinCoroutinesTest {
                 // Child coroutine inherits context automatically.
                 assertThat(Context.current().get(ANIMAL)).isEqualTo("cat")
             }.await()
+
+            coroutineScope {
+                // Child coroutine inherits context automatically.
+                assertThat(Context.current().get(ANIMAL)).isEqualTo("cat")
+            }
         }
     }
 

--- a/extensions/kotlin/src/test/kotlin/io/opentelemetry/extension/kotlin/KotlinCoroutinesTest.kt
+++ b/extensions/kotlin/src/test/kotlin/io/opentelemetry/extension/kotlin/KotlinCoroutinesTest.kt
@@ -42,6 +42,11 @@ class KotlinCoroutinesTest {
                 // Child coroutine inherits context automatically.
                 assertThat(Context.current().get(ANIMAL)).isEqualTo("cat")
             }
+
+            CoroutineScope(Dispatchers.IO).async {
+                // Non-child coroutine does not inherit context automatically.
+                assertThat(Context.current().get(ANIMAL)).isNull()
+            }.await()
         }
     }
 


### PR DESCRIPTION
`GlobalScope.launch` isn't supposed to inherit context

https://kotlinlang.org/docs/coroutine-context-and-dispatchers.html#children-of-a-coroutine

But the test didn't fail since actually we weren't awaiting on the result anyways. Switched to launching a child coroutine the correct way (I think) and awaiting