### PR TITLE
Don't fail fast on tests.

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -10,6 +10,7 @@ jobs:
     name: Build
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:
           - macos-latest

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -10,6 +10,7 @@ jobs:
     name: Build
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:
           - macos-latest


### PR DESCRIPTION
@jkwatson While sorting through some of the very common CI failures like the HttpSpanExporter one, let's go ahead and use our judgment to merge PRs when a reasonable representative set of the jobs pass, if that's ok with you.