### PR TITLE
Make Jaeger remote sampler available via SPI

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-jaeger-remote-sampler.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-jaeger-remote-sampler.txt
@@ -2,3 +2,9 @@ Comparing source compatibility of  against
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.extension.trace.jaeger.sampler.JaegerRemoteSampler  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) void close()
++++  NEW CLASS: PUBLIC(+) io.opentelemetry.sdk.extension.trace.jaeger.sampler.JaegerRemoteSamplerProvider  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW CONSTRUCTOR: PUBLIC(+) JaegerRemoteSamplerProvider()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.samplers.Sampler createSampler(io.opentelemetry.sdk.autoconfigure.ConfigProperties)
+	+++  NEW METHOD: PUBLIC(+) java.lang.String getName()

--- a/sdk-extensions/jaeger-remote-sampler/build.gradle.kts
+++ b/sdk-extensions/jaeger-remote-sampler/build.gradle.kts
@@ -10,6 +10,7 @@ otelJava.moduleName.set("io.opentelemetry.sdk.extension.trace.jaeger")
 
 dependencies {
   api(project(":sdk:all"))
+  compileOnly(project(":sdk-extensions:autoconfigure"))
 
   implementation(project(":sdk:all"))
   implementation("io.grpc:grpc-api")
@@ -18,6 +19,7 @@ dependencies {
   implementation("com.google.protobuf:protobuf-java")
 
   testImplementation(project(":sdk:testing"))
+  testImplementation(project(":sdk-extensions:autoconfigure"))
 
   testImplementation("io.grpc:grpc-testing")
   testImplementation("org.testcontainers:junit-jupiter")

--- a/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerProvider.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.extension.trace.jaeger.sampler;
+
+import io.opentelemetry.sdk.autoconfigure.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurableSamplerProvider;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class JaegerRemoteSamplerProvider implements ConfigurableSamplerProvider {
+
+  private static final String ENDPOINT_KEY = "endpoint";
+  private static final String POLLING_INTERVAL = "pollingInterval";
+  private static final String INITIAL_SAMPLING_RATE = "initialSamplingRate";
+
+  @Override
+  public Sampler createSampler(ConfigProperties config) {
+    String serviceName = config.getString("otel.service.name");
+    if (serviceName == null) {
+      Map<String, String> resourceAttributes =
+          config.getCommaSeparatedMap("otel.resource.attributes");
+      serviceName = resourceAttributes.get("otel.service.name");
+    }
+
+    JaegerRemoteSamplerBuilder builder = JaegerRemoteSampler.builder().setServiceName(serviceName);
+    Map<String, String> params = config.getCommaSeparatedMap("otel.traces.sampler.arg");
+
+    // Optional configuration
+    String endpoint = params.get(ENDPOINT_KEY);
+    if (endpoint != null) {
+      builder.setEndpoint(endpoint);
+    }
+    String pollingInterval = params.get(POLLING_INTERVAL);
+    if (pollingInterval != null) {
+      builder.setPollingInterval(Integer.valueOf(pollingInterval), TimeUnit.MILLISECONDS);
+    }
+    String initialSamplingRate = params.get(INITIAL_SAMPLING_RATE);
+    if (initialSamplingRate != null) {
+      builder.setInitialSampler(Sampler.traceIdRatioBased(Double.valueOf(initialSamplingRate)));
+    }
+    return builder.build();
+  }
+
+  @Override
+  public String getName() {
+    return "jaeger_remote";
+  }
+}

--- a/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerProvider.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerProvider.java
@@ -13,21 +13,24 @@ import java.util.concurrent.TimeUnit;
 
 public class JaegerRemoteSamplerProvider implements ConfigurableSamplerProvider {
 
+  private static final String ATTRIBUTE_PROPERTY = "otel.resource.attributes";
+  private static final String SERVICE_NAME_PROPERTY = "otel.service.name";
+  private static final String SAMPLER_ARG_PROPERTY = "otel.traces.sampler.arg";
+
   private static final String ENDPOINT_KEY = "endpoint";
   private static final String POLLING_INTERVAL = "pollingInterval";
   private static final String INITIAL_SAMPLING_RATE = "initialSamplingRate";
 
   @Override
   public Sampler createSampler(ConfigProperties config) {
-    String serviceName = config.getString("otel.service.name");
+    String serviceName = config.getString(SERVICE_NAME_PROPERTY);
     if (serviceName == null) {
-      Map<String, String> resourceAttributes =
-          config.getCommaSeparatedMap("otel.resource.attributes");
-      serviceName = resourceAttributes.get("otel.service.name");
+      Map<String, String> resourceAttributes = config.getCommaSeparatedMap(ATTRIBUTE_PROPERTY);
+      serviceName = resourceAttributes.get(SERVICE_NAME_PROPERTY);
     }
 
     JaegerRemoteSamplerBuilder builder = JaegerRemoteSampler.builder().setServiceName(serviceName);
-    Map<String, String> params = config.getCommaSeparatedMap("otel.traces.sampler.arg");
+    Map<String, String> params = config.getCommaSeparatedMap(SAMPLER_ARG_PROPERTY);
 
     // Optional configuration
     String endpoint = params.get(ENDPOINT_KEY);

--- a/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerProvider.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerProvider.java
@@ -13,9 +13,10 @@ import java.util.concurrent.TimeUnit;
 
 public class JaegerRemoteSamplerProvider implements ConfigurableSamplerProvider {
 
-  private static final String ATTRIBUTE_PROPERTY = "otel.resource.attributes";
-  private static final String SERVICE_NAME_PROPERTY = "otel.service.name";
-  private static final String SAMPLER_ARG_PROPERTY = "otel.traces.sampler.arg";
+  // visible for testing
+  static final String ATTRIBUTE_PROPERTY = "otel.resource.attributes";
+  static final String SERVICE_NAME_PROPERTY = "otel.service.name";
+  static final String SAMPLER_ARG_PROPERTY = "otel.traces.sampler.arg";
 
   private static final String ENDPOINT_KEY = "endpoint";
   private static final String POLLING_INTERVAL = "pollingInterval";
@@ -43,7 +44,8 @@ public class JaegerRemoteSamplerProvider implements ConfigurableSamplerProvider 
     }
     String initialSamplingRate = params.get(INITIAL_SAMPLING_RATE);
     if (initialSamplingRate != null) {
-      builder.setInitialSampler(Sampler.traceIdRatioBased(Double.valueOf(initialSamplingRate)));
+      builder.setInitialSampler(
+          Sampler.parentBased(Sampler.traceIdRatioBased(Double.valueOf(initialSamplingRate))));
     }
     return builder.build();
   }

--- a/sdk-extensions/jaeger-remote-sampler/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ConfigurableSamplerProvider
+++ b/sdk-extensions/jaeger-remote-sampler/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ConfigurableSamplerProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.sdk.extension.trace.jaeger.sampler.JaegerRemoteSamplerProvider

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerProviderTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerProviderTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.extension.trace.jaeger.sampler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurableSamplerProvider;
+import java.util.ServiceLoader;
+import org.junit.jupiter.api.Test;
+
+public class JaegerRemoteSamplerProviderTest {
+
+  @Test
+  void serviceProvider() {
+    ServiceLoader<ConfigurableSamplerProvider> samplerProviders =
+        ServiceLoader.load(ConfigurableSamplerProvider.class);
+    assertThat(samplerProviders).hasAtLeastOneElementOfType(JaegerRemoteSamplerProvider.class);
+    assertThat(samplerProviders)
+        .singleElement(type(JaegerRemoteSamplerProvider.class))
+        .satisfies(provider -> assertThat(provider.getName()).isEqualTo("jaeger_remote"));
+  }
+}

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerProviderTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerProviderTest.java
@@ -34,8 +34,8 @@ public class JaegerRemoteSamplerProviderTest {
     HashMap<String, String> samplerArgs = new HashMap<>();
     samplerArgs.put("endpoint", "localhost:9999");
     samplerArgs.put("pollingInterval", "99");
-    Double samplingRate = 0.33;
-    samplerArgs.put("initialSamplingRate", samplingRate.toString());
+    double samplingRate = 0.33;
+    samplerArgs.put("initialSamplingRate", String.valueOf(samplingRate));
     when(mockConfig.getCommaSeparatedMap(JaegerRemoteSamplerProvider.SAMPLER_ARG_PROPERTY))
         .thenReturn(samplerArgs);
 

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerProviderTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerProviderTest.java
@@ -7,8 +7,13 @@ package io.opentelemetry.sdk.extension.trace.jaeger.sampler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import io.opentelemetry.sdk.autoconfigure.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurableSamplerProvider;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.util.HashMap;
 import java.util.ServiceLoader;
 import org.junit.jupiter.api.Test;
 
@@ -22,5 +27,56 @@ public class JaegerRemoteSamplerProviderTest {
     assertThat(samplerProviders)
         .singleElement(type(JaegerRemoteSamplerProvider.class))
         .satisfies(provider -> assertThat(provider.getName()).isEqualTo("jaeger_remote"));
+
+    ConfigProperties mockConfig = mock(ConfigProperties.class);
+    when(mockConfig.getString(JaegerRemoteSamplerProvider.SERVICE_NAME_PROPERTY))
+        .thenReturn("test_service");
+    HashMap<String, String> samplerArgs = new HashMap<>();
+    samplerArgs.put("endpoint", "localhost:9999");
+    samplerArgs.put("pollingInterval", "99");
+    Double samplingRate = 0.33;
+    samplerArgs.put("initialSamplingRate", samplingRate.toString());
+    when(mockConfig.getCommaSeparatedMap(JaegerRemoteSamplerProvider.SAMPLER_ARG_PROPERTY))
+        .thenReturn(samplerArgs);
+
+    Sampler sampler = Sampler.parentBased(Sampler.traceIdRatioBased(samplingRate));
+    assertThat(samplerProviders)
+        .singleElement(type(JaegerRemoteSamplerProvider.class))
+        .satisfies(
+            provider ->
+                assertThat(provider.createSampler(mockConfig))
+                    .extracting("sampler", type(Sampler.class))
+                    .asString()
+                    .isEqualTo(sampler.toString()))
+        .satisfies(
+            provider ->
+                assertThat(provider.createSampler(mockConfig))
+                    .extracting("serviceName")
+                    .isEqualTo("test_service"))
+        .satisfies(
+            provider ->
+                assertThat(provider.createSampler(mockConfig))
+                    .extracting("channel")
+                    .extracting("delegate")
+                    .extracting("target")
+                    .isEqualTo("localhost:9999"));
+  }
+
+  @Test
+  void serviceNameInAttributeProperties() {
+    ConfigProperties mockConfig = mock(ConfigProperties.class);
+    HashMap<String, String> attributeProperties = new HashMap<>();
+    attributeProperties.put(JaegerRemoteSamplerProvider.SERVICE_NAME_PROPERTY, "test_service2");
+    when(mockConfig.getCommaSeparatedMap(JaegerRemoteSamplerProvider.ATTRIBUTE_PROPERTY))
+        .thenReturn(attributeProperties);
+    ServiceLoader<ConfigurableSamplerProvider> samplerProviders =
+        ServiceLoader.load(ConfigurableSamplerProvider.class);
+    assertThat(samplerProviders)
+        .singleElement(type(JaegerRemoteSamplerProvider.class))
+        .satisfies(
+            provider ->
+                assertThat(provider.createSampler(mockConfig))
+                    .extracting("serviceName")
+                    .isEqualTo("test_service2"));
   }
 }

--- a/sdk-extensions/jaeger-remote-sampler/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/sdk-extensions/jaeger-remote-sampler/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

This PR makes `JaegerRemoteSampler` available via SPI. The ultimate goal is to make it available in the java auto-instrumentation (javaagent).  I have talked about this with @tedsuo and @yurishkuro that including it in the javaagent distro should be fine (Jaeger is considered as a special vendor). 


After this PR is merged I will create a PR to auto-instrumentation to package it in the final distribution. We should also document it in https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration