### PR TITLE
rev ubuntu up to 20.04

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-18.04
+          - ubuntu-20.04
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             testAdditionalJavaVersions: true
             coverage: true
     steps:
@@ -53,7 +53,7 @@ jobs:
     name: Publish snapshots
     if: ${{ github.event_name == 'push' && github.repository == 'open-telemetry/opentelemetry-java' }}
     needs: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   prepare-release-branch:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       release-branch-name: ${{ steps.parse-release-branch.outputs.release-branch-name }}
     steps:
@@ -42,7 +42,7 @@ jobs:
           git checkout -b ${{ steps.parse-release-branch.outputs.release-branch-name }}
           git push --set-upstream origin ${{ steps.parse-release-branch.outputs.release-branch-name }}
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: prepare-release-branch
     steps:
       - name: Checkout release branch

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-18.04
+          - ubuntu-20.04
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             testAdditionalJavaVersions: true
             coverage: true
     steps:

--- a/.github/workflows/pr-examples-build.yml
+++ b/.github/workflows/pr-examples-build.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-18.04
+          - ubuntu-20.04
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             testAdditionalJavaVersions: true
             coverage: true
     steps:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Build and release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2


### PR DESCRIPTION
For some reason, now 18.04 is failing, but 20.04 is passing. I don't understand what's going on here, but hopefully this will move our PRs forward again. 

Note: I changed the branch protection rules to require 20.04 on PRs, assuming this will move forward.