### PR TITLE
Remove jcenter and google repositories from build.

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -28,7 +28,6 @@ subprojects {
 
     repositories {
         mavenCentral()
-        jcenter()
         maven {
             // Add snapshot repository
             url "https://oss.sonatype.org/content/repositories/snapshots"

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -4,11 +4,6 @@ pluginManagement {
         id "com.github.johnrengelman.shadow" version "6.1.0"
         id 'com.google.protobuf' version '0.8.8'
     }
-
-    repositories {
-        gradlePluginPortal()
-        google()
-    }
 }
 
 rootProject.name = "opentelemetry-java-examples"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,11 +15,6 @@ pluginManagement {
         id("org.unbroken-dome.test-sets") version "3.0.1"
         id("ru.vyarus.animalsniffer") version "1.5.2"
     }
-
-    repositories {
-        gradlePluginPortal()
-        google()
-    }
 }
 
 plugins {
@@ -29,7 +24,6 @@ plugins {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        jcenter()
         mavenLocal()
     }
 }


### PR DESCRIPTION
Former is sunset and flaky, latter we don't need since no Android build