### PR TITLE
Add TraceAssert.getSpan

### DIFF
--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SpanDataAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SpanDataAssert.java
@@ -112,6 +112,11 @@ public final class SpanDataAssert extends AbstractAssert<SpanDataAssert, SpanDat
     return this;
   }
 
+  /** Asserts the span has the given parent {@link SpanData span}. */
+  public SpanDataAssert hasParent(SpanData parent) {
+    return hasParentSpanId(parent.getSpanId());
+  }
+
   /** Asserts the span has the given {@link Resource}. */
   public SpanDataAssert hasResource(Resource resource) {
     isNotNull();

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SpanDataAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SpanDataAssert.java
@@ -112,7 +112,11 @@ public final class SpanDataAssert extends AbstractAssert<SpanDataAssert, SpanDat
     return this;
   }
 
-  /** Asserts the span has the given parent {@link SpanData span}. */
+  /**
+   * Asserts the span has the given parent {@link SpanData span}.
+   *
+   * <p>Equivalent to {@code span.hasParentSpanId(parent.getSpanId())}.
+   */
   public SpanDataAssert hasParent(SpanData parent) {
     return hasParentSpanId(parent.getSpanId());
   }

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TraceAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TraceAssert.java
@@ -52,6 +52,14 @@ public final class TraceAssert
     return this;
   }
 
+  /**
+   * Returns the {@linkplain SpanData span} at the {@code index} within the trace. This can be
+   * useful for asserting the parent of a span.
+   */
+  public SpanData getSpan(int index) {
+    return actual.get(0);
+  }
+
   @Override
   protected SpanDataAssert toAssert(SpanData value, String description) {
     return new SpanDataAssert(value).as(description);

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TraceAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TraceAssert.java
@@ -57,7 +57,7 @@ public final class TraceAssert
    * useful for asserting the parent of a span.
    */
   public SpanData getSpan(int index) {
-    return actual.get(0);
+    return actual.get(index);
   }
 
   @Override

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
@@ -85,7 +85,12 @@ class OpenTelemetryExtensionTest {
             trace ->
                 trace
                     .hasTraceId(traceId)
-                    .hasSpansSatisfyingExactly(s -> s.hasName("testa1"), s -> s.hasName("testa2"))
+                    .hasSpansSatisfyingExactly(
+                        s -> s.hasName("testa1"),
+                        s ->
+                            s.hasName("testa2")
+                                .hasParentSpanId(trace.getSpan(0).getSpanId())
+                                .hasParent(trace.getSpan(0)))
                     .first()
                     .hasName("testa1"),
             trace ->


### PR DESCRIPTION
For the common pattern of `hasSpansSatisfyingExactly`, there isn't any way to verify the parent of a span since we don't have any trace data in scope, only a TraceAssert. Allowing access of spans through the TraceAssert enables this and is similar to what we have in instrumentation repo (this is probably the biggest gap between the two right now). Also added a shortcut `hasParent` which seems worth it.