### PR TITLE
Revert "Revert "Fix bug where AsynchronousInstrumentAccumulator does not call configured LabelProcessorFactory."

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AsynchronousInstrumentAccumulator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AsynchronousInstrumentAccumulator.java
@@ -6,9 +6,11 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.api.metrics.AsynchronousInstrument;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.processor.LabelsProcessor;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
@@ -33,8 +35,13 @@ final class AsynchronousInstrumentAccumulator extends AbstractAccumulator {
       return new AsynchronousInstrumentAccumulator(instrumentProcessor, () -> {});
     }
 
+    LabelsProcessor labelsProcessor =
+        getLabelsProcessor(meterProviderSharedState, meterSharedState, descriptor);
     AsynchronousInstrument.DoubleResult result =
-        (value, labels) -> instrumentProcessor.batch(labels, aggregator.accumulateDouble(value));
+        (value, labels) ->
+            instrumentProcessor.batch(
+                labelsProcessor.onLabelsBound(Context.current(), labels),
+                aggregator.accumulateDouble(value));
 
     return new AsynchronousInstrumentAccumulator(
         instrumentProcessor, () -> metricUpdater.accept(result));
@@ -54,8 +61,13 @@ final class AsynchronousInstrumentAccumulator extends AbstractAccumulator {
       return new AsynchronousInstrumentAccumulator(instrumentProcessor, () -> {});
     }
 
+    LabelsProcessor labelsProcessor =
+        getLabelsProcessor(meterProviderSharedState, meterSharedState, descriptor);
     AsynchronousInstrument.LongResult result =
-        (value, labels) -> instrumentProcessor.batch(labels, aggregator.accumulateLong(value));
+        (value, labels) ->
+            instrumentProcessor.batch(
+                labelsProcessor.onLabelsBound(Context.current(), labels),
+                aggregator.accumulateLong(value));
 
     return new AsynchronousInstrumentAccumulator(
         instrumentProcessor, () -> metricUpdater.accept(result));

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AsynchronousInstrumentAccumulatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AsynchronousInstrumentAccumulatorTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics;
+
+import io.opentelemetry.api.metrics.common.Labels;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.internal.TestClock;
+import io.opentelemetry.sdk.metrics.aggregator.AggregatorFactory;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
+import io.opentelemetry.sdk.metrics.common.InstrumentType;
+import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
+import io.opentelemetry.sdk.metrics.processor.LabelsProcessor;
+import io.opentelemetry.sdk.metrics.view.InstrumentSelector;
+import io.opentelemetry.sdk.metrics.view.View;
+import io.opentelemetry.sdk.resources.Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class AsynchronousInstrumentAccumulatorTest {
+  private final TestClock testClock = TestClock.create();
+  private final MeterProviderSharedState meterProviderSharedState =
+      MeterProviderSharedState.create(testClock, Resource.empty());
+  private final MeterSharedState meterSharedState =
+      MeterSharedState.create(InstrumentationLibraryInfo.empty());
+  private LabelsProcessor spyLabelProcessor;
+
+  @BeforeEach
+  void setup() {
+    spyLabelProcessor =
+        Mockito.spy(
+            new LabelsProcessor() {
+              @Override
+              public Labels onLabelsBound(Context ctx, Labels labels) {
+                return labels.toBuilder().build();
+              }
+            });
+    meterProviderSharedState
+        .getViewRegistry()
+        .registerView(
+            InstrumentSelector.builder().setInstrumentType(InstrumentType.VALUE_OBSERVER).build(),
+            View.builder()
+                .setAggregatorFactory(AggregatorFactory.lastValue())
+                .setLabelsProcessorFactory(
+                    (resource, instrumentationLibraryInfo, descriptor) -> spyLabelProcessor)
+                .build());
+  }
+
+  @Test
+  void doubleAsynchronousAccumulator_LabelsProcessor_used() {
+    AsynchronousInstrumentAccumulator.doubleAsynchronousAccumulator(
+            meterProviderSharedState,
+            meterSharedState,
+            InstrumentDescriptor.create(
+                "name",
+                "description",
+                "unit",
+                InstrumentType.VALUE_OBSERVER,
+                InstrumentValueType.DOUBLE),
+            value -> value.observe(1.0, Labels.empty()))
+        .collectAll(testClock.nanoTime());
+    Mockito.verify(spyLabelProcessor).onLabelsBound(Context.current(), Labels.empty());
+  }
+
+  @Test
+  void longAsynchronousAccumulator_LabelsProcessor_used() {
+    AsynchronousInstrumentAccumulator.longAsynchronousAccumulator(
+            meterProviderSharedState,
+            meterSharedState,
+            InstrumentDescriptor.create(
+                "name",
+                "description",
+                "unit",
+                InstrumentType.VALUE_OBSERVER,
+                InstrumentValueType.LONG),
+            value -> value.observe(1, Labels.empty()))
+        .collectAll(testClock.nanoTime());
+    Mockito.verify(spyLabelProcessor).onLabelsBound(Context.current(), Labels.empty());
+  }
+}


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-java#3088

Turns out this wasn't what was breaking the build.