### PR TITLE
Serialize proto directly into okhttp buffer.

### DIFF
--- a/exporters/otlp-http/trace/build.gradle.kts
+++ b/exporters/otlp-http/trace/build.gradle.kts
@@ -1,8 +1,9 @@
 plugins {
-    id("otel.java-conventions")
-    id("otel.publish-conventions")
+  id("otel.java-conventions")
+  id("otel.jmh-conventions")
+  id("otel.publish-conventions")
 
-    id("otel.animalsniffer-conventions")
+  id("otel.animalsniffer-conventions")
 }
 
 description = "OpenTelemetry Protocol HTTP Trace Exporter"
@@ -21,4 +22,6 @@ dependencies {
 
   testImplementation("com.google.api.grpc:proto-google-common-protos")
   testImplementation("com.linecorp.armeria:armeria-junit5")
+
+  jmh(project(":sdk:testing"))
 }

--- a/exporters/otlp-http/trace/src/jmh/java/io/opentelemetry/exporter/otlp/http/trace/HttpSpanExporterBenchmark.java
+++ b/exporters/otlp-http/trace/src/jmh/java/io/opentelemetry/exporter/otlp/http/trace/HttpSpanExporterBenchmark.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.http.trace;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.RequestBody;
+import okio.Buffer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode({Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(1)
+public class HttpSpanExporterBenchmark {
+
+  @Benchmark
+  @Threads(1)
+  public Buffer writeByteArray(TraceBenchmarkState state) throws IOException {
+    try (Buffer buffer = new Buffer()) {
+      RequestBody body = RequestBody.create(state.request.toByteArray());
+      body.writeTo(buffer);
+      return buffer;
+    }
+  }
+
+  @Benchmark
+  @Threads(1)
+  public Buffer writeDirect(TraceBenchmarkState state) throws IOException {
+    try (Buffer buffer = new Buffer()) {
+      RequestBody body = new ProtoRequestBody(state.request);
+      body.writeTo(buffer);
+      return buffer;
+    }
+  }
+}

--- a/exporters/otlp-http/trace/src/jmh/java/io/opentelemetry/exporter/otlp/http/trace/TraceBenchmarkState.java
+++ b/exporters/otlp-http/trace/src/jmh/java/io/opentelemetry/exporter/otlp/http/trace/TraceBenchmarkState.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.http.trace;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.exporter.otlp.internal.SpanAdapter;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.testing.trace.TestSpanData;
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class TraceBenchmarkState {
+  private static final Resource RESOURCE =
+      Resource.create(
+          Attributes.builder()
+              .put(AttributeKey.booleanKey("key_bool"), true)
+              .put(AttributeKey.stringKey("key_string"), "string")
+              .put(AttributeKey.longKey("key_int"), 100L)
+              .put(AttributeKey.doubleKey("key_double"), 100.3)
+              .put(
+                  AttributeKey.stringArrayKey("key_string_array"),
+                  Arrays.asList("string", "string"))
+              .put(AttributeKey.longArrayKey("key_long_array"), Arrays.asList(12L, 23L))
+              .put(AttributeKey.doubleArrayKey("key_double_array"), Arrays.asList(12.3, 23.1))
+              .put(AttributeKey.booleanArrayKey("key_boolean_array"), Arrays.asList(true, false))
+              .build());
+
+  private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
+      InstrumentationLibraryInfo.create("name", null);
+  private static final String TRACE_ID = "7b2e170db4df2d593ddb4ddf2ddf2d59";
+  private static final String SPAN_ID = "170d3ddb4d23e81f";
+  private static final SpanContext SPAN_CONTEXT =
+      SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault());
+
+  @Param({"512"})
+  int numSpans;
+
+  List<SpanData> spanDataList;
+  ExportTraceServiceRequest request;
+
+  @Setup
+  public void setup() {
+    spanDataList = new ArrayList<>(numSpans);
+    for (int i = 0; i < numSpans; i++) {
+      spanDataList.add(createSpanData());
+    }
+    request =
+        ExportTraceServiceRequest.newBuilder()
+            .addAllResourceSpans(SpanAdapter.toProtoResourceSpans(spanDataList))
+            .build();
+  }
+
+  private static SpanData createSpanData() {
+    return TestSpanData.builder()
+        .setResource(RESOURCE)
+        .setInstrumentationLibraryInfo(INSTRUMENTATION_LIBRARY_INFO)
+        .setHasEnded(true)
+        .setSpanContext(SPAN_CONTEXT)
+        .setParentSpanContext(SpanContext.getInvalid())
+        .setName("GET /api/endpoint")
+        .setKind(SpanKind.SERVER)
+        .setStartEpochNanos(12345)
+        .setEndEpochNanos(12349)
+        .setAttributes(
+            Attributes.builder()
+                .put(AttributeKey.booleanKey("key_bool"), true)
+                .put(AttributeKey.stringKey("key_string"), "string")
+                .put(AttributeKey.longKey("key_int"), 100L)
+                .put(AttributeKey.doubleKey("key_double"), 100.3)
+                .build())
+        .setTotalAttributeCount(2)
+        .setEvents(
+            Arrays.asList(
+                EventData.create(12347, "my_event_1", Attributes.empty()),
+                EventData.create(
+                    12348,
+                    "my_event_2",
+                    Attributes.of(AttributeKey.longKey("event_attr_key"), 1234L)),
+                EventData.create(12349, "my_event_3", Attributes.empty())))
+        .setTotalRecordedEvents(4)
+        .setLinks(
+            Arrays.asList(
+                LinkData.create(SPAN_CONTEXT),
+                LinkData.create(
+                    SPAN_CONTEXT, Attributes.of(AttributeKey.stringKey("link_attr_key"), "value"))))
+        .setTotalRecordedLinks(3)
+        .setStatus(StatusData.ok())
+        .build();
+  }
+}

--- a/exporters/otlp-http/trace/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporter.java
+++ b/exporters/otlp-http/trace/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporter.java
@@ -48,8 +48,6 @@ public final class OtlpHttpSpanExporter implements SpanExporter {
   private static final Attributes EXPORT_FAILURE_LABELS =
       Attributes.builder().put("exporter", EXPORTER_NAME).put("success", false).build();
 
-  private static final MediaType PROTOBUF_MEDIA_TYPE = MediaType.parse("application/x-protobuf");
-
   private static final Logger internalLogger =
       Logger.getLogger(OtlpHttpSpanExporter.class.getName());
 
@@ -96,8 +94,7 @@ public final class OtlpHttpSpanExporter implements SpanExporter {
     if (headers != null) {
       requestBuilder.headers(headers);
     }
-    RequestBody requestBody =
-        RequestBody.create(exportTraceServiceRequest.toByteArray(), PROTOBUF_MEDIA_TYPE);
+    RequestBody requestBody = new ProtoRequestBody(exportTraceServiceRequest);
     if (compressionEnabled) {
       requestBuilder.addHeader("Content-Encoding", "gzip");
       requestBuilder.post(gzipRequestBody(requestBody));

--- a/exporters/otlp-http/trace/src/main/java/io/opentelemetry/exporter/otlp/http/trace/ProtoRequestBody.java
+++ b/exporters/otlp-http/trace/src/main/java/io/opentelemetry/exporter/otlp/http/trace/ProtoRequestBody.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.http.trace;
+
+import com.google.protobuf.Message;
+import java.io.IOException;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
+import okio.BufferedSink;
+import org.jetbrains.annotations.NotNull;
+
+final class ProtoRequestBody extends RequestBody {
+
+  private static final MediaType PROTOBUF_MEDIA_TYPE = MediaType.parse("application/x-protobuf");
+
+  private final Message proto;
+  private final long contentLength;
+
+  ProtoRequestBody(Message proto) {
+    this.proto = proto;
+    contentLength = proto.getSerializedSize();
+  }
+
+  @Override
+  public long contentLength() {
+    return contentLength;
+  }
+
+  @Override
+  public MediaType contentType() {
+    return PROTOBUF_MEDIA_TYPE;
+  }
+
+  @Override
+  public void writeTo(@NotNull BufferedSink bufferedSink) throws IOException {
+    proto.writeTo(bufferedSink.outputStream());
+  }
+}


### PR DESCRIPTION
Was curious about the difference between writing through `toByteArray` and straight for okhttp. The additional time for a relatively large, but single buffer, isn't that big of a deal but there is definitely more GC activity introduced. The `ProtoRequestBody` is pretty tiny and simple so think this could be worth it but what do you think? The pattern will also be a bit easier to adapt to `TraceMarshaler`.

```
Benchmark                                                               (numSpans)  Mode  Cnt       Score       Error   Units
HttpSpanExporterBenchmark.writeByteArray                                       512  avgt   10     360.983 ±    11.766   us/op
HttpSpanExporterBenchmark.writeByteArray:·gc.alloc.rate                        512  avgt   10     628.052 ±    19.436  MB/sec
HttpSpanExporterBenchmark.writeByteArray:·gc.alloc.rate.norm                   512  avgt   10  356896.149 ±     0.011    B/op
HttpSpanExporterBenchmark.writeByteArray:·gc.churn.G1_Eden_Space               512  avgt   10     635.385 ±    73.561  MB/sec
HttpSpanExporterBenchmark.writeByteArray:·gc.churn.G1_Eden_Space.norm          512  avgt   10  360938.453 ± 36874.388    B/op
HttpSpanExporterBenchmark.writeByteArray:·gc.churn.G1_Old_Gen                  512  avgt   10       0.171 ±     0.202  MB/sec
HttpSpanExporterBenchmark.writeByteArray:·gc.churn.G1_Old_Gen.norm             512  avgt   10      97.165 ±   113.920    B/op
HttpSpanExporterBenchmark.writeByteArray:·gc.count                             512  avgt   10      63.000              counts
HttpSpanExporterBenchmark.writeByteArray:·gc.time                              512  avgt   10      24.000                  ms
HttpSpanExporterBenchmark.writeDirect                                          512  avgt   10     360.528 ±    13.232   us/op
HttpSpanExporterBenchmark.writeDirect:·gc.alloc.rate                           512  avgt   10     327.274 ±    11.562  MB/sec
HttpSpanExporterBenchmark.writeDirect:·gc.alloc.rate.norm                      512  avgt   10  185648.150 ±     0.010    B/op
HttpSpanExporterBenchmark.writeDirect:·gc.churn.G1_Eden_Space                  512  avgt   10     340.109 ±    77.470  MB/sec
HttpSpanExporterBenchmark.writeDirect:·gc.churn.G1_Eden_Space.norm             512  avgt   10  192691.328 ± 41320.094    B/op
HttpSpanExporterBenchmark.writeDirect:·gc.churn.G1_Old_Gen                     512  avgt   10       0.060 ±     0.054  MB/sec
HttpSpanExporterBenchmark.writeDirect:·gc.churn.G1_Old_Gen.norm                512  avgt   10      34.099 ±    30.587    B/op
HttpSpanExporterBenchmark.writeDirect:·gc.churn.G1_Survivor_Space              512  avgt   10       0.199 ±     0.954  MB/sec
HttpSpanExporterBenchmark.writeDirect:·gc.churn.G1_Survivor_Space.norm         512  avgt   10     112.187 ±   536.357    B/op
HttpSpanExporterBenchmark.writeDirect:·gc.count                                512  avgt   10      28.000              counts
HttpSpanExporterBenchmark.writeDirect:·gc.time                                 512  avgt   10      14.000                  ms
```