### PR TITLE
Fix IntervalMetricReader breaking if export() throws.

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
@@ -117,7 +117,6 @@ public final class IntervalMetricReader {
     }
 
     @Override
-    @SuppressWarnings("BooleanParameter")
     public void run() {
       // Ignore the CompletableResultCode from doRun() in order to keep run() asynchronous
       doRun();
@@ -141,8 +140,9 @@ public final class IntervalMetricReader {
                 flushResult.succeed();
                 exportAvailable.set(true);
               });
-        } catch (RuntimeException e) {
-          logger.log(Level.WARNING, "Exporter threw an Exception", e);
+        } catch (Throwable t) {
+          exportAvailable.set(true);
+          logger.log(Level.WARNING, "Exporter threw an Exception", t);
           flushResult.fail();
         }
       } else {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
@@ -120,8 +120,9 @@ class IntervalMetricReaderTest {
             .buildAndStart();
 
     try {
-      assertThat(waitingMetricExporter.waitForNumberOfExports(1))
-          .containsExactly(Collections.singletonList(METRIC_DATA));
+      assertThat(waitingMetricExporter.waitForNumberOfExports(2))
+          .containsExactly(
+              Collections.singletonList(METRIC_DATA), Collections.singletonList(METRIC_DATA));
     } finally {
       intervalMetricReader.shutdown();
     }


### PR DESCRIPTION
Also fix the test that was in place to check this but was a false negative since the first export still works without this bugfix, but not any further ones.

CC @arminru @thisthat 