### PR TITLE
Define an extension for otel-specific configuration of Java.

### DIFF
--- a/all/build.gradle.kts
+++ b/all/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 description = "OpenTelemetry All"
-extra["moduleName"] = "io.opentelemetry.all"
+otelJava.moduleName.set("io.opentelemetry.all")
 
 tasks {
     // We don't compile much here, just some API boundary tests. This project is mostly for

--- a/api/all/build.gradle.kts
+++ b/api/all/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 description = "OpenTelemetry API"
-extra["moduleName"] = "io.opentelemetry.api"
+otelJava.moduleName.set("io.opentelemetry.api")
 base.archivesBaseName = "opentelemetry-api"
 
 dependencies {

--- a/api/metrics/build.gradle.kts
+++ b/api/metrics/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 description = "OpenTelemetry API"
-extra["moduleName"] = "io.opentelemetry.api.metrics"
+otelJava.moduleName.set("io.opentelemetry.api.metrics")
 
 dependencies {
     api(project(":api:all"))

--- a/buildSrc/src/main/kotlin/io/opentelemetry/gradle/OtelJavaExtension.kt
+++ b/buildSrc/src/main/kotlin/io/opentelemetry/gradle/OtelJavaExtension.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.gradle
+
+import org.gradle.api.provider.Property
+
+abstract class OtelJavaExtension {
+    abstract val moduleName: Property<String>
+}

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -1,3 +1,4 @@
+import io.opentelemetry.gradle.OtelJavaExtension
 import net.ltgt.gradle.errorprone.CheckSeverity
 import net.ltgt.gradle.errorprone.errorprone
 import net.ltgt.gradle.nullaway.nullaway
@@ -16,6 +17,7 @@ plugins {
     id("net.ltgt.nullaway")
 }
 
+val otelJava = extensions.create<OtelJavaExtension>("otelJava")
 
 val enableNullaway: String? by project
 
@@ -188,26 +190,25 @@ tasks {
         }
     }
 
+    withType<Jar>().configureEach {
+        inputs.property("moduleName", otelJava.moduleName)
+
+        manifest {
+            attributes(
+                    "Automatic-Module-Name" to otelJava.moduleName,
+                    "Built-By" to System.getProperty("user.name"),
+                    "Built-JDK" to System.getProperty("java.version"),
+                    "Implementation-Title" to project.name,
+                    "Implementation-Version" to project.version)
+        }
+    }
+
     afterEvaluate {
         withType<Javadoc>().configureEach {
             with(options as StandardJavadocDocletOptions) {
                 val title = "${project.description}"
                 docTitle = title
                 windowTitle = title
-            }
-        }
-
-        withType<Jar>().configureEach {
-            val moduleName: String by project
-            inputs.property("moduleName", moduleName)
-
-            manifest {
-                attributes(
-                        "Automatic-Module-Name" to moduleName,
-                        "Built-By" to System.getProperty("user.name"),
-                        "Built-JDK" to System.getProperty("java.version"),
-                        "Implementation-Title" to project.name,
-                        "Implementation-Version" to project.version)
             }
         }
     }

--- a/context/build.gradle.kts
+++ b/context/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 description = "OpenTelemetry Context (Incubator)"
-extra["moduleName"] = "io.opentelemetry.context"
+otelJava.moduleName.set("io.opentelemetry.context")
 
 testSets {
     create("grpcInOtelTest")

--- a/exporters/jaeger-thrift/build.gradle.kts
+++ b/exporters/jaeger-thrift/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry - Jaeger Thrift Exporter"
-extra["moduleName"] = "io.opentelemetry.exporter.jaeger.thrift"
+otelJava.moduleName.set("io.opentelemetry.exporter.jaeger.thrift")
 
 dependencies {
     api(project(":sdk:all"))

--- a/exporters/jaeger/build.gradle.kts
+++ b/exporters/jaeger/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 description = "OpenTelemetry - Jaeger Exporter"
-extra["moduleName"] = "io.opentelemetry.exporter.jaeger"
+otelJava.moduleName.set("io.opentelemetry.exporter.jaeger")
 
 dependencies {
     api(project(":sdk:all"))

--- a/exporters/logging-otlp/build.gradle.kts
+++ b/exporters/logging-otlp/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry Protocol JSON Logging Exporters"
-extra["moduleName"] = "io.opentelemetry.exporter.logging.otlp"
+otelJava.moduleName.set("io.opentelemetry.exporter.logging.otlp")
 
 dependencies {
     compileOnly(project(":sdk:trace"))

--- a/exporters/logging/build.gradle.kts
+++ b/exporters/logging/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry - Logging Exporter"
-extra["moduleName"] = "io.opentelemetry.exporter.logging"
+otelJava.moduleName.set("io.opentelemetry.exporter.logging")
 
 dependencies {
     api(project(":sdk:all"))

--- a/exporters/otlp/all/build.gradle.kts
+++ b/exporters/otlp/all/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 description = "OpenTelemetry Protocol Exporters"
-extra["moduleName"] = "io.opentelemetry.exporter.otlp"
+otelJava.moduleName.set("io.opentelemetry.exporter.otlp")
 base.archivesBaseName = "opentelemetry-exporter-otlp"
 
 dependencies {

--- a/exporters/otlp/common/build.gradle.kts
+++ b/exporters/otlp/common/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 description = "OpenTelemetry Protocol Exporter"
-extra["moduleName"] = "io.opentelemetry.exporter.otlp.internal"
+otelJava.moduleName.set("io.opentelemetry.exporter.otlp.internal")
 
 dependencies {
     api(project(":api:all"))

--- a/exporters/otlp/metrics/build.gradle.kts
+++ b/exporters/otlp/metrics/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry Protocol Metrics Exporter"
-extra["moduleName"] = "io.opentelemetry.exporter.otlp.metrics"
+otelJava.moduleName.set("io.opentelemetry.exporter.otlp.metrics")
 
 dependencies {
     api(project(":sdk:metrics"))

--- a/exporters/otlp/trace/build.gradle.kts
+++ b/exporters/otlp/trace/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 description = "OpenTelemetry Protocol Trace Exporter"
-extra["moduleName"] = "io.opentelemetry.exporter.otlp.trace"
+otelJava.moduleName.set("io.opentelemetry.exporter.otlp.trace")
 
 testSets {
     create("testGrpcNetty")

--- a/exporters/prometheus/build.gradle.kts
+++ b/exporters/prometheus/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry Prometheus Exporter"
-extra["moduleName"] = "io.opentelemetry.exporter.prometheus"
+otelJava.moduleName.set("io.opentelemetry.exporter.prometheus")
 
 dependencies {
     api(project(":sdk:metrics"))

--- a/exporters/zipkin/build.gradle.kts
+++ b/exporters/zipkin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry - Zipkin Exporter"
-extra["moduleName"] = "io.opentelemetry.exporter.zipkin"
+otelJava.moduleName.set("io.opentelemetry.exporter.zipkin")
 
 dependencies {
     compileOnly("com.google.auto.value:auto-value")

--- a/extensions/annotations/build.gradle.kts
+++ b/extensions/annotations/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry Extension Annotations"
-extra["moduleName"] = "io.opentelemetry.extension.annotations"
+otelJava.moduleName.set("io.opentelemetry.extension.annotations")
 
 dependencies {
     api(project(":api:all"))

--- a/extensions/aws/build.gradle.kts
+++ b/extensions/aws/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry API Extensions for AWS"
-extra["moduleName"] = "io.opentelemetry.extension.aws"
+otelJava.moduleName.set("io.opentelemetry.extension.aws")
 
 dependencies {
     api(project(":api:all"))

--- a/extensions/incubator/build.gradle.kts
+++ b/extensions/incubator/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 description = "OpenTelemetry API Incubator"
-extra["moduleName"] = "io.opentelemetry.extension.incubator"
+otelJava.moduleName.set("io.opentelemetry.extension.incubator")
 
 dependencies {
     api(project(":api:all"))

--- a/extensions/kotlin/build.gradle.kts
+++ b/extensions/kotlin/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 description = "OpenTelemetry Kotlin Extensions"
-extra["moduleName"] = "io.opentelemetry.extension.kotlin"
+otelJava.moduleName.set("io.opentelemetry.extension.kotlin")
 
 testSets {
     create("testStrictContext")

--- a/extensions/noop-api/build.gradle.kts
+++ b/extensions/noop-api/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry Noop API"
-extra["moduleName"] = "io.opentelemetry.extension.noopapi"
+otelJava.moduleName.set("io.opentelemetry.extension.noopapi")
 
 dependencies {
     api(project(":api:all"))

--- a/extensions/trace-propagators/build.gradle.kts
+++ b/extensions/trace-propagators/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 description = "OpenTelemetry Extension : Trace Propagators"
-extra["moduleName"] = "io.opentelemetry.extension.trace.propagation"
+otelJava.moduleName.set("io.opentelemetry.extension.trace.propagation")
 
 dependencies {
     api(project(":api:all"))

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 description = "OpenTelemetry Integration Tests"
-extra["moduleName"] = "io.opentelemetry.integration.tests"
+otelJava.moduleName.set("io.opentelemetry.integration.tests")
 
 dependencies {
     implementation(project(":sdk:all"))

--- a/integration-tests/tracecontext/build.gradle.kts
+++ b/integration-tests/tracecontext/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 description = "OpenTelemetry W3C Context Propagation Integration Tests"
-extra["moduleName"] = "io.opentelemetry.tracecontext.integration.tests"
+otelJava.moduleName.set("io.opentelemetry.tracecontext.integration.tests")
 
 dependencies {
     implementation(project(":sdk:all"))

--- a/opencensus-shim/build.gradle.kts
+++ b/opencensus-shim/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 description = "OpenTelemetry OpenCensus Shim"
-extra["moduleName"] = "io.opentelemetry.opencensusshim"
+otelJava.moduleName.set("io.opentelemetry.opencensusshim")
 
 dependencies {
     api(project(":api:all"))

--- a/opentracing-shim/build.gradle.kts
+++ b/opentracing-shim/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 description = "OpenTelemetry OpenTracing Bridge"
-extra["moduleName"] = "io.opentelemetry.opentracingshim"
+otelJava.moduleName.set("io.opentelemetry.opentracingshim")
 
 dependencies {
     api(project(":api:all"))

--- a/perf-harness/build.gradle.kts
+++ b/perf-harness/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 description = "Performance Testing Harness"
-extra["moduleName"] = "io.opentelemetry.perf-harness"
+otelJava.moduleName.set("io.opentelemetry.perf-harness")
 
 dependencies {
     implementation(project(":api:all"))

--- a/proto/build.gradle.kts
+++ b/proto/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 description = "OpenTelemetry Proto"
-extra["moduleName"] = "io.opentelemetry.proto"
+otelJava.moduleName.set("io.opentelemetry.proto")
 
 dependencies {
     api("com.google.protobuf:protobuf-java")

--- a/sdk-extensions/async-processor/build.gradle.kts
+++ b/sdk-extensions/async-processor/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry SDK Extension: Async SpanProcessor"
-extra["moduleName"] = "io.opentelemetry.sdk.extension.trace.export"
+otelJava.moduleName.set("io.opentelemetry.sdk.extension.trace.export")
 
 dependencies {
     api(project(":api:all"))

--- a/sdk-extensions/autoconfigure/build.gradle.kts
+++ b/sdk-extensions/autoconfigure/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry SDK Auto-configuration"
-extra["moduleName"] = "io.opentelemetry.sdk.autoconfigure"
+otelJava.moduleName.set("io.opentelemetry.sdk.autoconfigure")
 
 testSets {
     create("testConfigError")

--- a/sdk-extensions/aws/build.gradle.kts
+++ b/sdk-extensions/aws/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry SDK AWS Instrumentation Support"
-extra["moduleName"] = "io.opentelemetry.sdk.extension.trace.aws"
+otelJava.moduleName.set("io.opentelemetry.sdk.extension.trace.aws")
 
 dependencies {
     api(project(":api:all"))

--- a/sdk-extensions/jaeger-remote-sampler/build.gradle.kts
+++ b/sdk-extensions/jaeger-remote-sampler/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 description = "OpenTelemetry - Jaeger Remote sampler"
-extra["moduleName"] = "io.opentelemetry.sdk.extension.trace.jaeger"
+otelJava.moduleName.set("io.opentelemetry.sdk.extension.trace.jaeger")
 
 dependencies {
     api(project(":sdk:all"))

--- a/sdk-extensions/jfr-events/build.gradle.kts
+++ b/sdk-extensions/jfr-events/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 description = "OpenTelemetry SDK Extension JFR"
-extra["moduleName"] = "io.opentelemetry.sdk.extension.jfr"
+otelJava.moduleName.set("io.opentelemetry.sdk.extension.jfr")
 
 dependencies {
     implementation(project(":api:all"))

--- a/sdk-extensions/logging/build.gradle.kts
+++ b/sdk-extensions/logging/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry Contrib Logging Support"
-extra["moduleName"] = "io.opentelemetry.sdk.extension.logging"
+otelJava.moduleName.set("io.opentelemetry.sdk.extension.logging")
 
 dependencies {
     api(project(":sdk:all"))

--- a/sdk-extensions/resources/build.gradle.kts
+++ b/sdk-extensions/resources/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry SDK Resource Providers"
-extra["moduleName"] = "io.opentelemetry.sdk.extension.resources"
+otelJava.moduleName.set("io.opentelemetry.sdk.extension.resources")
 
 val mrJarVersions = listOf(11)
 

--- a/sdk-extensions/tracing-incubator/build.gradle.kts
+++ b/sdk-extensions/tracing-incubator/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 // SDK modules that are still being developed.
 
 description = "OpenTelemetry SDK Tracing Incubator"
-extra["moduleName"] = "io.opentelemetry.sdk.extension.trace.incubator"
+otelJava.moduleName.set("io.opentelemetry.sdk.extension.trace.incubator")
 
 dependencies {
     api(project(":api:all"))

--- a/sdk-extensions/zpages/build.gradle.kts
+++ b/sdk-extensions/zpages/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry - zPages"
-extra["moduleName"] = "io.opentelemetry.sdk.extension.zpages"
+otelJava.moduleName.set("io.opentelemetry.sdk.extension.zpages")
 
 dependencies {
     implementation(project(":api:all"))

--- a/sdk/all/build.gradle.kts
+++ b/sdk/all/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 description = "OpenTelemetry SDK"
-extra["moduleName"] = "io.opentelemetry.sdk"
+otelJava.moduleName.set("io.opentelemetry.sdk")
 base.archivesBaseName = "opentelemetry-sdk"
 
 dependencies {

--- a/sdk/common/build.gradle.kts
+++ b/sdk/common/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 description = "OpenTelemetry SDK Common"
-extra["moduleName"] = "io.opentelemetry.sdk.common"
+otelJava.moduleName.set("io.opentelemetry.sdk.common")
 
 val mrJarVersions = listOf(9)
 

--- a/sdk/metrics/build.gradle.kts
+++ b/sdk/metrics/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 description = "OpenTelemetry SDK Metrics"
-extra["moduleName"] = "io.opentelemetry.sdk.metrics"
+otelJava.moduleName.set("io.opentelemetry.sdk.metrics")
 
 dependencies {
     api(project(":api:metrics"))

--- a/sdk/testing/build.gradle.kts
+++ b/sdk/testing/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 description = "OpenTelemetry SDK Testing utilities"
-extra["moduleName"] = "io.opentelemetry.sdk.testing"
+otelJava.moduleName.set("io.opentelemetry.sdk.testing")
 
 dependencies {
     api(project(":api:all"))

--- a/sdk/trace-shaded-deps/build.gradle.kts
+++ b/sdk/trace-shaded-deps/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 // This project is not published, it is bundled into :sdk:trace
 
 description = "Internal use only - shaded dependencies of OpenTelemetry SDK for Tracing"
-extra["moduleName"] = "io.opentelemetry.sdk.trace.internal"
+otelJava.moduleName.set("io.opentelemetry.sdk.trace.internal")
 
 dependencies {
     implementation("org.jctools:jctools-core")

--- a/sdk/trace/build.gradle.kts
+++ b/sdk/trace/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 description = "OpenTelemetry SDK For Tracing"
-extra["moduleName"] = "io.opentelemetry.sdk.trace"
+otelJava.moduleName.set("io.opentelemetry.sdk.trace")
 
 evaluationDependsOn(":sdk:trace-shaded-deps")
 

--- a/semconv/build.gradle.kts
+++ b/semconv/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry Semantic Conventions"
-extra["moduleName"] = "io.opentelemetry.semconv"
+otelJava.moduleName.set("io.opentelemetry.semconv")
 
 dependencies {
     api(project(":api:all"))


### PR DESCRIPTION
Provides compile time safety instead of using the String, and allows lazy evaluation by using `Property<String>` so no need to worry about evaluation order