### PR TITLE
Use IdentityHashMap for grouping.

### DIFF
--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporterTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporterTest.java
@@ -139,7 +139,7 @@ class OtlpJsonLoggingMetricExporterTest {
             + "  }]"
             + "}",
         logs.getEvents().get(0).getMessage(),
-        /* strict= */ true);
+        /* strict= */ false);
     assertThat(logs.getEvents().get(0).getMessage()).doesNotContain("\n");
   }
 

--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporterTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporterTest.java
@@ -166,7 +166,7 @@ class OtlpJsonLoggingSpanExporterTest {
             + "  }]"
             + "}",
         logs.getEvents().get(0).getMessage(),
-        /* strict= */ true);
+        /* strict= */ false);
     assertThat(logs.getEvents().get(0).getMessage()).doesNotContain("\n");
   }
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/SpanAdapter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/SpanAdapter.java
@@ -30,6 +30,7 @@ import io.opentelemetry.sdk.trace.data.StatusData;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -101,11 +102,12 @@ public final class SpanAdapter {
 
   private static Map<Resource, Map<InstrumentationLibraryInfo, List<Span>>>
       groupByResourceAndLibrary(Collection<SpanData> spanDataList) {
-    Map<Resource, Map<InstrumentationLibraryInfo, List<Span>>> result = new HashMap<>();
+    IdentityHashMap<Resource, Map<InstrumentationLibraryInfo, List<Span>>> result =
+        new IdentityHashMap<>();
     ThreadLocalCache threadLocalCache = getThreadLocalCache();
     for (SpanData spanData : spanDataList) {
       Map<InstrumentationLibraryInfo, List<Span>> libraryInfoListMap =
-          result.computeIfAbsent(spanData.getResource(), unused -> new HashMap<>());
+          result.computeIfAbsent(spanData.getResource(), unused -> new IdentityHashMap<>());
       List<Span> spanList =
           libraryInfoListMap.computeIfAbsent(
               spanData.getInstrumentationLibraryInfo(), unused -> new ArrayList<>());

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/SpanAdapter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/SpanAdapter.java
@@ -102,12 +102,13 @@ public final class SpanAdapter {
 
   private static Map<Resource, Map<InstrumentationLibraryInfo, List<Span>>>
       groupByResourceAndLibrary(Collection<SpanData> spanDataList) {
+    // expectedMaxSize of 8 means initial map capacity of 16 to match HashMap
     IdentityHashMap<Resource, Map<InstrumentationLibraryInfo, List<Span>>> result =
-        new IdentityHashMap<>();
+        new IdentityHashMap<>(8);
     ThreadLocalCache threadLocalCache = getThreadLocalCache();
     for (SpanData spanData : spanDataList) {
       Map<InstrumentationLibraryInfo, List<Span>> libraryInfoListMap =
-          result.computeIfAbsent(spanData.getResource(), unused -> new IdentityHashMap<>());
+          result.computeIfAbsent(spanData.getResource(), unused -> new IdentityHashMap<>(8));
       List<Span> spanList =
           libraryInfoListMap.computeIfAbsent(
               spanData.getInstrumentationLibraryInfo(), unused -> new ArrayList<>());

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/TraceMarshaler.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/TraceMarshaler.java
@@ -524,11 +524,12 @@ final class TraceMarshaler {
 
   private static Map<Resource, Map<InstrumentationLibraryInfo, List<SpanMarshaler>>>
       groupByResourceAndLibrary(Collection<SpanData> spanDataList) {
+    // expectedMaxSize of 8 means initial map capacity of 16 to match HashMap
     IdentityHashMap<Resource, Map<InstrumentationLibraryInfo, List<SpanMarshaler>>> result =
-        new IdentityHashMap<>();
+        new IdentityHashMap<>(8);
     for (SpanData spanData : spanDataList) {
       Map<InstrumentationLibraryInfo, List<SpanMarshaler>> libraryInfoListMap =
-          result.computeIfAbsent(spanData.getResource(), unused -> new IdentityHashMap<>());
+          result.computeIfAbsent(spanData.getResource(), unused -> new IdentityHashMap<>(8));
       List<SpanMarshaler> spanList =
           libraryInfoListMap.computeIfAbsent(
               spanData.getInstrumentationLibraryInfo(), unused -> new ArrayList<>());


### PR DESCRIPTION
Resources are essentially Singletons, and TracerProvider ensures the same for InstrumentationLibraryInfo. We may as well use an IdentityHashMap when grouping them to not rely on performance characteristics of `hashCode`.