### PR TITLE
Default the tracer name to an empty string

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
  */
 public final class SdkTracerProvider implements TracerProvider, Closeable {
   private static final Logger logger = Logger.getLogger(SdkTracerProvider.class.getName());
-  static final String DEFAULT_TRACER_NAME = "unknown";
+  static final String DEFAULT_TRACER_NAME = "";
   private final TracerSharedState sharedState;
   private final ComponentRegistry<SdkTracer> tracerSdkComponentRegistry;
 
@@ -65,7 +65,7 @@ public final class SdkTracerProvider implements TracerProvider, Closeable {
 
   @Override
   public Tracer get(String instrumentationName, @Nullable String instrumentationVersion) {
-    // Per the spec, both null and empty are "invalid" and a "default" should be used.
+    // Per the spec, both null and empty are "invalid" and a default value should be used.
     if (instrumentationName == null || instrumentationName.isEmpty()) {
       logger.fine("Tracer requested without instrumentation name.");
       instrumentationName = DEFAULT_TRACER_NAME;


### PR DESCRIPTION
An alternative to #3153, assuming that the spec gets updated to default to an empty string, rather than null.