### PR TITLE
Fix javadoc

### DIFF
--- a/exporters/jaeger-thrift/README.md
+++ b/exporters/jaeger-thrift/README.md
@@ -25,5 +25,5 @@ the [autoconfigure](../../sdk-extensions/autoconfigure) module.
 
 As with the OpenTelemetry SDK itself, this exporter is compatible with Java 8+ and Android API level 24+.
 
-[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporters-jaeger-thrift.svg
-[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporters-jaeger-thrift
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporter-jaeger-thrift.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporter-jaeger-thrift

--- a/exporters/jaeger/README.md
+++ b/exporters/jaeger/README.md
@@ -32,5 +32,5 @@ At this moment, they have to be manually synchronized, but a [discussion exists]
 
 [proto-origin]: https://github.com/jaegertracing/jaeger/tree/5b8c1f40f932897b9322bf3f110d830536ae4c71/model/proto
 [proto-discussion]: https://github.com/open-telemetry/opentelemetry-java/issues/235
-[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporters-jaeger.svg
-[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporters-jaeger
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporter-jaeger.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporter-jaeger

--- a/exporters/logging/README.md
+++ b/exporters/logging/README.md
@@ -2,5 +2,5 @@
 
 [![Javadocs][javadoc-image]][javadoc-url]
 
-[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporters-logging.svg
-[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporters-logging
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporter-logging.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporter-logging

--- a/exporters/otlp-http/metrics/README.md
+++ b/exporters/otlp-http/metrics/README.md
@@ -1,5 +1,8 @@
 # OpenTelemetry - OTLP Metrics Exporter - HTTP
 
+[![Javadocs][javadoc-image]][javadoc-url]
+
 This is the OpenTelemetry exporter, sending metric data to OpenTelemetry collector via HTTP without gRPC.
 
-// TODO: add javadoc links once published
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporter-otlp-http-metrics.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporter-otlp-http-metrics

--- a/exporters/otlp-http/trace/README.md
+++ b/exporters/otlp-http/trace/README.md
@@ -1,5 +1,8 @@
 # OpenTelemetry - OTLP Trace Exporter - HTTP
 
+[![Javadocs][javadoc-image]][javadoc-url]
+
 This is the OpenTelemetry exporter, sending span data to OpenTelemetry collector via HTTP without gRPC.
 
-// TODO: add javadoc links once published
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporter-otlp-http-trace.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporter-otlp-http-trace

--- a/exporters/otlp/common/README.md
+++ b/exporters/otlp/common/README.md
@@ -1,9 +1,8 @@
-# OpenTelemetry Proto Utils
+# OpenTelemetry - OTLP Common
 
 [![Javadocs][javadoc-image]][javadoc-url]
 
-This module contains code to helps with conversions betewen OpenTelemetry proto objects and API or 
-SDK objects (e.g. SpanId, TraceId, TraceConfig, SpanData etc.).
+This module contains common utility code used by other OpenTelemetry OTLP modules, including conversion between OpenTelemetry API or SDK objects and proto objects.
 
-[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-sdk-contrib-otproto.svg
-[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-contrib-otproto
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporter-otlp-common.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporter-otlp-common

--- a/exporters/otlp/metrics/README.md
+++ b/exporters/otlp/metrics/README.md
@@ -4,5 +4,5 @@
 
 This is the OpenTelemetry exporter, sending metrics data to OpenTelemetry collector via gRPC.
 
-[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporters-otlp.svg
-[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporters-otlp
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporter-otlp-metrics.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporter-otlp-metrics

--- a/exporters/otlp/trace/README.md
+++ b/exporters/otlp/trace/README.md
@@ -4,5 +4,5 @@
 
 This is the OpenTelemetry exporter, sending span data to OpenTelemetry collector via gRPC.
 
-[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporters-otlp.svg
-[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporters-otlp
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporter-otlp-trace.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporter-otlp-trace

--- a/exporters/prometheus/README.md
+++ b/exporters/prometheus/README.md
@@ -4,5 +4,5 @@
 
 This is the OpenTelemetry's Prometheus exporter, allowing Prometheus to query metrics data.
 
-[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporters-prometheus.svg
-[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporters-prometheus
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporter-prometheus.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporter-prometheus

--- a/exporters/zipkin/README.md
+++ b/exporters/zipkin/README.md
@@ -56,6 +56,6 @@ As with the OpenTelemetry SDK itself, this exporter is compatible with Java 8+ a
 
 The code in this module is based on the [OpenCensus Zipkin exporter][oc-origin] code.
 
-[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporters-zipkin.svg
-[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporters-zipkin
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-exporter-zipkin.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-exporter-zipkin
 [oc-origin]: https://github.com/census-instrumentation/opencensus-java/

--- a/extensions/annotations/README.md
+++ b/extensions/annotations/README.md
@@ -1,4 +1,4 @@
-OpenTelemetry Contrib Annotations
+OpenTelemetry Extension Annotations
 ======================================================
 
 [![Javadocs][javadoc-image]][javadoc-url]
@@ -6,5 +6,5 @@ OpenTelemetry Contrib Annotations
 This module contains various annotations that can be used by clients of OpenTelemetry API.
 Please see [Javadocs][javadoc-url] for more information.
 
-[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-contrib-auto-annotations.svg
-[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-contrib-auto-annotations
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-extension-annotations.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-extension-annotations

--- a/extensions/trace-propagators/README.md
+++ b/extensions/trace-propagators/README.md
@@ -1,10 +1,10 @@
-OpenTelemetry Contrib Trace Propagators
+OpenTelemetry Extension Trace Propagators
 ======================================================
 
 [![Javadocs][javadoc-image]][javadoc-url]
 
-[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-contrib-trace-propagators.svg
-[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-contrib-trace-propagators
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-extension-trace-propagators.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-extension-trace-propagators
 
 This repository provides several 
 [trace propagators](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/api-propagators.md),

--- a/sdk-extensions/async-processor/README.md
+++ b/sdk-extensions/async-processor/README.md
@@ -1,4 +1,4 @@
-# OpenTelemetry SDK Contrib Async Processor
+# OpenTelemetry SDK Extension Async Processor
 
 [![Javadocs][javadoc-image]][javadoc-url]
 
@@ -6,5 +6,5 @@ An implementation of the trace `SpanProcessors` that uses
 [Disruptor](https://github.com/LMAX-Exchange/disruptor) to make all the `SpanProcessors` hooks run
 async.
 
-[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-sdk-contrib-async-processor.svg
-[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-contrib-async-processor
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-sdk-extension-async-processor.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-extension-async-processor

--- a/sdk-extensions/aws/README.md
+++ b/sdk-extensions/aws/README.md
@@ -2,8 +2,8 @@
 
 [![Javadocs][javadoc-image]][javadoc-url]
 
-[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-sdk-aws.svg
-[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-aws
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-sdk-extension-aws.svg
+[javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-extension-aws
 
 ---
 #### Running micro-benchmarks


### PR DESCRIPTION
Went to add javadoc links to the new OTLP http modules, and noticed that a bunch of broken javadoc links. Went through and fixed all the ones I found.

Separately, there are a bunch of readmes that are missing altogether, or are missing javadoc links. Figure I'll add those in a separate PR. 