### PR TITLE
Run w3c tracecontext tests as part of build.

### DIFF
--- a/integration-tests/tracecontext/build.gradle.kts
+++ b/integration-tests/tracecontext/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
 
     implementation("com.linecorp.armeria:armeria")
     implementation("org.slf4j:slf4j-simple")
+
+    testImplementation("org.testcontainers:junit-jupiter")
 }
 
 tasks {
@@ -22,5 +24,11 @@ tasks {
         manifest {
             attributes("Main-Class" to "io.opentelemetry.Application")
         }
+    }
+
+    withType(Test::class) {
+        dependsOn(shadowJar)
+
+        jvmArgs("-Dio.opentelemetry.testArchive=${shadowJar.get().archiveFile.get().asFile.absolutePath}")
     }
 }

--- a/integration-tests/tracecontext/src/main/java/io/opentelemetry/Application.java
+++ b/integration-tests/tracecontext/src/main/java/io/opentelemetry/Application.java
@@ -15,6 +15,8 @@ import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.annotation.Blocking;
 import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.armeria.server.healthcheck.HealthCheckService;
+import com.linecorp.armeria.server.logging.LoggingService;
 import io.netty.util.AsciiString;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
@@ -95,6 +97,7 @@ public final class Application {
 
         RequestHeadersBuilder outHeaders =
             RequestHeaders.builder(HttpMethod.POST, req.getUrl()).contentType(MediaType.JSON_UTF_8);
+        System.out.println(req.getUrl());
         openTelemetry
             .getPropagators()
             .getTextMapPropagator()
@@ -120,7 +123,13 @@ public final class Application {
 
   /** Entry point. */
   public static void main(String[] args) {
-    Server server = Server.builder().http(5000).annotatedService(new Service()).build();
+    Server server =
+        Server.builder()
+            .http(5000)
+            .annotatedService(new Service())
+            .service("/health", HealthCheckService.of())
+            .decorator(LoggingService.newDecorator())
+            .build();
     server.start().join();
     Runtime.getRuntime().addShutdownHook(new Thread(() -> server.stop().join()));
   }

--- a/integration-tests/tracecontext/src/main/java/io/opentelemetry/Application.java
+++ b/integration-tests/tracecontext/src/main/java/io/opentelemetry/Application.java
@@ -97,7 +97,6 @@ public final class Application {
 
         RequestHeadersBuilder outHeaders =
             RequestHeaders.builder(HttpMethod.POST, req.getUrl()).contentType(MediaType.JSON_UTF_8);
-        System.out.println(req.getUrl());
         openTelemetry
             .getPropagators()
             .getTextMapPropagator()

--- a/integration-tests/tracecontext/src/test/java/io/opentelemetry/integrationtests/tracecontext/TraceContextIntegrationTest.java
+++ b/integration-tests/tracecontext/src/test/java/io/opentelemetry/integrationtests/tracecontext/TraceContextIntegrationTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.integrationtests.tracecontext;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+@Testcontainers(disabledWithoutDocker = true)
+class TraceContextIntegrationTest {
+
+  @Container
+  private static final GenericContainer<?> appContainer =
+      new GenericContainer<>(
+              DockerImageName.parse("ghcr.io/open-telemetry/java-test-containers:openjdk8"))
+          .withExposedPorts(5000)
+          .withNetwork(Network.SHARED)
+          .withNetworkAliases("app")
+          .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("app")))
+          .withCommand("java", "-jar", "/opt/app.jar")
+          .waitingFor(Wait.forHttp("/health"))
+          .withCopyFileToContainer(
+              MountableFile.forHostPath(System.getProperty("io.opentelemetry.testArchive")),
+              "/opt/app.jar");
+
+  @Container
+  private static final GenericContainer<?> testSuiteContainer =
+      new GenericContainer<>(
+              DockerImageName.parse(
+                  "ghcr.io/open-telemetry/java-test-containers:w3c-tracecontext-testsuite"))
+          .withNetwork(Network.SHARED)
+          .withNetworkAliases("testsuite")
+          .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("testsuite")))
+          .withCommand("http://app:5000/verify-tracecontext")
+          .withEnv("HARNESS_HOST", "testsuite")
+          .waitingFor(Wait.forLogMessage(".*Ran \\d+ tests in \\d+\\.\\d+s.*", 1))
+          .dependsOn(appContainer);
+
+  @Test
+  void run() {
+    // TODO(anuraaga): We currently run all tests to print logs of our compatibility, including many
+    // failing tests. If we are ever able to fix the tests we can add an assertion here that the
+    // test succeeded.
+  }
+}


### PR DESCRIPTION
Due to many failures can't actually assert anything yet but it's still worth having logs of where we are.