### PR TITLE
Use autoconfigure SPI for trace-propagators extension.

### DIFF
--- a/extensions/trace-propagators/build.gradle.kts
+++ b/extensions/trace-propagators/build.gradle.kts
@@ -12,6 +12,8 @@ extra["moduleName"] = "io.opentelemetry.extension.trace.propagation"
 dependencies {
     api(project(":api:all"))
 
+    compileOnly(project(":sdk-extensions:autoconfigure"))
+
     testImplementation("io.jaegertracing:jaeger-client")
     testImplementation("com.google.guava:guava")
 

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3ConfigurablePropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3ConfigurablePropagator.java
@@ -12,7 +12,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
  * A {@link ConfigurablePropagatorProvider} which allows enabling the {@linkplain
  * B3Propagator#injectingSingleHeader()} B3-single propagator} with the propagator name {@code b3}.
  */
-public class B3ConfigurablePropagator implements ConfigurablePropagatorProvider {
+public final class B3ConfigurablePropagator implements ConfigurablePropagatorProvider {
   @Override
   public TextMapPropagator getPropagator() {
     return B3Propagator.injectingSingleHeader();

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3ConfigurablePropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3ConfigurablePropagator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.extension.trace.propagation;
+
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
+
+/**
+ * A {@link ConfigurablePropagatorProvider} which allows enabling the {@linkplain
+ * B3Propagator#injectingSingleHeader()} B3-single propagator} with the propagator name {@code b3}.
+ */
+public class B3ConfigurablePropagator implements ConfigurablePropagatorProvider {
+  @Override
+  public TextMapPropagator getPropagator() {
+    return B3Propagator.injectingSingleHeader();
+  }
+
+  @Override
+  public String getName() {
+    return "b3";
+  }
+}

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3MultiConfigurablePropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3MultiConfigurablePropagator.java
@@ -13,7 +13,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
  * B3Propagator#injectingMultiHeaders() B3-multi propagator} with the propagator name {@code
  * b3multi}.
  */
-public class B3MultiConfigurablePropagator implements ConfigurablePropagatorProvider {
+public final class B3MultiConfigurablePropagator implements ConfigurablePropagatorProvider {
   @Override
   public TextMapPropagator getPropagator() {
     return B3Propagator.injectingMultiHeaders();

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3MultiConfigurablePropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3MultiConfigurablePropagator.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.extension.trace.propagation;
+
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
+
+/**
+ * A {@link ConfigurablePropagatorProvider} which allows enabling the {@linkplain
+ * B3Propagator#injectingMultiHeaders() B3-multi propagator} with the propagator name {@code
+ * b3multi}.
+ */
+public class B3MultiConfigurablePropagator implements ConfigurablePropagatorProvider {
+  @Override
+  public TextMapPropagator getPropagator() {
+    return B3Propagator.injectingMultiHeaders();
+  }
+
+  @Override
+  public String getName() {
+    return "b3multi";
+  }
+}

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/JaegerConfigurablePropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/JaegerConfigurablePropagator.java
@@ -12,7 +12,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
  * A {@link ConfigurablePropagatorProvider} which allows enabling the {@link JaegerPropagator} with
  * the propagator name {@code jaeger}.
  */
-public class JaegerConfigurablePropagator implements ConfigurablePropagatorProvider {
+public final class JaegerConfigurablePropagator implements ConfigurablePropagatorProvider {
   @Override
   public TextMapPropagator getPropagator() {
     return JaegerPropagator.getInstance();

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/JaegerConfigurablePropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/JaegerConfigurablePropagator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.extension.trace.propagation;
+
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
+
+/**
+ * A {@link ConfigurablePropagatorProvider} which allows enabling the {@link JaegerPropagator} with
+ * the propagator name {@code jaeger}.
+ */
+public class JaegerConfigurablePropagator implements ConfigurablePropagatorProvider {
+  @Override
+  public TextMapPropagator getPropagator() {
+    return JaegerPropagator.getInstance();
+  }
+
+  @Override
+  public String getName() {
+    return "jaeger";
+  }
+}

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/OtTraceConfigurablePropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/OtTraceConfigurablePropagator.java
@@ -12,7 +12,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
  * A {@link ConfigurablePropagatorProvider} which allows enabling the {@link OtTracePropagator} with
  * the propagator name {@code ottrace}.
  */
-public class OtTraceConfigurablePropagator implements ConfigurablePropagatorProvider {
+public final class OtTraceConfigurablePropagator implements ConfigurablePropagatorProvider {
   @Override
   public TextMapPropagator getPropagator() {
     return OtTracePropagator.getInstance();

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/OtTraceConfigurablePropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/OtTraceConfigurablePropagator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.extension.trace.propagation;
+
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
+
+/**
+ * A {@link ConfigurablePropagatorProvider} which allows enabling the {@link OtTracePropagator} with
+ * the propagator name {@code ottrace}.
+ */
+public class OtTraceConfigurablePropagator implements ConfigurablePropagatorProvider {
+  @Override
+  public TextMapPropagator getPropagator() {
+    return OtTracePropagator.getInstance();
+  }
+
+  @Override
+  public String getName() {
+    return "ottrace";
+  }
+}

--- a/extensions/trace-propagators/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider
+++ b/extensions/trace-propagators/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider
@@ -1,0 +1,4 @@
+io.opentelemetry.extension.trace.propagation.B3ConfigurablePropagator
+io.opentelemetry.extension.trace.propagation.B3MultiConfigurablePropagator
+io.opentelemetry.extension.trace.propagation.JaegerConfigurablePropagator
+io.opentelemetry.extension.trace.propagation.OtTraceConfigurablePropagator

--- a/sdk-extensions/autoconfigure/build.gradle.kts
+++ b/sdk-extensions/autoconfigure/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
 
     implementation(project(":semconv"))
 
-    compileOnly(project(":extensions:trace-propagators"))
     compileOnly(project(":exporters:jaeger"))
     compileOnly(project(":exporters:logging"))
     compileOnly(project(":exporters:otlp:all"))

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/PropagatorConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/PropagatorConfiguration.java
@@ -9,9 +9,6 @@ import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.extension.trace.propagation.B3Propagator;
-import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
-import io.opentelemetry.extension.trace.propagation.OtTracePropagator;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -54,29 +51,14 @@ final class PropagatorConfiguration {
       return W3CBaggagePropagator.getInstance();
     }
 
-    // Other propagators are in the extension artifact. Check one of the propagators.
-    ClasspathUtil.checkClassExists(
-        "io.opentelemetry.extension.trace.propagation.B3Propagator",
-        name + " propagator",
-        "opentelemetry-extension-trace-propagators");
-
-    switch (name) {
-      case "b3":
-        return B3Propagator.injectingSingleHeader();
-      case "b3multi":
-        return B3Propagator.injectingMultiHeaders();
-      case "jaeger":
-        return JaegerPropagator.getInstance();
-        // NB: https://github.com/open-telemetry/opentelemetry-specification/pull/1406
-      case "ottrace":
-        return OtTracePropagator.getInstance();
-      default:
-        TextMapPropagator spiPropagator = spiPropagators.get(name);
-        if (spiPropagator != null) {
-          return spiPropagator;
-        }
-        throw new ConfigurationException("Unrecognized value for otel.propagators: " + name);
+    TextMapPropagator spiPropagator = spiPropagators.get(name);
+    if (spiPropagator != null) {
+      return spiPropagator;
     }
+    throw new ConfigurationException(
+        "Unrecognized value for otel.propagators: "
+            + name
+            + ". Make sure the artifact including the propagator is on the classpath.");
   }
 
   private PropagatorConfiguration() {}

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/NotOnClasspathTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/NotOnClasspathTest.java
@@ -93,8 +93,6 @@ class NotOnClasspathTest {
                     ConfigProperties.createForTest(
                         Collections.singletonMap("otel.propagators", "b3"))))
         .isInstanceOf(ConfigurationException.class)
-        .hasMessageContaining(
-            "b3 propagator enabled but opentelemetry-extension-trace-propagators not found on "
-                + "classpath");
+        .hasMessageContaining("Unrecognized value for otel.propagators: b3");
   }
 }

--- a/sdk-extensions/autoconfigure/src/testConfigError/java/io/opentelemetry/sdk/autoconfigure/ConfigErrorTest.java
+++ b/sdk-extensions/autoconfigure/src/testConfigError/java/io/opentelemetry/sdk/autoconfigure/ConfigErrorTest.java
@@ -30,7 +30,9 @@ class ConfigErrorTest {
   void invalidPropagator() {
     assertThatThrownBy(OpenTelemetrySdkAutoConfiguration::initialize)
         .isInstanceOf(ConfigurationException.class)
-        .hasMessage("Unrecognized value for otel.propagators: cat");
+        .hasMessage(
+            "Unrecognized value for otel.propagators: cat. Make sure the artifact "
+                + "including the propagator is on the classpath.");
   }
 
   @Test


### PR DESCRIPTION
While I'm not exactly sure what @kenfinnigan will do with them, if there's a use case I don't see anything wrong with this since the autoconfigure dep isn't leaked at all.

https://github.com/open-telemetry/opentelemetry-java/discussions/3284