### PR TITLE
Make proto dependency on gRPC compileOnly.

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -69,6 +69,7 @@ val DEPENDENCY_SETS = listOf(
 
 val DEPENDENCIES = listOf(
   "com.github.stefanbirkner:system-rules:1.19.0",
+  "com.google.api.grpc:proto-google-common-protos:2.3.2",
   "com.google.code.findbugs:jsr305:3.0.2",
   "com.google.code.gson:gson:2.8.7",
   "com.google.guava:guava-beta-checker:1.0",

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-common.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-common.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC ABSTRACT io.opentelemetry.sdk.resources.Resource  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	---  REMOVED METHOD: PUBLIC(-) ABSTRACT(-) int hashCode()

--- a/exporters/otlp-http/metrics/build.gradle.kts
+++ b/exporters/otlp-http/metrics/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
 
   implementation(project(":exporters:otlp:common"))
 
+  implementation("com.google.api.grpc:proto-google-common-protos")
   implementation("com.squareup.okhttp3:okhttp")
   implementation("com.squareup.okhttp3:okhttp-tls")
   implementation("com.squareup.okio:okio")

--- a/exporters/otlp-http/metrics/build.gradle.kts
+++ b/exporters/otlp-http/metrics/build.gradle.kts
@@ -13,12 +13,12 @@ dependencies {
 
   implementation(project(":exporters:otlp:common"))
 
-  implementation("com.google.api.grpc:proto-google-common-protos")
   implementation("com.squareup.okhttp3:okhttp")
   implementation("com.squareup.okhttp3:okhttp-tls")
   implementation("com.squareup.okio:okio")
 
   testImplementation(project(":sdk:testing"))
 
+  testImplementation("com.google.api.grpc:proto-google-common-protos")
   testImplementation("com.linecorp.armeria:armeria-junit5")
 }

--- a/exporters/otlp-http/metrics/src/main/java/io/opentelemetry/exporter/otlp/http/metric/OtlpHttpMetricExporter.java
+++ b/exporters/otlp-http/metrics/src/main/java/io/opentelemetry/exporter/otlp/http/metric/OtlpHttpMetricExporter.java
@@ -5,8 +5,7 @@
 
 package io.opentelemetry.exporter.otlp.http.metric;
 
-import com.google.rpc.Code;
-import com.google.rpc.Status;
+import io.opentelemetry.exporter.otlp.internal.GrpcStatusUtil;
 import io.opentelemetry.exporter.otlp.internal.MetricAdapter;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.sdk.common.CompletableResultCode;
@@ -106,14 +105,14 @@ public final class OtlpHttpMetricExporter implements MetricExporter {
 
                 int code = response.code();
 
-                Status status = extractErrorStatus(response);
+                String status = extractErrorStatus(response);
 
                 logger.log(
                     Level.WARNING,
                     "Failed to export metrics. Server responded with HTTP status code "
                         + code
                         + ". Error message: "
-                        + status.getMessage());
+                        + status);
                 result.fail();
               }
             });
@@ -142,21 +141,15 @@ public final class OtlpHttpMetricExporter implements MetricExporter {
     };
   }
 
-  private static Status extractErrorStatus(Response response) {
+  private static String extractErrorStatus(Response response) {
     ResponseBody responseBody = response.body();
     if (responseBody == null) {
-      return Status.newBuilder()
-          .setMessage("Response body missing, HTTP status message: " + response.message())
-          .setCode(Code.UNKNOWN.getNumber())
-          .build();
+      return "Response body missing, HTTP status message: " + response.message();
     }
     try {
-      return Status.parseFrom(responseBody.bytes());
+      return GrpcStatusUtil.getStatusMessage(responseBody.bytes());
     } catch (IOException e) {
-      return Status.newBuilder()
-          .setMessage("Unable to parse response body, HTTP status message: " + response.message())
-          .setCode(Code.UNKNOWN.getNumber())
-          .build();
+      return "Unable to parse response body, HTTP status message: " + response.message();
     }
   }
 

--- a/exporters/otlp-http/metrics/src/main/java/io/opentelemetry/exporter/otlp/http/metric/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp-http/metrics/src/main/java/io/opentelemetry/exporter/otlp/http/metric/OtlpHttpMetricExporterBuilder.java
@@ -8,7 +8,6 @@ package io.opentelemetry.exporter.otlp.http.metric;
 import static io.opentelemetry.api.internal.Utils.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.base.Preconditions;
 import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -84,7 +83,7 @@ public final class OtlpHttpMetricExporterBuilder {
    */
   public OtlpHttpMetricExporterBuilder setCompression(String compressionMethod) {
     requireNonNull(compressionMethod, "compressionMethod");
-    Preconditions.checkArgument(
+    checkArgument(
         compressionMethod.equals("gzip"),
         "Unsupported compression method. Supported compression methods include: gzip.");
     this.compressionEnabled = true;

--- a/exporters/otlp-http/trace/build.gradle.kts
+++ b/exporters/otlp-http/trace/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
 
   implementation(project(":exporters:otlp:common"))
 
+  implementation("com.google.api.grpc:proto-google-common-protos")
   implementation("com.squareup.okhttp3:okhttp")
   implementation("com.squareup.okhttp3:okhttp-tls")
   implementation("com.squareup.okio:okio")

--- a/exporters/otlp-http/trace/build.gradle.kts
+++ b/exporters/otlp-http/trace/build.gradle.kts
@@ -13,12 +13,12 @@ dependencies {
 
   implementation(project(":exporters:otlp:common"))
 
-  implementation("com.google.api.grpc:proto-google-common-protos")
   implementation("com.squareup.okhttp3:okhttp")
   implementation("com.squareup.okhttp3:okhttp-tls")
   implementation("com.squareup.okio:okio")
 
   testImplementation(project(":sdk:testing"))
 
+  testImplementation("com.google.api.grpc:proto-google-common-protos")
   testImplementation("com.linecorp.armeria:armeria-junit5")
 }

--- a/exporters/otlp-http/trace/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp-http/trace/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -8,7 +8,6 @@ package io.opentelemetry.exporter.otlp.http.trace;
 import static io.opentelemetry.api.internal.Utils.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.base.Preconditions;
 import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -84,7 +83,7 @@ public final class OtlpHttpSpanExporterBuilder {
    */
   public OtlpHttpSpanExporterBuilder setCompression(String compressionMethod) {
     requireNonNull(compressionMethod, "compressionMethod");
-    Preconditions.checkArgument(
+    checkArgument(
         compressionMethod.equals("gzip"),
         "Unsupported compression method. Supported compression methods include: gzip.");
     this.compressionEnabled = true;

--- a/exporters/otlp/common/build.gradle.kts
+++ b/exporters/otlp/common/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
 
   testImplementation(project(":sdk:testing"))
 
+  testImplementation("com.google.api.grpc:proto-google-common-protos")
   testImplementation("io.grpc:grpc-testing")
   testRuntimeOnly("io.grpc:grpc-netty-shaded")
 

--- a/exporters/otlp/common/build.gradle.kts
+++ b/exporters/otlp/common/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
   compileOnly("io.grpc:grpc-netty")
   compileOnly("io.grpc:grpc-netty-shaded")
   compileOnly("io.grpc:grpc-okhttp")
+  compileOnly("io.grpc:grpc-stub")
 
   testImplementation(project(":sdk:testing"))
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/GrpcStatusUtil.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/GrpcStatusUtil.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal;
+
+import com.google.protobuf.CodedInputStream;
+import java.io.IOException;
+
+/** Utilities for working with gRPC status without requiring dependencies on gRPC. */
+public final class GrpcStatusUtil {
+
+  /** Parses the message out of a serialized gRPC Status. */
+  public static String getStatusMessage(byte[] serializedStatus) throws IOException {
+    CodedInputStream input = CodedInputStream.newInstance(serializedStatus);
+    boolean done = false;
+    while (!done) {
+      int tag = input.readTag();
+      switch (tag) {
+        case 0:
+          done = true;
+          break;
+        case 18:
+          return input.readStringRequireUtf8();
+        default:
+          input.skipField(tag);
+          break;
+      }
+    }
+    // Serialized Status proto had no message, proto always defaults to empty string when not found.
+    return "";
+  }
+
+  private GrpcStatusUtil() {}
+}

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/GrpcStatusUtilTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/GrpcStatusUtilTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
+import com.google.rpc.Status;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+class GrpcStatusUtilTest {
+
+  @Test
+  void parseMessage() throws Exception {
+    assertThat(
+            GrpcStatusUtil.getStatusMessage(
+                Status.newBuilder().setMessage("test").build().toByteArray()))
+        .isEqualTo("test");
+    assertThat(
+            GrpcStatusUtil.getStatusMessage(
+                Status.newBuilder().setCode(2).setMessage("test2").build().toByteArray()))
+        .isEqualTo("test2");
+    assertThat(
+            GrpcStatusUtil.getStatusMessage(
+                Status.newBuilder()
+                    .setCode(2)
+                    .setMessage("test3")
+                    .addDetails(Any.newBuilder().setValue(ByteString.copyFromUtf8("any")).build())
+                    .build()
+                    .toByteArray()))
+        .isEqualTo("test3");
+    assertThat(
+            GrpcStatusUtil.getStatusMessage(
+                Status.newBuilder()
+                    .setCode(2)
+                    .addDetails(Any.newBuilder().setValue(ByteString.copyFromUtf8("any")).build())
+                    .build()
+                    .toByteArray()))
+        .isEmpty();
+    assertThat(GrpcStatusUtil.getStatusMessage(Status.getDefaultInstance().toByteArray()))
+        .isEmpty();
+    assertThatThrownBy(() -> GrpcStatusUtil.getStatusMessage(new byte[] {0, 1, 3, 0}))
+        .isInstanceOf(IOException.class);
+  }
+}

--- a/exporters/otlp/metrics/build.gradle.kts
+++ b/exporters/otlp/metrics/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
   implementation(project(":exporters:otlp:common"))
 
+  api("io.grpc:grpc-stub")
   implementation("io.grpc:grpc-api")
   implementation("io.grpc:grpc-protobuf")
   implementation("io.grpc:grpc-stub")

--- a/exporters/otlp/trace/build.gradle.kts
+++ b/exporters/otlp/trace/build.gradle.kts
@@ -24,9 +24,9 @@ dependencies {
   compileOnly("io.grpc:grpc-okhttp")
 
   implementation(project(":exporters:otlp:common"))
+  api("io.grpc:grpc-stub")
   implementation("io.grpc:grpc-api")
   implementation("io.grpc:grpc-protobuf")
-  implementation("io.grpc:grpc-stub")
   implementation("com.google.protobuf:protobuf-java")
 
   testImplementation(project(":sdk:testing"))

--- a/proto/build.gradle.kts
+++ b/proto/build.gradle.kts
@@ -14,9 +14,10 @@ otelJava.moduleName.set("io.opentelemetry.proto")
 
 dependencies {
   api("com.google.protobuf:protobuf-java")
-  api("io.grpc:grpc-api")
-  api("io.grpc:grpc-protobuf")
-  api("io.grpc:grpc-stub")
+
+  compileOnly("io.grpc:grpc-api")
+  compileOnly("io.grpc:grpc-protobuf")
+  compileOnly("io.grpc:grpc-stub")
 }
 
 val protoVersion = "0.9.0"


### PR DESCRIPTION
otlp-http currently includes an unused gRPC dependency because of this which isn't intended. Our gRPC exporters actually already had implementation dependencies on these artifacts anyways.