### PR TITLE
Add a prototype PassThroughPropagator

### DIFF
--- a/extensions/incubator/build.gradle.kts
+++ b/extensions/incubator/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     `java-library`
     `maven-publish`
 
+    id("me.champeau.jmh")
     id("ru.vyarus.animalsniffer")
 }
 

--- a/extensions/incubator/src/jmh/java/io/opentelemetry/extension/incubator/PassThroughPropagatorBenchmark.java
+++ b/extensions/incubator/src/jmh/java/io/opentelemetry/extension/incubator/PassThroughPropagatorBenchmark.java
@@ -12,6 +12,7 @@ import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.extension.incubator.propagation.PassThroughPropagator;
 import java.util.Collections;
 import java.util.HashMap;
@@ -61,7 +62,7 @@ public class PassThroughPropagatorBenchmark {
         }
       };
 
-  private static final PassThroughPropagator passthrough =
+  private static final TextMapPropagator passthrough =
       PassThroughPropagator.create(W3CTraceContextPropagator.getInstance().fields());
 
   @Benchmark

--- a/extensions/incubator/src/jmh/java/io/opentelemetry/extension/incubator/PassThroughPropagatorBenchmark.java
+++ b/extensions/incubator/src/jmh/java/io/opentelemetry/extension/incubator/PassThroughPropagatorBenchmark.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.extension.incubator;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.extension.incubator.propagation.PassThroughPropagator;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Threads(value = 1)
+@Fork(3)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 20, time = 1)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class PassThroughPropagatorBenchmark {
+
+  private static final SpanContext SPAN_CONTEXT =
+      SpanContext.create(
+          "0102030405060708090a0b0c0d0e0f00",
+          "090a0b0c0d0e0f00",
+          TraceFlags.getDefault(),
+          TraceState.getDefault());
+  private static final Map<String, String> INCOMING;
+
+  static {
+    Map<String, String> incoming = new HashMap<>();
+    W3CTraceContextPropagator.getInstance()
+        .inject(Context.root().with(Span.wrap(SPAN_CONTEXT)), incoming, Map::put);
+    INCOMING = Collections.unmodifiableMap(incoming);
+  }
+
+  private static final TextMapGetter<Map<String, String>> getter =
+      new TextMapGetter<Map<String, String>>() {
+        @Override
+        public Iterable<String> keys(Map<String, String> carrier) {
+          return carrier.keySet();
+        }
+
+        @Nullable
+        @Override
+        public String get(Map<String, String> carrier, String key) {
+          return carrier.get(key);
+        }
+      };
+
+  private static final PassThroughPropagator passthrough =
+      PassThroughPropagator.create(W3CTraceContextPropagator.getInstance().fields());
+
+  @Benchmark
+  public void passthrough() {
+    Context extracted = passthrough.extract(Context.root(), INCOMING, getter);
+    passthrough.inject(extracted, new HashMap<>(), Map::put);
+  }
+
+  @Benchmark
+  public void parse() {
+    Context extracted =
+        W3CTraceContextPropagator.getInstance().extract(Context.root(), INCOMING, getter);
+    W3CTraceContextPropagator.getInstance().inject(extracted, new HashMap<>(), Map::put);
+  }
+}

--- a/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/propagation/PassThroughPropagator.java
+++ b/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/propagation/PassThroughPropagator.java
@@ -38,6 +38,12 @@ public final class PassThroughPropagator implements TextMapPropagator {
   private static final ContextKey<List<String>> EXTRACTED_KEY_VALUES =
       ContextKey.named("passthroughpropagator-keyvalues");
 
+  private final List<String> fields;
+
+  private PassThroughPropagator(List<String> fields) {
+    this.fields = Collections.unmodifiableList(fields);
+  }
+
   /**
    * Returns a {@link TextMapPropagator} which will propagate the given {@code fields} from
    * extraction to injection.
@@ -61,12 +67,6 @@ public final class PassThroughPropagator implements TextMapPropagator {
       return TextMapPropagator.noop();
     }
     return new PassThroughPropagator(fieldsList);
-  }
-
-  private final List<String> fields;
-
-  private PassThroughPropagator(List<String> fields) {
-    this.fields = Collections.unmodifiableList(fields);
   }
 
   @Override

--- a/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/propagation/PassThroughPropagator.java
+++ b/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/propagation/PassThroughPropagator.java
@@ -33,7 +33,7 @@ import javax.annotation.Nullable;
  * io.opentelemetry.api.OpenTelemetry} that only propagates. Similarly, you will never need this
  * when using the OpenTelemetry SDK to enable telemetry.
  */
-public class PassThroughPropagator implements TextMapPropagator {
+public final class PassThroughPropagator implements TextMapPropagator {
 
   private static final ContextKey<List<String>> EXTRACTED_KEY_VALUES =
       ContextKey.named("passthroughpropagator-keyvalues");

--- a/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/propagation/PassThroughPropagator.java
+++ b/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/propagation/PassThroughPropagator.java
@@ -39,24 +39,27 @@ public final class PassThroughPropagator implements TextMapPropagator {
       ContextKey.named("passthroughpropagator-keyvalues");
 
   /**
-   * Returns a {@link PassThroughPropagator} which will propagate the given {@code fields} from
+   * Returns a {@link TextMapPropagator} which will propagate the given {@code fields} from
    * extraction to injection.
    */
-  public static PassThroughPropagator create(String... fields) {
+  public static TextMapPropagator create(String... fields) {
     requireNonNull(fields, "fields");
     return create(Arrays.asList(fields));
   }
 
   /**
-   * Returns a {@link PassThroughPropagator} which will propagate the given {@code fields} from
+   * Returns a {@link TextMapPropagator} which will propagate the given {@code fields} from
    * extraction to injection.
    */
-  public static PassThroughPropagator create(Iterable<String> fields) {
+  public static TextMapPropagator create(Iterable<String> fields) {
     requireNonNull(fields, "fields");
     List<String> fieldsList =
         StreamSupport.stream(fields.spliterator(), false)
             .map(field -> requireNonNull(field, "field"))
             .collect(Collectors.toList());
+    if (fieldsList.isEmpty()) {
+      return TextMapPropagator.noop();
+    }
     return new PassThroughPropagator(fieldsList);
   }
 

--- a/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/propagation/PassThroughPropagator.java
+++ b/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/propagation/PassThroughPropagator.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.extension.incubator.propagation;
+
+import static java.util.Objects.requireNonNull;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.context.propagation.TextMapSetter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import javax.annotation.Nullable;
+
+/**
+ * A {@link TextMapPropagator} which can be configured with a set of fields, which will be extracted
+ * and stored in {@link Context}. If the {@link Context} is used again to inject, the values will be
+ * injected as-is. This {@link TextMapPropagator} is appropriate for a service that does not need to
+ * participate in telemetry in any way and provides the most efficient way of propagating incoming
+ * context to outgoing requests. In almost all cases, you will configure this single {@link
+ * TextMapPropagator} when using {@link
+ * io.opentelemetry.api.OpenTelemetry#propagating(ContextPropagators)} to create an {@link
+ * io.opentelemetry.api.OpenTelemetry} that only propagates. Similarly, you will never need this
+ * when using the OpenTelemetry SDK to enable telemetry.
+ */
+public class PassThroughPropagator implements TextMapPropagator {
+
+  private static final ContextKey<List<String>> EXTRACTED_KEY_VALUES =
+      ContextKey.named("passthroughpropagator-keyvalues");
+
+  /**
+   * Returns a {@link PassThroughPropagator} which will propagate the given {@code fields} from
+   * extraction to injection.
+   */
+  public static PassThroughPropagator create(String... fields) {
+    requireNonNull(fields, "fields");
+    return create(Arrays.asList(fields));
+  }
+
+  /**
+   * Returns a {@link PassThroughPropagator} which will propagate the given {@code fields} from
+   * extraction to injection.
+   */
+  public static PassThroughPropagator create(Iterable<String> fields) {
+    requireNonNull(fields, "fields");
+    List<String> fieldsList =
+        StreamSupport.stream(fields.spliterator(), false)
+            .map(field -> requireNonNull(field, "field"))
+            .collect(Collectors.toList());
+    return new PassThroughPropagator(fieldsList);
+  }
+
+  private final List<String> fields;
+
+  private PassThroughPropagator(List<String> fields) {
+    this.fields = Collections.unmodifiableList(fields);
+  }
+
+  @Override
+  public Collection<String> fields() {
+    return fields;
+  }
+
+  @Override
+  public <C> void inject(Context context, @Nullable C carrier, TextMapSetter<C> setter) {
+    List<String> extracted = context.get(EXTRACTED_KEY_VALUES);
+    if (extracted != null) {
+      for (int i = 0; i < extracted.size(); i += 2) {
+        setter.set(carrier, extracted.get(i), extracted.get(i + 1));
+      }
+    }
+  }
+
+  @Override
+  public <C> Context extract(Context context, @Nullable C carrier, TextMapGetter<C> getter) {
+    List<String> extracted = null;
+    for (String field : fields) {
+      String value = getter.get(carrier, field);
+      if (value != null) {
+        if (extracted == null) {
+          extracted = new ArrayList<>();
+        }
+        extracted.add(field);
+        extracted.add(value);
+      }
+    }
+    return extracted != null ? context.with(EXTRACTED_KEY_VALUES, extracted) : context;
+  }
+}

--- a/extensions/incubator/src/test/java/io/opentelemetry/extension/incubator/propagation/PassThroughPropagatorTest.java
+++ b/extensions/incubator/src/test/java/io/opentelemetry/extension/incubator/propagation/PassThroughPropagatorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.extension.incubator.propagation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+
+class PassThroughPropagatorTest {
+  private static final TextMapPropagator propagator =
+      PassThroughPropagator.create("animal", "food");
+
+  private static final TextMapGetter<Map<String, String>> getter =
+      new TextMapGetter<Map<String, String>>() {
+        @Override
+        public Iterable<String> keys(Map<String, String> carrier) {
+          return carrier.keySet();
+        }
+
+        @Nullable
+        @Override
+        public String get(Map<String, String> carrier, String key) {
+          return carrier.get(key);
+        }
+      };
+
+  @Test
+  void propagates() {
+    Map<String, String> incoming = new HashMap<>();
+    incoming.put("animal", "cat");
+    incoming.put("food", "pizza");
+    incoming.put("country", "japan");
+
+    Context context = propagator.extract(Context.root(), incoming, getter);
+
+    Map<String, String> outgoing = new HashMap<>();
+    propagator.inject(context, outgoing, Map::put);
+    assertThat(outgoing).containsOnly(entry("animal", "cat"), entry("food", "pizza"));
+  }
+
+  @Test
+  void emptyMap() {
+    Map<String, String> incoming = new HashMap<>();
+
+    Context context = propagator.extract(Context.root(), incoming, getter);
+
+    Map<String, String> outgoing = new HashMap<>();
+    propagator.inject(context, outgoing, Map::put);
+    assertThat(outgoing).isEmpty();
+  }
+
+  @Test
+  void nullFields() {
+    assertThatThrownBy(() -> PassThroughPropagator.create((String[]) null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("fields");
+    assertThatThrownBy(() -> PassThroughPropagator.create((Iterable<String>) null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("fields");
+    assertThatThrownBy(() -> PassThroughPropagator.create("cat", null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("field");
+  }
+}

--- a/extensions/incubator/src/test/java/io/opentelemetry/extension/incubator/propagation/PassThroughPropagatorTest.java
+++ b/extensions/incubator/src/test/java/io/opentelemetry/extension/incubator/propagation/PassThroughPropagatorTest.java
@@ -50,6 +50,21 @@ class PassThroughPropagatorTest {
   }
 
   @Test
+  void noFields() {
+    TextMapPropagator propagator = PassThroughPropagator.create();
+    Map<String, String> incoming = new HashMap<>();
+    incoming.put("animal", "cat");
+    incoming.put("food", "pizza");
+    incoming.put("country", "japan");
+
+    Context context = propagator.extract(Context.root(), incoming, getter);
+
+    Map<String, String> outgoing = new HashMap<>();
+    propagator.inject(context, outgoing, Map::put);
+    assertThat(outgoing).isEmpty();
+  }
+
+  @Test
   void emptyMap() {
     Map<String, String> incoming = new HashMap<>();
 


### PR DESCRIPTION
For https://github.com/open-telemetry/opentelemetry-specification/issues/1717

About 3x performance for passing through vs parse/serialize.

```
Benchmark                                                                 Mode  Cnt      Score     Error   Units
PassThroughPropagatorBenchmark.parse                                     thrpt   60   5705.975 ±  75.797  ops/ms
PassThroughPropagatorBenchmark.parse:·gc.alloc.rate                      thrpt   60   2174.161 ±  28.934  MB/sec
PassThroughPropagatorBenchmark.parse:·gc.alloc.rate.norm                 thrpt   60    600.000 ±   0.001    B/op
PassThroughPropagatorBenchmark.parse:·gc.churn.G1_Eden_Space             thrpt   60   2178.084 ±  43.372  MB/sec
PassThroughPropagatorBenchmark.parse:·gc.churn.G1_Eden_Space.norm        thrpt   60    601.123 ±   9.464    B/op
PassThroughPropagatorBenchmark.parse:·gc.churn.G1_Old_Gen                thrpt   60      0.002 ±   0.001  MB/sec
PassThroughPropagatorBenchmark.parse:·gc.churn.G1_Old_Gen.norm           thrpt   60      0.001 ±   0.001    B/op
PassThroughPropagatorBenchmark.parse:·gc.count                           thrpt   60    792.000            counts
PassThroughPropagatorBenchmark.parse:·gc.time                            thrpt   60    336.000                ms
PassThroughPropagatorBenchmark.passthrough                               thrpt   60  14528.893 ± 158.380  ops/ms
PassThroughPropagatorBenchmark.passthrough:·gc.alloc.rate                thrpt   60   2878.115 ±  31.488  MB/sec
PassThroughPropagatorBenchmark.passthrough:·gc.alloc.rate.norm           thrpt   60    312.000 ±   0.001    B/op
PassThroughPropagatorBenchmark.passthrough:·gc.churn.G1_Eden_Space       thrpt   60   2886.064 ±  51.659  MB/sec
PassThroughPropagatorBenchmark.passthrough:·gc.churn.G1_Eden_Space.norm  thrpt   60    312.864 ±   4.436    B/op
PassThroughPropagatorBenchmark.passthrough:·gc.churn.G1_Old_Gen          thrpt   60      0.002 ±   0.001  MB/sec
PassThroughPropagatorBenchmark.passthrough:·gc.churn.G1_Old_Gen.norm     thrpt   60     ≈ 10⁻⁴              B/op
PassThroughPropagatorBenchmark.passthrough:·gc.count                     thrpt   60    807.000            counts
PassThroughPropagatorBenchmark.passthrough:·gc.time                      thrpt   60    388.000                ms
```