### PR TITLE
Marshal directly to bytebuffer where possible.

### DIFF
--- a/exporters/otlp/trace/build.gradle.kts
+++ b/exporters/otlp/trace/build.gradle.kts
@@ -14,6 +14,7 @@ testSets {
   create("testGrpcNetty")
   create("testGrpcNettyShaded")
   create("testGrpcOkhttp")
+  create("testGrpcNetty138")
 }
 
 dependencies {
@@ -42,6 +43,12 @@ dependencies {
   add("testGrpcNettyRuntimeOnly", "io.grpc:grpc-netty")
   add("testGrpcNettyRuntimeOnly", "org.bouncycastle:bcpkix-jdk15on")
 
+  add("testGrpcNetty138Implementation", enforcedPlatform("io.grpc:grpc-bom:1.38.0"))
+  add("testGrpcNetty138Implementation", "com.linecorp.armeria:armeria-grpc")
+  add("testGrpcNetty138Implementation", "com.linecorp.armeria:armeria-junit5")
+  add("testGrpcNetty138RuntimeOnly", "io.grpc:grpc-netty")
+  add("testGrpcNetty138RuntimeOnly", "org.bouncycastle:bcpkix-jdk15on")
+
   add("testGrpcNettyShadedImplementation", "com.linecorp.armeria:armeria-grpc")
   add("testGrpcNettyShadedImplementation", "com.linecorp.armeria:armeria-junit5")
   add("testGrpcNettyShadedRuntimeOnly", "io.grpc:grpc-netty-shaded")
@@ -53,10 +60,11 @@ dependencies {
   add("testGrpcOkhttpRuntimeOnly", "org.bouncycastle:bcpkix-jdk15on")
 
   jmh(project(":sdk:testing"))
+  jmh("io.grpc:grpc-netty")
 }
 
 tasks {
   named("check") {
-    dependsOn("testGrpcNetty", "testGrpcNettyShaded", "testGrpcOkhttp")
+    dependsOn("testGrpcNetty", "testGrpcNetty138", "testGrpcNettyShaded", "testGrpcOkhttp")
   }
 }

--- a/exporters/otlp/trace/src/jmh/java/io/opentelemetry/exporter/otlp/trace/MarshalerInputStreamBenchmarks.java
+++ b/exporters/otlp/trace/src/jmh/java/io/opentelemetry/exporter/otlp/trace/MarshalerInputStreamBenchmarks.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.trace;
+
+import io.grpc.HasByteBuffer;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufOutputStream;
+import io.netty.buffer.PooledByteBufAllocator;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode({Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(1)
+public class MarshalerInputStreamBenchmarks {
+
+  @Benchmark
+  @Threads(1)
+  public void marshalToNettyBuffer(RequestMarshalState state) {
+    MarshalerInputStream stream =
+        new MarshalerInputStream(TraceMarshaler.RequestMarshaler.create(state.spanDataList));
+    // Roughly reproduce how grpc-netty should behave, it's classes are internal so hard to use
+    // directly.
+    ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer(stream.available());
+    try (NettyOutputStream nettyStream = new NettyOutputStream(buf)) {
+      stream.drainTo(nettyStream);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private static class NettyOutputStream extends ByteBufOutputStream implements HasByteBuffer {
+
+    private final ByteBuffer byteBuffer;
+
+    NettyOutputStream(ByteBuf buf) {
+      super(buf);
+      byteBuffer = buf.nioBuffer(0, buf.writableBytes());
+    }
+
+    @Override
+    public boolean byteBufferSupported() {
+      return true;
+    }
+
+    @Nullable
+    @Override
+    public ByteBuffer getByteBuffer() {
+      return byteBuffer;
+    }
+
+    @Override
+    public void close() {
+      buffer().release();
+    }
+  }
+}


### PR DESCRIPTION
Uses a new API introduced in 1.39 to let us write straight to a netty buffer instead of going through a wasteful buffered outputstream

After
```
Benchmark                                                                         (numSpans)  Mode  Cnt      Score      Error   Units
MarshalerInputStreamBenchmarks.marshalToNettyBuffer                                       16  avgt   10     15.713 ±    0.133   us/op
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.alloc.rate                        16  avgt   10    916.361 ±    7.812  MB/sec
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.alloc.rate.norm                   16  avgt   10  22678.477 ±    0.554    B/op
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.churn.G1_Eden_Space               16  avgt   10    923.821 ±   95.072  MB/sec
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.churn.G1_Eden_Space.norm          16  avgt   10  22861.759 ± 2312.486    B/op
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.churn.G1_Old_Gen                  16  avgt   10      0.015 ±    0.006  MB/sec
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.churn.G1_Old_Gen.norm             16  avgt   10      0.372 ±    0.148    B/op
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.count                             16  avgt   10     76.000             counts
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.time                              16  avgt   10     33.000                 ms
```

Before
```

Benchmark                                                                         (numSpans)  Mode  Cnt      Score      Error   Units
MarshalerInputStreamBenchmarks.marshalToNettyBuffer                                       16  avgt   10     18.072 ±    0.390   us/op
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.alloc.rate                        16  avgt   10    936.069 ±   20.049  MB/sec
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.alloc.rate.norm                   16  avgt   10  26638.468 ±    0.297    B/op
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.churn.G1_Eden_Space               16  avgt   10    935.413 ±   88.690  MB/sec
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.churn.G1_Eden_Space.norm          16  avgt   10  26621.998 ± 2515.013    B/op
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.churn.G1_Old_Gen                  16  avgt   10      0.015 ±    0.007  MB/sec
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.churn.G1_Old_Gen.norm             16  avgt   10      0.432 ±    0.212    B/op
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.count                             16  avgt   10     77.000             counts
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.time                              16  avgt   10     32.000                 ms
```