### PR TITLE
Set jobid for build cache.

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -55,6 +55,7 @@ jobs:
           java-version: 11
       - uses: burrunan/gradle-cache-action@v1.10
         with:
+          job-id: jdk${{ matrix.test-java-version }}
           remote-build-cache-proxy-enabled: false
           arguments: build --stacktrace ${{ matrix.coverage && 'jacocoTestReport' || '' }}
           properties: |
@@ -84,6 +85,7 @@ jobs:
           java-version: 11
       - uses: burrunan/gradle-cache-action@v1.10
         with:
+          job-id: jdk11
           remote-build-cache-proxy-enabled: false
           arguments: snapshot --stacktrace
         env:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -55,6 +55,7 @@ jobs:
           java-version: 11
       - uses: burrunan/gradle-cache-action@v1.10
         with:
+          job-id: jdk${{ matrix.test-java-version }}
           remote-build-cache-proxy-enabled: false
           arguments: build --stacktrace ${{ matrix.coverage && 'jacocoTestReport' || '' }}
           properties: |


### PR DESCRIPTION
Prevents build cache from one java overwriting the other, preventing caching of all but one java version. This was needed when we migrated to use same pattern as instrumentation for testJavaVersion.