### PR TITLE
Cache Resource and Instrumentationlibrary protos.

### DIFF
--- a/exporters/otlp/common/build.gradle.kts
+++ b/exporters/otlp/common/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     `java-library`
     `maven-publish`
 
+    id("me.champeau.jmh")
     id("ru.vyarus.animalsniffer")
 }
 
@@ -20,4 +21,6 @@ dependencies {
 
     testImplementation("io.grpc:grpc-testing")
     testRuntimeOnly("io.grpc:grpc-netty-shaded")
+
+    jmhImplementation(project(":sdk-extensions:resources"))
 }

--- a/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/otlp/internal/CommonAdapterBenchmark.java
+++ b/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/otlp/internal/CommonAdapterBenchmark.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal;
+
+import io.opentelemetry.proto.common.v1.InstrumentationLibrary;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode({Mode.AverageTime})
+@Fork(3)
+@Measurement(iterations = 15, time = 1)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+public class CommonAdapterBenchmark {
+
+  private static final InstrumentationLibraryInfo INFO =
+      InstrumentationLibraryInfo.create("io.opentelemetry.instrumentation.benchmark-1.0", "1.2.0");
+
+  @Benchmark
+  public InstrumentationLibrary toProto() {
+    return CommonAdapter.toProtoInstrumentationLibrary(INFO);
+  }
+}

--- a/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/otlp/internal/ResourceAdapterBenchmark.java
+++ b/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/otlp/internal/ResourceAdapterBenchmark.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal;
+
+import io.opentelemetry.sdk.extension.resources.HostResource;
+import io.opentelemetry.sdk.extension.resources.OsResource;
+import io.opentelemetry.sdk.extension.resources.ProcessResource;
+import io.opentelemetry.sdk.extension.resources.ProcessRuntimeResource;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode({Mode.AverageTime})
+@Fork(3)
+@Measurement(iterations = 15, time = 1)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+public class ResourceAdapterBenchmark {
+
+  // A default resource, which is pretty big. Resource in practice will generally be even bigger by
+  // containing cloud attributes.
+  private static final Resource RESOURCE =
+      ProcessResource.get()
+          .merge(ProcessRuntimeResource.get())
+          .merge(OsResource.get())
+          .merge(HostResource.get())
+          .merge(Resource.getDefault());
+
+  @Benchmark
+  public io.opentelemetry.proto.resource.v1.Resource toProto() {
+    return ResourceAdapter.toProtoResource(RESOURCE);
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ResourceAdapter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ResourceAdapter.java
@@ -5,15 +5,28 @@
 
 package io.opentelemetry.exporter.otlp.internal;
 
+import io.opentelemetry.context.internal.shaded.WeakConcurrentMap;
 import io.opentelemetry.proto.resource.v1.Resource;
 
 final class ResourceAdapter {
+
+  private static final WeakConcurrentMap<io.opentelemetry.sdk.resources.Resource, Resource>
+      RESOURCE_PROTO_CACHE = new WeakConcurrentMap.WithInlinedExpunction<>();
+
   static Resource toProtoResource(io.opentelemetry.sdk.resources.Resource resource) {
-    final Resource.Builder builder = Resource.newBuilder();
-    resource
-        .getAttributes()
-        .forEach((key, value) -> builder.addAttributes(CommonAdapter.toProtoAttribute(key, value)));
-    return builder.build();
+    Resource cached = RESOURCE_PROTO_CACHE.get(resource);
+    if (cached == null) {
+      // Since WeakConcurrentMap doesn't support computeIfAbsent, we may end up doing the conversion
+      // a few times until the cache gets filled which is fine.
+      Resource.Builder builder = Resource.newBuilder();
+      resource
+          .getAttributes()
+          .forEach(
+              (key, value) -> builder.addAttributes(CommonAdapter.toProtoAttribute(key, value)));
+      cached = builder.build();
+      RESOURCE_PROTO_CACHE.put(resource, cached);
+    }
+    return cached;
   }
 
   private ResourceAdapter() {}

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/CommonAdapterTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/CommonAdapterTest.java
@@ -136,11 +136,13 @@ class CommonAdapterTest {
 
   @Test
   void toProtoInstrumentationLibrary() {
+    InstrumentationLibraryInfo info = InstrumentationLibraryInfo.create("name", "version");
     InstrumentationLibrary instrumentationLibrary =
-        CommonAdapter.toProtoInstrumentationLibrary(
-            InstrumentationLibraryInfo.create("name", "version"));
+        CommonAdapter.toProtoInstrumentationLibrary(info);
     assertThat(instrumentationLibrary.getName()).isEqualTo("name");
     assertThat(instrumentationLibrary.getVersion()).isEqualTo("version");
+    // Memoized
+    assertThat(CommonAdapter.toProtoInstrumentationLibrary(info)).isSameAs(instrumentationLibrary);
   }
 
   @Test

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/ResourceAdapterTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/ResourceAdapterTest.java
@@ -18,21 +18,24 @@ import io.opentelemetry.sdk.resources.Resource;
 import org.junit.jupiter.api.Test;
 
 class ResourceAdapterTest {
+
   @Test
   void toProtoResource() {
-    assertThat(
-            ResourceAdapter.toProtoResource(
-                    Resource.create(
-                        Attributes.of(
-                            booleanKey("key_bool"),
-                            true,
-                            stringKey("key_string"),
-                            "string",
-                            longKey("key_int"),
-                            100L,
-                            doubleKey("key_double"),
-                            100.3)))
-                .getAttributesList())
+    Resource resource =
+        Resource.create(
+            Attributes.of(
+                booleanKey("key_bool"),
+                true,
+                stringKey("key_string"),
+                "string",
+                longKey("key_int"),
+                100L,
+                doubleKey("key_double"),
+                100.3));
+    io.opentelemetry.proto.resource.v1.Resource protoResource =
+        ResourceAdapter.toProtoResource(resource);
+
+    assertThat(protoResource.getAttributesList())
         .containsExactlyInAnyOrder(
             KeyValue.newBuilder()
                 .setKey("key_bool")
@@ -50,6 +53,8 @@ class ResourceAdapterTest {
                 .setKey("key_double")
                 .setValue(AnyValue.newBuilder().setDoubleValue(100.3).build())
                 .build());
+    // Memoized
+    assertThat(ResourceAdapter.toProtoResource(resource)).isSameAs(protoResource);
   }
 
   @Test


### PR DESCRIPTION
Since Resource and IL are essentially constants we can reduce GC pressure by caching conversion to proto. An interesting takeaway is Before actually GC's while After doesn't, I think it demonstrates going from affecting an app's GC to not affecting it for these two codepaths.

After
```
Benchmark                                             Mode  Cnt   Score    Error   Units
CommonAdapterBenchmark.toProto                        avgt   45  11.798 ±  0.055   ns/op
CommonAdapterBenchmark.toProto:·gc.alloc.rate         avgt   45   0.001 ±  0.001  MB/sec
CommonAdapterBenchmark.toProto:·gc.alloc.rate.norm    avgt   45  ≈ 10⁻⁵             B/op
CommonAdapterBenchmark.toProto:·gc.count              avgt   45     ≈ 0           counts
ResourceAdapterBenchmark.toProto                      avgt   45  11.933 ±  0.258   ns/op
ResourceAdapterBenchmark.toProto:·gc.alloc.rate       avgt   45   0.001 ±  0.001  MB/sec
ResourceAdapterBenchmark.toProto:·gc.alloc.rate.norm  avgt   45  ≈ 10⁻⁵             B/op
ResourceAdapterBenchmark.toProto:·gc.count            avgt   45     ≈ 0           counts
```

Before
```
Benchmark                                                      Mode  Cnt     Score    Error   Units
CommonAdapterBenchmark.toProto                                 avgt   45    16.437 ±  0.087   ns/op
CommonAdapterBenchmark.toProto:·gc.alloc.rate                  avgt   45  1544.861 ±  8.070  MB/sec
CommonAdapterBenchmark.toProto:·gc.alloc.rate.norm             avgt   45    40.000 ±  0.001    B/op
CommonAdapterBenchmark.toProto:·gc.churn.G1_Eden_Space         avgt   45  1549.997 ± 36.339  MB/sec
CommonAdapterBenchmark.toProto:·gc.churn.G1_Eden_Space.norm    avgt   45    40.130 ±  0.885    B/op
CommonAdapterBenchmark.toProto:·gc.churn.G1_Old_Gen            avgt   45     0.002 ±  0.001  MB/sec
CommonAdapterBenchmark.toProto:·gc.churn.G1_Old_Gen.norm       avgt   45    ≈ 10⁻⁴             B/op
CommonAdapterBenchmark.toProto:·gc.count                       avgt   45   423.000           counts
CommonAdapterBenchmark.toProto:·gc.time                        avgt   45   184.000               ms
ResourceAdapterBenchmark.toProto                               avgt   45   361.830 ±  8.614   ns/op
ResourceAdapterBenchmark.toProto:·gc.alloc.rate                avgt   45  2980.543 ± 52.396  MB/sec
ResourceAdapterBenchmark.toProto:·gc.alloc.rate.norm           avgt   45  1696.000 ± 12.518    B/op
ResourceAdapterBenchmark.toProto:·gc.churn.G1_Eden_Space       avgt   45  2987.938 ± 73.829  MB/sec
ResourceAdapterBenchmark.toProto:·gc.churn.G1_Eden_Space.norm  avgt   45  1700.379 ± 34.620    B/op
ResourceAdapterBenchmark.toProto:·gc.churn.G1_Old_Gen          avgt   45     0.003 ±  0.001  MB/sec
ResourceAdapterBenchmark.toProto:·gc.churn.G1_Old_Gen.norm     avgt   45     0.002 ±  0.001    B/op
ResourceAdapterBenchmark.toProto:·gc.count                     avgt   45   624.000           counts
ResourceAdapterBenchmark.toProto:·gc.time                      avgt   45   307.000               ms
```