### PR TITLE
Apply optimizations to TraceMarshaler that were already made to SpanA…

### DIFF
--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/InstrumentationLibraryMarshaler.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/InstrumentationLibraryMarshaler.java
@@ -6,31 +6,49 @@
 package io.opentelemetry.exporter.otlp.trace;
 
 import com.google.protobuf.CodedOutputStream;
+import io.opentelemetry.context.internal.shaded.WeakConcurrentMap;
 import io.opentelemetry.proto.common.v1.InstrumentationLibrary;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 final class InstrumentationLibraryMarshaler extends MarshalerWithSize {
-  private final byte[] name;
-  private final byte[] version;
+
+  private static final WeakConcurrentMap<
+          InstrumentationLibraryInfo, InstrumentationLibraryMarshaler>
+      LIBRARY_MARSHALER_CACHE = new WeakConcurrentMap.WithInlinedExpunction<>();
+
+  private final byte[] serializedInfo;
 
   static InstrumentationLibraryMarshaler create(InstrumentationLibraryInfo libraryInfo) {
-    byte[] name = MarshalerUtil.toBytes(libraryInfo.getName());
-    byte[] version = MarshalerUtil.toBytes(libraryInfo.getVersion());
-
-    return new InstrumentationLibraryMarshaler(name, version);
+    InstrumentationLibraryMarshaler cached = LIBRARY_MARSHALER_CACHE.get(libraryInfo);
+    if (cached == null) {
+      // Since WeakConcurrentMap doesn't support computeIfAbsent, we may end up doing the conversion
+      // a few times until the cache gets filled which is fine.
+      byte[] name = MarshalerUtil.toBytes(libraryInfo.getName());
+      byte[] version = MarshalerUtil.toBytes(libraryInfo.getVersion());
+      cached = new InstrumentationLibraryMarshaler(name, version);
+      LIBRARY_MARSHALER_CACHE.put(libraryInfo, cached);
+    }
+    return cached;
   }
 
   private InstrumentationLibraryMarshaler(byte[] name, byte[] version) {
     super(computeSize(name, version));
-    this.name = name;
-    this.version = version;
+    serializedInfo = new byte[getSerializedSize()];
+    CodedOutputStream output = CodedOutputStream.newInstance(serializedInfo);
+    try {
+      MarshalerUtil.marshalBytes(InstrumentationLibrary.NAME_FIELD_NUMBER, name, output);
+      MarshalerUtil.marshalBytes(InstrumentationLibrary.VERSION_FIELD_NUMBER, version, output);
+    } catch (IOException e) {
+      // Presized so can't happen (we would have already thrown OutOfMemoryError)
+      throw new UncheckedIOException(e);
+    }
   }
 
   @Override
   public void writeTo(CodedOutputStream output) throws IOException {
-    MarshalerUtil.marshalBytes(InstrumentationLibrary.NAME_FIELD_NUMBER, name, output);
-    MarshalerUtil.marshalBytes(InstrumentationLibrary.VERSION_FIELD_NUMBER, version, output);
+    output.writeRawBytes(serializedInfo);
   }
 
   private static int computeSize(byte[] name, byte[] version) {

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/ResourceMarshaler.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/ResourceMarshaler.java
@@ -6,25 +6,46 @@
 package io.opentelemetry.exporter.otlp.trace;
 
 import com.google.protobuf.CodedOutputStream;
+import io.opentelemetry.context.internal.shaded.WeakConcurrentMap;
 import io.opentelemetry.proto.resource.v1.Resource;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 final class ResourceMarshaler extends MarshalerWithSize {
-  private final AttributeMarshaler[] attributeMarshalers;
+
+  private static final WeakConcurrentMap<io.opentelemetry.sdk.resources.Resource, ResourceMarshaler>
+      RESOURCE_MARSHALER_CACHE = new WeakConcurrentMap.WithInlinedExpunction<>();
+
+  private final byte[] serializedResource;
 
   static ResourceMarshaler create(io.opentelemetry.sdk.resources.Resource resource) {
-    return new ResourceMarshaler(AttributeMarshaler.createRepeated(resource.getAttributes()));
+    ResourceMarshaler cached = RESOURCE_MARSHALER_CACHE.get(resource);
+    if (cached == null) {
+      // Since WeakConcurrentMap doesn't support computeIfAbsent, we may end up doing the conversion
+      // a few times until the cache gets filled which is fine.
+      cached = new ResourceMarshaler(AttributeMarshaler.createRepeated(resource.getAttributes()));
+      RESOURCE_MARSHALER_CACHE.put(resource, cached);
+    }
+    return cached;
   }
 
   private ResourceMarshaler(AttributeMarshaler[] attributeMarshalers) {
     super(calculateSize(attributeMarshalers));
-    this.attributeMarshalers = attributeMarshalers;
+    serializedResource = new byte[getSerializedSize()];
+    CodedOutputStream output = CodedOutputStream.newInstance(serializedResource);
+    try {
+      MarshalerUtil.marshalRepeatedMessage(
+          Resource.ATTRIBUTES_FIELD_NUMBER, attributeMarshalers, output);
+      output.flush();
+    } catch (IOException e) {
+      // Presized so can't happen (we would have already thrown OutOfMemoryError)
+      throw new UncheckedIOException(e);
+    }
   }
 
   @Override
   public void writeTo(CodedOutputStream output) throws IOException {
-    MarshalerUtil.marshalRepeatedMessage(
-        Resource.ATTRIBUTES_FIELD_NUMBER, attributeMarshalers, output);
+    output.writeRawBytes(serializedResource);
   }
 
   private static int calculateSize(AttributeMarshaler[] attributeMarshalers) {

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/TraceMarshaler.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/TraceMarshaler.java
@@ -32,11 +32,17 @@ import io.opentelemetry.sdk.trace.data.StatusData;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 
 final class TraceMarshaler {
+
+  // In practice, there is often only one thread that calls this code in the BatchSpanProcessor so
+  // reusing buffers for the thread is almost free. Even with multiple threads, it should still be
+  // worth it and is common practice in serialization libraries such as Jackson.
+  private static final ThreadLocal<ThreadLocalCache> THREAD_LOCAL_CACHE = new ThreadLocal<>();
 
   static final class RequestMarshaler extends MarshalerWithSize {
     private final ResourceSpansMarshaler[] resourceSpansMarshalers;
@@ -195,21 +201,35 @@ final class TraceMarshaler {
     private final SpanStatusMarshaler spanStatusMarshaler;
 
     // Because SpanMarshaler is always part of a repeated field, it cannot return "null".
-    private static SpanMarshaler create(SpanData spanData) {
+    private static SpanMarshaler create(SpanData spanData, ThreadLocalCache threadLocalCache) {
       AttributeMarshaler[] attributeMarshalers =
           AttributeMarshaler.createRepeated(spanData.getAttributes());
       SpanEventMarshaler[] spanEventMarshalers = SpanEventMarshaler.create(spanData.getEvents());
-      SpanLinkMarshaler[] spanLinkMarshalers = SpanLinkMarshaler.create(spanData.getLinks());
+      SpanLinkMarshaler[] spanLinkMarshalers =
+          SpanLinkMarshaler.create(spanData.getLinks(), threadLocalCache);
+      Map<String, byte[]> idBytesCache = threadLocalCache.idBytesCache;
+
+      byte[] traceId =
+          idBytesCache.computeIfAbsent(
+              spanData.getSpanContext().getTraceId(),
+              unused -> spanData.getSpanContext().getTraceIdBytes());
+      byte[] spanId =
+          idBytesCache.computeIfAbsent(
+              spanData.getSpanContext().getSpanId(),
+              unused -> spanData.getSpanContext().getSpanIdBytes());
 
       byte[] parentSpanId = MarshalerUtil.EMPTY_BYTES;
       SpanContext parentSpanContext = spanData.getParentSpanContext();
       if (parentSpanContext.isValid()) {
-        parentSpanId = parentSpanContext.getSpanIdBytes();
+        parentSpanId =
+            idBytesCache.computeIfAbsent(
+                spanData.getParentSpanContext().getSpanId(),
+                unused -> spanData.getParentSpanContext().getSpanIdBytes());
       }
 
       return new SpanMarshaler(
-          spanData.getSpanContext().getTraceIdBytes(),
-          spanData.getSpanContext().getSpanIdBytes(),
+          traceId,
+          spanId,
           parentSpanId,
           MarshalerUtil.toBytes(spanData.getName()),
           toProtoSpanKind(spanData.getKind()).getNumber(),
@@ -417,18 +437,24 @@ final class TraceMarshaler {
     private final AttributeMarshaler[] attributeMarshalers;
     private final int droppedAttributesCount;
 
-    private static SpanLinkMarshaler[] create(List<LinkData> links) {
+    private static SpanLinkMarshaler[] create(
+        List<LinkData> links, ThreadLocalCache threadLocalCache) {
       if (links.isEmpty()) {
         return EMPTY;
       }
+      Map<String, byte[]> idBytesCache = threadLocalCache.idBytesCache;
 
       SpanLinkMarshaler[] result = new SpanLinkMarshaler[links.size()];
       int pos = 0;
       for (LinkData link : links) {
         result[pos++] =
             new SpanLinkMarshaler(
-                link.getSpanContext().getTraceIdBytes(),
-                link.getSpanContext().getSpanIdBytes(),
+                idBytesCache.computeIfAbsent(
+                    link.getSpanContext().getTraceId(),
+                    unused -> link.getSpanContext().getTraceIdBytes()),
+                idBytesCache.computeIfAbsent(
+                    link.getSpanContext().getSpanId(),
+                    unused -> link.getSpanContext().getSpanIdBytes()),
                 AttributeMarshaler.createRepeated(link.getAttributes()),
                 link.getTotalAttributeCount() - link.getAttributes().size());
       }
@@ -545,14 +571,16 @@ final class TraceMarshaler {
     // expectedMaxSize of 8 means initial map capacity of 16 to match HashMap
     IdentityHashMap<Resource, Map<InstrumentationLibraryInfo, List<SpanMarshaler>>> result =
         new IdentityHashMap<>(8);
+    ThreadLocalCache threadLocalCache = getThreadLocalCache();
     for (SpanData spanData : spanDataList) {
       Map<InstrumentationLibraryInfo, List<SpanMarshaler>> libraryInfoListMap =
           result.computeIfAbsent(spanData.getResource(), unused -> new IdentityHashMap<>(8));
       List<SpanMarshaler> spanList =
           libraryInfoListMap.computeIfAbsent(
               spanData.getInstrumentationLibraryInfo(), unused -> new ArrayList<>());
-      spanList.add(SpanMarshaler.create(spanData));
+      spanList.add(SpanMarshaler.create(spanData, threadLocalCache));
     }
+    threadLocalCache.idBytesCache.clear();
     return result;
   }
 
@@ -570,6 +598,19 @@ final class TraceMarshaler {
         return SPAN_KIND_CONSUMER;
     }
     return Span.SpanKind.UNRECOGNIZED;
+  }
+
+  private static ThreadLocalCache getThreadLocalCache() {
+    ThreadLocalCache result = THREAD_LOCAL_CACHE.get();
+    if (result == null) {
+      result = new ThreadLocalCache();
+      THREAD_LOCAL_CACHE.set(result);
+    }
+    return result;
+  }
+
+  private static final class ThreadLocalCache {
+    final Map<String, byte[]> idBytesCache = new HashMap<>();
   }
 
   private TraceMarshaler() {}


### PR DESCRIPTION
…dapter

- Cache byte conversions
- Memoize Resource / InstrumentationLibraryInfo marshalers

After
```
RequestMarshalBenchmarks.marshalCustom                                             16  avgt   10  15471.733 ±   92.915   ns/op
RequestMarshalBenchmarks.marshalCustom:·gc.alloc.rate                              16  avgt   10   1079.549 ±    6.495  MB/sec
RequestMarshalBenchmarks.marshalCustom:·gc.alloc.rate.norm                         16  avgt   10  26304.006 ±    0.001    B/op
RequestMarshalBenchmarks.marshalCustom:·gc.churn.G1_Eden_Space                     16  avgt   10   1081.712 ±   57.368  MB/sec
RequestMarshalBenchmarks.marshalCustom:·gc.churn.G1_Eden_Space.norm                16  avgt   10  26355.435 ± 1333.469    B/op
RequestMarshalBenchmarks.marshalCustom:·gc.churn.G1_Old_Gen                        16  avgt   10      0.005 ±    0.004  MB/sec
RequestMarshalBenchmarks.marshalCustom:·gc.churn.G1_Old_Gen.norm                   16  avgt   10      0.113 ±    0.091    B/op
RequestMarshalBenchmarks.marshalCustom:·gc.count                                   16  avgt   10     89.000             counts
RequestMarshalBenchmarks.marshalCustom:·gc.time                                    16  avgt   10     39.000                 ms
```

Before
```
RequestMarshalBenchmarks.marshalCustom                                             16  avgt   10  18349.004 ±  161.701   ns/op
RequestMarshalBenchmarks.marshalCustom:·gc.alloc.rate                              16  avgt   10    972.386 ±    9.237  MB/sec
RequestMarshalBenchmarks.marshalCustom:·gc.alloc.rate.norm                         16  avgt   10  28104.008 ±    0.001    B/op
RequestMarshalBenchmarks.marshalCustom:·gc.churn.G1_Eden_Space                     16  avgt   10    971.490 ±    1.653  MB/sec
RequestMarshalBenchmarks.marshalCustom:·gc.churn.G1_Eden_Space.norm                16  avgt   10  28079.132 ±  274.389    B/op
RequestMarshalBenchmarks.marshalCustom:·gc.churn.G1_Old_Gen                        16  avgt   10      0.026 ±    0.009  MB/sec
RequestMarshalBenchmarks.marshalCustom:·gc.churn.G1_Old_Gen.norm                   16  avgt   10      0.765 ±    0.264    B/op
RequestMarshalBenchmarks.marshalCustom:·gc.count                                   16  avgt   10     80.000             counts
RequestMarshalBenchmarks.marshalCustom:·gc.time                                    16  avgt   10     36.000                 ms
```