### PR TITLE
Performance tweaks to SpanAdapter

### DIFF
--- a/exporters/otlp/common/build.gradle.kts
+++ b/exporters/otlp/common/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     `java-library`
     `maven-publish`
 
+    id("me.champeau.jmh")
     id("ru.vyarus.animalsniffer")
 }
 
@@ -20,4 +21,7 @@ dependencies {
 
     testImplementation("io.grpc:grpc-testing")
     testRuntimeOnly("io.grpc:grpc-netty-shaded")
+
+    jmhImplementation(project(":sdk:testing"))
+    jmhImplementation(project(":sdk-extensions:resources"))
 }

--- a/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/otlp/internal/SpanAdapterBenchmark.java
+++ b/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/otlp/internal/SpanAdapterBenchmark.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal;
+
+import static io.opentelemetry.api.common.AttributeKey.booleanKey;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.extension.resources.HostResource;
+import io.opentelemetry.sdk.extension.resources.OsResource;
+import io.opentelemetry.sdk.extension.resources.ProcessResource;
+import io.opentelemetry.sdk.extension.resources.ProcessRuntimeResource;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.testing.trace.TestSpanData;
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode({Mode.AverageTime})
+@Fork(3)
+@Measurement(iterations = 15, time = 1)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1)
+public class SpanAdapterBenchmark {
+  // A default resource, which is pretty big. Resource in practice will generally be even bigger by
+  // containing cloud attributes.
+  private static final Resource RESOURCE =
+      ProcessResource.get()
+          .merge(ProcessRuntimeResource.get())
+          .merge(OsResource.get())
+          .merge(HostResource.get())
+          .merge(Resource.getDefault());
+
+  private static final InstrumentationLibraryInfo LIBRARY1 =
+      InstrumentationLibraryInfo.create("io.opentelemetry.instrumentation.benchmark-1.0", "1.2.0");
+  private static final InstrumentationLibraryInfo LIBRARY2 =
+      InstrumentationLibraryInfo.create("io.opentelemetry.instrumentation.benchmark-2.0", "1.3.0");
+  private static final InstrumentationLibraryInfo LIBRARY3 =
+      InstrumentationLibraryInfo.create("io.opentelemetry.instrumentation.benchmark-3.0", "1.4.0");
+
+  private static final String TRACE_ID = "0102030405060708090a0b0c0d0e0f00";
+  private static final String SPAN_ID = "090a0b0c0d0e0f00";
+  private static final SpanContext SPAN_CONTEXT =
+      SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault());
+
+  // One resource, 3 libraries, 2 spans each.
+  private static final List<SpanData> SPANS =
+      Arrays.asList(
+          spanData(LIBRARY1),
+          spanData(LIBRARY1),
+          spanData(LIBRARY2),
+          spanData(LIBRARY2),
+          spanData(LIBRARY3),
+          spanData(LIBRARY3));
+
+  @Benchmark
+  public List<ResourceSpans> toProto() {
+    return SpanAdapter.toProtoResourceSpans(SPANS);
+  }
+
+  private static SpanData spanData(InstrumentationLibraryInfo library) {
+    return TestSpanData.builder()
+        .setHasEnded(true)
+        .setSpanContext(SPAN_CONTEXT)
+        .setParentSpanContext(SpanContext.getInvalid())
+        .setName("GET /api/endpoint")
+        .setKind(SpanKind.SERVER)
+        .setStartEpochNanos(12345)
+        .setEndEpochNanos(12349)
+        .setAttributes(Attributes.of(booleanKey("key"), true))
+        .setTotalAttributeCount(2)
+        .setEvents(
+            Collections.singletonList(EventData.create(12347, "my_event", Attributes.empty())))
+        .setTotalRecordedEvents(3)
+        .setLinks(Collections.singletonList(LinkData.create(SPAN_CONTEXT)))
+        .setTotalRecordedLinks(2)
+        .setStatus(StatusData.ok())
+        .setResource(RESOURCE)
+        .setInstrumentationLibraryInfo(library)
+        .build();
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/CommonAdapter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/CommonAdapter.java
@@ -16,7 +16,6 @@ import java.util.List;
 final class CommonAdapter {
   @SuppressWarnings("unchecked")
   public static KeyValue toProtoAttribute(AttributeKey<?> key, Object value) {
-    KeyValue.Builder builder = KeyValue.newBuilder().setKey(key.getKey());
     switch (key.getType()) {
       case STRING:
         return makeStringKeyValue(key, (String) value);
@@ -35,7 +34,10 @@ final class CommonAdapter {
       case STRING_ARRAY:
         return makeStringArrayKeyValue(key, (List<String>) value);
     }
-    return builder.setValue(AnyValue.getDefaultInstance()).build();
+    return KeyValue.newBuilder()
+        .setKey(key.getKey())
+        .setValue(AnyValue.getDefaultInstance())
+        .build();
   }
 
   private static KeyValue makeLongArrayKeyValue(AttributeKey<?> key, List<Long> value) {

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/SpanAdapter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/SpanAdapter.java
@@ -69,14 +69,13 @@ public final class SpanAdapter {
           List<InstrumentationLibrarySpans> instrumentationLibrarySpans =
               new ArrayList<>(librarySpans.size());
           librarySpans.forEach(
-              (library, spans) -> {
-                instrumentationLibrarySpans.add(
-                    InstrumentationLibrarySpans.newBuilder()
-                        .setInstrumentationLibrary(
-                            CommonAdapter.toProtoInstrumentationLibrary(library))
-                        .addAllSpans(spans)
-                        .build());
-              });
+              (library, spans) ->
+                  instrumentationLibrarySpans.add(
+                      InstrumentationLibrarySpans.newBuilder()
+                          .setInstrumentationLibrary(
+                              CommonAdapter.toProtoInstrumentationLibrary(library))
+                          .addAllSpans(spans)
+                          .build()));
           resourceSpans.add(
               ResourceSpans.newBuilder()
                   .setResource(ResourceAdapter.toProtoResource(resource))

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/SpanAdapter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/SpanAdapter.java
@@ -36,6 +36,9 @@ import java.util.Map;
 /** Converter from SDK {@link SpanData} to OTLP {@link ResourceSpans}. */
 public final class SpanAdapter {
 
+  // In practice, there is often only one thread that calls this code in the BatchSpanProcessor so
+  // reusing buffers for the thread is almost free. Even with multiple threads, it should still be
+  // worth it and is common practice in serialization libraries such as Jackson.
   private static final ThreadLocal<ThreadLocalCache> THREAD_LOCAL_CACHE = new ThreadLocal<>();
 
   // Still set DeprecatedCode
@@ -79,6 +82,7 @@ public final class SpanAdapter {
                               CommonAdapter.toProtoInstrumentationLibrary(library))
                           .addAllSpans(spans)
                           .build()));
+          resourceSpans.add(resourceSpansBuilder.build());
         });
     return resourceSpans;
   }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/SpanAdapter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/SpanAdapter.java
@@ -64,25 +64,25 @@ public final class SpanAdapter {
     Map<Resource, Map<InstrumentationLibraryInfo, List<Span>>> resourceAndLibraryMap =
         groupByResourceAndLibrary(spanDataList);
     List<ResourceSpans> resourceSpans = new ArrayList<>(resourceAndLibraryMap.size());
-    for (Map.Entry<Resource, Map<InstrumentationLibraryInfo, List<Span>>> entryResource :
-        resourceAndLibraryMap.entrySet()) {
-      List<InstrumentationLibrarySpans> instrumentationLibrarySpans =
-          new ArrayList<>(entryResource.getValue().size());
-      for (Map.Entry<InstrumentationLibraryInfo, List<Span>> entryLibrary :
-          entryResource.getValue().entrySet()) {
-        instrumentationLibrarySpans.add(
-            InstrumentationLibrarySpans.newBuilder()
-                .setInstrumentationLibrary(
-                    CommonAdapter.toProtoInstrumentationLibrary(entryLibrary.getKey()))
-                .addAllSpans(entryLibrary.getValue())
-                .build());
-      }
-      resourceSpans.add(
-          ResourceSpans.newBuilder()
-              .setResource(ResourceAdapter.toProtoResource(entryResource.getKey()))
-              .addAllInstrumentationLibrarySpans(instrumentationLibrarySpans)
-              .build());
-    }
+    resourceAndLibraryMap.forEach(
+        (resource, librarySpans) -> {
+          List<InstrumentationLibrarySpans> instrumentationLibrarySpans =
+              new ArrayList<>(librarySpans.size());
+          librarySpans.forEach(
+              (library, spans) -> {
+                instrumentationLibrarySpans.add(
+                    InstrumentationLibrarySpans.newBuilder()
+                        .setInstrumentationLibrary(
+                            CommonAdapter.toProtoInstrumentationLibrary(library))
+                        .addAllSpans(spans)
+                        .build());
+              });
+          resourceSpans.add(
+              ResourceSpans.newBuilder()
+                  .setResource(ResourceAdapter.toProtoResource(resource))
+                  .addAllInstrumentationLibrarySpans(instrumentationLibrarySpans)
+                  .build());
+        });
     return resourceSpans;
   }
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/SpanAdapter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/SpanAdapter.java
@@ -70,21 +70,16 @@ public final class SpanAdapter {
     List<ResourceSpans> resourceSpans = new ArrayList<>(resourceAndLibraryMap.size());
     resourceAndLibraryMap.forEach(
         (resource, librarySpans) -> {
-          List<InstrumentationLibrarySpans> instrumentationLibrarySpans =
-              new ArrayList<>(librarySpans.size());
+          ResourceSpans.Builder resourceSpansBuilder =
+              ResourceSpans.newBuilder().setResource(ResourceAdapter.toProtoResource(resource));
           librarySpans.forEach(
               (library, spans) ->
-                  instrumentationLibrarySpans.add(
+                  resourceSpansBuilder.addInstrumentationLibrarySpans(
                       InstrumentationLibrarySpans.newBuilder()
                           .setInstrumentationLibrary(
                               CommonAdapter.toProtoInstrumentationLibrary(library))
                           .addAllSpans(spans)
                           .build()));
-          resourceSpans.add(
-              ResourceSpans.newBuilder()
-                  .setResource(ResourceAdapter.toProtoResource(resource))
-                  .addAllInstrumentationLibrarySpans(instrumentationLibrarySpans)
-                  .build());
         });
     return resourceSpans;
   }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/SpanAdapter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/SpanAdapter.java
@@ -144,6 +144,8 @@ public final class SpanAdapter {
     builder.setDroppedLinksCount(spanData.getTotalRecordedLinks() - spanData.getLinks().size());
     builder.setStatus(toStatusProto(spanData.getStatus()));
     Span span = builder.build();
+    // We reuse the builder instance to create multiple spans to reduce allocation of intermediary
+    // storage. It means we MUST clear here or we'd keep on building on the same object.
     builder.clear();
     return span;
   }
@@ -175,6 +177,8 @@ public final class SpanAdapter {
     builder.setDroppedAttributesCount(
         event.getTotalAttributeCount() - event.getAttributes().size());
     Span.Event built = builder.build();
+    // We reuse the builder instance to create multiple spans to reduce allocation of intermediary
+    // storage. It means we MUST clear here or we'd keep on building on the same object.
     builder.clear();
     return built;
   }
@@ -198,6 +202,8 @@ public final class SpanAdapter {
 
     builder.setDroppedAttributesCount(link.getTotalAttributeCount() - attributes.size());
     Span.Link built = builder.build();
+    // We reuse the builder instance to create multiple spans to reduce allocation of intermediary
+    // storage. It means we MUST clear here or we'd keep on building on the same object.
     builder.clear();
     return built;
   }

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/SpanAdapterTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/SpanAdapterTest.java
@@ -69,7 +69,8 @@ class SpanAdapterTest {
                 .setLinks(Collections.singletonList(LinkData.create(SPAN_CONTEXT)))
                 .setTotalRecordedLinks(2)
                 .setStatus(StatusData.ok())
-                .build());
+                .build(),
+            Collections.emptyMap());
 
     assertThat(span.getTraceId().toByteArray()).isEqualTo(TRACE_ID_BYTES);
     assertThat(span.getSpanId().toByteArray()).isEqualTo(SPAN_ID_BYTES);
@@ -176,7 +177,7 @@ class SpanAdapterTest {
 
   @Test
   void toProtoSpanLink_WithoutAttributes() {
-    assertThat(SpanAdapter.toProtoSpanLink(LinkData.create(SPAN_CONTEXT)))
+    assertThat(SpanAdapter.toProtoSpanLink(LinkData.create(SPAN_CONTEXT), Collections.emptyMap()))
         .isEqualTo(
             Span.Link.newBuilder()
                 .setTraceId(ByteString.copyFrom(TRACE_ID_BYTES))
@@ -188,7 +189,8 @@ class SpanAdapterTest {
   void toProtoSpanLink_WithAttributes() {
     assertThat(
             SpanAdapter.toProtoSpanLink(
-                LinkData.create(SPAN_CONTEXT, Attributes.of(stringKey("key_string"), "string"), 5)))
+                LinkData.create(SPAN_CONTEXT, Attributes.of(stringKey("key_string"), "string"), 5),
+                Collections.emptyMap()))
         .isEqualTo(
             Span.Link.newBuilder()
                 .setTraceId(ByteString.copyFrom(TRACE_ID_BYTES))

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/SpanAdapterTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/SpanAdapterTest.java
@@ -37,6 +37,7 @@ import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import java.util.Collections;
+import java.util.HashMap;
 import org.junit.jupiter.api.Test;
 
 class SpanAdapterTest {
@@ -70,7 +71,7 @@ class SpanAdapterTest {
                 .setTotalRecordedLinks(2)
                 .setStatus(StatusData.ok())
                 .build(),
-            Collections.emptyMap());
+            new HashMap<>());
 
     assertThat(span.getTraceId().toByteArray()).isEqualTo(TRACE_ID_BYTES);
     assertThat(span.getSpanId().toByteArray()).isEqualTo(SPAN_ID_BYTES);
@@ -177,7 +178,7 @@ class SpanAdapterTest {
 
   @Test
   void toProtoSpanLink_WithoutAttributes() {
-    assertThat(SpanAdapter.toProtoSpanLink(LinkData.create(SPAN_CONTEXT), Collections.emptyMap()))
+    assertThat(SpanAdapter.toProtoSpanLink(LinkData.create(SPAN_CONTEXT), new HashMap<>()))
         .isEqualTo(
             Span.Link.newBuilder()
                 .setTraceId(ByteString.copyFrom(TRACE_ID_BYTES))
@@ -190,7 +191,7 @@ class SpanAdapterTest {
     assertThat(
             SpanAdapter.toProtoSpanLink(
                 LinkData.create(SPAN_CONTEXT, Attributes.of(stringKey("key_string"), "string"), 5),
-                Collections.emptyMap()))
+                new HashMap<>()))
         .isEqualTo(
             Span.Link.newBuilder()
                 .setTraceId(ByteString.copyFrom(TRACE_ID_BYTES))


### PR DESCRIPTION
- Don't allocate `KeyValue.Builder` when not used
- Use singleton `Status` proto if no description
- `computeIfAbsent` / forEach because Java 8 now
- Cache ID bytes conversion (we'll expect many cache hits for trace ID, and some cache hits for span ID which are parents of other spans)

After
```
Benchmark                                                  Mode  Cnt     Score     Error   Units
SpanAdapterBenchmark.toProto                               avgt   45     2.803 ±   0.013   us/op
SpanAdapterBenchmark.toProto:·gc.alloc.rate                avgt   45  1692.960 ±   8.383  MB/sec
SpanAdapterBenchmark.toProto:·gc.alloc.rate.norm           avgt   45  7472.003 ±  12.027    B/op
SpanAdapterBenchmark.toProto:·gc.churn.G1_Eden_Space       avgt   45  1694.252 ±  43.026  MB/sec
SpanAdapterBenchmark.toProto:·gc.churn.G1_Eden_Space.norm  avgt   45  7477.808 ± 187.806    B/op
SpanAdapterBenchmark.toProto:·gc.churn.G1_Old_Gen          avgt   45     0.004 ±   0.001  MB/sec
SpanAdapterBenchmark.toProto:·gc.churn.G1_Old_Gen.norm     avgt   45     0.017 ±   0.004    B/op
SpanAdapterBenchmark.toProto:·gc.count                     avgt   45   462.000            counts
SpanAdapterBenchmark.toProto:·gc.time                      avgt   45   211.000                ms
```

Before
```
Benchmark                                                  Mode  Cnt      Score     Error   Units
SpanAdapterBenchmark.toProto                               avgt   45      3.459 ±   0.143   us/op
SpanAdapterBenchmark.toProto:·gc.alloc.rate                avgt   45   1862.199 ±  53.989  MB/sec
SpanAdapterBenchmark.toProto:·gc.alloc.rate.norm           avgt   45  10101.337 ±  82.186    B/op
SpanAdapterBenchmark.toProto:·gc.churn.G1_Eden_Space       avgt   45   1866.701 ±  66.144  MB/sec
SpanAdapterBenchmark.toProto:·gc.churn.G1_Eden_Space.norm  avgt   45  10122.074 ± 193.132    B/op
SpanAdapterBenchmark.toProto:·gc.churn.G1_Old_Gen          avgt   45      0.006 ±   0.001  MB/sec
SpanAdapterBenchmark.toProto:·gc.churn.G1_Old_Gen.norm     avgt   45      0.033 ±   0.007    B/op
SpanAdapterBenchmark.toProto:·gc.count                     avgt   45    551.000            counts
SpanAdapterBenchmark.toProto:·gc.time                      avgt   45    238.000                ms
```