### PR TITLE
Coerce null AttributeKey to empty string

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedAttributes.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedAttributes.java
@@ -41,7 +41,7 @@ final class ArrayBackedAttributes extends ImmutableKeyValuePairs<AttributeKey<?>
     // so they will then be removed by the sortAndFilter method.
     for (int i = 0; i < data.length; i += 2) {
       AttributeKey<?> key = (AttributeKey<?>) data[i];
-      if (key != null && (key.getKey() == null || "".equals(key.getKey()))) {
+      if (key != null && key.getKey().isEmpty()) {
         data[i] = null;
       }
     }

--- a/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedAttributesBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedAttributesBuilder.java
@@ -33,7 +33,7 @@ class ArrayBackedAttributesBuilder implements AttributesBuilder {
 
   @Override
   public <T> AttributesBuilder put(AttributeKey<T> key, T value) {
-    if (key == null || key.getKey() == null || key.getKey().length() == 0 || value == null) {
+    if (key == null || key.getKey().isEmpty() || value == null) {
       return this;
     }
     data.add(key);

--- a/api/all/src/main/java/io/opentelemetry/api/common/AttributeKeyImpl.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/AttributeKeyImpl.java
@@ -24,8 +24,8 @@ abstract class AttributeKeyImpl<T> implements AttributeKey<T> {
   // the class loader automatically resolves its super classes (interfaces), which in this case is
   // Context, which would be the same class (interface) being instrumented at that time,
   // which would lead to the JVM throwing a LinkageError "attempted duplicate interface definition"
-  static <T> AttributeKey<T> create(String key, AttributeType type) {
-    return new AutoValue_AttributeKeyImpl<>(type, key);
+  static <T> AttributeKey<T> create(@Nullable String key, AttributeType type) {
+    return new AutoValue_AttributeKeyImpl<>(type, key != null ? key : "");
   }
 
   @Override

--- a/api/all/src/test/java/io/opentelemetry/api/common/AttributeKeyTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/common/AttributeKeyTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.api.common;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
@@ -14,5 +16,10 @@ class AttributeKeyTest {
   @SuppressWarnings("AutoValueSubclassLeaked")
   void equalsVerifier() {
     EqualsVerifier.forClass(AutoValue_AttributeKeyImpl.class).verify();
+  }
+
+  @Test
+  void nullToEmpty() {
+    assertThat(AttributeKey.stringKey(null).getKey()).isEmpty();
   }
 }


### PR DESCRIPTION
`AttributeKey.getKey()` does not have the `@Nullable` annotation, but can return `null` which isn't really allowed. We hide this from users in almost all practical APIs, for example by filtering them out when building `Attributes` but still, I think we should make our `@Nullable` aspect correct (well, I am trying to add Nullaway to the build and found this, which Nullaway doesn't like correctly. Most Nullaway fixes will be trivial but split this one out since it's a logic change). 

The spec forbids both null and empty string keys
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes

We end up creating them to avoid crashing apps. But I think it means that coercing null to empty does not make us any less spec compliant and fixes the nullness issue.