### PR TITLE
Fix disableErrorProne to not disable compilation

### DIFF
--- a/buildSrc/src/main/kotlin/otel.errorprone-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.errorprone-conventions.gradle.kts
@@ -17,7 +17,7 @@ tasks {
             errorprone {
                 if (disableErrorProne) {
                     logger.warn("Errorprone has been disabled. Build may not result in a valid PR build.")
-                    enabled = false
+                    isEnabled.set(false)
                 }
 
                 disableWarningsInGeneratedCode.set(true)


### PR DESCRIPTION
Disabling all compilation tasks completely is an interesting way of disabling the check :) This needed an update when changed from Groovy to Kotlin