### PR TITLE
Use JDK 10 API to fetch process pid

### DIFF
--- a/sdk-extensions/resources/build.gradle.kts
+++ b/sdk-extensions/resources/build.gradle.kts
@@ -8,6 +8,8 @@ plugins {
 description = "OpenTelemetry SDK Resource Providers"
 extra["moduleName"] = "io.opentelemetry.sdk.extension.resources"
 
+val mrJarVersions = listOf(11)
+
 dependencies {
     api(project(":sdk:common"))
     
@@ -18,4 +20,66 @@ dependencies {
     compileOnly("org.codehaus.mojo:animal-sniffer-annotations")
 
     testImplementation("org.junit-pioneer:junit-pioneer")
+}
+
+sourceSets {
+    main {
+        output.dir("build/generated/properties", "builtBy" to "generateVersionResource")
+    }
+}
+
+tasks {
+    register("generateVersionResource") {
+        val propertiesDir = file("build/generated/properties/io/opentelemetry/sdk/extension/resources")
+        outputs.dir(propertiesDir)
+
+        doLast {
+            File(propertiesDir, "version.properties").writeText("sdk.version=${project.version}")
+        }
+    }
+}
+
+for (version in mrJarVersions) {
+    sourceSets {
+        create("java${version}") {
+            java {
+                setSrcDirs(listOf("src/main/java${version}"))
+            }
+        }
+    }
+
+    tasks {
+        named<JavaCompile>("compileJava${version}Java") {
+            sourceCompatibility = "${version}"
+            targetCompatibility = "${version}"
+            options.release.set(version)
+        }
+    }
+
+    configurations {
+        named("java${version}Implementation") {
+            extendsFrom(configurations["implementation"])
+        }
+        named("java${version}CompileOnly") {
+            extendsFrom(configurations["compileOnly"])
+        }
+    }
+
+    dependencies {
+        // Common to reference classes in main sourceset from Java 9 one (e.g., to return a common interface)
+        add("java${version}Implementation", files(sourceSets.main.get().output.classesDirs))
+    }
+}
+
+tasks {
+    withType(Jar::class) {
+        for (version in mrJarVersions) {
+            into("META-INF/versions/${version}") {
+                from(sourceSets["java${version}"].output)
+            }
+        }
+        manifest.attributes(
+                "Multi-Release" to "true"
+        )
+    }
 }

--- a/sdk-extensions/resources/src/main/java/io/opentelemetry/sdk/extension/resources/ProcessPid.java
+++ b/sdk-extensions/resources/src/main/java/io/opentelemetry/sdk/extension/resources/ProcessPid.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.extension.resources;
+
+import java.lang.management.ManagementFactory;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
+
+final class ProcessPid {
+
+  private ProcessPid() {}
+
+  @IgnoreJRERequirement
+  static long getPid() {
+    // While this is not strictly defined, almost all commonly used JVMs format this as
+    // pid@hostname.
+    String runtimeName = ManagementFactory.getRuntimeMXBean().getName();
+    int atIndex = runtimeName.indexOf('@');
+    if (atIndex >= 0) {
+      String pidString = runtimeName.substring(0, atIndex);
+      try {
+        return Long.parseLong(pidString);
+      } catch (NumberFormatException ignored) {
+        // Ignore parse failure.
+      }
+    }
+    return -1;
+  }
+}

--- a/sdk-extensions/resources/src/main/java/io/opentelemetry/sdk/extension/resources/ProcessResource.java
+++ b/sdk-extensions/resources/src/main/java/io/opentelemetry/sdk/extension/resources/ProcessResource.java
@@ -42,21 +42,9 @@ public final class ProcessResource {
   private static Resource doBuildResource() {
     AttributesBuilder attributes = Attributes.builder();
 
-    // TODO(anuraaga): Use reflection to get more stable values on Java 9+
     RuntimeMXBean runtime = ManagementFactory.getRuntimeMXBean();
-    long pid = -1;
-    // While this is not strictly defined, almost all commonly used JVMs format this as
-    // pid@hostname.
-    String runtimeName = ManagementFactory.getRuntimeMXBean().getName();
-    int atIndex = runtimeName.indexOf('@');
-    if (atIndex >= 0) {
-      String pidString = runtimeName.substring(0, atIndex);
-      try {
-        pid = Long.parseLong(pidString);
-      } catch (NumberFormatException ignored) {
-        // Ignore parse failure.
-      }
-    }
+
+    long pid = ProcessPid.getPid();
 
     if (pid >= 0) {
       attributes.put(ResourceAttributes.PROCESS_PID, pid);

--- a/sdk-extensions/resources/src/main/java11/io/opentelemetry/sdk/extension/resources/ProcessPid.java
+++ b/sdk-extensions/resources/src/main/java11/io/opentelemetry/sdk/extension/resources/ProcessPid.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.extension.resources;
+
+import java.lang.management.ManagementFactory;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
+
+final class ProcessPid {
+
+  private ProcessPid() {}
+
+  @IgnoreJRERequirement
+  static long getPid() {
+    return ManagementFactory.getRuntimeMXBean().getPid();
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java/issues/1564
`ManagementFactory.getRuntimeMXBean().getPid()` is available since JDK 10, but I've come across https://bugs.openjdk.java.net/browse/JDK-8209058 when compiling. I've decided to go with JDK 11 because the code compiles and it is LTS release anyway.