### PR TITLE
Add @SpanAttribute annotation for adding attributes to spans created through instrumentation

### DIFF
--- a/extensions/annotations/src/main/java/io/opentelemetry/extension/annotations/SpanAttribute.java
+++ b/extensions/annotations/src/main/java/io/opentelemetry/extension/annotations/SpanAttribute.java
@@ -17,7 +17,7 @@ import java.lang.annotation.Target;
  * within the body of the method.
  *
  * <p>Application developers can use this annotation to signal OpenTelemetry auto-instrumentation
- * that a new span should be created whenever marked method is executed.
+ * that a new span attribute should be added to a span created when the parent method is executed.
  *
  * <p>If you are a library developer, then probably you should NOT use this annotation, because it
  * is non-functional without the OpenTelemetry auto-instrumentation agent, or some other annotation

--- a/extensions/annotations/src/main/java/io/opentelemetry/extension/annotations/SpanAttribute.java
+++ b/extensions/annotations/src/main/java/io/opentelemetry/extension/annotations/SpanAttribute.java
@@ -13,6 +13,8 @@ import java.lang.annotation.Target;
 /**
  * This annotation marks that a parameter of a method annotated by the {@link WithSpan} annotation
  * should be added as an attribute to the newly created {@link io.opentelemetry.api.trace.Span}.
+ * Using this annotation is equivalent to calling {@code Span.currentSpan().setAttribute(...)}
+ * within the body of the method.
  *
  * <p>Application developers can use this annotation to signal OpenTelemetry auto-instrumentation
  * that a new span should be created whenever marked method is executed.

--- a/extensions/annotations/src/main/java/io/opentelemetry/extension/annotations/SpanAttribute.java
+++ b/extensions/annotations/src/main/java/io/opentelemetry/extension/annotations/SpanAttribute.java
@@ -21,22 +21,18 @@ import java.lang.annotation.Target;
  * is non-functional without the OpenTelemetry auto-instrumentation agent, or some other annotation
  * processor.
  *
- * @see <a href="https://github.com/open-telemetry/opentelemetry-auto-instr-java">OpenTelemetry
- *     Auto-Instrumentation</a>
+ * @see <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation">OpenTelemetry
+ *     OpenTelemetry Instrumentation for Java</a>
  */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface WithSpanAttribute {
+public @interface SpanAttribute {
   /**
    * Optional name of the attribute.
    *
-   * <p>If not specified, an appropriate default name should be created by auto-instrumentation.
-   * E.g. the name of the parameter if formal parameter names are stored in the class file on
-   * compilation using the {@code -parameters} compiler option.
-   *
-   * @see <a
-   *     href="https://docs.oracle.com/javase/tutorial/reflect/member/methodparameterreflection.html">Obtaining
-   *     Names of Method Parameters</a>
+   * <p>If not specified and the code is compiled using the `{@code -parameters}` argument to
+   * `javac`, the parameter name will be used instead. If the parameter name is not available, e.g.,
+   * because the code was not compiled with that flag, the attribute will be ignored.
    */
   String value() default "";
 }

--- a/extensions/annotations/src/main/java/io/opentelemetry/extension/annotations/SpanAttribute.java
+++ b/extensions/annotations/src/main/java/io/opentelemetry/extension/annotations/SpanAttribute.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
  *
  * @see <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation">OpenTelemetry
  *     OpenTelemetry Instrumentation for Java</a>
- * @since 1.2.0
+ * @since 1.4.0
  */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)

--- a/extensions/annotations/src/main/java/io/opentelemetry/extension/annotations/SpanAttribute.java
+++ b/extensions/annotations/src/main/java/io/opentelemetry/extension/annotations/SpanAttribute.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Target;
  *
  * @see <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation">OpenTelemetry
  *     OpenTelemetry Instrumentation for Java</a>
+ * @since 1.2.0
  */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)

--- a/extensions/annotations/src/main/java/io/opentelemetry/extension/annotations/WithSpan.java
+++ b/extensions/annotations/src/main/java/io/opentelemetry/extension/annotations/WithSpan.java
@@ -22,8 +22,8 @@ import java.lang.annotation.Target;
  * is non-functional without the OpenTelemetry auto-instrumentation agent, or some other annotation
  * processor.
  *
- * @see <a href="https://github.com/open-telemetry/opentelemetry-auto-instr-java">OpenTelemetry
- *     Auto-Instrumentation</a>
+ * @see <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation">OpenTelemetry
+ *     OpenTelemetry Instrumentation for Java</a>
  */
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
 @Retention(RetentionPolicy.RUNTIME)

--- a/extensions/annotations/src/main/java/io/opentelemetry/extension/annotations/WithSpanAttribute.java
+++ b/extensions/annotations/src/main/java/io/opentelemetry/extension/annotations/WithSpanAttribute.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.extension.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation marks that a parameter of a method annotated by the {@link WithSpan} annotation
+ * should be added as an attribute to the newly created {@link io.opentelemetry.api.trace.Span}.
+ *
+ * <p>Application developers can use this annotation to signal OpenTelemetry auto-instrumentation
+ * that a new span should be created whenever marked method is executed.
+ *
+ * <p>If you are a library developer, then probably you should NOT use this annotation, because it
+ * is non-functional without the OpenTelemetry auto-instrumentation agent, or some other annotation
+ * processor.
+ *
+ * @see <a href="https://github.com/open-telemetry/opentelemetry-auto-instr-java">OpenTelemetry
+ *     Auto-Instrumentation</a>
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WithSpanAttribute {
+  /**
+   * Optional name of the attribute.
+   *
+   * <p>If not specified, an appropriate default name should be created by auto-instrumentation.
+   * E.g. {@code "className"."method"}
+   */
+  String value() default "";
+}

--- a/extensions/annotations/src/main/java/io/opentelemetry/extension/annotations/WithSpanAttribute.java
+++ b/extensions/annotations/src/main/java/io/opentelemetry/extension/annotations/WithSpanAttribute.java
@@ -31,7 +31,12 @@ public @interface WithSpanAttribute {
    * Optional name of the attribute.
    *
    * <p>If not specified, an appropriate default name should be created by auto-instrumentation.
-   * E.g. {@code "className"."method"}
+   * E.g. the name of the parameter if formal parameter names are stored in the class file on
+   * compilation using the {@code -parameters} compiler option.
+   *
+   * @see <a
+   *     href="https://docs.oracle.com/javase/tutorial/reflect/member/methodparameterreflection.html">Obtaining
+   *     Names of Method Parameters</a>
    */
   String value() default "";
 }

--- a/extensions/annotations/src/test/java/io/opentelemetry/extension/annotations/WithSpanUsageExamples.java
+++ b/extensions/annotations/src/test/java/io/opentelemetry/extension/annotations/WithSpanUsageExamples.java
@@ -34,4 +34,14 @@ public class WithSpanUsageExamples {
    */
   @WithSpan(kind = SpanKind.CONSUMER)
   public void consume() {}
+
+  /**
+   * A {@link Span} with the default name and kind and with default span attributes.
+   *
+   * @param attribute1 A span attribute with the default name of {@code attribute1}.
+   * @param value A span attribute with the name {@code attribute2}.
+   */
+  @WithSpan
+  public void attributes(
+      @WithSpanAttribute String attribute1, @WithSpanAttribute("attribute2") long value) {}
 }

--- a/extensions/annotations/src/test/java/io/opentelemetry/extension/annotations/WithSpanUsageExamples.java
+++ b/extensions/annotations/src/test/java/io/opentelemetry/extension/annotations/WithSpanUsageExamples.java
@@ -43,5 +43,5 @@ public class WithSpanUsageExamples {
    */
   @WithSpan
   public void attributes(
-      @WithSpanAttribute String attribute1, @WithSpanAttribute("attribute2") long value) {}
+      @SpanAttribute String attribute1, @SpanAttribute("attribute2") long value) {}
 }

--- a/extensions/annotations/src/test/java/io/opentelemetry/extension/annotations/WithSpanUsageExamples.java
+++ b/extensions/annotations/src/test/java/io/opentelemetry/extension/annotations/WithSpanUsageExamples.java
@@ -39,7 +39,7 @@ public class WithSpanUsageExamples {
    * A {@link Span} with the default name and kind and with default span attributes.
    *
    * @param attribute1 A span attribute with the default name of {@code attribute1}.
-   * @param value A span attribute with the name {@code attribute2}.
+   * @param value A span attribute with the name "attribute2".
    */
   @WithSpan
   public void attributes(


### PR DESCRIPTION
Adds a new annotated that when combined with the `@WithSpan` annotation will add the value of the annotated parameter as an attribute to the newly-created `Span`:

```java
@WithSpan("method")
public void someMethod(@SpanAttribute("name") String someName) {
    // do stuff
}
```

For the above example the OTel auto-instrumentation will create a new `Span` with the name "method" and will take the value of the parameter `someName` and add it as a String attribute with the name "name".

For the attribute names there is the caveat that, by default, the Java compiler does not include the parameter name metadata in the compiled classes.  You can opt-into this by passing the `-parameters` compiler argument.  Without this the instrumentation cannot derive a useful name for the parameter.  This could be an argument to make the `value` element of the annotation not have a default value.

See: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/3188