### PR TITLE
Extract java conventions plugin.

### DIFF
--- a/all/build.gradle.kts
+++ b/all/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    java
+    id("otel.java-conventions")
 }
 
 description = "OpenTelemetry All"

--- a/api/all/build.gradle.kts
+++ b/api/all/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("java-library")
+    id("otel.java-conventions")
     id("maven-publish")
 
     id("me.champeau.jmh")

--- a/api/metrics/build.gradle.kts
+++ b/api/metrics/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("java-library")
+    id("otel.java-conventions")
     id("maven-publish")
 
     id("me.champeau.jmh")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,12 +25,9 @@ plugins {
     id("de.marcphilipp.nexus-publish") apply false
     id("io.morethan.jmhreport") apply false
     id("me.champeau.jmh") apply false
-    id("net.ltgt.errorprone") apply false
-    id("net.ltgt.nullaway") apply false
     id("ru.vyarus.animalsniffer") apply false
     id("me.champeau.gradle.japicmp") apply false
 }
-
 
 /**
  * Locate the project's artifact of a particular version.
@@ -106,310 +103,10 @@ nexusStaging {
     delayBetweenRetriesInMillis = 10000
 }
 
-val enableNullaway: String? by project
-
 subprojects {
     group = "io.opentelemetry"
 
     plugins.withId("java") {
-        plugins.apply("checkstyle")
-        plugins.apply("eclipse")
-        plugins.apply("idea")
-        plugins.apply("jacoco")
-
-        plugins.apply("com.diffplug.spotless")
-        plugins.apply("net.ltgt.errorprone")
-        plugins.apply("net.ltgt.nullaway")
-
-        configure<BasePluginConvention> {
-            archivesBaseName = "opentelemetry-${name}"
-        }
-
-        configure<JavaPluginExtension> {
-            toolchain {
-                languageVersion.set(JavaLanguageVersion.of(11))
-            }
-
-            withJavadocJar()
-            withSourcesJar()
-        }
-
-        configure<CheckstyleExtension> {
-            configDirectory.set(file("$rootDir/buildscripts/"))
-            toolVersion = "8.12"
-            isIgnoreFailures = false
-            configProperties["rootDir"] = rootDir
-        }
-
-        configure<JacocoPluginExtension> {
-            toolVersion = "0.8.7"
-        }
-
-        val javaToolchains = the<JavaToolchainService>()
-
-        tasks {
-            val testJava8 by registering(Test::class) {
-                javaLauncher.set(javaToolchains.launcherFor {
-                    languageVersion.set(JavaLanguageVersion.of(8))
-                })
-
-                configure<JacocoTaskExtension> {
-                    enabled = false
-                }
-            }
-
-            val testAdditionalJavaVersions: String? by rootProject
-            if (testAdditionalJavaVersions == "true") {
-                named("check") {
-                    dependsOn(testJava8)
-                }
-            }
-
-            withType(JavaCompile::class) {
-                options.release.set(8)
-
-                if (name != "jmhCompileGeneratedClasses") {
-                    options.compilerArgs.addAll(listOf(
-                            "-Xlint:all",
-                            // We suppress the "try" warning because it disallows managing an auto-closeable with
-                            // try-with-resources without referencing the auto-closeable within the try block.
-                            "-Xlint:-try",
-                            // We suppress the "processing" warning as suggested in
-                            // https://groups.google.com/forum/#!topic/bazel-discuss/_R3A9TJSoPM
-                            "-Xlint:-processing",
-                            // We suppress the "options" warning because it prevents compilation on modern JDKs
-                            "-Xlint:-options",
-
-                            // Fail build on any warning
-                            "-Werror"
-                    ))
-                }
-                //disable deprecation warnings for the protobuf module
-                if (project.name == "proto") {
-                    options.compilerArgs.add("-Xlint:-deprecation")
-                }
-
-                options.encoding = "UTF-8"
-
-                if (name.contains("Test")) {
-                    // serialVersionUID is basically guaranteed to be useless in tests
-                    options.compilerArgs.add("-Xlint:-serial")
-                }
-
-                (options as ExtensionAware).extensions.configure<ErrorProneOptions> {
-                    disableWarningsInGeneratedCode.set(true)
-                    allDisabledChecksAsWarnings.set(true)
-
-                    (this as ExtensionAware).extensions.configure<NullAwayOptions> {
-                        // Enable nullaway on main sources.
-                        // TODO(anuraaga): Remove enableNullaway flag when all errors fixed
-                        if (!name.contains("Test") && !name.contains("Jmh") && enableNullaway == "true") {
-                            severity.set(CheckSeverity.ERROR)
-                        } else {
-                            severity.set(CheckSeverity.OFF)
-                        }
-                        annotatedPackages.add("io.opentelemetry")
-                    }
-
-                    // Doesn't currently use Var annotations.
-                    disable("Var") // "-Xep:Var:OFF"
-
-                    // ImmutableRefactoring suggests using com.google.errorprone.annotations.Immutable,
-                    // but currently uses javax.annotation.concurrent.Immutable
-                    disable("ImmutableRefactoring") // "-Xep:ImmutableRefactoring:OFF"
-
-                    // AutoValueImmutableFields suggests returning Guava types from API methods
-                    disable("AutoValueImmutableFields")
-                    // Suggests using Guava types for fields but we don't use Guava
-                    disable("ImmutableMemberCollection")
-                    // "-Xep:AutoValueImmutableFields:OFF"
-
-                    // Fully qualified names may be necessary when deprecating a class to avoid
-                    // deprecation warning.
-                    disable("UnnecessarilyFullyQualified")
-
-                    // Ignore warnings for protobuf and jmh generated files.
-                    excludedPaths.set(".*generated.*|.*internal.shaded.*")
-                    // "-XepExcludedPaths:.*/build/generated/source/proto/.*"
-
-                    disable("Java7ApiChecker")
-                    disable("AndroidJdkLibsChecker")
-                    //apparently disabling android doesn't disable this
-                    disable("StaticOrDefaultInterfaceMethod")
-
-                    //until we have everything converted, we need these
-                    disable("JdkObsolete")
-                    disable("UnnecessaryAnonymousClass")
-
-                    // Limits APIs
-                    disable("NoFunctionalReturnType")
-
-                    // We don't depend on Guava so use normal splitting
-                    disable("StringSplitter")
-
-                    // Prevents lazy initialization
-                    disable("InitializeInline")
-
-                    if (name.contains("Jmh") || name.contains("Test")) {
-                        // Allow underscore in test-type method names
-                        disable("MemberName")
-                    }
-                }
-            }
-
-            withType(Test::class) {
-                useJUnitPlatform()
-
-                testLogging {
-                    exceptionFormat = TestExceptionFormat.FULL
-                    showExceptions = true
-                    showCauses = true
-                    showStackTraces = true
-                }
-                maxHeapSize = "1500m"
-            }
-
-            withType(Javadoc::class) {
-                exclude("io/opentelemetry/**/internal/**")
-
-                with(options as StandardJavadocDocletOptions) {
-                    source = "8"
-                    encoding = "UTF-8"
-                    docEncoding = "UTF-8"
-                    breakIterator(true)
-
-                    addBooleanOption("html5", true)
-
-                    links("https://docs.oracle.com/javase/8/docs/api/")
-                    addBooleanOption("Xdoclint:all,-missing", true)
-
-                    afterEvaluate {
-                        val title = "${project.description}"
-                        docTitle = title
-                        windowTitle = title
-                    }
-                }
-            }
-
-            afterEvaluate {
-                withType(Jar::class) {
-                    val moduleName: String by project
-                    inputs.property("moduleName", moduleName)
-
-                    manifest {
-                        attributes(
-                                "Automatic-Module-Name" to moduleName,
-                                "Built-By" to System.getProperty("user.name"),
-                                "Built-JDK" to System.getProperty("java.version"),
-                                "Implementation-Title" to project.name,
-                                "Implementation-Version" to project.version)
-                    }
-                }
-            }
-        }
-
-        // https://docs.gradle.org/current/samples/sample_jvm_multi_project_with_code_coverage.html
-
-        // Do not generate reports for individual projects
-        tasks.named("jacocoTestReport") {
-            enabled = false
-        }
-
-        configurations {
-            val implementation by getting
-
-            create("transitiveSourceElements") {
-                isVisible = false
-                isCanBeResolved = false
-                isCanBeConsumed = true
-                extendsFrom(implementation)
-                attributes {
-                    attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
-                    attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
-                    attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("source-folders"))
-                }
-                val mainSources = the<JavaPluginConvention>().sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
-                mainSources.java.srcDirs.forEach {
-                    outgoing.artifact(it)
-                }
-            }
-
-            create("coverageDataElements") {
-                isVisible = false
-                isCanBeResolved = false
-                isCanBeConsumed = true
-                extendsFrom(implementation)
-                attributes {
-                    attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
-                    attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
-                    attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("jacoco-coverage-data"))
-                }
-                // This will cause the test task to run if the coverage data is requested by the aggregation task
-                tasks.withType(Test::class) {
-                    outgoing.artifact(extensions.getByType<JacocoTaskExtension>().destinationFile!!)
-                }
-            }
-
-            configureEach {
-                resolutionStrategy {
-                    failOnVersionConflict()
-                    preferProjectModules()
-                }
-            }
-        }
-
-        configure<SpotlessExtension> {
-            java {
-                googleJavaFormat("1.9")
-                licenseHeaderFile(rootProject.file("buildscripts/spotless.license.java"), "(package|import|class|// Includes work from:)")
-            }
-        }
-
-        val dependencyManagement by configurations.creating {
-            isCanBeConsumed = false
-            isCanBeResolved = false
-            isVisible = false
-        }
-
-        dependencies {
-            add(dependencyManagement.name, platform(project(":dependencyManagement")))
-            afterEvaluate {
-                configurations.configureEach {
-                    if (isCanBeResolved && !isCanBeConsumed) {
-                        extendsFrom(dependencyManagement)
-                    }
-                }
-            }
-
-            add(COMPILE_ONLY_CONFIGURATION_NAME, "com.google.auto.value:auto-value-annotations")
-            add(COMPILE_ONLY_CONFIGURATION_NAME, "com.google.code.findbugs:jsr305")
-
-            add(TEST_COMPILE_ONLY_CONFIGURATION_NAME, "com.google.auto.value:auto-value-annotations")
-            add(TEST_COMPILE_ONLY_CONFIGURATION_NAME, "com.google.errorprone:error_prone_annotations")
-            add(TEST_COMPILE_ONLY_CONFIGURATION_NAME, "com.google.code.findbugs:jsr305")
-
-            add(TEST_IMPLEMENTATION_CONFIGURATION_NAME, "org.junit.jupiter:junit-jupiter-api")
-            add(TEST_IMPLEMENTATION_CONFIGURATION_NAME, "org.junit.jupiter:junit-jupiter-params")
-            add(TEST_IMPLEMENTATION_CONFIGURATION_NAME, "nl.jqno.equalsverifier:equalsverifier")
-            add(TEST_IMPLEMENTATION_CONFIGURATION_NAME, "org.mockito:mockito-core")
-            add(TEST_IMPLEMENTATION_CONFIGURATION_NAME, "org.mockito:mockito-junit-jupiter")
-            add(TEST_IMPLEMENTATION_CONFIGURATION_NAME, "org.assertj:assertj-core")
-            add(TEST_IMPLEMENTATION_CONFIGURATION_NAME, "org.awaitility:awaitility")
-            add(TEST_IMPLEMENTATION_CONFIGURATION_NAME, "io.github.netmikey.logunit:logunit-jul")
-
-            add(TEST_RUNTIME_ONLY_CONFIGURATION_NAME, "org.junit.jupiter:junit-jupiter-engine")
-            add(TEST_RUNTIME_ONLY_CONFIGURATION_NAME, "org.junit.vintage:junit-vintage-engine")
-
-            add(ErrorPronePlugin.CONFIGURATION_NAME, "com.google.errorprone:error_prone_core")
-            add(ErrorPronePlugin.CONFIGURATION_NAME, "com.uber.nullaway:nullaway")
-
-            add(ANNOTATION_PROCESSOR_CONFIGURATION_NAME, "com.google.guava:guava-beta-checker")
-
-            // Workaround for @javax.annotation.Generated
-            // see: https://github.com/grpc/grpc-java/issues/3633
-            add(COMPILE_ONLY_CONFIGURATION_NAME, "javax.annotation:javax.annotation-api")
-        }
-
         plugins.withId("com.google.protobuf") {
             protobuf {
                 val versions: Map<String, String> by project
@@ -492,45 +189,45 @@ subprojects {
                 }
             }
         }
-    }
 
-    plugins.withId("me.champeau.gradle.japicmp") {
-        afterEvaluate {
-            tasks {
-                val jApiCmp by registering(JapicmpTask::class) {
-                    dependsOn("jar")
-                    // the japicmp "old" version is either the user-specified one, or the latest release.
-                    val userRequestedBase = project.properties["apiBaseVersion"] as String?
-                    val baselineVersion: String = userRequestedBase ?: latestReleasedVersion
-                    val baselineArtifact: File = project.findArtifact(baselineVersion)
-                    oldClasspath = files(baselineArtifact)
+        plugins.withId("me.champeau.gradle.japicmp") {
+            afterEvaluate {
+                tasks {
+                    val jApiCmp by registering(JapicmpTask::class) {
+                        dependsOn("jar")
+                        // the japicmp "old" version is either the user-specified one, or the latest release.
+                        val userRequestedBase = project.properties["apiBaseVersion"] as String?
+                        val baselineVersion: String = userRequestedBase ?: latestReleasedVersion
+                        val baselineArtifact: File = project.findArtifact(baselineVersion)
+                        oldClasspath = files(baselineArtifact)
 
-                    // the japicmp "new" version is either the user-specified one, or the locally built jar.
-                    val newVersion : String? = project.properties["apiNewVersion"] as String?
-                    val newArtifact: File = if (newVersion == null) {
-                        val jar = getByName("jar") as Jar
-                        file(jar.archiveFile)
-                    } else {
-                        project.findArtifact(newVersion)
+                        // the japicmp "new" version is either the user-specified one, or the locally built jar.
+                        val newVersion: String? = project.properties["apiNewVersion"] as String?
+                        val newArtifact: File = if (newVersion == null) {
+                            val jar = getByName("jar") as Jar
+                            file(jar.archiveFile)
+                        } else {
+                            project.findArtifact(newVersion)
+                        }
+                        newClasspath = files(newArtifact)
+
+                        //only output changes, not everything
+                        isOnlyModified = true
+                        //this is needed so that we only consider the current artifact, and not dependencies
+                        isIgnoreMissingClasses = true
+                        // double wildcards don't seem to work here (*.internal.*)
+                        packageExcludes = listOf("*.internal", "io.opentelemetry.internal.shaded.jctools.*")
+                        if (newVersion == null) {
+                            val baseVersionString = if (userRequestedBase == null) "latest" else baselineVersion
+                            txtOutputFile = file("$rootDir/docs/apidiffs/current_vs_${baseVersionString}/${project.base.archivesBaseName}.txt")
+                        } else {
+                            txtOutputFile = file("$rootDir/docs/apidiffs/${newVersion}_vs_${baselineVersion}/${project.base.archivesBaseName}.txt")
+                        }
                     }
-                    newClasspath = files(newArtifact)
-
-                    //only output changes, not everything
-                    isOnlyModified = true
-                    //this is needed so that we only consider the current artifact, and not dependencies
-                    isIgnoreMissingClasses = true
-                    // double wildcards don't seem to work here (*.internal.*)
-                    packageExcludes = listOf("*.internal", "io.opentelemetry.internal.shaded.jctools.*")
-                    if (newVersion == null) {
-                        val baseVersionString = if (userRequestedBase == null) "latest" else baselineVersion
-                        txtOutputFile = file("$rootDir/docs/apidiffs/current_vs_${baseVersionString}/${project.base.archivesBaseName}.txt")
-                    } else {
-                        txtOutputFile = file("$rootDir/docs/apidiffs/${newVersion}_vs_${baselineVersion}/${project.base.archivesBaseName}.txt")
+                    // have the check task depend on the api comparison task, to make it more likely it will get used.
+                    named("check") {
+                        dependsOn(jApiCmp)
                     }
-                }
-                // have the check task depend on the api comparison task, to make it more likely it will get used.
-                named("check") {
-                    dependsOn(jApiCmp)
                 }
             }
         }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+    gradlePluginPortal()
+    mavenLocal()
+}
+
+dependencies {
+    implementation("com.diffplug.spotless:spotless-plugin-gradle:5.13.0")
+    implementation("net.ltgt.gradle:gradle-errorprone-plugin:2.0.1")
+    implementation("net.ltgt.gradle:gradle-nullaway-plugin:1.1.0")
+}

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -1,0 +1,316 @@
+import net.ltgt.gradle.errorprone.CheckSeverity
+import net.ltgt.gradle.errorprone.errorprone
+import net.ltgt.gradle.nullaway.nullaway
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
+plugins {
+    `java-library`
+
+    checkstyle
+    eclipse
+    idea
+    jacoco
+
+    id("com.diffplug.spotless")
+    id("net.ltgt.errorprone")
+    id("net.ltgt.nullaway")
+}
+
+
+val enableNullaway: String? by project
+
+base {
+    // May be set already by a parent project, only set if not.
+    // TODO(anuraaga): Make this less hacky by creating a "module group" plugin.
+    if (!archivesBaseName.startsWith("opentelemetry-")) {
+        archivesBaseName = "opentelemetry-${name}"
+    }
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+
+    withJavadocJar()
+    withSourcesJar()
+}
+
+checkstyle {
+    configDirectory.set(file("$rootDir/buildscripts/"))
+    toolVersion = "8.12"
+    isIgnoreFailures = false
+    configProperties["rootDir"] = rootDir
+}
+
+jacoco {
+    toolVersion = "0.8.7"
+}
+
+tasks {
+    val testJava8 by registering(Test::class) {
+        javaLauncher.set(javaToolchains.launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(8))
+        })
+
+        configure<JacocoTaskExtension> {
+            enabled = false
+        }
+    }
+
+    val testAdditionalJavaVersions: String? by rootProject
+    if (testAdditionalJavaVersions == "true") {
+        named("check") {
+            dependsOn(testJava8)
+        }
+    }
+
+    withType<JavaCompile>().configureEach {
+        with(options) {
+            release.set(8)
+
+            if (name != "jmhCompileGeneratedClasses") {
+                compilerArgs.addAll(listOf(
+                        "-Xlint:all",
+                        // We suppress the "try" warning because it disallows managing an auto-closeable with
+                        // try-with-resources without referencing the auto-closeable within the try block.
+                        "-Xlint:-try",
+                        // We suppress the "processing" warning as suggested in
+                        // https://groups.google.com/forum/#!topic/bazel-discuss/_R3A9TJSoPM
+                        "-Xlint:-processing",
+                        // We suppress the "options" warning because it prevents compilation on modern JDKs
+                        "-Xlint:-options",
+
+                        // Fail build on any warning
+                        "-Werror"
+                ))
+            }
+
+            //disable deprecation warnings for the protobuf module
+            if (project.name == "proto") {
+                compilerArgs.add("-Xlint:-deprecation")
+            }
+
+            encoding = "UTF-8"
+
+            if (name.contains("Test")) {
+                // serialVersionUID is basically guaranteed to be useless in tests
+                compilerArgs.add("-Xlint:-serial")
+            }
+
+            errorprone {
+                disableWarningsInGeneratedCode.set(true)
+                allDisabledChecksAsWarnings.set(true)
+
+                // Doesn't currently use Var annotations.
+                disable("Var") // "-Xep:Var:OFF"
+
+                // ImmutableRefactoring suggests using com.google.errorprone.annotations.Immutable,
+                // but currently uses javax.annotation.concurrent.Immutable
+                disable("ImmutableRefactoring") // "-Xep:ImmutableRefactoring:OFF"
+
+                // AutoValueImmutableFields suggests returning Guava types from API methods
+                disable("AutoValueImmutableFields")
+                // Suggests using Guava types for fields but we don't use Guava
+                disable("ImmutableMemberCollection")
+                // "-Xep:AutoValueImmutableFields:OFF"
+
+                // Fully qualified names may be necessary when deprecating a class to avoid
+                // deprecation warning.
+                disable("UnnecessarilyFullyQualified")
+
+                // Ignore warnings for protobuf and jmh generated files.
+                excludedPaths.set(".*generated.*|.*internal.shaded.*")
+                // "-XepExcludedPaths:.*/build/generated/source/proto/.*"
+
+                disable("Java7ApiChecker")
+                disable("AndroidJdkLibsChecker")
+                //apparently disabling android doesn't disable this
+                disable("StaticOrDefaultInterfaceMethod")
+
+                //until we have everything converted, we need these
+                disable("JdkObsolete")
+                disable("UnnecessaryAnonymousClass")
+
+                // Limits APIs
+                disable("NoFunctionalReturnType")
+
+                // We don't depend on Guava so use normal splitting
+                disable("StringSplitter")
+
+                // Prevents lazy initialization
+                disable("InitializeInline")
+
+                if (name.contains("Jmh") || name.contains("Test")) {
+                    // Allow underscore in test-type method names
+                    disable("MemberName")
+                }
+            }
+
+            errorprone.nullaway {
+                // Enable nullaway on main sources.
+                // TODO(anuraaga): Remove enableNullaway flag when all errors fixed
+                if (!name.contains("Test") && !name.contains("Jmh") && enableNullaway == "true") {
+                    severity.set(CheckSeverity.ERROR)
+                } else {
+                    severity.set(CheckSeverity.OFF)
+                }
+                annotatedPackages.add("io.opentelemetry")
+            }
+        }
+    }
+
+    withType<Test>().configureEach {
+        useJUnitPlatform()
+
+        testLogging {
+            exceptionFormat = TestExceptionFormat.FULL
+            showExceptions = true
+            showCauses = true
+            showStackTraces = true
+        }
+        maxHeapSize = "1500m"
+    }
+
+    withType<Javadoc>().configureEach {
+        exclude("io/opentelemetry/**/internal/**")
+
+        with(options as StandardJavadocDocletOptions) {
+            source = "8"
+            encoding = "UTF-8"
+            docEncoding = "UTF-8"
+            breakIterator(true)
+
+            addBooleanOption("html5", true)
+
+            links("https://docs.oracle.com/javase/8/docs/api/")
+            addBooleanOption("Xdoclint:all,-missing", true)
+        }
+    }
+
+    afterEvaluate {
+        withType<Javadoc>().configureEach {
+            with(options as StandardJavadocDocletOptions) {
+                val title = "${project.description}"
+                docTitle = title
+                windowTitle = title
+            }
+        }
+
+        withType<Jar>().configureEach {
+            val moduleName: String by project
+            inputs.property("moduleName", moduleName)
+
+            manifest {
+                attributes(
+                        "Automatic-Module-Name" to moduleName,
+                        "Built-By" to System.getProperty("user.name"),
+                        "Built-JDK" to System.getProperty("java.version"),
+                        "Implementation-Title" to project.name,
+                        "Implementation-Version" to project.version)
+            }
+        }
+    }
+}
+
+// https://docs.gradle.org/current/samples/sample_jvm_multi_project_with_code_coverage.html
+
+// Do not generate reports for individual projects
+tasks.named("jacocoTestReport") {
+    enabled = false
+}
+
+configurations {
+    val implementation by getting
+
+    create("transitiveSourceElements") {
+        isVisible = false
+        isCanBeResolved = false
+        isCanBeConsumed = true
+        extendsFrom(implementation)
+        attributes {
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
+            attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("source-folders"))
+        }
+        val mainSources = the<JavaPluginConvention>().sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+        mainSources.java.srcDirs.forEach {
+            outgoing.artifact(it)
+        }
+    }
+
+    create("coverageDataElements") {
+        isVisible = false
+        isCanBeResolved = false
+        isCanBeConsumed = true
+        extendsFrom(implementation)
+        attributes {
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
+            attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("jacoco-coverage-data"))
+        }
+        // This will cause the test task to run if the coverage data is requested by the aggregation task
+        tasks.withType(Test::class) {
+            outgoing.artifact(extensions.getByType<JacocoTaskExtension>().destinationFile!!)
+        }
+    }
+
+    configureEach {
+        resolutionStrategy {
+            failOnVersionConflict()
+            preferProjectModules()
+        }
+    }
+}
+
+spotless {
+    java {
+        googleJavaFormat("1.9")
+        licenseHeaderFile(rootProject.file("buildscripts/spotless.license.java"), "(package|import|class|// Includes work from:)")
+    }
+}
+
+val dependencyManagement by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = false
+    isVisible = false
+}
+
+dependencies {
+    dependencyManagement(platform(project(":dependencyManagement")))
+    afterEvaluate {
+        configurations.configureEach {
+            if (isCanBeResolved && !isCanBeConsumed) {
+                extendsFrom(dependencyManagement)
+            }
+        }
+    }
+
+    compileOnly("com.google.auto.value:auto-value-annotations")
+    compileOnly("com.google.code.findbugs:jsr305")
+
+    testCompileOnly("com.google.auto.value:auto-value-annotations")
+    testCompileOnly("com.google.errorprone:error_prone_annotations")
+    testCompileOnly("com.google.code.findbugs:jsr305")
+
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testImplementation("nl.jqno.equalsverifier:equalsverifier")
+    testImplementation("org.mockito:mockito-core")
+    testImplementation("org.mockito:mockito-junit-jupiter")
+    testImplementation("org.assertj:assertj-core")
+    testImplementation("org.awaitility:awaitility")
+    testImplementation("io.github.netmikey.logunit:logunit-jul")
+
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
+
+    errorprone("com.google.errorprone:error_prone_core")
+    errorprone("com.uber.nullaway:nullaway")
+
+    annotationProcessor("com.google.guava:guava-beta-checker")
+
+    // Workaround for @javax.annotation.Generated
+    // see: https://github.com/grpc/grpc-java/issues/3633
+    compileOnly("javax.annotation:javax.annotation-api")
+}

--- a/context/build.gradle.kts
+++ b/context/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("java-library")
+    id("otel.java-conventions")
     id("maven-publish")
 
     id("me.champeau.jmh")

--- a/docs/apidiffs/current_vs_latest/opentelemetry-extension-annotations.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-extension-annotations.txt
@@ -1,2 +1,10 @@
 Comparing source compatibility of  against 
-No changes.
++++  NEW ANNOTATION: PUBLIC(+) ABSTRACT(+) io.opentelemetry.extension.annotations.SpanAttribute  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: java.lang.annotation.Annotation
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) java.lang.String value()
+	+++  NEW ANNOTATION: java.lang.annotation.Target
+		+++  NEW ELEMENT: value=java.lang.annotation.ElementType.PARAMETER (+)
+	+++  NEW ANNOTATION: java.lang.annotation.Retention
+		+++  NEW ELEMENT: value=java.lang.annotation.RetentionPolicy.RUNTIME (+)

--- a/exporters/jaeger-thrift/build.gradle.kts
+++ b/exporters/jaeger-thrift/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("ru.vyarus.animalsniffer")

--- a/exporters/jaeger/build.gradle.kts
+++ b/exporters/jaeger/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("com.google.protobuf")

--- a/exporters/logging-otlp/build.gradle.kts
+++ b/exporters/logging-otlp/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("ru.vyarus.animalsniffer")

--- a/exporters/logging/build.gradle.kts
+++ b/exporters/logging/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("ru.vyarus.animalsniffer")

--- a/exporters/otlp/all/build.gradle.kts
+++ b/exporters/otlp/all/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("me.champeau.jmh")

--- a/exporters/otlp/common/build.gradle.kts
+++ b/exporters/otlp/common/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("me.champeau.jmh")

--- a/exporters/otlp/metrics/build.gradle.kts
+++ b/exporters/otlp/metrics/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("ru.vyarus.animalsniffer")

--- a/exporters/otlp/trace/build.gradle.kts
+++ b/exporters/otlp/trace/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("me.champeau.jmh")

--- a/exporters/prometheus/build.gradle.kts
+++ b/exporters/prometheus/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("ru.vyarus.animalsniffer")

--- a/exporters/zipkin/build.gradle.kts
+++ b/exporters/zipkin/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("ru.vyarus.animalsniffer")

--- a/extensions/annotations/build.gradle.kts
+++ b/extensions/annotations/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("ru.vyarus.animalsniffer")

--- a/extensions/aws/build.gradle.kts
+++ b/extensions/aws/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("ru.vyarus.animalsniffer")

--- a/extensions/incubator/build.gradle.kts
+++ b/extensions/incubator/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("me.champeau.jmh")

--- a/extensions/kotlin/build.gradle.kts
+++ b/extensions/kotlin/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("me.champeau.jmh")

--- a/extensions/noop-api/build.gradle.kts
+++ b/extensions/noop-api/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("java-library")
+    id("otel.java-conventions")
     id("maven-publish")
 
     id("ru.vyarus.animalsniffer")

--- a/extensions/trace-propagators/build.gradle.kts
+++ b/extensions/trace-propagators/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("ru.vyarus.animalsniffer")

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    java
+    id("otel.java-conventions")
 }
 
 description = "OpenTelemetry Integration Tests"

--- a/integration-tests/tracecontext/build.gradle.kts
+++ b/integration-tests/tracecontext/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    java
+    id("otel.java-conventions")
 
     id("com.github.johnrengelman.shadow")
 }

--- a/opencensus-shim/build.gradle.kts
+++ b/opencensus-shim/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 }
 

--- a/opentracing-shim/build.gradle.kts
+++ b/opentracing-shim/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 }
 

--- a/perf-harness/build.gradle.kts
+++ b/perf-harness/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    java
+    id("otel.java-conventions")
 }
 
 description = "Performance Testing Harness"

--- a/proto/build.gradle.kts
+++ b/proto/build.gradle.kts
@@ -2,7 +2,7 @@ import de.undercouch.gradle.tasks.download.Download
 import de.undercouch.gradle.tasks.download.Verify
 
 plugins {
-    id("java-library")
+    id("otel.java-conventions")
     id("maven-publish")
 
     id("com.google.protobuf")

--- a/sdk-extensions/async-processor/build.gradle.kts
+++ b/sdk-extensions/async-processor/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("ru.vyarus.animalsniffer")

--- a/sdk-extensions/autoconfigure/build.gradle.kts
+++ b/sdk-extensions/autoconfigure/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("org.unbroken-dome.test-sets")

--- a/sdk-extensions/aws/build.gradle.kts
+++ b/sdk-extensions/aws/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("me.champeau.jmh")

--- a/sdk-extensions/jaeger-remote-sampler/build.gradle.kts
+++ b/sdk-extensions/jaeger-remote-sampler/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("com.google.protobuf")

--- a/sdk-extensions/jfr-events/build.gradle.kts
+++ b/sdk-extensions/jfr-events/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 }
 

--- a/sdk-extensions/logging/build.gradle.kts
+++ b/sdk-extensions/logging/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("ru.vyarus.animalsniffer")

--- a/sdk-extensions/resources/build.gradle.kts
+++ b/sdk-extensions/resources/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("ru.vyarus.animalsniffer")

--- a/sdk-extensions/tracing-incubator/build.gradle.kts
+++ b/sdk-extensions/tracing-incubator/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("me.champeau.jmh")

--- a/sdk-extensions/zpages/build.gradle.kts
+++ b/sdk-extensions/zpages/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("me.champeau.jmh")

--- a/sdk/all/build.gradle.kts
+++ b/sdk/all/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("java-library")
+    id("otel.java-conventions")
     id("maven-publish")
 
     id("me.champeau.jmh")

--- a/sdk/common/build.gradle.kts
+++ b/sdk/common/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("java-library")
+    id("otel.java-conventions")
     id("maven-publish")
 
     id("ru.vyarus.animalsniffer")

--- a/sdk/metrics/build.gradle.kts
+++ b/sdk/metrics/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("java-library")
+    id("otel.java-conventions")
     id("maven-publish")
 
     id("me.champeau.jmh")

--- a/sdk/testing/build.gradle.kts
+++ b/sdk/testing/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("java-library")
+    id("otel.java-conventions")
     id("maven-publish")
 }
 

--- a/sdk/trace-shaded-deps/build.gradle.kts
+++ b/sdk/trace-shaded-deps/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
 
     id("com.github.johnrengelman.shadow")
 }

--- a/sdk/trace/build.gradle.kts
+++ b/sdk/trace/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("java-library")
+    id("otel.java-conventions")
     id("maven-publish")
 
     id("me.champeau.jmh")

--- a/semconv/build.gradle.kts
+++ b/semconv/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library`
+    id("otel.java-conventions")
     `maven-publish`
 
     id("ru.vyarus.animalsniffer")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,5 @@
 pluginManagement {
     plugins {
-        id("com.diffplug.spotless") version "5.12.5"
         id("com.github.ben-manes.versions") version "0.39.0"
         id("com.github.johnrengelman.shadow") version "7.0.0"
         id("com.google.protobuf") version "0.8.16"
@@ -11,8 +10,6 @@ pluginManagement {
         id("io.morethan.jmhreport") version "0.9.0"
         id("me.champeau.jmh") version "0.6.5"
         id("nebula.release") version "15.3.1"
-        id("net.ltgt.errorprone") version "2.0.1"
-        id("net.ltgt.nullaway") version "1.1.0"
         id("org.checkerframework") version "0.5.20"
         id("org.jetbrains.kotlin.jvm") version "1.5.10"
         id("org.unbroken-dome.test-sets") version "4.0.0"


### PR DESCRIPTION
There is a relatively recent Gradle idiom to write shared build logic as convention plugins

https://docs.gradle.org/current/samples/sample_convention_plugins.html

This allows us to split our current giant build.gradle into separate plugins for each type of configuration. I will follow up with moving / extracting more files. There is another great improvement in being able to use the native DSL instead of things like `configure<>` in these plugins.