### PR TITLE
Update View-wiring to match SDK specificaiton

### DIFF
--- a/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/aggregator/DoubleHistogramBenchmark.java
+++ b/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/aggregator/DoubleHistogramBenchmark.java
@@ -10,6 +10,7 @@ import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -34,11 +35,8 @@ public class DoubleHistogramBenchmark {
               Resource.getDefault(),
               InstrumentationLibraryInfo.empty(),
               InstrumentDescriptor.create(
-                  "name",
-                  "description",
-                  "1",
-                  InstrumentType.HISTOGRAM,
-                  InstrumentValueType.DOUBLE));
+                  "name", "description", "1", InstrumentType.HISTOGRAM, InstrumentValueType.DOUBLE),
+              MetricDescriptor.create("name", "description", "1"));
   private AggregatorHandle<HistogramAccumulation> aggregatorHandle;
 
   @Setup(Level.Trial)

--- a/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountBenchmark.java
+++ b/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountBenchmark.java
@@ -9,6 +9,7 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -32,11 +33,8 @@ public class DoubleMinMaxSumCountBenchmark {
               Resource.getDefault(),
               InstrumentationLibraryInfo.empty(),
               InstrumentDescriptor.create(
-                  "name",
-                  "description",
-                  "1",
-                  InstrumentType.HISTOGRAM,
-                  InstrumentValueType.DOUBLE));
+                  "name", "description", "1", InstrumentType.HISTOGRAM, InstrumentValueType.DOUBLE),
+              MetricDescriptor.create("name", "description", "1"));
   private AggregatorHandle<MinMaxSumCountAccumulation> aggregatorHandle;
 
   @Setup(Level.Trial)

--- a/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountBenchmark.java
+++ b/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountBenchmark.java
@@ -9,6 +9,7 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -32,7 +33,8 @@ public class LongMinMaxSumCountBenchmark {
               Resource.getDefault(),
               InstrumentationLibraryInfo.empty(),
               InstrumentDescriptor.create(
-                  "name", "description", "1", InstrumentType.HISTOGRAM, InstrumentValueType.LONG));
+                  "name", "description", "1", InstrumentType.HISTOGRAM, InstrumentValueType.LONG),
+              MetricDescriptor.create("name", "description", "1"));
   private AggregatorHandle<MinMaxSumCountAccumulation> aggregatorHandle;
 
   @Setup(Level.Trial)

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/AbstractAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/AbstractAggregator.java
@@ -6,23 +6,23 @@
 package io.opentelemetry.sdk.metrics.aggregator;
 
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 
 public abstract class AbstractAggregator<T> implements Aggregator<T> {
   private final Resource resource;
   private final InstrumentationLibraryInfo instrumentationLibraryInfo;
-  private final InstrumentDescriptor instrumentDescriptor;
+  private final MetricDescriptor metricDescriptor;
   private final boolean stateful;
 
   protected AbstractAggregator(
       Resource resource,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
-      InstrumentDescriptor instrumentDescriptor,
+      MetricDescriptor metricDescriptor,
       boolean stateful) {
     this.resource = resource;
     this.instrumentationLibraryInfo = instrumentationLibraryInfo;
-    this.instrumentDescriptor = instrumentDescriptor;
+    this.metricDescriptor = metricDescriptor;
     this.stateful = stateful;
   }
 
@@ -39,7 +39,7 @@ public abstract class AbstractAggregator<T> implements Aggregator<T> {
     return instrumentationLibraryInfo;
   }
 
-  protected final InstrumentDescriptor getInstrumentDescriptor() {
-    return instrumentDescriptor;
+  protected final MetricDescriptor getMetricDescriptor() {
+    return metricDescriptor;
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/AbstractMinMaxSumCountAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/AbstractMinMaxSumCountAggregator.java
@@ -7,9 +7,9 @@ package io.opentelemetry.sdk.metrics.aggregator;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.data.DoubleSummaryData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Map;
 
@@ -19,8 +19,8 @@ abstract class AbstractMinMaxSumCountAggregator
   AbstractMinMaxSumCountAggregator(
       Resource resource,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
-      InstrumentDescriptor instrumentDescriptor) {
-    super(resource, instrumentationLibraryInfo, instrumentDescriptor, /* stateful= */ false);
+      MetricDescriptor metricDescriptor) {
+    super(resource, instrumentationLibraryInfo, metricDescriptor, /* stateful= */ false);
   }
 
   @Override
@@ -42,9 +42,9 @@ abstract class AbstractMinMaxSumCountAggregator
     return MetricData.createDoubleSummary(
         getResource(),
         getInstrumentationLibraryInfo(),
-        getInstrumentDescriptor().getName(),
-        getInstrumentDescriptor().getDescription(),
-        getInstrumentDescriptor().getUnit(),
+        getMetricDescriptor().getName(),
+        getMetricDescriptor().getDescription(),
+        getMetricDescriptor().getUnit(),
         DoubleSummaryData.create(
             MetricDataUtils.toDoubleSummaryPointList(
                 accumulationByLabels, lastCollectionEpoch, epochNanos)));

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/AbstractSumAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/AbstractSumAggregator.java
@@ -9,6 +9,7 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 
 abstract class AbstractSumAggregator<T> extends AbstractAggregator<T> {
@@ -20,11 +21,12 @@ abstract class AbstractSumAggregator<T> extends AbstractAggregator<T> {
       Resource resource,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
       InstrumentDescriptor instrumentDescriptor,
+      MetricDescriptor metricDescriptor,
       AggregationTemporality temporality) {
     super(
         resource,
         instrumentationLibraryInfo,
-        instrumentDescriptor,
+        metricDescriptor,
         resolveStateful(instrumentDescriptor.getType(), temporality));
     InstrumentType type = instrumentDescriptor.getType();
     this.isMonotonic = type == InstrumentType.COUNTER || type == InstrumentType.OBSERVABLE_SUM;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/AggregatorFactory.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/AggregatorFactory.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.metrics.aggregator;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
@@ -116,11 +117,14 @@ public interface AggregatorFactory {
    *     measurements.
    * @param instrumentationLibraryInfo the InstrumentationLibraryInfo associated with the {@code
    *     Instrument} that will record measurements.
-   * @param descriptor the descriptor of the {@code Instrument} that will record measurements.
+   * @param instrumentDescriptor the descriptor of the {@code Instrument} that will record
+   *     measurements.
+   * @param metricDescriptor the descriptor of the {@code MetricData} that should be generated.
    * @return a new {@link Aggregator}.
    */
   <T> Aggregator<T> create(
       Resource resource,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
-      InstrumentDescriptor descriptor);
+      InstrumentDescriptor instrumentDescriptor,
+      MetricDescriptor metricDescriptor);
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/CountAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/CountAggregator.java
@@ -7,10 +7,10 @@ package io.opentelemetry.sdk.metrics.aggregator;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.LongSumData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Map;
 import java.util.concurrent.atomic.LongAdder;
@@ -23,7 +23,7 @@ final class CountAggregator extends AbstractAggregator<Long> {
   CountAggregator(
       Resource resource,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
-      InstrumentDescriptor descriptor,
+      MetricDescriptor descriptor,
       AggregationTemporality temporality) {
     super(
         resource,
@@ -62,8 +62,8 @@ final class CountAggregator extends AbstractAggregator<Long> {
     return MetricData.createLongSum(
         getResource(),
         getInstrumentationLibraryInfo(),
-        getInstrumentDescriptor().getName(),
-        getInstrumentDescriptor().getDescription(),
+        getMetricDescriptor().getName(),
+        getMetricDescriptor().getDescription(),
         "1",
         LongSumData.create(
             /* isMonotonic= */ true,

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/CountAggregatorFactory.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/CountAggregatorFactory.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.metrics.aggregator;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 
 final class CountAggregatorFactory implements AggregatorFactory {
@@ -22,8 +23,9 @@ final class CountAggregatorFactory implements AggregatorFactory {
   public <T> Aggregator<T> create(
       Resource resource,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
-      InstrumentDescriptor descriptor) {
+      InstrumentDescriptor unused,
+      MetricDescriptor metricDescriptor) {
     return (Aggregator<T>)
-        new CountAggregator(resource, instrumentationLibraryInfo, descriptor, temporality);
+        new CountAggregator(resource, instrumentationLibraryInfo, metricDescriptor, temporality);
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleHistogramAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleHistogramAggregator.java
@@ -8,10 +8,10 @@ package io.opentelemetry.sdk.metrics.aggregator;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.internal.GuardedBy;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.DoubleHistogramData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,10 +29,10 @@ final class DoubleHistogramAggregator extends AbstractAggregator<HistogramAccumu
   DoubleHistogramAggregator(
       Resource resource,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
-      InstrumentDescriptor instrumentDescriptor,
+      MetricDescriptor metricDescriptor,
       double[] boundaries,
       boolean stateful) {
-    super(resource, instrumentationLibraryInfo, instrumentDescriptor, stateful);
+    super(resource, instrumentationLibraryInfo, metricDescriptor, stateful);
     this.boundaries = boundaries;
 
     List<Double> boundaryList = new ArrayList<>(this.boundaries.length);
@@ -70,9 +70,9 @@ final class DoubleHistogramAggregator extends AbstractAggregator<HistogramAccumu
     return MetricData.createDoubleHistogram(
         getResource(),
         getInstrumentationLibraryInfo(),
-        getInstrumentDescriptor().getName(),
-        getInstrumentDescriptor().getDescription(),
-        getInstrumentDescriptor().getUnit(),
+        getMetricDescriptor().getName(),
+        getMetricDescriptor().getDescription(),
+        getMetricDescriptor().getUnit(),
         DoubleHistogramData.create(
             isStateful() ? AggregationTemporality.CUMULATIVE : AggregationTemporality.DELTA,
             MetricDataUtils.toDoubleHistogramPointList(

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleLastValueAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleLastValueAggregator.java
@@ -7,9 +7,9 @@ package io.opentelemetry.sdk.metrics.aggregator;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.data.DoubleGaugeData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -29,7 +29,7 @@ final class DoubleLastValueAggregator extends AbstractAggregator<Double> {
   DoubleLastValueAggregator(
       Resource resource,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
-      InstrumentDescriptor descriptor) {
+      MetricDescriptor descriptor) {
     super(resource, instrumentationLibraryInfo, descriptor, /* stateful= */ true);
   }
 
@@ -58,9 +58,9 @@ final class DoubleLastValueAggregator extends AbstractAggregator<Double> {
     return MetricData.createDoubleGauge(
         getResource(),
         getInstrumentationLibraryInfo(),
-        getInstrumentDescriptor().getName(),
-        getInstrumentDescriptor().getDescription(),
-        getInstrumentDescriptor().getUnit(),
+        getMetricDescriptor().getName(),
+        getMetricDescriptor().getDescription(),
+        getMetricDescriptor().getUnit(),
         DoubleGaugeData.create(
             MetricDataUtils.toDoublePointList(accumulationByLabels, 0, epochNanos)));
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountAggregator.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.metrics.aggregator;
 
 import io.opentelemetry.api.internal.GuardedBy;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.annotation.concurrent.ThreadSafe;
@@ -17,7 +17,7 @@ final class DoubleMinMaxSumCountAggregator extends AbstractMinMaxSumCountAggrega
   DoubleMinMaxSumCountAggregator(
       Resource resource,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
-      InstrumentDescriptor descriptor) {
+      MetricDescriptor descriptor) {
     super(resource, instrumentationLibraryInfo, descriptor);
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleSumAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/DoubleSumAggregator.java
@@ -11,6 +11,7 @@ import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.DoubleSumData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Map;
 import java.util.concurrent.atomic.DoubleAdder;
@@ -19,9 +20,11 @@ final class DoubleSumAggregator extends AbstractSumAggregator<Double> {
   DoubleSumAggregator(
       Resource resource,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
-      InstrumentDescriptor descriptor,
+      InstrumentDescriptor instrumentDescriptor,
+      MetricDescriptor metricDescriptor,
       AggregationTemporality temporality) {
-    super(resource, instrumentationLibraryInfo, descriptor, temporality);
+    super(
+        resource, instrumentationLibraryInfo, instrumentDescriptor, metricDescriptor, temporality);
   }
 
   @Override
@@ -53,9 +56,9 @@ final class DoubleSumAggregator extends AbstractSumAggregator<Double> {
     return MetricData.createDoubleSum(
         getResource(),
         getInstrumentationLibraryInfo(),
-        getInstrumentDescriptor().getName(),
-        getInstrumentDescriptor().getDescription(),
-        getInstrumentDescriptor().getUnit(),
+        getMetricDescriptor().getName(),
+        getMetricDescriptor().getDescription(),
+        getMetricDescriptor().getUnit(),
         DoubleSumData.create(
             isMonotonic(),
             temporality(),

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/HistogramAggregatorFactory.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/HistogramAggregatorFactory.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.metrics.aggregator;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.List;
 
@@ -45,14 +46,15 @@ final class HistogramAggregatorFactory implements AggregatorFactory {
   public <T> Aggregator<T> create(
       Resource resource,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
-      InstrumentDescriptor descriptor) {
+      InstrumentDescriptor instrumentDescriptor,
+      MetricDescriptor metricDescriptor) {
     final boolean stateful = this.temporality == AggregationTemporality.CUMULATIVE;
-    switch (descriptor.getValueType()) {
+    switch (instrumentDescriptor.getValueType()) {
       case LONG:
       case DOUBLE:
         return (Aggregator<T>)
             new DoubleHistogramAggregator(
-                resource, instrumentationLibraryInfo, descriptor, this.boundaries, stateful);
+                resource, instrumentationLibraryInfo, metricDescriptor, this.boundaries, stateful);
     }
     throw new IllegalArgumentException("Invalid instrument value type");
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LastValueAggregatorFactory.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LastValueAggregatorFactory.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.metrics.aggregator;
 
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 
 final class LastValueAggregatorFactory implements AggregatorFactory {
@@ -19,14 +20,15 @@ final class LastValueAggregatorFactory implements AggregatorFactory {
   public <T> Aggregator<T> create(
       Resource resource,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
-      InstrumentDescriptor descriptor) {
+      InstrumentDescriptor descriptor,
+      MetricDescriptor metricDescriptor) {
     switch (descriptor.getValueType()) {
       case LONG:
         return (Aggregator<T>)
-            new LongLastValueAggregator(resource, instrumentationLibraryInfo, descriptor);
+            new LongLastValueAggregator(resource, instrumentationLibraryInfo, metricDescriptor);
       case DOUBLE:
         return (Aggregator<T>)
-            new DoubleLastValueAggregator(resource, instrumentationLibraryInfo, descriptor);
+            new DoubleLastValueAggregator(resource, instrumentationLibraryInfo, metricDescriptor);
     }
     throw new IllegalArgumentException("Invalid instrument value type");
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongLastValueAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongLastValueAggregator.java
@@ -7,9 +7,9 @@ package io.opentelemetry.sdk.metrics.aggregator;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.data.LongGaugeData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -27,7 +27,7 @@ final class LongLastValueAggregator extends AbstractAggregator<Long> {
   LongLastValueAggregator(
       Resource resource,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
-      InstrumentDescriptor descriptor) {
+      MetricDescriptor descriptor) {
     super(resource, instrumentationLibraryInfo, descriptor, /* stateful= */ false);
   }
 
@@ -56,9 +56,9 @@ final class LongLastValueAggregator extends AbstractAggregator<Long> {
     return MetricData.createLongGauge(
         getResource(),
         getInstrumentationLibraryInfo(),
-        getInstrumentDescriptor().getName(),
-        getInstrumentDescriptor().getDescription(),
-        getInstrumentDescriptor().getUnit(),
+        getMetricDescriptor().getName(),
+        getMetricDescriptor().getDescription(),
+        getMetricDescriptor().getUnit(),
         LongGaugeData.create(MetricDataUtils.toLongPointList(accumulationByLabels, 0, epochNanos)));
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountAggregator.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.metrics.aggregator;
 
 import io.opentelemetry.api.internal.GuardedBy;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.annotation.concurrent.ThreadSafe;
@@ -17,7 +17,7 @@ final class LongMinMaxSumCountAggregator extends AbstractMinMaxSumCountAggregato
   LongMinMaxSumCountAggregator(
       Resource resource,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
-      InstrumentDescriptor descriptor) {
+      MetricDescriptor descriptor) {
     super(resource, instrumentationLibraryInfo, descriptor);
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongSumAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/LongSumAggregator.java
@@ -11,6 +11,7 @@ import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.LongSumData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Map;
 import java.util.concurrent.atomic.LongAdder;
@@ -20,9 +21,11 @@ final class LongSumAggregator extends AbstractSumAggregator<Long> {
   LongSumAggregator(
       Resource resource,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
-      InstrumentDescriptor descriptor,
+      InstrumentDescriptor instrumentDescriptor,
+      MetricDescriptor metricDescriptor,
       AggregationTemporality temporality) {
-    super(resource, instrumentationLibraryInfo, descriptor, temporality);
+    super(
+        resource, instrumentationLibraryInfo, instrumentDescriptor, metricDescriptor, temporality);
   }
 
   @Override
@@ -51,7 +54,7 @@ final class LongSumAggregator extends AbstractSumAggregator<Long> {
       long startEpochNanos,
       long lastCollectionEpoch,
       long epochNanos) {
-    InstrumentDescriptor descriptor = getInstrumentDescriptor();
+    MetricDescriptor descriptor = getMetricDescriptor();
     return MetricData.createLongSum(
         getResource(),
         getInstrumentationLibraryInfo(),

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/MinMaxSumCountAggregatorFactory.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/MinMaxSumCountAggregatorFactory.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.metrics.aggregator;
 
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 
 final class MinMaxSumCountAggregatorFactory implements AggregatorFactory {
@@ -19,14 +20,17 @@ final class MinMaxSumCountAggregatorFactory implements AggregatorFactory {
   public <T> Aggregator<T> create(
       Resource resource,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
-      InstrumentDescriptor descriptor) {
-    switch (descriptor.getValueType()) {
+      InstrumentDescriptor instrumentDescriptor,
+      MetricDescriptor metricDescriptor) {
+    switch (instrumentDescriptor.getValueType()) {
       case LONG:
         return (Aggregator<T>)
-            new LongMinMaxSumCountAggregator(resource, instrumentationLibraryInfo, descriptor);
+            new LongMinMaxSumCountAggregator(
+                resource, instrumentationLibraryInfo, metricDescriptor);
       case DOUBLE:
         return (Aggregator<T>)
-            new DoubleMinMaxSumCountAggregator(resource, instrumentationLibraryInfo, descriptor);
+            new DoubleMinMaxSumCountAggregator(
+                resource, instrumentationLibraryInfo, metricDescriptor);
     }
     throw new IllegalArgumentException("Invalid instrument value type");
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/SumAggregatorFactory.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/aggregator/SumAggregatorFactory.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.metrics.aggregator;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 
 final class SumAggregatorFactory implements AggregatorFactory {
@@ -23,14 +24,25 @@ final class SumAggregatorFactory implements AggregatorFactory {
   public <T> Aggregator<T> create(
       Resource resource,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
-      InstrumentDescriptor descriptor) {
-    switch (descriptor.getValueType()) {
+      InstrumentDescriptor instrumentDescriptor,
+      MetricDescriptor metricDescriptor) {
+    switch (instrumentDescriptor.getValueType()) {
       case LONG:
         return (Aggregator<T>)
-            new LongSumAggregator(resource, instrumentationLibraryInfo, descriptor, temporality);
+            new LongSumAggregator(
+                resource,
+                instrumentationLibraryInfo,
+                instrumentDescriptor,
+                metricDescriptor,
+                temporality);
       case DOUBLE:
         return (Aggregator<T>)
-            new DoubleSumAggregator(resource, instrumentationLibraryInfo, descriptor, temporality);
+            new DoubleSumAggregator(
+                resource,
+                instrumentationLibraryInfo,
+                instrumentDescriptor,
+                metricDescriptor,
+                temporality);
     }
     throw new IllegalArgumentException("Invalid instrument value type");
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/descriptor/MetricDescriptor.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/descriptor/MetricDescriptor.java
@@ -7,6 +7,8 @@ package io.opentelemetry.sdk.metrics.internal.descriptor;
 
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.extension.memoized.Memoized;
+import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
+import io.opentelemetry.sdk.metrics.view.View;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -23,6 +25,14 @@ public abstract class MetricDescriptor {
 
   public static MetricDescriptor create(String name, String description, String unit) {
     return new AutoValue_MetricDescriptor(name, description, unit);
+  }
+
+  /** Constructs a metric descriptor for a given View + instrument. */
+  public static MetricDescriptor create(View view, InstrumentDescriptor instrument) {
+    final String name = (view.getName() == null) ? instrument.getName() : view.getName();
+    final String description =
+        (view.getDescription() == null) ? instrument.getDescription() : view.getDescription();
+    return create(name, description, instrument.getUnit());
   }
 
   public abstract String getName();

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorage.java
@@ -32,6 +32,7 @@ public final class AsynchronousMetricStorage implements MetricStorage {
   private final InstrumentProcessor<?> instrumentProcessor;
   private final Runnable metricUpdater;
 
+  /** Constructs storage for {@code double} valued instruments. */
   public static <T> AsynchronousMetricStorage doubleAsynchronousAccumulator(
       View view,
       InstrumentDescriptor instrument,

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorage.java
@@ -9,11 +9,14 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.metrics.processor.LabelsProcessor;
+import io.opentelemetry.sdk.metrics.view.View;
+import io.opentelemetry.sdk.resources.Resource;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
@@ -29,19 +32,22 @@ public final class AsynchronousMetricStorage implements MetricStorage {
   private final InstrumentProcessor<?> instrumentProcessor;
   private final Runnable metricUpdater;
 
-  /** Constructs storage for {@code double} valued instruments. */
   public static <T> AsynchronousMetricStorage doubleAsynchronousAccumulator(
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState,
-      InstrumentDescriptor descriptor,
+      View view,
+      InstrumentDescriptor instrument,
+      Resource resource,
+      InstrumentationLibraryInfo instrumentationLibraryInfo,
+      long startEpochNanos,
       Consumer<ObservableDoubleMeasurement> metricUpdater) {
-    Aggregator<T> aggregator = meterProviderSharedState.getAggregator(meterSharedState, descriptor);
+    final MetricDescriptor metricDescriptor = MetricDescriptor.create(view, instrument);
+    // TODO: Send metric descriptor to aggregator.
+    Aggregator<T> aggregator =
+        view.getAggregatorFactory().create(resource, instrumentationLibraryInfo, instrument);
     final InstrumentProcessor<T> instrumentProcessor =
-        new InstrumentProcessor<>(aggregator, meterProviderSharedState.getStartEpochNanos());
-
+        new InstrumentProcessor<>(aggregator, startEpochNanos);
     final LabelsProcessor labelsProcessor =
-        meterProviderSharedState.getLabelsProcessor(meterSharedState, descriptor);
-
+        view.getLabelsProcessorFactory().create(resource, instrumentationLibraryInfo, instrument);
+    // TODO: Find a way to grab the measurement JUST ONCE for all async metrics.
     final ObservableDoubleMeasurement result =
         new ObservableDoubleMeasurement() {
           @Override
@@ -56,27 +62,27 @@ public final class AsynchronousMetricStorage implements MetricStorage {
             observe(value, Attributes.empty());
           }
         };
-
     return new AsynchronousMetricStorage(
-        // TODO: View can change metric name/description.  Update this when wired in.
-        MetricDescriptor.create(
-            descriptor.getName(), descriptor.getDescription(), descriptor.getUnit()),
-        instrumentProcessor,
-        () -> metricUpdater.accept(result));
+        metricDescriptor, instrumentProcessor, () -> metricUpdater.accept(result));
   }
 
   /** Constructs storage for {@code long} valued instruments. */
   public static <T> AsynchronousMetricStorage longAsynchronousAccumulator(
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState,
-      InstrumentDescriptor descriptor,
+      View view,
+      InstrumentDescriptor instrument,
+      Resource resource,
+      InstrumentationLibraryInfo instrumentationLibraryInfo,
+      long startEpochNanos,
       Consumer<ObservableLongMeasurement> metricUpdater) {
-    Aggregator<T> aggregator = meterProviderSharedState.getAggregator(meterSharedState, descriptor);
+    final MetricDescriptor metricDescriptor = MetricDescriptor.create(view, instrument);
+    // TODO: Send metric descriptor to aggregator.
+    Aggregator<T> aggregator =
+        view.getAggregatorFactory().create(resource, instrumentationLibraryInfo, instrument);
     final InstrumentProcessor<T> instrumentProcessor =
-        new InstrumentProcessor<>(aggregator, meterProviderSharedState.getStartEpochNanos());
-
+        new InstrumentProcessor<>(aggregator, startEpochNanos);
     final LabelsProcessor labelsProcessor =
-        meterProviderSharedState.getLabelsProcessor(meterSharedState, descriptor);
+        view.getLabelsProcessorFactory().create(resource, instrumentationLibraryInfo, instrument);
+    // TODO: Find a way to grab the measurement JUST ONCE for all async metrics.
     final ObservableLongMeasurement result =
         new ObservableLongMeasurement() {
 
@@ -93,11 +99,7 @@ public final class AsynchronousMetricStorage implements MetricStorage {
           }
         };
     return new AsynchronousMetricStorage(
-        // TODO: View can change metric name/description.  Update this when wired in.
-        MetricDescriptor.create(
-            descriptor.getName(), descriptor.getDescription(), descriptor.getUnit()),
-        instrumentProcessor,
-        () -> metricUpdater.accept(result));
+        metricDescriptor, instrumentProcessor, () -> metricUpdater.accept(result));
   }
 
   private AsynchronousMetricStorage(

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorage.java
@@ -42,7 +42,8 @@ public final class AsynchronousMetricStorage implements MetricStorage {
     final MetricDescriptor metricDescriptor = MetricDescriptor.create(view, instrument);
     // TODO: Send metric descriptor to aggregator.
     Aggregator<T> aggregator =
-        view.getAggregatorFactory().create(resource, instrumentationLibraryInfo, instrument);
+        view.getAggregatorFactory()
+            .create(resource, instrumentationLibraryInfo, instrument, metricDescriptor);
     final InstrumentProcessor<T> instrumentProcessor =
         new InstrumentProcessor<>(aggregator, startEpochNanos);
     final LabelsProcessor labelsProcessor =
@@ -77,7 +78,8 @@ public final class AsynchronousMetricStorage implements MetricStorage {
     final MetricDescriptor metricDescriptor = MetricDescriptor.create(view, instrument);
     // TODO: Send metric descriptor to aggregator.
     Aggregator<T> aggregator =
-        view.getAggregatorFactory().create(resource, instrumentationLibraryInfo, instrument);
+        view.getAggregatorFactory()
+            .create(resource, instrumentationLibraryInfo, instrument, metricDescriptor);
     final InstrumentProcessor<T> instrumentProcessor =
         new InstrumentProcessor<>(aggregator, startEpochNanos);
     final LabelsProcessor labelsProcessor =

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MeterProviderSharedState.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MeterProviderSharedState.java
@@ -7,10 +7,7 @@ package io.opentelemetry.sdk.metrics.internal.state;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.sdk.common.Clock;
-import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
-import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.internal.view.ViewRegistry;
-import io.opentelemetry.sdk.metrics.processor.LabelsProcessor;
 import io.opentelemetry.sdk.resources.Resource;
 import javax.annotation.concurrent.Immutable;
 
@@ -42,22 +39,4 @@ public abstract class MeterProviderSharedState {
    * epoch time.
    */
   abstract long getStartEpochNanos();
-
-  /** Returns the {@link Aggregator} to use for a given instrument. */
-  public <T> Aggregator<T> getAggregator(
-      MeterSharedState meterSharedState, InstrumentDescriptor descriptor) {
-    return getViewRegistry()
-        .findView(descriptor, meterSharedState.getInstrumentationLibraryInfo())
-        .getAggregatorFactory()
-        .create(getResource(), meterSharedState.getInstrumentationLibraryInfo(), descriptor);
-  }
-
-  /** Returns the {@link LabelsProcessor} to use for a given instrument. */
-  public LabelsProcessor getLabelsProcessor(
-      MeterSharedState meterSharedState, InstrumentDescriptor descriptor) {
-    return getViewRegistry()
-        .findView(descriptor, meterSharedState.getInstrumentationLibraryInfo())
-        .getLabelsProcessorFactory()
-        .create(getResource(), meterSharedState.getInstrumentationLibraryInfo(), descriptor);
-  }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MeterSharedState.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MeterSharedState.java
@@ -11,6 +11,7 @@ import io.opentelemetry.api.metrics.ObservableLongMeasurement;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.view.View;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -55,8 +56,19 @@ public abstract class MeterSharedState {
   /** Registers new synchronous storage associated with a given instrument. */
   public final WriteableMetricStorage registerSynchronousMetricStorage(
       InstrumentDescriptor instrument, MeterProviderSharedState meterProviderSharedState) {
+    // TODO - we  need to iterate over all possible views here and register each we find.
+    View view =
+        meterProviderSharedState
+            .getViewRegistry()
+            .findView(instrument, getInstrumentationLibraryInfo());
     return getMetricStorageRegistry()
-        .register(SynchronousMetricStorage.create(meterProviderSharedState, this, instrument));
+        .register(
+            SynchronousMetricStorage.create(
+                view,
+                instrument,
+                meterProviderSharedState.getResource(),
+                getInstrumentationLibraryInfo(),
+                meterProviderSharedState.getStartEpochNanos()));
   }
 
   /** Registers new asynchronous storage associated with a given {@code long} instrument. */
@@ -64,10 +76,20 @@ public abstract class MeterSharedState {
       InstrumentDescriptor instrument,
       MeterProviderSharedState meterProviderSharedState,
       Consumer<ObservableLongMeasurement> metricUpdater) {
+    // TODO - we  need to iterate over all possible views here and register each we find.
+    View view =
+        meterProviderSharedState
+            .getViewRegistry()
+            .findView(instrument, getInstrumentationLibraryInfo());
     return getMetricStorageRegistry()
         .register(
             AsynchronousMetricStorage.longAsynchronousAccumulator(
-                meterProviderSharedState, this, instrument, metricUpdater));
+                view,
+                instrument,
+                meterProviderSharedState.getResource(),
+                getInstrumentationLibraryInfo(),
+                meterProviderSharedState.getStartEpochNanos(),
+                metricUpdater));
   }
 
   /** Registers new asynchronous storage associated with a given {@code double} instrument. */
@@ -75,10 +97,19 @@ public abstract class MeterSharedState {
       InstrumentDescriptor instrument,
       MeterProviderSharedState meterProviderSharedState,
       Consumer<ObservableDoubleMeasurement> metricUpdater) {
-
+    // TODO - we  need to iterate over all possible views here and register each we find.
+    View view =
+        meterProviderSharedState
+            .getViewRegistry()
+            .findView(instrument, getInstrumentationLibraryInfo());
     return getMetricStorageRegistry()
         .register(
             AsynchronousMetricStorage.doubleAsynchronousAccumulator(
-                meterProviderSharedState, this, instrument, metricUpdater));
+                view,
+                instrument,
+                meterProviderSharedState.getResource(),
+                getInstrumentationLibraryInfo(),
+                meterProviderSharedState.getStartEpochNanos(),
+                metricUpdater));
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorage.java
@@ -7,12 +7,15 @@ package io.opentelemetry.sdk.metrics.internal.state;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.aggregator.AggregatorHandle;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.metrics.processor.LabelsProcessor;
+import io.opentelemetry.sdk.metrics.view.View;
+import io.opentelemetry.sdk.resources.Resource;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -32,19 +35,23 @@ public final class SynchronousMetricStorage<T> implements WriteableMetricStorage
   private final InstrumentProcessor<T> instrumentProcessor;
   private final LabelsProcessor labelsProcessor;
 
-  /** Constructs metric storage for a given synchronous instrument. */
+  /** Constructs metric storage for a given synchronous instrument and view. */
   public static <T> SynchronousMetricStorage<T> create(
-      MeterProviderSharedState meterProviderSharedState,
-      MeterSharedState meterSharedState,
-      InstrumentDescriptor descriptor) {
-    Aggregator<T> aggregator = meterProviderSharedState.getAggregator(meterSharedState, descriptor);
+      View view,
+      InstrumentDescriptor descriptor,
+      Resource resource,
+      InstrumentationLibraryInfo instrumentationLibraryInfo,
+      long startEpochNanos) {
+    final MetricDescriptor metricDescriptor = MetricDescriptor.create(view, descriptor);
+    final Aggregator<T> aggregator =
+        view.getAggregatorFactory().create(resource, instrumentationLibraryInfo, descriptor);
+    final LabelsProcessor labelsProcessor =
+        view.getLabelsProcessorFactory().create(resource, instrumentationLibraryInfo, descriptor);
     return new SynchronousMetricStorage<>(
-        // TODO: View can change metric name/description.  Update this when wired in.
-        MetricDescriptor.create(
-            descriptor.getName(), descriptor.getDescription(), descriptor.getUnit()),
+        metricDescriptor,
         aggregator,
-        new InstrumentProcessor<>(aggregator, meterProviderSharedState.getStartEpochNanos()),
-        meterProviderSharedState.getLabelsProcessor(meterSharedState, descriptor));
+        new InstrumentProcessor<>(aggregator, startEpochNanos),
+        labelsProcessor);
   }
 
   SynchronousMetricStorage(

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorage.java
@@ -38,15 +38,17 @@ public final class SynchronousMetricStorage<T> implements WriteableMetricStorage
   /** Constructs metric storage for a given synchronous instrument and view. */
   public static <T> SynchronousMetricStorage<T> create(
       View view,
-      InstrumentDescriptor descriptor,
+      InstrumentDescriptor instrumentDescriptor,
       Resource resource,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
       long startEpochNanos) {
-    final MetricDescriptor metricDescriptor = MetricDescriptor.create(view, descriptor);
+    final MetricDescriptor metricDescriptor = MetricDescriptor.create(view, instrumentDescriptor);
     final Aggregator<T> aggregator =
-        view.getAggregatorFactory().create(resource, instrumentationLibraryInfo, descriptor);
+        view.getAggregatorFactory()
+            .create(resource, instrumentationLibraryInfo, instrumentDescriptor, metricDescriptor);
     final LabelsProcessor labelsProcessor =
-        view.getLabelsProcessorFactory().create(resource, instrumentationLibraryInfo, descriptor);
+        view.getLabelsProcessorFactory()
+            .create(resource, instrumentationLibraryInfo, instrumentDescriptor);
     return new SynchronousMetricStorage<>(
         metricDescriptor,
         aggregator,

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/ViewRegistryBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/ViewRegistryBuilder.java
@@ -24,11 +24,7 @@ public class ViewRegistryBuilder {
 
   /** Returns the {@link ViewRegistry}. */
   public ViewRegistry build() {
-    // We add views in reverse order so normal iteration order is the priority of usage.
-    // TODO: Verify this is correct with the specification.
-    List<RegisteredView> reversedOrder = new ArrayList<>(orderedViews);
-    Collections.reverse(reversedOrder);
-    return new ViewRegistry(Collections.unmodifiableList(reversedOrder));
+    return new ViewRegistry(Collections.unmodifiableList(orderedViews));
   }
 
   /**

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/View.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/View.java
@@ -8,12 +8,27 @@ package io.opentelemetry.sdk.metrics.view;
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.sdk.metrics.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.processor.LabelsProcessorFactory;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /** TODO: javadoc. */
 @AutoValue
 @Immutable
 public abstract class View {
+
+  /**
+   * The name of the resulting metric to generate, or {@code null} if the same as the instrument.
+   */
+  @Nullable
+  public abstract String getName();
+
+  /**
+   * The name of the resulting metric to generate, or {@code null} if the same as the instrument.
+   */
+  @Nullable
+  public abstract String getDescription();
+
+  /** A mechanism of constructing aggregators for this view. */
   public abstract AggregatorFactory getAggregatorFactory();
 
   public abstract LabelsProcessorFactory getLabelsProcessorFactory();
@@ -23,7 +38,10 @@ public abstract class View {
   }
 
   static View create(
-      AggregatorFactory aggregatorFactory, LabelsProcessorFactory labelsProcessorFactory) {
-    return new AutoValue_View(aggregatorFactory, labelsProcessorFactory);
+      String name,
+      String description,
+      AggregatorFactory aggregatorFactory,
+      LabelsProcessorFactory labelsProcessorFactory) {
+    return new AutoValue_View(name, description, aggregatorFactory, labelsProcessorFactory);
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/ViewBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/ViewBuilder.java
@@ -8,11 +8,37 @@ package io.opentelemetry.sdk.metrics.view;
 import io.opentelemetry.sdk.metrics.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.processor.LabelsProcessorFactory;
 
+/** Builder of metric {@link View}s. */
 public final class ViewBuilder {
+  private String name = null;
+  private String description = null;
   private AggregatorFactory aggregatorFactory;
   private LabelsProcessorFactory labelsProcessorFactory = LabelsProcessorFactory.noop();
 
   ViewBuilder() {}
+
+  /**
+   * sets the name of the resulting metric.
+   *
+   * @param name metric name or {@code null} if the underlying instrument name should be used.
+   * @return this Builder.
+   */
+  public ViewBuilder setName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  /**
+   * sets the name of the resulting metric.
+   *
+   * @param description metric description or {@code null} if the underlying instrument description
+   *     should be used.
+   * @return this Builder.
+   */
+  public ViewBuilder setDescription(String description) {
+    this.description = description;
+    return this;
+  }
 
   /**
    * sets {@link AggregatorFactory}.
@@ -36,7 +62,9 @@ public final class ViewBuilder {
     return this;
   }
 
+  /** Returns the resulting {@link View}. */
   public View build() {
-    return View.create(this.aggregatorFactory, this.labelsProcessorFactory);
+    return View.create(
+        this.name, this.description, this.aggregatorFactory, this.labelsProcessorFactory);
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderTest.java
@@ -427,7 +427,7 @@ public class SdkMeterProviderTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  void ViewSdk_AllowRenames() {
+  void viewSdk_AllowRenames() {
     SdkMeterProvider provider =
         sdkMeterProviderBuilder
             .registerView(

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/AggregatorFactoryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/AggregatorFactoryTest.java
@@ -13,12 +13,16 @@ import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class AggregatorFactoryTest {
+  private static final MetricDescriptor SIMPLE_METRIC_DESCRIPTOR =
+      MetricDescriptor.create("name", "description", "unit");
+
   @Test
   void getCountAggregatorFactory() {
     AggregatorFactory count = AggregatorFactory.count(AggregationTemporality.CUMULATIVE);
@@ -31,7 +35,8 @@ class AggregatorFactoryTest {
                     "description",
                     "unit",
                     InstrumentType.COUNTER,
-                    InstrumentValueType.LONG)))
+                    InstrumentValueType.LONG),
+                SIMPLE_METRIC_DESCRIPTOR))
         .isInstanceOf(CountAggregator.class);
     assertThat(
             count.create(
@@ -42,7 +47,8 @@ class AggregatorFactoryTest {
                     "description",
                     "unit",
                     InstrumentType.COUNTER,
-                    InstrumentValueType.DOUBLE)))
+                    InstrumentValueType.DOUBLE),
+                SIMPLE_METRIC_DESCRIPTOR))
         .isInstanceOf(CountAggregator.class);
   }
 
@@ -58,7 +64,8 @@ class AggregatorFactoryTest {
                     "description",
                     "unit",
                     InstrumentType.COUNTER,
-                    InstrumentValueType.LONG)))
+                    InstrumentValueType.LONG),
+                SIMPLE_METRIC_DESCRIPTOR))
         .isInstanceOf(LongLastValueAggregator.class);
     assertThat(
             lastValue.create(
@@ -69,7 +76,8 @@ class AggregatorFactoryTest {
                     "description",
                     "unit",
                     InstrumentType.COUNTER,
-                    InstrumentValueType.DOUBLE)))
+                    InstrumentValueType.DOUBLE),
+                SIMPLE_METRIC_DESCRIPTOR))
         .isInstanceOf(DoubleLastValueAggregator.class);
   }
 
@@ -85,7 +93,8 @@ class AggregatorFactoryTest {
                     "description",
                     "unit",
                     InstrumentType.COUNTER,
-                    InstrumentValueType.LONG)))
+                    InstrumentValueType.LONG),
+                SIMPLE_METRIC_DESCRIPTOR))
         .isInstanceOf(LongMinMaxSumCountAggregator.class);
     assertThat(
             minMaxSumCount.create(
@@ -96,7 +105,8 @@ class AggregatorFactoryTest {
                     "description",
                     "unit",
                     InstrumentType.COUNTER,
-                    InstrumentValueType.DOUBLE)))
+                    InstrumentValueType.DOUBLE),
+                SIMPLE_METRIC_DESCRIPTOR))
         .isInstanceOf(DoubleMinMaxSumCountAggregator.class);
   }
 
@@ -112,7 +122,8 @@ class AggregatorFactoryTest {
                     "description",
                     "unit",
                     InstrumentType.COUNTER,
-                    InstrumentValueType.LONG)))
+                    InstrumentValueType.LONG),
+                SIMPLE_METRIC_DESCRIPTOR))
         .isInstanceOf(LongSumAggregator.class);
     assertThat(
             sum.create(
@@ -123,7 +134,8 @@ class AggregatorFactoryTest {
                     "description",
                     "unit",
                     InstrumentType.COUNTER,
-                    InstrumentValueType.DOUBLE)))
+                    InstrumentValueType.DOUBLE),
+                SIMPLE_METRIC_DESCRIPTOR))
         .isInstanceOf(DoubleSumAggregator.class);
   }
 
@@ -140,7 +152,8 @@ class AggregatorFactoryTest {
                     "description",
                     "unit",
                     InstrumentType.HISTOGRAM,
-                    InstrumentValueType.LONG)))
+                    InstrumentValueType.LONG),
+                SIMPLE_METRIC_DESCRIPTOR))
         .isInstanceOf(DoubleHistogramAggregator.class);
     assertThat(
             histogram.create(
@@ -151,7 +164,8 @@ class AggregatorFactoryTest {
                     "description",
                     "unit",
                     InstrumentType.HISTOGRAM,
-                    InstrumentValueType.DOUBLE)))
+                    InstrumentValueType.DOUBLE),
+                SIMPLE_METRIC_DESCRIPTOR))
         .isInstanceOf(DoubleHistogramAggregator.class);
 
     assertThat(
@@ -164,7 +178,8 @@ class AggregatorFactoryTest {
                         "description",
                         "unit",
                         InstrumentType.HISTOGRAM,
-                        InstrumentValueType.LONG))
+                        InstrumentValueType.LONG),
+                    SIMPLE_METRIC_DESCRIPTOR)
                 .isStateful())
         .isFalse();
     assertThat(
@@ -178,7 +193,8 @@ class AggregatorFactoryTest {
                         "description",
                         "unit",
                         InstrumentType.HISTOGRAM,
-                        InstrumentValueType.DOUBLE))
+                        InstrumentValueType.DOUBLE),
+                    SIMPLE_METRIC_DESCRIPTOR)
                 .isStateful())
         .isTrue();
 

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/CountAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/CountAggregatorTest.java
@@ -10,30 +10,29 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
-import io.opentelemetry.sdk.metrics.common.InstrumentType;
-import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link CountAggregator}. */
 class CountAggregatorTest {
+  private static final MetricDescriptor SIMPLE_METRIC_DESCRIPTOR =
+      MetricDescriptor.create("name", "description", "unit");
+
   private static final CountAggregator cumulativeAggregator =
       new CountAggregator(
           Resource.getDefault(),
           InstrumentationLibraryInfo.empty(),
-          InstrumentDescriptor.create(
-              "name", "description", "unit", InstrumentType.HISTOGRAM, InstrumentValueType.LONG),
+          SIMPLE_METRIC_DESCRIPTOR,
           AggregationTemporality.CUMULATIVE);
   private static final CountAggregator deltaAggregator =
       new CountAggregator(
           Resource.getDefault(),
           InstrumentationLibraryInfo.empty(),
-          InstrumentDescriptor.create(
-              "name", "description", "unit", InstrumentType.HISTOGRAM, InstrumentValueType.LONG),
+          SIMPLE_METRIC_DESCRIPTOR,
           AggregationTemporality.DELTA);
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleHistogramAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleHistogramAggregatorTest.java
@@ -10,12 +10,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
-import io.opentelemetry.sdk.metrics.common.InstrumentType;
-import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricDataType;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
 import java.util.concurrent.Executors;
@@ -31,8 +29,7 @@ public class DoubleHistogramAggregatorTest {
       new DoubleHistogramAggregator(
           Resource.getDefault(),
           InstrumentationLibraryInfo.empty(),
-          InstrumentDescriptor.create(
-              "name", "description", "unit", InstrumentType.HISTOGRAM, InstrumentValueType.LONG),
+          MetricDescriptor.create("name", "description", "unit"),
           boundaries,
           /* stateful= */ false);
 

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleLastValueAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleLastValueAggregatorTest.java
@@ -10,10 +10,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
-import io.opentelemetry.sdk.metrics.common.InstrumentType;
-import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -24,12 +22,7 @@ class DoubleLastValueAggregatorTest {
       new DoubleLastValueAggregator(
           Resource.getDefault(),
           InstrumentationLibraryInfo.empty(),
-          InstrumentDescriptor.create(
-              "name",
-              "description",
-              "unit",
-              InstrumentType.OBSERVABLE_GAUGE,
-              InstrumentValueType.DOUBLE));
+          MetricDescriptor.create("name", "description", "unit"));
 
   @Test
   void createHandle() {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleMinMaxSumCountAggregatorTest.java
@@ -10,11 +10,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
-import io.opentelemetry.sdk.metrics.common.InstrumentType;
-import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricDataType;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,8 +28,7 @@ class DoubleMinMaxSumCountAggregatorTest {
       new DoubleMinMaxSumCountAggregator(
           Resource.getDefault(),
           InstrumentationLibraryInfo.empty(),
-          InstrumentDescriptor.create(
-              "name", "description", "unit", InstrumentType.HISTOGRAM, InstrumentValueType.DOUBLE));
+          MetricDescriptor.create("name", "description", "unit"));
 
   @Test
   void createHandle() {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleSumAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/DoubleSumAggregatorTest.java
@@ -16,6 +16,7 @@ import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,12 @@ class DoubleSumAggregatorTest {
           Resource.getDefault(),
           InstrumentationLibraryInfo.empty(),
           InstrumentDescriptor.create(
-              "name", "description", "unit", InstrumentType.COUNTER, InstrumentValueType.DOUBLE),
+              "instrument_name",
+              "instrument_description",
+              "instrument_unit",
+              InstrumentType.COUNTER,
+              InstrumentValueType.DOUBLE),
+          MetricDescriptor.create("name", "description", "unit"),
           AggregationTemporality.CUMULATIVE);
 
   @Test
@@ -84,6 +90,7 @@ class DoubleSumAggregatorTest {
                 InstrumentationLibraryInfo.empty(),
                 InstrumentDescriptor.create(
                     "name", "description", "unit", instrumentType, InstrumentValueType.LONG),
+                MetricDescriptor.create("name", "description", "unit"),
                 temporality);
         MergeStrategy expectedMergeStrategy =
             AbstractSumAggregator.resolveMergeStrategy(instrumentType, temporality);
@@ -110,6 +117,9 @@ class DoubleSumAggregatorTest {
             10,
             100);
     assertThat(metricData)
+        .hasName("name")
+        .hasDescription("description")
+        .hasUnit("unit")
         .hasDoubleSum()
         .isCumulative()
         .isMonotonic()

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongLastValueAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongLastValueAggregatorTest.java
@@ -9,12 +9,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
-import io.opentelemetry.sdk.metrics.common.InstrumentType;
-import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.LongGaugeData;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -25,12 +23,7 @@ class LongLastValueAggregatorTest {
       new LongLastValueAggregator(
           Resource.getDefault(),
           InstrumentationLibraryInfo.empty(),
-          InstrumentDescriptor.create(
-              "name",
-              "description",
-              "unit",
-              InstrumentType.OBSERVABLE_GAUGE,
-              InstrumentValueType.LONG));
+          MetricDescriptor.create("name", "description", "unit"));
 
   @Test
   void createHandle() {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongMinMaxSumCountAggregatorTest.java
@@ -10,11 +10,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
-import io.opentelemetry.sdk.metrics.common.InstrumentType;
-import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricDataType;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,8 +28,7 @@ class LongMinMaxSumCountAggregatorTest {
       new LongMinMaxSumCountAggregator(
           Resource.getDefault(),
           InstrumentationLibraryInfo.empty(),
-          InstrumentDescriptor.create(
-              "name", "description", "unit", InstrumentType.HISTOGRAM, InstrumentValueType.LONG));
+          MetricDescriptor.create("name", "description", "unit"));
 
   @Test
   void createHandle() {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongSumAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/aggregator/LongSumAggregatorTest.java
@@ -16,6 +16,7 @@ import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,12 @@ class LongSumAggregatorTest {
           Resource.getDefault(),
           InstrumentationLibraryInfo.empty(),
           InstrumentDescriptor.create(
-              "name", "description", "unit", InstrumentType.COUNTER, InstrumentValueType.LONG),
+              "instrument_name",
+              "instrument_description",
+              "instrument_unit",
+              InstrumentType.COUNTER,
+              InstrumentValueType.LONG),
+          MetricDescriptor.create("name", "description", "unit"),
           AggregationTemporality.CUMULATIVE);
 
   @Test
@@ -86,6 +92,7 @@ class LongSumAggregatorTest {
                 InstrumentationLibraryInfo.empty(),
                 InstrumentDescriptor.create(
                     "name", "description", "unit", instrumentType, InstrumentValueType.LONG),
+                MetricDescriptor.create("name", "description", "unit"),
                 temporality);
         MergeStrategy expectedMergeStrategy =
             AbstractSumAggregator.resolveMergeStrategy(instrumentType, temporality);
@@ -112,6 +119,9 @@ class LongSumAggregatorTest {
             10,
             100);
     assertThat(metricData)
+        .hasName("name")
+        .hasDescription("description")
+        .hasUnit("unit")
         .hasLongSum()
         .isCumulative()
         .isMonotonic()

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorageTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorageTest.java
@@ -35,7 +35,11 @@ public class SynchronousMetricStorageTest {
   private final TestClock testClock = TestClock.create();
   private final Aggregator<Long> aggregator =
       AggregatorFactory.lastValue()
-          .create(Resource.empty(), InstrumentationLibraryInfo.create("test", "1.0"), DESCRIPTOR);
+          .create(
+              Resource.empty(),
+              InstrumentationLibraryInfo.create("test", "1.0"),
+              DESCRIPTOR,
+              METRIC_DESCRIPTOR);
   private final LabelsProcessor labelsProcessor =
       LabelsProcessorFactory.noop()
           .create(Resource.empty(), InstrumentationLibraryInfo.create("test", "1.0"), DESCRIPTOR);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/view/ViewRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/view/ViewRegistryTest.java
@@ -80,7 +80,7 @@ class ViewRegistryTest {
   }
 
   @Test
-  void selection_LastAddedViewWins() {
+  void selection_FirstAddedViewWins() {
     AggregatorFactory factory1 = AggregatorFactory.lastValue();
     View view1 = View.builder().setAggregatorFactory(factory1).build();
     AggregatorFactory factory2 = AggregatorFactory.minMaxSumCount();
@@ -91,15 +91,15 @@ class ViewRegistryTest {
             .addView(
                 InstrumentSelector.builder()
                     .setInstrumentType(InstrumentType.COUNTER)
-                    .setInstrumentNameRegex(".*")
-                    .build(),
-                view1)
-            .addView(
-                InstrumentSelector.builder()
-                    .setInstrumentType(InstrumentType.COUNTER)
                     .setInstrumentNameRegex("overridden")
                     .build(),
                 view2)
+            .addView(
+                InstrumentSelector.builder()
+                    .setInstrumentType(InstrumentType.COUNTER)
+                    .setInstrumentNameRegex(".*")
+                    .build(),
+                view1)
             .build();
 
     assertThat(


### PR DESCRIPTION
- Look at views in order of registration
- Allow views to change name/description of instruments in addition to aggregation

Future work for this to be good for users:

- Do not crash (by default) when a metric name conflict is detected, instead issue an error.
-  Allow multiple views per-instrument as long as there are no name conflicts
-  Improve error message + provenance of metric-name clashes.