### PR TITLE
Add Resource.getAttribute() 

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-common.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-common.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC ABSTRACT io.opentelemetry.sdk.resources.Resource  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) java.lang.Object getAttribute(io.opentelemetry.api.common.AttributeKey)

--- a/exporters/jaeger-thrift/src/main/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftSpanExporter.java
+++ b/exporters/jaeger-thrift/src/main/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftSpanExporter.java
@@ -109,9 +109,9 @@ public final class JaegerThriftSpanExporter implements SpanExporter {
   private Process createProcess(Resource resource) {
     Process result = new Process(this.process);
 
-    String serviceName = resource.getAttributes().get(ResourceAttributes.SERVICE_NAME);
+    String serviceName = resource.getAttribute(ResourceAttributes.SERVICE_NAME);
     if (serviceName == null || serviceName.isEmpty()) {
-      serviceName = Resource.getDefault().getAttributes().get(ResourceAttributes.SERVICE_NAME);
+      serviceName = Resource.getDefault().getAttribute(ResourceAttributes.SERVICE_NAME);
     }
     result.setServiceName(serviceName);
 

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporter.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporter.java
@@ -151,9 +151,9 @@ public final class JaegerGrpcSpanExporter implements SpanExporter {
   private Collector.PostSpansRequest buildRequest(Resource resource, List<SpanData> spans) {
     Model.Process.Builder builder = this.processBuilder.clone();
 
-    String serviceName = resource.getAttributes().get(ResourceAttributes.SERVICE_NAME);
+    String serviceName = resource.getAttribute(ResourceAttributes.SERVICE_NAME);
     if (serviceName == null || serviceName.isEmpty()) {
-      serviceName = Resource.getDefault().getAttributes().get(ResourceAttributes.SERVICE_NAME);
+      serviceName = Resource.getDefault().getAttribute(ResourceAttributes.SERVICE_NAME);
     }
     builder.setServiceName(serviceName);
 

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
@@ -158,7 +158,7 @@ public final class ZipkinSpanExporter implements SpanExporter {
     // use the service.name from the Resource, if it's been set.
     String serviceNameValue = resourceAttributes.get(ResourceAttributes.SERVICE_NAME);
     if (serviceNameValue == null) {
-      serviceNameValue = Resource.getDefault().getAttributes().get(ResourceAttributes.SERVICE_NAME);
+      serviceNameValue = Resource.getDefault().getAttribute(ResourceAttributes.SERVICE_NAME);
     }
     return Endpoint.newBuilder().serviceName(serviceNameValue).ip(localAddress).build();
   }

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterTest.java
@@ -177,7 +177,7 @@ class ZipkinSpanExporterTest {
 
     Endpoint expectedEndpoint =
         Endpoint.newBuilder()
-            .serviceName(Resource.getDefault().getAttributes().get(ResourceAttributes.SERVICE_NAME))
+            .serviceName(Resource.getDefault().getAttribute(ResourceAttributes.SERVICE_NAME))
             .ip(exporter.getLocalAddressForTest())
             .build();
     Span expectedZipkinSpan =

--- a/sdk-extensions/autoconfigure/src/testResourceDisabledByEnv/java/io/opentelemetry/sdk/resources/ResourceDisabledByEnvTest.java
+++ b/sdk-extensions/autoconfigure/src/testResourceDisabledByEnv/java/io/opentelemetry/sdk/resources/ResourceDisabledByEnvTest.java
@@ -17,8 +17,8 @@ class ResourceDisabledByEnvTest {
   void osAndProcessDisabled() {
     Resource resource = OpenTelemetryResourceAutoConfiguration.configureResource();
 
-    assertThat(resource.getAttributes().get(ResourceAttributes.OS_TYPE)).isNull();
-    assertThat(resource.getAttributes().get(ResourceAttributes.PROCESS_PID)).isNull();
-    assertThat(resource.getAttributes().get(ResourceAttributes.PROCESS_RUNTIME_NAME)).isNotNull();
+    assertThat(resource.getAttribute(ResourceAttributes.OS_TYPE)).isNull();
+    assertThat(resource.getAttribute(ResourceAttributes.PROCESS_PID)).isNull();
+    assertThat(resource.getAttribute(ResourceAttributes.PROCESS_RUNTIME_NAME)).isNotNull();
   }
 }

--- a/sdk-extensions/autoconfigure/src/testResourceDisabledByProperty/java/io/opentelemetry/sdk/resources/ResourceDisabledByPropertyTest.java
+++ b/sdk-extensions/autoconfigure/src/testResourceDisabledByProperty/java/io/opentelemetry/sdk/resources/ResourceDisabledByPropertyTest.java
@@ -17,8 +17,8 @@ class ResourceDisabledByPropertyTest {
   void osAndProcessDisabled() {
     Resource resource = OpenTelemetryResourceAutoConfiguration.configureResource();
 
-    assertThat(resource.getAttributes().get(ResourceAttributes.OS_TYPE)).isNull();
-    assertThat(resource.getAttributes().get(ResourceAttributes.PROCESS_PID)).isNull();
-    assertThat(resource.getAttributes().get(ResourceAttributes.PROCESS_RUNTIME_NAME)).isNotNull();
+    assertThat(resource.getAttribute(ResourceAttributes.OS_TYPE)).isNull();
+    assertThat(resource.getAttribute(ResourceAttributes.PROCESS_PID)).isNull();
+    assertThat(resource.getAttribute(ResourceAttributes.PROCESS_RUNTIME_NAME)).isNotNull();
   }
 }

--- a/sdk-extensions/resources/src/test/java/io/opentelemetry/sdk/extension/resources/ContainerResourceTest.java
+++ b/sdk-extensions/resources/src/test/java/io/opentelemetry/sdk/extension/resources/ContainerResourceTest.java
@@ -75,7 +75,7 @@ public class ContainerResourceTest {
   }
 
   private static String getContainerId(Resource resource) {
-    return resource.getAttributes().get(ResourceAttributes.CONTAINER_ID);
+    return resource.getAttribute(ResourceAttributes.CONTAINER_ID);
   }
 
   private static Path createCGroup(Path path, String line) throws IOException {

--- a/sdk-extensions/resources/src/test/java/io/opentelemetry/sdk/extension/resources/OsResourceTest.java
+++ b/sdk-extensions/resources/src/test/java/io/opentelemetry/sdk/extension/resources/OsResourceTest.java
@@ -7,7 +7,6 @@ package io.opentelemetry.sdk.extension.resources;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import org.junit.jupiter.api.Nested;
@@ -25,10 +24,9 @@ class OsResourceTest {
   void linux() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(ResourceAttributes.SCHEMA_URL);
-    Attributes attributes = resource.getAttributes();
-    assertThat(attributes.get(ResourceAttributes.OS_TYPE))
+    assertThat(resource.getAttribute(ResourceAttributes.OS_TYPE))
         .isEqualTo(ResourceAttributes.OsTypeValues.LINUX);
-    assertThat(attributes.get(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -36,10 +34,9 @@ class OsResourceTest {
   void macos() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(ResourceAttributes.SCHEMA_URL);
-    Attributes attributes = resource.getAttributes();
-    assertThat(attributes.get(ResourceAttributes.OS_TYPE))
+    assertThat(resource.getAttribute(ResourceAttributes.OS_TYPE))
         .isEqualTo(ResourceAttributes.OsTypeValues.DARWIN);
-    assertThat(attributes.get(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -47,10 +44,9 @@ class OsResourceTest {
   void windows() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(ResourceAttributes.SCHEMA_URL);
-    Attributes attributes = resource.getAttributes();
-    assertThat(attributes.get(ResourceAttributes.OS_TYPE))
+    assertThat(resource.getAttribute(ResourceAttributes.OS_TYPE))
         .isEqualTo(ResourceAttributes.OsTypeValues.WINDOWS);
-    assertThat(attributes.get(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -58,10 +54,9 @@ class OsResourceTest {
   void freebsd() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(ResourceAttributes.SCHEMA_URL);
-    Attributes attributes = resource.getAttributes();
-    assertThat(attributes.get(ResourceAttributes.OS_TYPE))
+    assertThat(resource.getAttribute(ResourceAttributes.OS_TYPE))
         .isEqualTo(ResourceAttributes.OsTypeValues.FREEBSD);
-    assertThat(attributes.get(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -69,10 +64,9 @@ class OsResourceTest {
   void netbsd() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(ResourceAttributes.SCHEMA_URL);
-    Attributes attributes = resource.getAttributes();
-    assertThat(attributes.get(ResourceAttributes.OS_TYPE))
+    assertThat(resource.getAttribute(ResourceAttributes.OS_TYPE))
         .isEqualTo(ResourceAttributes.OsTypeValues.NETBSD);
-    assertThat(attributes.get(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -80,10 +74,9 @@ class OsResourceTest {
   void openbsd() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(ResourceAttributes.SCHEMA_URL);
-    Attributes attributes = resource.getAttributes();
-    assertThat(attributes.get(ResourceAttributes.OS_TYPE))
+    assertThat(resource.getAttribute(ResourceAttributes.OS_TYPE))
         .isEqualTo(ResourceAttributes.OsTypeValues.OPENBSD);
-    assertThat(attributes.get(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -91,10 +84,9 @@ class OsResourceTest {
   void dragonflybsd() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(ResourceAttributes.SCHEMA_URL);
-    Attributes attributes = resource.getAttributes();
-    assertThat(attributes.get(ResourceAttributes.OS_TYPE))
+    assertThat(resource.getAttribute(ResourceAttributes.OS_TYPE))
         .isEqualTo(ResourceAttributes.OsTypeValues.DRAGONFLYBSD);
-    assertThat(attributes.get(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -102,10 +94,9 @@ class OsResourceTest {
   void hpux() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(ResourceAttributes.SCHEMA_URL);
-    Attributes attributes = resource.getAttributes();
-    assertThat(attributes.get(ResourceAttributes.OS_TYPE))
+    assertThat(resource.getAttribute(ResourceAttributes.OS_TYPE))
         .isEqualTo(ResourceAttributes.OsTypeValues.HPUX);
-    assertThat(attributes.get(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -113,10 +104,9 @@ class OsResourceTest {
   void aix() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(ResourceAttributes.SCHEMA_URL);
-    Attributes attributes = resource.getAttributes();
-    assertThat(attributes.get(ResourceAttributes.OS_TYPE))
+    assertThat(resource.getAttribute(ResourceAttributes.OS_TYPE))
         .isEqualTo(ResourceAttributes.OsTypeValues.AIX);
-    assertThat(attributes.get(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -124,10 +114,9 @@ class OsResourceTest {
   void solaris() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(ResourceAttributes.SCHEMA_URL);
-    Attributes attributes = resource.getAttributes();
-    assertThat(attributes.get(ResourceAttributes.OS_TYPE))
+    assertThat(resource.getAttribute(ResourceAttributes.OS_TYPE))
         .isEqualTo(ResourceAttributes.OsTypeValues.SOLARIS);
-    assertThat(attributes.get(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -135,10 +124,9 @@ class OsResourceTest {
   void zos() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(ResourceAttributes.SCHEMA_URL);
-    Attributes attributes = resource.getAttributes();
-    assertThat(attributes.get(ResourceAttributes.OS_TYPE))
+    assertThat(resource.getAttribute(ResourceAttributes.OS_TYPE))
         .isEqualTo(ResourceAttributes.OsTypeValues.Z_OS);
-    assertThat(attributes.get(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -146,9 +134,8 @@ class OsResourceTest {
   void unknown() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(ResourceAttributes.SCHEMA_URL);
-    Attributes attributes = resource.getAttributes();
-    assertThat(attributes.get(ResourceAttributes.OS_TYPE)).isNull();
-    assertThat(attributes.get(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(ResourceAttributes.OS_TYPE)).isNull();
+    assertThat(resource.getAttribute(ResourceAttributes.OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Nested

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/resources/Resource.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/resources/Resource.java
@@ -139,6 +139,15 @@ public abstract class Resource {
    */
   public abstract Attributes getAttributes();
 
+  /**
+   * Returns the value for a given resource attribute key.
+   *
+   * @return the value of the attribute with the given key
+   */
+  public <T> T getAttribute(AttributeKey<T> key) {
+    return getAttributes().get(key);
+  }
+
   @Memoized
   @Override
   public abstract int hashCode();

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/resources/ResourceTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/resources/ResourceTest.java
@@ -207,11 +207,12 @@ class ResourceTest {
   @Test
   void testDefaultResources() {
     Resource resource = Resource.getDefault();
-    Attributes attributes = resource.getAttributes();
-    assertThat(attributes.get(ResourceAttributes.SERVICE_NAME)).isEqualTo("unknown_service:java");
-    assertThat(attributes.get(ResourceAttributes.TELEMETRY_SDK_NAME)).isEqualTo("opentelemetry");
-    assertThat(attributes.get(ResourceAttributes.TELEMETRY_SDK_LANGUAGE)).isEqualTo("java");
-    assertThat(attributes.get(ResourceAttributes.TELEMETRY_SDK_VERSION)).isNotNull();
+    assertThat(resource.getAttribute(ResourceAttributes.SERVICE_NAME))
+        .isEqualTo("unknown_service:java");
+    assertThat(resource.getAttribute(ResourceAttributes.TELEMETRY_SDK_NAME))
+        .isEqualTo("opentelemetry");
+    assertThat(resource.getAttribute(ResourceAttributes.TELEMETRY_SDK_LANGUAGE)).isEqualTo("java");
+    assertThat(resource.getAttribute(ResourceAttributes.TELEMETRY_SDK_VERSION)).isNotNull();
   }
 
   @Test
@@ -224,7 +225,7 @@ class ResourceTest {
 
     // then no exception is thrown
     // and
-    assertThat(builder.build().getAttributes().get(ResourceAttributes.SERVICE_NAME))
+    assertThat(builder.build().getAttribute(ResourceAttributes.SERVICE_NAME))
         .isEqualTo("unknown_service:java");
   }
 
@@ -239,7 +240,7 @@ class ResourceTest {
     // then
     Resource resource = builder.build();
     assertThat(resource).isNotSameAs(Resource.getDefault());
-    assertThat(resource.getAttributes().get(stringKey("dog says what?"))).isEqualTo("woof");
+    assertThat(resource.getAttribute(stringKey("dog says what?"))).isEqualTo("woof");
   }
 
   @Test


### PR DESCRIPTION
It's pretty common to see code that just wants to get the value of a single resource attribute...and there wasn't a method to do this, so there were law of demeter violations sprinkled about. This adds the `getResource(key)` method and cleans up some of the `.getAttributes().get(key)` calls. 

Vendors will be able to leverage this too.