### PR TITLE
Have the B3Propagator only include the relevant fields for injection format

### DIFF
--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3Propagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3Propagator.java
@@ -10,9 +10,7 @@ import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.context.propagation.TextMapSetter;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -24,7 +22,7 @@ import javax.annotation.concurrent.Immutable;
  * href=https://github.com/openzipkin/b3-propagation>openzipkin/b3-propagation</a>.
  *
  * <p>Also see <a
- * href=https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/api-propagators.md#b3-requirements>B3
+ * href=https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/api-propagators.md#b3-requirements>B3
  * Requirements</a>
  *
  * <p>To register the default B3 propagator, which injects a single header, use:
@@ -63,10 +61,6 @@ public final class B3Propagator implements TextMapPropagator {
   static final char IS_SAMPLED = '1';
   static final char NOT_SAMPLED = '0';
   static final char DEBUG_SAMPLED = 'd';
-
-  private static final Collection<String> FIELDS =
-      Collections.unmodifiableList(
-          Arrays.asList(TRACE_ID_HEADER, SPAN_ID_HEADER, SAMPLED_HEADER, COMBINED_HEADER));
 
   private static final B3Propagator SINGLE_HEADER_INSTANCE =
       new B3Propagator(new B3PropagatorInjectorSingleHeader());
@@ -109,7 +103,7 @@ public final class B3Propagator implements TextMapPropagator {
 
   @Override
   public Collection<String> fields() {
-    return FIELDS;
+    return b3PropagatorInjector.fields();
   }
 
   @Override

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorInjector.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorInjector.java
@@ -7,10 +7,13 @@ package io.opentelemetry.extension.trace.propagation;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapSetter;
+import java.util.Collection;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
 interface B3PropagatorInjector {
   <C> void inject(Context context, @Nullable C carrier, TextMapSetter<C> setter);
+
+  Collection<String> fields();
 }

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorInjectorMultipleHeaders.java
@@ -5,15 +5,25 @@
 
 package io.opentelemetry.extension.trace.propagation;
 
+import static io.opentelemetry.extension.trace.propagation.B3Propagator.SAMPLED_HEADER;
+import static io.opentelemetry.extension.trace.propagation.B3Propagator.SPAN_ID_HEADER;
+import static io.opentelemetry.extension.trace.propagation.B3Propagator.TRACE_ID_HEADER;
+
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapSetter;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
 final class B3PropagatorInjectorMultipleHeaders implements B3PropagatorInjector {
+  private static final Collection<String> FIELDS =
+      Collections.unmodifiableList(Arrays.asList(TRACE_ID_HEADER, SPAN_ID_HEADER, SAMPLED_HEADER));
+
   @Override
   public <C> void inject(Context context, @Nullable C carrier, TextMapSetter<C> setter) {
     if (context == null) {
@@ -35,8 +45,13 @@ final class B3PropagatorInjectorMultipleHeaders implements B3PropagatorInjector 
       sampled = Common.TRUE_INT;
     }
 
-    setter.set(carrier, B3Propagator.TRACE_ID_HEADER, spanContext.getTraceId());
-    setter.set(carrier, B3Propagator.SPAN_ID_HEADER, spanContext.getSpanId());
-    setter.set(carrier, B3Propagator.SAMPLED_HEADER, sampled);
+    setter.set(carrier, TRACE_ID_HEADER, spanContext.getTraceId());
+    setter.set(carrier, SPAN_ID_HEADER, spanContext.getSpanId());
+    setter.set(carrier, SAMPLED_HEADER, sampled);
+  }
+
+  @Override
+  public Collection<String> fields() {
+    return FIELDS;
   }
 }

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorInjectorSingleHeader.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorInjectorSingleHeader.java
@@ -5,12 +5,16 @@
 
 package io.opentelemetry.extension.trace.propagation;
 
+import static io.opentelemetry.extension.trace.propagation.B3Propagator.COMBINED_HEADER;
+
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapSetter;
+import java.util.Collection;
+import java.util.Collections;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -24,6 +28,7 @@ final class B3PropagatorInjectorSingleHeader implements B3PropagatorInjector {
   private static final int SAMPLED_FLAG_OFFSET =
       SPAN_ID_OFFSET + SPAN_ID_HEX_SIZE + COMBINED_HEADER_DELIMITER_SIZE;
   private static final int COMBINED_HEADER_SIZE = SAMPLED_FLAG_OFFSET + SAMPLED_FLAG_SIZE;
+  private static final Collection<String> FIELDS = Collections.singletonList(COMBINED_HEADER);
 
   @Override
   public <C> void inject(Context context, @Nullable C carrier, TextMapSetter<C> setter) {
@@ -54,6 +59,11 @@ final class B3PropagatorInjectorSingleHeader implements B3PropagatorInjector {
       chars[SAMPLED_FLAG_OFFSET] =
           spanContext.isSampled() ? B3Propagator.IS_SAMPLED : B3Propagator.NOT_SAMPLED;
     }
-    setter.set(carrier, B3Propagator.COMBINED_HEADER, new String(chars));
+    setter.set(carrier, COMBINED_HEADER, new String(chars));
+  }
+
+  @Override
+  public Collection<String> fields() {
+    return FIELDS;
   }
 }

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/B3PropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/B3PropagatorTest.java
@@ -617,13 +617,15 @@ class B3PropagatorTest {
   }
 
   @Test
-  void fieldsList() {
+  void fieldsList_multiInject() {
     assertThat(b3Propagator.fields())
         .containsExactly(
-            B3Propagator.TRACE_ID_HEADER,
-            B3Propagator.SPAN_ID_HEADER,
-            B3Propagator.SAMPLED_HEADER,
-            B3Propagator.COMBINED_HEADER);
+            B3Propagator.TRACE_ID_HEADER, B3Propagator.SPAN_ID_HEADER, B3Propagator.SAMPLED_HEADER);
+  }
+
+  @Test
+  void fieldsList_singleHeader() {
+    assertThat(b3PropagatorSingleHeader.fields()).containsExactly(B3Propagator.COMBINED_HEADER);
   }
 
   @Test

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FullConfigTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FullConfigTest.java
@@ -127,6 +127,7 @@ class FullConfigTest {
     keys.addAll(W3CTraceContextPropagator.getInstance().fields());
     keys.addAll(W3CBaggagePropagator.getInstance().fields());
     keys.addAll(B3Propagator.injectingSingleHeader().fields());
+    keys.addAll(B3Propagator.injectingMultiHeaders().fields());
     keys.addAll(JaegerPropagator.getInstance().fields());
     keys.addAll(OtTracePropagator.getInstance().fields());
     keys.addAll(AwsXrayPropagator.getInstance().fields());


### PR DESCRIPTION
See this spec change from v1.2.0: https://github.com/open-telemetry/opentelemetry-specification/pull/1570