### PR TITLE
Allow forceFlush of IntervalMetricReader, globally too for autoconfig…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ version of the OpenTelemetry schema the files were generated from. There are no 
 - You can now assign an OpenTelemetry schema URL to a `Meter` via the new `MeterBuilder` class that is
 accessed via the `MeterProvider` or any global instances that delegate to one.
 - The metrics SDK now utilizes `Attributes` rather than `Labels` internally.
+- You can now register an `IntervalMetricReader` as global and `forceFlush` the global reader.
 
 ---
 ## Version 1.3.0 - 2021-06-09

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
@@ -96,7 +96,7 @@ final class MetricExporterConfiguration {
     if (exportInterval != null) {
       readerBuilder.setExportIntervalMillis(exportInterval.toMillis());
     }
-    IntervalMetricReader reader = readerBuilder.buildAndStart();
+    IntervalMetricReader reader = readerBuilder.build().startAndRegisterGlobal();
     Runtime.getRuntime().addShutdownHook(new Thread(reader::shutdown));
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/IntervalMetricReader.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.concurrent.Immutable;
@@ -30,11 +31,30 @@ import javax.annotation.concurrent.Immutable;
 public final class IntervalMetricReader {
   private static final Logger logger = Logger.getLogger(IntervalMetricReader.class.getName());
 
+  private static final AtomicReference<IntervalMetricReader> globalIntervalMetricReader =
+      new AtomicReference<>();
+
   private final Exporter exporter;
   private final ScheduledExecutorService scheduler;
 
   private volatile ScheduledFuture<?> scheduledFuture;
   private final Object lock = new Object();
+
+  /**
+   * {@linkplain IntervalMetricReader#forceFlush() Force flushes} the globally registered {@link
+   * IntervalMetricReader} if available, or does nothing otherwise.
+   */
+  public static CompletableResultCode forceFlushGlobal() {
+    IntervalMetricReader intervalMetricReader = globalIntervalMetricReader.get();
+    if (intervalMetricReader != null) {
+      return intervalMetricReader.forceFlush();
+    }
+    return CompletableResultCode.ofSuccess();
+  }
+
+  static void resetGlobalForTest() {
+    globalIntervalMetricReader.set(null);
+  }
 
   /** Stops the scheduled task and calls export one more time. */
   public CompletableResultCode shutdown() {
@@ -75,6 +95,14 @@ public final class IntervalMetricReader {
     return new IntervalMetricReaderBuilder(InternalState.builder());
   }
 
+  /**
+   * Requests the {@link IntervalMetricReader} to export current metrics and returns a {@link
+   * CompletableResultCode} which is completed when the flush is finished.
+   */
+  public CompletableResultCode forceFlush() {
+    return exporter.doRun();
+  }
+
   IntervalMetricReader(InternalState internalState) {
     this(
         internalState,
@@ -87,11 +115,7 @@ public final class IntervalMetricReader {
     this.scheduler = intervalMetricReader;
   }
 
-  /**
-   * Starts this {@link IntervalMetricReader} to report to the configured exporter.
-   *
-   * @return this for fluent usage along with the builder.
-   */
+  /** Starts this {@link IntervalMetricReader} to report to the configured exporter. */
   public IntervalMetricReader start() {
     synchronized (lock) {
       if (scheduledFuture != null) {
@@ -105,6 +129,18 @@ public final class IntervalMetricReader {
               TimeUnit.MILLISECONDS);
       return this;
     }
+  }
+
+  /**
+   * Starts this {@link IntervalMetricReader} and registers it as the global {@link
+   * IntervalMetricReader}.
+   */
+  public IntervalMetricReader startAndRegisterGlobal() {
+    start();
+    if (!globalIntervalMetricReader.compareAndSet(null, this)) {
+      logger.log(Level.WARNING, "Global IntervalMetricReader already registered, ignoring.");
+    }
+    return this;
   }
 
   private static final class Exporter implements Runnable {


### PR DESCRIPTION
…ure / agent.

@jkwatson Sorry for this late change - it would be really helpful for some prototypes of metrics on AWS Lambda to have this ability to force flush, and I'm hoping the alpha status of the metrics artifacts makes it ok.