### PR TITLE
Use switch instead of enummap for status creation

### DIFF
--- a/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/StatusBenchmark.java
+++ b/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/StatusBenchmark.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.trace;
+
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Threads(value = 1)
+@BenchmarkMode(Mode.AverageTime)
+@Fork(3)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class StatusBenchmark {
+
+  @Benchmark
+  public StatusData createWithoutDescription() {
+    return StatusData.create(StatusCode.UNSET, "");
+  }
+}

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/ImmutableStatusData.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/ImmutableStatusData.java
@@ -8,7 +8,6 @@ package io.opentelemetry.sdk.trace.data;
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
-import java.util.EnumMap;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -32,25 +31,6 @@ abstract class ImmutableStatusData implements StatusData {
   /** The operation contains an error. */
   static final StatusData ERROR = createInternal(StatusCode.ERROR, "");
 
-  // Visible for test
-  static final EnumMap<StatusCode, StatusData> codeToStatus = new EnumMap<>(StatusCode.class);
-
-  static {
-    codeToStatus.put(StatusCode.UNSET, StatusData.unset());
-    codeToStatus.put(StatusCode.OK, StatusData.ok());
-    codeToStatus.put(StatusCode.ERROR, StatusData.error());
-
-    // Ensure all values are in the map, even if we don't have constants defined.
-    // This can happen if the API version is newer than the SDK and new values were added there.
-    StatusCode[] codes = StatusCode.values();
-    for (StatusCode code : codes) {
-      StatusData status = codeToStatus.get(code);
-      if (status == null) {
-        codeToStatus.put(code, createInternal(code, ""));
-      }
-    }
-  }
-
   /**
    * Creates a derived instance of {@code Status} with the given description.
    *
@@ -59,7 +39,14 @@ abstract class ImmutableStatusData implements StatusData {
    */
   static StatusData create(StatusCode statusCode, String description) {
     if (description == null || description.isEmpty()) {
-      return codeToStatus.get(statusCode);
+      switch (statusCode) {
+        case UNSET:
+          return StatusData.unset();
+        case OK:
+          return StatusData.ok();
+        case ERROR:
+          return StatusData.error();
+      }
     }
     return createInternal(statusCode, description);
   }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/data/ImmutableStatusDataTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/data/ImmutableStatusDataTest.java
@@ -10,17 +10,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.api.trace.StatusCode;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link ImmutableStatusData}. */
 class ImmutableStatusDataTest {
   @Test
-  void defaultConstants() {
+  void statuses() {
     StatusCode[] codes = StatusCode.values();
-    assertThat(codes).hasSize(3);
-    assertThat(StatusData.unset().getStatusCode()).isEqualTo(StatusCode.UNSET);
-    assertThat(StatusData.unset().getDescription()).isEmpty();
-    assertThat(StatusData.ok().getStatusCode()).isEqualTo(StatusCode.OK);
-    assertThat(StatusData.ok().getDescription()).isEmpty();
-    assertThat(StatusData.error().getStatusCode()).isEqualTo(StatusCode.ERROR);
-    assertThat(StatusData.error().getDescription()).isEmpty();
+    for (StatusCode code : codes) {
+      StatusData status = ImmutableStatusData.create(code, "");
+      switch (code) {
+        case UNSET:
+          assertThat(status).isSameAs(StatusData.unset());
+          break;
+        case OK:
+          assertThat(status).isSameAs(StatusData.ok());
+          break;
+        case ERROR:
+          assertThat(status).isSameAs(StatusData.error());
+          break;
+      }
+      assertThat(status).isNotNull();
+      assertThat(status.getStatusCode()).isEqualTo(code);
+      assertThat(status.getDescription()).isEmpty();
+    }
   }
 }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/data/ImmutableStatusDataTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/data/ImmutableStatusDataTest.java
@@ -23,15 +23,4 @@ class ImmutableStatusDataTest {
     assertThat(StatusData.error().getStatusCode()).isEqualTo(StatusCode.ERROR);
     assertThat(StatusData.error().getDescription()).isEmpty();
   }
-
-  @Test
-  void generateCodeToStatus() {
-    StatusCode[] codes = StatusCode.values();
-    assertThat(ImmutableStatusData.codeToStatus).hasSize(codes.length);
-    for (StatusCode code : codes) {
-      assertThat(ImmutableStatusData.codeToStatus.get(code)).isNotNull();
-      assertThat(ImmutableStatusData.codeToStatus.get(code).getStatusCode()).isEqualTo(code);
-      assertThat(ImmutableStatusData.codeToStatus.get(code).getDescription()).isEmpty();
-    }
-  }
 }


### PR DESCRIPTION
For a complete enum-switch, Java bytecode is a table lookup within the bytecode so always beats a memory lookup via EnumMap. More importantly, it's way less code

After (Ran benchmarks before setting to more appropriate AverageTime and too lazy to rerun for an obvious improvement, higher is better)
```
Benchmark                                                      Mode  Cnt   Score    Error   Units
StatusBenchmark.createWithoutDescription                      thrpt   30   0.384 ±  0.004  ops/ns
StatusBenchmark.createWithoutDescription:·gc.alloc.rate       thrpt   30  ≈ 10⁻⁴           MB/sec
StatusBenchmark.createWithoutDescription:·gc.alloc.rate.norm  thrpt   30  ≈ 10⁻⁶             B/op
StatusBenchmark.createWithoutDescription:·gc.count            thrpt   30     ≈ 0           counts
```

Before
```
Benchmark                                                      Mode  Cnt   Score    Error   Units
StatusBenchmark.createWithoutDescription                      thrpt   30   0.231 ±  0.003  ops/ns
StatusBenchmark.createWithoutDescription:·gc.alloc.rate       thrpt   30  ≈ 10⁻⁴           MB/sec
StatusBenchmark.createWithoutDescription:·gc.alloc.rate.norm  thrpt   30  ≈ 10⁻⁶             B/op
StatusBenchmark.createWithoutDescription:·gc.count            thrpt   30     ≈ 0           counts
```