### PR TITLE
Fix missing apidiff from #3168.

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-extension-annotations.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-extension-annotations.txt
@@ -1,2 +1,10 @@
 Comparing source compatibility of  against 
-No changes.
++++  NEW ANNOTATION: PUBLIC(+) ABSTRACT(+) io.opentelemetry.extension.annotations.SpanAttribute  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: java.lang.annotation.Annotation
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) java.lang.String value()
+	+++  NEW ANNOTATION: java.lang.annotation.Target
+		+++  NEW ELEMENT: value=java.lang.annotation.ElementType.PARAMETER (+)
+	+++  NEW ANNOTATION: java.lang.annotation.Retention
+		+++  NEW ELEMENT: value=java.lang.annotation.RetentionPolicy.RUNTIME (+)


### PR DESCRIPTION
#3168 added a new annotation but the apidiff update is missing. As a result, the diff crops up in other PRs, e.g. https://github.com/open-telemetry/opentelemetry-java/pull/3312/files#diff-619e30119c066f6bb370538e7126a2c0acaa4316bafc55441dccaf3e3e438182