### PR TITLE
Add some javadoc to the new ExecutorServiceSpanProcessor & builder.

### DIFF
--- a/sdk-extensions/tracing-incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/trace/ExecutorServiceSpanProcessor.java
+++ b/sdk-extensions/tracing-incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/trace/ExecutorServiceSpanProcessor.java
@@ -28,6 +28,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 import org.jctools.queues.MpscArrayQueue;
 
+/**
+ * A Batch {@link SpanProcessor} that uses a user-provided {@link
+ * java.util.concurrent.ScheduledExecutorService} to run background tasks.
+ */
 @SuppressWarnings("FutureReturnValueIgnored")
 public final class ExecutorServiceSpanProcessor implements SpanProcessor {
 
@@ -46,6 +50,15 @@ public final class ExecutorServiceSpanProcessor implements SpanProcessor {
   private final boolean ownsExecutorService;
   private final ScheduledExecutorService executorService;
 
+  /**
+   * Create a new {@link ExecutorServiceSpanProcessorBuilder} with the required components.
+   *
+   * @param spanExporter The {@link SpanExporter} to be used for exports.
+   * @param executorService The {@link ScheduledExecutorService} for running background tasks.
+   * @param ownsExecutorService Whether this component can be considered the "owner" of the provided
+   *     {@link ScheduledExecutorService}. If true, the {@link ScheduledExecutorService} will be
+   *     shut down when this SpanProcessor is shut down.
+   */
   public static ExecutorServiceSpanProcessorBuilder builder(
       SpanExporter spanExporter,
       ScheduledExecutorService executorService,

--- a/sdk-extensions/tracing-incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/trace/ExecutorServiceSpanProcessorBuilder.java
+++ b/sdk-extensions/tracing-incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/trace/ExecutorServiceSpanProcessorBuilder.java
@@ -13,6 +13,11 @@ import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Builder class for the {@link ExecutorServiceSpanProcessor}.
+ *
+ * @see ExecutorServiceSpanProcessor#builder(SpanExporter, ScheduledExecutorService, boolean)
+ */
 public class ExecutorServiceSpanProcessorBuilder {
 
   // Visible for testing


### PR DESCRIPTION
I realized this got merged without quite all the required javadoc.