### PR TITLE
adding implementation-version to manifest files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -237,7 +237,9 @@ subprojects {
                     inputs.property("moduleName", moduleName)
 
                     manifest {
-                        attributes("Automatic-Module-Name" to moduleName)
+                        attributes(
+                                "Automatic-Module-Name" to moduleName,
+                                "Implementation-Version" to "${project.version}")
                     }
                 }
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -120,8 +120,9 @@ subprojects {
                 }
             }
 
+            val releaseVersion = 8
             withType(JavaCompile::class) {
-                options.release.set(8)
+                options.release.set(releaseVersion)
 
                 if (name != "jmhCompileGeneratedClasses") {
                     options.compilerArgs.addAll(listOf(
@@ -239,7 +240,11 @@ subprojects {
                     manifest {
                         attributes(
                                 "Automatic-Module-Name" to moduleName,
-                                "Implementation-Version" to "${project.version}")
+                                "Built-By" to System.getProperty("user.name"),
+                                "Built-JDK" to System.getProperty("java.version"),
+                                "Implementation-Title" to project.name,
+                                "Implementation-Version" to project.version,
+                                "Release-Version" to releaseVersion)
                     }
                 }
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -120,9 +120,8 @@ subprojects {
                 }
             }
 
-            val releaseVersion = 8
             withType(JavaCompile::class) {
-                options.release.set(releaseVersion)
+                options.release.set(8)
 
                 if (name != "jmhCompileGeneratedClasses") {
                     options.compilerArgs.addAll(listOf(
@@ -243,8 +242,7 @@ subprojects {
                                 "Built-By" to System.getProperty("user.name"),
                                 "Built-JDK" to System.getProperty("java.version"),
                                 "Implementation-Title" to project.name,
-                                "Implementation-Version" to project.version,
-                                "Release-Version" to releaseVersion)
+                                "Implementation-Version" to project.version)
                     }
                 }
             }


### PR DESCRIPTION
Resolves #3032 

Once implementation version is included in manifest files, it can be easily read in the runtime. 