### PR TITLE
Add a benchmark comparing OTLP and Jaeger exporter

### DIFF
--- a/sdk/trace/build.gradle.kts
+++ b/sdk/trace/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
         // dependencies.
         isTransitive = false
     }
+    jmh(project(":exporters:jaeger-thrift"))
     jmh(project(":exporters:otlp:trace")) {
         // The opentelemetry-exporter-otlp-trace depends on this project itself. So don"t pull in
         // the transitive dependencies.

--- a/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/ExporterBenchmark.java
+++ b/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/ExporterBenchmark.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.trace;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.exporter.jaeger.thrift.JaegerThriftSpanExporter;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+public class ExporterBenchmark {
+  private ExporterBenchmark() {}
+
+  @State(Scope.Benchmark)
+  public abstract static class AbstractProcessorBenchmark {
+    private static final DockerImageName OTLP_COLLECTOR_IMAGE =
+        DockerImageName.parse("otel/opentelemetry-collector-dev:latest");
+    protected static final int OTLP_PORT = 5678;
+    protected static final int JAEGER_PORT = 14268;
+    private static final int HEALTH_CHECK_PORT = 13133;
+    protected SdkSpanBuilder sdkSpanBuilder;
+
+    protected abstract SpanExporter createExporter(GenericContainer<?> collector);
+
+    @Setup(Level.Trial)
+    public void setup() {
+      // Configuring the collector test-container
+      GenericContainer<?> collector =
+          new GenericContainer<>(OTLP_COLLECTOR_IMAGE)
+              .withExposedPorts(OTLP_PORT, HEALTH_CHECK_PORT, JAEGER_PORT)
+              .waitingFor(Wait.forHttp("/").forPort(HEALTH_CHECK_PORT))
+              .withCopyFileToContainer(
+                  MountableFile.forClasspathResource("/otel.yaml"), "/etc/otel.yaml")
+              .withCommand("--config /etc/otel.yaml");
+
+      collector.start();
+
+      SdkTracerProvider tracerProvider =
+          SdkTracerProvider.builder()
+              .setSampler(Sampler.alwaysOn())
+              .addSpanProcessor(SimpleSpanProcessor.create(createExporter(collector)))
+              .build();
+
+      Tracer tracerSdk = tracerProvider.get("PipelineBenchmarkTracer");
+      sdkSpanBuilder = (SdkSpanBuilder) tracerSdk.spanBuilder("PipelineBenchmarkSpan");
+    }
+
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @Warmup(iterations = 5, time = 1)
+    @Measurement(iterations = 10, time = 1)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    @Fork(1)
+    @Threads(1)
+    public Span createAndExportSpan() {
+      Span span = sdkSpanBuilder.startSpan();
+      span.end();
+      return span;
+    }
+  }
+
+  public static class OtlpBenchmark extends AbstractProcessorBenchmark {
+    @Override
+    protected OtlpGrpcSpanExporter createExporter(GenericContainer<?> collector) {
+      String host = collector.getHost();
+      int port = collector.getMappedPort(OTLP_PORT);
+      return OtlpGrpcSpanExporter.builder()
+          .setEndpoint("http://" + host + ":" + port)
+          .setTimeout(Duration.ofSeconds(50))
+          .build();
+    }
+
+  }
+
+  public static class JaegerBenchmark extends AbstractProcessorBenchmark {
+    @Override
+    protected JaegerThriftSpanExporter createExporter(GenericContainer<?> collector) {
+      String host = collector.getHost();
+      int port = collector.getMappedPort(JAEGER_PORT);
+      return JaegerThriftSpanExporter.builder()
+          .setEndpoint("http://" + host + ":" + port + "/api/traces")
+          .build();
+    }
+
+  }
+}

--- a/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/ExporterBenchmark.java
+++ b/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/ExporterBenchmark.java
@@ -68,7 +68,6 @@ public class ExporterBenchmark {
       sdkSpanBuilder = (SdkSpanBuilder) tracerSdk.spanBuilder("PipelineBenchmarkSpan");
     }
 
-
     @Benchmark
     @BenchmarkMode(Mode.AverageTime)
     @Warmup(iterations = 5, time = 1)
@@ -93,7 +92,6 @@ public class ExporterBenchmark {
           .setTimeout(Duration.ofSeconds(50))
           .build();
     }
-
   }
 
   public static class JaegerBenchmark extends AbstractProcessorBenchmark {
@@ -105,6 +103,5 @@ public class ExporterBenchmark {
           .setEndpoint("http://" + host + ":" + port + "/api/traces")
           .build();
     }
-
   }
 }

--- a/sdk/trace/src/jmh/resources/otel.yaml
+++ b/sdk/trace/src/jmh/resources/otel.yaml
@@ -3,10 +3,9 @@ receivers:
     protocols:
       grpc:
         endpoint: 0.0.0.0:5678
-
-processors:
-  batch:
-  queued_retry:
+  jaeger:
+    protocols:
+      thrift_http:
 
 extensions:
   health_check:
@@ -19,6 +18,5 @@ service:
   extensions: [health_check]
   pipelines:
     traces:
-      receivers: [otlp]
-      processors: [batch, queued_retry]
+      receivers: [otlp, jaeger]
       exporters: [logging]


### PR DESCRIPTION
But something strange happening here. On my machine I got the following results:

```
Benchmark                                                                                 Mode  Cnt        Score        Error   Units
ExporterBenchmark.JaegerBenchmark.createAndExportSpan                                     avgt   10  1320789.103 ± 161003.787   ns/op
ExporterBenchmark.JaegerBenchmark.createAndExportSpan:·gc.alloc.rate                      avgt   10        5.898 ±      0.520  MB/sec
ExporterBenchmark.JaegerBenchmark.createAndExportSpan:·gc.alloc.rate.norm                 avgt   10    12219.282 ±    381.806    B/op
ExporterBenchmark.JaegerBenchmark.createAndExportSpan:·gc.churn.G1_Eden_Space             avgt   10        5.303 ±     25.351  MB/sec
ExporterBenchmark.JaegerBenchmark.createAndExportSpan:·gc.churn.G1_Eden_Space.norm        avgt   10    10551.708 ±  50446.794    B/op
ExporterBenchmark.JaegerBenchmark.createAndExportSpan:·gc.churn.G1_Old_Gen                avgt   10        0.001 ±      0.004  MB/sec
ExporterBenchmark.JaegerBenchmark.createAndExportSpan:·gc.churn.G1_Old_Gen.norm           avgt   10        1.551 ±      7.414    B/op
ExporterBenchmark.JaegerBenchmark.createAndExportSpan:·gc.count                           avgt   10        1.000               counts
ExporterBenchmark.JaegerBenchmark.createAndExportSpan:·gc.time                            avgt   10        3.000                   ms
ExporterBenchmark.OtlpBenchmark.createAndExportSpan                                       avgt   10    18494.316 ±   4066.954   ns/op
ExporterBenchmark.OtlpBenchmark.createAndExportSpan:·gc.alloc.rate                        avgt   10      341.864 ±     92.993  MB/sec
ExporterBenchmark.OtlpBenchmark.createAndExportSpan:·gc.alloc.rate.norm                   avgt   10     9731.375 ±    256.630    B/op
ExporterBenchmark.OtlpBenchmark.createAndExportSpan:·gc.churn.G1_Eden_Space               avgt   10      343.365 ±     86.045  MB/sec
ExporterBenchmark.OtlpBenchmark.createAndExportSpan:·gc.churn.G1_Eden_Space.norm          avgt   10    10017.377 ±   3601.848    B/op
ExporterBenchmark.OtlpBenchmark.createAndExportSpan:·gc.churn.G1_Old_Gen                  avgt   10        0.116 ±      0.554  MB/sec
ExporterBenchmark.OtlpBenchmark.createAndExportSpan:·gc.churn.G1_Old_Gen.norm             avgt   10        3.126 ±     14.946    B/op
ExporterBenchmark.OtlpBenchmark.createAndExportSpan:·gc.churn.G1_Survivor_Space           avgt   10        6.768 ±     13.624  MB/sec
ExporterBenchmark.OtlpBenchmark.createAndExportSpan:·gc.churn.G1_Survivor_Space.norm      avgt   10      200.185 ±    408.477    B/op
ExporterBenchmark.OtlpBenchmark.createAndExportSpan:·gc.count                             avgt   10       17.000               counts
ExporterBenchmark.OtlpBenchmark.createAndExportSpan:·gc.time                              avgt   10     1394.000                   ms
```

I cannot believe that exporting one span via JaegerThrift takes more than a second. Compared with 18ms for OTLP.