### PR TITLE
Add hasAttributes which takes a list of entries.

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
@@ -1,2 +1,5 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.SpanDataAssert  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.SpanDataAssert hasAttributes(java.util.Map$Entry[])
+		+++  NEW ANNOTATION: java.lang.SafeVarargs

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SpanDataAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SpanDataAssert.java
@@ -7,7 +7,9 @@ package io.opentelemetry.sdk.testing.assertj;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -19,6 +21,7 @@ import io.opentelemetry.sdk.trace.data.StatusData;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.assertj.core.api.AbstractAssert;
@@ -208,6 +211,18 @@ public final class SpanDataAssert extends AbstractAssert<SpanDataAssert, SpanDat
           actual.getAttributes());
     }
     return this;
+  }
+
+  /** Asserts the span has the given attributes. */
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  @SafeVarargs
+  public final SpanDataAssert hasAttributes(Map.Entry<? extends AttributeKey<?>, ?>... entries) {
+    AttributesBuilder attributesBuilder = Attributes.builder();
+    for (Map.Entry<? extends AttributeKey<?>, ?> attr : entries) {
+      attributesBuilder.put((AttributeKey) attr.getKey(), attr.getValue());
+    }
+    Attributes attributes = attributesBuilder.build();
+    return hasAttributes(attributes);
   }
 
   private boolean attributesAreEqual(Attributes attributes) {

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertionsTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertionsTest.java
@@ -119,6 +119,15 @@ class OpenTelemetryAssertionsTest {
         .startsAt(100, TimeUnit.NANOSECONDS)
         .startsAt(Instant.ofEpochSecond(0, 100))
         .hasAttributes(ATTRIBUTES)
+        .hasAttributes(
+            attributeEntry("bear", "mya"),
+            attributeEntry("warm", true),
+            attributeEntry("temperature", 30),
+            attributeEntry("length", 1.2),
+            attributeEntry("colors", "red", "blue"),
+            attributeEntry("conditions", false, true),
+            attributeEntry("scores", 0L, 1L),
+            attributeEntry("coins", 0.01, 0.05, 0.1))
         .hasAttributesSatisfying(
             attributes ->
                 assertThat(attributes)
@@ -202,6 +211,8 @@ class OpenTelemetryAssertionsTest {
     assertThatThrownBy(() -> assertThat(SPAN1).startsAt(Instant.EPOCH))
         .isInstanceOf(AssertionError.class);
     assertThatThrownBy(() -> assertThat(SPAN1).hasAttributes(Attributes.empty()))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> assertThat(SPAN1).hasAttributes(attributeEntry("food", "burger")))
         .isInstanceOf(AssertionError.class);
     assertThatThrownBy(
             () ->


### PR DESCRIPTION
For attributes it's very common to just assert the entries in the attributes, so this can reduce two indents