### PR TITLE
Don't auto-start the IntervalMetricReader in the constructor.

### DIFF
--- a/perf-harness/src/test/java/io/opentelemetry/perf/OtlpPipelineStressTest.java
+++ b/perf-harness/src/test/java/io/opentelemetry/perf/OtlpPipelineStressTest.java
@@ -252,7 +252,7 @@ public class OtlpPipelineStressTest {
             .setMetricExporter(metricExporter)
             .setMetricProducers(Collections.singleton(meterProvider))
             .setExportIntervalMillis(1000)
-            .build();
+            .buildAndStart();
 
     // set up the span exporter and wire it into the SDK
     OtlpGrpcSpanExporter spanExporter =

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
@@ -96,7 +96,7 @@ final class MetricExporterConfiguration {
     if (exportIntervalMillis != null) {
       readerBuilder.setExportIntervalMillis(exportIntervalMillis);
     }
-    IntervalMetricReader reader = readerBuilder.build();
+    IntervalMetricReader reader = readerBuilder.buildAndStart();
     Runtime.getRuntime().addShutdownHook(new Thread(reader::shutdown));
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
@@ -76,9 +76,15 @@ public final class IntervalMetricReader {
   }
 
   IntervalMetricReader(InternalState internalState) {
+    this(
+        internalState,
+        Executors.newScheduledThreadPool(1, new DaemonThreadFactory("IntervalMetricReader")));
+  }
+
+  // visible for testing
+  IntervalMetricReader(InternalState internalState, ScheduledExecutorService intervalMetricReader) {
     this.exporter = new Exporter(internalState);
-    this.scheduler =
-        Executors.newScheduledThreadPool(1, new DaemonThreadFactory("IntervalMetricReader"));
+    this.scheduler = intervalMetricReader;
   }
 
   /**

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderBuilder.java
@@ -52,7 +52,8 @@ public final class IntervalMetricReaderBuilder {
   }
 
   /**
-   * Builds a new {@link IntervalMetricReader} with current settings.
+   * Builds a new {@link IntervalMetricReader} with current settings. Does not start the background
+   * thread. Please call {@link IntervalMetricReader#start()} to do that.
    *
    * @return a {@code IntervalMetricReader}.
    */
@@ -62,5 +63,15 @@ public final class IntervalMetricReaderBuilder {
         internalState.getExportIntervalMillis() > 0, "Export interval must be positive");
 
     return new IntervalMetricReader(internalState);
+  }
+
+  /**
+   * Builds a new {@link IntervalMetricReader} with current settings and starts the background
+   * thread running.
+   *
+   * @return a {@code IntervalMetricReader}.
+   */
+  public IntervalMetricReader buildAndStart() {
+    return build().start();
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
@@ -73,7 +73,7 @@ class IntervalMetricReaderTest {
     intervalMetricReader.start();
 
     // wait for 2 cycles. We should only have 2 metrics collected, not more.
-    Thread.sleep(250);
+    Thread.sleep(290);
     assertThat(waitingMetricExporter.numberOfExports.get()).isEqualTo(2);
   }
 

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
@@ -65,7 +65,7 @@ class IntervalMetricReaderTest {
             .setExportIntervalMillis(100)
             .setMetricExporter(waitingMetricExporter)
             .setMetricProducers(Collections.singletonList(metricProducer))
-            .build();
+            .buildAndStart();
 
     try {
       assertThat(waitingMetricExporter.waitForNumberOfExports(1))
@@ -88,7 +88,7 @@ class IntervalMetricReaderTest {
             .setExportIntervalMillis(100)
             .setMetricExporter(waitingMetricExporter)
             .setMetricProducers(Collections.singletonList(metricProducer))
-            .build();
+            .buildAndStart();
 
     try {
       assertThat(waitingMetricExporter.waitForNumberOfExports(1))
@@ -106,7 +106,7 @@ class IntervalMetricReaderTest {
             .setExportIntervalMillis(100_000)
             .setMetricExporter(waitingMetricExporter)
             .setMetricProducers(Collections.singletonList(metricProducer))
-            .build();
+            .buildAndStart();
 
     // Assume that this will be called in less than 100 seconds.
     intervalMetricReader.shutdown();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
@@ -76,7 +76,7 @@ class IntervalMetricReaderTest {
     // wait for 2 cycles. We should only have 2 metrics collected, not more.
     await()
         .during(Duration.ofMillis(100))
-        .atMost(Duration.ofMillis(250))
+        .atMost(Duration.ofMillis(290))
         .until(() -> waitingMetricExporter.queue.size() < 3);
   }
 


### PR DESCRIPTION
This changes the IntervalMetricReaderBuilder.build() method to not auto-start the IMR. There is a new method on the builder `buildAndStart()` which will do both for you.  

Adds a method to the IntervalMetricReader to start the background thread, but this is not called as a part of the constructor.