### PR TITLE
CHANGELOG updates for release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased:
 
+---
+## Version 1.3.0 - 2021-06-09
+
 ### API
 #### Enhancements
 - Parsing of the W3C Baggage header has been optimized.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ is published under the `io.opentelemetry.extension.noopapi` name.
 - The `io.opentelemetry.sdk.autoconfigure` module now supports the `OTEL_SERVICE_NAME`/`otel.service.name`
 environment variable/system property for configuring the SDK's `Resource` implementation.
 
+### Metrics (alpha)
+- The autoconfiguration code for metrics now supports durations to be provided with units attached to them (eg. "`100ms`"). This includes
+the following environment variables/system properties:
+  - `OTEL_EXPORTER_OTLP_TIMEOUT`/`otel.exporter.otlp.timeout`
+  - `OTEL_IMR_EXPORT_INTERVAL`/`otel.imr.export.interval`
+
 ---
 
 ## Version 1.2.0 - 2021-05-07


### PR DESCRIPTION
also adds a missing apidiffs change from an already merged PR