### PR TITLE
Provide an option for disabling errorprone for a smoother dev experience

### DIFF
--- a/buildSrc/src/main/kotlin/otel.errorprone-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.errorprone-conventions.gradle.kts
@@ -9,10 +9,14 @@ plugins {
 
 val enableNullaway: String? by project
 
+val disableErrorProne = properties["disableErrorProne"]
+
 tasks {
     withType<JavaCompile>().configureEach {
         with(options) {
             errorprone {
+                enabled = (disableErrorProne != "true")
+
                 disableWarningsInGeneratedCode.set(true)
                 allDisabledChecksAsWarnings.set(true)
 

--- a/buildSrc/src/main/kotlin/otel.errorprone-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.errorprone-conventions.gradle.kts
@@ -9,13 +9,16 @@ plugins {
 
 val enableNullaway: String? by project
 
-val disableErrorProne = properties["disableErrorProne"]
+val disableErrorProne = properties["disableErrorProne"]?.toString()?.toBoolean() ?: false
 
 tasks {
     withType<JavaCompile>().configureEach {
         with(options) {
             errorprone {
-                enabled = (disableErrorProne != "true")
+                if (disableErrorProne) {
+                    logger.warn("Errorprone has been disabled. Build may not result in a valid PR build.")
+                    enabled = false
+                }
 
                 disableWarningsInGeneratedCode.set(true)
                 allDisabledChecksAsWarnings.set(true)


### PR DESCRIPTION
Just `-PdisableErrorProne=true` or put it in your personal gradle.properties file.