### PR TITLE
Adds getParentSpanContext to ReadableSpan interface

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
@@ -1,4 +1,7 @@
 Comparing source compatibility of  against 
+**** MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.trace.ReadableSpan  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++* NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.trace.SpanContext getParentSpanContext()
 ***! MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.trace.samplers.SamplingResult  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++! NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.trace.samplers.SamplingResult drop()

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java
@@ -24,6 +24,14 @@ public interface ReadableSpan {
   SpanContext getSpanContext();
 
   /**
+   * Returns the parent {@link SpanContext} of the {@link Span}, or {@link SpanContext#getInvalid()}
+   * if this is a root span.
+   *
+   * @return the parent {@link SpanContext} of the {@link Span}
+   */
+  SpanContext getParentSpanContext();
+
+  /**
    * Returns the name of the {@code Span}.
    *
    * <p>The name can be changed during the lifetime of the Span by using the {@link

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -202,6 +202,11 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
     return context;
   }
 
+  @Override
+  public SpanContext getParentSpanContext() {
+    return parentSpanContext;
+  }
+
   /**
    * Returns the name of the {@code Span}.
    *
@@ -449,10 +454,6 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
     synchronized (lock) {
       return status;
     }
-  }
-
-  SpanContext getParentSpanContext() {
-    return parentSpanContext;
   }
 
   Resource getResource() {

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -214,8 +214,24 @@ class RecordEventsReadableSpanTest {
     } finally {
       span.end();
     }
+    assertThat(span.getParentSpanContext().isValid()).isFalse();
     SpanData spanData = span.toSpanData();
     assertThat(SpanId.isValid(spanData.getParentSpanId())).isFalse();
+  }
+
+  @Test
+  void toSpanData_ChildSpan() {
+    RecordEventsReadableSpan span = createTestSpan(SpanKind.INTERNAL);
+    try {
+      spanDoWork(span, null, null);
+    } finally {
+      span.end();
+    }
+    assertThat(span.getParentSpanContext().isValid()).isTrue();
+    assertThat(span.getParentSpanContext().getTraceId()).isEqualTo(traceId);
+    assertThat(span.getParentSpanContext().getSpanId()).isEqualTo(parentSpanId);
+    SpanData spanData = span.toSpanData();
+    assertThat(spanData.getParentSpanId()).isEqualTo(parentSpanId);
   }
 
   @Test


### PR DESCRIPTION
Adds the `getParentSpanContext` method to the `ReadableSpan` interface to get the `SpanContext` of the parent span, or `SpanContext#getInvalid` if the span is a root span.  I believe that this is already allowed by the opentelemetry-specification as it states:

> A function receiving this as argument MUST be able to access all information that was added to the span, as listed in the API spec.

and the API spec explicitly lists the parent span or span context as one of those pieces of information.

This information is already accessible via calling `toSpanData`, but that method is expensive as it synchronized and needs to make copies of the mutable state of the span.