### PR TITLE
Small tweak to name of internal method.

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -299,7 +299,7 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
         EventData.create(
             clock.now(),
             name,
-            copyAndLimitAttributes(attributes, spanLimits.getMaxNumberOfAttributesPerEvent()),
+            ensureAttributesLimit(attributes, spanLimits.getMaxNumberOfAttributesPerEvent()),
             totalAttributeCount));
     return this;
   }
@@ -317,13 +317,13 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
         EventData.create(
             unit.toNanos(timestamp),
             name,
-            copyAndLimitAttributes(attributes, spanLimits.getMaxNumberOfAttributesPerEvent()),
+            ensureAttributesLimit(attributes, spanLimits.getMaxNumberOfAttributesPerEvent()),
             totalAttributeCount));
     return this;
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})
-  static Attributes copyAndLimitAttributes(final Attributes attributes, final int limit) {
+  static Attributes ensureAttributesLimit(final Attributes attributes, final int limit) {
     if (attributes.isEmpty() || attributes.size() <= limit) {
       return attributes;
     }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -299,7 +299,7 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
         EventData.create(
             clock.now(),
             name,
-            ensureAttributesLimit(attributes, spanLimits.getMaxNumberOfAttributesPerEvent()),
+            applyAttributesLimit(attributes, spanLimits.getMaxNumberOfAttributesPerEvent()),
             totalAttributeCount));
     return this;
   }
@@ -317,13 +317,13 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
         EventData.create(
             unit.toNanos(timestamp),
             name,
-            ensureAttributesLimit(attributes, spanLimits.getMaxNumberOfAttributesPerEvent()),
+            applyAttributesLimit(attributes, spanLimits.getMaxNumberOfAttributesPerEvent()),
             totalAttributeCount));
     return this;
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})
-  static Attributes ensureAttributesLimit(final Attributes attributes, final int limit) {
+  static Attributes applyAttributesLimit(final Attributes attributes, final int limit) {
     if (attributes.isEmpty() || attributes.size() <= limit) {
       return attributes;
     }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java
@@ -105,7 +105,7 @@ final class SdkSpanBuilder implements SpanBuilder {
     addLink(
         LinkData.create(
             spanContext,
-            RecordEventsReadableSpan.copyAndLimitAttributes(
+            RecordEventsReadableSpan.ensureAttributesLimit(
                 attributes, spanLimits.getMaxNumberOfAttributesPerLink()),
             totalAttributeCount));
     return this;

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java
@@ -105,7 +105,7 @@ final class SdkSpanBuilder implements SpanBuilder {
     addLink(
         LinkData.create(
             spanContext,
-            RecordEventsReadableSpan.ensureAttributesLimit(
+            RecordEventsReadableSpan.applyAttributesLimit(
                 attributes, spanLimits.getMaxNumberOfAttributesPerLink()),
             totalAttributeCount));
     return this;


### PR DESCRIPTION
When reading code, randomly found this method which was a bit confusing since it doesn't always copy, only when it is ensuring a limit.