### PR TITLE
Different pattern for embedding shaded dependency.

### DIFF
--- a/sdk/trace-shaded-deps/build.gradle.kts
+++ b/sdk/trace-shaded-deps/build.gradle.kts
@@ -19,4 +19,10 @@ tasks {
 
         relocate("org.jctools", "io.opentelemetry.internal.shaded.jctools")
     }
+
+    val extractShadowJar by registering(Copy::class) {
+        dependsOn(shadowJar)
+        from(zipTree(shadowJar.get().archiveFile))
+        into("build/extracted/shadow")
+    }
 }


### PR DESCRIPTION
Seeing https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/3471 I thought of making another attempt to find a cleaner approach to embedding a relocated archive. This pattern is different - it's probably a little better

- Does not "side-step" Gradle by copying into the output Jar. So the classes are available in areas Gradle knows they should be (we see this with the removal of `jmh(":sdk:trace-shaded-deps")`). It doesn't remove the need of `compileOnly` though since it only adds classes to the output, not Java to the input (which don't exist in shaded form) which is needed for compilation
- No evaluation order dependency, always a benefit to reduce build fragility

Because shadow outputs straight to a jar though we still don't seem to have a way to avoid having the extractShadowJar, which is very similar to the reconfiguration of Jar we used to have.

@trask What do you think?