### PR TITLE
BatchSpanProcessor falls back to ArrayBlockingQueue if `jdk.unsupported` is not available

### DIFF
--- a/sdk/trace-shaded-deps/src/main/java/io/opentelemetry/sdk/trace/internal/JcTools.java
+++ b/sdk/trace-shaded-deps/src/main/java/io/opentelemetry/sdk/trace/internal/JcTools.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.trace.internal;
 
 import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.MpscArrayQueue;
 
@@ -16,15 +17,24 @@ public final class JcTools {
    * Returns a new {@link Queue} appropriate for use with multiple producers and a single consumer.
    */
   public static <T> Queue<T> newFixedSizeQueue(int capacity) {
-    return new MpscArrayQueue<>(capacity);
+    try {
+      return new MpscArrayQueue<>(capacity);
+    } catch (java.lang.NoClassDefFoundError e) {
+      // Happens when modules such as jdk.unsupported are disabled in a custom JRE distribution
+      return new ArrayBlockingQueue<>(capacity);
+    }
   }
 
   /**
-   * Returns the capacity of the {@link Queue}, which must be a JcTools queue. We cast to the
-   * implementation so callers do not need to use the shaded classes.
+   * Returns the capacity of the {@link Queue}. We cast to the implementation so callers do not need
+   * to use the shaded classes.
    */
   public static long capacity(Queue<?> queue) {
-    return ((MessagePassingQueue<?>) queue).capacity();
+    if (queue instanceof MessagePassingQueue) {
+      return ((MessagePassingQueue<?>) queue).capacity();
+    } else {
+      return (long) ((ArrayBlockingQueue<?>) queue).remainingCapacity() + queue.size();
+    }
   }
 
   private JcTools() {}

--- a/sdk/trace-shaded-deps/src/main/java/io/opentelemetry/sdk/trace/internal/JcTools.java
+++ b/sdk/trace-shaded-deps/src/main/java/io/opentelemetry/sdk/trace/internal/JcTools.java
@@ -15,7 +15,7 @@ public final class JcTools {
   /**
    * Returns a new {@link Queue} appropriate for use with multiple producers and a single consumer.
    */
-  public static <T> Queue<T> newMpscArrayQueue(int capacity) {
+  public static <T> Queue<T> newFixedSizeQueue(int capacity) {
     return new MpscArrayQueue<>(capacity);
   }
 

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -72,7 +72,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
             scheduleDelayNanos,
             maxExportBatchSize,
             exporterTimeoutNanos,
-            JcTools.newMpscArrayQueue(maxQueueSize));
+            JcTools.newFixedSizeQueue(maxQueueSize));
     Thread workerThread = new DaemonThreadFactory(WORKER_THREAD_NAME).newThread(worker);
     workerThread.start();
   }


### PR DESCRIPTION
We are currently using `jlink` and we favour not including the `jdk.unsupported` module in our builds. This causes a failure in open-telemetry, though:

```
[otel.javaagent 2021-06-22 05:21:27:988 +0000] [main] INFO io.opentelemetry.javaagent.tooling.VersionLogger - opentelemetry-javaagent - version: 1.3.0
[otel.javaagent 2021-06-22 05:21:28:177 +0000] [main] INFO io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent - Your platform does not provide complete low-level API for accessing direct buffers reliably. Unless explicitly requested, heap buffer will always be preferred to avoid potential system instability.
ERROR io.opentelemetry.javaagent.OpenTelemetryAgent
java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at io.opentelemetry.javaagent.bootstrap.AgentInitializer.initialize(AgentInitializer.java:40)
	at io.opentelemetry.javaagent.OpenTelemetryAgent.agentmain(OpenTelemetryAgent.java:56)
	at io.opentelemetry.javaagent.OpenTelemetryAgent.premain(OpenTelemetryAgent.java:50)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(Unknown Source)
	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(Unknown Source)
Caused by: java.lang.NoClassDefFoundError: sun/misc/Unsafe
	at io.opentelemetry.internal.shaded.jctools.util.UnsafeAccess.getUnsafe(UnsafeAccess.java:54)
	at io.opentelemetry.internal.shaded.jctools.util.UnsafeAccess.<clinit>(UnsafeAccess.java:44)
	at io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueueProducerIndexField.<clinit>(MpscArrayQueue.java:48)
	at io.opentelemetry.sdk.trace.internal.JcTools.newMpscArrayQueue(JcTools.java:19)
	at io.opentelemetry.sdk.trace.export.BatchSpanProcessor.<init>(BatchSpanProcessor.java:75)
	at io.opentelemetry.sdk.trace.export.BatchSpanProcessorBuilder.build(BatchSpanProcessorBuilder.java:141)
	at io.opentelemetry.sdk.autoconfigure.TracerProviderConfiguration.configureSpanProcessor(TracerProviderConfiguration.java:95)
	at io.opentelemetry.sdk.autoconfigure.TracerProviderConfiguration.configureSpanProcessor(TracerProviderConfiguration.java:68)
	at io.opentelemetry.sdk.autoconfigure.TracerProviderConfiguration.configureTracerProvider(TracerProviderConfiguration.java:54)
	at io.opentelemetry.sdk.autoconfigure.OpenTelemetrySdkAutoConfiguration.initialize(OpenTelemetrySdkAutoConfiguration.java:47)
	at io.opentelemetry.javaagent.tooling.OpenTelemetryInstaller.installAgentTracer(OpenTelemetryInstaller.java:40)
	at io.opentelemetry.javaagent.tooling.OpenTelemetryInstaller.beforeAgent(OpenTelemetryInstaller.java:27)
	at io.opentelemetry.javaagent.tooling.AgentInstaller.runBeforeAgentListeners(AgentInstaller.java:171)
	at io.opentelemetry.javaagent.tooling.AgentInstaller.installBytebuddyAgent(AgentInstaller.java:114)
	at io.opentelemetry.javaagent.tooling.AgentInstaller.installBytebuddyAgent(AgentInstaller.java:97)
	... 13 more
Caused by: java.lang.ClassNotFoundException: sun.misc.Unsafe
	at java.base/java.net.URLClassLoader.findClass(Unknown Source)
	at io.opentelemetry.javaagent.bootstrap.AgentClassLoader.findClass(AgentClassLoader.java:165)
	at java.base/java.lang.ClassLoader.loadClass(Unknown Source)
	at io.opentelemetry.javaagent.bootstrap.AgentClassLoader.loadClass(AgentClassLoader.java:146)
	at java.base/java.lang.ClassLoader.loadClass(Unknown Source)
	... 28 more"
```

This PR proposes a fix discussed in https://github.com/open-telemetry/opentelemetry-java/issues/3339 where we fall back to a `ArrayBlockingQueue` when the JCTools one is not an option.