### PR TITLE
Now `MultiTextMapPropagator` allows to select extractors and injectors separately

### DIFF
--- a/context/src/main/java/io/opentelemetry/context/propagation/CompositeTextMapPropagatorBuilder.java
+++ b/context/src/main/java/io/opentelemetry/context/propagation/CompositeTextMapPropagatorBuilder.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.context.propagation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder for configuring an {@link TextMapPropagator} specifying which propagators should be used for extracting the context and which should be used for injecting the context.
+ */
+public final class CompositeTextMapPropagatorBuilder {
+
+  private final List<TextMapPropagator> extractors;
+  private final List<TextMapPropagator> injectors;
+
+  /**
+   * Package protected to disallow direct initialization.
+   *
+   * @see TextMapPropagator#builder()
+   */
+  CompositeTextMapPropagatorBuilder() {
+    this.extractors = new ArrayList<>();
+    this.injectors = new ArrayList<>();
+  }
+
+  /**
+   * Add a {@link TextMapPropagator} to be used only to extract the context.
+   */
+  public CompositeTextMapPropagatorBuilder extractor(TextMapPropagator propagator) {
+    this.extractors.add(propagator);
+    return this;
+  }
+
+  /**
+   * Add a {@link TextMapPropagator} to be used only to inject the context.
+   */
+  public CompositeTextMapPropagatorBuilder injector(TextMapPropagator propagator) {
+    this.injectors.add(propagator);
+    return this;
+  }
+
+  /**
+   * Add a {@link TextMapPropagator} to be used both to extract and inject the context.
+   */
+  public CompositeTextMapPropagatorBuilder propagator(TextMapPropagator propagator) {
+    this.injectors.add(propagator);
+    this.extractors.add(propagator);
+    return this;
+  }
+
+  /**
+   * Returns the built {@link TextMapPropagator}
+   *
+   * @see CompositeTextMapPropagatorBuilder
+   */
+  public TextMapPropagator build() {
+    if (this.injectors.isEmpty()) {
+      this.injectors.add(TextMapPropagator.noop());
+    }
+    if (this.extractors.isEmpty()) {
+      this.extractors.add(TextMapPropagator.noop());
+    }
+
+    return new MultiTextMapPropagator(this.extractors, this.injectors);
+  }
+}

--- a/context/src/main/java/io/opentelemetry/context/propagation/MultiTextMapPropagator.java
+++ b/context/src/main/java/io/opentelemetry/context/propagation/MultiTextMapPropagator.java
@@ -16,7 +16,8 @@ import java.util.Set;
 import javax.annotation.Nullable;
 
 final class MultiTextMapPropagator implements TextMapPropagator {
-  private final TextMapPropagator[] textPropagators;
+  private final TextMapPropagator[] extractors;
+  private final TextMapPropagator[] injectors;
   private final Collection<String> allFields;
 
   MultiTextMapPropagator(TextMapPropagator... textPropagators) {
@@ -24,9 +25,20 @@ final class MultiTextMapPropagator implements TextMapPropagator {
   }
 
   MultiTextMapPropagator(List<TextMapPropagator> textPropagators) {
-    this.textPropagators = new TextMapPropagator[textPropagators.size()];
-    textPropagators.toArray(this.textPropagators);
-    this.allFields = Collections.unmodifiableList(getAllFields(this.textPropagators));
+    this.extractors = new TextMapPropagator[textPropagators.size()];
+    textPropagators.toArray(this.extractors);
+    this.injectors = this.extractors; // No need to copy
+    this.allFields = Collections.unmodifiableList(getAllFields(this.injectors));
+  }
+
+  MultiTextMapPropagator(List<TextMapPropagator> extractors, List<TextMapPropagator> injectors) {
+    this.extractors = new TextMapPropagator[extractors.size()];
+    extractors.toArray(this.extractors);
+
+    this.injectors = new TextMapPropagator[injectors.size()];
+    injectors.toArray(this.injectors);
+
+    this.allFields = Collections.unmodifiableList(getAllFields(this.injectors));
   }
 
   @Override
@@ -48,7 +60,7 @@ final class MultiTextMapPropagator implements TextMapPropagator {
     if (context == null || setter == null) {
       return;
     }
-    for (TextMapPropagator textPropagator : textPropagators) {
+    for (TextMapPropagator textPropagator : injectors) {
       textPropagator.inject(context, carrier, setter);
     }
   }
@@ -61,7 +73,7 @@ final class MultiTextMapPropagator implements TextMapPropagator {
     if (getter == null) {
       return context;
     }
-    for (TextMapPropagator textPropagator : textPropagators) {
+    for (TextMapPropagator textPropagator : extractors) {
       context = textPropagator.extract(context, carrier, getter);
     }
     return context;

--- a/context/src/main/java/io/opentelemetry/context/propagation/TextMapPropagator.java
+++ b/context/src/main/java/io/opentelemetry/context/propagation/TextMapPropagator.java
@@ -44,6 +44,13 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface TextMapPropagator {
 
   /**
+   * Returns a composite text map propagator builder that allows to specify specific propagators as extractors and specific propagators as injectors.
+   */
+  static CompositeTextMapPropagatorBuilder builder() {
+    return new CompositeTextMapPropagatorBuilder();
+  }
+
+  /**
    * Returns a {@link TextMapPropagator} which simply delegates injection and extraction to the
    * provided propagators.
    *


### PR DESCRIPTION
Fix #3364

This PR includes:

* A patch for `MultiTextMapPropagator` to select extractors and injectors separately
* The builder `CompositeTextMapPropagatorBuilder`
* Unit test

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>