### PR TITLE
Add Iterable versions of hasTraces / Spans

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
@@ -10,3 +10,7 @@ Comparing source compatibility of  against
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.TraceAssert  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.data.SpanData getSpan(int)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.TraceAssert hasSpansSatisfyingExactly(java.lang.Iterable)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.TracesAssert  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.TracesAssert hasTracesSatisfyingExactly(java.lang.Iterable)

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TraceAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TraceAssert.java
@@ -46,9 +46,20 @@ public final class TraceAssert
   @SafeVarargs
   @SuppressWarnings("varargs")
   public final TraceAssert hasSpansSatisfyingExactly(Consumer<SpanDataAssert>... assertions) {
-    hasSize(assertions.length);
-    zipSatisfy(
-        Arrays.asList(assertions), (span, assertion) -> assertion.accept(new SpanDataAssert(span)));
+    return hasSpansSatisfyingExactly(Arrays.asList(assertions));
+  }
+
+  /**
+   * Asserts that the trace under assertion has the same number of spans as provided {@code
+   * assertions} and executes each {@link SpanDataAssert} in {@code assertions} in order with the
+   * corresponding span.
+   */
+  public TraceAssert hasSpansSatisfyingExactly(
+      Iterable<? extends Consumer<SpanDataAssert>> assertions) {
+    List<Consumer<SpanDataAssert>> assertionsList =
+        StreamSupport.stream(assertions.spliterator(), false).collect(Collectors.toList());
+    hasSize(assertionsList.size());
+    zipSatisfy(assertionsList, (span, assertion) -> assertion.accept(new SpanDataAssert(span)));
     return this;
   }
 

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TracesAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TracesAssert.java
@@ -49,9 +49,20 @@ public final class TracesAssert
   @SafeVarargs
   @SuppressWarnings("varargs")
   public final TracesAssert hasTracesSatisfyingExactly(Consumer<TraceAssert>... assertions) {
-    hasSize(assertions.length);
-    zipSatisfy(
-        Arrays.asList(assertions), (trace, assertion) -> assertion.accept(new TraceAssert(trace)));
+    return hasTracesSatisfyingExactly(Arrays.asList(assertions));
+  }
+
+  /**
+   * Asserts that the traces under assertion have the same number of traces as provided {@code
+   * assertions} and executes each {@link TracesAssert} in {@code assertions} in order with the
+   * corresponding trace.
+   */
+  public TracesAssert hasTracesSatisfyingExactly(
+      Iterable<? extends Consumer<TraceAssert>> assertions) {
+    List<Consumer<TraceAssert>> assertionsList =
+        StreamSupport.stream(assertions.spliterator(), false).collect(toList());
+    hasSize(assertionsList.size());
+    zipSatisfy(assertionsList, (trace, assertion) -> assertion.accept(new TraceAssert(trace)));
     return this;
   }
 

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
@@ -12,6 +12,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
@@ -106,6 +107,18 @@ class OpenTelemetryExtensionTest {
                         s -> s.hasException(new IllegalStateException("exception occurred")))
                     .filteredOn(s -> s.getName().endsWith("1"))
                     .hasSize(1));
+
+    otelTesting
+        .assertTraces()
+        .hasTracesSatisfyingExactly(
+            Arrays.asList(
+                trace -> trace.hasTraceId(traceId),
+                trace ->
+                    trace.hasSpansSatisfyingExactly(
+                        Arrays.asList(
+                            s -> s.hasName("testb1"),
+                            s -> s.hasName("testb2"),
+                            s -> s.hasName("testexception")))));
 
     assertThatThrownBy(
             () ->


### PR DESCRIPTION
It's reasonable to need to set up assertions programatically, for example when testing a method that executes dozens of requests to verify concurrency. This way a List type of thing doesn't need to be converted to an array and is consistent with the other vararg methods we have in our APIs