### PR TITLE
Fix the javadoc link for the logging-otlp exporter

### DIFF
--- a/exporters/logging-otlp/README.md
+++ b/exporters/logging-otlp/README.md
@@ -5,5 +5,5 @@
 Exporters for writing data to logs using OTLP JSON format. They are appropriate for writing spans or
 metrics to logs in a way that is both human-readable and structured for machine parsing.
 
-[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporters-otlpjson.svg
-[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporters-otlpjson
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporter-logging-otlp.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporter-logging-otlp


### PR DESCRIPTION
fixes #3283 