### PR TITLE
Don't default the tracer name.

### DIFF
--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/Adapter.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/Adapter.java
@@ -112,11 +112,13 @@ final class Adapter {
               .build());
     }
 
-    target.addTags(
-        Model.KeyValue.newBuilder()
-            .setKey(KEY_INSTRUMENTATION_LIBRARY_NAME)
-            .setVStr(span.getInstrumentationLibraryInfo().getName())
-            .build());
+    if (span.getInstrumentationLibraryInfo().getName() != null) {
+      target.addTags(
+          Model.KeyValue.newBuilder()
+              .setKey(KEY_INSTRUMENTATION_LIBRARY_NAME)
+              .setVStr(span.getInstrumentationLibraryInfo().getName())
+              .build());
+    }
 
     if (span.getInstrumentationLibraryInfo().getVersion() != null) {
       target.addTags(

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/CommonAdapter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/CommonAdapter.java
@@ -145,7 +145,10 @@ final class CommonAdapter {
   static InstrumentationLibrary toProtoInstrumentationLibrary(
       InstrumentationLibraryInfo instrumentationLibraryInfo) {
     return InstrumentationLibrary.newBuilder()
-        .setName(instrumentationLibraryInfo.getName())
+        .setName(
+            instrumentationLibraryInfo.getName() == null
+                ? ""
+                : instrumentationLibraryInfo.getName())
         .setVersion(
             instrumentationLibraryInfo.getVersion() == null
                 ? ""

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/CommonAdapterTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/CommonAdapterTest.java
@@ -144,6 +144,14 @@ class CommonAdapterTest {
   }
 
   @Test
+  void toProtoInstrumentationLibrary_nullName() {
+    InstrumentationLibrary instrumentationLibrary =
+        CommonAdapter.toProtoInstrumentationLibrary(InstrumentationLibraryInfo.create(null, null));
+    assertThat(instrumentationLibrary.getName()).isEmpty();
+    assertThat(instrumentationLibrary.getVersion()).isEmpty();
+  }
+
+  @Test
   void toProtoInstrumentationLibrary_NoVersion() {
     InstrumentationLibrary instrumentationLibrary =
         CommonAdapter.toProtoInstrumentationLibrary(

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
@@ -122,7 +122,8 @@ public final class ZipkinSpanExporter implements SpanExporter {
     InstrumentationLibraryInfo instrumentationLibraryInfo =
         spanData.getInstrumentationLibraryInfo();
 
-    if (!instrumentationLibraryInfo.getName().isEmpty()) {
+    if (!(instrumentationLibraryInfo.getName() == null
+        || instrumentationLibraryInfo.getName().isEmpty())) {
       spanBuilder.putTag(KEY_INSTRUMENTATION_LIBRARY_NAME, instrumentationLibraryInfo.getName());
     }
     if (instrumentationLibraryInfo.getVersion() != null) {

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterTest.java
@@ -107,6 +107,20 @@ class ZipkinSpanExporterTest {
   }
 
   @Test
+  void generateSpan_nullInstrumentationLibaryInfoName() {
+    SpanData data =
+        buildStandardSpan()
+            .setInstrumentationLibraryInfo(InstrumentationLibraryInfo.create(null, null))
+            .build();
+
+    assertThat(exporter.generateSpan(data))
+        .isEqualTo(
+            standardZipkinSpanBuilder(Span.Kind.SERVER)
+                .putTag(ZipkinSpanExporter.OTEL_STATUS_CODE, "OK")
+                .build());
+  }
+
+  @Test
   void generateSpan_ClientKind() {
     SpanData data = buildStandardSpan().setKind(SpanKind.CLIENT).build();
 

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfo.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfo.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.sdk.common;
 
-import static java.util.Objects.requireNonNull;
-
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.trace.Tracer;
 import javax.annotation.Nullable;
@@ -30,7 +28,6 @@ public abstract class InstrumentationLibraryInfo {
    * @return the new instance
    */
   public static InstrumentationLibraryInfo create(String name, @Nullable String version) {
-    requireNonNull(name, "name");
     return new AutoValue_InstrumentationLibraryInfo(name, version);
   }
 
@@ -48,6 +45,7 @@ public abstract class InstrumentationLibraryInfo {
    *
    * @return the name of the instrumentation library.
    */
+  @Nullable
   public abstract String getName();
 
   /**

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/ComponentRegistry.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/ComponentRegistry.java
@@ -48,7 +48,8 @@ public final class ComponentRegistry<V> {
    * @param instrumentationVersion the version of the instrumentation library.
    * @return the registered value associated with this name and version.
    */
-  public final V get(String instrumentationName, @Nullable String instrumentationVersion) {
+  public final V get(
+      @Nullable String instrumentationName, @Nullable String instrumentationVersion) {
     InstrumentationLibraryInfo instrumentationLibraryInfo =
         InstrumentationLibraryInfo.create(instrumentationName, instrumentationVersion);
 

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfoTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfoTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.sdk.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
@@ -20,9 +19,7 @@ class InstrumentationLibraryInfoTest {
   }
 
   @Test
-  void nullName() {
-    assertThatThrownBy(() -> InstrumentationLibraryInfo.create(null, "1.0.0"))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage("name");
+  void nullName_doesNotBreak() {
+    assertThat(InstrumentationLibraryInfo.create(null, null).getName()).isNull();
   }
 }

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/internal/ComponentRegistryTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/internal/ComponentRegistryTest.java
@@ -6,12 +6,10 @@
 package io.opentelemetry.sdk.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import org.junit.jupiter.api.Test;
 
-/** Tests for {@link InstrumentationLibraryInfo}. */
 class ComponentRegistryTest {
 
   private static final String INSTRUMENTATION_NAME = "test_name";
@@ -20,10 +18,11 @@ class ComponentRegistryTest {
       new ComponentRegistry<>(TestComponent::new);
 
   @Test
-  void libraryName_MustNotBeNull() {
-    assertThatThrownBy(() -> registry.get(null, "version"))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage("name");
+  void libraryName_AllowsNull() {
+    TestComponent testComponent = registry.get(null, null);
+    assertThat(testComponent).isNotNull();
+    assertThat(testComponent.instrumentationLibraryInfo.getName()).isNull();
+    assertThat(testComponent.instrumentationLibraryInfo.getVersion()).isNull();
   }
 
   @Test

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
  */
 public final class SdkTracerProvider implements TracerProvider, Closeable {
   private static final Logger logger = Logger.getLogger(SdkTracerProvider.class.getName());
-  static final String DEFAULT_TRACER_NAME = "unknown";
+  static final String DEFAULT_TRACER_NAME = "";
   private final TracerSharedState sharedState;
   private final ComponentRegistry<SdkTracer> tracerSdkComponentRegistry;
 
@@ -68,7 +68,6 @@ public final class SdkTracerProvider implements TracerProvider, Closeable {
     // Per the spec, both null and empty are "invalid" and a "default" should be used.
     if (instrumentationName == null || instrumentationName.isEmpty()) {
       logger.fine("Tracer requested without instrumentation name.");
-      instrumentationName = DEFAULT_TRACER_NAME;
     }
     return tracerSdkComponentRegistry.get(instrumentationName, instrumentationVersion);
   }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderTest.java
@@ -201,22 +201,18 @@ class SdkTracerProviderTest {
   @Test
   void suppliesDefaultTracerForNullName() {
     SdkTracer tracer = (SdkTracer) tracerFactory.get(null);
-    assertThat(tracer.getInstrumentationLibraryInfo().getName())
-        .isEqualTo(SdkTracerProvider.DEFAULT_TRACER_NAME);
+    assertThat(tracer.getInstrumentationLibraryInfo().getName()).isNull();
 
     tracer = (SdkTracer) tracerFactory.get(null, null);
-    assertThat(tracer.getInstrumentationLibraryInfo().getName())
-        .isEqualTo(SdkTracerProvider.DEFAULT_TRACER_NAME);
+    assertThat(tracer.getInstrumentationLibraryInfo().getName()).isNull();
   }
 
   @Test
   void suppliesDefaultTracerForEmptyName() {
     SdkTracer tracer = (SdkTracer) tracerFactory.get("");
-    assertThat(tracer.getInstrumentationLibraryInfo().getName())
-        .isEqualTo(SdkTracerProvider.DEFAULT_TRACER_NAME);
+    assertThat(tracer.getInstrumentationLibraryInfo().getName()).isEqualTo("");
 
     tracer = (SdkTracer) tracerFactory.get("", "");
-    assertThat(tracer.getInstrumentationLibraryInfo().getName())
-        .isEqualTo(SdkTracerProvider.DEFAULT_TRACER_NAME);
+    assertThat(tracer.getInstrumentationLibraryInfo().getName()).isEqualTo("");
   }
 }


### PR DESCRIPTION
And, make sure that the standard exporters can handle a null InstrumentationLibraryInfo name.

The spec changed in v1.2.0 to say we should no longer have a default: https://github.com/open-telemetry/opentelemetry-specification/pull/1534