### PR TITLE
Preserve spaces in gradle.properties

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -754,7 +754,7 @@ ij_json_wrap_long_lines = false
 
 [{*.properties, spring.handlers, spring.schemas}]
 ij_properties_align_group_field_declarations = false
-ij_properties_keep_blank_lines = false
+ij_properties_keep_blank_lines = true
 ij_properties_key_value_delimiter = equals
 ij_properties_spaces_around_key_value_delimiter = false
 


### PR DESCRIPTION
Syncing with otel-java-instrumentation (#3677)