### PR TITLE
Staticially initialize HTTP exporter loggers.

### DIFF
--- a/exporters/otlp-http/metrics/src/main/java/io/opentelemetry/exporter/otlp/http/metric/OtlpHttpMetricExporter.java
+++ b/exporters/otlp-http/metrics/src/main/java/io/opentelemetry/exporter/otlp/http/metric/OtlpHttpMetricExporter.java
@@ -38,8 +38,10 @@ public final class OtlpHttpMetricExporter implements MetricExporter {
 
   private static final MediaType PROTOBUF_MEDIA_TYPE = MediaType.parse("application/x-protobuf");
 
-  private final ThrottlingLogger logger =
-      new ThrottlingLogger(Logger.getLogger(OtlpHttpMetricExporter.class.getName()));
+  private static final Logger internalLogger =
+      Logger.getLogger(OtlpHttpMetricExporter.class.getName());
+
+  private final ThrottlingLogger logger = new ThrottlingLogger(internalLogger);
 
   private final OkHttpClient client;
   private final String endpoint;

--- a/exporters/otlp-http/trace/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporter.java
+++ b/exporters/otlp-http/trace/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporter.java
@@ -51,8 +51,10 @@ public final class OtlpHttpSpanExporter implements SpanExporter {
 
   private static final MediaType PROTOBUF_MEDIA_TYPE = MediaType.parse("application/x-protobuf");
 
-  private final ThrottlingLogger logger =
-      new ThrottlingLogger(Logger.getLogger(OtlpHttpSpanExporter.class.getName()));
+  private static final Logger internalLogger =
+      Logger.getLogger(OtlpHttpSpanExporter.class.getName());
+
+  private final ThrottlingLogger logger = new ThrottlingLogger(internalLogger);
 
   private final BoundLongCounter spansSeen;
   private final BoundLongCounter spansExportedSuccess;


### PR DESCRIPTION
I can't reason out why this would actually cause a different in the flaky test we're seeing but want to give it a YOLO attempt. I have been able to confirm that the test fails despite the log message definitely being printed as below. 

Logunit's general structure is `beforeTestExecution`, essentially `Logger.getLogger(name).addHandler(listHandler)`. I don't see any thread safety issues or anything, digging through JDK code I could see getLogger returning a different instance if the calling class's "module" (JMS) is different but that shouldn't be the case. But anyways, maybe `static` does something let's see.

```
    Aug 10, 2021 6:13:21 AM io.opentelemetry.sdk.internal.ThrottlingLogger doLog
    WARNING: Failed to export metrics. Server responded with HTTP status code 500. Error message: Server error!

> Task :exporters:otlp-http:trace:test
Finished generating test XML results (0.0 secs) into: /home/runner/work/opentelemetry-java/opentelemetry-java/exporters/otlp-http/trace/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.002 secs) into: /home/runner/work/opentelemetry-java/opentelemetry-java/exporters/otlp-http/trace/build/reports/tests/test
Watching 3726 directories to track changes
Watching 3727 directories to track changes
Watching 3733 directories to track changes
Watching 3734 directories to track changes
:exporters:otlp-http:trace:test (Thread[Execution worker for ':',5,main]) completed. Took 10.78 secs.
:exporters:otlp-http:trace:check (Thread[Execution worker for ':',5,main]) started.

> Task :exporters:otlp-http:trace:check
Skipping task ':exporters:otlp-http:trace:check' as it has no actions.
:exporters:otlp-http:trace:check (Thread[Execution worker for ':',5,main]) completed. Took 0.0 secs.
:exporters:otlp-http:trace:build (Thread[Execution worker for ':',5,main]) started.

> Task :exporters:otlp-http:trace:build
Skipping task ':exporters:otlp-http:trace:build' as it has no actions.
:exporters:otlp-http:trace:build (Thread[Execution worker for ':',5,main]) completed. Took 0.0 secs.

> Task :exporters:otlp-http:metrics:test

OtlpHttpMetricExporterTest > testServerError() FAILED
    org.awaitility.core.ConditionTimeoutException: Assertion condition defined as a io.opentelemetry.exporter.otlp.http.metric.OtlpHttpMetricExporterTest Contain the string <Failed to export metrics. Server responded with HTTP status code 500. Error message: Server error!> ==> None of the 0 captured log events matched the filter predicate within 10 seconds.
        at org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:166)
        at org.awaitility.core.AssertionCondition.await(AssertionCondition.java:119)
        at org.awaitility.core.AssertionCondition.await(AssertionCondition.java:31)
        at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:939)
        at org.awaitility.core.ConditionFactory.untilAsserted(ConditionFactory.java:723)
        at io.opentelemetry.exporter.otlp.http.metric.OtlpHttpMetricExporterTest.testServerError(OtlpHttpMetricExporterTest.java:197)

        Caused by:
        org.opentest4j.AssertionFailedError: Contain the string <Failed to export metrics. Server responded with HTTP status code 500. Error message: Server error!> ==> None of the 0 captured log events matched the filter predicate
            at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:39)
            at org.junit.jupiter.api.Assertions.fail(Assertions.java:117)
            at io.github.netmikey.logunit.api.LogCapturer.lambda$assertContains$3(LogCap
```