### PR TITLE
Use constant for baggage validation bitsets

### DIFF
--- a/api/all/src/jmh/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorBenchmark.java
+++ b/api/all/src/jmh/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorBenchmark.java
@@ -32,19 +32,22 @@ public class W3CBaggagePropagatorBenchmark {
   private static final Map<String, String> LARGE_BAGGAGE;
 
   static {
-    List<String> baggages = IntStream.range(0, 100)
-        .mapToObj(i -> "key"
-            + i
-            + " = value"
-            + i
-            + ";metaKey"
-            + i
-            + "=\tmetaVal"
-            + i
-            + ",broken)key"
-            + i
-            + "=value")
-        .collect(Collectors.toList());
+    List<String> baggages =
+        IntStream.range(0, 100)
+            .mapToObj(
+                i ->
+                    "key"
+                        + i
+                        + " = value"
+                        + i
+                        + ";metaKey"
+                        + i
+                        + "=\tmetaVal"
+                        + i
+                        + ",broken)key"
+                        + i
+                        + "=value")
+            .collect(Collectors.toList());
     SMALL_BAGGAGE = Collections.singletonMap("baggage", String.join(",", baggages.subList(0, 5)));
     LARGE_BAGGAGE = Collections.singletonMap("baggage", String.join(",", baggages));
   }

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Element.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Element.java
@@ -14,6 +14,21 @@ import java.util.BitSet;
  */
 class Element {
 
+  private static final BitSet EXCLUDED_KEY_CHARS = new BitSet(128);
+  private static final BitSet EXCLUDED_VALUE_CHARS = new BitSet(128);
+
+  static {
+    for (char c :
+        new char[] {
+          '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=', '{', '}'
+        }) {
+      EXCLUDED_KEY_CHARS.set(c);
+    }
+    for (char c : new char[] {'"', ',', ';', '\\'}) {
+      EXCLUDED_VALUE_CHARS.set(c);
+    }
+  }
+
   private final BitSet excluded;
 
   private boolean leadingSpace;
@@ -22,6 +37,14 @@ class Element {
   private int start;
   private int end;
   private String value;
+
+  static Element createKeyElement() {
+    return new Element(EXCLUDED_KEY_CHARS);
+  }
+
+  static Element createValueElement() {
+    return new Element(EXCLUDED_VALUE_CHARS);
+  }
 
   /**
    * Constructs element instance.

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Element.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Element.java
@@ -51,7 +51,7 @@ class Element {
    *
    * @param excluded characters that are not allowed for this type of an element
    */
-  Element(BitSet excluded) {
+  private Element(BitSet excluded) {
     this.excluded = excluded;
     reset(0);
   }

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Element.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Element.java
@@ -14,7 +14,7 @@ import java.util.BitSet;
  */
 class Element {
 
-  private final BitSet excluded = new BitSet(128);
+  private final BitSet excluded;
 
   private boolean leadingSpace;
   private boolean readingValue;
@@ -26,12 +26,10 @@ class Element {
   /**
    * Constructs element instance.
    *
-   * @param excludedChars characters that are not allowed for this type of an element
+   * @param excluded characters that are not allowed for this type of an element
    */
-  Element(char[] excludedChars) {
-    for (char excludedChar : excludedChars) {
-      excluded.set(excludedChar);
-    }
+  Element(BitSet excluded) {
+    this.excluded = excluded;
     reset(0);
   }
 

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Parser.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Parser.java
@@ -7,7 +7,6 @@ package io.opentelemetry.api.baggage.propagation;
 
 import io.opentelemetry.api.baggage.BaggageBuilder;
 import io.opentelemetry.api.baggage.BaggageEntryMetadata;
-import java.util.BitSet;
 
 /**
  * Implements single-pass Baggage parsing in accordance with https://w3c.github.io/baggage/ Key /
@@ -19,21 +18,6 @@ import java.util.BitSet;
  */
 class Parser {
 
-  private static final BitSet EXCLUDED_KEY_CHARS = new BitSet(128);
-  private static final BitSet EXCLUDED_VALUE_CHARS = new BitSet(128);
-
-  static {
-    for (char c :
-        new char[] {
-          '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=', '{', '}'
-        }) {
-      EXCLUDED_KEY_CHARS.set(c);
-    }
-    for (char c : new char[] {'"', ',', ';', '\\'}) {
-      EXCLUDED_VALUE_CHARS.set(c);
-    }
-  }
-
   private enum State {
     KEY,
     VALUE,
@@ -42,8 +26,8 @@ class Parser {
 
   private final String baggageHeader;
 
-  private final Element key = new Element(EXCLUDED_KEY_CHARS);
-  private final Element value = new Element(EXCLUDED_VALUE_CHARS);
+  private final Element key = Element.createKeyElement();
+  private final Element value = Element.createValueElement();
   private String meta;
 
   private State state;

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Parser.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Parser.java
@@ -7,6 +7,7 @@ package io.opentelemetry.api.baggage.propagation;
 
 import io.opentelemetry.api.baggage.BaggageBuilder;
 import io.opentelemetry.api.baggage.BaggageEntryMetadata;
+import java.util.BitSet;
 
 /**
  * Implements single-pass Baggage parsing in accordance with https://w3c.github.io/baggage/ Key /
@@ -18,6 +19,21 @@ import io.opentelemetry.api.baggage.BaggageEntryMetadata;
  */
 class Parser {
 
+  private static final BitSet EXCLUDED_KEY_CHARS = new BitSet(128);
+  private static final BitSet EXCLUDED_VALUE_CHARS = new BitSet(128);
+
+  static {
+    for (char c :
+        new char[] {
+          '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=', '{', '}'
+        }) {
+      EXCLUDED_KEY_CHARS.set(c);
+    }
+    for (char c : new char[] {'"', ',', ';', '\\'}) {
+      EXCLUDED_VALUE_CHARS.set(c);
+    }
+  }
+
   private enum State {
     KEY,
     VALUE,
@@ -26,12 +42,8 @@ class Parser {
 
   private final String baggageHeader;
 
-  private final Element key =
-      new Element(
-          new char[] {
-            '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=', '{', '}'
-          });
-  private final Element value = new Element(new char[] {'"', ',', ';', '\\'});
+  private final Element key = new Element(EXCLUDED_KEY_CHARS);
+  private final Element value = new Element(EXCLUDED_VALUE_CHARS);
   private String meta;
 
   private State state;


### PR DESCRIPTION
Randomly noticed. Just small improvement

After
```
Benchmark                                                                Mode  Cnt      Score      Error   Units
W3CBaggagePropagatorBenchmark.largeBaggage                               avgt   45     42.915 ±    0.496   us/op
W3CBaggagePropagatorBenchmark.largeBaggage:·gc.alloc.rate                avgt   45    368.208 ±    4.159  MB/sec
W3CBaggagePropagatorBenchmark.largeBaggage:·gc.alloc.rate.norm           avgt   45  24872.049 ±    0.062    B/op
W3CBaggagePropagatorBenchmark.largeBaggage:·gc.churn.G1_Eden_Space       avgt   45    370.006 ±   25.219  MB/sec
W3CBaggagePropagatorBenchmark.largeBaggage:·gc.churn.G1_Eden_Space.norm  avgt   45  24992.676 ± 1681.603    B/op
W3CBaggagePropagatorBenchmark.largeBaggage:·gc.churn.G1_Old_Gen          avgt   45      0.010 ±    0.002  MB/sec
W3CBaggagePropagatorBenchmark.largeBaggage:·gc.churn.G1_Old_Gen.norm     avgt   45      0.706 ±    0.146    B/op
W3CBaggagePropagatorBenchmark.largeBaggage:·gc.count                     avgt   45    165.000             counts
W3CBaggagePropagatorBenchmark.largeBaggage:·gc.time                      avgt   45     67.000                 ms
W3CBaggagePropagatorBenchmark.smallBaggage                               avgt   45      1.923 ±    0.053   us/op
W3CBaggagePropagatorBenchmark.smallBaggage:·gc.alloc.rate                avgt   45    452.804 ±   12.043  MB/sec
W3CBaggagePropagatorBenchmark.smallBaggage:·gc.alloc.rate.norm           avgt   45   1368.002 ±    0.003    B/op
W3CBaggagePropagatorBenchmark.smallBaggage:·gc.churn.G1_Eden_Space       avgt   45    450.834 ±   26.759  MB/sec
W3CBaggagePropagatorBenchmark.smallBaggage:·gc.churn.G1_Eden_Space.norm  avgt   45   1361.720 ±   69.804    B/op
W3CBaggagePropagatorBenchmark.smallBaggage:·gc.churn.G1_Old_Gen          avgt   45      0.001 ±    0.001  MB/sec
W3CBaggagePropagatorBenchmark.smallBaggage:·gc.churn.G1_Old_Gen.norm     avgt   45      0.003 ±    0.002    B/op
W3CBaggagePropagatorBenchmark.smallBaggage:·gc.count                     avgt   45    201.000             counts
W3CBaggagePropagatorBenchmark.smallBaggage:·gc.time                      avgt   45     77.000                 ms
```

Before
```
Benchmark                                                                Mode  Cnt      Score      Error   Units
W3CBaggagePropagatorBenchmark.largeBaggage                               avgt   45     44.097 ±    0.276   us/op
W3CBaggagePropagatorBenchmark.largeBaggage:·gc.alloc.rate                avgt   45    360.876 ±    2.217  MB/sec
W3CBaggagePropagatorBenchmark.largeBaggage:·gc.alloc.rate.norm           avgt   45  25064.050 ±    0.063    B/op
W3CBaggagePropagatorBenchmark.largeBaggage:·gc.churn.G1_Eden_Space       avgt   45    363.243 ±   26.208  MB/sec
W3CBaggagePropagatorBenchmark.largeBaggage:·gc.churn.G1_Eden_Space.norm  avgt   45  25228.640 ± 1814.921    B/op
W3CBaggagePropagatorBenchmark.largeBaggage:·gc.churn.G1_Old_Gen          avgt   45      0.005 ±    0.001  MB/sec
W3CBaggagePropagatorBenchmark.largeBaggage:·gc.churn.G1_Old_Gen.norm     avgt   45      0.376 ±    0.097    B/op
W3CBaggagePropagatorBenchmark.largeBaggage:·gc.count                     avgt   45    162.000             counts
W3CBaggagePropagatorBenchmark.largeBaggage:·gc.time                      avgt   45     65.000                 ms
W3CBaggagePropagatorBenchmark.smallBaggage                               avgt   45      2.043 ±    0.049   us/op
W3CBaggagePropagatorBenchmark.smallBaggage:·gc.alloc.rate                avgt   45    485.899 ±   12.099  MB/sec
W3CBaggagePropagatorBenchmark.smallBaggage:·gc.alloc.rate.norm           avgt   45   1560.002 ±    0.003    B/op
W3CBaggagePropagatorBenchmark.smallBaggage:·gc.churn.G1_Eden_Space       avgt   45    486.558 ±   26.021  MB/sec
W3CBaggagePropagatorBenchmark.smallBaggage:·gc.churn.G1_Eden_Space.norm  avgt   45   1561.931 ±   74.079    B/op
W3CBaggagePropagatorBenchmark.smallBaggage:·gc.churn.G1_Old_Gen          avgt   45      0.001 ±    0.001  MB/sec
W3CBaggagePropagatorBenchmark.smallBaggage:·gc.churn.G1_Old_Gen.norm     avgt   45      0.004 ±    0.002    B/op
W3CBaggagePropagatorBenchmark.smallBaggage:·gc.count                     avgt   45    217.000             counts
W3CBaggagePropagatorBenchmark.smallBaggage:·gc.time                      avgt   45     84.000                 ms
```