### PR TITLE
Move TemporaryBuffers to internal and use it everywhere.

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/internal/TemporaryBuffers.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/TemporaryBuffers.java
@@ -11,6 +11,9 @@ package io.opentelemetry.api.internal;
  * multiple derived objects at the same time because the same memory will be used. In general, you
  * should get a temporary buffer, fill it with data, and finish by converting into the derived
  * object within the same method to avoid multiple usages of the same buffer.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
  */
 public final class TemporaryBuffers {
 

--- a/api/all/src/main/java/io/opentelemetry/api/internal/TemporaryBuffers.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/TemporaryBuffers.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.api.trace.propagation;
+package io.opentelemetry.api.internal;
 
 /**
  * {@link ThreadLocal} buffers for use when creating new derived objects such as {@link String}s.
@@ -12,7 +12,7 @@ package io.opentelemetry.api.trace.propagation;
  * should get a temporary buffer, fill it with data, and finish by converting into the derived
  * object within the same method to avoid multiple usages of the same buffer.
  */
-final class TemporaryBuffers {
+public final class TemporaryBuffers {
 
   private static final ThreadLocal<char[]> CHAR_ARRAY = new ThreadLocal<>();
 
@@ -22,7 +22,7 @@ final class TemporaryBuffers {
    * not be zeroed and may be larger than the requested size, you must make sure to fill the entire
    * content to the desired value and set the length explicitly when converting to a {@link String}.
    */
-  static char[] chars(int len) {
+  public static char[] chars(int len) {
     char[] buffer = CHAR_ARRAY.get();
     if (buffer == null || buffer.length < len) {
       buffer = new char[len];

--- a/api/all/src/main/java/io/opentelemetry/api/trace/SpanId.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/SpanId.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.api.trace;
 
 import io.opentelemetry.api.internal.OtelEncodingUtils;
+import io.opentelemetry.api.internal.TemporaryBuffers;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -21,8 +22,6 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public final class SpanId {
-  private static final ThreadLocal<char[]> charBuffer = new ThreadLocal<>();
-
   private static final int BYTES_LENGTH = 8;
   private static final int HEX_LENGTH = 2 * BYTES_LENGTH;
   private static final String INVALID = "0000000000000000";
@@ -75,9 +74,9 @@ public final class SpanId {
     if (spanIdBytes == null || spanIdBytes.length < BYTES_LENGTH) {
       return INVALID;
     }
-    char[] result = getTemporaryBuffer();
+    char[] result = TemporaryBuffers.chars(HEX_LENGTH);
     OtelEncodingUtils.bytesToBase16(spanIdBytes, result, BYTES_LENGTH);
-    return new String(result);
+    return new String(result, 0, HEX_LENGTH);
   }
 
   /**
@@ -98,17 +97,8 @@ public final class SpanId {
     if (id == 0) {
       return getInvalid();
     }
-    char[] result = getTemporaryBuffer();
+    char[] result = TemporaryBuffers.chars(HEX_LENGTH);
     OtelEncodingUtils.longToBase16String(id, result, 0);
-    return new String(result);
-  }
-
-  private static char[] getTemporaryBuffer() {
-    char[] chars = charBuffer.get();
-    if (chars == null) {
-      chars = new char[HEX_LENGTH];
-      charBuffer.set(chars);
-    }
-    return chars;
+    return new String(result, 0, HEX_LENGTH);
   }
 }

--- a/api/all/src/main/java/io/opentelemetry/api/trace/TraceId.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/TraceId.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.api.trace;
 
 import io.opentelemetry.api.internal.OtelEncodingUtils;
+import io.opentelemetry.api.internal.TemporaryBuffers;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -25,8 +26,6 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public final class TraceId {
-  private static final ThreadLocal<char[]> charBuffer = new ThreadLocal<>();
-
   private static final int BYTES_LENGTH = 16;
   private static final int HEX_LENGTH = 2 * BYTES_LENGTH;
   private static final String INVALID = "00000000000000000000000000000000";
@@ -79,9 +78,9 @@ public final class TraceId {
     if (traceIdBytes == null || traceIdBytes.length < BYTES_LENGTH) {
       return INVALID;
     }
-    char[] result = getTemporaryBuffer();
+    char[] result = TemporaryBuffers.chars(HEX_LENGTH);
     OtelEncodingUtils.bytesToBase16(traceIdBytes, result, BYTES_LENGTH);
-    return new String(result);
+    return new String(result, 0, HEX_LENGTH);
   }
 
   /**
@@ -105,18 +104,9 @@ public final class TraceId {
     if (traceIdLongHighPart == 0 && traceIdLongLowPart == 0) {
       return getInvalid();
     }
-    char[] chars = getTemporaryBuffer();
+    char[] chars = TemporaryBuffers.chars(HEX_LENGTH);
     OtelEncodingUtils.longToBase16String(traceIdLongHighPart, chars, 0);
     OtelEncodingUtils.longToBase16String(traceIdLongLowPart, chars, 16);
-    return new String(chars);
-  }
-
-  private static char[] getTemporaryBuffer() {
-    char[] chars = charBuffer.get();
-    if (chars == null) {
-      chars = new char[HEX_LENGTH];
-      charBuffer.set(chars);
-    }
-    return chars;
+    return new String(chars, 0, HEX_LENGTH);
   }
 }

--- a/api/all/src/main/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagator.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagator.java
@@ -8,6 +8,7 @@ package io.opentelemetry.api.trace.propagation;
 import static io.opentelemetry.api.internal.Utils.checkArgument;
 
 import io.opentelemetry.api.internal.OtelEncodingUtils;
+import io.opentelemetry.api.internal.TemporaryBuffers;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanId;
@@ -115,16 +116,12 @@ public final class W3CTraceContextPropagator implements TextMapPropagator {
     chars[2] = TRACEPARENT_DELIMITER;
 
     String traceId = spanContext.getTraceId();
-    for (int i = 0; i < traceId.length(); i++) {
-      chars[TRACE_ID_OFFSET + i] = traceId.charAt(i);
-    }
+    traceId.getChars(0, traceId.length(), chars, TRACE_ID_OFFSET);
 
     chars[SPAN_ID_OFFSET - 1] = TRACEPARENT_DELIMITER;
 
     String spanId = spanContext.getSpanId();
-    for (int i = 0; i < spanId.length(); i++) {
-      chars[SPAN_ID_OFFSET + i] = spanId.charAt(i);
-    }
+    spanId.getChars(0, spanId.length(), chars, SPAN_ID_OFFSET);
 
     chars[TRACE_OPTION_OFFSET - 1] = TRACEPARENT_DELIMITER;
     String traceFlagsHex = spanContext.getTraceFlags().asHex();

--- a/api/all/src/test/java/io/opentelemetry/api/internal/TemporaryBuffersTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/internal/TemporaryBuffersTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.api.trace.propagation;
+package io.opentelemetry.api.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/HexEncodingStringJsonGenerator.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/HexEncodingStringJsonGenerator.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.io.SegmentedStringWriter;
 import com.fasterxml.jackson.core.util.JsonGeneratorDelegate;
+import io.opentelemetry.api.internal.TemporaryBuffers;
 import java.io.IOException;
 
 final class HexEncodingStringJsonGenerator extends JsonGeneratorDelegate {
@@ -39,12 +40,13 @@ final class HexEncodingStringJsonGenerator extends JsonGeneratorDelegate {
   private static final char[] HEX_ARRAY = "0123456789abcdef".toCharArray();
 
   private static String bytesToHex(byte[] bytes, int offset, int len) {
-    char[] hexChars = new char[len * 2];
+    int hexLength = len * 2;
+    char[] hexChars = TemporaryBuffers.chars(hexLength);
     for (int i = 0; i < len; i++) {
       int v = bytes[offset + i] & 0xFF;
       hexChars[i * 2] = HEX_ARRAY[v >>> 4];
       hexChars[i * 2 + 1] = HEX_ARRAY[v & 0x0F];
     }
-    return new String(hexChars);
+    return new String(hexChars, 0, hexLength);
   }
 }

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorInjectorSingleHeader.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3PropagatorInjectorSingleHeader.java
@@ -7,6 +7,7 @@ package io.opentelemetry.extension.trace.propagation;
 
 import static io.opentelemetry.extension.trace.propagation.B3Propagator.COMBINED_HEADER;
 
+import io.opentelemetry.api.internal.TemporaryBuffers;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanId;
@@ -44,13 +45,13 @@ final class B3PropagatorInjectorSingleHeader implements B3PropagatorInjector {
       return;
     }
 
-    char[] chars = new char[COMBINED_HEADER_SIZE];
+    char[] chars = TemporaryBuffers.chars(COMBINED_HEADER_SIZE);
     String traceId = spanContext.getTraceId();
     traceId.getChars(0, traceId.length(), chars, 0);
     chars[SPAN_ID_OFFSET - 1] = B3Propagator.COMBINED_HEADER_DELIMITER_CHAR;
 
     String spanId = spanContext.getSpanId();
-    System.arraycopy(spanId.toCharArray(), 0, chars, SPAN_ID_OFFSET, SpanId.getLength());
+    spanId.getChars(0, SpanId.getLength(), chars, SPAN_ID_OFFSET);
 
     chars[SAMPLED_FLAG_OFFSET - 1] = B3Propagator.COMBINED_HEADER_DELIMITER_CHAR;
     if (Boolean.TRUE.equals(context.get(B3Propagator.DEBUG_CONTEXT_KEY))) {
@@ -59,7 +60,7 @@ final class B3PropagatorInjectorSingleHeader implements B3PropagatorInjector {
       chars[SAMPLED_FLAG_OFFSET] =
           spanContext.isSampled() ? B3Propagator.IS_SAMPLED : B3Propagator.NOT_SAMPLED;
     }
-    setter.set(carrier, COMBINED_HEADER, new String(chars));
+    setter.set(carrier, COMBINED_HEADER, new String(chars, 0, COMBINED_HEADER_SIZE));
   }
 
   @Override


### PR DESCRIPTION
Also replaces loop over `String` with `getChars` which is hotspottable.