### PR TITLE
Add hasNoParent assertion

### DIFF
--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SpanDataAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SpanDataAssert.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -119,6 +120,25 @@ public final class SpanDataAssert extends AbstractAssert<SpanDataAssert, SpanDat
    */
   public SpanDataAssert hasParent(SpanData parent) {
     return hasParentSpanId(parent.getSpanId());
+  }
+
+  /**
+   * Asserts the span has no parent {@link SpanData span}.
+   *
+   * <p>Equivalent to {@code span.hasParentSpanId(SpanId.getInvalid())}.
+   */
+  public SpanDataAssert hasNoParent() {
+    isNotNull();
+    String actualParentSpanId = actual.getParentSpanId();
+    if (!actualParentSpanId.equals(SpanId.getInvalid())) {
+      failWithActualExpectedAndMessage(
+          actualParentSpanId,
+          SpanId.getInvalid(),
+          "Expected span [%s] to have no parent but had parent span ID <%s>",
+          actual.getName(),
+          actualParentSpanId);
+    }
+    return this;
   }
 
   /** Asserts the span has the given {@link Resource}. */

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertionsTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertionsTest.java
@@ -196,6 +196,7 @@ class OpenTelemetryAssertionsTest {
     assertThatThrownBy(() -> assertThat(SPAN1).isNotSampled()).isInstanceOf(AssertionError.class);
     assertThatThrownBy(() -> assertThat(SPAN1).hasTraceState(TraceState.getDefault()))
         .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> assertThat(SPAN1).hasNoParent()).isInstanceOf(AssertionError.class);
     assertThatThrownBy(() -> assertThat(SPAN1).hasParentSpanId("foo"))
         .isInstanceOf(AssertionError.class);
     assertThatThrownBy(() -> assertThat(SPAN1).hasResource(Resource.empty()))

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
@@ -86,7 +86,7 @@ class OpenTelemetryExtensionTest {
                 trace
                     .hasTraceId(traceId)
                     .hasSpansSatisfyingExactly(
-                        s -> s.hasName("testa1"),
+                        s -> s.hasName("testa1").hasNoParent(),
                         s ->
                             s.hasName("testa2")
                                 .hasParentSpanId(trace.getSpan(0).getSpanId())


### PR DESCRIPTION
It's awkward to have to use an ID, the invalid ID, when just wanting to check that there is no parent span.