### PR TITLE
Remove redundant build script code.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,6 @@ import net.ltgt.gradle.errorprone.ErrorProneOptions
 import net.ltgt.gradle.errorprone.ErrorPronePlugin
 import org.gradle.api.plugins.JavaPlugin.*
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import ru.vyarus.gradle.plugin.animalsniffer.AnimalSniffer
 import ru.vyarus.gradle.plugin.animalsniffer.AnimalSnifferExtension
 import ru.vyarus.gradle.plugin.animalsniffer.AnimalSnifferPlugin
 import java.time.Duration
@@ -82,9 +81,6 @@ subprojects {
         }
 
         configure<JavaPluginExtension> {
-            sourceCompatibility = JavaVersion.VERSION_1_8
-            targetCompatibility = JavaVersion.VERSION_1_8
-
             toolchain {
                 languageVersion.set(JavaLanguageVersion.of(11))
             }


### PR DESCRIPTION
We already set the release compiler option, so no need to set the target/source compatibility.
According to <https://docs.gradle.org/current/dsl/org.gradle.api.tasks.compile.CompileOptions.html#org.gradle.api.tasks.compile.CompileOptions:release>,

> If set, it will take precedences over the `AbstractCompile.getSourceCompatibility()` and
`AbstractCompile.getTargetCompatibility()` settings.