### PR TITLE
Don't create Supplier when decoding byte

### DIFF
--- a/api/all/src/jmh/java/io/opentelemetry/api/trace/SpanIdBenchmark.java
+++ b/api/all/src/jmh/java/io/opentelemetry/api/trace/SpanIdBenchmark.java
@@ -22,7 +22,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 15, time = 1)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(1)
+@Fork(3)
 @Threads(1)
 public class SpanIdBenchmark {
 

--- a/api/all/src/main/java/io/opentelemetry/api/internal/OtelEncodingUtils.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/OtelEncodingUtils.java
@@ -14,7 +14,7 @@ public final class OtelEncodingUtils {
   static final int BYTE_BASE16 = 2;
   static final int LONG_BASE16 = BYTE_BASE16 * LONG_BYTES;
   private static final String ALPHABET = "0123456789abcdef";
-  private static final int ASCII_CHARACTERS = 128;
+  private static final int NUM_ASCII_CHARACTERS = 128;
   private static final char[] ENCODING = buildEncodingArray();
   private static final byte[] DECODING = buildDecodingArray();
 
@@ -28,7 +28,7 @@ public final class OtelEncodingUtils {
   }
 
   private static byte[] buildDecodingArray() {
-    byte[] decoding = new byte[ASCII_CHARACTERS];
+    byte[] decoding = new byte[NUM_ASCII_CHARACTERS];
     Arrays.fill(decoding, (byte) -1);
     for (int i = 0; i < ALPHABET.length(); i++) {
       char c = ALPHABET.charAt(i);
@@ -110,10 +110,12 @@ public final class OtelEncodingUtils {
    * @return the resulting {@code byte}
    */
   public static byte byteFromBase16(char first, char second) {
-    Utils.checkArgument(
-        first < ASCII_CHARACTERS && DECODING[first] != -1, () -> "invalid character " + first);
-    Utils.checkArgument(
-        second < ASCII_CHARACTERS && DECODING[second] != -1, () -> "invalid character " + second);
+    if (first >= NUM_ASCII_CHARACTERS || DECODING[first] == -1) {
+      throw new IllegalArgumentException("invalid character " + first);
+    }
+    if (second >= NUM_ASCII_CHARACTERS || DECODING[second] == -1) {
+      throw new IllegalArgumentException("invalid character " + second);
+    }
     int decoded = DECODING[first] << 4 | DECODING[second];
     return (byte) decoded;
   }

--- a/api/all/src/main/java/io/opentelemetry/api/internal/Utils.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/Utils.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.api.internal;
 
-import java.util.function.Supplier;
 import javax.annotation.concurrent.Immutable;
 
 /** General internal utility methods. */
@@ -24,19 +23,6 @@ public final class Utils {
   public static void checkArgument(boolean isValid, String errorMessage) {
     if (!isValid) {
       throw new IllegalArgumentException(errorMessage);
-    }
-  }
-
-  /**
-   * Throws an {@link IllegalArgumentException} if the argument is false. This method is similar to
-   * {@code Preconditions.checkArgument(boolean, Object)} from Guava.
-   *
-   * @param isValid whether the argument check passed.
-   * @param errorMessage the supplier of the message to use for the exception.
-   */
-  public static void checkArgument(boolean isValid, Supplier<String> errorMessage) {
-    if (!isValid) {
-      throw new IllegalArgumentException(errorMessage.get());
     }
   }
 }


### PR DESCRIPTION
I realized we should avoid this too given just how hot the code path is. Over many forks I can confirm there is a significant (not huge) change in the execution time, so I guess the GC profiler somehow doesn't keep track of lambda overhead.

I considered porting over Guava's `Preconditions` handling of `%s` but figured it's not worth it, the tried and trued if statement pattern doesn't seem like much of a regression to me.

After
```
Benchmark                                                    Mode  Cnt    Score    Error   Units
SpanIdBenchmark.getSpanIdBytes                               avgt   45   22.248 ±  0.098   ns/op
SpanIdBenchmark.getSpanIdBytes:·gc.alloc.rate                avgt   45  685.071 ±  3.113  MB/sec
SpanIdBenchmark.getSpanIdBytes:·gc.alloc.rate.norm           avgt   45   24.000 ±  0.001    B/op
SpanIdBenchmark.getSpanIdBytes:·gc.churn.G1_Eden_Space       avgt   45  682.211 ± 25.920  MB/sec
SpanIdBenchmark.getSpanIdBytes:·gc.churn.G1_Eden_Space.norm  avgt   45   23.901 ±  0.910    B/op
SpanIdBenchmark.getSpanIdBytes:·gc.churn.G1_Old_Gen          avgt   45    0.002 ±  0.001  MB/sec
SpanIdBenchmark.getSpanIdBytes:·gc.churn.G1_Old_Gen.norm     avgt   45   ≈ 10⁻⁴             B/op
SpanIdBenchmark.getSpanIdBytes:·gc.count                     avgt   45  287.000           counts
SpanIdBenchmark.getSpanIdBytes:·gc.time                      avgt   45  111.000               ms
```

Before
```
Benchmark                                                    Mode  Cnt    Score    Error   Units
SpanIdBenchmark.getSpanIdBytes                               avgt   45   26.344 ±  0.101   ns/op
SpanIdBenchmark.getSpanIdBytes:·gc.alloc.rate                avgt   45  578.526 ±  2.254  MB/sec
SpanIdBenchmark.getSpanIdBytes:·gc.alloc.rate.norm           avgt   45   24.000 ±  0.001    B/op
SpanIdBenchmark.getSpanIdBytes:·gc.churn.G1_Eden_Space       avgt   45  581.850 ± 25.282  MB/sec
SpanIdBenchmark.getSpanIdBytes:·gc.churn.G1_Eden_Space.norm  avgt   45   24.143 ±  1.074    B/op
SpanIdBenchmark.getSpanIdBytes:·gc.churn.G1_Old_Gen          avgt   45    0.002 ±  0.001  MB/sec
SpanIdBenchmark.getSpanIdBytes:·gc.churn.G1_Old_Gen.norm     avgt   45   ≈ 10⁻⁴             B/op
SpanIdBenchmark.getSpanIdBytes:·gc.count                     avgt   45  230.000           counts
SpanIdBenchmark.getSpanIdBytes:·gc.time                      avgt   45   94.000               ms
```