### PR TITLE
Fix more tracestate testsuite cases.

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/trace/ArrayBasedTraceStateBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/ArrayBasedTraceStateBuilder.java
@@ -126,8 +126,9 @@ final class ArrayBasedTraceStateBuilder implements TraceStateBuilder {
         if (i > MAX_TENANT_ID_SIZE) {
           return false;
         }
-        // vendor id (the part to the right of the '@' sign) must be 13 characters or less
-        if (key.length() - i > MAX_VENDOR_ID_SIZE) {
+        // vendor id (the part to the right of the '@' sign) must be 1-13 characters long
+        int remainingKeyChars = key.length() - i - 1;
+        if (remainingKeyChars > MAX_VENDOR_ID_SIZE || remainingKeyChars == 0) {
           return false;
         }
       }

--- a/api/all/src/main/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagator.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagator.java
@@ -245,6 +245,11 @@ public final class W3CTraceContextPropagator implements TextMapPropagator {
       checkArgument(index != -1, "Invalid TraceState list-member format.");
       traceStateBuilder.put(listMember.substring(0, index), listMember.substring(index + 1));
     }
-    return traceStateBuilder.build();
+    TraceState traceState = traceStateBuilder.build();
+    if (traceState.size() != listMembers.length) {
+      // Validation failure, drop the tracestate
+      return TraceState.getDefault();
+    }
+    return traceState;
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -319,6 +319,7 @@ subprojects {
             add(TEST_COMPILE_ONLY_CONFIGURATION_NAME, "com.google.code.findbugs:jsr305")
 
             add(TEST_IMPLEMENTATION_CONFIGURATION_NAME, "org.junit.jupiter:junit-jupiter-api")
+            add(TEST_IMPLEMENTATION_CONFIGURATION_NAME, "org.junit.jupiter:junit-jupiter-params")
             add(TEST_IMPLEMENTATION_CONFIGURATION_NAME, "nl.jqno.equalsverifier:equalsverifier")
             add(TEST_IMPLEMENTATION_CONFIGURATION_NAME, "org.mockito:mockito-core")
             add(TEST_IMPLEMENTATION_CONFIGURATION_NAME, "org.mockito:mockito-junit-jupiter")

--- a/integration-tests/tracecontext/src/main/java/io/opentelemetry/Application.java
+++ b/integration-tests/tracecontext/src/main/java/io/opentelemetry/Application.java
@@ -25,6 +25,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapSetter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -39,8 +40,9 @@ public final class Application {
 
   static {
     openTelemetry =
-        OpenTelemetry.propagating(
-            ContextPropagators.create(W3CTraceContextPropagator.getInstance()));
+        OpenTelemetrySdk.builder()
+            .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+            .build();
   }
 
   private enum ArmeriaGetter implements TextMapGetter<RequestHeaders> {


### PR DESCRIPTION
Got down to just 6 failures of the testsuite, all requiring support for handling multiple instances of a header which OpenTelemetry doesn't support yet.

Biggest changes were

- Trace state discarded if any item fails (I don't see this in the spec but it's being tested by test suite)
- Load SDK since trace ID generation is tested