### PR TITLE
Add a ValueRecorder to the otlp example and properly start the IntervalMetricReader

### DIFF
--- a/examples/otlp/docker/otel-collector-config-demo.yaml
+++ b/examples/otlp/docker/otel-collector-config-demo.yaml
@@ -28,7 +28,6 @@ exporters:
 
 processors:
   batch:
-  queued_retry:
 
 extensions:
   health_check:
@@ -42,9 +41,9 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch, queued_retry]
+      processors: [batch]
       exporters: [logging, zipkin, jaeger]
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging,prometheus]
+      exporters: [logging, prometheus]

--- a/examples/otlp/src/main/java/io/opentelemetry/example/otlp/ExampleConfiguration.java
+++ b/examples/otlp/src/main/java/io/opentelemetry/example/otlp/ExampleConfiguration.java
@@ -65,7 +65,7 @@ public final class ExampleConfiguration {
             .setMetricExporter(metricExporter)
             .setMetricProducers(Collections.singleton(meterProvider))
             .setExportIntervalMillis(1000)
-            .build();
+            .buildAndStart();
 
     Runtime.getRuntime().addShutdownHook(new Thread(intervalMetricReader::shutdown));
 

--- a/examples/otlp/src/main/java/io/opentelemetry/example/otlp/OtlpExporterExample.java
+++ b/examples/otlp/src/main/java/io/opentelemetry/example/otlp/OtlpExporterExample.java
@@ -38,7 +38,8 @@ public final class OtlpExporterExample {
     Tracer tracer = openTelemetry.getTracer("io.opentelemetry.example");
     Meter meter = meterProvider.get("io.opentelemetry.example");
     LongCounter counter = meter.longCounterBuilder("example_counter").build();
-    LongValueRecorder recorder = meter.longValueRecorderBuilder("super_timer").setUnit("ms").build();
+    LongValueRecorder recorder =
+        meter.longValueRecorderBuilder("super_timer").setUnit("ms").build();
 
     for (int i = 0; i < 10; i++) {
       long startTime = System.currentTimeMillis();

--- a/examples/otlp/src/main/java/io/opentelemetry/example/otlp/OtlpExporterExample.java
+++ b/examples/otlp/src/main/java/io/opentelemetry/example/otlp/OtlpExporterExample.java
@@ -7,6 +7,7 @@ package io.opentelemetry.example.otlp;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongValueRecorder;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.trace.Span;
@@ -37,8 +38,10 @@ public final class OtlpExporterExample {
     Tracer tracer = openTelemetry.getTracer("io.opentelemetry.example");
     Meter meter = meterProvider.get("io.opentelemetry.example");
     LongCounter counter = meter.longCounterBuilder("example_counter").build();
+    LongValueRecorder recorder = meter.longValueRecorderBuilder("super_timer").setUnit("ms").build();
 
     for (int i = 0; i < 10; i++) {
+      long startTime = System.currentTimeMillis();
       Span exampleSpan = tracer.spanBuilder("exampleSpan").startSpan();
       try (Scope scope = exampleSpan.makeCurrent()) {
         counter.add(1);
@@ -46,6 +49,7 @@ public final class OtlpExporterExample {
         exampleSpan.setAttribute("exampleNumber", i);
         Thread.sleep(100);
       } finally {
+        recorder.record(System.currentTimeMillis() - startTime);
         exampleSpan.end();
       }
     }


### PR DESCRIPTION
Also, fixes a broken collector config for the latest dev version.