### PR TITLE
Add spotbugs at reportLevel high; fix or exclude found items.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     id("io.codearte.nexus-staging")
     id("nebula.release")
 
+    id("com.github.spotbugs") apply false
     id("com.google.protobuf") apply false
     id("de.marcphilipp.nexus-publish") apply false
     id("io.morethan.jmhreport") apply false
@@ -72,8 +73,18 @@ subprojects {
         plugins.apply("eclipse")
         plugins.apply("idea")
         plugins.apply("jacoco")
-
         plugins.apply("com.diffplug.spotless")
+
+        plugins.apply("com.github.spotbugs")
+        configure<com.github.spotbugs.snom.SpotBugsExtension> {
+            setEffort("max")
+            setReportLevel("high")
+            excludeFilter.set(file("$rootDir/buildscripts/spotbugs-exclude.xml"))
+        }
+        tasks.named("spotbugsTest")  {
+            enabled = false
+        }
+
         plugins.apply("net.ltgt.errorprone")
 
         configure<BasePluginConvention> {

--- a/buildscripts/spotbugs-exclude.xml
+++ b/buildscripts/spotbugs-exclude.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <!-- Nullable-related stuff seem busted against this repo for whatever reason -->
+  <Match>
+    <Bug pattern="NP_NONNULL_PARAM_VIOLATION"/>
+  </Match>
+  <Match>
+    <Bug pattern="NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE"/>
+  </Match>
+  <Match>
+  <!-- This an an oddly specific one... -->
+    <Bug pattern="SC_START_IN_CTOR"/>
+  </Match>
+  <Match>
+    <!-- https://github.com/spotbugs/spotbugs/issues/573 kotlin is not well supported (yet) -->
+    <Source name="~.*\.kt"/>
+  </Match>
+  <Match>
+    <Source name="~.*(Test|Benchmark).*"/>
+  </Match>
+  <Match>
+    <!-- Another broken null detector -->
+    <Class name="io.opentelemetry.api.common.AttributesBuilder"/>
+    <Bug pattern="NP_NULL_PARAM_DEREF"/>
+  </Match>
+  <Match>
+    <!-- Assuming native file encoding seems sane here -->
+    <Class name="io.opentelemetry.sdk.extension.aws.resource.DockerHelper"/>
+    <Bug pattern="DM_DEFAULT_ENCODING"/>
+  </Match>
+  <Match>
+    <!-- This twisty maze of type checks is ok -->
+    <Class name="io.opentelemetry.context.internal.shaded.WeakConcurrentMap$LookupKey"/>
+    <Bug pattern="EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS"/>
+  </Match>
+</FindBugsFilter>

--- a/context/src/main/java/io/opentelemetry/context/internal/shaded/AbstractWeakConcurrentMap.java
+++ b/context/src/main/java/io/opentelemetry/context/internal/shaded/AbstractWeakConcurrentMap.java
@@ -283,7 +283,7 @@ abstract class AbstractWeakConcurrentMap<K, V, L> extends ReferenceQueue<K>
       if (other instanceof WeakKey<?>) {
         return ((WeakKey<?>) other).get() == get();
       } else {
-        return other == null ? false : other.equals(this);
+        return other != null && other.equals(this);
       }
     }
 

--- a/context/src/main/java/io/opentelemetry/context/internal/shaded/AbstractWeakConcurrentMap.java
+++ b/context/src/main/java/io/opentelemetry/context/internal/shaded/AbstractWeakConcurrentMap.java
@@ -283,7 +283,7 @@ abstract class AbstractWeakConcurrentMap<K, V, L> extends ReferenceQueue<K>
       if (other instanceof WeakKey<?>) {
         return ((WeakKey<?>) other).get() == get();
       } else {
-        return other.equals(this);
+        return other == null ? false : other.equals(this);
       }
     }
 

--- a/context/src/main/java/io/opentelemetry/context/internal/shaded/WeakConcurrentMap.java
+++ b/context/src/main/java/io/opentelemetry/context/internal/shaded/WeakConcurrentMap.java
@@ -179,8 +179,10 @@ public class WeakConcurrentMap<K, V>
     public boolean equals(Object other) {
       if (other instanceof WeakConcurrentMap.LookupKey<?>) {
         return ((LookupKey<?>) other).key == key;
-      } else {
+      } else if (other instanceof WeakKey<?>) {
         return ((WeakKey<?>) other).get() == key;
+      } else {
+        return false;
       }
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,7 @@ pluginManagement {
         id("org.jetbrains.kotlin.jvm") version "1.4.21"
         id("org.unbroken-dome.test-sets") version "3.0.1"
         id("ru.vyarus.animalsniffer") version "1.5.3"
+	id("com.github.spotbugs") version "4.7.0"
     }
 }
 


### PR DESCRIPTION
I've found spotbugs with reportLevel=high to generally have a good signal:noise ratio for a linting tool.  `opentelemetry-java-instrumentation` uses it as well.  This PR suggests adding it to the default `check` target as a build failure, fixes some suboptimal `equals` implementations it found, and adds exclusion rules to make the build pass.