### PR TITLE
Move registerView from SdkMeterProvider to SdkMeterProviderBuilder. (#3060)

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProvider.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProvider.java
@@ -83,4 +83,32 @@ public final class SdkMeterProvider implements MeterProvider, MetricProducer {
   public static SdkMeterProviderBuilder builder() {
     return new SdkMeterProviderBuilder();
   }
+
+  /**
+   * Register a view with the given {@link InstrumentSelector}.
+   *
+   * <p>Example on how to register a view:
+   *
+   * <pre>{@code
+   * // get a handle to the MeterSdkProvider
+   * MeterSdkProvider meterProvider = OpenTelemetrySdk.getMeterProvider();
+   *
+   * // create a selector to select which instruments to customize:
+   * InstrumentSelector instrumentSelector = InstrumentSelector.builder()
+   *   .setInstrumentType(InstrumentType.COUNTER)
+   *   .buildInstrument();
+   *
+   * // create a specification of how you want the metrics aggregated:
+   * AggregatorFactory aggregatorFactory = AggregatorFactory.minMaxSumCount();
+   *
+   * //register the view with the MeterSdkProvider
+   * meterProvider.registerView(instrumentSelector, View.builder()
+   *   .setAggregatorFactory(aggregatorFactory).build());
+   * }</pre>
+   * @deprecated Use {@link SdkMeterProviderBuilder#registerView(InstrumentSelector, View)}
+   */
+  @Deprecated
+  public void registerView(InstrumentSelector selector, View view) {
+    sharedState.getViewRegistry().registerView(selector, view);
+  }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProvider.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProvider.java
@@ -91,12 +91,12 @@ public final class SdkMeterProvider implements MeterProvider, MetricProducer {
    *
    * <pre>{@code
    * // get a handle to the MeterSdkProvider
-   * MeterSdkProvider meterProvider = OpenTelemetrySdk.getMeterProvider();
+   * SdkMeterProvider meterProvider = SdkMeterProvider.builder().build();
    *
    * // create a selector to select which instruments to customize:
    * InstrumentSelector instrumentSelector = InstrumentSelector.builder()
    *   .setInstrumentType(InstrumentType.COUNTER)
-   *   .buildInstrument();
+   *   .build();
    *
    * // create a specification of how you want the metrics aggregated:
    * AggregatorFactory aggregatorFactory = AggregatorFactory.minMaxSumCount();
@@ -105,6 +105,7 @@ public final class SdkMeterProvider implements MeterProvider, MetricProducer {
    * meterProvider.registerView(instrumentSelector, View.builder()
    *   .setAggregatorFactory(aggregatorFactory).build());
    * }</pre>
+   *
    * @deprecated Use {@link SdkMeterProviderBuilder#registerView(InstrumentSelector, View)}
    */
   @Deprecated

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProviderBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProviderBuilder.java
@@ -64,13 +64,13 @@ public final class SdkMeterProviderBuilder {
    * // create a selector to select which instruments to customize:
    * InstrumentSelector instrumentSelector = InstrumentSelector.builder()
    *   .setInstrumentType(InstrumentType.COUNTER)
-   *   .buildInstrument();
+   *   .build();
    *
    * // create a specification of how you want the metrics aggregated:
    * AggregatorFactory aggregatorFactory = AggregatorFactory.minMaxSumCount();
    *
    * // register the view with the SdkMeterProviderBuilder
-   * register.registerView(instrumentSelector, View.builder()
+   * meterProviderBuilder.registerView(instrumentSelector, View.builder()
    *   .setAggregatorFactory(aggregatorFactory).build());
    * }</pre>
    */

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProviderBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProviderBuilder.java
@@ -8,7 +8,11 @@ package io.opentelemetry.sdk.metrics;
 import io.opentelemetry.api.metrics.GlobalMetricsProvider;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.internal.SystemClock;
+import io.opentelemetry.sdk.metrics.view.InstrumentSelector;
+import io.opentelemetry.sdk.metrics.view.View;
 import io.opentelemetry.sdk.resources.Resource;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 
@@ -20,6 +24,7 @@ public final class SdkMeterProviderBuilder {
 
   private Clock clock = SystemClock.getInstance();
   private Resource resource = Resource.getDefault();
+  private final Map<InstrumentSelector, View> instrumentSelectorViews = new HashMap<>();
 
   SdkMeterProviderBuilder() {}
 
@@ -48,6 +53,35 @@ public final class SdkMeterProviderBuilder {
   }
 
   /**
+   * Register a view with the given {@link InstrumentSelector}.
+   *
+   * <p>Example on how to register a view:
+   *
+   * <pre>{@code
+   * // create a SdkMeterProviderBuilder
+   * SdkMeterProviderBuilder meterProviderBuilder = SdkMeterProvider.builder();
+   *
+   * // create a selector to select which instruments to customize:
+   * InstrumentSelector instrumentSelector = InstrumentSelector.builder()
+   *   .setInstrumentType(InstrumentType.COUNTER)
+   *   .buildInstrument();
+   *
+   * // create a specification of how you want the metrics aggregated:
+   * AggregatorFactory aggregatorFactory = AggregatorFactory.minMaxSumCount();
+   *
+   * // register the view with the SdkMeterProviderBuilder
+   * register.registerView(instrumentSelector, View.builder()
+   *   .setAggregatorFactory(aggregatorFactory).build());
+   * }</pre>
+   */
+  public SdkMeterProviderBuilder registerView(InstrumentSelector selector, View view) {
+    Objects.requireNonNull(selector, "selector");
+    Objects.requireNonNull(view, "view");
+    instrumentSelectorViews.put(selector, view);
+    return this;
+  }
+
+  /**
    * Returns a new {@link SdkMeterProvider} built with the configuration of this {@link
    * SdkMeterProviderBuilder} and registers it as the global {@link
    * io.opentelemetry.api.metrics.MeterProvider}.
@@ -71,6 +105,6 @@ public final class SdkMeterProviderBuilder {
    * @see GlobalMetricsProvider
    */
   public SdkMeterProvider build() {
-    return new SdkMeterProvider(clock, resource);
+    return new SdkMeterProvider(clock, resource, instrumentSelectorViews);
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderTest.java
@@ -44,17 +44,19 @@ public class SdkMeterProviderTest {
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
       InstrumentationLibraryInfo.create(SdkMeterProviderTest.class.getName(), null);
   private final TestClock testClock = TestClock.create();
-  private final SdkMeterProvider sdkMeterProvider =
-      SdkMeterProvider.builder().setClock(testClock).setResource(RESOURCE).build();
-  private final SdkMeter sdkMeter = sdkMeterProvider.get(SdkMeterProviderTest.class.getName());
+  private final SdkMeterProviderBuilder sdkMeterProviderBuilder =
+      SdkMeterProvider.builder().setClock(testClock).setResource(RESOURCE);
 
   @Test
   void defaultMeterName() {
+    SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
     assertThat(sdkMeterProvider.get(null)).isSameAs(sdkMeterProvider.get("unknown"));
   }
 
   @Test
   void collectAllSyncInstruments() {
+    SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
+    SdkMeter sdkMeter = sdkMeterProvider.get(SdkMeterProviderTest.class.getName());
     LongCounter longCounter = sdkMeter.longCounterBuilder("testLongCounter").build();
     longCounter.add(10, Labels.empty());
     LongUpDownCounter longUpDownCounter =
@@ -160,9 +162,11 @@ public class SdkMeterProviderTest {
 
   @Test
   void collectAllSyncInstruments_OverwriteTemporality() {
-    sdkMeterProvider.registerView(
+    sdkMeterProviderBuilder.registerView(
         InstrumentSelector.builder().setInstrumentType(InstrumentType.COUNTER).build(),
         View.builder().setAggregatorFactory(AggregatorFactory.sum(false)).build());
+    SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
+    SdkMeter sdkMeter = sdkMeterProvider.get(SdkMeterProviderTest.class.getName());
 
     LongCounter longCounter = sdkMeter.longCounterBuilder("testLongCounter").build();
     longCounter.add(10, Labels.empty());
@@ -205,7 +209,9 @@ public class SdkMeterProviderTest {
   @Test
   void collectAllSyncInstruments_DeltaCount() {
     registerViewForAllTypes(
-        sdkMeterProvider, AggregatorFactory.count(AggregationTemporality.DELTA));
+        sdkMeterProviderBuilder, AggregatorFactory.count(AggregationTemporality.DELTA));
+    SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
+    SdkMeter sdkMeter = sdkMeterProvider.get(SdkMeterProviderTest.class.getName());
     LongCounter longCounter = sdkMeter.longCounterBuilder("testLongCounter").build();
     longCounter.add(10, Labels.empty());
     LongUpDownCounter longUpDownCounter =
@@ -387,6 +393,8 @@ public class SdkMeterProviderTest {
 
   @Test
   void collectAllAsyncInstruments() {
+    SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
+    SdkMeter sdkMeter = sdkMeterProvider.get(SdkMeterProviderTest.class.getName());
     sdkMeter
         .longSumObserverBuilder("testLongSumObserver")
         .setUpdater(longResult -> longResult.observe(10, Labels.empty()))
@@ -486,7 +494,9 @@ public class SdkMeterProviderTest {
   @Test
   void collectAllAsyncInstruments_CumulativeCount() {
     registerViewForAllTypes(
-        sdkMeterProvider, AggregatorFactory.count(AggregationTemporality.CUMULATIVE));
+        sdkMeterProviderBuilder, AggregatorFactory.count(AggregationTemporality.CUMULATIVE));
+    SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
+    SdkMeter sdkMeter = sdkMeterProvider.get(SdkMeterProviderTest.class.getName());
     sdkMeter
         .longSumObserverBuilder("testLongSumObserver")
         .setUpdater(longResult -> longResult.observe(10, Labels.empty()))
@@ -669,9 +679,9 @@ public class SdkMeterProviderTest {
   }
 
   private static void registerViewForAllTypes(
-      SdkMeterProvider meterProvider, AggregatorFactory factory) {
+      SdkMeterProviderBuilder meterProviderBuilder, AggregatorFactory factory) {
     for (InstrumentType instrumentType : InstrumentType.values()) {
-      meterProvider.registerView(
+      meterProviderBuilder.registerView(
           InstrumentSelector.builder().setInstrumentType(instrumentType).build(),
           View.builder().setAggregatorFactory(factory).build());
     }


### PR DESCRIPTION
Clears the way for #3060 by making SdkMeterProvider immutable. 