### PR TITLE
Fix:fix the error in flaky test

### DIFF
--- a/context/src/main/java/io/opentelemetry/context/ThreadLocalContextStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/ThreadLocalContextStorage.java
@@ -36,6 +36,7 @@ enum ThreadLocalContextStorage implements ContextStorage {
             Level.FINE,
             "Context in storage not the expected context, Scope.close was not called correctly");
       }
+      NoopScope.INSTANCE.close();
       THREAD_LOCAL_STORAGE.set(beforeAttach);
     };
   }
@@ -50,6 +51,8 @@ enum ThreadLocalContextStorage implements ContextStorage {
     INSTANCE;
 
     @Override
-    public void close() {}
+    public void close() {
+      logger.log(Level.SEVERE, "Scope garbage collected before being closed.");
+    }
   }
 }


### PR DESCRIPTION
Link: #3311 

When I change the `log` source to `ThreadLocalContextStorage` and test in `StrictContextEnabledTest.java`，the error in the issue will be reproduced.

1. I think the error caused by scope
2. Scope should be closed when test is over
3. So I add the Scope.close when the when the current context should be restored to what it was before attaching toAttach.