### PR TITLE
Fix OpenTelemetrySdk(.tracerProvider).tracerBuilder() being noop.

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
@@ -206,5 +206,10 @@ public final class GlobalOpenTelemetry {
     public ContextPropagators getPropagators() {
       return delegate.getPropagators();
     }
+
+    @Override
+    public TracerBuilder tracerBuilder(String instrumentationName) {
+      return delegate.tracerBuilder(instrumentationName);
+    }
   }
 }

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerBuilder;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -71,6 +72,11 @@ public final class OpenTelemetrySdk implements OpenTelemetry {
     @Override
     public Tracer get(String instrumentationName, String instrumentationVersion) {
       return delegate.get(instrumentationName, instrumentationVersion);
+    }
+
+    @Override
+    public TracerBuilder tracerBuilder(String instrumentationName) {
+      return delegate.tracerBuilder(instrumentationName);
     }
 
     public SdkTracerProvider unobfuscate() {

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -73,9 +73,20 @@ class OpenTelemetrySdkTest {
   @Test
   void testShortcutVersions() {
     assertThat(GlobalOpenTelemetry.getTracer("testTracer1"))
-        .isEqualTo(GlobalOpenTelemetry.getTracerProvider().get("testTracer1"));
+        .isSameAs(GlobalOpenTelemetry.getTracerProvider().get("testTracer1"));
     assertThat(GlobalOpenTelemetry.getTracer("testTracer2", "testVersion"))
-        .isEqualTo(GlobalOpenTelemetry.getTracerProvider().get("testTracer2", "testVersion"));
+        .isSameAs(GlobalOpenTelemetry.getTracerProvider().get("testTracer2", "testVersion"));
+    assertThat(
+            GlobalOpenTelemetry.tracerBuilder("testTracer2")
+                .setInstrumentationVersion("testVersion")
+                .setSchemaUrl("https://example.invalid")
+                .build())
+        .isSameAs(
+            GlobalOpenTelemetry.getTracerProvider()
+                .tracerBuilder("testTracer2")
+                .setInstrumentationVersion("testVersion")
+                .setSchemaUrl("https://example.invalid")
+                .build());
   }
 
   @Test

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.mockito.Mockito.mock;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
@@ -131,6 +132,20 @@ class OpenTelemetrySdkTest {
         .hasFieldOrPropertyWithValue("clock", clock)
         .hasFieldOrPropertyWithValue("resource", resource)
         .hasFieldOrPropertyWithValue("idGenerator", idGenerator);
+  }
+
+  @Test
+  void testTracerBuilder() {
+    final OpenTelemetrySdk openTelemetry = OpenTelemetrySdk.builder().build();
+    assertThat(openTelemetry.tracerBuilder("instr"))
+        .isNotSameAs(OpenTelemetry.noop().tracerBuilder("instr"));
+  }
+
+  @Test
+  void testTracerBuilderViaProvider() {
+    final OpenTelemetrySdk openTelemetry = OpenTelemetrySdk.builder().build();
+    assertThat(openTelemetry.getTracerProvider().tracerBuilder("instr"))
+        .isNotSameAs(OpenTelemetry.noop().tracerBuilder("instr"));
   }
 
   @Test


### PR DESCRIPTION
The default method implementation of TracerProvider.tracerBuilder and OpenTelemetry.tracerBuilder is not very helpful, as demonstrated by this PR.

~~I will amend the PR later to provide a fix, just wanted to give you a quick heads-up  since the release of 1.5 seems imminent -- probably this should be fixed before. @jkwatson @anuraaga~~