### PR TITLE
Remove the OTLP receiver legacy gRPC port(55680) references

### DIFF
--- a/perf-harness/src/test/java/io/opentelemetry/perf/OtlpPipelineStressTest.java
+++ b/perf-harness/src/test/java/io/opentelemetry/perf/OtlpPipelineStressTest.java
@@ -58,8 +58,7 @@ import org.testcontainers.utility.MountableFile;
 @SuppressWarnings({"FutureReturnValueIgnored", "CatchAndPrintStackTrace"})
 public class OtlpPipelineStressTest {
 
-  public static final int OTLP_RECEIVER_PORT =
-      55680; // todo: switch to 4317 when that port makes it into the collector docker image.
+  public static final int OTLP_RECEIVER_PORT = 4317;
   public static final int COLLECTOR_PROXY_PORT = 44444;
   public static final int TOXIPROXY_CONTROL_PORT = 8474;
   public static Network network = Network.newNetwork();


### PR DESCRIPTION
**Description:**
The legacy gRPC port(55680) in OTLP Receiver will be disabled in OTel Collector before the collector GA.

This CR replaced all gRPC port occurrences from `55680` to `4317` in this repo.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/2565