### PR TITLE
Allow Jaeger remote sampler to be closed.

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-jaeger-remote-sampler.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-jaeger-remote-sampler.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.extension.trace.jaeger.sampler.JaegerRemoteSampler  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) void close()

--- a/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerBuilder.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerBuilder.java
@@ -26,6 +26,7 @@ public final class JaegerRemoteSamplerBuilder {
   private String serviceName;
   private Sampler initialSampler = INITIAL_SAMPLER;
   private int pollingIntervalMillis = DEFAULT_POLLING_INTERVAL_MILLIS;
+  private boolean closeChannel = true;
 
   /**
    * Sets the service name to be used by this exporter. Required.
@@ -53,6 +54,7 @@ public final class JaegerRemoteSamplerBuilder {
   public JaegerRemoteSamplerBuilder setChannel(ManagedChannel channel) {
     requireNonNull(channel, "channel");
     this.channel = channel;
+    closeChannel = false;
     return this;
   }
 
@@ -95,7 +97,8 @@ public final class JaegerRemoteSamplerBuilder {
     if (channel == null) {
       channel = ManagedChannelBuilder.forTarget(endpoint).usePlaintext().build();
     }
-    return new JaegerRemoteSampler(serviceName, channel, pollingIntervalMillis, initialSampler);
+    return new JaegerRemoteSampler(
+        serviceName, channel, pollingIntervalMillis, initialSampler, closeChannel);
   }
 
   JaegerRemoteSamplerBuilder() {}

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerIntegrationTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerIntegrationTest.java
@@ -36,29 +36,29 @@ class JaegerRemoteSamplerIntegrationTest {
 
   @Test
   void remoteSampling_perOperation() {
-    final JaegerRemoteSampler remoteSampler =
+    try (JaegerRemoteSampler remoteSampler =
         JaegerRemoteSampler.builder()
             .setEndpoint("127.0.0.1:" + jaegerContainer.getMappedPort(COLLECTOR_PORT))
             .setServiceName(SERVICE_NAME)
-            .build();
-
-    await()
-        .atMost(Duration.ofSeconds(10))
-        .untilAsserted(samplerIsType(remoteSampler, PerOperationSampler.class));
-    assertThat(remoteSampler.getDescription()).contains("0.33").doesNotContain("150");
+            .build()) {
+      await()
+          .atMost(Duration.ofSeconds(10))
+          .untilAsserted(samplerIsType(remoteSampler, PerOperationSampler.class));
+      assertThat(remoteSampler.getDescription()).contains("0.33").doesNotContain("150");
+    }
   }
 
   @Test
   void remoteSampling_rateLimiting() {
-    final JaegerRemoteSampler remoteSampler =
+    try (JaegerRemoteSampler remoteSampler =
         JaegerRemoteSampler.builder()
             .setEndpoint("127.0.0.1:" + jaegerContainer.getMappedPort(COLLECTOR_PORT))
             .setServiceName(SERVICE_NAME_RATE_LIMITING)
-            .build();
-
-    await()
-        .atMost(Duration.ofSeconds(10))
-        .untilAsserted(samplerIsType(remoteSampler, RateLimitingSampler.class));
-    assertThat(remoteSampler.getDescription()).contains("RateLimitingSampler{150.00}");
+            .build()) {
+      await()
+          .atMost(Duration.ofSeconds(10))
+          .untilAsserted(samplerIsType(remoteSampler, RateLimitingSampler.class));
+      assertThat(remoteSampler.getDescription()).contains("RateLimitingSampler{150.00}");
+    }
   }
 }

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerTest.java
@@ -100,6 +100,7 @@ class JaegerRemoteSamplerTest {
             .setChannel(inProcessChannel)
             .setServiceName(SERVICE_NAME)
             .build();
+    closer.register(sampler);
 
     await()
         .atMost(Duration.ofSeconds(10))
@@ -121,6 +122,7 @@ class JaegerRemoteSamplerTest {
             .setChannel(inProcessChannel)
             .setServiceName(SERVICE_NAME)
             .build();
+    closer.register(sampler);
     assertThat(sampler.getDescription())
         .startsWith("JaegerRemoteSampler{ParentBased{root:TraceIdRatioBased{0.001000}");
 
@@ -141,6 +143,7 @@ class JaegerRemoteSamplerTest {
             .setServiceName(SERVICE_NAME)
             .setInitialSampler(Sampler.alwaysOn())
             .build();
+    closer.register(sampler);
     assertThat(sampler.getDescription()).startsWith("JaegerRemoteSampler{AlwaysOnSampler}");
   }
 
@@ -152,6 +155,7 @@ class JaegerRemoteSamplerTest {
             .setServiceName(SERVICE_NAME)
             .setPollingInterval(1, TimeUnit.MILLISECONDS)
             .build();
+    closer.register(sampler);
 
     // wait until the sampling strategy is retrieved before exiting test method
     await()
@@ -171,6 +175,7 @@ class JaegerRemoteSamplerTest {
             .setServiceName(SERVICE_NAME)
             .setPollingInterval(Duration.ofMillis(1))
             .build();
+    closer.register(sampler);
 
     // wait until the sampling strategy is retrieved before exiting test method
     await()


### PR DESCRIPTION
When debugging logs of CI, I noticed 90% of the log is spam from leaked jaeger pollers.