### PR TITLE
Add removeAll method to Attributes.

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedAttributes.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedAttributes.java
@@ -82,9 +82,6 @@ final class ArrayBackedAttributes extends ImmutableKeyValuePairs<AttributeKey<?>
 
   /** Default implementation to use. */
   private static Attributes removeAllSlow(Attributes source, Attributes other) {
-    if (other.isEmpty()) {
-      return source;
-    }
     final List<Object> result = new ArrayList<>();
     source.forEach(
         (key, value) -> {

--- a/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedAttributes.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedAttributes.java
@@ -51,7 +51,11 @@ final class ArrayBackedAttributes extends ImmutableKeyValuePairs<AttributeKey<?>
           KEY_COMPARATOR_FOR_CONSTRUCTION.compare(
               (AttributeKey<?>) source.getRaw(i), (AttributeKey<?>) other.getRaw(j));
       if (keyCompare == 0) {
-        // Match, drop our value (TODO: iff values are equal)
+        // Match, drop our value, No-Match we still add it.
+        if (!source.getRaw(i + 1).equals(other.getRaw(j + 1))) {
+          result.add(source.getRaw(i));
+          result.add(source.getRaw(i + 1));
+        }
         i += 2;
         j += 2;
       } else if (keyCompare < 0) {
@@ -84,7 +88,7 @@ final class ArrayBackedAttributes extends ImmutableKeyValuePairs<AttributeKey<?>
     final List<Object> result = new ArrayList<>();
     source.forEach(
         (key, value) -> {
-          if (other.get(key) == null) {
+          if (!value.equals(other.get(key))) {
             result.add(key);
             result.add(value);
           }

--- a/api/all/src/main/java/io/opentelemetry/api/common/Attributes.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/Attributes.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.api.common;
 
+import static io.opentelemetry.api.common.ArrayBackedAttributes.removeAllImpl;
 import static io.opentelemetry.api.common.ArrayBackedAttributes.sortAndFilterToAttributes;
 
 import java.util.Map;
@@ -48,6 +49,16 @@ public interface Attributes {
 
   /** Returns a read-only view of this {@link Attributes} as a {@link Map}. */
   Map<AttributeKey<?>, Object> asMap();
+
+  /**
+   * Returns a {@link Attributes} instance containing only key-value pairs that are unique to this
+   * instance compared to the input.
+   *
+   * @param other The {@link Attributes} to remove from this instance.
+   */
+  default Attributes removeAll(Attributes other) {
+    return removeAllImpl(this, other);
+  }
 
   /** Returns a {@link Attributes} instance with no attributes. */
   static Attributes empty() {

--- a/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
@@ -52,6 +52,10 @@ public abstract class ImmutableKeyValuePairs<K, V> {
     return Arrays.asList(data);
   }
 
+  protected final Object getRaw(int index) {
+    return data[index];
+  }
+
   public final int size() {
     return data.length / 2;
   }

--- a/api/all/src/test/java/io/opentelemetry/api/common/AttributesTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/common/AttributesTest.java
@@ -83,6 +83,14 @@ class AttributesTest {
   }
 
   @Test
+  void removeAll_onlyRemovesExactMatch() {
+    Attributes complete = Attributes.builder().put("x", 1).put("y", 2).put("z", 3).build();
+    Attributes removed = Attributes.builder().put("y", "2").build();
+    assertThat(complete.removeAll(removed))
+        .isEqualTo(Attributes.builder().put("x", 1).put("y", 2).put("z", 3).build());
+  }
+
+  @Test
   @SuppressWarnings("unchecked")
   void removeAll_nonstandardImplementation() {
     final Attributes myHipsterImpl =
@@ -133,6 +141,9 @@ class AttributesTest {
         .isEqualTo(Attributes.builder().put("x", 1).put("z", 3).build());
     assertThat(myHipsterImpl.removeAll(myHipsterImpl)).isEqualTo(Attributes.empty());
     assertThat(removed.removeAll(myHipsterImpl)).isEqualTo(Attributes.empty());
+    // verify exact match required for removal.
+    assertThat(myHipsterImpl.removeAll(Attributes.builder().put("y", "1").build()))
+        .isEqualTo(Attributes.builder().put("x", 1).put("y", 2).put("z", 3).build());
   }
 
   @SuppressWarnings("CollectionIncompatibleType")

--- a/api/all/src/test/java/io/opentelemetry/api/common/AttributesTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/common/AttributesTest.java
@@ -72,6 +72,7 @@ class AttributesTest {
   void removeAll() {
     Attributes complete = Attributes.builder().put("x", 1).put("y", 2).put("z", 3).build();
     Attributes removed = Attributes.builder().put("y", 2).build();
+    assertThat(complete.removeAll(Attributes.empty())).isEqualTo(complete);
     assertThat(complete.removeAll(removed))
         .isEqualTo(Attributes.builder().put("x", 1).put("z", 3).build());
     assertThat(complete.removeAll(complete)).isEqualTo(Attributes.empty());

--- a/docs/apidiffs/current_vs_latest/opentelemetry-api.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-api.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+***! MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.api.common.Attributes  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++! NEW METHOD: PUBLIC(+) io.opentelemetry.api.common.Attributes removeAll(io.opentelemetry.api.common.Attributes)


### PR DESCRIPTION
Create a mechanism to filter out attributes existing in another instance.

- Adds two implementations, one for sorted list-based array-backed attributes, one generic
- Exposes this functionality for Exemplars (not in this PR) where we need to record the attribtues NOT already recorded within a datapoint.  This allows us to avoid an allocation in the hotpath by preserving all measurement attributes and filtering when constructing metric points.