### PR TITLE
Remove unneeded forEach from AttributesMap.

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/AttributesMap.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/AttributesMap.java
@@ -11,10 +11,8 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.BiConsumer;
 
 /** A map with a fixed capacity that drops attributes when the map gets full. */
-@SuppressWarnings({"rawtypes", "unchecked"})
 final class AttributesMap extends HashMap<AttributeKey<?>, Object> implements Attributes {
 
   private static final long serialVersionUID = -5072696312123632376L;
@@ -42,16 +40,6 @@ final class AttributesMap extends HashMap<AttributeKey<?>, Object> implements At
   @Override
   public <T> T get(AttributeKey<T> key) {
     return (T) super.get(key);
-  }
-
-  @SuppressWarnings({"rawtypes", "unchecked"})
-  @Override
-  public void forEach(BiConsumer<? super AttributeKey<?>, ? super Object> consumer) {
-    for (Map.Entry<AttributeKey<?>, Object> entry : entrySet()) {
-      AttributeKey key = entry.getKey();
-      Object value = entry.getValue();
-      consumer.accept((AttributeKey<?>) key, value);
-    }
   }
 
   @Override


### PR DESCRIPTION
Already implemented by HashMap more directly.