### PR TITLE
Add AttributesAssert.containsKey

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
@@ -2,6 +2,8 @@ Comparing source compatibility of  against
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.AttributesAssert  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.AttributesAssert containsEntry(io.opentelemetry.api.common.AttributeKey, int)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.AttributesAssert containsKey(io.opentelemetry.api.common.AttributeKey)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.AttributesAssert containsKey(java.lang.String)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.SpanDataAssert  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.SpanDataAssert hasException(java.lang.Throwable)

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/AttributesAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/AttributesAssert.java
@@ -10,14 +10,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.error.ShouldContainKeys;
 
 /** Assertions for {@link Attributes}. */
 public final class AttributesAssert extends AbstractAssert<AttributesAssert, Attributes> {
+
   AttributesAssert(Attributes actual) {
     super(actual, AttributesAssert.class);
   }
@@ -25,6 +29,7 @@ public final class AttributesAssert extends AbstractAssert<AttributesAssert, Att
   /** Asserts the attributes have the given key and value. */
   public <T> AttributesAssert containsEntry(AttributeKey<T> key, T value) {
     isNotNull();
+    containsKey(key);
     T actualValue = actual.get(key);
     if (!Objects.equals(actualValue, value)) {
       failWithActualExpectedAndMessage(
@@ -86,6 +91,7 @@ public final class AttributesAssert extends AbstractAssert<AttributesAssert, Att
   /** Asserts the attributes have the given key and string array value. */
   public AttributesAssert containsEntryWithStringValuesOf(String key, Iterable<String> value) {
     isNotNull();
+    containsKey(key);
     List<String> actualValue = actual.get(AttributeKey.stringArrayKey(key));
     assertThat(actualValue)
         .withFailMessage(
@@ -98,6 +104,7 @@ public final class AttributesAssert extends AbstractAssert<AttributesAssert, Att
   /** Asserts the attributes have the given key and boolean array value. */
   public AttributesAssert containsEntryWithBooleanValuesOf(String key, Iterable<Boolean> value) {
     isNotNull();
+    containsKey(key);
     List<Boolean> actualValue = actual.get(AttributeKey.booleanArrayKey(key));
     assertThat(actualValue)
         .withFailMessage(
@@ -110,6 +117,7 @@ public final class AttributesAssert extends AbstractAssert<AttributesAssert, Att
   /** Asserts the attributes have the given key and long array value. */
   public AttributesAssert containsEntryWithLongValuesOf(String key, Iterable<Long> value) {
     isNotNull();
+    containsKey(key);
     List<Long> actualValue = actual.get(AttributeKey.longArrayKey(key));
     assertThat(actualValue)
         .withFailMessage(
@@ -122,6 +130,7 @@ public final class AttributesAssert extends AbstractAssert<AttributesAssert, Att
   /** Asserts the attributes have the given key and double array value. */
   public AttributesAssert containsEntryWithDoubleValuesOf(String key, Iterable<Double> value) {
     isNotNull();
+    containsKey(key);
     List<Double> actualValue = actual.get(AttributeKey.doubleArrayKey(key));
     assertThat(actualValue)
         .withFailMessage(
@@ -134,6 +143,7 @@ public final class AttributesAssert extends AbstractAssert<AttributesAssert, Att
   /** Asserts the attributes have the given key with a value satisfying the given condition. */
   public <T> AttributesAssert hasEntrySatisfying(AttributeKey<T> key, Consumer<T> valueCondition) {
     isNotNull();
+    containsKey(key);
     assertThat(actual.get(key)).as("value").satisfies(valueCondition);
     return this;
   }
@@ -145,6 +155,30 @@ public final class AttributesAssert extends AbstractAssert<AttributesAssert, Att
   public final AttributesAssert containsOnly(Map.Entry<? extends AttributeKey<?>, ?>... entries) {
     isNotNull();
     assertThat(actual.asMap()).containsOnly(entries);
+    return this;
+  }
+
+  /** Asserts the attributes contain the given key. */
+  public AttributesAssert containsKey(AttributeKey<?> key) {
+    if (actual.get(key) == null) {
+      failWithMessage(
+          ShouldContainKeys.shouldContainKeys(actual, Collections.singleton(key))
+              .create(info.description(), info.representation()));
+    }
+    return this;
+  }
+
+  /** Asserts the attributes contain the given key. */
+  public AttributesAssert containsKey(String key) {
+    Optional<AttributeKey<?>> resolved =
+        actual.asMap().keySet().stream()
+            .filter(attributeKey -> attributeKey.getKey().equals(key))
+            .findFirst();
+    if (!resolved.isPresent()) {
+      failWithMessage(
+          ShouldContainKeys.shouldContainKeys(actual, Collections.singleton(key))
+              .create(info.description(), info.representation()));
+    }
     return this;
   }
 

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertionsTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertionsTest.java
@@ -157,6 +157,8 @@ class OpenTelemetryAssertionsTest {
                     .containsEntryWithLongValuesOf("scores", Arrays.asList(0L, 1L))
                     .containsEntry("coins", 0.01, 0.05, 0.1)
                     .containsEntryWithDoubleValuesOf("coins", Arrays.asList(0.01, 0.05, 0.1))
+                    .containsKey(AttributeKey.stringKey("bear"))
+                    .containsKey("bear")
                     .containsOnly(
                         attributeEntry("bear", "mya"),
                         attributeEntry("warm", true),
@@ -235,6 +237,19 @@ class OpenTelemetryAssertionsTest {
                 assertThat(SPAN1)
                     .hasAttributesSatisfying(
                         attributes -> assertThat(attributes).containsEntry("cat", "bark")))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(SPAN1)
+                    .hasAttributesSatisfying(
+                        attributes ->
+                            assertThat(attributes).containsKey(AttributeKey.stringKey("cat"))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(SPAN1)
+                    .hasAttributesSatisfying(
+                        attributes -> assertThat(attributes).containsKey("cat")))
         .isInstanceOf(AssertionError.class);
     assertThatThrownBy(
             () ->


### PR DESCRIPTION
While it's more common to check both key and value, it may be appropriate to only check key. In particular, this is extremely important to add to `hasEntrySatisfying` (as in this PR) since otherwise in the case of a missing key, it fallsback to a null check with an unhelpful assertion message `Expecting actual to not be null`