### PR TITLE
Remock shutdown after reset.

### DIFF
--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -365,6 +365,7 @@ class BatchSpanProcessorTest {
     // Still processing new spans.
     CountDownLatch exportedAgain = new CountDownLatch(1);
     reset(mockSpanExporter);
+    when(mockSpanExporter.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
     when(mockSpanExporter.export(
             argThat(
                 spans -> {


### PR DESCRIPTION
This doesn't seem too elegant but for one location figured it's simple enough.

Fixes test flake

```
BatchSpanProcessorTest > continuesIfExporterTimesOut() FAILED
    java.lang.NullPointerException: Cannot invoke "io.opentelemetry.sdk.common.CompletableResultCode.whenComplete(java.lang.Runnable)" because "shutdownResult" is null
        at io.opentelemetry.sdk.trace.export.BatchSpanProcessor$Worker.lambda$shutdown$2(BatchSpanProcessor.java:257)
        at io.opentelemetry.sdk.common.CompletableResultCode.whenComplete(CompletableResultCode.java:126)
        at io.opentelemetry.sdk.trace.export.BatchSpanProcessor$Worker.shutdown(BatchSpanProcessor.java:253)
        at io.opentelemetry.sdk.trace.export.BatchSpanProcessor$Worker.access$200(BatchSpanProcessor.java:121)
        at io.opentelemetry.sdk.trace.export.BatchSpanProcessor.shutdown(BatchSpanProcessor.java:106)
        at io.opentelemetry.sdk.trace.TracerSharedState.shutdown(TracerSharedState.java:96)
        at io.opentelemetry.sdk.trace.SdkTracerProvider.shutdown(SdkTracerProvider.java:115)
        at io.opentelemetry.sdk.trace.export.BatchSpanProcessorTest.cleanup(BatchSpanProcessorTest.java:70)
```