### PR TITLE
Fix Resource version properties lookup and extract version file gener…

### DIFF
--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -134,23 +134,28 @@ tasks {
       }
     }
   }
-
-  register("generateVersionResource") {
-    val moduleName = otelJava.moduleName
-    val propertiesDir = moduleName.map { file("build/generated/properties/${it.replace('.', '/')}") }
-
-    inputs.property("project.version", project.version.toString())
-    outputs.dir(propertiesDir)
-
-    doLast {
-      File(propertiesDir.get(), "version.properties").writeText("sdk.version=${project.version}")
-    }
-  }
 }
 
-sourceSets {
-  main {
-    output.dir("build/generated/properties", "builtBy" to "generateVersionResource")
+// Add version information to published artifacts.
+plugins.withId("maven-publish") {
+  tasks {
+    register("generateVersionResource") {
+      val moduleName = otelJava.moduleName
+      val propertiesDir = moduleName.map { file("build/generated/properties/${it.replace('.', '/')}") }
+
+      inputs.property("project.version", project.version.toString())
+      outputs.dir(propertiesDir)
+
+      doLast {
+        File(propertiesDir.get(), "version.properties").writeText("sdk.version=${project.version}")
+      }
+    }
+  }
+
+  sourceSets {
+    main {
+      output.dir("build/generated/properties", "builtBy" to "generateVersionResource")
+    }
   }
 }
 

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -134,6 +134,24 @@ tasks {
       }
     }
   }
+
+  register("generateVersionResource") {
+    val moduleName = otelJava.moduleName
+    val propertiesDir = moduleName.map { file("build/generated/properties/${it.replace('.', '/')}") }
+
+    inputs.property("project.version", project.version.toString())
+    outputs.dir(propertiesDir)
+
+    doLast {
+      File(propertiesDir.get(), "version.properties").writeText("sdk.version=${project.version}")
+    }
+  }
+}
+
+sourceSets {
+  main {
+    output.dir("build/generated/properties", "builtBy" to "generateVersionResource")
+  }
 }
 
 configurations.configureEach {

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -137,11 +137,11 @@ tasks {
 }
 
 // Add version information to published artifacts.
-plugins.withId("maven-publish") {
+plugins.withId("otel.publish-conventions") {
   tasks {
     register("generateVersionResource") {
       val moduleName = otelJava.moduleName
-      val propertiesDir = moduleName.map { file("build/generated/properties/${it.replace('.', '/')}") }
+      val propertiesDir = moduleName.map { File(buildDir, "generated/properties/${it.replace('.', '/')}") }
 
       inputs.property("project.version", project.version.toString())
       outputs.dir(propertiesDir)
@@ -154,7 +154,7 @@ plugins.withId("maven-publish") {
 
   sourceSets {
     main {
-      output.dir("build/generated/properties", "builtBy" to "generateVersionResource")
+      output.dir("$buildDir/generated/properties", "builtBy" to "generateVersionResource")
     }
   }
 }

--- a/sdk-extensions/resources/build.gradle.kts
+++ b/sdk-extensions/resources/build.gradle.kts
@@ -22,23 +22,6 @@ dependencies {
   testImplementation("org.junit-pioneer:junit-pioneer")
 }
 
-sourceSets {
-  main {
-    output.dir("build/generated/properties", "builtBy" to "generateVersionResource")
-  }
-}
-
-tasks {
-  register("generateVersionResource") {
-    val propertiesDir = file("build/generated/properties/io/opentelemetry/sdk/extension/resources")
-    outputs.dir(propertiesDir)
-
-    doLast {
-      File(propertiesDir, "version.properties").writeText("sdk.version=${project.version}")
-    }
-  }
-}
-
 for (version in mrJarVersions) {
   sourceSets {
     create("java${version}") {

--- a/sdk/all/build.gradle.kts
+++ b/sdk/all/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 description = "OpenTelemetry SDK"
 otelJava.moduleName.set("io.opentelemetry.sdk")
-base.archivesBaseName = "opentelemetry-sdk"
+base.archivesName.set("opentelemetry-sdk")
 
 dependencies {
   api(project(":api:all"))
@@ -20,21 +20,4 @@ dependencies {
   testAnnotationProcessor("com.google.auto.value:auto-value")
 
   testImplementation(project(":sdk:testing"))
-}
-
-sourceSets {
-  main {
-    output.dir("build/generated/properties", "builtBy" to "generateVersionResource")
-  }
-}
-
-tasks {
-  register("generateVersionResource") {
-    val propertiesDir = file("build/generated/properties/io/opentelemetry/sdk")
-    outputs.dir(propertiesDir)
-
-    doLast {
-      File(propertiesDir, "version.properties").writeText("sdk.version=${project.version}")
-    }
-  }
 }

--- a/sdk/common/build.gradle.kts
+++ b/sdk/common/build.gradle.kts
@@ -30,23 +30,6 @@ dependencies {
   testImplementation("com.google.guava:guava-testlib")
 }
 
-sourceSets {
-  main {
-    output.dir("build/generated/properties", "builtBy" to "generateVersionResource")
-  }
-}
-
-tasks {
-  register("generateVersionResource") {
-    val propertiesDir = file("build/generated/properties/io/opentelemetry/sdk/common")
-    outputs.dir(propertiesDir)
-
-    doLast {
-      File(propertiesDir, "version.properties").writeText("sdk.version=${project.version}")
-    }
-  }
-}
-
 for (version in mrJarVersions) {
   sourceSets {
     create("java${version}") {
@@ -86,5 +69,10 @@ tasks {
     manifest.attributes(
       "Multi-Release" to "true"
     )
+  }
+
+  test {
+    // For checking version number included in Resource.
+    systemProperty("otel.test.project-version", project.version.toString())
   }
 }

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/resources/Resource.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/resources/Resource.java
@@ -115,7 +115,7 @@ public abstract class Resource {
     Properties properties = new Properties();
     try {
       properties.load(
-          Resource.class.getResourceAsStream("/io/opentelemetry/sdk/version.properties"));
+          Resource.class.getResourceAsStream("/io/opentelemetry/sdk/common/version.properties"));
     } catch (Exception e) {
       // we left the attribute empty
       return "unknown";

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/resources/ResourceTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/resources/ResourceTest.java
@@ -207,7 +207,6 @@ class ResourceTest {
   @Test
   void testDefaultResources() {
     Resource resource = Resource.getDefault();
-    Attributes attributes = resource.getAttributes();
     assertThat(resource.getAttribute(ResourceAttributes.SERVICE_NAME))
         .isEqualTo("unknown_service:java");
     assertThat(resource.getAttribute(ResourceAttributes.TELEMETRY_SDK_NAME))

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/resources/ResourceTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/resources/ResourceTest.java
@@ -208,17 +208,13 @@ class ResourceTest {
   void testDefaultResources() {
     Resource resource = Resource.getDefault();
     Attributes attributes = resource.getAttributes();
-    assertThat(attributes.get(ResourceAttributes.SERVICE_NAME)).isEqualTo("unknown_service:java");
-    assertThat(attributes.get(ResourceAttributes.TELEMETRY_SDK_NAME)).isEqualTo("opentelemetry");
-    assertThat(attributes.get(ResourceAttributes.TELEMETRY_SDK_LANGUAGE)).isEqualTo("java");
-    assertThat(attributes.get(ResourceAttributes.TELEMETRY_SDK_VERSION))
-        .isEqualTo(System.getProperty("otel.test.project-version"));
     assertThat(resource.getAttribute(ResourceAttributes.SERVICE_NAME))
         .isEqualTo("unknown_service:java");
     assertThat(resource.getAttribute(ResourceAttributes.TELEMETRY_SDK_NAME))
         .isEqualTo("opentelemetry");
     assertThat(resource.getAttribute(ResourceAttributes.TELEMETRY_SDK_LANGUAGE)).isEqualTo("java");
-    assertThat(resource.getAttribute(ResourceAttributes.TELEMETRY_SDK_VERSION)).isNotNull();
+    assertThat(resource.getAttribute(ResourceAttributes.TELEMETRY_SDK_VERSION))
+        .isEqualTo(System.getProperty("otel.test.project-version"));
   }
 
   @Test

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/resources/ResourceTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/resources/ResourceTest.java
@@ -211,7 +211,8 @@ class ResourceTest {
     assertThat(attributes.get(ResourceAttributes.SERVICE_NAME)).isEqualTo("unknown_service:java");
     assertThat(attributes.get(ResourceAttributes.TELEMETRY_SDK_NAME)).isEqualTo("opentelemetry");
     assertThat(attributes.get(ResourceAttributes.TELEMETRY_SDK_LANGUAGE)).isEqualTo("java");
-    assertThat(attributes.get(ResourceAttributes.TELEMETRY_SDK_VERSION)).isNotNull();
+    assertThat(attributes.get(ResourceAttributes.TELEMETRY_SDK_VERSION))
+        .isEqualTo(System.getProperty("otel.test.project-version"));
   }
 
   @Test

--- a/sdk/metrics/build.gradle.kts
+++ b/sdk/metrics/build.gradle.kts
@@ -26,24 +26,3 @@ dependencies {
   testImplementation(project(":sdk:testing"))
   testImplementation("com.google.guava:guava")
 }
-
-sourceSets {
-  main {
-    output.dir("build/generated/properties", "builtBy" to "generateVersionResource")
-  }
-}
-
-tasks {
-  register("generateVersionResource") {
-    val propertiesDir = file("build/generated/properties/io/opentelemetry/sdk/metrics")
-    outputs.dir(propertiesDir)
-
-    doLast {
-      File(propertiesDir, "version.properties").writeText("sdk.version=${project.version}")
-    }
-  }
-  withType(JavaCompile::class) {
-    // Ignore deprecation warnings that AutoValue creates for now.
-    options.compilerArgs.add("-Xlint:-deprecation")
-  }
-}

--- a/sdk/trace/build.gradle.kts
+++ b/sdk/trace/build.gradle.kts
@@ -11,7 +11,6 @@ plugins {
 description = "OpenTelemetry SDK For Tracing"
 otelJava.moduleName.set("io.opentelemetry.sdk.trace")
 
-
 sourceSets {
   main {
     val traceShadedDeps = project(":sdk:trace-shaded-deps")
@@ -60,22 +59,7 @@ dependencies {
   jmh("org.testcontainers:testcontainers") // testContainer for OTLP collector
 }
 
-sourceSets {
-  main {
-    output.dir("build/generated/properties", "builtBy" to "generateVersionResource")
-  }
-}
-
 tasks {
-  register("generateVersionResource") {
-    val propertiesDir = file("build/generated/properties/io/opentelemetry/sdk/trace")
-    outputs.dir(propertiesDir)
-
-    doLast {
-      File(propertiesDir, "version.properties").writeText("sdk.version=${project.version}")
-    }
-  }
-
   withType<AnimalSniffer>().configureEach {
     // We catch NoClassDefFoundError to fallback to non-jctools queues.
     exclude("**/internal/shaded/jctools/**")


### PR DESCRIPTION
…ation.

I think it's good practice to add the version to a file in any JARs we publish as it allows verification of version alignment at runtime as needed. So this extracts creation of the version specifier to the java conventions itself. Note that `MANIFEST` tends to not work well for this because fatjars often lose it.