### PR TITLE
Add assertion for exception

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
@@ -1,6 +1,8 @@
 Comparing source compatibility of  against 
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.SpanDataAssert  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.SpanDataAssert hasException(java.lang.Throwable)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.SpanDataAssert hasNoParent()
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.SpanDataAssert hasParent(io.opentelemetry.sdk.trace.data.SpanData)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.TraceAssert  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0

--- a/sdk/testing/build.gradle.kts
+++ b/sdk/testing/build.gradle.kts
@@ -16,5 +16,7 @@ dependencies {
 
     annotationProcessor("com.google.auto.value:auto-value")
 
+    implementation(project(":semconv"))
+
     testImplementation("junit:junit")
 }

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SpanDataAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SpanDataAssert.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.sdk.testing.assertj;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -19,6 +19,7 @@ import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
@@ -264,6 +265,43 @@ public final class SpanDataAssert extends AbstractAssert<SpanDataAssert, SpanDat
   public SpanDataAssert hasAttributesSatisfying(Consumer<Attributes> attributes) {
     isNotNull();
     assertThat(actual.getAttributes()).as("attributes").satisfies(attributes);
+    return this;
+  }
+
+  /**
+   * Asserts the span has an exception event for the given {@link Throwable}. The stack trace is not
+   * matched against.
+   */
+  public SpanDataAssert hasException(Throwable exception) {
+    EventData exceptionEvent =
+        actual.getEvents().stream()
+            .filter(event -> event.getName().equals(SemanticAttributes.EXCEPTION_EVENT_NAME))
+            .findFirst()
+            .orElse(null);
+
+    if (exceptionEvent == null) {
+      failWithMessage(
+          "Expected span [%s] to have an exception event but only had events <%s>",
+          actual.getName(), actual.getEvents());
+      // Never executed but to reduce IntelliJ warnings.
+      return this;
+    }
+
+    assertThat(exceptionEvent.getAttributes())
+        .as("exception.type")
+        .containsEntry(SemanticAttributes.EXCEPTION_TYPE, exception.getClass().getCanonicalName());
+    if (exception.getMessage() != null) {
+      assertThat(exceptionEvent.getAttributes())
+          .as("exception.message")
+          .containsEntry(SemanticAttributes.EXCEPTION_MESSAGE, exception.getMessage());
+    }
+
+    // Exceptions used in assertions always have a different stack trace, just confirm it was
+    // recorded.
+    assertThat(exceptionEvent.getAttributes().get(SemanticAttributes.EXCEPTION_STACKTRACE))
+        .as("exception.stacktrace")
+        .isNotNull();
+
     return this;
   }
 

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertionsTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertionsTest.java
@@ -22,6 +22,7 @@ import io.opentelemetry.sdk.testing.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.StatusData;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
@@ -53,8 +54,15 @@ class OpenTelemetryAssertionsTest {
   private static final List<EventData> EVENTS =
       Arrays.asList(
           EventData.create(10, "event", Attributes.empty()),
+          EventData.create(20, "event2", Attributes.builder().put("cookie monster", "yum").build()),
           EventData.create(
-              20, "event2", Attributes.builder().put("cookie monster", "yum").build()));
+              30,
+              SemanticAttributes.EXCEPTION_EVENT_NAME,
+              Attributes.builder()
+                  .put(SemanticAttributes.EXCEPTION_TYPE, "java.lang.IllegalArgumentException")
+                  .put(SemanticAttributes.EXCEPTION_MESSAGE, "bad argument")
+                  .put(SemanticAttributes.EXCEPTION_STACKTRACE, "some obfuscated stack")
+                  .build()));
   private static final List<LinkData> LINKS =
       Arrays.asList(
           LinkData.create(
@@ -172,7 +180,10 @@ class OpenTelemetryAssertionsTest {
                   .hasAttributesSatisfying(attributes -> assertThat(attributes).isEmpty());
             })
         .hasEventsSatisfyingExactly(
-            event -> event.hasName("event"), event -> event.hasName("event2"))
+            event -> event.hasName("event"),
+            event -> event.hasName("event2"),
+            event -> event.hasName(SemanticAttributes.EXCEPTION_EVENT_NAME))
+        .hasException(new IllegalArgumentException("bad argument"))
         .hasLinks(LINKS)
         .hasLinks(LINKS.toArray(new LinkData[0]))
         .hasLinksSatisfying(links -> assertThat(links).hasSize(LINKS.size()))
@@ -290,6 +301,12 @@ class OpenTelemetryAssertionsTest {
                                 .hasAttributesSatisfying(
                                     attributes ->
                                         assertThat(attributes).containsEntry("dogs", "meow"))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () -> assertThat(SPAN1).hasException(new IllegalStateException("bad argument")))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () -> assertThat(SPAN1).hasException(new IllegalArgumentException("good argument")))
         .isInstanceOf(AssertionError.class);
     assertThatThrownBy(() -> assertThat(SPAN1).hasLinks()).isInstanceOf(AssertionError.class);
     assertThatThrownBy(() -> assertThat(SPAN1).hasLinks(Collections.emptyList()))

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
@@ -63,6 +63,11 @@ class OpenTelemetryExtensionTest {
     span = tracer.spanBuilder("testb1").startSpan();
     try (Scope ignored = span.makeCurrent()) {
       tracer.spanBuilder("testb2").startSpan().end();
+      tracer
+          .spanBuilder("testexception")
+          .startSpan()
+          .recordException(new IllegalStateException("exception occurred"))
+          .end();
     } finally {
       span.end();
     }
@@ -95,7 +100,10 @@ class OpenTelemetryExtensionTest {
                     .hasName("testa1"),
             trace ->
                 trace
-                    .hasSpansSatisfyingExactly(s -> s.hasName("testb1"), s -> s.hasName("testb2"))
+                    .hasSpansSatisfyingExactly(
+                        s -> s.hasName("testb1"),
+                        s -> s.hasName("testb2"),
+                        s -> s.hasException(new IllegalStateException("exception occurred")))
                     .filteredOn(s -> s.getName().endsWith("1"))
                     .hasSize(1));
 
@@ -115,9 +123,7 @@ class OpenTelemetryExtensionTest {
         .filteredOn(trace -> trace.size() == 2)
         .hasTracesSatisfyingExactly(
             trace ->
-                trace.hasSpansSatisfyingExactly(s -> s.hasName("testa1"), s -> s.hasName("testa2")),
-            trace ->
                 trace.hasSpansSatisfyingExactly(
-                    s -> s.hasName("testb1"), s -> s.hasName("testb2")));
+                    s -> s.hasName("testa1"), s -> s.hasName("testa2")));
   }
 }


### PR DESCRIPTION
Exceptions are converted to data by our SDK so it makes sense to have an assertion matching the logic