### PR TITLE
Rename instruments from *Sdk. -> Sdk*

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleCounter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleCounter.java
@@ -21,10 +21,10 @@ import io.opentelemetry.sdk.metrics.internal.state.MeterSharedState;
 import io.opentelemetry.sdk.metrics.internal.state.WriteableMetricStorage;
 import java.util.function.Consumer;
 
-final class DoubleCounterSdk extends AbstractInstrument implements DoubleCounter {
+final class SdkDoubleCounter extends AbstractInstrument implements DoubleCounter {
   private final WriteableMetricStorage storage;
 
-  private DoubleCounterSdk(InstrumentDescriptor descriptor, WriteableMetricStorage storage) {
+  private SdkDoubleCounter(InstrumentDescriptor descriptor, WriteableMetricStorage storage) {
     super(descriptor);
     this.storage = storage;
   }
@@ -86,7 +86,7 @@ final class DoubleCounterSdk extends AbstractInstrument implements DoubleCounter
     }
   }
 
-  static final class Builder extends AbstractInstrumentBuilder<DoubleCounterSdk.Builder>
+  static final class Builder extends AbstractInstrumentBuilder<SdkDoubleCounter.Builder>
       implements DoubleCounterBuilder {
 
     Builder(
@@ -111,14 +111,14 @@ final class DoubleCounterSdk extends AbstractInstrument implements DoubleCounter
     }
 
     @Override
-    public DoubleCounterSdk build() {
+    public SdkDoubleCounter build() {
       return buildSynchronousInstrument(
-          InstrumentType.COUNTER, InstrumentValueType.DOUBLE, DoubleCounterSdk::new);
+          InstrumentType.COUNTER, InstrumentValueType.DOUBLE, SdkDoubleCounter::new);
     }
 
     @Override
     public LongCounterBuilder ofLongs() {
-      return swapBuilder(LongCounterSdk.Builder::new);
+      return swapBuilder(SdkLongCounter.Builder::new);
     }
 
     @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleGaugeBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleGaugeBuilder.java
@@ -7,23 +7,23 @@ package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.api.metrics.DoubleGaugeBuilder;
 import io.opentelemetry.api.metrics.LongGaugeBuilder;
-import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.internal.state.MeterProviderSharedState;
 import io.opentelemetry.sdk.metrics.internal.state.MeterSharedState;
 import java.util.function.Consumer;
 
-final class LongGaugeBuilderSdk extends AbstractInstrumentBuilder<LongGaugeBuilderSdk>
-    implements LongGaugeBuilder {
+final class SdkDoubleGaugeBuilder extends AbstractInstrumentBuilder<SdkDoubleGaugeBuilder>
+    implements DoubleGaugeBuilder {
 
-  LongGaugeBuilderSdk(
+  SdkDoubleGaugeBuilder(
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState meterSharedState,
       String name) {
     this(meterProviderSharedState, meterSharedState, name, "", "1");
   }
 
-  LongGaugeBuilderSdk(
+  SdkDoubleGaugeBuilder(
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState sharedState,
       String name,
@@ -33,17 +33,17 @@ final class LongGaugeBuilderSdk extends AbstractInstrumentBuilder<LongGaugeBuild
   }
 
   @Override
-  protected LongGaugeBuilderSdk getThis() {
+  protected SdkDoubleGaugeBuilder getThis() {
     return this;
   }
 
   @Override
-  public DoubleGaugeBuilder ofDoubles() {
-    return swapBuilder(DoubleGaugeBuilderSdk::new);
+  public LongGaugeBuilder ofLongs() {
+    return swapBuilder(SdkLongGaugeBuilder::new);
   }
 
   @Override
-  public void buildWithCallback(Consumer<ObservableLongMeasurement> callback) {
-    registerLongAsynchronousInstrument(InstrumentType.OBSERVABLE_GAUGE, callback);
+  public void buildWithCallback(Consumer<ObservableDoubleMeasurement> callback) {
+    registerDoubleAsynchronousInstrument(InstrumentType.OBSERVABLE_GAUGE, callback);
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleHistogram.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleHistogram.java
@@ -19,10 +19,10 @@ import io.opentelemetry.sdk.metrics.internal.state.MeterProviderSharedState;
 import io.opentelemetry.sdk.metrics.internal.state.MeterSharedState;
 import io.opentelemetry.sdk.metrics.internal.state.WriteableMetricStorage;
 
-final class DoubleHistogramSdk extends AbstractInstrument implements DoubleHistogram {
+final class SdkDoubleHistogram extends AbstractInstrument implements DoubleHistogram {
   private final WriteableMetricStorage storage;
 
-  private DoubleHistogramSdk(InstrumentDescriptor descriptor, WriteableMetricStorage storage) {
+  private SdkDoubleHistogram(InstrumentDescriptor descriptor, WriteableMetricStorage storage) {
     super(descriptor);
     this.storage = storage;
   }
@@ -72,7 +72,7 @@ final class DoubleHistogramSdk extends AbstractInstrument implements DoubleHisto
     }
   }
 
-  static final class Builder extends AbstractInstrumentBuilder<DoubleHistogramSdk.Builder>
+  static final class Builder extends AbstractInstrumentBuilder<SdkDoubleHistogram.Builder>
       implements DoubleHistogramBuilder {
 
     Builder(
@@ -97,14 +97,14 @@ final class DoubleHistogramSdk extends AbstractInstrument implements DoubleHisto
     }
 
     @Override
-    public DoubleHistogramSdk build() {
+    public SdkDoubleHistogram build() {
       return buildSynchronousInstrument(
-          InstrumentType.HISTOGRAM, InstrumentValueType.DOUBLE, DoubleHistogramSdk::new);
+          InstrumentType.HISTOGRAM, InstrumentValueType.DOUBLE, SdkDoubleHistogram::new);
     }
 
     @Override
     public LongHistogramBuilder ofLongs() {
-      return swapBuilder(LongHistogramSdk.Builder::new);
+      return swapBuilder(SdkLongHistogram.Builder::new);
     }
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleUpDownCounter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleUpDownCounter.java
@@ -6,11 +6,11 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.metrics.BoundLongUpDownCounter;
+import io.opentelemetry.api.metrics.BoundDoubleUpDownCounter;
+import io.opentelemetry.api.metrics.DoubleUpDownCounter;
 import io.opentelemetry.api.metrics.DoubleUpDownCounterBuilder;
-import io.opentelemetry.api.metrics.LongUpDownCounter;
 import io.opentelemetry.api.metrics.LongUpDownCounterBuilder;
-import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
@@ -21,35 +21,35 @@ import io.opentelemetry.sdk.metrics.internal.state.MeterSharedState;
 import io.opentelemetry.sdk.metrics.internal.state.WriteableMetricStorage;
 import java.util.function.Consumer;
 
-final class LongUpDownCounterSdk extends AbstractInstrument implements LongUpDownCounter {
+final class SdkDoubleUpDownCounter extends AbstractInstrument implements DoubleUpDownCounter {
   private final WriteableMetricStorage storage;
 
-  private LongUpDownCounterSdk(InstrumentDescriptor descriptor, WriteableMetricStorage storage) {
+  private SdkDoubleUpDownCounter(InstrumentDescriptor descriptor, WriteableMetricStorage storage) {
     super(descriptor);
     this.storage = storage;
   }
 
   @Override
-  public void add(long increment, Attributes attributes, Context context) {
-    storage.recordLong(increment, attributes, context);
+  public void add(double increment, Attributes attributes, Context context) {
+    storage.recordDouble(increment, attributes, context);
   }
 
   @Override
-  public void add(long increment, Attributes attributes) {
+  public void add(double increment, Attributes attributes) {
     add(increment, attributes, Context.current());
   }
 
   @Override
-  public void add(long increment) {
+  public void add(double increment) {
     add(increment, Attributes.empty());
   }
 
   @Override
-  public BoundLongUpDownCounter bind(Attributes attributes) {
+  public BoundDoubleUpDownCounter bind(Attributes attributes) {
     return new BoundInstrument(storage.bind(attributes), attributes);
   }
 
-  static final class BoundInstrument implements BoundLongUpDownCounter {
+  static final class BoundInstrument implements BoundDoubleUpDownCounter {
     private final BoundStorageHandle handle;
     private final Attributes attributes;
 
@@ -59,12 +59,12 @@ final class LongUpDownCounterSdk extends AbstractInstrument implements LongUpDow
     }
 
     @Override
-    public void add(long increment, Context context) {
-      handle.recordLong(increment, attributes, context);
+    public void add(double increment, Context context) {
+      handle.recordDouble(increment, attributes, context);
     }
 
     @Override
-    public void add(long increment) {
+    public void add(double increment) {
       add(increment, Context.current());
     }
 
@@ -74,8 +74,8 @@ final class LongUpDownCounterSdk extends AbstractInstrument implements LongUpDow
     }
   }
 
-  static final class Builder extends AbstractInstrumentBuilder<LongUpDownCounterSdk.Builder>
-      implements LongUpDownCounterBuilder {
+  static final class Builder extends AbstractInstrumentBuilder<SdkDoubleUpDownCounter.Builder>
+      implements DoubleUpDownCounterBuilder {
 
     Builder(
         MeterProviderSharedState meterProviderSharedState,
@@ -99,19 +99,19 @@ final class LongUpDownCounterSdk extends AbstractInstrument implements LongUpDow
     }
 
     @Override
-    public LongUpDownCounter build() {
+    public DoubleUpDownCounter build() {
       return buildSynchronousInstrument(
-          InstrumentType.UP_DOWN_COUNTER, InstrumentValueType.LONG, LongUpDownCounterSdk::new);
+          InstrumentType.UP_DOWN_COUNTER, InstrumentValueType.DOUBLE, SdkDoubleUpDownCounter::new);
     }
 
     @Override
-    public DoubleUpDownCounterBuilder ofDoubles() {
-      return swapBuilder(DoubleUpDownCounterSdk.Builder::new);
+    public LongUpDownCounterBuilder ofLongs() {
+      return swapBuilder(SdkLongUpDownCounter.Builder::new);
     }
 
     @Override
-    public void buildWithCallback(Consumer<ObservableLongMeasurement> callback) {
-      registerLongAsynchronousInstrument(InstrumentType.OBSERVABLE_UP_DOWN_SUM, callback);
+    public void buildWithCallback(Consumer<ObservableDoubleMeasurement> callback) {
+      registerDoubleAsynchronousInstrument(InstrumentType.OBSERVABLE_UP_DOWN_SUM, callback);
     }
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongCounter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongCounter.java
@@ -6,11 +6,11 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.metrics.BoundDoubleUpDownCounter;
-import io.opentelemetry.api.metrics.DoubleUpDownCounter;
-import io.opentelemetry.api.metrics.DoubleUpDownCounterBuilder;
-import io.opentelemetry.api.metrics.LongUpDownCounterBuilder;
-import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
+import io.opentelemetry.api.metrics.BoundLongCounter;
+import io.opentelemetry.api.metrics.DoubleCounterBuilder;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongCounterBuilder;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
@@ -21,35 +21,38 @@ import io.opentelemetry.sdk.metrics.internal.state.MeterSharedState;
 import io.opentelemetry.sdk.metrics.internal.state.WriteableMetricStorage;
 import java.util.function.Consumer;
 
-final class DoubleUpDownCounterSdk extends AbstractInstrument implements DoubleUpDownCounter {
+final class SdkLongCounter extends AbstractInstrument implements LongCounter {
   private final WriteableMetricStorage storage;
 
-  private DoubleUpDownCounterSdk(InstrumentDescriptor descriptor, WriteableMetricStorage storage) {
+  private SdkLongCounter(InstrumentDescriptor descriptor, WriteableMetricStorage storage) {
     super(descriptor);
     this.storage = storage;
   }
 
   @Override
-  public void add(double increment, Attributes attributes, Context context) {
-    storage.recordDouble(increment, attributes, context);
+  public void add(long increment, Attributes attributes, Context context) {
+    if (increment < 0) {
+      throw new IllegalArgumentException("Counters can only increase");
+    }
+    storage.recordLong(increment, attributes, context);
   }
 
   @Override
-  public void add(double increment, Attributes attributes) {
+  public void add(long increment, Attributes attributes) {
     add(increment, attributes, Context.current());
   }
 
   @Override
-  public void add(double increment) {
+  public void add(long increment) {
     add(increment, Attributes.empty());
   }
 
   @Override
-  public BoundDoubleUpDownCounter bind(Attributes attributes) {
+  public BoundLongCounter bind(Attributes attributes) {
     return new BoundInstrument(storage.bind(attributes), attributes);
   }
 
-  static final class BoundInstrument implements BoundDoubleUpDownCounter {
+  static final class BoundInstrument implements BoundLongCounter {
     private final BoundStorageHandle handle;
     private final Attributes attributes;
 
@@ -59,12 +62,15 @@ final class DoubleUpDownCounterSdk extends AbstractInstrument implements DoubleU
     }
 
     @Override
-    public void add(double increment, Context context) {
-      handle.recordDouble(increment, attributes, context);
+    public void add(long increment, Context context) {
+      if (increment < 0) {
+        throw new IllegalArgumentException("Counters can only increase");
+      }
+      handle.recordLong(increment, attributes, context);
     }
 
     @Override
-    public void add(double increment) {
+    public void add(long increment) {
       add(increment, Context.current());
     }
 
@@ -74,8 +80,8 @@ final class DoubleUpDownCounterSdk extends AbstractInstrument implements DoubleU
     }
   }
 
-  static final class Builder extends AbstractInstrumentBuilder<DoubleUpDownCounterSdk.Builder>
-      implements DoubleUpDownCounterBuilder {
+  static final class Builder extends AbstractInstrumentBuilder<Builder>
+      implements LongCounterBuilder {
 
     Builder(
         MeterProviderSharedState meterProviderSharedState,
@@ -99,19 +105,19 @@ final class DoubleUpDownCounterSdk extends AbstractInstrument implements DoubleU
     }
 
     @Override
-    public DoubleUpDownCounter build() {
+    public SdkLongCounter build() {
       return buildSynchronousInstrument(
-          InstrumentType.UP_DOWN_COUNTER, InstrumentValueType.DOUBLE, DoubleUpDownCounterSdk::new);
+          InstrumentType.COUNTER, InstrumentValueType.LONG, SdkLongCounter::new);
     }
 
     @Override
-    public LongUpDownCounterBuilder ofLongs() {
-      return swapBuilder(LongUpDownCounterSdk.Builder::new);
+    public DoubleCounterBuilder ofDoubles() {
+      return swapBuilder(SdkDoubleCounter.Builder::new);
     }
 
     @Override
-    public void buildWithCallback(Consumer<ObservableDoubleMeasurement> callback) {
-      registerDoubleAsynchronousInstrument(InstrumentType.OBSERVABLE_UP_DOWN_SUM, callback);
+    public void buildWithCallback(Consumer<ObservableLongMeasurement> callback) {
+      registerLongAsynchronousInstrument(InstrumentType.OBSERVABLE_SUM, callback);
     }
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongGaugeBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongGaugeBuilder.java
@@ -7,23 +7,23 @@ package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.api.metrics.DoubleGaugeBuilder;
 import io.opentelemetry.api.metrics.LongGaugeBuilder;
-import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.internal.state.MeterProviderSharedState;
 import io.opentelemetry.sdk.metrics.internal.state.MeterSharedState;
 import java.util.function.Consumer;
 
-final class DoubleGaugeBuilderSdk extends AbstractInstrumentBuilder<DoubleGaugeBuilderSdk>
-    implements DoubleGaugeBuilder {
+final class SdkLongGaugeBuilder extends AbstractInstrumentBuilder<SdkLongGaugeBuilder>
+    implements LongGaugeBuilder {
 
-  DoubleGaugeBuilderSdk(
+  SdkLongGaugeBuilder(
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState meterSharedState,
       String name) {
     this(meterProviderSharedState, meterSharedState, name, "", "1");
   }
 
-  DoubleGaugeBuilderSdk(
+  SdkLongGaugeBuilder(
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState sharedState,
       String name,
@@ -33,17 +33,17 @@ final class DoubleGaugeBuilderSdk extends AbstractInstrumentBuilder<DoubleGaugeB
   }
 
   @Override
-  protected DoubleGaugeBuilderSdk getThis() {
+  protected SdkLongGaugeBuilder getThis() {
     return this;
   }
 
   @Override
-  public LongGaugeBuilder ofLongs() {
-    return swapBuilder(LongGaugeBuilderSdk::new);
+  public DoubleGaugeBuilder ofDoubles() {
+    return swapBuilder(SdkDoubleGaugeBuilder::new);
   }
 
   @Override
-  public void buildWithCallback(Consumer<ObservableDoubleMeasurement> callback) {
-    registerDoubleAsynchronousInstrument(InstrumentType.OBSERVABLE_GAUGE, callback);
+  public void buildWithCallback(Consumer<ObservableLongMeasurement> callback) {
+    registerLongAsynchronousInstrument(InstrumentType.OBSERVABLE_GAUGE, callback);
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongUpDownCounter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongUpDownCounter.java
@@ -6,10 +6,11 @@
 package io.opentelemetry.sdk.metrics;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.metrics.BoundLongHistogram;
-import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
-import io.opentelemetry.api.metrics.LongHistogram;
-import io.opentelemetry.api.metrics.LongHistogramBuilder;
+import io.opentelemetry.api.metrics.BoundLongUpDownCounter;
+import io.opentelemetry.api.metrics.DoubleUpDownCounterBuilder;
+import io.opentelemetry.api.metrics.LongUpDownCounter;
+import io.opentelemetry.api.metrics.LongUpDownCounterBuilder;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
@@ -18,36 +19,37 @@ import io.opentelemetry.sdk.metrics.internal.state.BoundStorageHandle;
 import io.opentelemetry.sdk.metrics.internal.state.MeterProviderSharedState;
 import io.opentelemetry.sdk.metrics.internal.state.MeterSharedState;
 import io.opentelemetry.sdk.metrics.internal.state.WriteableMetricStorage;
+import java.util.function.Consumer;
 
-final class LongHistogramSdk extends AbstractInstrument implements LongHistogram {
+final class SdkLongUpDownCounter extends AbstractInstrument implements LongUpDownCounter {
   private final WriteableMetricStorage storage;
 
-  private LongHistogramSdk(InstrumentDescriptor descriptor, WriteableMetricStorage storage) {
+  private SdkLongUpDownCounter(InstrumentDescriptor descriptor, WriteableMetricStorage storage) {
     super(descriptor);
     this.storage = storage;
   }
 
   @Override
-  public void record(long value, Attributes attributes, Context context) {
-    storage.recordLong(value, attributes, context);
+  public void add(long increment, Attributes attributes, Context context) {
+    storage.recordLong(increment, attributes, context);
   }
 
   @Override
-  public void record(long value, Attributes attributes) {
-    record(value, attributes, Context.current());
+  public void add(long increment, Attributes attributes) {
+    add(increment, attributes, Context.current());
   }
 
   @Override
-  public void record(long value) {
-    record(value, Attributes.empty());
+  public void add(long increment) {
+    add(increment, Attributes.empty());
   }
 
   @Override
-  public BoundLongHistogram bind(Attributes attributes) {
+  public BoundLongUpDownCounter bind(Attributes attributes) {
     return new BoundInstrument(storage.bind(attributes), attributes);
   }
 
-  static final class BoundInstrument implements BoundLongHistogram {
+  static final class BoundInstrument implements BoundLongUpDownCounter {
     private final BoundStorageHandle handle;
     private final Attributes attributes;
 
@@ -57,13 +59,13 @@ final class LongHistogramSdk extends AbstractInstrument implements LongHistogram
     }
 
     @Override
-    public void record(long value, Context context) {
-      handle.recordLong(value, attributes, context);
+    public void add(long increment, Context context) {
+      handle.recordLong(increment, attributes, context);
     }
 
     @Override
-    public void record(long value) {
-      record(value, Context.current());
+    public void add(long increment) {
+      add(increment, Context.current());
     }
 
     @Override
@@ -72,8 +74,8 @@ final class LongHistogramSdk extends AbstractInstrument implements LongHistogram
     }
   }
 
-  static final class Builder extends AbstractInstrumentBuilder<LongHistogramSdk.Builder>
-      implements LongHistogramBuilder {
+  static final class Builder extends AbstractInstrumentBuilder<SdkLongUpDownCounter.Builder>
+      implements LongUpDownCounterBuilder {
 
     Builder(
         MeterProviderSharedState meterProviderSharedState,
@@ -97,14 +99,19 @@ final class LongHistogramSdk extends AbstractInstrument implements LongHistogram
     }
 
     @Override
-    public LongHistogramSdk build() {
+    public LongUpDownCounter build() {
       return buildSynchronousInstrument(
-          InstrumentType.HISTOGRAM, InstrumentValueType.LONG, LongHistogramSdk::new);
+          InstrumentType.UP_DOWN_COUNTER, InstrumentValueType.LONG, SdkLongUpDownCounter::new);
     }
 
     @Override
-    public DoubleHistogramBuilder ofDoubles() {
-      return swapBuilder(DoubleHistogramSdk.Builder::new);
+    public DoubleUpDownCounterBuilder ofDoubles() {
+      return swapBuilder(SdkDoubleUpDownCounter.Builder::new);
+    }
+
+    @Override
+    public void buildWithCallback(Consumer<ObservableLongMeasurement> callback) {
+      registerLongAsynchronousInstrument(InstrumentType.OBSERVABLE_UP_DOWN_SUM, callback);
     }
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java
@@ -40,21 +40,21 @@ final class SdkMeter implements Meter {
 
   @Override
   public LongCounterBuilder counterBuilder(String name) {
-    return new LongCounterSdk.Builder(meterProviderSharedState, meterSharedState, name);
+    return new SdkLongCounter.Builder(meterProviderSharedState, meterSharedState, name);
   }
 
   @Override
   public LongUpDownCounterBuilder upDownCounterBuilder(String name) {
-    return new LongUpDownCounterSdk.Builder(meterProviderSharedState, meterSharedState, name);
+    return new SdkLongUpDownCounter.Builder(meterProviderSharedState, meterSharedState, name);
   }
 
   @Override
   public DoubleHistogramBuilder histogramBuilder(String name) {
-    return new DoubleHistogramSdk.Builder(meterProviderSharedState, meterSharedState, name);
+    return new SdkDoubleHistogram.Builder(meterProviderSharedState, meterSharedState, name);
   }
 
   @Override
   public DoubleGaugeBuilder gaugeBuilder(String name) {
-    return new DoubleGaugeBuilderSdk(meterProviderSharedState, meterSharedState, name);
+    return new SdkDoubleGaugeBuilder(meterProviderSharedState, meterSharedState, name);
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleGaugeBuilderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleGaugeBuilderTest.java
@@ -16,12 +16,12 @@ import io.opentelemetry.sdk.testing.time.TestClock;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link LongValueObserverSdk}. */
-class LongGaugeBuilderSdkTest {
+/** Unit tests for {@link DoubleValueObserverSdk}. */
+class SdkDoubleGaugeBuilderTest {
   private static final Resource RESOURCE =
       Resource.create(Attributes.of(stringKey("resource_key"), "resource_value"));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
-      InstrumentationLibraryInfo.create(LongGaugeBuilderSdkTest.class.getName(), null);
+      InstrumentationLibraryInfo.create(SdkDoubleGaugeBuilderTest.class.getName(), null);
   private final TestClock testClock = TestClock.create();
   private final SdkMeterProvider sdkMeterProvider =
       SdkMeterProvider.builder().setClock(testClock).setResource(RESOURCE).build();
@@ -31,8 +31,7 @@ class LongGaugeBuilderSdkTest {
   void collectMetrics_NoRecords() {
     sdkMeter
         .gaugeBuilder("testObserver")
-        .ofLongs()
-        .setDescription("My own LongValueObserver")
+        .setDescription("My own DoubleValueObserver")
         .setUnit("ms")
         .buildWithCallback(result -> {});
     assertThat(sdkMeterProvider.collectAllMetrics()).isEmpty();
@@ -43,9 +42,10 @@ class LongGaugeBuilderSdkTest {
   void collectMetrics_WithOneRecord() {
     sdkMeter
         .gaugeBuilder("testObserver")
-        .ofLongs()
+        .setDescription("My own DoubleValueObserver")
+        .setUnit("ms")
         .buildWithCallback(
-            result -> result.observe(12, Attributes.builder().put("k", "v").build()));
+            result -> result.observe(12.1d, Attributes.builder().put("k", "v").build()));
     testClock.advance(Duration.ofSeconds(1));
     assertThat(sdkMeterProvider.collectAllMetrics())
         .satisfiesExactly(
@@ -54,7 +54,9 @@ class LongGaugeBuilderSdkTest {
                     .hasResource(RESOURCE)
                     .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
                     .hasName("testObserver")
-                    .hasLongGauge()
+                    .hasDescription("My own DoubleValueObserver")
+                    .hasUnit("ms")
+                    .hasDoubleGauge()
                     .points()
                     .satisfiesExactlyInAnyOrder(
                         point ->
@@ -62,7 +64,7 @@ class LongGaugeBuilderSdkTest {
                                 .hasStartEpochNanos(0)
                                 .hasEpochNanos(testClock.now())
                                 .hasAttributes(Attributes.builder().put("k", "v").build())
-                                .hasValue(12)));
+                                .hasValue(12.1d)));
     testClock.advance(Duration.ofSeconds(1));
     assertThat(sdkMeterProvider.collectAllMetrics())
         .satisfiesExactly(
@@ -71,7 +73,9 @@ class LongGaugeBuilderSdkTest {
                     .hasResource(RESOURCE)
                     .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
                     .hasName("testObserver")
-                    .hasLongGauge()
+                    .hasDescription("My own DoubleValueObserver")
+                    .hasUnit("ms")
+                    .hasDoubleGauge()
                     .points()
                     .satisfiesExactlyInAnyOrder(
                         point ->
@@ -79,6 +83,6 @@ class LongGaugeBuilderSdkTest {
                                 .hasStartEpochNanos(0)
                                 .hasEpochNanos(testClock.now())
                                 .hasAttributes(Attributes.builder().put("k", "v").build())
-                                .hasValue(12)));
+                                .hasValue(12.1d)));
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleHistogramTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleHistogramTest.java
@@ -7,11 +7,12 @@ package io.opentelemetry.sdk.metrics;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.metrics.MetricAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.metrics.BoundLongCounter;
-import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.BoundDoubleHistogram;
+import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.StressTestRunner.OperationUpdater;
@@ -20,36 +21,37 @@ import io.opentelemetry.sdk.testing.time.TestClock;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link LongCounterSdk}. */
-class LongCounterSdkTest {
+/** Unit tests for {@link SdkDoubleHistogram}. */
+class SdkDoubleHistogramTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(Attributes.of(stringKey("resource_key"), "resource_value"));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
-      InstrumentationLibraryInfo.create(LongCounterSdkTest.class.getName(), null);
+      InstrumentationLibraryInfo.create(SdkDoubleHistogramTest.class.getName(), null);
   private final TestClock testClock = TestClock.create();
   private final SdkMeterProvider sdkMeterProvider =
       SdkMeterProvider.builder().setClock(testClock).setResource(RESOURCE).build();
   private final Meter sdkMeter = sdkMeterProvider.get(getClass().getName());
 
   @Test
-  void add_PreventNullAttributes() {
-    assertThatThrownBy(() -> sdkMeter.counterBuilder("testCounter").build().add(1, null))
+  void record_PreventNullAttributes() {
+    assertThatThrownBy(() -> sdkMeter.histogramBuilder("testRecorder").build().record(1.0, null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("attributes");
   }
 
   @Test
   void bound_PreventNullAttributes() {
-    assertThatThrownBy(() -> sdkMeter.counterBuilder("testCounter").build().bind(null))
+    assertThatThrownBy(() -> sdkMeter.histogramBuilder("testRecorder").build().bind(null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("attributes");
   }
 
   @Test
   void collectMetrics_NoRecords() {
-    LongCounter longCounter = sdkMeter.counterBuilder("Counter").build();
-    BoundLongCounter bound = longCounter.bind(Attributes.builder().put("foo", "bar").build());
+    DoubleHistogram doubleRecorder = sdkMeter.histogramBuilder("testRecorder").build();
+    BoundDoubleHistogram bound =
+        doubleRecorder.bind(Attributes.builder().put("key", "value").build());
     try {
       assertThat(sdkMeterProvider.collectAllMetrics()).isEmpty();
     } finally {
@@ -58,24 +60,26 @@ class LongCounterSdkTest {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   void collectMetrics_WithEmptyAttributes() {
-    LongCounter longCounter =
-        sdkMeter.counterBuilder("testCounter").setDescription("description").setUnit("By").build();
+    DoubleHistogram doubleRecorder =
+        sdkMeter
+            .histogramBuilder("testRecorder")
+            .setDescription("description")
+            .setUnit("ms")
+            .build();
     testClock.advance(Duration.ofNanos(SECOND_NANOS));
-    longCounter.add(12, Attributes.empty());
-    longCounter.add(12);
+    doubleRecorder.record(12d, Attributes.empty());
+    doubleRecorder.record(12d);
     assertThat(sdkMeterProvider.collectAllMetrics())
         .satisfiesExactly(
             metric ->
                 assertThat(metric)
                     .hasResource(RESOURCE)
                     .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
-                    .hasName("testCounter")
+                    .hasName("testRecorder")
                     .hasDescription("description")
-                    .hasUnit("By")
-                    .hasLongSum()
-                    .isMonotonic()
+                    .hasUnit("ms")
+                    .hasDoubleHistogram()
                     .isCumulative()
                     .points()
                     .satisfiesExactly(
@@ -84,34 +88,37 @@ class LongCounterSdkTest {
                                 .hasStartEpochNanos(testClock.now() - SECOND_NANOS)
                                 .hasEpochNanos(testClock.now())
                                 .hasAttributes(Attributes.empty())
-                                .hasValue(24)));
+                                .hasCount(2)
+                                .hasSum(24)
+                                .hasBucketBoundaries(
+                                    5, 10, 25, 50, 75, 100, 250, 500, 750, 1_000, 2_500, 5_000,
+                                    7_500, 10_000)
+                                .hasBucketCounts(0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)));
   }
 
   @Test
   @SuppressWarnings("unchecked")
   void collectMetrics_WithMultipleCollects() {
     long startTime = testClock.now();
-    LongCounter longCounter = sdkMeter.counterBuilder("testCounter").build();
-    BoundLongCounter bound = longCounter.bind(Attributes.builder().put("K", "V").build());
+    DoubleHistogram doubleRecorder = sdkMeter.histogramBuilder("testRecorder").build();
+    BoundDoubleHistogram bound = doubleRecorder.bind(Attributes.builder().put("K", "V").build());
     try {
       // Do some records using bounds and direct calls and bindings.
-      longCounter.add(12, Attributes.empty());
-      bound.add(123);
-      longCounter.add(21, Attributes.empty());
+      doubleRecorder.record(12.1d, Attributes.empty());
+      bound.record(123.3d);
+      doubleRecorder.record(-13.1d, Attributes.empty());
       // Advancing time here should not matter.
       testClock.advance(Duration.ofNanos(SECOND_NANOS));
-      bound.add(321);
-      longCounter.add(111, Attributes.builder().put("K", "V").build());
+      bound.record(321.5d);
+      doubleRecorder.record(-121.5d, Attributes.builder().put("K", "V").build());
       assertThat(sdkMeterProvider.collectAllMetrics())
           .satisfiesExactly(
               metric ->
                   assertThat(metric)
                       .hasResource(RESOURCE)
                       .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
-                      .hasName("testCounter")
-                      .hasLongSum()
-                      .isMonotonic()
-                      .isCumulative()
+                      .hasName("testRecorder")
+                      .hasDoubleHistogram()
                       .points()
                       .allSatisfy(
                           point ->
@@ -119,26 +126,31 @@ class LongCounterSdkTest {
                                   .hasStartEpochNanos(startTime)
                                   .hasEpochNanos(testClock.now()))
                       .satisfiesExactlyInAnyOrder(
-                          point -> assertThat(point).hasAttributes(Attributes.empty()).hasValue(33),
                           point ->
                               assertThat(point)
-                                  .hasAttributes(Attributes.of(stringKey("K"), "V"))
-                                  .hasValue(555)));
+                                  .hasCount(3)
+                                  .hasSum(323.3d)
+                                  .hasBucketCounts(1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0)
+                                  .hasAttributes(Attributes.builder().put("K", "V").build()),
+                          point ->
+                              assertThat(point)
+                                  .hasCount(2)
+                                  .hasSum(-1.0d)
+                                  .hasBucketCounts(1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+                                  .hasAttributes(Attributes.empty())));
 
-      // Repeat to prove we keep previous values.
+      // Histograms are cumulative by default.
       testClock.advance(Duration.ofNanos(SECOND_NANOS));
-      bound.add(222);
-      longCounter.add(11, Attributes.empty());
+      bound.record(222d);
+      doubleRecorder.record(17d, Attributes.empty());
       assertThat(sdkMeterProvider.collectAllMetrics())
           .satisfiesExactly(
               metric ->
                   assertThat(metric)
                       .hasResource(RESOURCE)
                       .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
-                      .hasName("testCounter")
-                      .hasLongSum()
-                      .isMonotonic()
-                      .isCumulative()
+                      .hasName("testRecorder")
+                      .hasDoubleHistogram()
                       .points()
                       .allSatisfy(
                           point ->
@@ -146,100 +158,44 @@ class LongCounterSdkTest {
                                   .hasStartEpochNanos(startTime)
                                   .hasEpochNanos(testClock.now()))
                       .satisfiesExactlyInAnyOrder(
-                          point -> assertThat(point).hasAttributes(Attributes.empty()).hasValue(44),
                           point ->
                               assertThat(point)
-                                  .hasAttributes(Attributes.of(stringKey("K"), "V"))
-                                  .hasValue(777)));
+                                  .hasCount(4)
+                                  .hasSum(545.3)
+                                  .hasBucketCounts(1, 0, 0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0)
+                                  .hasAttributes(Attributes.builder().put("K", "V").build()),
+                          point ->
+                              assertThat(point)
+                                  .hasCount(3)
+                                  .hasSum(16)
+                                  .hasBucketCounts(1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+                                  .hasAttributes(Attributes.empty())));
     } finally {
       bound.unbind();
     }
   }
 
   @Test
-  void longCounterAdd_MonotonicityCheck() {
-    LongCounter longCounter = sdkMeter.counterBuilder("testCounter").build();
-
-    assertThatThrownBy(() -> longCounter.add(-45, Attributes.empty()))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  void boundLongCounterAdd_MonotonicityCheck() {
-    LongCounter longCounter = sdkMeter.counterBuilder("testCounter").build();
-
-    assertThatThrownBy(() -> longCounter.bind(Attributes.empty()).add(-9))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
   void stressTest() {
-    final LongCounter longCounter = sdkMeter.counterBuilder("testCounter").build();
+    final DoubleHistogram doubleRecorder = sdkMeter.histogramBuilder("testRecorder").build();
 
     StressTestRunner.Builder stressTestBuilder =
         StressTestRunner.builder()
-            .setInstrument((LongCounterSdk) longCounter)
+            .setInstrument((SdkDoubleHistogram) doubleRecorder)
             .setCollectionIntervalMs(100);
 
     for (int i = 0; i < 4; i++) {
       stressTestBuilder.addOperation(
           StressTestRunner.Operation.create(
-              2_000, 1, new OperationUpdaterDirectCall(longCounter, "K", "V")));
-      stressTestBuilder.addOperation(
-          StressTestRunner.Operation.create(
-              2_000,
-              1,
-              new OperationUpdaterWithBinding(
-                  longCounter.bind(Attributes.builder().put("K", "V").build()))));
-    }
-
-    stressTestBuilder.build().run();
-    assertThat(sdkMeterProvider.collectAllMetrics())
-        .satisfiesExactly(
-            metric ->
-                assertThat(metric)
-                    .hasResource(RESOURCE)
-                    .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
-                    .hasName("testCounter")
-                    .hasLongSum()
-                    .isCumulative()
-                    .isMonotonic()
-                    .points()
-                    .satisfiesExactlyInAnyOrder(
-                        point ->
-                            assertThat(point)
-                                .hasStartEpochNanos(testClock.now())
-                                .hasEpochNanos(testClock.now())
-                                .hasValue(160_000)
-                                .attributes()
-                                .hasSize(1)
-                                .containsEntry("K", "V")));
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  void stressTest_WithDifferentLabelSet() {
-    final String[] keys = {"Key_1", "Key_2", "Key_3", "Key_4"};
-    final String[] values = {"Value_1", "Value_2", "Value_3", "Value_4"};
-    final LongCounter longCounter = sdkMeter.counterBuilder("testCounter").build();
-
-    StressTestRunner.Builder stressTestBuilder =
-        StressTestRunner.builder()
-            .setInstrument((LongCounterSdk) longCounter)
-            .setCollectionIntervalMs(100);
-
-    for (int i = 0; i < 4; i++) {
-      stressTestBuilder.addOperation(
-          StressTestRunner.Operation.create(
-              1_000, 2, new OperationUpdaterDirectCall(longCounter, keys[i], values[i])));
-
+              1_000,
+              2,
+              new SdkDoubleHistogramTest.OperationUpdaterDirectCall(doubleRecorder, "K", "V")));
       stressTestBuilder.addOperation(
           StressTestRunner.Operation.create(
               1_000,
               2,
               new OperationUpdaterWithBinding(
-                  longCounter.bind(Attributes.builder().put(keys[i], values[i]).build()))));
+                  doubleRecorder.bind(Attributes.builder().put("K", "V").build()))));
     }
 
     stressTestBuilder.build().run();
@@ -249,17 +205,64 @@ class LongCounterSdkTest {
                 assertThat(metric)
                     .hasResource(RESOURCE)
                     .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
-                    .hasName("testCounter")
-                    .hasLongSum()
-                    .isCumulative()
-                    .isMonotonic()
+                    .hasName("testRecorder")
+                    .hasDoubleHistogram()
+                    .points()
+                    .satisfiesExactly(
+                        point ->
+                            assertThat(point)
+                                .hasStartEpochNanos(testClock.now())
+                                .hasEpochNanos(testClock.now())
+                                .hasAttributes(Attributes.of(stringKey("K"), "V"))
+                                .hasCount(8_000)
+                                .hasSum(80_000)));
+  }
+
+  @Test
+  void stressTest_WithDifferentLabelSet() {
+    final String[] keys = {"Key_1", "Key_2", "Key_3", "Key_4"};
+    final String[] values = {"Value_1", "Value_2", "Value_3", "Value_4"};
+    final DoubleHistogram doubleRecorder = sdkMeter.histogramBuilder("testRecorder").build();
+
+    StressTestRunner.Builder stressTestBuilder =
+        StressTestRunner.builder()
+            .setInstrument((SdkDoubleHistogram) doubleRecorder)
+            .setCollectionIntervalMs(100);
+
+    for (int i = 0; i < 4; i++) {
+      stressTestBuilder.addOperation(
+          StressTestRunner.Operation.create(
+              2_000,
+              1,
+              new SdkDoubleHistogramTest.OperationUpdaterDirectCall(
+                  doubleRecorder, keys[i], values[i])));
+
+      stressTestBuilder.addOperation(
+          StressTestRunner.Operation.create(
+              2_000,
+              1,
+              new OperationUpdaterWithBinding(
+                  doubleRecorder.bind(Attributes.builder().put(keys[i], values[i]).build()))));
+    }
+
+    stressTestBuilder.build().run();
+    assertThat(sdkMeterProvider.collectAllMetrics())
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasResource(RESOURCE)
+                    .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
+                    .hasName("testRecorder")
+                    .hasDoubleHistogram()
                     .points()
                     .allSatisfy(
                         point ->
                             assertThat(point)
                                 .hasStartEpochNanos(testClock.now())
                                 .hasEpochNanos(testClock.now())
-                                .hasValue(20_000))
+                                .hasCount(4_000)
+                                .hasSum(40_000)
+                                .hasBucketCounts(0, 2000, 2000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
                     .extracting(point -> point.getAttributes())
                     .containsExactlyInAnyOrder(
                         Attributes.of(stringKey(keys[0]), values[0]),
@@ -269,38 +272,38 @@ class LongCounterSdkTest {
   }
 
   private static class OperationUpdaterWithBinding extends OperationUpdater {
-    private final BoundLongCounter boundLongCounter;
+    private final BoundDoubleHistogram boundDoubleValueRecorder;
 
-    private OperationUpdaterWithBinding(BoundLongCounter boundLongCounter) {
-      this.boundLongCounter = boundLongCounter;
+    private OperationUpdaterWithBinding(BoundDoubleHistogram boundDoubleValueRecorder) {
+      this.boundDoubleValueRecorder = boundDoubleValueRecorder;
     }
 
     @Override
     void update() {
-      boundLongCounter.add(9);
+      boundDoubleValueRecorder.record(11.0);
     }
 
     @Override
     void cleanup() {
-      boundLongCounter.unbind();
+      boundDoubleValueRecorder.unbind();
     }
   }
 
   private static class OperationUpdaterDirectCall extends OperationUpdater {
-
-    private final LongCounter longCounter;
+    private final DoubleHistogram doubleValueRecorder;
     private final String key;
     private final String value;
 
-    private OperationUpdaterDirectCall(LongCounter longCounter, String key, String value) {
-      this.longCounter = longCounter;
+    private OperationUpdaterDirectCall(
+        DoubleHistogram doubleValueRecorder, String key, String value) {
+      this.doubleValueRecorder = doubleValueRecorder;
       this.key = key;
       this.value = value;
     }
 
     @Override
     void update() {
-      longCounter.add(11, Attributes.builder().put(key, value).build());
+      doubleValueRecorder.record(9.0, Attributes.builder().put(key, value).build());
     }
 
     @Override

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleSumObserverTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleSumObserverTest.java
@@ -21,13 +21,13 @@ import io.opentelemetry.sdk.testing.time.TestClock;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link DoubleUpDownSumObserverSdk}. */
-class DoubleUpDownSumObserverSdkTest {
+/** Unit tests for {@link DoubleSumObserverSdk}. */
+class SdkDoubleSumObserverTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(Attributes.of(stringKey("resource_key"), "resource_value"));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
-      InstrumentationLibraryInfo.create(DoubleUpDownSumObserverSdkTest.class.getName(), null);
+      InstrumentationLibraryInfo.create(SdkDoubleSumObserverTest.class.getName(), null);
   private final TestClock testClock = TestClock.create();
   private final SdkMeterProviderBuilder sdkMeterProviderBuilder =
       SdkMeterProvider.builder().setClock(testClock).setResource(RESOURCE);
@@ -37,9 +37,9 @@ class DoubleUpDownSumObserverSdkTest {
     SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
     sdkMeterProvider
         .get(getClass().getName())
-        .upDownCounterBuilder("testObserver")
+        .counterBuilder("testObserver")
         .ofDoubles()
-        .setDescription("My own DoubleUpDownSumObserver")
+        .setDescription("My own DoubleSumObserver")
         .setUnit("ms")
         .buildWithCallback(result -> {});
     assertThat(sdkMeterProvider.collectAllMetrics()).isEmpty();
@@ -51,8 +51,10 @@ class DoubleUpDownSumObserverSdkTest {
     SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
     sdkMeterProvider
         .get(getClass().getName())
-        .upDownCounterBuilder("testObserver")
+        .counterBuilder("testObserver")
         .ofDoubles()
+        .setDescription("My own DoubleSumObserver")
+        .setUnit("ms")
         .buildWithCallback(
             result -> result.observe(12.1d, Attributes.builder().put("k", "v").build()));
     testClock.advance(Duration.ofNanos(SECOND_NANOS));
@@ -63,9 +65,11 @@ class DoubleUpDownSumObserverSdkTest {
                     .hasResource(RESOURCE)
                     .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
                     .hasName("testObserver")
+                    .hasDescription("My own DoubleSumObserver")
+                    .hasUnit("ms")
                     .hasDoubleSum()
                     .isCumulative()
-                    .isNotMonotonic()
+                    .isMonotonic()
                     .points()
                     .satisfiesExactlyInAnyOrder(
                         point ->
@@ -86,7 +90,7 @@ class DoubleUpDownSumObserverSdkTest {
                     .hasName("testObserver")
                     .hasDoubleSum()
                     .isCumulative()
-                    .isNotMonotonic()
+                    .isMonotonic()
                     .points()
                     .satisfiesExactlyInAnyOrder(
                         point ->
@@ -106,7 +110,7 @@ class DoubleUpDownSumObserverSdkTest {
         sdkMeterProviderBuilder
             .registerView(
                 InstrumentSelector.builder()
-                    .setInstrumentType(InstrumentType.OBSERVABLE_UP_DOWN_SUM)
+                    .setInstrumentType(InstrumentType.OBSERVABLE_SUM)
                     .build(),
                 View.builder()
                     .setLabelsProcessorFactory(LabelsProcessorFactory.noop())
@@ -115,8 +119,10 @@ class DoubleUpDownSumObserverSdkTest {
             .build();
     sdkMeterProvider
         .get(getClass().getName())
-        .upDownCounterBuilder("testObserver")
+        .counterBuilder("testObserver")
         .ofDoubles()
+        .setDescription("My own DoubleSumObserver")
+        .setUnit("ms")
         .buildWithCallback(
             result -> result.observe(12.1d, Attributes.builder().put("k", "v").build()));
     testClock.advance(Duration.ofNanos(SECOND_NANOS));
@@ -127,9 +133,11 @@ class DoubleUpDownSumObserverSdkTest {
                     .hasResource(RESOURCE)
                     .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
                     .hasName("testObserver")
+                    .hasDescription("My own DoubleSumObserver")
+                    .hasUnit("ms")
                     .hasDoubleSum()
                     .isDelta()
-                    .isNotMonotonic()
+                    .isMonotonic()
                     .points()
                     .satisfiesExactlyInAnyOrder(
                         point ->
@@ -148,9 +156,11 @@ class DoubleUpDownSumObserverSdkTest {
                     .hasResource(RESOURCE)
                     .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
                     .hasName("testObserver")
+                    .hasDescription("My own DoubleSumObserver")
+                    .hasUnit("ms")
                     .hasDoubleSum()
                     .isDelta()
-                    .isNotMonotonic()
+                    .isMonotonic()
                     .points()
                     .satisfiesExactlyInAnyOrder(
                         point ->

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleUpDownSumObserverTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleUpDownSumObserverTest.java
@@ -21,13 +21,13 @@ import io.opentelemetry.sdk.testing.time.TestClock;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link DoubleSumObserverSdk}. */
-class DoubleSumObserverSdkTest {
+/** Unit tests for {@link DoubleUpDownSumObserverSdk}. */
+class SdkDoubleUpDownSumObserverTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(Attributes.of(stringKey("resource_key"), "resource_value"));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
-      InstrumentationLibraryInfo.create(DoubleSumObserverSdkTest.class.getName(), null);
+      InstrumentationLibraryInfo.create(SdkDoubleUpDownSumObserverTest.class.getName(), null);
   private final TestClock testClock = TestClock.create();
   private final SdkMeterProviderBuilder sdkMeterProviderBuilder =
       SdkMeterProvider.builder().setClock(testClock).setResource(RESOURCE);
@@ -37,9 +37,9 @@ class DoubleSumObserverSdkTest {
     SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
     sdkMeterProvider
         .get(getClass().getName())
-        .counterBuilder("testObserver")
+        .upDownCounterBuilder("testObserver")
         .ofDoubles()
-        .setDescription("My own DoubleSumObserver")
+        .setDescription("My own DoubleUpDownSumObserver")
         .setUnit("ms")
         .buildWithCallback(result -> {});
     assertThat(sdkMeterProvider.collectAllMetrics()).isEmpty();
@@ -51,10 +51,8 @@ class DoubleSumObserverSdkTest {
     SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
     sdkMeterProvider
         .get(getClass().getName())
-        .counterBuilder("testObserver")
+        .upDownCounterBuilder("testObserver")
         .ofDoubles()
-        .setDescription("My own DoubleSumObserver")
-        .setUnit("ms")
         .buildWithCallback(
             result -> result.observe(12.1d, Attributes.builder().put("k", "v").build()));
     testClock.advance(Duration.ofNanos(SECOND_NANOS));
@@ -65,11 +63,9 @@ class DoubleSumObserverSdkTest {
                     .hasResource(RESOURCE)
                     .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
                     .hasName("testObserver")
-                    .hasDescription("My own DoubleSumObserver")
-                    .hasUnit("ms")
                     .hasDoubleSum()
                     .isCumulative()
-                    .isMonotonic()
+                    .isNotMonotonic()
                     .points()
                     .satisfiesExactlyInAnyOrder(
                         point ->
@@ -90,7 +86,7 @@ class DoubleSumObserverSdkTest {
                     .hasName("testObserver")
                     .hasDoubleSum()
                     .isCumulative()
-                    .isMonotonic()
+                    .isNotMonotonic()
                     .points()
                     .satisfiesExactlyInAnyOrder(
                         point ->
@@ -110,7 +106,7 @@ class DoubleSumObserverSdkTest {
         sdkMeterProviderBuilder
             .registerView(
                 InstrumentSelector.builder()
-                    .setInstrumentType(InstrumentType.OBSERVABLE_SUM)
+                    .setInstrumentType(InstrumentType.OBSERVABLE_UP_DOWN_SUM)
                     .build(),
                 View.builder()
                     .setLabelsProcessorFactory(LabelsProcessorFactory.noop())
@@ -119,10 +115,8 @@ class DoubleSumObserverSdkTest {
             .build();
     sdkMeterProvider
         .get(getClass().getName())
-        .counterBuilder("testObserver")
+        .upDownCounterBuilder("testObserver")
         .ofDoubles()
-        .setDescription("My own DoubleSumObserver")
-        .setUnit("ms")
         .buildWithCallback(
             result -> result.observe(12.1d, Attributes.builder().put("k", "v").build()));
     testClock.advance(Duration.ofNanos(SECOND_NANOS));
@@ -133,11 +127,9 @@ class DoubleSumObserverSdkTest {
                     .hasResource(RESOURCE)
                     .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
                     .hasName("testObserver")
-                    .hasDescription("My own DoubleSumObserver")
-                    .hasUnit("ms")
                     .hasDoubleSum()
                     .isDelta()
-                    .isMonotonic()
+                    .isNotMonotonic()
                     .points()
                     .satisfiesExactlyInAnyOrder(
                         point ->
@@ -156,11 +148,9 @@ class DoubleSumObserverSdkTest {
                     .hasResource(RESOURCE)
                     .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
                     .hasName("testObserver")
-                    .hasDescription("My own DoubleSumObserver")
-                    .hasUnit("ms")
                     .hasDoubleSum()
                     .isDelta()
-                    .isMonotonic()
+                    .isNotMonotonic()
                     .points()
                     .satisfiesExactlyInAnyOrder(
                         point ->

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkLongGaugeBuilderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkLongGaugeBuilderTest.java
@@ -16,12 +16,12 @@ import io.opentelemetry.sdk.testing.time.TestClock;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link DoubleValueObserverSdk}. */
-class DoubleGaugeBuilderSdkTest {
+/** Unit tests for {@link LongValueObserverSdk}. */
+class SdkLongGaugeBuilderTest {
   private static final Resource RESOURCE =
       Resource.create(Attributes.of(stringKey("resource_key"), "resource_value"));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
-      InstrumentationLibraryInfo.create(DoubleGaugeBuilderSdkTest.class.getName(), null);
+      InstrumentationLibraryInfo.create(SdkLongGaugeBuilderTest.class.getName(), null);
   private final TestClock testClock = TestClock.create();
   private final SdkMeterProvider sdkMeterProvider =
       SdkMeterProvider.builder().setClock(testClock).setResource(RESOURCE).build();
@@ -31,7 +31,8 @@ class DoubleGaugeBuilderSdkTest {
   void collectMetrics_NoRecords() {
     sdkMeter
         .gaugeBuilder("testObserver")
-        .setDescription("My own DoubleValueObserver")
+        .ofLongs()
+        .setDescription("My own LongValueObserver")
         .setUnit("ms")
         .buildWithCallback(result -> {});
     assertThat(sdkMeterProvider.collectAllMetrics()).isEmpty();
@@ -42,10 +43,9 @@ class DoubleGaugeBuilderSdkTest {
   void collectMetrics_WithOneRecord() {
     sdkMeter
         .gaugeBuilder("testObserver")
-        .setDescription("My own DoubleValueObserver")
-        .setUnit("ms")
+        .ofLongs()
         .buildWithCallback(
-            result -> result.observe(12.1d, Attributes.builder().put("k", "v").build()));
+            result -> result.observe(12, Attributes.builder().put("k", "v").build()));
     testClock.advance(Duration.ofSeconds(1));
     assertThat(sdkMeterProvider.collectAllMetrics())
         .satisfiesExactly(
@@ -54,9 +54,7 @@ class DoubleGaugeBuilderSdkTest {
                     .hasResource(RESOURCE)
                     .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
                     .hasName("testObserver")
-                    .hasDescription("My own DoubleValueObserver")
-                    .hasUnit("ms")
-                    .hasDoubleGauge()
+                    .hasLongGauge()
                     .points()
                     .satisfiesExactlyInAnyOrder(
                         point ->
@@ -64,7 +62,7 @@ class DoubleGaugeBuilderSdkTest {
                                 .hasStartEpochNanos(0)
                                 .hasEpochNanos(testClock.now())
                                 .hasAttributes(Attributes.builder().put("k", "v").build())
-                                .hasValue(12.1d)));
+                                .hasValue(12)));
     testClock.advance(Duration.ofSeconds(1));
     assertThat(sdkMeterProvider.collectAllMetrics())
         .satisfiesExactly(
@@ -73,9 +71,7 @@ class DoubleGaugeBuilderSdkTest {
                     .hasResource(RESOURCE)
                     .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
                     .hasName("testObserver")
-                    .hasDescription("My own DoubleValueObserver")
-                    .hasUnit("ms")
-                    .hasDoubleGauge()
+                    .hasLongGauge()
                     .points()
                     .satisfiesExactlyInAnyOrder(
                         point ->
@@ -83,6 +79,6 @@ class DoubleGaugeBuilderSdkTest {
                                 .hasStartEpochNanos(0)
                                 .hasEpochNanos(testClock.now())
                                 .hasAttributes(Attributes.builder().put("k", "v").build())
-                                .hasValue(12.1d)));
+                                .hasValue(12)));
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkLongSumObserverTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkLongSumObserverTest.java
@@ -21,13 +21,13 @@ import io.opentelemetry.sdk.testing.time.TestClock;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link LongUpDownSumObserverSdk}. */
-class LongUpDownSumObserverSdkTest {
+/** Unit tests for {@link LongSumObserverSdk}. */
+class SdkLongSumObserverTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(Attributes.of(stringKey("resource_key"), "resource_value"));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
-      InstrumentationLibraryInfo.create(LongUpDownSumObserverSdkTest.class.getName(), null);
+      InstrumentationLibraryInfo.create(SdkLongSumObserverTest.class.getName(), null);
   private final TestClock testClock = TestClock.create();
   private final SdkMeterProviderBuilder sdkMeterProviderBuilder =
       SdkMeterProvider.builder().setClock(testClock).setResource(RESOURCE);
@@ -37,8 +37,8 @@ class LongUpDownSumObserverSdkTest {
     SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
     sdkMeterProvider
         .get(getClass().getName())
-        .upDownCounterBuilder("testObserver")
-        .setDescription("My own LongUpDownSumObserver")
+        .counterBuilder("testObserver")
+        .setDescription("My own LongSumObserver")
         .setUnit("ms")
         .buildWithCallback(result -> {});
     assertThat(sdkMeterProvider.collectAllMetrics()).isEmpty();
@@ -50,7 +50,7 @@ class LongUpDownSumObserverSdkTest {
     SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
     sdkMeterProvider
         .get(getClass().getName())
-        .upDownCounterBuilder("testObserver")
+        .counterBuilder("testObserver")
         .buildWithCallback(
             result -> result.observe(12, Attributes.builder().put("k", "v").build()));
     testClock.advance(Duration.ofNanos(SECOND_NANOS));
@@ -62,7 +62,7 @@ class LongUpDownSumObserverSdkTest {
                     .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
                     .hasName("testObserver")
                     .hasLongSum()
-                    .isNotMonotonic()
+                    .isMonotonic()
                     .isCumulative()
                     .points()
                     .satisfiesExactly(
@@ -83,7 +83,7 @@ class LongUpDownSumObserverSdkTest {
                     .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
                     .hasName("testObserver")
                     .hasLongSum()
-                    .isNotMonotonic()
+                    .isMonotonic()
                     .isCumulative()
                     .points()
                     .satisfiesExactly(
@@ -104,7 +104,7 @@ class LongUpDownSumObserverSdkTest {
         sdkMeterProviderBuilder
             .registerView(
                 InstrumentSelector.builder()
-                    .setInstrumentType(InstrumentType.OBSERVABLE_UP_DOWN_SUM)
+                    .setInstrumentType(InstrumentType.OBSERVABLE_SUM)
                     .build(),
                 View.builder()
                     .setLabelsProcessorFactory(LabelsProcessorFactory.noop())
@@ -113,7 +113,7 @@ class LongUpDownSumObserverSdkTest {
             .build();
     sdkMeterProvider
         .get(getClass().getName())
-        .upDownCounterBuilder("testObserver")
+        .counterBuilder("testObserver")
         .buildWithCallback(
             result -> result.observe(12, Attributes.builder().put("k", "v").build()));
     testClock.advance(Duration.ofNanos(SECOND_NANOS));
@@ -125,7 +125,7 @@ class LongUpDownSumObserverSdkTest {
                     .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
                     .hasName("testObserver")
                     .hasLongSum()
-                    .isNotMonotonic()
+                    .isMonotonic()
                     .isDelta()
                     .points()
                     .satisfiesExactly(
@@ -146,7 +146,7 @@ class LongUpDownSumObserverSdkTest {
                     .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
                     .hasName("testObserver")
                     .hasLongSum()
-                    .isNotMonotonic()
+                    .isMonotonic()
                     .isDelta()
                     .points()
                     .satisfiesExactly(

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkLongUpDownSumObserverTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkLongUpDownSumObserverTest.java
@@ -21,13 +21,13 @@ import io.opentelemetry.sdk.testing.time.TestClock;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link LongSumObserverSdk}. */
-class LongSumObserverSdkTest {
+/** Unit tests for {@link LongUpDownSumObserverSdk}. */
+class SdkLongUpDownSumObserverTest {
   private static final long SECOND_NANOS = 1_000_000_000;
   private static final Resource RESOURCE =
       Resource.create(Attributes.of(stringKey("resource_key"), "resource_value"));
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
-      InstrumentationLibraryInfo.create(LongSumObserverSdkTest.class.getName(), null);
+      InstrumentationLibraryInfo.create(SdkLongUpDownSumObserverTest.class.getName(), null);
   private final TestClock testClock = TestClock.create();
   private final SdkMeterProviderBuilder sdkMeterProviderBuilder =
       SdkMeterProvider.builder().setClock(testClock).setResource(RESOURCE);
@@ -37,8 +37,8 @@ class LongSumObserverSdkTest {
     SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
     sdkMeterProvider
         .get(getClass().getName())
-        .counterBuilder("testObserver")
-        .setDescription("My own LongSumObserver")
+        .upDownCounterBuilder("testObserver")
+        .setDescription("My own LongUpDownSumObserver")
         .setUnit("ms")
         .buildWithCallback(result -> {});
     assertThat(sdkMeterProvider.collectAllMetrics()).isEmpty();
@@ -50,7 +50,7 @@ class LongSumObserverSdkTest {
     SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
     sdkMeterProvider
         .get(getClass().getName())
-        .counterBuilder("testObserver")
+        .upDownCounterBuilder("testObserver")
         .buildWithCallback(
             result -> result.observe(12, Attributes.builder().put("k", "v").build()));
     testClock.advance(Duration.ofNanos(SECOND_NANOS));
@@ -62,7 +62,7 @@ class LongSumObserverSdkTest {
                     .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
                     .hasName("testObserver")
                     .hasLongSum()
-                    .isMonotonic()
+                    .isNotMonotonic()
                     .isCumulative()
                     .points()
                     .satisfiesExactly(
@@ -83,7 +83,7 @@ class LongSumObserverSdkTest {
                     .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
                     .hasName("testObserver")
                     .hasLongSum()
-                    .isMonotonic()
+                    .isNotMonotonic()
                     .isCumulative()
                     .points()
                     .satisfiesExactly(
@@ -104,7 +104,7 @@ class LongSumObserverSdkTest {
         sdkMeterProviderBuilder
             .registerView(
                 InstrumentSelector.builder()
-                    .setInstrumentType(InstrumentType.OBSERVABLE_SUM)
+                    .setInstrumentType(InstrumentType.OBSERVABLE_UP_DOWN_SUM)
                     .build(),
                 View.builder()
                     .setLabelsProcessorFactory(LabelsProcessorFactory.noop())
@@ -113,7 +113,7 @@ class LongSumObserverSdkTest {
             .build();
     sdkMeterProvider
         .get(getClass().getName())
-        .counterBuilder("testObserver")
+        .upDownCounterBuilder("testObserver")
         .buildWithCallback(
             result -> result.observe(12, Attributes.builder().put("k", "v").build()));
     testClock.advance(Duration.ofNanos(SECOND_NANOS));
@@ -125,7 +125,7 @@ class LongSumObserverSdkTest {
                     .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
                     .hasName("testObserver")
                     .hasLongSum()
-                    .isMonotonic()
+                    .isNotMonotonic()
                     .isDelta()
                     .points()
                     .satisfiesExactly(
@@ -146,7 +146,7 @@ class LongSumObserverSdkTest {
                     .hasInstrumentationLibrary(INSTRUMENTATION_LIBRARY_INFO)
                     .hasName("testObserver")
                     .hasLongSum()
-                    .isMonotonic()
+                    .isNotMonotonic()
                     .isDelta()
                     .points()
                     .satisfiesExactly(


### PR DESCRIPTION
The was a comment from @jkwatson.   I liked it, so I took the 5 minutes to do it.  Happy to take it or leave it.

Should not change anything materially as these classes are all package-private.