### PR TITLE
Remove unnecessary string allocation on hot path

### DIFF
--- a/api/all/src/jmh/java/io/opentelemetry/api/trace/SpanIdBenchmark.java
+++ b/api/all/src/jmh/java/io/opentelemetry/api/trace/SpanIdBenchmark.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.trace;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 15, time = 1)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Threads(1)
+public class SpanIdBenchmark {
+
+  @Benchmark
+  public byte[] getSpanIdBytes() {
+    return SpanContext.getInvalid().getSpanIdBytes();
+  }
+}

--- a/api/all/src/main/java/io/opentelemetry/api/internal/OtelEncodingUtils.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/OtelEncodingUtils.java
@@ -111,9 +111,9 @@ public final class OtelEncodingUtils {
    */
   public static byte byteFromBase16(char first, char second) {
     Utils.checkArgument(
-        first < ASCII_CHARACTERS && DECODING[first] != -1, "invalid character " + first);
+        first < ASCII_CHARACTERS && DECODING[first] != -1, () -> "invalid character " + first);
     Utils.checkArgument(
-        second < ASCII_CHARACTERS && DECODING[second] != -1, "invalid character " + second);
+        second < ASCII_CHARACTERS && DECODING[second] != -1, () -> "invalid character " + second);
     int decoded = DECODING[first] << 4 | DECODING[second];
     return (byte) decoded;
   }

--- a/api/all/src/main/java/io/opentelemetry/api/internal/Utils.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/Utils.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.api.internal;
 
+import java.util.function.Supplier;
 import javax.annotation.concurrent.Immutable;
 
 /** General internal utility methods. */
@@ -23,6 +24,19 @@ public final class Utils {
   public static void checkArgument(boolean isValid, String errorMessage) {
     if (!isValid) {
       throw new IllegalArgumentException(errorMessage);
+    }
+  }
+
+  /**
+   * Throws an {@link IllegalArgumentException} if the argument is false. This method is similar to
+   * {@code Preconditions.checkArgument(boolean, Object)} from Guava.
+   *
+   * @param isValid whether the argument check passed.
+   * @param errorMessage the supplier of the message to use for the exception.
+   */
+  public static void checkArgument(boolean isValid, Supplier<String> errorMessage) {
+    if (!isValid) {
+      throw new IllegalArgumentException(errorMessage.get());
     }
   }
 }


### PR DESCRIPTION
Benchmark results before (pay special to attention to `gc.alloc.rate.norm`):

```
Benchmark                                                    Mode  Cnt     Score     Error   Units
SpanIdBenchmark.getSpanIdBytes                               avgt   15    66.128 ±   0.299   ns/op
SpanIdBenchmark.getSpanIdBytes:·gc.alloc.rate                avgt   15  6367.137 ±  28.810  MB/sec
SpanIdBenchmark.getSpanIdBytes:·gc.alloc.rate.norm           avgt   15   664.000 ±   0.001    B/op
SpanIdBenchmark.getSpanIdBytes:·gc.churn.G1_Eden_Space       avgt   15  6373.704 ± 159.516  MB/sec
SpanIdBenchmark.getSpanIdBytes:·gc.churn.G1_Eden_Space.norm  avgt   15   664.673 ±  15.814    B/op
SpanIdBenchmark.getSpanIdBytes:·gc.churn.G1_Old_Gen          avgt   15     0.011 ±   0.004  MB/sec
SpanIdBenchmark.getSpanIdBytes:·gc.churn.G1_Old_Gen.norm     avgt   15     0.001 ±   0.001    B/op
SpanIdBenchmark.getSpanIdBytes:·gc.count                     avgt   15   267.000            counts
SpanIdBenchmark.getSpanIdBytes:·gc.time                      avgt   15   147.000                ms
```

After:
```
Benchmark                                                    Mode  Cnt    Score    Error   Units
SpanIdBenchmark.getSpanIdBytes                               avgt   15   17.189 ±  0.084   ns/op
SpanIdBenchmark.getSpanIdBytes:·gc.alloc.rate                avgt   15  885.418 ±  4.361  MB/sec
SpanIdBenchmark.getSpanIdBytes:·gc.alloc.rate.norm           avgt   15   24.000 ±  0.001    B/op
SpanIdBenchmark.getSpanIdBytes:·gc.churn.G1_Eden_Space       avgt   15  897.040 ± 55.715  MB/sec
SpanIdBenchmark.getSpanIdBytes:·gc.churn.G1_Eden_Space.norm  avgt   15   24.313 ±  1.448    B/op
SpanIdBenchmark.getSpanIdBytes:·gc.churn.G1_Old_Gen          avgt   15    0.003 ±  0.002  MB/sec
SpanIdBenchmark.getSpanIdBytes:·gc.churn.G1_Old_Gen.norm     avgt   15   ≈ 10⁻⁴             B/op
SpanIdBenchmark.getSpanIdBytes:·gc.count                     avgt   15   92.000           counts
SpanIdBenchmark.getSpanIdBytes:·gc.time                      avgt   15   39.000               ms
```