### PR TITLE
Fix jacoco by eagerly configuring it.

### DIFF
--- a/all/build.gradle.kts
+++ b/all/build.gradle.kts
@@ -82,10 +82,10 @@ tasks.named<JacocoReport>("jacocoTestReport") {
     reports {
         // xml is usually used to integrate code coverage with
         // other tools like SonarQube, Coveralls or Codecov
-        xml.isEnabled = true
+        xml.required.set(true)
 
         // HTML reports can be used to see code coverage
         // without any external tools
-        html.isEnabled = true
+        html.required.set(true)
     }
 }

--- a/buildSrc/src/main/kotlin/otel.jacoco-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.jacoco-conventions.gradle.kts
@@ -44,7 +44,9 @@ configurations {
             attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("jacoco-coverage-data"))
         }
         // This will cause the test task to run if the coverage data is requested by the aggregation task
-        tasks.withType<Test>().configureEach {
+        // The tasks must be eagerly evaluated (no configureEach) to ensure jacoco is wired up
+        // correctly.
+        tasks.withType<Test>() {
             outgoing.artifact(the<JacocoTaskExtension>().destinationFile!!)
         }
     }


### PR DESCRIPTION
Broke this when trying to switch to `<>` syntax but muscle memory adding the configureEach

https://github.com/open-telemetry/opentelemetry-java/commit/ce9c8854c7484b8af260d8da122525b919fa8a42#diff-272fb3a27b813eb474376e65452cf2753ac06c9cafe5e6e35e7d05a92d7e4f58L46