### PR TITLE
Add autoconfiguration SdkMeterProviderConfigurer SPI. (#3060)

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/SdkMeterProviderConfigurer.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/SdkMeterProviderConfigurer.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure.spi;
+
+import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
+
+/**
+ * A service provider interface (SPI) for performing additional programmatic configuration of a
+ * {@link SdkMeterProviderBuilder} during initialization. When using auto-configuration, you should
+ * prefer to use system properties or environment variables for configuration, but this may be
+ * useful to register components that are not part of the SDK such as registering views.
+ */
+public interface SdkMeterProviderConfigurer {
+  /** Configures the {@link SdkMeterProviderBuilder}. */
+  void configure(SdkMeterProviderBuilder meterProviderBuilder);
+}

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/SdkTracerProviderConfigurer.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/SdkTracerProviderConfigurer.java
@@ -15,5 +15,5 @@ import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
  */
 public interface SdkTracerProviderConfigurer {
   /** Configures the {@link SdkTracerProviderBuilder}. */
-  void configure(SdkTracerProviderBuilder tracerProvider);
+  void configure(SdkTracerProviderBuilder tracerProviderBuilder);
 }

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FullConfigTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FullConfigTest.java
@@ -30,6 +30,10 @@ import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.common.v1.StringKeyValue;
+import io.opentelemetry.proto.metrics.v1.InstrumentationLibraryMetrics;
+import io.opentelemetry.proto.metrics.v1.Metric;
+import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -173,5 +177,48 @@ class FullConfigTest {
                 .setKey("cat")
                 .setValue(AnyValue.newBuilder().setStringValue("meow").build())
                 .build());
+
+    ExportMetricsServiceRequest metricRequest = otlpMetricsRequests.take();
+    assertThat(metricRequest.getResourceMetrics(0).getResource().getAttributesList())
+        .contains(
+            KeyValue.newBuilder()
+                .setKey("service.name")
+                .setValue(AnyValue.newBuilder().setStringValue("test").build())
+                .build(),
+            KeyValue.newBuilder()
+                .setKey("cat")
+                .setValue(AnyValue.newBuilder().setStringValue("meow").build())
+                .build());
+    for (ResourceMetrics resourceMetrics : metricRequest.getResourceMetricsList()) {
+      for (InstrumentationLibraryMetrics instrumentationLibraryMetrics :
+          resourceMetrics.getInstrumentationLibraryMetricsList()) {
+        for (Metric metric : instrumentationLibraryMetrics.getMetricsList()) {
+          assertThat(getFirstDataPointLabels(metric))
+              .contains(StringKeyValue.newBuilder().setKey("configured").setValue("true").build());
+        }
+      }
+    }
+  }
+
+  private static List<StringKeyValue> getFirstDataPointLabels(Metric metric) {
+    switch (metric.getDataCase()) {
+      case INT_GAUGE:
+        return metric.getIntGauge().getDataPoints(0).getLabelsList();
+      case DOUBLE_GAUGE:
+        return metric.getDoubleGauge().getDataPoints(0).getLabelsList();
+      case INT_SUM:
+        return metric.getIntSum().getDataPoints(0).getLabelsList();
+      case DOUBLE_SUM:
+        return metric.getDoubleSum().getDataPoints(0).getLabelsList();
+      case INT_HISTOGRAM:
+        return metric.getIntHistogram().getDataPoints(0).getLabelsList();
+      case DOUBLE_HISTOGRAM:
+        return metric.getDoubleHistogram().getDataPoints(0).getLabelsList();
+      case DOUBLE_SUMMARY:
+        return metric.getDoubleSummary().getDataPoints(0).getLabelsList();
+      default:
+        throw new IllegalArgumentException(
+            "Unrecognized metric data case: " + metric.getDataCase().name());
+    }
   }
 }

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/TestMeterProviderConfigurer.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/TestMeterProviderConfigurer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import io.opentelemetry.sdk.autoconfigure.spi.SdkMeterProviderConfigurer;
+import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
+import io.opentelemetry.sdk.metrics.aggregator.AggregatorFactory;
+import io.opentelemetry.sdk.metrics.common.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.processor.LabelsProcessorFactory;
+import io.opentelemetry.sdk.metrics.view.InstrumentSelector;
+import io.opentelemetry.sdk.metrics.view.View;
+
+public class TestMeterProviderConfigurer implements SdkMeterProviderConfigurer {
+
+  @Override
+  public void configure(SdkMeterProviderBuilder meterProviderBuilder) {
+    LabelsProcessorFactory labelsProcessorFactory =
+        (resource, instrumentationLibraryInfo, descriptor) ->
+            (ctx, labels) -> labels.toBuilder().put("configured", "true").build();
+
+    for (InstrumentType instrumentType : InstrumentType.values()) {
+      meterProviderBuilder.registerView(
+          InstrumentSelector.builder().setInstrumentType(instrumentType).build(),
+          View.builder()
+              .setAggregatorFactory(AggregatorFactory.count(AggregationTemporality.DELTA))
+              .setLabelsProcessorFactory(labelsProcessorFactory)
+              .build());
+    }
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.SdkMeterProviderConfigurer
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.SdkMeterProviderConfigurer
@@ -1,0 +1,1 @@
+io.opentelemetry.sdk.autoconfigure.TestMeterProviderConfigurer

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProviderBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProviderBuilder.java
@@ -14,7 +14,6 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import javax.annotation.Nonnull;
 
 /**
  * Builder class for the {@link SdkMeterProvider}. Has fully functional default implementations of
@@ -34,7 +33,7 @@ public final class SdkMeterProviderBuilder {
    * @param clock The clock to use for all temporal needs.
    * @return this
    */
-  public SdkMeterProviderBuilder setClock(@Nonnull Clock clock) {
+  public SdkMeterProviderBuilder setClock(Clock clock) {
     Objects.requireNonNull(clock, "clock");
     this.clock = clock;
     return this;
@@ -46,7 +45,7 @@ public final class SdkMeterProviderBuilder {
    * @param resource A Resource implementation.
    * @return this
    */
-  public SdkMeterProviderBuilder setResource(@Nonnull Resource resource) {
+  public SdkMeterProviderBuilder setResource(Resource resource) {
     Objects.requireNonNull(resource, "resource");
     this.resource = resource;
     return this;


### PR DESCRIPTION
Adds `SdkMeterProviderConfigurer` SPI to the autoconfiguration module. 

Closes #3060. 