### PR TITLE
Change the autoconfigure module to only have a test dependency on the semantic conventions module.

### DIFF
--- a/sdk-extensions/autoconfigure/build.gradle.kts
+++ b/sdk-extensions/autoconfigure/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     api(project(":sdk:all"))
     api(project(":sdk:metrics"))
 
-    implementation(project(":semconv"))
+    testImplementation(project(":semconv"))
 
     compileOnly(project(":extensions:trace-propagators"))
     compileOnly(project(":exporters:jaeger"))


### PR DESCRIPTION
It's only used in tests, so no need to depend on it for anything else.