### PR TITLE
Use static loggers for gRPC exporters too.

### DIFF
--- a/exporters/otlp/metrics/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporter.java
+++ b/exporters/otlp/metrics/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporter.java
@@ -30,8 +30,10 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class OtlpGrpcMetricExporter implements MetricExporter {
 
-  private final ThrottlingLogger logger =
-      new ThrottlingLogger(Logger.getLogger(OtlpGrpcMetricExporter.class.getName()));
+  private static final Logger internalLogger =
+      Logger.getLogger(OtlpGrpcMetricExporter.class.getName());
+
+  private final ThrottlingLogger logger = new ThrottlingLogger(internalLogger);
 
   private final MetricsServiceFutureStub metricsService;
   private final ManagedChannel managedChannel;

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporter.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporter.java
@@ -46,8 +46,10 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
   private static final Attributes EXPORT_FAILURE_ATTRIBUTES =
       Attributes.of(EXPORTER_KEY, EXPORTER_NAME, SUCCESS_KEY, "false");
 
-  private final ThrottlingLogger logger =
-      new ThrottlingLogger(Logger.getLogger(OtlpGrpcSpanExporter.class.getName()));
+  private static final Logger internalLogger =
+      Logger.getLogger(OtlpGrpcSpanExporter.class.getName());
+
+  private final ThrottlingLogger logger = new ThrottlingLogger(internalLogger);
 
   private final TraceServiceFutureStub traceService;
 


### PR DESCRIPTION
Haven't seen the HTTP exporters flake in a while and finally saw a gRPC one do so. So applying same pattern.

Ref: https://github.com/open-telemetry/opentelemetry-java/pull/3459#issuecomment-897363405