### PR TITLE
Update the metrics autoconfigure code with support for duration units.

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
@@ -92,9 +92,9 @@ final class MetricExporterConfiguration {
         IntervalMetricReader.builder()
             .setMetricProducers(Collections.singleton(meterProvider))
             .setMetricExporter(exporter);
-    Duration exportIntervalMillis = config.getDuration("otel.imr.export.interval");
-    if (exportIntervalMillis != null) {
-      readerBuilder.setExportIntervalMillis(exportIntervalMillis.toMillis());
+    Duration exportInterval = config.getDuration("otel.imr.export.interval");
+    if (exportInterval != null) {
+      readerBuilder.setExportIntervalMillis(exportInterval.toMillis());
     }
     IntervalMetricReader reader = readerBuilder.buildAndStart();
     Runtime.getRuntime().addShutdownHook(new Thread(reader::shutdown));

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
@@ -74,9 +74,9 @@ final class MetricExporterConfiguration {
 
     config.getCommaSeparatedMap("otel.exporter.otlp.headers").forEach(builder::addHeader);
 
-    Long timeoutMillis = config.getLong("otel.exporter.otlp.timeout");
-    if (timeoutMillis != null) {
-      builder.setTimeout(Duration.ofMillis(timeoutMillis));
+    Duration timeout = config.getDuration("otel.exporter.otlp.timeout");
+    if (timeout != null) {
+      builder.setTimeout(timeout);
     }
 
     OtlpGrpcMetricExporter exporter = builder.build();
@@ -92,9 +92,9 @@ final class MetricExporterConfiguration {
         IntervalMetricReader.builder()
             .setMetricProducers(Collections.singleton(meterProvider))
             .setMetricExporter(exporter);
-    Long exportIntervalMillis = config.getLong("otel.imr.export.interval");
+    Duration exportIntervalMillis = config.getDuration("otel.imr.export.interval");
     if (exportIntervalMillis != null) {
-      readerBuilder.setExportIntervalMillis(exportIntervalMillis);
+      readerBuilder.setExportIntervalMillis(exportIntervalMillis.toMillis());
     }
     IntervalMetricReader reader = readerBuilder.buildAndStart();
     Runtime.getRuntime().addShutdownHook(new Thread(reader::shutdown));

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfigurationTest.java
@@ -7,9 +7,9 @@ package io.opentelemetry.sdk.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
-import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
@@ -20,7 +20,9 @@ class MetricExporterConfigurationTest {
     OtlpGrpcMetricExporter exporter =
         MetricExporterConfiguration.configureOtlpMetrics(
             ConfigProperties.createForTest(
-                Collections.singletonMap("otel.exporter.otlp.timeout", "10")),
+                ImmutableMap.of(
+                    "otel.exporter.otlp.timeout", "10ms",
+                    "otel.imr.export.interval", "5s")),
             SdkMeterProvider.builder().build());
     try {
       assertThat(exporter)


### PR DESCRIPTION
Even though metrics aren't stable yet, it seems good to have some configuration consistency.