### PR TITLE
Rename GlobalMetricsProvider to GlobalMeterProvider

### DIFF
--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/GlobalMeterProvider.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/GlobalMeterProvider.java
@@ -11,11 +11,11 @@ import java.util.concurrent.atomic.AtomicReference;
  * IMPORTANT: This is a temporary class, and solution for the metrics package until it will be
  * marked as stable.
  */
-public final class GlobalMetricsProvider {
+public final class GlobalMeterProvider {
   private static final Object mutex = new Object();
   private static final AtomicReference<MeterProvider> globalMeterProvider = new AtomicReference<>();
 
-  private GlobalMetricsProvider() {}
+  private GlobalMeterProvider() {}
 
   /** Returns the globally registered {@link MeterProvider}. */
   public static MeterProvider get() {

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporter.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporter.java
@@ -12,7 +12,7 @@ import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import io.opentelemetry.api.metrics.BoundLongCounter;
-import io.opentelemetry.api.metrics.GlobalMetricsProvider;
+import io.opentelemetry.api.metrics.GlobalMeterProvider;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.common.Labels;
@@ -60,7 +60,7 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
    *     0 or to a negative value, the exporter will wait indefinitely.
    */
   OtlpGrpcSpanExporter(ManagedChannel channel, long timeoutNanos) {
-    Meter meter = GlobalMetricsProvider.getMeter("io.opentelemetry.exporters.otlp");
+    Meter meter = GlobalMeterProvider.getMeter("io.opentelemetry.exporters.otlp");
     this.spansSeen =
         meter.longCounterBuilder("spansSeenByExporter").build().bind(EXPORTER_NAME_LABELS);
     LongCounter spansExportedCounter = meter.longCounterBuilder("spansExportedByExporter").build();

--- a/sdk-extensions/autoconfigure/src/testPrometheus/java/io/opentelemetry/sdk/autoconfigure/PrometheusTest.java
+++ b/sdk-extensions/autoconfigure/src/testPrometheus/java/io/opentelemetry/sdk/autoconfigure/PrometheusTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
-import io.opentelemetry.api.metrics.GlobalMetricsProvider;
+import io.opentelemetry.api.metrics.GlobalMeterProvider;
 import io.opentelemetry.api.metrics.common.Labels;
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -35,7 +35,7 @@ class PrometheusTest {
     System.setProperty("otel.exporter.prometheus.port", String.valueOf(port));
     OpenTelemetrySdkAutoConfiguration.initialize();
 
-    GlobalMetricsProvider.get()
+    GlobalMeterProvider.get()
         .get("test")
         .longValueObserverBuilder("test")
         .setUpdater(result -> result.observe(2, Labels.empty()))

--- a/sdk-extensions/logging/src/main/java/io/opentelemetry/sdk/logging/export/BatchLogProcessor.java
+++ b/sdk-extensions/logging/src/main/java/io/opentelemetry/sdk/logging/export/BatchLogProcessor.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.logging.export;
 
 import io.opentelemetry.api.metrics.BoundLongCounter;
-import io.opentelemetry.api.metrics.GlobalMetricsProvider;
+import io.opentelemetry.api.metrics.GlobalMeterProvider;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.common.Labels;
@@ -66,7 +66,7 @@ public final class BatchLogProcessor implements LogProcessor {
 
   private static class Worker implements Runnable {
     static {
-      Meter meter = GlobalMetricsProvider.getMeter("io.opentelemetry.sdk.logging");
+      Meter meter = GlobalMeterProvider.getMeter("io.opentelemetry.sdk.logging");
       LongCounter logRecordsProcessed =
           meter
               .longCounterBuilder("logRecordsProcessed")

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProviderBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProviderBuilder.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import io.opentelemetry.api.metrics.GlobalMetricsProvider;
+import io.opentelemetry.api.metrics.GlobalMeterProvider;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.internal.SystemClock;
 import io.opentelemetry.sdk.resources.Resource;
@@ -52,11 +52,11 @@ public final class SdkMeterProviderBuilder {
    * SdkMeterProviderBuilder} and registers it as the global {@link
    * io.opentelemetry.api.metrics.MeterProvider}.
    *
-   * @see GlobalMetricsProvider
+   * @see GlobalMeterProvider
    */
   public SdkMeterProvider buildAndRegisterGlobal() {
     SdkMeterProvider meterProvider = build();
-    GlobalMetricsProvider.set(meterProvider);
+    GlobalMeterProvider.set(meterProvider);
     return meterProvider;
   }
 
@@ -68,7 +68,7 @@ public final class SdkMeterProviderBuilder {
    * that requires access to a global instance of {@link
    * io.opentelemetry.api.metrics.MeterProvider}.
    *
-   * @see GlobalMetricsProvider
+   * @see GlobalMeterProvider
    */
   public SdkMeterProvider build() {
     return new SdkMeterProvider(clock, resource);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderBuilderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderBuilderTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.api.metrics.GlobalMetricsProvider;
+import io.opentelemetry.api.metrics.GlobalMeterProvider;
 import io.opentelemetry.sdk.resources.Resource;
 import org.junit.jupiter.api.Test;
 
@@ -17,9 +17,9 @@ class SdkMeterProviderBuilderTest {
   void buildAndRegisterGlobal() {
     SdkMeterProvider meterProvider = SdkMeterProvider.builder().buildAndRegisterGlobal();
     try {
-      assertThat(GlobalMetricsProvider.get()).isSameAs(meterProvider);
+      assertThat(GlobalMeterProvider.get()).isSameAs(meterProvider);
     } finally {
-      GlobalMetricsProvider.set(null);
+      GlobalMeterProvider.set(null);
     }
   }
 

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.trace.export;
 
 import io.opentelemetry.api.metrics.BoundLongCounter;
-import io.opentelemetry.api.metrics.GlobalMetricsProvider;
+import io.opentelemetry.api.metrics.GlobalMeterProvider;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.common.Labels;
@@ -156,7 +156,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
       this.exporterTimeoutNanos = exporterTimeoutNanos;
       this.queue = queue;
       this.signal = new ArrayBlockingQueue<>(1);
-      Meter meter = GlobalMetricsProvider.getMeter("io.opentelemetry.sdk.trace");
+      Meter meter = GlobalMeterProvider.getMeter("io.opentelemetry.sdk.trace");
       meter
           .longValueObserverBuilder("queueSize")
           .setDescription("The number of spans queued")


### PR DESCRIPTION
I think this was just an accidental naming snafu.