### PR TITLE
Fixes #3392 - Metric benchmark no longer throws NPE

### DIFF
--- a/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/MetricsTestOperationBuilder.java
+++ b/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/MetricsTestOperationBuilder.java
@@ -88,6 +88,28 @@ public enum MetricsTestOperationBuilder {
           }
         };
       }),
+  DoubleHistogramRecorderRecord(
+      meter -> {
+        return new Operation() {
+          final DoubleValueRecorder metric =
+              meter.doubleValueRecorderBuilder("double_histogram_recorder").build();
+          final BoundDoubleValueRecorder boundMetric =
+              meter
+                  .doubleValueRecorderBuilder("bound_double_histogram_recorder")
+                  .build()
+                  .bind(Labels.of("KEY", "VALUE"));
+
+          @Override
+          public void perform(Labels labels) {
+            metric.record(5.0d, labels);
+          }
+
+          @Override
+          public void performBound() {
+            boundMetric.record(5.0d);
+          }
+        };
+      }),
   LongValueRecorderRecord(
       meter -> {
         return new Operation() {

--- a/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/TestSdk.java
+++ b/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/TestSdk.java
@@ -8,13 +8,13 @@ package io.opentelemetry.sdk.metrics;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.sdk.common.Clock;
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.metrics.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.view.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.view.View;
 import io.opentelemetry.sdk.resources.Resource;
-import java.util.EnumMap;
-import java.util.LinkedHashMap;
-import java.util.regex.Pattern;
+import java.util.Arrays;
 
 @SuppressWarnings("ImmutableEnumChecker")
 public enum TestSdk {
@@ -29,17 +29,25 @@ public enum TestSdk {
       new SdkBuilder() {
         @Override
         Meter build() {
-          MeterProviderSharedState meterProviderSharedState =
-              MeterProviderSharedState.create(
-                  Clock.getDefault(),
-                  Resource.empty(),
-                  new ViewRegistry(
-                      new EnumMap<InstrumentType, LinkedHashMap<Pattern, View>>(
-                          InstrumentType.class)));
-          InstrumentationLibraryInfo instrumentationLibraryInfo =
-              InstrumentationLibraryInfo.create("io.opentelemetry.sdk.metrics", null);
-
-          return new SdkMeter(meterProviderSharedState, instrumentationLibraryInfo);
+          return SdkMeterProvider.builder()
+              .setClock(Clock.getDefault())
+              .setResource(Resource.empty())
+              .registerView(
+                  InstrumentSelector.builder()
+                      .setInstrumentNameRegex(".*histogram_recorder")
+                      .setInstrumentType(InstrumentType.VALUE_RECORDER)
+                      .build(),
+                  // Histogram buckets the same as the metrics prototype/prometheus.
+                  View.builder()
+                      .setAggregatorFactory(
+                          AggregatorFactory.histogram(
+                              Arrays.<Double>asList(
+                                  5d, 10d, 25d, 50d, 75d, 100d, 250d, 500d, 750d, 1_000d, 2_500d,
+                                  5_000d, 7_500d, 10_000d),
+                              AggregationTemporality.CUMULATIVE))
+                      .build())
+              .build()
+              .get("io.opentelemetry.sdk.metrics");
         }
       });
 


### PR DESCRIPTION
- Fix benchmark setup to use `SdkMeterProviderBuilder` rather than directly instantiate and risk not configuring necessary components.
- add 'realistic' histogram benchmark for comparison against prototype.