### PR TITLE
Clean up generating version.properties.

### DIFF
--- a/sdk/all/build.gradle.kts
+++ b/sdk/all/build.gradle.kts
@@ -21,20 +21,3 @@ dependencies {
 
   testImplementation(project(":sdk:testing"))
 }
-
-sourceSets {
-  main {
-    output.dir("build/generated/properties", "builtBy" to "generateVersionResource")
-  }
-}
-
-tasks {
-  register("generateVersionResource") {
-    val propertiesDir = file("build/generated/properties/io/opentelemetry/sdk")
-    outputs.dir(propertiesDir)
-
-    doLast {
-      File(propertiesDir, "version.properties").writeText("sdk.version=${project.version}")
-    }
-  }
-}

--- a/sdk/common/build.gradle.kts
+++ b/sdk/common/build.gradle.kts
@@ -41,7 +41,7 @@ sourceSets {
 
 tasks {
   register("generateVersionResource") {
-    inputs.property("project.version", project.version)
+    inputs.property("project.version", "${project.version}")
     val propertiesDir = file("$genResourceDir/io/opentelemetry/sdk")
     outputs.dir(propertiesDir)
 

--- a/sdk/common/build.gradle.kts
+++ b/sdk/common/build.gradle.kts
@@ -30,15 +30,19 @@ dependencies {
   testImplementation("com.google.guava:guava-testlib")
 }
 
+val genResourceDir = "$buildDir/generated/resources/"
+
 sourceSets {
   main {
-    output.dir("build/generated/properties", "builtBy" to "generateVersionResource")
+    output.dir(genResourceDir, "builtBy" to "generateVersionResource")
   }
 }
 
+
 tasks {
   register("generateVersionResource") {
-    val propertiesDir = file("build/generated/properties/io/opentelemetry/sdk/common")
+    inputs.property("project.version", project.version)
+    val propertiesDir = file("$genResourceDir/io/opentelemetry/sdk")
     outputs.dir(propertiesDir)
 
     doLast {

--- a/sdk/metrics/build.gradle.kts
+++ b/sdk/metrics/build.gradle.kts
@@ -27,21 +27,7 @@ dependencies {
   testImplementation("com.google.guava:guava")
 }
 
-sourceSets {
-  main {
-    output.dir("build/generated/properties", "builtBy" to "generateVersionResource")
-  }
-}
-
 tasks {
-  register("generateVersionResource") {
-    val propertiesDir = file("build/generated/properties/io/opentelemetry/sdk/metrics")
-    outputs.dir(propertiesDir)
-
-    doLast {
-      File(propertiesDir, "version.properties").writeText("sdk.version=${project.version}")
-    }
-  }
   withType(JavaCompile::class) {
     // Ignore deprecation warnings that AutoValue creates for now.
     options.compilerArgs.add("-Xlint:-deprecation")

--- a/sdk/trace/build.gradle.kts
+++ b/sdk/trace/build.gradle.kts
@@ -60,22 +60,7 @@ dependencies {
   jmh("org.testcontainers:testcontainers") // testContainer for OTLP collector
 }
 
-sourceSets {
-  main {
-    output.dir("build/generated/properties", "builtBy" to "generateVersionResource")
-  }
-}
-
 tasks {
-  register("generateVersionResource") {
-    val propertiesDir = file("build/generated/properties/io/opentelemetry/sdk/trace")
-    outputs.dir(propertiesDir)
-
-    doLast {
-      File(propertiesDir, "version.properties").writeText("sdk.version=${project.version}")
-    }
-  }
-
   withType<AnimalSniffer>().configureEach {
     // We catch NoClassDefFoundError to fallback to non-jctools queues.
     exclude("**/internal/shaded/jctools/**")


### PR DESCRIPTION
Crucially, this adds `inputs.property("project.version", project.version)` to avoid stale builds.