### PR TITLE
Add a new configurable metric exporter to autoconf

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigurableMetricExporterProvider.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigurableMetricExporterProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure.spi;
+
+import io.opentelemetry.sdk.autoconfigure.ConfigProperties;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+
+/**
+ * A service provider interface (SPI) for providing additional exporters that can be used with the
+ * autoconfigured SDK. If the {@code otel.metrics.exporter} property contains a value equal to what
+ * is returned by {@link #getName()}, the exporter returned by {@link
+ * #createExporter(ConfigProperties)} will be enabled and added to the SDK.
+ */
+public interface ConfigurableMetricExporterProvider {
+
+  /**
+   * Returns a {@link MetricExporter} that can be registered to OpenTelemetry by providing the
+   * property value specified by {@link #getName()}.
+   */
+  MetricExporter createExporter(ConfigProperties config);
+
+  /**
+   * Returns the name of this exporter, which can be specified with the {@code
+   * otel.metrics.exporter} property to enable it. The name returned should NOT be the same as any
+   * other exporter name. If the name does conflict with another exporter name, the resulting
+   * behavior is undefined and it is explicitly unspecified which exporter will actually be used.
+   */
+  String getName();
+}

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableMetricExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableMetricExporterTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class ConfigurableMetricExporterTest {
+
+  @Test
+  void configuration() {
+    ConfigProperties config =
+        ConfigProperties.createForTest(ImmutableMap.of("test.option", "true"));
+    MetricExporter metricExporter =
+        MetricExporterConfiguration.configureSpiExporter("testExporter", config);
+
+    assertThat(metricExporter)
+        .isInstanceOf(TestConfigurableMetricExporterProvider.TestMetricExporter.class)
+        .extracting("config")
+        .isSameAs(config);
+  }
+
+  @Test
+  void exporterNotFound() {
+    SdkMeterProvider provider = SdkMeterProvider.builder().build();
+    assertThatThrownBy(
+            () ->
+                MetricExporterConfiguration.configureExporter(
+                    "catExporter",
+                    ConfigProperties.createForTest(Collections.emptyMap()),
+                    provider))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("catExporter");
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/TestConfigurableMetricExporterProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/TestConfigurableMetricExporterProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurableMetricExporterProvider;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.Collection;
+
+public class TestConfigurableMetricExporterProvider implements ConfigurableMetricExporterProvider {
+
+  @Override
+  public MetricExporter createExporter(ConfigProperties config) {
+    return new TestMetricExporter(config);
+  }
+
+  @Override
+  public String getName() {
+    return "testExporter";
+  }
+
+  public static class TestMetricExporter implements MetricExporter {
+    private final ConfigProperties config;
+
+    public TestMetricExporter(ConfigProperties config) {
+      this.config = config;
+    }
+
+    @Override
+    public CompletableResultCode export(Collection<MetricData> metrics) {
+      return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode flush() {
+      return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+      return CompletableResultCode.ofSuccess();
+    }
+
+    public ConfigProperties getConfig() {
+      return config;
+    }
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ConfigurableMetricExporterProvider
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ConfigurableMetricExporterProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.sdk.autoconfigure.TestConfigurableMetricExporterProvider


### PR DESCRIPTION
- Creates ConfigurableMetricExporterProvider SPI
- Updates Metric setup to use SPI registry after built-in