### PR TITLE
Plugin the custom marshaler to otlp:trace span exporter.

### DIFF
--- a/exporters/otlp/trace/build.gradle.kts
+++ b/exporters/otlp/trace/build.gradle.kts
@@ -19,18 +19,19 @@ testSets {
 dependencies {
   api(project(":sdk:trace"))
 
+  implementation(project(":api:metrics"))
+  implementation(project(":exporters:otlp:common"))
+
   compileOnly("io.grpc:grpc-netty")
   compileOnly("io.grpc:grpc-netty-shaded")
   compileOnly("io.grpc:grpc-okhttp")
 
-  implementation(project(":exporters:otlp:common"))
   api("io.grpc:grpc-stub")
   implementation("io.grpc:grpc-api")
-  implementation("io.grpc:grpc-protobuf")
-  implementation("com.google.protobuf:protobuf-java")
 
   testImplementation(project(":sdk:testing"))
 
+  testImplementation("io.grpc:grpc-protobuf")
   testImplementation("io.grpc:grpc-testing")
   testImplementation("org.slf4j:slf4j-simple")
 

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/ExportTraceServiceResponse.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/ExportTraceServiceResponse.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.trace;
+
+// A Java object to correspond to the gRPC response for the TraceService.Export method. If fields
+// are added to the type in the future, this can be converted to an actual class.
+//
+// It may seem like Void could be used instead but gRPC does not allow response values to be
+// null.
+enum ExportTraceServiceResponse {
+  INSTANCE;
+}

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/MarshalerInputStream.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/MarshalerInputStream.java
@@ -15,7 +15,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import javax.annotation.Nullable;
 
-// Adapated from gRPC ProtoInputStream but using our Marshaller
+// Adapted from gRPC ProtoInputStream but using our Marshaller
 // https://github.com/grpc/grpc-java/blob/2c2ebaebd5a93acec92fbd2708faac582db99371/protobuf-lite/src/main/java/io/grpc/protobuf/lite/ProtoInputStream.java
 final class MarshalerInputStream extends InputStream implements Drainable, KnownLength {
   @Nullable private Marshaler message;

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/MarshalerInputStream.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/MarshalerInputStream.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.trace;
+
+import com.google.common.io.ByteStreams;
+import com.google.protobuf.CodedOutputStream;
+import io.grpc.Drainable;
+import io.grpc.KnownLength;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import javax.annotation.Nullable;
+
+// Adapated from gRPC ProtoInputStream but using our Marshaller
+// https://github.com/grpc/grpc-java/blob/2c2ebaebd5a93acec92fbd2708faac582db99371/protobuf-lite/src/main/java/io/grpc/protobuf/lite/ProtoInputStream.java
+final class MarshalerInputStream extends InputStream implements Drainable, KnownLength {
+  @Nullable private Marshaler message;
+  @Nullable private ByteArrayInputStream partial;
+
+  MarshalerInputStream(Marshaler message) {
+    this.message = message;
+  }
+
+  @Override
+  public int drainTo(OutputStream target) throws IOException {
+    int written;
+    if (message != null) {
+      written = message.getSerializedSize();
+      CodedOutputStream cos = CodedOutputStream.newInstance(target);
+      message.writeTo(cos);
+      cos.flush();
+      message = null;
+    } else if (partial != null) {
+      written = (int) ByteStreams.copy(partial, target);
+      partial = null;
+    } else {
+      written = 0;
+    }
+    return written;
+  }
+
+  @Override
+  public int read() throws IOException {
+    if (message != null) {
+      partial = new ByteArrayInputStream(toByteArray(message));
+      message = null;
+    }
+    if (partial != null) {
+      return partial.read();
+    }
+    return -1;
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    if (message != null) {
+      int size = message.getSerializedSize();
+      if (size == 0) {
+        message = null;
+        partial = null;
+        return -1;
+      }
+      if (len >= size) {
+        // This is the only case that is zero-copy.
+        CodedOutputStream stream = CodedOutputStream.newInstance(b, off, size);
+        message.writeTo(stream);
+        stream.flush();
+        stream.checkNoSpaceLeft();
+
+        message = null;
+        partial = null;
+        return size;
+      }
+
+      partial = new ByteArrayInputStream(toByteArray(message));
+      message = null;
+    }
+    if (partial != null) {
+      return partial.read(b, off, len);
+    }
+    return -1;
+  }
+
+  private static byte[] toByteArray(Marshaler message) throws IOException {
+    byte[] output = new byte[message.getSerializedSize()];
+    message.writeTo(CodedOutputStream.newInstance(output));
+    return output;
+  }
+
+  @Override
+  public int available() {
+    if (message != null) {
+      return message.getSerializedSize();
+    } else if (partial != null) {
+      return partial.available();
+    }
+    return 0;
+  }
+}

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/MarshalerTraceServiceGrpc.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/MarshalerTraceServiceGrpc.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.trace;
+
+import static io.grpc.MethodDescriptor.generateFullMethodName;
+
+import io.grpc.MethodDescriptor;
+import java.io.InputStream;
+
+// Adapted from the protoc generated code for TraceServiceGrpc.
+final class MarshalerTraceServiceGrpc {
+
+  private static final String SERVICE_NAME = "opentelemetry.proto.collector.trace.v1.TraceService";
+
+  private static final MethodDescriptor.Marshaller<TraceMarshaler.RequestMarshaler>
+      REQUEST_MARSHALLER =
+          new MethodDescriptor.Marshaller<TraceMarshaler.RequestMarshaler>() {
+            @Override
+            public InputStream stream(TraceMarshaler.RequestMarshaler value) {
+              return new MarshalerInputStream(value);
+            }
+
+            @Override
+            public TraceMarshaler.RequestMarshaler parse(InputStream stream) {
+              throw new UnsupportedOperationException("Only for serializing");
+            }
+          };
+
+  private static final MethodDescriptor.Marshaller<ExportTraceServiceResponse> RESPONSE_MARSHALER =
+      new MethodDescriptor.Marshaller<ExportTraceServiceResponse>() {
+        @Override
+        public InputStream stream(ExportTraceServiceResponse value) {
+          throw new UnsupportedOperationException("Only for parsing");
+        }
+
+        @Override
+        public ExportTraceServiceResponse parse(InputStream stream) {
+          return ExportTraceServiceResponse.INSTANCE;
+        }
+      };
+
+  private static volatile io.grpc.MethodDescriptor<
+          TraceMarshaler.RequestMarshaler, ExportTraceServiceResponse>
+      getExportMethod;
+
+  static TraceServiceFutureStub newFutureStub(io.grpc.Channel channel) {
+    io.grpc.stub.AbstractStub.StubFactory<TraceServiceFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<TraceServiceFutureStub>() {
+          @java.lang.Override
+          public TraceServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new TraceServiceFutureStub(channel, callOptions);
+          }
+        };
+    return TraceServiceFutureStub.newStub(factory, channel);
+  }
+
+  static final class TraceServiceFutureStub
+      extends io.grpc.stub.AbstractFutureStub<MarshalerTraceServiceGrpc.TraceServiceFutureStub> {
+    private TraceServiceFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+      super(channel, callOptions);
+    }
+
+    @java.lang.Override
+    protected MarshalerTraceServiceGrpc.TraceServiceFutureStub build(
+        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+      return new MarshalerTraceServiceGrpc.TraceServiceFutureStub(channel, callOptions);
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * For performance reasons, it is recommended to keep this RPC
+     * alive for the entire life of the application.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<ExportTraceServiceResponse> export(
+        TraceMarshaler.RequestMarshaler request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getExportMethod(), getCallOptions()), request);
+    }
+  }
+
+  private static io.grpc.MethodDescriptor<
+          TraceMarshaler.RequestMarshaler, ExportTraceServiceResponse>
+      getExportMethod() {
+    io.grpc.MethodDescriptor<TraceMarshaler.RequestMarshaler, ExportTraceServiceResponse>
+        getExportMethod;
+    if ((getExportMethod = MarshalerTraceServiceGrpc.getExportMethod) == null) {
+      synchronized (MarshalerTraceServiceGrpc.class) {
+        if ((getExportMethod = MarshalerTraceServiceGrpc.getExportMethod) == null) {
+          MarshalerTraceServiceGrpc.getExportMethod =
+              getExportMethod =
+                  io.grpc.MethodDescriptor
+                      .<TraceMarshaler.RequestMarshaler, ExportTraceServiceResponse>newBuilder()
+                      .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "Export"))
+                      .setSampledToLocalTracing(true)
+                      .setRequestMarshaller(REQUEST_MARSHALLER)
+                      .setResponseMarshaller(RESPONSE_MARSHALER)
+                      .build();
+        }
+      }
+    }
+    return getExportMethod;
+  }
+
+  private MarshalerTraceServiceGrpc() {}
+}

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/MarshalerTraceServiceGrpc.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/MarshalerTraceServiceGrpc.java
@@ -70,15 +70,7 @@ final class MarshalerTraceServiceGrpc {
       return new MarshalerTraceServiceGrpc.TraceServiceFutureStub(channel, callOptions);
     }
 
-    /**
-     *
-     *
-     * <pre>
-     * For performance reasons, it is recommended to keep this RPC
-     * alive for the entire life of the application.
-     * </pre>
-     */
-    public com.google.common.util.concurrent.ListenableFuture<ExportTraceServiceResponse> export(
+    com.google.common.util.concurrent.ListenableFuture<ExportTraceServiceResponse> export(
         TraceMarshaler.RequestMarshaler request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getExportMethod(), getCallOptions()), request);
@@ -99,7 +91,6 @@ final class MarshalerTraceServiceGrpc {
                       .<TraceMarshaler.RequestMarshaler, ExportTraceServiceResponse>newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(generateFullMethodName(SERVICE_NAME, "Export"))
-                      .setSampledToLocalTracing(true)
                       .setRequestMarshaller(REQUEST_MARSHALLER)
                       .setResponseMarshaller(RESPONSE_MARSHALER)
                       .build();


### PR DESCRIPTION
This is almost exactly like @bogdandrutu's #2890 though I made a few tweaks to avoid any dependency on the generated gRPC code to in the future allow us to remove dependency on the generated proto completely.