### PR TITLE
Add benchmark for recording exception on a span

### DIFF
--- a/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/ExceptionBenchmark.java
+++ b/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/ExceptionBenchmark.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.trace;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Benchmark)
+public class ExceptionBenchmark {
+  private static SpanBuilder spanBuilder;
+
+  @Setup(Level.Trial)
+  public final void setup() {
+    SdkTracerProvider tracerProvider =
+        SdkTracerProvider.builder()
+            .setSampler(Sampler.alwaysOn())
+            .build();
+
+    Tracer tracer = tracerProvider.get("benchmarkTracer");
+    spanBuilder = tracer.spanBuilder("benchmarkSpanBuilder");
+  }
+
+  @Benchmark
+  @Threads(value = 1)
+  @Fork(1)
+  @Warmup(iterations = 5, time = 1)
+  @Measurement(iterations = 10, time = 1)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  @BenchmarkMode(Mode.AverageTime)
+  public Span createSpan() {
+    Span span = spanBuilder.startSpan();
+    span.end();
+    return span;
+  }
+
+  @Benchmark
+  @Threads(value = 1)
+  @Fork(1)
+  @Warmup(iterations = 5, time = 1)
+  @Measurement(iterations = 10, time = 1)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  @BenchmarkMode(Mode.AverageTime)
+  public Span createSpanAndRecordException() {
+    Span span = spanBuilder.startSpan();
+    span.recordException(new RuntimeException());
+    span.end();
+    return span;
+  }
+
+  @Benchmark
+  @Threads(value = 1)
+  @Fork(1)
+  @Warmup(iterations = 5, time = 1)
+  @Measurement(iterations = 10, time = 1)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  @BenchmarkMode(Mode.AverageTime)
+  public RuntimeException createException() {
+    return new RuntimeException();
+  }
+
+}

--- a/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/ExceptionBenchmark.java
+++ b/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/ExceptionBenchmark.java
@@ -30,9 +30,7 @@ public class ExceptionBenchmark {
   @Setup(Level.Trial)
   public final void setup() {
     SdkTracerProvider tracerProvider =
-        SdkTracerProvider.builder()
-            .setSampler(Sampler.alwaysOn())
-            .build();
+        SdkTracerProvider.builder().setSampler(Sampler.alwaysOn()).build();
 
     Tracer tracer = tracerProvider.get("benchmarkTracer");
     spanBuilder = tracer.spanBuilder("benchmarkSpanBuilder");
@@ -75,5 +73,4 @@ public class ExceptionBenchmark {
   public RuntimeException createException() {
     return new RuntimeException();
   }
-
 }


### PR DESCRIPTION
Results from my machine demonstrate that recording exception may be quite an expensive operation:

```
Benchmark                                                                     Mode  Cnt      Score      Error   Units
ExceptionBenchmark.createException                                            avgt   10   1043.408 ±   52.696   ns/op
ExceptionBenchmark.createException:·gc.alloc.rate                             avgt   10    438.773 ±   23.161  MB/sec
ExceptionBenchmark.createException:·gc.alloc.rate.norm                        avgt   10    720.000 ±    0.001    B/op
ExceptionBenchmark.createException:·gc.churn.G1_Eden_Space                    avgt   10    442.504 ±  129.812  MB/sec
ExceptionBenchmark.createException:·gc.churn.G1_Eden_Space.norm               avgt   10    724.855 ±  193.585    B/op
ExceptionBenchmark.createException:·gc.churn.G1_Old_Gen                       avgt   10      0.020 ±    0.046  MB/sec
ExceptionBenchmark.createException:·gc.churn.G1_Old_Gen.norm                  avgt   10      0.034 ±    0.078    B/op
ExceptionBenchmark.createException:·gc.churn.G1_Survivor_Space                avgt   10      0.266 ±    1.274  MB/sec
ExceptionBenchmark.createException:·gc.churn.G1_Survivor_Space.norm           avgt   10      0.440 ±    2.104    B/op
ExceptionBenchmark.createException:·gc.count                                  avgt   10     22.000             counts
ExceptionBenchmark.createException:·gc.time                                   avgt   10     21.000                 ms
ExceptionBenchmark.createSpan                                                 avgt   10    453.535 ±   46.864   ns/op
ExceptionBenchmark.createSpan:·gc.alloc.rate                                  avgt   10    461.407 ±   48.407  MB/sec
ExceptionBenchmark.createSpan:·gc.alloc.rate.norm                             avgt   10    328.000 ±    0.001    B/op
ExceptionBenchmark.createSpan:·gc.churn.G1_Eden_Space                         avgt   10    443.071 ±  128.458  MB/sec
ExceptionBenchmark.createSpan:·gc.churn.G1_Eden_Space.norm                    avgt   10    315.730 ±   91.491    B/op
ExceptionBenchmark.createSpan:·gc.churn.G1_Old_Gen                            avgt   10      0.006 ±    0.020  MB/sec
ExceptionBenchmark.createSpan:·gc.churn.G1_Old_Gen.norm                       avgt   10      0.004 ±    0.013    B/op
ExceptionBenchmark.createSpan:·gc.churn.G1_Survivor_Space                     avgt   10      0.265 ±    1.269  MB/sec
ExceptionBenchmark.createSpan:·gc.churn.G1_Survivor_Space.norm                avgt   10      0.172 ±    0.822    B/op
ExceptionBenchmark.createSpan:·gc.count                                       avgt   10     22.000             counts
ExceptionBenchmark.createSpan:·gc.time                                        avgt   10     18.000                 ms
ExceptionBenchmark.createSpanAndRecordException                               avgt   10  12022.184 ±  548.125   ns/op
ExceptionBenchmark.createSpanAndRecordException:·gc.alloc.rate                avgt   10   1153.336 ±   52.255  MB/sec
ExceptionBenchmark.createSpanAndRecordException:·gc.alloc.rate.norm           avgt   10  21824.005 ±    0.001    B/op
ExceptionBenchmark.createSpanAndRecordException:·gc.churn.G1_Eden_Space       avgt   10   1150.708 ±  147.878  MB/sec
ExceptionBenchmark.createSpanAndRecordException:·gc.churn.G1_Eden_Space.norm  avgt   10  21756.995 ± 2271.406    B/op
ExceptionBenchmark.createSpanAndRecordException:·gc.churn.G1_Old_Gen          avgt   10      0.002 ±    0.003  MB/sec
ExceptionBenchmark.createSpanAndRecordException:·gc.churn.G1_Old_Gen.norm     avgt   10      0.043 ±    0.048    B/op
ExceptionBenchmark.createSpanAndRecordException:·gc.count                     avgt   10     57.000             counts
ExceptionBenchmark.createSpanAndRecordException:·gc.time                      avgt   10     29.000                 ms
```
