### PR TITLE
Introduce usage of the OpenTelemetry schema with a Tracer/MeterBuilder

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
@@ -7,6 +7,7 @@ package io.opentelemetry.api;
 
 import io.opentelemetry.api.internal.GuardedBy;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerBuilder;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import java.lang.reflect.InvocationTargetException;
@@ -127,23 +128,17 @@ public final class GlobalOpenTelemetry {
   }
 
   /**
-   * Gets or creates a named and versioned tracer instance from the globally registered {@link
-   * TracerProvider}.
+   * Creates a TracerBuilder for a named {@link Tracer} instance.
    *
-   * <p>This is a shortcut method for {@code getTracerProvider().get(instrumentationName,
-   * instrumentationVersion, schemaUrl)}
+   * <p>This is a shortcut method for {@code get().tracerBuilder(instrumentationName)}
    *
    * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.
-   * @param instrumentationVersion The version of the instrumentation library (e.g., "1.0.0").
-   * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation
-   *     library.
-   * @return a tracer instance.
+   *     instrument*ed* library.
+   * @return a TracerBuilder instance.
    * @since 1.4.0
    */
-  public static Tracer getTracer(
-      String instrumentationName, @Nullable String instrumentationVersion, String schemaUrl) {
-    return get().getTracer(instrumentationName, instrumentationVersion, schemaUrl);
+  public static TracerBuilder tracerBuilder(String instrumentationName) {
+    return get().tracerBuilder(instrumentationName);
   }
 
   /**

--- a/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
@@ -131,7 +131,7 @@ public final class GlobalOpenTelemetry {
    * TracerProvider}.
    *
    * <p>This is a shortcut method for {@code getTracerProvider().get(instrumentationName,
-   * instrumentationVersion)}
+   * instrumentationVersion, schemaUrl)}
    *
    * @param instrumentationName The name of the instrumentation library, not the name of the
    *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.

--- a/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
@@ -127,6 +127,25 @@ public final class GlobalOpenTelemetry {
   }
 
   /**
+   * Gets or creates a named and versioned tracer instance from the globally registered {@link
+   * TracerProvider}.
+   *
+   * <p>This is a shortcut method for {@code getTracerProvider().get(instrumentationName,
+   * instrumentationVersion)}
+   *
+   * @param instrumentationName The name of the instrumentation library, not the name of the
+   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.
+   * @param instrumentationVersion The version of the instrumentation library (e.g., "1.0.0").
+   * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation
+   *     library.
+   * @return a tracer instance.
+   */
+  public static Tracer getTracer(
+      String instrumentationName, String instrumentationVersion, String schemaUrl) {
+    return get().getTracer(instrumentationName, instrumentationVersion, schemaUrl);
+  }
+
+  /**
    * Unsets the global {@link OpenTelemetry}. This is only meant to be used from tests which need to
    * reconfigure {@link OpenTelemetry}.
    */

--- a/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
@@ -139,9 +139,10 @@ public final class GlobalOpenTelemetry {
    * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation
    *     library.
    * @return a tracer instance.
+   * @since 1.4.0
    */
   public static Tracer getTracer(
-      String instrumentationName, String instrumentationVersion, String schemaUrl) {
+      String instrumentationName, @Nullable String instrumentationVersion, String schemaUrl) {
     return get().getTracer(instrumentationName, instrumentationVersion, schemaUrl);
   }
 

--- a/api/all/src/main/java/io/opentelemetry/api/OpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/OpenTelemetry.java
@@ -63,6 +63,22 @@ public interface OpenTelemetry {
     return getTracerProvider().get(instrumentationName, instrumentationVersion);
   }
 
+  /**
+   * Gets or creates a named and versioned tracer instance from the {@link TracerProvider} in this
+   * {@link OpenTelemetry}.
+   *
+   * @param instrumentationName The name of the instrumentation library, not the name of the
+   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.
+   * @param instrumentationVersion The version of the instrumentation library (e.g., "1.0.0").
+   * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation
+   *     library.
+   * @return a tracer instance.
+   */
+  default Tracer getTracer(
+      String instrumentationName, String instrumentationVersion, String schemaUrl) {
+    return getTracerProvider().get(instrumentationName, instrumentationVersion, schemaUrl);
+  }
+
   /** Returns the {@link ContextPropagators} for this {@link OpenTelemetry}. */
   ContextPropagators getPropagators();
 }

--- a/api/all/src/main/java/io/opentelemetry/api/OpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/OpenTelemetry.java
@@ -8,6 +8,7 @@ package io.opentelemetry.api;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
+import javax.annotation.Nullable;
 
 /**
  * The entrypoint to telemetry functionality for tracing, metrics and baggage.
@@ -73,9 +74,10 @@ public interface OpenTelemetry {
    * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation
    *     library.
    * @return a tracer instance.
+   * @since 1.4.0
    */
   default Tracer getTracer(
-      String instrumentationName, String instrumentationVersion, String schemaUrl) {
+      String instrumentationName, @Nullable String instrumentationVersion, String schemaUrl) {
     return getTracerProvider().get(instrumentationName, instrumentationVersion, schemaUrl);
   }
 

--- a/api/all/src/main/java/io/opentelemetry/api/OpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/OpenTelemetry.java
@@ -6,9 +6,9 @@
 package io.opentelemetry.api;
 
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerBuilder;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
-import javax.annotation.Nullable;
 
 /**
  * The entrypoint to telemetry functionality for tracing, metrics and baggage.
@@ -65,20 +65,15 @@ public interface OpenTelemetry {
   }
 
   /**
-   * Gets or creates a named and versioned tracer instance from the {@link TracerProvider} in this
-   * {@link OpenTelemetry}.
+   * Creates a {@link TracerBuilder} for a named {@link Tracer} instance.
    *
    * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.
-   * @param instrumentationVersion The version of the instrumentation library (e.g., "1.0.0").
-   * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation
-   *     library.
-   * @return a tracer instance.
+   *     instrument*ed* library.
+   * @return a TracerBuilder instance.
    * @since 1.4.0
    */
-  default Tracer getTracer(
-      String instrumentationName, @Nullable String instrumentationVersion, String schemaUrl) {
-    return getTracerProvider().get(instrumentationName, instrumentationVersion, schemaUrl);
+  default TracerBuilder tracerBuilder(String instrumentationName) {
+    return getTracerProvider().tracerBuilder(instrumentationName);
   }
 
   /** Returns the {@link ContextPropagators} for this {@link OpenTelemetry}. */

--- a/api/all/src/main/java/io/opentelemetry/api/trace/DefaultTracerBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/DefaultTracerBuilder.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.trace;
+
+class DefaultTracerBuilder implements TracerBuilder {
+  private static final DefaultTracerBuilder INSTANCE = new DefaultTracerBuilder();
+
+  static TracerBuilder getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public TracerBuilder setSchemaUrl(String schemaUrl) {
+    return this;
+  }
+
+  @Override
+  public TracerBuilder setInstrumentationVersion(String instrumentationVersion) {
+    return this;
+  }
+
+  @Override
+  public Tracer build() {
+    return DefaultTracer.getInstance();
+  }
+}

--- a/api/all/src/main/java/io/opentelemetry/api/trace/TracerBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/TracerBuilder.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.trace;
+
+/**
+ * Builder class for creating {@link Tracer} instances.
+ *
+ * @since 1.4.0
+ */
+public interface TracerBuilder {
+
+  /**
+   * Assign an OpenTelemetry schema URL to the resulting Tracer.
+   *
+   * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation
+   *     library.
+   * @return this
+   */
+  TracerBuilder setSchemaUrl(String schemaUrl);
+
+  /**
+   * Assign a version to the instrumentation library that is using the resulting Tracer.
+   *
+   * @param instrumentationVersion The version of the instrumentation library.
+   * @return this
+   */
+  TracerBuilder setInstrumentationVersion(String instrumentationVersion);
+
+  /**
+   * Gets or creates a {@link Tracer} instance.
+   *
+   * @return a {@link Tracer} instance configured with the provided options.
+   */
+  Tracer build();
+}

--- a/api/all/src/main/java/io/opentelemetry/api/trace/TracerProvider.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/TracerProvider.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.api.trace;
 
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -49,23 +48,14 @@ public interface TracerProvider {
   Tracer get(String instrumentationName, String instrumentationVersion);
 
   /**
-   * Gets or creates a named and versioned tracer instance associated with a specific version of the
-   * OpenTelemetry schema.
+   * Creates a TracerBuilder for a named {@link Tracer} instance.
    *
    * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null. If the
-   *     instrumented library is providing its own instrumentation, this should match the library
-   *     name.
-   * @param instrumentationVersion The version of the instrumentation library (e.g., "1.0.0").
-   * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation
-   *     library.
-   * @return a tracer instance.
+   *     instrument*ed* library.
+   * @return a TracerBuilder instance.
    * @since 1.4.0
    */
-  default Tracer get(
-      String instrumentationName, @Nullable String instrumentationVersion, String schemaUrl) {
-    return instrumentationVersion == null
-        ? get(instrumentationName)
-        : get(instrumentationName, instrumentationVersion);
+  default TracerBuilder tracerBuilder(String instrumentationName) {
+    return DefaultTracerBuilder.getInstance();
   }
 }

--- a/api/all/src/main/java/io/opentelemetry/api/trace/TracerProvider.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/TracerProvider.java
@@ -60,6 +60,7 @@ public interface TracerProvider {
    * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation
    *     library.
    * @return a tracer instance.
+   * @since 1.4.0
    */
   default Tracer get(
       String instrumentationName, @Nullable String instrumentationVersion, String schemaUrl) {

--- a/api/all/src/main/java/io/opentelemetry/api/trace/TracerProvider.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/TracerProvider.java
@@ -46,4 +46,21 @@ public interface TracerProvider {
    * @return a tracer instance.
    */
   Tracer get(String instrumentationName, String instrumentationVersion);
+
+  /**
+   * Gets or creates a named and versioned tracer instance associated with a specific version of the
+   * OpenTelemetry schema.
+   *
+   * @param instrumentationName The name of the instrumentation library, not the name of the
+   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null. If the
+   *     instrumented library is providing its own instrumentation, this should match the library
+   *     name.
+   * @param instrumentationVersion The version of the instrumentation library (e.g., "1.0.0").
+   * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation
+   *     library.
+   * @return a tracer instance.
+   */
+  default Tracer get(String instrumentationName, String instrumentationVersion, String schemaUrl) {
+    return get(instrumentationName, instrumentationVersion);
+  }
 }

--- a/api/all/src/main/java/io/opentelemetry/api/trace/TracerProvider.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/TracerProvider.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.api.trace;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -60,7 +61,10 @@ public interface TracerProvider {
    *     library.
    * @return a tracer instance.
    */
-  default Tracer get(String instrumentationName, String instrumentationVersion, String schemaUrl) {
-    return get(instrumentationName, instrumentationVersion);
+  default Tracer get(
+      String instrumentationName, @Nullable String instrumentationVersion, String schemaUrl) {
+    return instrumentationVersion == null
+        ? get(instrumentationName)
+        : get(instrumentationName, instrumentationVersion);
   }
 }

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/DefaultMeterBuilder.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/DefaultMeterBuilder.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.metrics;
+
+class DefaultMeterBuilder implements MeterBuilder {
+  private static final MeterBuilder INSTANCE = new DefaultMeterBuilder();
+
+  static MeterBuilder getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public MeterBuilder setSchemaUrl(String schemaUrl) {
+    return this;
+  }
+
+  @Override
+  public MeterBuilder setInstrumentationVersion(String instrumentationVersion) {
+    return this;
+  }
+
+  @Override
+  public Meter build() {
+    return DefaultMeter.getInstance();
+  }
+}

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/GlobalMeterProvider.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/GlobalMeterProvider.java
@@ -68,4 +68,23 @@ public final class GlobalMeterProvider {
   public static Meter getMeter(String instrumentationName, String instrumentationVersion) {
     return get().get(instrumentationName, instrumentationVersion);
   }
+
+  /**
+   * Gets or creates a named and versioned meter instance from the globally registered {@link
+   * MeterProvider}.
+   *
+   * <p>This is a shortcut method for {@code getGlobalMeterProvider().get(instrumentationName,
+   * instrumentationVersion)}
+   *
+   * @param instrumentationName The name of the instrumentation library, not the name of the
+   *     instrument*ed* library.
+   * @param instrumentationVersion The version of the instrumentation library.
+   * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation
+   *     library.
+   * @return a tracer instance.
+   */
+  public static Meter getMeter(
+      String instrumentationName, String instrumentationVersion, String schemaUrl) {
+    return get().get(instrumentationName, instrumentationVersion, schemaUrl);
+  }
 }

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/GlobalMeterProvider.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/GlobalMeterProvider.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.api.metrics;
 
 import java.util.concurrent.atomic.AtomicReference;
-import javax.annotation.Nullable;
 
 /**
  * IMPORTANT: This is a temporary class, and solution for the metrics package until it will be
@@ -71,22 +70,16 @@ public final class GlobalMeterProvider {
   }
 
   /**
-   * Gets or creates a named and versioned meter instance from the globally registered {@link
-   * MeterProvider}.
+   * Creates a {@link MeterBuilder} for a named meter instance.
    *
-   * <p>This is a shortcut method for {@code getGlobalMeterProvider().get(instrumentationName,
-   * instrumentationVersion)}
+   * <p>This is a shortcut method for {@code get().meterBuilder(instrumentationName)}
    *
    * @param instrumentationName The name of the instrumentation library, not the name of the
    *     instrument*ed* library.
-   * @param instrumentationVersion The version of the instrumentation library.
-   * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation
-   *     library.
-   * @return a tracer instance.
+   * @return a MeterBuilder instance.
    * @since 1.4.0
    */
-  public static Meter getMeter(
-      String instrumentationName, @Nullable String instrumentationVersion, String schemaUrl) {
-    return get().get(instrumentationName, instrumentationVersion, schemaUrl);
+  public static MeterBuilder meterBuilder(String instrumentationName) {
+    return get().meterBuilder(instrumentationName);
   }
 }

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/GlobalMeterProvider.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/GlobalMeterProvider.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.api.metrics;
 
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
 
 /**
  * IMPORTANT: This is a temporary class, and solution for the metrics package until it will be
@@ -82,9 +83,10 @@ public final class GlobalMeterProvider {
    * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation
    *     library.
    * @return a tracer instance.
+   * @since 1.4.0
    */
   public static Meter getMeter(
-      String instrumentationName, String instrumentationVersion, String schemaUrl) {
+      String instrumentationName, @Nullable String instrumentationVersion, String schemaUrl) {
     return get().get(instrumentationName, instrumentationVersion, schemaUrl);
   }
 }

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/MeterBuilder.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/MeterBuilder.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.metrics;
+
+/**
+ * Builder class for creating {@link Meter} instances.
+ *
+ * @since 1.4.0
+ */
+public interface MeterBuilder {
+
+  /**
+   * Assign an OpenTelemetry schema URL to the resulting Meter.
+   *
+   * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation
+   *     library.
+   * @return this
+   */
+  MeterBuilder setSchemaUrl(String schemaUrl);
+
+  /**
+   * Assign a version to the instrumentation library that is using the resulting Meter.
+   *
+   * @param instrumentationVersion The version of the instrumentation library.
+   * @return this
+   */
+  MeterBuilder setInstrumentationVersion(String instrumentationVersion);
+
+  /**
+   * Gets or creates a {@link Meter} instance.
+   *
+   * @return a {@link Meter} instance configured with the provided options.
+   */
+  Meter build();
+}

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/MeterProvider.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/MeterProvider.java
@@ -54,6 +54,7 @@ public interface MeterProvider {
    * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation
    *     library.
    * @return a tracer instance.
+   * @since 1.4.0
    */
   default Meter get(
       String instrumentationName, @Nullable String instrumentationVersion, String schemaUrl) {

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/MeterProvider.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/MeterProvider.java
@@ -42,4 +42,19 @@ public interface MeterProvider {
    * @return a tracer instance.
    */
   Meter get(String instrumentationName, String instrumentationVersion);
+
+  /**
+   * Gets or creates a named and versioned meter instance associated with a specific version of *
+   * the OpenTelemetry schema.
+   *
+   * @param instrumentationName The name of the instrumentation library, not the name of the
+   *     instrument*ed* library.
+   * @param instrumentationVersion The version of the instrumentation library.
+   * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation
+   *     library.
+   * @return a tracer instance.
+   */
+  default Meter get(String instrumentationName, String instrumentationVersion, String schemaUrl) {
+    return get(instrumentationName, instrumentationVersion);
+  }
 }

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/MeterProvider.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/MeterProvider.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.api.metrics;
 
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -45,21 +44,14 @@ public interface MeterProvider {
   Meter get(String instrumentationName, String instrumentationVersion);
 
   /**
-   * Gets or creates a named and versioned meter instance associated with a specific version of *
-   * the OpenTelemetry schema.
+   * Creates a MeterBuilder for a named meter instance.
    *
    * @param instrumentationName The name of the instrumentation library, not the name of the
    *     instrument*ed* library.
-   * @param instrumentationVersion The version of the instrumentation library.
-   * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation
-   *     library.
-   * @return a tracer instance.
+   * @return a MeterBuilder instance.
    * @since 1.4.0
    */
-  default Meter get(
-      String instrumentationName, @Nullable String instrumentationVersion, String schemaUrl) {
-    return instrumentationVersion == null
-        ? get(instrumentationName)
-        : get(instrumentationName, instrumentationVersion);
+  default MeterBuilder meterBuilder(String instrumentationName) {
+    return DefaultMeterBuilder.getInstance();
   }
 }

--- a/api/metrics/src/main/java/io/opentelemetry/api/metrics/MeterProvider.java
+++ b/api/metrics/src/main/java/io/opentelemetry/api/metrics/MeterProvider.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.api.metrics;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -54,7 +55,10 @@ public interface MeterProvider {
    *     library.
    * @return a tracer instance.
    */
-  default Meter get(String instrumentationName, String instrumentationVersion, String schemaUrl) {
-    return get(instrumentationName, instrumentationVersion);
+  default Meter get(
+      String instrumentationName, @Nullable String instrumentationVersion, String schemaUrl) {
+    return instrumentationVersion == null
+        ? get(instrumentationName)
+        : get(instrumentationName, instrumentationVersion);
   }
 }

--- a/api/metrics/src/test/java/io/opentelemetry/api/metrics/DefaultMeterTest.java
+++ b/api/metrics/src/test/java/io/opentelemetry/api/metrics/DefaultMeterTest.java
@@ -15,5 +15,7 @@ class DefaultMeterTest {
     assertThat(MeterProvider.noop().get("test")).isInstanceOf(DefaultMeter.class);
     assertThat(MeterProvider.noop().get("test")).isSameAs(DefaultMeter.getInstance());
     assertThat(MeterProvider.noop().get("test", "0.1.0")).isSameAs(DefaultMeter.getInstance());
+    assertThat(MeterProvider.noop().get("test", "0.1.0", "http://url"))
+        .isSameAs(DefaultMeter.getInstance());
   }
 }

--- a/api/metrics/src/test/java/io/opentelemetry/api/metrics/DefaultMeterTest.java
+++ b/api/metrics/src/test/java/io/opentelemetry/api/metrics/DefaultMeterTest.java
@@ -15,7 +15,12 @@ class DefaultMeterTest {
     assertThat(MeterProvider.noop().get("test")).isInstanceOf(DefaultMeter.class);
     assertThat(MeterProvider.noop().get("test")).isSameAs(DefaultMeter.getInstance());
     assertThat(MeterProvider.noop().get("test", "0.1.0")).isSameAs(DefaultMeter.getInstance());
-    assertThat(MeterProvider.noop().get("test", "0.1.0", "http://url"))
+    assertThat(
+            MeterProvider.noop()
+                .meterBuilder("test")
+                .setInstrumentationVersion("0.1.0")
+                .setSchemaUrl("http://url")
+                .build())
         .isSameAs(DefaultMeter.getInstance());
   }
 }

--- a/docs/apidiffs/current_vs_latest/opentelemetry-api.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-api.txt
@@ -1,2 +1,10 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.api.GlobalOpenTelemetry  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.api.trace.Tracer getTracer(java.lang.String, java.lang.String, java.lang.String)
+***! MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.api.OpenTelemetry  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++! NEW METHOD: PUBLIC(+) io.opentelemetry.api.trace.Tracer getTracer(java.lang.String, java.lang.String, java.lang.String)
+***! MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.api.trace.TracerProvider  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++! NEW METHOD: PUBLIC(+) io.opentelemetry.api.trace.Tracer get(java.lang.String, java.lang.String, java.lang.String)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-api.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-api.txt
@@ -1,10 +1,16 @@
 Comparing source compatibility of  against 
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.api.GlobalOpenTelemetry  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.api.trace.Tracer getTracer(java.lang.String, java.lang.String, java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.api.trace.TracerBuilder tracerBuilder(java.lang.String)
 ***! MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.api.OpenTelemetry  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++! NEW METHOD: PUBLIC(+) io.opentelemetry.api.trace.Tracer getTracer(java.lang.String, java.lang.String, java.lang.String)
+	+++! NEW METHOD: PUBLIC(+) io.opentelemetry.api.trace.TracerBuilder tracerBuilder(java.lang.String)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.trace.TracerBuilder  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.trace.Tracer build()
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.trace.TracerBuilder setInstrumentationVersion(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.trace.TracerBuilder setSchemaUrl(java.lang.String)
 ***! MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.api.trace.TracerProvider  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++! NEW METHOD: PUBLIC(+) io.opentelemetry.api.trace.Tracer get(java.lang.String, java.lang.String, java.lang.String)
+	+++! NEW METHOD: PUBLIC(+) io.opentelemetry.api.trace.TracerBuilder tracerBuilder(java.lang.String)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-extension-trace-propagators.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-extension-trace-propagators.txt
@@ -1,2 +1,25 @@
 Comparing source compatibility of  against 
-No changes.
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.extension.trace.propagation.B3ConfigurablePropagator  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW CONSTRUCTOR: PUBLIC(+) B3ConfigurablePropagator()
+	+++  NEW METHOD: PUBLIC(+) java.lang.String getName()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.context.propagation.TextMapPropagator getPropagator()
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.extension.trace.propagation.B3MultiConfigurablePropagator  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW CONSTRUCTOR: PUBLIC(+) B3MultiConfigurablePropagator()
+	+++  NEW METHOD: PUBLIC(+) java.lang.String getName()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.context.propagation.TextMapPropagator getPropagator()
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.extension.trace.propagation.JaegerConfigurablePropagator  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW CONSTRUCTOR: PUBLIC(+) JaegerConfigurablePropagator()
+	+++  NEW METHOD: PUBLIC(+) java.lang.String getName()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.context.propagation.TextMapPropagator getPropagator()
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.extension.trace.propagation.OtTraceConfigurablePropagator  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW CONSTRUCTOR: PUBLIC(+) OtTraceConfigurablePropagator()
+	+++  NEW METHOD: PUBLIC(+) java.lang.String getName()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.context.propagation.TextMapPropagator getPropagator()

--- a/docs/apidiffs/current_vs_latest/opentelemetry-extension-trace-propagators.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-extension-trace-propagators.txt
@@ -1,25 +1,2 @@
 Comparing source compatibility of  against 
-+++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.extension.trace.propagation.B3ConfigurablePropagator  (not serializable)
-	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
-	+++  NEW SUPERCLASS: java.lang.Object
-	+++  NEW CONSTRUCTOR: PUBLIC(+) B3ConfigurablePropagator()
-	+++  NEW METHOD: PUBLIC(+) java.lang.String getName()
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.context.propagation.TextMapPropagator getPropagator()
-+++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.extension.trace.propagation.B3MultiConfigurablePropagator  (not serializable)
-	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
-	+++  NEW SUPERCLASS: java.lang.Object
-	+++  NEW CONSTRUCTOR: PUBLIC(+) B3MultiConfigurablePropagator()
-	+++  NEW METHOD: PUBLIC(+) java.lang.String getName()
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.context.propagation.TextMapPropagator getPropagator()
-+++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.extension.trace.propagation.JaegerConfigurablePropagator  (not serializable)
-	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
-	+++  NEW SUPERCLASS: java.lang.Object
-	+++  NEW CONSTRUCTOR: PUBLIC(+) JaegerConfigurablePropagator()
-	+++  NEW METHOD: PUBLIC(+) java.lang.String getName()
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.context.propagation.TextMapPropagator getPropagator()
-+++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.extension.trace.propagation.OtTraceConfigurablePropagator  (not serializable)
-	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
-	+++  NEW SUPERCLASS: java.lang.Object
-	+++  NEW CONSTRUCTOR: PUBLIC(+) OtTraceConfigurablePropagator()
-	+++  NEW METHOD: PUBLIC(+) java.lang.String getName()
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.context.propagation.TextMapPropagator getPropagator()
+No changes.

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-common.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-common.txt
@@ -1,2 +1,6 @@
 Comparing source compatibility of  against 
-No changes.
+**** MODIFIED CLASS: PUBLIC ABSTRACT io.opentelemetry.sdk.common.InstrumentationLibraryInfo  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.common.InstrumentationLibraryInfo create(java.lang.String, java.lang.String, java.lang.String)
+	+++* NEW METHOD: PUBLIC(+) ABSTRACT(+) java.lang.String getSchemaUrl()
+		+++  NEW ANNOTATION: javax.annotation.Nullable

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.SdkTracerProvider  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.trace.Tracer get(java.lang.String, java.lang.String, java.lang.String)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
@@ -1,4 +1,4 @@
 Comparing source compatibility of  against 
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.SdkTracerProvider  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.trace.Tracer get(java.lang.String, java.lang.String, java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.trace.TracerBuilder tracerBuilder(java.lang.String)

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MetricAdapter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MetricAdapter.java
@@ -58,15 +58,7 @@ public final class MetricAdapter {
           new ArrayList<>(entryResource.getValue().size());
       for (Map.Entry<InstrumentationLibraryInfo, List<Metric>> entryLibrary :
           entryResource.getValue().entrySet()) {
-        InstrumentationLibraryMetrics.Builder metricsBuilder =
-            InstrumentationLibraryMetrics.newBuilder()
-                .setInstrumentationLibrary(
-                    CommonAdapter.toProtoInstrumentationLibrary(entryLibrary.getKey()))
-                .addAllMetrics(entryLibrary.getValue());
-        if (entryLibrary.getKey().getSchemaUrl() != null) {
-          metricsBuilder.setSchemaUrl(entryLibrary.getKey().getSchemaUrl());
-        }
-        instrumentationLibraryMetrics.add(metricsBuilder.build());
+        instrumentationLibraryMetrics.add(buildInstrumentationLibraryMetrics(entryLibrary));
       }
       resourceMetrics.add(
           ResourceMetrics.newBuilder()
@@ -75,6 +67,19 @@ public final class MetricAdapter {
               .build());
     }
     return resourceMetrics;
+  }
+
+  private static InstrumentationLibraryMetrics buildInstrumentationLibraryMetrics(
+      Map.Entry<InstrumentationLibraryInfo, List<Metric>> entryLibrary) {
+    InstrumentationLibraryMetrics.Builder metricsBuilder =
+        InstrumentationLibraryMetrics.newBuilder()
+            .setInstrumentationLibrary(
+                CommonAdapter.toProtoInstrumentationLibrary(entryLibrary.getKey()))
+            .addAllMetrics(entryLibrary.getValue());
+    if (entryLibrary.getKey().getSchemaUrl() != null) {
+      metricsBuilder.setSchemaUrl(entryLibrary.getKey().getSchemaUrl());
+    }
+    return metricsBuilder.build();
   }
 
   private static Map<Resource, Map<InstrumentationLibraryInfo, List<Metric>>>

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MetricAdapter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MetricAdapter.java
@@ -58,12 +58,15 @@ public final class MetricAdapter {
           new ArrayList<>(entryResource.getValue().size());
       for (Map.Entry<InstrumentationLibraryInfo, List<Metric>> entryLibrary :
           entryResource.getValue().entrySet()) {
-        instrumentationLibraryMetrics.add(
+        InstrumentationLibraryMetrics.Builder metricsBuilder =
             InstrumentationLibraryMetrics.newBuilder()
                 .setInstrumentationLibrary(
                     CommonAdapter.toProtoInstrumentationLibrary(entryLibrary.getKey()))
-                .addAllMetrics(entryLibrary.getValue())
-                .build());
+                .addAllMetrics(entryLibrary.getValue());
+        if (entryLibrary.getKey().getSchemaUrl() != null) {
+          metricsBuilder.setSchemaUrl(entryLibrary.getKey().getSchemaUrl());
+        }
+        instrumentationLibraryMetrics.add(metricsBuilder.build());
       }
       resourceMetrics.add(
           ResourceMetrics.newBuilder()

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/SpanAdapter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/SpanAdapter.java
@@ -76,19 +76,24 @@ public final class SpanAdapter {
               ResourceSpans.newBuilder().setResource(ResourceAdapter.toProtoResource(resource));
           librarySpans.forEach(
               (library, spans) -> {
-                InstrumentationLibrarySpans.Builder spansBuilder =
-                    InstrumentationLibrarySpans.newBuilder()
-                        .setInstrumentationLibrary(
-                            CommonAdapter.toProtoInstrumentationLibrary(library))
-                        .addAllSpans(spans);
-                if (library.getSchemaUrl() != null) {
-                  spansBuilder.setSchemaUrl(library.getSchemaUrl());
-                }
-                resourceSpansBuilder.addInstrumentationLibrarySpans(spansBuilder.build());
+                resourceSpansBuilder.addInstrumentationLibrarySpans(
+                    buildInstrumentationLibrarySpan(library, spans));
               });
           resourceSpans.add(resourceSpansBuilder.build());
         });
     return resourceSpans;
+  }
+
+  private static InstrumentationLibrarySpans buildInstrumentationLibrarySpan(
+      InstrumentationLibraryInfo library, List<Span> spans) {
+    InstrumentationLibrarySpans.Builder spansBuilder =
+        InstrumentationLibrarySpans.newBuilder()
+            .setInstrumentationLibrary(CommonAdapter.toProtoInstrumentationLibrary(library))
+            .addAllSpans(spans);
+    if (library.getSchemaUrl() != null) {
+      spansBuilder.setSchemaUrl(library.getSchemaUrl());
+    }
+    return spansBuilder.build();
   }
 
   private static Map<Resource, Map<InstrumentationLibraryInfo, List<Span>>>

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/SpanAdapter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/SpanAdapter.java
@@ -75,13 +75,17 @@ public final class SpanAdapter {
           ResourceSpans.Builder resourceSpansBuilder =
               ResourceSpans.newBuilder().setResource(ResourceAdapter.toProtoResource(resource));
           librarySpans.forEach(
-              (library, spans) ->
-                  resourceSpansBuilder.addInstrumentationLibrarySpans(
-                      InstrumentationLibrarySpans.newBuilder()
-                          .setInstrumentationLibrary(
-                              CommonAdapter.toProtoInstrumentationLibrary(library))
-                          .addAllSpans(spans)
-                          .build()));
+              (library, spans) -> {
+                InstrumentationLibrarySpans.Builder spansBuilder =
+                    InstrumentationLibrarySpans.newBuilder()
+                        .setInstrumentationLibrary(
+                            CommonAdapter.toProtoInstrumentationLibrary(library))
+                        .addAllSpans(spans);
+                if (library.getSchemaUrl() != null) {
+                  spansBuilder.setSchemaUrl(library.getSchemaUrl());
+                }
+                resourceSpansBuilder.addInstrumentationLibrarySpans(spansBuilder.build());
+              });
           resourceSpans.add(resourceSpansBuilder.build());
         });
     return resourceSpans;

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/MetricAdapterTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/MetricAdapterTest.java
@@ -568,7 +568,7 @@ class MetricAdapterTest {
     io.opentelemetry.proto.resource.v1.Resource emptyResourceProto =
         io.opentelemetry.proto.resource.v1.Resource.newBuilder().build();
     InstrumentationLibraryInfo instrumentationLibraryInfo =
-        InstrumentationLibraryInfo.create("name", "version");
+        InstrumentationLibraryInfo.create("name", "version", "http://url");
     InstrumentationLibrary instrumentationLibraryProto =
         InstrumentationLibrary.newBuilder().setName("name").setVersion("version").build();
     InstrumentationLibrary emptyInstrumentationLibraryProto =
@@ -652,6 +652,7 @@ class MetricAdapterTest {
                         InstrumentationLibraryMetrics.newBuilder()
                             .setInstrumentationLibrary(instrumentationLibraryProto)
                             .addAllMetrics(ImmutableList.of(metricDoubleSum, metricDoubleSum))
+                            .setSchemaUrl("http://url")
                             .build()))
                 .build(),
             ResourceMetrics.newBuilder()
@@ -659,11 +660,12 @@ class MetricAdapterTest {
                 .addAllInstrumentationLibraryMetrics(
                     ImmutableList.of(
                         InstrumentationLibraryMetrics.newBuilder()
-                            .setInstrumentationLibrary(emptyInstrumentationLibraryProto)
+                            .setInstrumentationLibrary(instrumentationLibraryProto)
                             .addAllMetrics(singletonList(metricDoubleSum))
+                            .setSchemaUrl("http://url")
                             .build(),
                         InstrumentationLibraryMetrics.newBuilder()
-                            .setInstrumentationLibrary(instrumentationLibraryProto)
+                            .setInstrumentationLibrary(emptyInstrumentationLibraryProto)
                             .addAllMetrics(singletonList(metricDoubleSum))
                             .build()))
                 .build());

--- a/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterTest.java
@@ -28,6 +28,7 @@ import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.testing.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
@@ -293,6 +294,8 @@ class OtlpGrpcSpanExporterTest {
         .setLinks(Collections.emptyList())
         .setTotalRecordedLinks(0)
         .setTotalRecordedEvents(0)
+        .setInstrumentationLibraryInfo(
+            InstrumentationLibraryInfo.create("testLib", "1.0", "http://url"))
         .build();
   }
 

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfo.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfo.java
@@ -43,6 +43,7 @@ public abstract class InstrumentationLibraryInfo {
    * @param schemaUrl the URL of the OpenTelemetry schema being used by this instrumentation
    *     library.
    * @return the new instance
+   * @since 1.4.0
    */
   public static InstrumentationLibraryInfo create(
       String name, @Nullable String version, @Nullable String schemaUrl) {

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfo.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfo.java
@@ -31,7 +31,21 @@ public abstract class InstrumentationLibraryInfo {
    */
   public static InstrumentationLibraryInfo create(String name, @Nullable String version) {
     requireNonNull(name, "name");
-    return new AutoValue_InstrumentationLibraryInfo(name, version);
+    return new AutoValue_InstrumentationLibraryInfo(name, version, null);
+  }
+
+  /**
+   * Creates a new instance of {@link InstrumentationLibraryInfo}.
+   *
+   * @param name name of the instrumentation library (e.g., "io.opentelemetry.contrib.mongodb"),
+   *     must not be null
+   * @param version version of the instrumentation library (e.g., "1.0.0"), might be null
+   * @return the new instance
+   */
+  public static InstrumentationLibraryInfo create(
+      String name, @Nullable String version, @Nullable String schemaUrl) {
+    requireNonNull(name, "name");
+    return new AutoValue_InstrumentationLibraryInfo(name, version, schemaUrl);
   }
 
   /**
@@ -57,6 +71,16 @@ public abstract class InstrumentationLibraryInfo {
    */
   @Nullable
   public abstract String getVersion();
+
+  /**
+   * Returns the URL of the schema used by this instrumentation library, or {@code null} if not
+   * available.
+   *
+   * @return the URL of the schema used by this instrumentation library, or {@code null} if not
+   *     available.
+   */
+  @Nullable
+  public abstract String getSchemaUrl();
 
   // Package protected ctor to avoid others to extend this class.
   InstrumentationLibraryInfo() {}

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfo.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/InstrumentationLibraryInfo.java
@@ -40,6 +40,8 @@ public abstract class InstrumentationLibraryInfo {
    * @param name name of the instrumentation library (e.g., "io.opentelemetry.contrib.mongodb"),
    *     must not be null
    * @param version version of the instrumentation library (e.g., "1.0.0"), might be null
+   * @param schemaUrl the URL of the OpenTelemetry schema being used by this instrumentation
+   *     library.
    * @return the new instance
    */
   public static InstrumentationLibraryInfo create(

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/ComponentRegistry.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/ComponentRegistry.java
@@ -49,8 +49,24 @@ public final class ComponentRegistry<V> {
    * @return the registered value associated with this name and version.
    */
   public final V get(String instrumentationName, @Nullable String instrumentationVersion) {
+    return get(instrumentationName, instrumentationVersion, null);
+  }
+
+  /**
+   * Returns the registered value associated with this name and version if any, otherwise creates a
+   * new instance and associates it with the given name and version.
+   *
+   * @param instrumentationName the name of the instrumentation library.
+   * @param instrumentationVersion the version of the instrumentation library.
+   * @param schemaUrl the URL of the OpenTelemetry schema used by the instrumentation library.
+   * @return the registered value associated with this name and version.
+   */
+  public final V get(
+      String instrumentationName,
+      @Nullable String instrumentationVersion,
+      @Nullable String schemaUrl) {
     InstrumentationLibraryInfo instrumentationLibraryInfo =
-        InstrumentationLibraryInfo.create(instrumentationName, instrumentationVersion);
+        InstrumentationLibraryInfo.create(instrumentationName, instrumentationVersion, schemaUrl);
 
     // Optimistic lookup, before creating the new component.
     V component = registry.get(instrumentationLibraryInfo);

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/ComponentRegistry.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/ComponentRegistry.java
@@ -61,6 +61,7 @@ public final class ComponentRegistry<V> {
    * @param instrumentationVersion the version of the instrumentation library.
    * @param schemaUrl the URL of the OpenTelemetry schema used by the instrumentation library.
    * @return the registered value associated with this name and version.
+   * @since 1.4.0
    */
   public final V get(
       String instrumentationName,

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/ComponentRegistry.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/ComponentRegistry.java
@@ -30,8 +30,8 @@ public final class ComponentRegistry<V> {
 
   /**
    * Returns the registered value associated with this name and {@code null} version if any,
-   * otherwise creates a new instance and associates it with the given name and {@code null}
-   * version.
+   * otherwise creates a new instance and associates it with the given name and {@code null} version
+   * and schemaUrl.
    *
    * @param instrumentationName the name of the instrumentation library.
    * @return the registered value associated with this name and {@code null} version.
@@ -42,7 +42,8 @@ public final class ComponentRegistry<V> {
 
   /**
    * Returns the registered value associated with this name and version if any, otherwise creates a
-   * new instance and associates it with the given name and version.
+   * new instance and associates it with the given name and version. The schemaUrl will be set to
+   * null.
    *
    * @param instrumentationName the name of the instrumentation library.
    * @param instrumentationVersion the version of the instrumentation library.

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterBuilder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics;
+
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterBuilder;
+import io.opentelemetry.sdk.internal.ComponentRegistry;
+
+class SdkMeterBuilder implements MeterBuilder {
+
+  private final ComponentRegistry<SdkMeter> registry;
+  private final String instrumentationName;
+  private String instrumentationVersion;
+  private String schemaUrl;
+
+  SdkMeterBuilder(ComponentRegistry<SdkMeter> registry, String instrumentationName) {
+    this.registry = registry;
+    this.instrumentationName = instrumentationName;
+  }
+
+  @Override
+  public MeterBuilder setSchemaUrl(String schemaUrl) {
+    this.schemaUrl = schemaUrl;
+    return this;
+  }
+
+  @Override
+  public MeterBuilder setInstrumentationVersion(String instrumentationVersion) {
+    this.instrumentationVersion = instrumentationVersion;
+    return this;
+  }
+
+  @Override
+  public Meter build() {
+    return registry.get(instrumentationName, instrumentationVersion, schemaUrl);
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProvider.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProvider.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterBuilder;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.internal.ComponentRegistry;
@@ -47,24 +48,23 @@ public final class SdkMeterProvider implements MeterProvider, MetricProducer {
 
   @Override
   public Meter get(String instrumentationName) {
-    return get(instrumentationName, null);
+    return meterBuilder(instrumentationName).build();
   }
 
   @Override
-  public Meter get(String instrumentationName, @Nullable String instrumentationVersion) {
-    return get(instrumentationName, instrumentationVersion, null);
+  public Meter get(String instrumentationName, String instrumentationVersion) {
+    return meterBuilder(instrumentationName)
+        .setInstrumentationVersion(instrumentationVersion)
+        .build();
   }
 
   @Override
-  public Meter get(
-      String instrumentationName,
-      @Nullable String instrumentationVersion,
-      @Nullable String schemaUrl) {
+  public MeterBuilder meterBuilder(@Nullable String instrumentationName) {
     if (instrumentationName == null || instrumentationName.isEmpty()) {
       LOGGER.fine("Meter requested without instrumentation name.");
       instrumentationName = DEFAULT_METER_NAME;
     }
-    return registry.get(instrumentationName, instrumentationVersion, schemaUrl);
+    return new SdkMeterBuilder(registry, instrumentationName);
   }
 
   @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProvider.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProvider.java
@@ -52,12 +52,19 @@ public final class SdkMeterProvider implements MeterProvider, MetricProducer {
 
   @Override
   public Meter get(String instrumentationName, @Nullable String instrumentationVersion) {
-    // Per the spec, both null and empty are "invalid" and a "default" should be used.
+    return get(instrumentationName, instrumentationVersion, null);
+  }
+
+  @Override
+  public Meter get(
+      String instrumentationName,
+      @Nullable String instrumentationVersion,
+      @Nullable String schemaUrl) {
     if (instrumentationName == null || instrumentationName.isEmpty()) {
       LOGGER.fine("Meter requested without instrumentation name.");
       instrumentationName = DEFAULT_METER_NAME;
     }
-    return registry.get(instrumentationName, instrumentationVersion);
+    return registry.get(instrumentationName, instrumentationVersion, schemaUrl);
   }
 
   @Override

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterRegistryTest.java
@@ -62,20 +62,30 @@ class SdkMeterRegistryTest {
   void getSameInstanceForSameName_WithoutVersion() {
     assertThat(meterProvider.get("test")).isSameAs(meterProvider.get("test"));
     assertThat(meterProvider.get("test")).isSameAs(meterProvider.get("test", null));
-    assertThat(meterProvider.get("test")).isSameAs(meterProvider.get("test", null, null));
+    assertThat(meterProvider.get("test")).isSameAs(meterProvider.meterBuilder("test").build());
   }
 
   @Test
   void getSameInstanceForSameName_WithVersion() {
     assertThat(meterProvider.get("test", "version"))
         .isSameAs(meterProvider.get("test", "version"))
-        .isSameAs(meterProvider.get("test", "version", null));
+        .isSameAs(meterProvider.meterBuilder("test").setInstrumentationVersion("version").build());
   }
 
   @Test
   void getSameInstanceForSameName_WithVersionAndSchema() {
-    assertThat(meterProvider.get("test", "version", "http://url"))
-        .isSameAs(meterProvider.get("test", "version", "http://url"));
+    assertThat(
+            meterProvider
+                .meterBuilder("test")
+                .setInstrumentationVersion("version")
+                .setSchemaUrl("http://url")
+                .build())
+        .isSameAs(
+            meterProvider
+                .meterBuilder("test")
+                .setInstrumentationVersion("version")
+                .setSchemaUrl("http://url")
+                .build());
   }
 
   @Test
@@ -84,7 +94,11 @@ class SdkMeterRegistryTest {
         InstrumentationLibraryInfo.create("theName", "theVersion", "http://theschema");
     SdkMeter meter =
         (SdkMeter)
-            meterProvider.get(expected.getName(), expected.getVersion(), expected.getSchemaUrl());
+            meterProvider
+                .meterBuilder(expected.getName())
+                .setInstrumentationVersion(expected.getVersion())
+                .setSchemaUrl(expected.getSchemaUrl())
+                .build();
     assertThat(meter.getInstrumentationLibraryInfo()).isEqualTo(expected);
   }
 
@@ -135,7 +149,7 @@ class SdkMeterRegistryTest {
     assertThat(meter.getInstrumentationLibraryInfo().getName())
         .isEqualTo(SdkMeterProvider.DEFAULT_METER_NAME);
 
-    meter = (SdkMeter) meterProvider.get(null, null, null);
+    meter = (SdkMeter) meterProvider.meterBuilder(null).build();
     assertThat(meter.getInstrumentationLibraryInfo().getName())
         .isEqualTo(SdkMeterProvider.DEFAULT_METER_NAME);
   }
@@ -150,7 +164,7 @@ class SdkMeterRegistryTest {
     assertThat(meter.getInstrumentationLibraryInfo().getName())
         .isEqualTo(SdkMeterProvider.DEFAULT_METER_NAME);
 
-    meter = (SdkMeter) meterProvider.get("", "", "");
+    meter = (SdkMeter) meterProvider.meterBuilder("").build();
     assertThat(meter.getInstrumentationLibraryInfo().getName())
         .isEqualTo(SdkMeterProvider.DEFAULT_METER_NAME);
   }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterRegistryTest.java
@@ -62,18 +62,29 @@ class SdkMeterRegistryTest {
   void getSameInstanceForSameName_WithoutVersion() {
     assertThat(meterProvider.get("test")).isSameAs(meterProvider.get("test"));
     assertThat(meterProvider.get("test")).isSameAs(meterProvider.get("test", null));
+    assertThat(meterProvider.get("test")).isSameAs(meterProvider.get("test", null, null));
   }
 
   @Test
   void getSameInstanceForSameName_WithVersion() {
-    assertThat(meterProvider.get("test", "version")).isSameAs(meterProvider.get("test", "version"));
+    assertThat(meterProvider.get("test", "version"))
+        .isSameAs(meterProvider.get("test", "version"))
+        .isSameAs(meterProvider.get("test", "version", null));
+  }
+
+  @Test
+  void getSameInstanceForSameName_WithVersionAndSchema() {
+    assertThat(meterProvider.get("test", "version", "http://url"))
+        .isSameAs(meterProvider.get("test", "version", "http://url"));
   }
 
   @Test
   void propagatesInstrumentationLibraryInfoToMeter() {
     InstrumentationLibraryInfo expected =
-        InstrumentationLibraryInfo.create("theName", "theVersion");
-    SdkMeter meter = (SdkMeter) meterProvider.get(expected.getName(), expected.getVersion());
+        InstrumentationLibraryInfo.create("theName", "theVersion", "http://theschema");
+    SdkMeter meter =
+        (SdkMeter)
+            meterProvider.get(expected.getName(), expected.getVersion(), expected.getSchemaUrl());
     assertThat(meter.getInstrumentationLibraryInfo()).isEqualTo(expected);
   }
 
@@ -123,6 +134,10 @@ class SdkMeterRegistryTest {
     meter = (SdkMeter) meterProvider.get(null, null);
     assertThat(meter.getInstrumentationLibraryInfo().getName())
         .isEqualTo(SdkMeterProvider.DEFAULT_METER_NAME);
+
+    meter = (SdkMeter) meterProvider.get(null, null, null);
+    assertThat(meter.getInstrumentationLibraryInfo().getName())
+        .isEqualTo(SdkMeterProvider.DEFAULT_METER_NAME);
   }
 
   @Test
@@ -132,6 +147,10 @@ class SdkMeterRegistryTest {
         .isEqualTo(SdkMeterProvider.DEFAULT_METER_NAME);
 
     meter = (SdkMeter) meterProvider.get("", "");
+    assertThat(meter.getInstrumentationLibraryInfo().getName())
+        .isEqualTo(SdkMeterProvider.DEFAULT_METER_NAME);
+
+    meter = (SdkMeter) meterProvider.get("", "", "");
     assertThat(meter.getInstrumentationLibraryInfo().getName())
         .isEqualTo(SdkMeterProvider.DEFAULT_METER_NAME);
   }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerBuilder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.trace;
+
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerBuilder;
+import io.opentelemetry.sdk.internal.ComponentRegistry;
+
+class SdkTracerBuilder implements TracerBuilder {
+
+  private final ComponentRegistry<SdkTracer> registry;
+  private final String instrumentationName;
+  private String instrumentationVersion;
+  private String schemaUrl;
+
+  SdkTracerBuilder(ComponentRegistry<SdkTracer> registry, String instrumentationName) {
+    this.registry = registry;
+    this.instrumentationName = instrumentationName;
+  }
+
+  @Override
+  public TracerBuilder setSchemaUrl(String schemaUrl) {
+    this.schemaUrl = schemaUrl;
+    return this;
+  }
+
+  @Override
+  public TracerBuilder setInstrumentationVersion(String instrumentationVersion) {
+    this.instrumentationVersion = instrumentationVersion;
+    return this;
+  }
+
+  @Override
+  public Tracer build() {
+    return registry.get(instrumentationName, instrumentationVersion, schemaUrl);
+  }
+}

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.trace;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerBuilder;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;
@@ -60,25 +61,24 @@ public final class SdkTracerProvider implements TracerProvider, Closeable {
 
   @Override
   public Tracer get(String instrumentationName) {
-    return get(instrumentationName, null);
+    return tracerBuilder(instrumentationName).build();
   }
 
   @Override
-  public Tracer get(String instrumentationName, @Nullable String instrumentationVersion) {
-    return get(instrumentationName, instrumentationVersion, null);
+  public Tracer get(String instrumentationName, String instrumentationVersion) {
+    return tracerBuilder(instrumentationName)
+        .setInstrumentationVersion(instrumentationVersion)
+        .build();
   }
 
   @Override
-  public Tracer get(
-      String instrumentationName,
-      @Nullable String instrumentationVersion,
-      @Nullable String schemaUrl) {
+  public TracerBuilder tracerBuilder(@Nullable String instrumentationName) {
     // Per the spec, both null and empty are "invalid" and a default value should be used.
     if (instrumentationName == null || instrumentationName.isEmpty()) {
       logger.fine("Tracer requested without instrumentation name.");
       instrumentationName = DEFAULT_TRACER_NAME;
     }
-    return tracerSdkComponentRegistry.get(instrumentationName, instrumentationVersion, schemaUrl);
+    return new SdkTracerBuilder(tracerSdkComponentRegistry, instrumentationName);
   }
 
   /** Returns the {@link SpanLimits} that are currently applied to created spans. */

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
@@ -65,12 +65,20 @@ public final class SdkTracerProvider implements TracerProvider, Closeable {
 
   @Override
   public Tracer get(String instrumentationName, @Nullable String instrumentationVersion) {
+    return get(instrumentationName, instrumentationVersion, null);
+  }
+
+  @Override
+  public Tracer get(
+      String instrumentationName,
+      @Nullable String instrumentationVersion,
+      @Nullable String schemaUrl) {
     // Per the spec, both null and empty are "invalid" and a default value should be used.
     if (instrumentationName == null || instrumentationName.isEmpty()) {
       logger.fine("Tracer requested without instrumentation name.");
       instrumentationName = DEFAULT_TRACER_NAME;
     }
-    return tracerSdkComponentRegistry.get(instrumentationName, instrumentationVersion);
+    return tracerSdkComponentRegistry.get(instrumentationName, instrumentationVersion, schemaUrl);
   }
 
   /** Returns the {@link SpanLimits} that are currently applied to created spans. */

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
@@ -957,7 +957,7 @@ class SdkSpanBuilderTest {
                 + "telemetry.sdk.language=\"java\", telemetry.sdk.name=\"opentelemetry\", "
                 + "telemetry.sdk.version=\"\\d+.\\d+.\\d+(-SNAPSHOT)?\"}}, "
                 + "instrumentationLibraryInfo=InstrumentationLibraryInfo\\{"
-                + "name=SpanBuilderSdkTest, version=null}, "
+                + "name=SpanBuilderSdkTest, version=null, schemaUrl=null}, "
                 + "name=span_name, "
                 + "kind=INTERNAL, "
                 + "startEpochNanos=[0-9]+, "

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderTest.java
@@ -139,19 +139,44 @@ class SdkTracerProviderTest {
   @Test
   void getSameInstanceForSameName_WithoutVersion() {
     assertThat(tracerFactory.get("test")).isSameAs(tracerFactory.get("test"));
-    assertThat(tracerFactory.get("test")).isSameAs(tracerFactory.get("test", null));
+    assertThat(tracerFactory.get("test"))
+        .isSameAs(tracerFactory.get("test", null))
+        .isSameAs(tracerFactory.tracerBuilder("test").build());
   }
 
   @Test
   void getSameInstanceForSameName_WithVersion() {
-    assertThat(tracerFactory.get("test", "version")).isSameAs(tracerFactory.get("test", "version"));
+    assertThat(tracerFactory.get("test", "version"))
+        .isSameAs(tracerFactory.get("test", "version"))
+        .isSameAs(tracerFactory.tracerBuilder("test").setInstrumentationVersion("version").build());
+  }
+
+  @Test
+  void getSameInstanceForSameName_WithVersionAndSchema() {
+    assertThat(
+            tracerFactory
+                .tracerBuilder("test")
+                .setInstrumentationVersion("version")
+                .setSchemaUrl("http://url")
+                .build())
+        .isSameAs(
+            tracerFactory
+                .tracerBuilder("test")
+                .setInstrumentationVersion("version")
+                .setSchemaUrl("http://url")
+                .build());
   }
 
   @Test
   void propagatesInstrumentationLibraryInfoToTracer() {
     InstrumentationLibraryInfo expected =
-        InstrumentationLibraryInfo.create("theName", "theVersion");
-    Tracer tracer = tracerFactory.get(expected.getName(), expected.getVersion());
+        InstrumentationLibraryInfo.create("theName", "theVersion", "http://url");
+    Tracer tracer =
+        tracerFactory
+            .tracerBuilder(expected.getName())
+            .setInstrumentationVersion(expected.getVersion())
+            .setSchemaUrl(expected.getSchemaUrl())
+            .build();
     assertThat(((SdkTracer) tracer).getInstrumentationLibraryInfo()).isEqualTo(expected);
   }
 

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerTest.java
@@ -33,10 +33,10 @@ class SdkTracerTest {
       (SdkTracer)
           SdkTracerProvider.builder()
               .build()
-              .get(
-                  INSTRUMENTATION_LIBRARY_NAME,
-                  INSTRUMENTATION_LIBRARY_VERSION,
-                  "http://schemaurl");
+              .tracerBuilder(INSTRUMENTATION_LIBRARY_NAME)
+              .setInstrumentationVersion(INSTRUMENTATION_LIBRARY_VERSION)
+              .setSchemaUrl("http://schemaurl")
+              .build();
 
   @Test
   void defaultSpanBuilder() {

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerTest.java
@@ -19,14 +19,7 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-/** Unit tests for {@link SdkTracer}. */
-// Need to suppress warnings for MustBeClosed because Android 14 does not support
-// try-with-resources.
-@SuppressWarnings("MustBeClosedChecker")
-@ExtendWith(MockitoExtension.class)
 class SdkTracerTest {
 
   private static final String SPAN_NAME = "span_name";
@@ -35,12 +28,15 @@ class SdkTracerTest {
   private static final String INSTRUMENTATION_LIBRARY_VERSION = "0.2.0";
   private static final InstrumentationLibraryInfo instrumentationLibraryInfo =
       InstrumentationLibraryInfo.create(
-          INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION);
+          INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION, "http://schemaurl");
   private final SdkTracer tracer =
       (SdkTracer)
           SdkTracerProvider.builder()
               .build()
-              .get(INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION);
+              .get(
+                  INSTRUMENTATION_LIBRARY_NAME,
+                  INSTRUMENTATION_LIBRARY_VERSION,
+                  "http://schemaurl");
 
   @Test
   void defaultSpanBuilder() {


### PR DESCRIPTION
This is an alternative approach to #3299 utilizing a builder for tracers/meters, rather than adding another overload with a confusing nullable parameter.