### PR TITLE
Test TraceMarshaler with random SpanData.

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -61,6 +61,11 @@ val DEPENDENCY_SETS = listOf(
     listOf("jmh-core", "jmh-generator-bytecode")
   ),
   DependencySet(
+    "org.jeasy",
+    "4.3.0",
+    listOf("easy-random-core", "easy-random-randomizers")
+  ),
+  DependencySet(
     "org.mockito",
     "3.11.2",
     listOf("mockito-core", "mockito-junit-jupiter")

--- a/exporters/otlp/trace/build.gradle.kts
+++ b/exporters/otlp/trace/build.gradle.kts
@@ -34,6 +34,8 @@ dependencies {
   testImplementation("io.grpc:grpc-testing")
   testImplementation("org.slf4j:slf4j-simple")
 
+  testImplementation("org.jeasy:easy-random-randomizers")
+
   add("testGrpcNettyImplementation", "com.linecorp.armeria:armeria-grpc")
   add("testGrpcNettyImplementation", "com.linecorp.armeria:armeria-junit5")
   add("testGrpcNettyRuntimeOnly", "io.grpc:grpc-netty")

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/InstrumentationLibraryMarshaler.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/InstrumentationLibraryMarshaler.java
@@ -17,6 +17,7 @@ final class InstrumentationLibraryMarshaler extends MarshalerWithSize {
   static InstrumentationLibraryMarshaler create(InstrumentationLibraryInfo libraryInfo) {
     byte[] name = MarshalerUtil.toBytes(libraryInfo.getName());
     byte[] version = MarshalerUtil.toBytes(libraryInfo.getVersion());
+
     return new InstrumentationLibraryMarshaler(name, version);
   }
 

--- a/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/SpanDataRandomizerRegistry.java
+++ b/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/SpanDataRandomizerRegistry.java
@@ -276,6 +276,10 @@ public final class SpanDataRandomizerRegistry implements RandomizerRegistry {
   private final class SpanContextRandomizer implements Randomizer<SpanContext> {
     @Override
     public SpanContext getRandomValue() {
+      boolean isInvalid = booleanRandomizer.getRandomValue();
+      if (isInvalid) {
+        return SpanContext.getInvalid();
+      }
       String traceId = randomHex(TraceId.getLength());
       String spanId = randomHex(SpanId.getLength());
       TraceFlags traceFlags = TraceFlags.fromByte(byteRandomizer.getRandomValue());

--- a/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/SpanDataRandomizerRegistry.java
+++ b/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/SpanDataRandomizerRegistry.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.trace;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.AttributeType;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceId;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.api.trace.TraceStateBuilder;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+import org.jeasy.random.api.Randomizer;
+import org.jeasy.random.api.RandomizerRegistry;
+import org.jeasy.random.randomizers.WordRandomizer;
+import org.jeasy.random.randomizers.collection.ListRandomizer;
+import org.jeasy.random.randomizers.collection.MapRandomizer;
+import org.jeasy.random.randomizers.misc.BooleanRandomizer;
+import org.jeasy.random.randomizers.number.ByteRandomizer;
+import org.jeasy.random.randomizers.number.DoubleRandomizer;
+import org.jeasy.random.randomizers.number.LongRandomizer;
+import org.jeasy.random.randomizers.range.IntegerRangeRandomizer;
+import org.jeasy.random.randomizers.text.StringRandomizer;
+
+public final class SpanDataRandomizerRegistry implements RandomizerRegistry {
+
+  private static final String HEX_ALPHABET = "0123456789abcdef";
+
+  static final RandomizerRegistry INSTANCE = new SpanDataRandomizerRegistry();
+
+  private EasyRandomParameters parameters;
+
+  private EasyRandom easyRandom;
+
+  private BooleanRandomizer booleanRandomizer;
+  private ByteRandomizer byteRandomizer;
+  private IntegerRangeRandomizer collectionSizeRandomizer;
+  private DoubleRandomizer doubleRandomizer;
+  private LongRandomizer longRandomizer;
+  private StringRandomizer stringRandomizer;
+
+  private AttributesRandomizer attributesRandomizer;
+  private Map<AttributeType, Supplier<Randomizer<?>>> attributeValueRandomizers;
+  private SpanContextRandomizer spanContextRandomizer;
+  private TraceStateRandomizer traceStateRandomizer;
+
+  private AutoValueRandomizer<EventData> eventDataRandomizer;
+  private AutoValueRandomizer<InstrumentationLibraryInfo> instrumentationLibraryInfoRandomizer;
+  private AutoValueRandomizer<LinkData> linkDataRandomizer;
+  private AutoValueRandomizer<Resource> resourceRandomizer;
+  private AutoValueRandomizer<SpanData> spanDataRandomizer;
+  private AutoValueRandomizer<StatusData> statusDataRandomizer;
+
+  @Override
+  public void init(EasyRandomParameters parameters) {
+    this.parameters = parameters;
+  }
+
+  // new EasyRandom() calls init, so we can't create it within init, or it will infinitely recurse.
+  private void setup() {
+    easyRandom = new EasyRandom(parameters);
+
+    booleanRandomizer = new BooleanRandomizer(parameters.getSeed());
+    byteRandomizer = new ByteRandomizer(parameters.getSeed());
+    collectionSizeRandomizer =
+        new IntegerRangeRandomizer(
+            parameters.getCollectionSizeRange().getMin(),
+            parameters.getCollectionSizeRange().getMax(),
+            parameters.getSeed());
+    doubleRandomizer = new DoubleRandomizer(parameters.getSeed());
+    longRandomizer = new LongRandomizer(parameters.getSeed());
+    stringRandomizer =
+        new StringRandomizer(
+            StandardCharsets.UTF_8,
+            parameters.getStringLengthRange().getMin(),
+            parameters.getStringLengthRange().getMax(),
+            parameters.getSeed());
+
+    attributeValueRandomizers = new EnumMap<>(AttributeType.class);
+    for (AttributeType type : AttributeType.values()) {
+      switch (type) {
+        case STRING:
+          attributeValueRandomizers.put(type, () -> stringRandomizer);
+          break;
+        case BOOLEAN:
+          attributeValueRandomizers.put(type, () -> booleanRandomizer);
+          break;
+        case LONG:
+          attributeValueRandomizers.put(type, () -> longRandomizer);
+          break;
+        case DOUBLE:
+          attributeValueRandomizers.put(type, () -> doubleRandomizer);
+          break;
+        case STRING_ARRAY:
+          attributeValueRandomizers.put(
+              type,
+              () ->
+                  new ListRandomizer<>(
+                      stringRandomizer, collectionSizeRandomizer.getRandomValue()));
+          break;
+        case BOOLEAN_ARRAY:
+          attributeValueRandomizers.put(
+              type,
+              () ->
+                  new ListRandomizer<>(
+                      booleanRandomizer, collectionSizeRandomizer.getRandomValue()));
+          break;
+        case LONG_ARRAY:
+          attributeValueRandomizers.put(
+              type,
+              () ->
+                  new ListRandomizer<>(longRandomizer, collectionSizeRandomizer.getRandomValue()));
+          break;
+        case DOUBLE_ARRAY:
+          attributeValueRandomizers.put(
+              type,
+              () ->
+                  new ListRandomizer<>(
+                      doubleRandomizer, collectionSizeRandomizer.getRandomValue()));
+          break;
+      }
+    }
+
+    attributesRandomizer = new AttributesRandomizer();
+    eventDataRandomizer =
+        new AutoValueRandomizer<>("io.opentelemetry.sdk.trace.data.AutoValue_ImmutableEventData");
+    instrumentationLibraryInfoRandomizer =
+        new AutoValueRandomizer<>(
+            "io.opentelemetry.sdk.common.AutoValue_InstrumentationLibraryInfo");
+    linkDataRandomizer =
+        new AutoValueRandomizer<>("io.opentelemetry.sdk.trace.data.AutoValue_ImmutableLinkData");
+    resourceRandomizer =
+        new AutoValueRandomizer<>("io.opentelemetry.sdk.resources.AutoValue_Resource");
+    spanContextRandomizer = new SpanContextRandomizer();
+    spanDataRandomizer =
+        new AutoValueRandomizer<>("io.opentelemetry.sdk.testing.trace.AutoValue_TestSpanData");
+    statusDataRandomizer =
+        new AutoValueRandomizer<>("io.opentelemetry.sdk.trace.data.AutoValue_ImmutableStatusData");
+    traceStateRandomizer = new TraceStateRandomizer();
+  }
+
+  @Override
+  @Nullable
+  public Randomizer<?> getRandomizer(Field field) {
+    // TODO(anuraaga): Make work for autovalue, unfortunately it only adds Nullable to constructor
+    // parameters / getters but not to fields.
+    if (field.getAnnotation(Nullable.class) == null) {
+      return null;
+    }
+    Randomizer<?> delegate = getRandomizer(field.getType());
+    if (delegate == null) {
+      return null;
+    }
+
+    return new NullableRandomizer<>(delegate);
+  }
+
+  @Override
+  @Nullable
+  public Randomizer<?> getRandomizer(Class<?> type) {
+    if (easyRandom == null) {
+      setup();
+    }
+
+    if (type == Attributes.class) {
+      return attributesRandomizer;
+    }
+    if (type == EventData.class) {
+      return eventDataRandomizer;
+    }
+    if (type == InstrumentationLibraryInfo.class) {
+      return instrumentationLibraryInfoRandomizer;
+    }
+    if (type == LinkData.class) {
+      return linkDataRandomizer;
+    }
+    if (type == Resource.class) {
+      return resourceRandomizer;
+    }
+    if (type == SpanContext.class) {
+      return spanContextRandomizer;
+    }
+    if (type == SpanData.class) {
+      return spanDataRandomizer;
+    }
+    if (type == StatusData.class) {
+      return statusDataRandomizer;
+    }
+    if (type == TraceState.class) {
+      return traceStateRandomizer;
+    }
+
+    return null;
+  }
+
+  private final class AttributesRandomizer implements Randomizer<Attributes> {
+
+    @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public Attributes getRandomValue() {
+      AttributesBuilder attributes = Attributes.builder();
+
+      int numAttributes = collectionSizeRandomizer.getRandomValue();
+      for (int i = 0; i < numAttributes; i++) {
+        AttributeType type = easyRandom.nextObject(AttributeType.class);
+        attributes.put(
+            (AttributeKey) randomKey(type),
+            attributeValueRandomizers.get(type).get().getRandomValue());
+      }
+
+      return attributes.build();
+    }
+
+    private AttributeKey<?> randomKey(AttributeType type) {
+      String key = stringRandomizer.getRandomValue();
+      switch (type) {
+        case STRING:
+          return AttributeKey.stringKey(key);
+        case BOOLEAN:
+          return AttributeKey.booleanKey(key);
+        case LONG:
+          return AttributeKey.longKey(key);
+        case DOUBLE:
+          return AttributeKey.doubleKey(key);
+        case STRING_ARRAY:
+          return AttributeKey.stringArrayKey(key);
+        case BOOLEAN_ARRAY:
+          return AttributeKey.booleanArrayKey(key);
+        case LONG_ARRAY:
+          return AttributeKey.longArrayKey(key);
+        case DOUBLE_ARRAY:
+          return AttributeKey.doubleArrayKey(key);
+      }
+      throw new IllegalStateException("Unexpected value: " + type);
+    }
+  }
+
+  private final class NullableRandomizer<T> implements Randomizer<T> {
+    private final Randomizer<T> delegate;
+
+    NullableRandomizer(Randomizer<T> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    @Nullable
+    public T getRandomValue() {
+      boolean isNull = booleanRandomizer.getRandomValue();
+      if (isNull) {
+        return null;
+      } else {
+        return delegate.getRandomValue();
+      }
+    }
+  }
+
+  private final class SpanContextRandomizer implements Randomizer<SpanContext> {
+    @Override
+    public SpanContext getRandomValue() {
+      String traceId = randomHex(TraceId.getLength());
+      String spanId = randomHex(SpanId.getLength());
+      TraceFlags traceFlags = TraceFlags.fromByte(byteRandomizer.getRandomValue());
+      TraceState traceState = easyRandom.nextObject(TraceState.class);
+      boolean isRemote = booleanRandomizer.getRandomValue();
+      if (isRemote) {
+        return SpanContext.createFromRemoteParent(traceId, spanId, traceFlags, traceState);
+      }
+      return SpanContext.create(traceId, spanId, traceFlags, traceState);
+    }
+  }
+
+  private final class TraceStateRandomizer implements Randomizer<TraceState> {
+
+    // Lorem ipsum - should generate values that are valid for trace state.
+    private final WordRandomizer wordRandomizer;
+
+    TraceStateRandomizer() {
+      wordRandomizer = new WordRandomizer(parameters.getSeed());
+    }
+
+    @Override
+    public TraceState getRandomValue() {
+      // Don't memoize so it always has a random size.
+      MapRandomizer<String, String> stringMapRandomizer =
+          new MapRandomizer<>(
+              wordRandomizer, wordRandomizer, collectionSizeRandomizer.getRandomValue());
+      TraceStateBuilder traceState = TraceState.builder();
+      stringMapRandomizer.getRandomValue().forEach(traceState::put);
+      return traceState.build();
+    }
+  }
+
+  // EasyRandom can only automatically instantiate public implementation classes. Because our
+  // AutoValue implementations are private, we have to point it at the implementation class using
+  // reflection.
+  private final class AutoValueRandomizer<T> implements Randomizer<T> {
+
+    private final String autoValueClassName;
+
+    AutoValueRandomizer(String autoValueClassName) {
+      this.autoValueClassName = autoValueClassName;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T getRandomValue() {
+      try {
+        return easyRandom.nextObject((Class<? extends T>) Class.forName(autoValueClassName));
+      } catch (ClassNotFoundException e) {
+        throw new AssertionError(e);
+      }
+    }
+  }
+
+  private String randomHex(int length) {
+    char[] chars = new char[length];
+    for (int i = 0; i < chars.length; i++) {
+      chars[i] = HEX_ALPHABET.charAt(easyRandom.nextInt(HEX_ALPHABET.length()));
+    }
+    return new String(chars);
+  }
+}

--- a/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/SpanDataRandomizerRegistry.java
+++ b/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/SpanDataRandomizerRegistry.java
@@ -163,6 +163,7 @@ public final class SpanDataRandomizerRegistry implements RandomizerRegistry {
   public Randomizer<?> getRandomizer(Field field) {
     // TODO(anuraaga): Make work for autovalue, unfortunately it only adds Nullable to constructor
     // parameters / getters but not to fields.
+    // https://github.com/open-telemetry/opentelemetry-java/issues/3498
     if (field.getAnnotation(Nullable.class) == null) {
       return null;
     }

--- a/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/TraceMarshalerTest.java
+++ b/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/TraceMarshalerTest.java
@@ -140,7 +140,7 @@ class TraceMarshalerTest {
             testSpanDataWithInstrumentationLibrary(InstrumentationLibraryInfo.create("", ""))));
   }
 
-  @RepeatedTest(10000)
+  @RepeatedTest(100)
   void randomData() throws Exception {
     SpanData span = EASY_RANDOM.nextObject(SpanData.class);
 

--- a/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/TraceMarshalerTest.java
+++ b/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/TraceMarshalerTest.java
@@ -140,7 +140,7 @@ class TraceMarshalerTest {
             testSpanDataWithInstrumentationLibrary(InstrumentationLibraryInfo.create("", ""))));
   }
 
-  @RepeatedTest(100)
+  @RepeatedTest(10000)
   void randomData() throws Exception {
     SpanData span = EASY_RANDOM.nextObject(SpanData.class);
 


### PR DESCRIPTION
And fix TraceMarshaler marshaling of schemaUrls.

This generates 100 different SpanData every CI run. Though I've ran through 100000 locally with no error.

It did solve the most important issue of automatically detecting schemaUrl had drifted. I think this gives good confidence and we can go ahead and switch the marshaler used by the exporters.