### PR TITLE
Schedule IntervalMetricReader with fixed delay.

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
@@ -121,6 +121,7 @@ public final class IntervalMetricReader {
       doRun().join(internalState.getExportIntervalMillis(), TimeUnit.MILLISECONDS);
     }
 
+    // Make sure not to throw any exceptions.
     CompletableResultCode doRun() {
       final CompletableResultCode flushResult = new CompletableResultCode();
       if (exportAvailable.compareAndSet(true, false)) {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
@@ -98,7 +98,7 @@ public final class IntervalMetricReader {
         return this;
       }
       scheduledFuture =
-          scheduler.scheduleAtFixedRate(
+          scheduler.scheduleWithFixedDelay(
               exporter,
               exporter.internalState.getExportIntervalMillis(),
               exporter.internalState.getExportIntervalMillis(),
@@ -118,8 +118,7 @@ public final class IntervalMetricReader {
 
     @Override
     public void run() {
-      // Ignore the CompletableResultCode from doRun() in order to keep run() asynchronous
-      doRun();
+      doRun().join(internalState.getExportIntervalMillis(), TimeUnit.MILLISECONDS);
     }
 
     CompletableResultCode doRun() {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReaderTest.java
@@ -70,7 +70,7 @@ class IntervalMetricReaderTest {
     ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
 
     ScheduledFuture mock = mock(ScheduledFuture.class);
-    when(scheduler.scheduleAtFixedRate(any(), anyLong(), anyLong(), any())).thenReturn(mock);
+    when(scheduler.scheduleWithFixedDelay(any(), anyLong(), anyLong(), any())).thenReturn(mock);
 
     IntervalMetricReader intervalMetricReader =
         new IntervalMetricReader(
@@ -83,7 +83,7 @@ class IntervalMetricReaderTest {
     intervalMetricReader.start();
     intervalMetricReader.start();
 
-    verify(scheduler, times(1)).scheduleAtFixedRate(any(), anyLong(), anyLong(), any());
+    verify(scheduler, times(1)).scheduleWithFixedDelay(any(), anyLong(), anyLong(), any());
   }
 
   @Test


### PR DESCRIPTION
Just randomly found this when looking at the class, I'm surprised we wouldn't use a fixed delay for an interval reader.