### PR TITLE
Make the test extensions defensively reset the GlobalOpenTelemetry instance before setting

### DIFF
--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/junit4/OpenTelemetryRule.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/junit4/OpenTelemetryRule.java
@@ -92,6 +92,7 @@ public final class OpenTelemetryRule extends ExternalResource {
 
   @Override
   protected void before() {
+    GlobalOpenTelemetry.resetForTest();
     GlobalOpenTelemetry.set(openTelemetry);
     clearSpans();
   }

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtension.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtension.java
@@ -120,6 +120,7 @@ public final class OpenTelemetryExtension
 
   @Override
   public void beforeAll(ExtensionContext context) {
+    GlobalOpenTelemetry.resetForTest();
     GlobalOpenTelemetry.set(openTelemetry);
   }
 


### PR DESCRIPTION
I've seen some tests fail due to this being missing on Ubuntu running on Windows WSL. Not sure why it runs differently on that setup.