### PR TITLE
SDK arch test - ensuring that API implmenetation returns only API types

### DIFF
--- a/all/src/test/java/io/opentelemetry/all/SdkDesignTest.java
+++ b/all/src/test/java/io/opentelemetry/all/SdkDesignTest.java
@@ -43,7 +43,7 @@ public class SdkDesignTest {
             .arePublic()
             .and()
             .arePublic()
-            .and(implmentOrOverride())
+            .and(implementOrOverride())
             .should()
             .haveRawReturnType(
                 inPackage("io.opentelemetry.api..", "io.opentelemetry.context..", "java.."))

--- a/all/src/test/java/io/opentelemetry/all/SdkDesignTest.java
+++ b/all/src/test/java/io/opentelemetry/all/SdkDesignTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.all;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.base.Optional;
+import com.tngtech.archunit.base.PackageMatcher;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClassList;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import com.tngtech.archunit.lang.syntax.elements.MethodsShouldConjunction;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class SdkDesignTest {
+
+  // TODO: limited to trace as currently metrics fails the test (SdkMeterProvider returns SdkMeter)
+  private static final JavaClasses SDK_OTEL_CLASSES =
+      new ClassFileImporter().importPackages("io.opentelemetry.sdk.trace");
+
+  /**
+   * Ensures that all SDK methods that: - are defined in classes that extend or implement API model
+   * and are public (to exclude protected builders) - are public (avoids issues with protected
+   * methods returning classes unavailable to test's CL) - override or implement parent method
+   * return only API, Context or generic Java type
+   */
+  @Test
+  void sdkImplementationOfApiClassesShouldReturnApiTypeOnly() {
+    MethodsShouldConjunction covariantReturnRule =
+        ArchRuleDefinition.methods()
+            .that()
+            .areDeclaredInClassesThat()
+            .areAssignableTo(inPackage("io.opentelemetry.api.."))
+            .and()
+            .areDeclaredInClassesThat()
+            .arePublic()
+            .and()
+            .arePublic()
+            .and(implmentOrOverride())
+            .should()
+            .haveRawReturnType(
+                inPackage("io.opentelemetry.api..", "io.opentelemetry.context..", "java.."))
+            .orShould()
+            .haveRawReturnType("void");
+
+    covariantReturnRule.check(SDK_OTEL_CLASSES);
+  }
+
+  static DescribedPredicate<? super JavaMethod> implmentOrOverride() {
+    return new DescribedPredicate<>("implement or override a method") {
+      @Override
+      public boolean apply(JavaMethod input) {
+        JavaClassList params = input.getRawParameterTypes();
+        Class<?>[] paramsType = new Class<?>[params.size()];
+        for (int i = 0, n = params.size(); i < n; i++) {
+          paramsType[i] = params.get(i).reflect();
+        }
+        String name = input.getName();
+
+        List<JavaClass> parents = new ArrayList<>(input.getOwner().getAllRawSuperclasses());
+        parents.addAll(input.getOwner().getAllInterfaces());
+
+        for (JavaClass parent : parents) {
+          Optional<JavaMethod> found = parent.tryGetMethod(name, paramsType);
+          if (found.isPresent()) {
+            return true;
+          }
+        }
+        return false;
+      }
+    };
+  }
+
+  static DescribedPredicate<? super JavaClass> inPackage(String... requiredPackages) {
+    return new DescribedPredicate<>("are in " + Arrays.toString(requiredPackages)) {
+      @Override
+      public boolean apply(JavaClass member) {
+        for (String requiredPackage : requiredPackages) {
+          if (PackageMatcher.of(requiredPackage).matches(member.getPackageName())) {
+            return true;
+          }
+        }
+        return false;
+      }
+    };
+  }
+}

--- a/all/src/test/java/io/opentelemetry/all/SdkDesignTest.java
+++ b/all/src/test/java/io/opentelemetry/all/SdkDesignTest.java
@@ -53,7 +53,7 @@ public class SdkDesignTest {
     covariantReturnRule.check(SDK_OTEL_CLASSES);
   }
 
-  static DescribedPredicate<? super JavaMethod> implmentOrOverride() {
+  static DescribedPredicate<? super JavaMethod> implementOrOverride() {
     return new DescribedPredicate<>("implement or override a method") {
       @Override
       public boolean apply(JavaMethod input) {

--- a/all/src/test/java/io/opentelemetry/all/SdkDesignTest.java
+++ b/all/src/test/java/io/opentelemetry/all/SdkDesignTest.java
@@ -22,15 +22,14 @@ import org.junit.jupiter.api.Test;
 
 public class SdkDesignTest {
 
-  // TODO: limited to trace as currently metrics fails the test (SdkMeterProvider returns SdkMeter)
   private static final JavaClasses SDK_OTEL_CLASSES =
-      new ClassFileImporter().importPackages("io.opentelemetry.sdk.trace");
+      new ClassFileImporter().importPackages("io.opentelemetry.sdk");
 
   /**
    * Ensures that all SDK methods that: - are defined in classes that extend or implement API model
    * and are public (to exclude protected builders) - are public (avoids issues with protected
    * methods returning classes unavailable to test's CL) - override or implement parent method
-   * return only API, Context or generic Java type
+   * return only API, Context or generic Java type.
    */
   @Test
   void sdkImplementationOfApiClassesShouldReturnApiTypeOnly() {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProvider.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProvider.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.internal.ComponentRegistry;
@@ -51,12 +52,12 @@ public final class SdkMeterProvider implements MeterProvider, MetricProducer {
   }
 
   @Override
-  public SdkMeter get(String instrumentationName) {
+  public Meter get(String instrumentationName) {
     return get(instrumentationName, null);
   }
 
   @Override
-  public SdkMeter get(String instrumentationName, @Nullable String instrumentationVersion) {
+  public Meter get(String instrumentationName, @Nullable String instrumentationVersion) {
     // Per the spec, both null and empty are "invalid" and a "default" should be used.
     if (instrumentationName == null || instrumentationName.isEmpty()) {
       LOGGER.fine("Meter requested without instrumentation name.");

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleSumObserverSdkTest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
@@ -30,7 +31,7 @@ class DoubleSumObserverSdkTest {
   private final TestClock testClock = TestClock.create();
   private final SdkMeterProvider sdkMeterProvider =
       SdkMeterProvider.builder().setClock(testClock).setResource(RESOURCE).build();
-  private final SdkMeter sdkMeter = sdkMeterProvider.get(getClass().getName());
+  private final Meter sdkMeter = sdkMeterProvider.get(getClass().getName());
 
   @Test
   void collectMetrics_NoCallback() {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleUpDownSumObserverSdkTest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
@@ -30,7 +31,7 @@ class DoubleUpDownSumObserverSdkTest {
   private final TestClock testClock = TestClock.create();
   private final SdkMeterProvider sdkMeterProvider =
       SdkMeterProvider.builder().setClock(testClock).setResource(RESOURCE).build();
-  private final SdkMeter sdkMeter = sdkMeterProvider.get(getClass().getName());
+  private final Meter sdkMeter = sdkMeterProvider.get(getClass().getName());
 
   @Test
   void collectMetrics_NoCallback() {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueObserverSdkTest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
@@ -29,7 +30,7 @@ class DoubleValueObserverSdkTest {
   private final TestClock testClock = TestClock.create();
   private final SdkMeterProvider sdkMeterProvider =
       SdkMeterProvider.builder().setClock(testClock).setResource(RESOURCE).build();
-  private final SdkMeter sdkMeter = sdkMeterProvider.get(getClass().getName());
+  private final Meter sdkMeter = sdkMeterProvider.get(getClass().getName());
 
   @Test
   void collectMetrics_NoCallback() {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/DoubleValueRecorderSdkTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.BoundDoubleValueRecorder;
 import io.opentelemetry.api.metrics.DoubleValueRecorder;
+import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
@@ -36,7 +37,7 @@ class DoubleValueRecorderSdkTest {
   private final TestClock testClock = TestClock.create();
   private final SdkMeterProvider sdkMeterProvider =
       SdkMeterProvider.builder().setClock(testClock).setResource(RESOURCE).build();
-  private final SdkMeter sdkMeter = sdkMeterProvider.get(getClass().getName());
+  private final Meter sdkMeter = sdkMeterProvider.get(getClass().getName());
 
   @Test
   void record_PreventNullLabels() {
@@ -55,7 +56,7 @@ class DoubleValueRecorderSdkTest {
 
   @Test
   void collectMetrics_NoRecords() {
-    DoubleValueRecorderSdk doubleRecorder =
+    DoubleValueRecorder doubleRecorder =
         sdkMeter.doubleValueRecorderBuilder("testRecorder").build();
     BoundDoubleValueRecorder bound = doubleRecorder.bind(Labels.of("key", "value"));
     try {
@@ -67,7 +68,7 @@ class DoubleValueRecorderSdkTest {
 
   @Test
   void collectMetrics_WithEmptyLabel() {
-    DoubleValueRecorderSdk doubleRecorder =
+    DoubleValueRecorder doubleRecorder =
         sdkMeter
             .doubleValueRecorderBuilder("testRecorder")
             .setDescription("description")
@@ -98,7 +99,7 @@ class DoubleValueRecorderSdkTest {
   @Test
   void collectMetrics_WithMultipleCollects() {
     long startTime = testClock.now();
-    DoubleValueRecorderSdk doubleRecorder =
+    DoubleValueRecorder doubleRecorder =
         sdkMeter.doubleValueRecorderBuilder("testRecorder").build();
     BoundDoubleValueRecorder bound = doubleRecorder.bind(Labels.of("K", "V"));
     try {
@@ -170,11 +171,13 @@ class DoubleValueRecorderSdkTest {
 
   @Test
   void stressTest() {
-    final DoubleValueRecorderSdk doubleRecorder =
+    final DoubleValueRecorder doubleRecorder =
         sdkMeter.doubleValueRecorderBuilder("testRecorder").build();
 
     StressTestRunner.Builder stressTestBuilder =
-        StressTestRunner.builder().setInstrument(doubleRecorder).setCollectionIntervalMs(100);
+        StressTestRunner.builder()
+            .setInstrument((DoubleValueRecorderSdk) doubleRecorder)
+            .setCollectionIntervalMs(100);
 
     for (int i = 0; i < 4; i++) {
       stressTestBuilder.addOperation(
@@ -211,11 +214,13 @@ class DoubleValueRecorderSdkTest {
   void stressTest_WithDifferentLabelSet() {
     final String[] keys = {"Key_1", "Key_2", "Key_3", "Key_4"};
     final String[] values = {"Value_1", "Value_2", "Value_3", "Value_4"};
-    final DoubleValueRecorderSdk doubleRecorder =
+    final DoubleValueRecorder doubleRecorder =
         sdkMeter.doubleValueRecorderBuilder("testRecorder").build();
 
     StressTestRunner.Builder stressTestBuilder =
-        StressTestRunner.builder().setInstrument(doubleRecorder).setCollectionIntervalMs(100);
+        StressTestRunner.builder()
+            .setInstrument((DoubleValueRecorderSdk) doubleRecorder)
+            .setCollectionIntervalMs(100);
 
     for (int i = 0; i < 4; i++) {
       stressTestBuilder.addOperation(

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongSumObserverSdkTest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
@@ -30,7 +31,7 @@ class LongSumObserverSdkTest {
   private final TestClock testClock = TestClock.create();
   private final SdkMeterProvider sdkMeterProvider =
       SdkMeterProvider.builder().setClock(testClock).setResource(RESOURCE).build();
-  private final SdkMeter sdkMeter = sdkMeterProvider.get(getClass().getName());
+  private final Meter sdkMeter = sdkMeterProvider.get(getClass().getName());
 
   @Test
   void collectMetrics_NoCallback() {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownSumObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongUpDownSumObserverSdkTest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
@@ -30,7 +31,7 @@ class LongUpDownSumObserverSdkTest {
   private final TestClock testClock = TestClock.create();
   private final SdkMeterProvider sdkMeterProvider =
       SdkMeterProvider.builder().setClock(testClock).setResource(RESOURCE).build();
-  private final SdkMeter sdkMeter = sdkMeterProvider.get(getClass().getName());
+  private final Meter sdkMeter = sdkMeterProvider.get(getClass().getName());
 
   @Test
   void collectMetrics_NoCallback() {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongValueObserverSdkTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/LongValueObserverSdkTest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
@@ -29,7 +30,7 @@ class LongValueObserverSdkTest {
   private final TestClock testClock = TestClock.create();
   private final SdkMeterProvider sdkMeterProvider =
       SdkMeterProvider.builder().setClock(testClock).setResource(RESOURCE).build();
-  private final SdkMeter sdkMeter = sdkMeterProvider.get(getClass().getName());
+  private final Meter sdkMeter = sdkMeterProvider.get(getClass().getName());
 
   @Test
   void collectMetrics_NoCallback() {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderTest.java
@@ -15,6 +15,7 @@ import io.opentelemetry.api.metrics.DoubleValueRecorder;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongUpDownCounter;
 import io.opentelemetry.api.metrics.LongValueRecorder;
+import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.internal.TestClock;
@@ -56,7 +57,7 @@ public class SdkMeterProviderTest {
   @Test
   void collectAllSyncInstruments() {
     SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
-    SdkMeter sdkMeter = sdkMeterProvider.get(SdkMeterProviderTest.class.getName());
+    Meter sdkMeter = sdkMeterProvider.get(SdkMeterProviderTest.class.getName());
     LongCounter longCounter = sdkMeter.longCounterBuilder("testLongCounter").build();
     longCounter.add(10, Labels.empty());
     LongUpDownCounter longUpDownCounter =
@@ -166,7 +167,7 @@ public class SdkMeterProviderTest {
         InstrumentSelector.builder().setInstrumentType(InstrumentType.COUNTER).build(),
         View.builder().setAggregatorFactory(AggregatorFactory.sum(false)).build());
     SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
-    SdkMeter sdkMeter = sdkMeterProvider.get(SdkMeterProviderTest.class.getName());
+    Meter sdkMeter = sdkMeterProvider.get(SdkMeterProviderTest.class.getName());
 
     LongCounter longCounter = sdkMeter.longCounterBuilder("testLongCounter").build();
     longCounter.add(10, Labels.empty());
@@ -211,7 +212,7 @@ public class SdkMeterProviderTest {
     registerViewForAllTypes(
         sdkMeterProviderBuilder, AggregatorFactory.count(AggregationTemporality.DELTA));
     SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
-    SdkMeter sdkMeter = sdkMeterProvider.get(SdkMeterProviderTest.class.getName());
+    Meter sdkMeter = sdkMeterProvider.get(SdkMeterProviderTest.class.getName());
     LongCounter longCounter = sdkMeter.longCounterBuilder("testLongCounter").build();
     longCounter.add(10, Labels.empty());
     LongUpDownCounter longUpDownCounter =
@@ -394,7 +395,7 @@ public class SdkMeterProviderTest {
   @Test
   void collectAllAsyncInstruments() {
     SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
-    SdkMeter sdkMeter = sdkMeterProvider.get(SdkMeterProviderTest.class.getName());
+    Meter sdkMeter = sdkMeterProvider.get(SdkMeterProviderTest.class.getName());
     sdkMeter
         .longSumObserverBuilder("testLongSumObserver")
         .setUpdater(longResult -> longResult.observe(10, Labels.empty()))
@@ -496,7 +497,7 @@ public class SdkMeterProviderTest {
     registerViewForAllTypes(
         sdkMeterProviderBuilder, AggregatorFactory.count(AggregationTemporality.CUMULATIVE));
     SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
-    SdkMeter sdkMeter = sdkMeterProvider.get(SdkMeterProviderTest.class.getName());
+    Meter sdkMeter = sdkMeterProvider.get(SdkMeterProviderTest.class.getName());
     sdkMeter
         .longSumObserverBuilder("testLongSumObserver")
         .setUpdater(longResult -> longResult.observe(10, Labels.empty()))

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterRegistryTest.java
@@ -9,6 +9,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.common.Labels;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -71,24 +73,24 @@ class SdkMeterRegistryTest {
   void propagatesInstrumentationLibraryInfoToMeter() {
     InstrumentationLibraryInfo expected =
         InstrumentationLibraryInfo.create("theName", "theVersion");
-    SdkMeter meter = meterProvider.get(expected.getName(), expected.getVersion());
+    SdkMeter meter = (SdkMeter) meterProvider.get(expected.getName(), expected.getVersion());
     assertThat(meter.getInstrumentationLibraryInfo()).isEqualTo(expected);
   }
 
   @Test
   void metricProducer_GetAllMetrics() {
-    SdkMeter sdkMeter1 = meterProvider.get("io.opentelemetry.sdk.metrics.MeterSdkRegistryTest_1");
-    LongCounterSdk longCounter1 = sdkMeter1.longCounterBuilder("testLongCounter").build();
+    Meter sdkMeter1 = meterProvider.get("io.opentelemetry.sdk.metrics.MeterSdkRegistryTest_1");
+    LongCounter longCounter1 = sdkMeter1.longCounterBuilder("testLongCounter").build();
     longCounter1.add(10, Labels.empty());
-    SdkMeter sdkMeter2 = meterProvider.get("io.opentelemetry.sdk.metrics.MeterSdkRegistryTest_2");
-    LongCounterSdk longCounter2 = sdkMeter2.longCounterBuilder("testLongCounter").build();
+    Meter sdkMeter2 = meterProvider.get("io.opentelemetry.sdk.metrics.MeterSdkRegistryTest_2");
+    LongCounter longCounter2 = sdkMeter2.longCounterBuilder("testLongCounter").build();
     longCounter2.add(10, Labels.empty());
 
     assertThat(meterProvider.collectAllMetrics())
         .containsExactlyInAnyOrder(
             MetricData.createLongSum(
                 Resource.empty(),
-                sdkMeter1.getInstrumentationLibraryInfo(),
+                ((SdkMeter) sdkMeter1).getInstrumentationLibraryInfo(),
                 "testLongCounter",
                 "",
                 "1",
@@ -100,7 +102,7 @@ class SdkMeterRegistryTest {
                             testClock.now(), testClock.now(), Labels.empty(), 10)))),
             MetricData.createLongSum(
                 Resource.empty(),
-                sdkMeter2.getInstrumentationLibraryInfo(),
+                ((SdkMeter) sdkMeter2).getInstrumentationLibraryInfo(),
                 "testLongCounter",
                 "",
                 "1",
@@ -114,22 +116,22 @@ class SdkMeterRegistryTest {
 
   @Test
   void suppliesDefaultMeterForNullName() {
-    SdkMeter meter = meterProvider.get(null);
+    SdkMeter meter = (SdkMeter) meterProvider.get(null);
     assertThat(meter.getInstrumentationLibraryInfo().getName())
         .isEqualTo(SdkMeterProvider.DEFAULT_METER_NAME);
 
-    meter = meterProvider.get(null, null);
+    meter = (SdkMeter) meterProvider.get(null, null);
     assertThat(meter.getInstrumentationLibraryInfo().getName())
         .isEqualTo(SdkMeterProvider.DEFAULT_METER_NAME);
   }
 
   @Test
   void suppliesDefaultMeterForEmptyName() {
-    SdkMeter meter = meterProvider.get("");
+    SdkMeter meter = (SdkMeter) meterProvider.get("");
     assertThat(meter.getInstrumentationLibraryInfo().getName())
         .isEqualTo(SdkMeterProvider.DEFAULT_METER_NAME);
 
-    meter = meterProvider.get("", "");
+    meter = (SdkMeter) meterProvider.get("", "");
     assertThat(meter.getInstrumentationLibraryInfo().getName())
         .isEqualTo(SdkMeterProvider.DEFAULT_METER_NAME);
   }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterTest.java
@@ -9,17 +9,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.metrics.BatchRecorder;
+import io.opentelemetry.api.metrics.DoubleCounter;
+import io.opentelemetry.api.metrics.DoubleSumObserver;
+import io.opentelemetry.api.metrics.DoubleUpDownCounter;
+import io.opentelemetry.api.metrics.DoubleUpDownSumObserver;
 import io.opentelemetry.api.metrics.DoubleValueObserver;
+import io.opentelemetry.api.metrics.DoubleValueRecorder;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongSumObserver;
+import io.opentelemetry.api.metrics.LongUpDownCounter;
+import io.opentelemetry.api.metrics.LongUpDownSumObserver;
 import io.opentelemetry.api.metrics.LongValueObserver;
+import io.opentelemetry.api.metrics.LongValueRecorder;
+import io.opentelemetry.api.metrics.Meter;
 import org.junit.jupiter.api.Test;
 
 class SdkMeterTest {
   private final SdkMeterProvider testMeterProvider = SdkMeterProvider.builder().build();
-  private final SdkMeter sdkMeter = testMeterProvider.get(getClass().getName());
+  private final Meter sdkMeter = testMeterProvider.get(getClass().getName());
 
   @Test
   void testLongCounter() {
-    LongCounterSdk longCounter =
+    LongCounter longCounter =
         sdkMeter
             .longCounterBuilder("testLongCounter")
             .setDescription("My very own counter")
@@ -45,7 +56,7 @@ class SdkMeterTest {
 
   @Test
   void testLongUpDownCounter() {
-    LongUpDownCounterSdk longUpDownCounter =
+    LongUpDownCounter longUpDownCounter =
         sdkMeter
             .longUpDownCounterBuilder("testLongUpDownCounter")
             .setDescription("My very own counter")
@@ -72,7 +83,7 @@ class SdkMeterTest {
 
   @Test
   void testLongValueRecorder() {
-    LongValueRecorderSdk longValueRecorder =
+    LongValueRecorder longValueRecorder =
         sdkMeter
             .longValueRecorderBuilder("testLongValueRecorder")
             .setDescription("My very own counter")
@@ -126,7 +137,7 @@ class SdkMeterTest {
 
   @Test
   void testLongSumObserver() {
-    LongSumObserverSdk longObserver =
+    LongSumObserver longObserver =
         sdkMeter
             .longSumObserverBuilder("testLongSumObserver")
             .setDescription("My very own counter")
@@ -154,7 +165,7 @@ class SdkMeterTest {
 
   @Test
   void testLongUpDownSumObserver() {
-    LongUpDownSumObserverSdk longObserver =
+    LongUpDownSumObserver longObserver =
         sdkMeter
             .longUpDownSumObserverBuilder("testLongUpDownSumObserver")
             .setDescription("My very own counter")
@@ -186,7 +197,7 @@ class SdkMeterTest {
 
   @Test
   void testDoubleCounter() {
-    DoubleCounterSdk doubleCounter =
+    DoubleCounter doubleCounter =
         sdkMeter
             .doubleCounterBuilder("testDoubleCounter")
             .setDescription("My very own counter")
@@ -213,7 +224,7 @@ class SdkMeterTest {
 
   @Test
   void testDoubleUpDownCounter() {
-    DoubleUpDownCounterSdk doubleUpDownCounter =
+    DoubleUpDownCounter doubleUpDownCounter =
         sdkMeter
             .doubleUpDownCounterBuilder("testDoubleUpDownCounter")
             .setDescription("My very own counter")
@@ -243,7 +254,7 @@ class SdkMeterTest {
 
   @Test
   void testDoubleValueRecorder() {
-    DoubleValueRecorderSdk doubleValueRecorder =
+    DoubleValueRecorder doubleValueRecorder =
         sdkMeter
             .doubleValueRecorderBuilder("testDoubleValueRecorder")
             .setDescription("My very own ValueRecorder")
@@ -273,7 +284,7 @@ class SdkMeterTest {
 
   @Test
   void testDoubleSumObserver() {
-    DoubleSumObserverSdk doubleObserver =
+    DoubleSumObserver doubleObserver =
         sdkMeter
             .doubleSumObserverBuilder("testDoubleSumObserver")
             .setDescription("My very own counter")
@@ -300,7 +311,7 @@ class SdkMeterTest {
 
   @Test
   void testDoubleUpDownSumObserver() {
-    DoubleUpDownSumObserverSdk doubleObserver =
+    DoubleUpDownSumObserver doubleObserver =
         sdkMeter
             .doubleUpDownSumObserverBuilder("testDoubleUpDownSumObserver")
             .setDescription("My very own counter")


### PR DESCRIPTION
Resolves #1718

There are numerous possible approaches to that. I decided to implement a weak guardrails, limiting the scope to known issues only. Basically the goal of the test is to ensure that public SDK methods, that override an API method will always return API type, java type or void. I intentionally decided against simple check if method returned by a SDK method is exactly the same as returned by corresponding API method to allow covariant returns within API scope.