### PR TITLE
Use property to specify test java version instead of adding tasks.

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -14,9 +14,12 @@ jobs:
         os:
           - macos-latest
           - ubuntu-18.04
+        test-java-version:
+          - 8
+          - 11
         include:
           - os: ubuntu-18.04
-            testAdditionalJavaVersions: true
+            test-java-version: 11
             coverage: true
     steps:
       - uses: actions/checkout@v2.3.4
@@ -40,7 +43,7 @@ jobs:
           remote-build-cache-proxy-enabled: false
           arguments: build --stacktrace ${{ matrix.coverage && 'jacocoTestReport' || '' }}
           properties: |
-            testAdditionalJavaVersions=${{ matrix.testAdditionalJavaVersions }}
+            testJavaVersion=${{ matrix.testJavaVersion }}
             org.gradle.java.installations.paths=${{ steps.setup-java-8.outputs.path }},${{ steps.setup-java-11.outputs.path }}
       - uses: codecov/codecov-action@v1.5.2
         if: ${{ matrix.coverage }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -43,7 +43,7 @@ jobs:
           remote-build-cache-proxy-enabled: false
           arguments: build --stacktrace ${{ matrix.coverage && 'jacocoTestReport' || '' }}
           properties: |
-            testJavaVersion=${{ matrix.testJavaVersion }}
+            testJavaVersion=${{ matrix.test-java-version }}
             org.gradle.java.installations.paths=${{ steps.setup-java-8.outputs.path }},${{ steps.setup-java-11.outputs.path }}
       - uses: codecov/codecov-action@v1.5.2
         if: ${{ matrix.coverage }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -14,9 +14,12 @@ jobs:
         os:
           - macos-latest
           - ubuntu-18.04
+        test-java-version:
+          - 8
+          - 11
         include:
           - os: ubuntu-18.04
-            testAdditionalJavaVersions: true
+            test-java-version: 11
             coverage: true
     steps:
       - uses: actions/checkout@v2.3.4
@@ -40,7 +43,7 @@ jobs:
           remote-build-cache-proxy-enabled: false
           arguments: build --stacktrace ${{ matrix.coverage && 'jacocoTestReport' || '' }}
           properties: |
-            testAdditionalJavaVersions=${{ matrix.testAdditionalJavaVersions }}
+            testJavaVersion=${{ matrix.testJavaVersion }}
             org.gradle.java.installations.paths=${{ steps.setup-java-8.outputs.path }},${{ steps.setup-java-11.outputs.path }}
       - uses: codecov/codecov-action@v1.5.2
         if: ${{ matrix.coverage }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -43,7 +43,7 @@ jobs:
           remote-build-cache-proxy-enabled: false
           arguments: build --stacktrace ${{ matrix.coverage && 'jacocoTestReport' || '' }}
           properties: |
-            testJavaVersion=${{ matrix.testJavaVersion }}
+            testJavaVersion=${{ matrix.test-java-version }}
             org.gradle.java.installations.paths=${{ steps.setup-java-8.outputs.path }},${{ steps.setup-java-11.outputs.path }}
       - uses: codecov/codecov-action@v1.5.2
         if: ${{ matrix.coverage }}

--- a/.github/workflows/pr-examples-build.yml
+++ b/.github/workflows/pr-examples-build.yml
@@ -15,10 +15,6 @@ jobs:
         os:
           - macos-latest
           - ubuntu-18.04
-        include:
-          - os: ubuntu-18.04
-            testAdditionalJavaVersions: true
-            coverage: true
     steps:
       - uses: actions/checkout@v2.3.4
       - id: setup-java-11

--- a/all/build.gradle.kts
+++ b/all/build.gradle.kts
@@ -14,8 +14,11 @@ tasks {
         options.release.set(11)
     }
 
-    named("testJava8") {
-        enabled = false
+    val testJavaVersion: String? by project
+    if (testJavaVersion == "8") {
+        test {
+            enabled = false
+        }
     }
 }
 

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -40,24 +40,9 @@ checkstyle {
     configProperties["rootDir"] = rootDir
 }
 
+val testJavaVersion = gradle.startParameter.projectProperties.get("testJavaVersion")?.let(JavaVersion::toVersion)
+
 tasks {
-    val testJava8 by registering(Test::class) {
-        javaLauncher.set(javaToolchains.launcherFor {
-            languageVersion.set(JavaLanguageVersion.of(8))
-        })
-
-        jacoco {
-            enabled = false
-        }
-    }
-
-    val testAdditionalJavaVersions: String? by rootProject
-    if (testAdditionalJavaVersions == "true") {
-        named("check") {
-            dependsOn(testJava8)
-        }
-    }
-
     withType<JavaCompile>().configureEach {
         with(options) {
             release.set(8)
@@ -95,6 +80,12 @@ tasks {
 
     withType<Test>().configureEach {
         useJUnitPlatform()
+
+        if (testJavaVersion != null) {
+            javaLauncher.set(javaToolchains.launcherFor {
+                languageVersion.set(JavaLanguageVersion.of(testJavaVersion.majorVersion))
+            })
+        }
 
         testLogging {
             exceptionFormat = TestExceptionFormat.FULL

--- a/sdk-extensions/jfr-events/build.gradle.kts
+++ b/sdk-extensions/jfr-events/build.gradle.kts
@@ -16,11 +16,12 @@ tasks {
         options.release.set(11)
     }
 
-    named("testJava8") {
-        enabled = false
-    }
+    test {
+        val testJavaVersion: String? by project
+        if (testJavaVersion == "8") {
+            enabled = false
+        }
 
-    named("test") {
         // Disabled due to https://bugs.openjdk.java.net/browse/JDK-8245283
         configure<JacocoTaskExtension> {
             enabled = false


### PR DESCRIPTION
As we add more java versions to our test set, adding tasks to the same build won't scale as well as going ahead and parallelizing on GHA. This makes us more consistent with instrumentation repo too.

BTW I found https://github.com/line/armeria/issues/3673