### PR TITLE
Vendor in required bits of CodedOutputStream and remove protobuf-java…

### DIFF
--- a/buildscripts/checkstyle.xml
+++ b/buildscripts/checkstyle.xml
@@ -121,7 +121,6 @@
             <property name="ignoreFinal" value="false"/>
             <property name="allowedAbbreviationLength" value="1"/>
         </module>
-        <module name="OverloadMethodsDeclarationOrder"/>
         <!-- <!-\- Many unit tests define all variables at the start of the method. -\-> -->
         <!-- <module name="VariableDeclarationUsageDistance"/> -->
         <module name="CustomImportOrder">

--- a/exporters/otlp/trace/build.gradle.kts
+++ b/exporters/otlp/trace/build.gradle.kts
@@ -29,8 +29,6 @@ dependencies {
     exclude(mapOf("module" to "proto"))
   }
 
-  implementation("com.google.protobuf:protobuf-java")
-
   compileOnly("io.grpc:grpc-netty")
   compileOnly("io.grpc:grpc-netty-shaded")
   compileOnly("io.grpc:grpc-okhttp")
@@ -41,6 +39,7 @@ dependencies {
   testImplementation(project(":proto"))
   testImplementation(project(":sdk:testing"))
 
+  testImplementation("com.google.protobuf:protobuf-java")
   testImplementation("io.grpc:grpc-protobuf")
   testImplementation("io.grpc:grpc-testing")
   testImplementation("org.slf4j:slf4j-simple")
@@ -64,6 +63,7 @@ dependencies {
 
   jmh(project(":proto"))
   jmh(project(":sdk:testing"))
+  jmh("io.grpc:grpc-netty")
 }
 
 tasks {

--- a/exporters/otlp/trace/src/jmh/java/io/opentelemetry/exporter/otlp/trace/MarshalerInputStreamBenchmarks.java
+++ b/exporters/otlp/trace/src/jmh/java/io/opentelemetry/exporter/otlp/trace/MarshalerInputStreamBenchmarks.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.trace;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufOutputStream;
+import io.netty.buffer.PooledByteBufAllocator;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode({Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(1)
+public class MarshalerInputStreamBenchmarks {
+
+  @Benchmark
+  @Threads(1)
+  public void marshalToNettyBuffer(RequestMarshalState state) throws IOException {
+    MarshalerInputStream stream =
+        new MarshalerInputStream(TraceMarshaler.RequestMarshaler.create(state.spanDataList));
+    // Roughly reproduce how grpc-netty should behave.
+    ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer(stream.available());
+    stream.drainTo(new ByteBufOutputStream(buf));
+    buf.release();
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void marshalToByteArray(RequestMarshalState state) throws IOException {
+    MarshalerInputStream stream =
+        new MarshalerInputStream(TraceMarshaler.RequestMarshaler.create(state.spanDataList));
+    stream.drainTo(new ByteArrayOutputStream(stream.available()));
+  }
+}

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/AttributeMarshaler.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/AttributeMarshaler.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.exporter.otlp.trace;
 
-import com.google.protobuf.CodedOutputStream;
-import com.google.protobuf.WireFormat;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.proto.common.v1.internal.AnyValue;

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/CodedOutputStream.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/CodedOutputStream.java
@@ -1,0 +1,1110 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.trace;
+
+import static io.opentelemetry.exporter.otlp.trace.WireFormat.FIXED32_SIZE;
+import static io.opentelemetry.exporter.otlp.trace.WireFormat.FIXED64_SIZE;
+import static io.opentelemetry.exporter.otlp.trace.WireFormat.MAX_VARINT32_SIZE;
+import static io.opentelemetry.exporter.otlp.trace.WireFormat.MAX_VARINT_SIZE;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+// Copied in and trimmed from
+// https://github.com/protocolbuffers/protobuf/blob/master/java/core/src/main/java/com/google/protobuf/CodedOutputStream.java
+//
+// Differences
+// - No support for Message/Lite
+// - No support for ByteString or ByteBuffer
+// - No support for message set extensions
+// - No support for Unsafe
+//
+// Unneeded lines of code are deleted as is, without any modifications otherwise.
+@SuppressWarnings({"UngroupedOverloads", "InlineMeSuggester"})
+abstract class CodedOutputStream {
+  private static final Logger logger = Logger.getLogger(CodedOutputStream.class.getName());
+
+  /** The buffer size used in {@link #newInstance(OutputStream)}. */
+  static final int DEFAULT_BUFFER_SIZE = 4096;
+
+  /**
+   * Returns the buffer size to efficiently write dataLength bytes to this CodedOutputStream. Used
+   * by AbstractMessageLite.
+   *
+   * @return the buffer size to efficiently write dataLength bytes to this CodedOutputStream.
+   */
+  static int computePreferredBufferSize(int dataLength) {
+    if (dataLength > DEFAULT_BUFFER_SIZE) {
+      return DEFAULT_BUFFER_SIZE;
+    }
+    return dataLength;
+  }
+
+  /**
+   * Create a new {@code CodedOutputStream} wrapping the given {@code OutputStream}.
+   *
+   * <p>NOTE: The provided {@link OutputStream} <strong>MUST NOT</strong> retain access or modify
+   * the provided byte arrays. Doing so may result in corrupted data, which would be difficult to
+   * debug.
+   */
+  static CodedOutputStream newInstance(final OutputStream output) {
+    return newInstance(output, DEFAULT_BUFFER_SIZE);
+  }
+
+  /**
+   * Create a new {@code CodedOutputStream} wrapping the given {@code OutputStream} with a given
+   * buffer size.
+   *
+   * <p>NOTE: The provided {@link OutputStream} <strong>MUST NOT</strong> retain access or modify
+   * the provided byte arrays. Doing so may result in corrupted data, which would be difficult to
+   * debug.
+   */
+  static CodedOutputStream newInstance(final OutputStream output, final int bufferSize) {
+    return new OutputStreamEncoder(output, bufferSize);
+  }
+
+  // Disallow construction outside of this class.
+  private CodedOutputStream() {}
+
+  // -----------------------------------------------------------------
+
+  /** Encode and write a tag. */
+  // Abstract to avoid overhead of additional virtual method calls.
+  abstract void writeTag(int fieldNumber, int wireType) throws IOException;
+
+  /** Write an {@code int32} field, including tag, to the stream. */
+  // Abstract to avoid overhead of additional virtual method calls.
+  abstract void writeInt32(int fieldNumber, int value) throws IOException;
+
+  /** Write a {@code uint32} field, including tag, to the stream. */
+  // Abstract to avoid overhead of additional virtual method calls.
+  abstract void writeUInt32(int fieldNumber, int value) throws IOException;
+
+  /** Write a {@code sint32} field, including tag, to the stream. */
+  final void writeSInt32(final int fieldNumber, final int value) throws IOException {
+    writeUInt32(fieldNumber, encodeZigZag32(value));
+  }
+
+  /** Write a {@code fixed32} field, including tag, to the stream. */
+  // Abstract to avoid overhead of additional virtual method calls.
+  abstract void writeFixed32(int fieldNumber, int value) throws IOException;
+
+  /** Write an {@code sfixed32} field, including tag, to the stream. */
+  final void writeSFixed32(final int fieldNumber, final int value) throws IOException {
+    writeFixed32(fieldNumber, value);
+  }
+
+  /** Write an {@code int64} field, including tag, to the stream. */
+  final void writeInt64(final int fieldNumber, final long value) throws IOException {
+    writeUInt64(fieldNumber, value);
+  }
+
+  /** Write a {@code uint64} field, including tag, to the stream. */
+  // Abstract to avoid overhead of additional virtual method calls.
+  abstract void writeUInt64(int fieldNumber, long value) throws IOException;
+
+  /** Write an {@code sint64} field, including tag, to the stream. */
+  final void writeSInt64(final int fieldNumber, final long value) throws IOException {
+    writeUInt64(fieldNumber, encodeZigZag64(value));
+  }
+
+  /** Write a {@code fixed64} field, including tag, to the stream. */
+  // Abstract to avoid overhead of additional virtual method calls.
+  abstract void writeFixed64(int fieldNumber, long value) throws IOException;
+
+  /** Write an {@code sfixed64} field, including tag, to the stream. */
+  final void writeSFixed64(final int fieldNumber, final long value) throws IOException {
+    writeFixed64(fieldNumber, value);
+  }
+
+  /** Write a {@code float} field, including tag, to the stream. */
+  final void writeFloat(final int fieldNumber, final float value) throws IOException {
+    writeFixed32(fieldNumber, Float.floatToRawIntBits(value));
+  }
+
+  /** Write a {@code double} field, including tag, to the stream. */
+  final void writeDouble(final int fieldNumber, final double value) throws IOException {
+    writeFixed64(fieldNumber, Double.doubleToRawLongBits(value));
+  }
+
+  /** Write a {@code bool} field, including tag, to the stream. */
+  // Abstract to avoid overhead of additional virtual method calls.
+  abstract void writeBool(int fieldNumber, boolean value) throws IOException;
+
+  /**
+   * Write an enum field, including tag, to the stream. The provided value is the numeric value used
+   * to represent the enum value on the wire (not the enum ordinal value).
+   */
+  final void writeEnum(final int fieldNumber, final int value) throws IOException {
+    writeInt32(fieldNumber, value);
+  }
+
+  /** Write a {@code string} field, including tag, to the stream. */
+  // Abstract to avoid overhead of additional virtual method calls.
+  abstract void writeString(int fieldNumber, String value) throws IOException;
+
+  /** Write a {@code bytes} field, including tag, to the stream. */
+  // Abstract to avoid overhead of additional virtual method calls.
+  abstract void writeByteArray(int fieldNumber, byte[] value) throws IOException;
+
+  /** Write a {@code bytes} field, including tag, to the stream. */
+  // Abstract to avoid overhead of additional virtual method calls.
+  abstract void writeByteArray(int fieldNumber, byte[] value, int offset, int length)
+      throws IOException;
+
+  /** Write a single byte. */
+  final void writeRawByte(final byte value) throws IOException {
+    write(value);
+  }
+
+  /** Write a single byte, represented by an integer value. */
+  final void writeRawByte(final int value) throws IOException {
+    write((byte) value);
+  }
+
+  /** Write an array of bytes. */
+  final void writeRawBytes(final byte[] value) throws IOException {
+    write(value, 0, value.length);
+  }
+
+  /** Write part of an array of bytes. */
+  final void writeRawBytes(final byte[] value, int offset, int length) throws IOException {
+    write(value, offset, length);
+  }
+
+  // -----------------------------------------------------------------
+
+  /** Write an {@code int32} field to the stream. */
+  // Abstract to avoid overhead of additional virtual method calls.
+  abstract void writeInt32NoTag(final int value) throws IOException;
+
+  /** Write a {@code uint32} field to the stream. */
+  // Abstract to avoid overhead of additional virtual method calls.
+  abstract void writeUInt32NoTag(int value) throws IOException;
+
+  /** Write a {@code sint32} field to the stream. */
+  final void writeSInt32NoTag(final int value) throws IOException {
+    writeUInt32NoTag(encodeZigZag32(value));
+  }
+
+  /** Write a {@code fixed32} field to the stream. */
+  // Abstract to avoid overhead of additional virtual method calls.
+  abstract void writeFixed32NoTag(int value) throws IOException;
+
+  /** Write a {@code sfixed32} field to the stream. */
+  final void writeSFixed32NoTag(final int value) throws IOException {
+    writeFixed32NoTag(value);
+  }
+
+  /** Write an {@code int64} field to the stream. */
+  final void writeInt64NoTag(final long value) throws IOException {
+    writeUInt64NoTag(value);
+  }
+
+  /** Write a {@code uint64} field to the stream. */
+  // Abstract to avoid overhead of additional virtual method calls.
+  abstract void writeUInt64NoTag(long value) throws IOException;
+
+  /** Write a {@code sint64} field to the stream. */
+  final void writeSInt64NoTag(final long value) throws IOException {
+    writeUInt64NoTag(encodeZigZag64(value));
+  }
+
+  /** Write a {@code fixed64} field to the stream. */
+  // Abstract to avoid overhead of additional virtual method calls.
+  abstract void writeFixed64NoTag(long value) throws IOException;
+
+  /** Write a {@code sfixed64} field to the stream. */
+  final void writeSFixed64NoTag(final long value) throws IOException {
+    writeFixed64NoTag(value);
+  }
+
+  /** Write a {@code float} field to the stream. */
+  final void writeFloatNoTag(final float value) throws IOException {
+    writeFixed32NoTag(Float.floatToRawIntBits(value));
+  }
+
+  /** Write a {@code double} field to the stream. */
+  final void writeDoubleNoTag(final double value) throws IOException {
+    writeFixed64NoTag(Double.doubleToRawLongBits(value));
+  }
+
+  /** Write a {@code bool} field to the stream. */
+  final void writeBoolNoTag(final boolean value) throws IOException {
+    write((byte) (value ? 1 : 0));
+  }
+
+  /**
+   * Write an enum field to the stream. The provided value is the numeric value used to represent
+   * the enum value on the wire (not the enum ordinal value).
+   */
+  final void writeEnumNoTag(final int value) throws IOException {
+    writeInt32NoTag(value);
+  }
+
+  /** Write a {@code string} field to the stream. */
+  // TODO(dweis): Document behavior on ill-formed UTF-16 input.
+  // Abstract to avoid overhead of additional virtual method calls.
+  abstract void writeStringNoTag(String value) throws IOException;
+
+  /** Write a {@code bytes} field to the stream. */
+  final void writeByteArrayNoTag(final byte[] value) throws IOException {
+    writeByteArrayNoTag(value, 0, value.length);
+  }
+
+  // =================================================================
+
+  abstract void write(byte value) throws IOException;
+
+  abstract void write(byte[] value, int offset, int length) throws IOException;
+
+  abstract void writeLazy(byte[] value, int offset, int length) throws IOException;
+
+  // =================================================================
+  // =================================================================
+
+  /**
+   * Compute the number of bytes that would be needed to encode an {@code int32} field, including
+   * tag.
+   */
+  static int computeInt32Size(final int fieldNumber, final int value) {
+    return computeTagSize(fieldNumber) + computeInt32SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a {@code uint32} field, including
+   * tag.
+   */
+  static int computeUInt32Size(final int fieldNumber, final int value) {
+    return computeTagSize(fieldNumber) + computeUInt32SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an {@code sint32} field, including
+   * tag.
+   */
+  static int computeSInt32Size(final int fieldNumber, final int value) {
+    return computeTagSize(fieldNumber) + computeSInt32SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a {@code fixed32} field, including
+   * tag.
+   */
+  static int computeFixed32Size(final int fieldNumber, final int value) {
+    return computeTagSize(fieldNumber) + computeFixed32SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an {@code sfixed32} field, including
+   * tag.
+   */
+  static int computeSFixed32Size(final int fieldNumber, final int value) {
+    return computeTagSize(fieldNumber) + computeSFixed32SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an {@code int64} field, including
+   * tag.
+   */
+  static int computeInt64Size(final int fieldNumber, final long value) {
+    return computeTagSize(fieldNumber) + computeInt64SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a {@code uint64} field, including
+   * tag.
+   */
+  static int computeUInt64Size(final int fieldNumber, final long value) {
+    return computeTagSize(fieldNumber) + computeUInt64SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an {@code sint64} field, including
+   * tag.
+   */
+  static int computeSInt64Size(final int fieldNumber, final long value) {
+    return computeTagSize(fieldNumber) + computeSInt64SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a {@code fixed64} field, including
+   * tag.
+   */
+  static int computeFixed64Size(final int fieldNumber, final long value) {
+    return computeTagSize(fieldNumber) + computeFixed64SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an {@code sfixed64} field, including
+   * tag.
+   */
+  static int computeSFixed64Size(final int fieldNumber, final long value) {
+    return computeTagSize(fieldNumber) + computeSFixed64SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a {@code float} field, including
+   * tag.
+   */
+  static int computeFloatSize(final int fieldNumber, final float value) {
+    return computeTagSize(fieldNumber) + computeFloatSizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a {@code double} field, including
+   * tag.
+   */
+  static int computeDoubleSize(final int fieldNumber, final double value) {
+    return computeTagSize(fieldNumber) + computeDoubleSizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a {@code bool} field, including tag.
+   */
+  static int computeBoolSize(final int fieldNumber, final boolean value) {
+    return computeTagSize(fieldNumber) + computeBoolSizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an enum field, including tag. The
+   * provided value is the numeric value used to represent the enum value on the wire (not the enum
+   * ordinal value).
+   */
+  static int computeEnumSize(final int fieldNumber, final int value) {
+    return computeTagSize(fieldNumber) + computeEnumSizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a {@code string} field, including
+   * tag.
+   */
+  static int computeStringSize(final int fieldNumber, final String value) {
+    return computeTagSize(fieldNumber) + computeStringSizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a {@code bytes} field, including
+   * tag.
+   */
+  static int computeByteArraySize(final int fieldNumber, final byte[] value) {
+    return computeTagSize(fieldNumber) + computeByteArraySizeNoTag(value);
+  }
+
+  // -----------------------------------------------------------------
+
+  /** Compute the number of bytes that would be needed to encode a tag. */
+  static int computeTagSize(final int fieldNumber) {
+    return computeUInt32SizeNoTag(WireFormat.makeTag(fieldNumber, 0));
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an {@code int32} field, including
+   * tag.
+   */
+  static int computeInt32SizeNoTag(final int value) {
+    if (value >= 0) {
+      return computeUInt32SizeNoTag(value);
+    } else {
+      // Must sign-extend.
+      return MAX_VARINT_SIZE;
+    }
+  }
+
+  /** Compute the number of bytes that would be needed to encode a {@code uint32} field. */
+  static int computeUInt32SizeNoTag(final int value) {
+    if ((value & (~0 << 7)) == 0) {
+      return 1;
+    }
+    if ((value & (~0 << 14)) == 0) {
+      return 2;
+    }
+    if ((value & (~0 << 21)) == 0) {
+      return 3;
+    }
+    if ((value & (~0 << 28)) == 0) {
+      return 4;
+    }
+    return 5;
+  }
+
+  /** Compute the number of bytes that would be needed to encode an {@code sint32} field. */
+  static int computeSInt32SizeNoTag(final int value) {
+    return computeUInt32SizeNoTag(encodeZigZag32(value));
+  }
+
+  /** Compute the number of bytes that would be needed to encode a {@code fixed32} field. */
+  static int computeFixed32SizeNoTag(@SuppressWarnings("unused") final int unused) {
+    return FIXED32_SIZE;
+  }
+
+  /** Compute the number of bytes that would be needed to encode an {@code sfixed32} field. */
+  static int computeSFixed32SizeNoTag(@SuppressWarnings("unused") final int unused) {
+    return FIXED32_SIZE;
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an {@code int64} field, including
+   * tag.
+   */
+  static int computeInt64SizeNoTag(final long value) {
+    return computeUInt64SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a {@code uint64} field, including
+   * tag.
+   */
+  static int computeUInt64SizeNoTag(long value) {
+    // handle two popular special cases up front ...
+    if ((value & (~0L << 7)) == 0L) {
+      return 1;
+    }
+    if (value < 0L) {
+      return 10;
+    }
+    // ... leaving us with 8 remaining, which we can divide and conquer
+    int n = 2;
+    if ((value & (~0L << 35)) != 0L) {
+      n += 4;
+      value >>>= 28;
+    }
+    if ((value & (~0L << 21)) != 0L) {
+      n += 2;
+      value >>>= 14;
+    }
+    if ((value & (~0L << 14)) != 0L) {
+      n += 1;
+    }
+    return n;
+  }
+
+  /** Compute the number of bytes that would be needed to encode an {@code sint64} field. */
+  static int computeSInt64SizeNoTag(final long value) {
+    return computeUInt64SizeNoTag(encodeZigZag64(value));
+  }
+
+  /** Compute the number of bytes that would be needed to encode a {@code fixed64} field. */
+  static int computeFixed64SizeNoTag(@SuppressWarnings("unused") final long unused) {
+    return FIXED64_SIZE;
+  }
+
+  /** Compute the number of bytes that would be needed to encode an {@code sfixed64} field. */
+  static int computeSFixed64SizeNoTag(@SuppressWarnings("unused") final long unused) {
+    return FIXED64_SIZE;
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a {@code float} field, including
+   * tag.
+   */
+  static int computeFloatSizeNoTag(@SuppressWarnings("unused") final float unused) {
+    return FIXED32_SIZE;
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a {@code double} field, including
+   * tag.
+   */
+  static int computeDoubleSizeNoTag(@SuppressWarnings("unused") final double unused) {
+    return FIXED64_SIZE;
+  }
+
+  /** Compute the number of bytes that would be needed to encode a {@code bool} field. */
+  static int computeBoolSizeNoTag(@SuppressWarnings("unused") final boolean unused) {
+    return 1;
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an enum field. The provided value is
+   * the numeric value used to represent the enum value on the wire (not the enum ordinal value).
+   */
+  static int computeEnumSizeNoTag(final int value) {
+    return computeInt32SizeNoTag(value);
+  }
+
+  /** Compute the number of bytes that would be needed to encode a {@code string} field. */
+  static int computeStringSizeNoTag(final String value) {
+    int length;
+    try {
+      length = Utf8.encodedLength(value);
+    } catch (Utf8.UnpairedSurrogateException e) {
+      final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+      length = bytes.length;
+    }
+
+    return computeLengthDelimitedFieldSize(length);
+  }
+
+  /** Compute the number of bytes that would be needed to encode a {@code bytes} field. */
+  static int computeByteArraySizeNoTag(final byte[] value) {
+    return computeLengthDelimitedFieldSize(value.length);
+  }
+
+  static int computeLengthDelimitedFieldSize(int fieldLength) {
+    return computeUInt32SizeNoTag(fieldLength) + fieldLength;
+  }
+
+  /**
+   * Encode a ZigZag-encoded 32-bit value. ZigZag encodes signed integers into values that can be
+   * efficiently encoded with varint. (Otherwise, negative values must be sign-extended to 64 bits
+   * to be varint encoded, thus always taking 10 bytes on the wire.)
+   *
+   * @param n A signed 32-bit integer.
+   * @return An unsigned 32-bit integer, stored in a signed int because Java has no explicit
+   *     unsigned support.
+   */
+  static int encodeZigZag32(final int n) {
+    // Note:  the right-shift must be arithmetic
+    return (n << 1) ^ (n >> 31);
+  }
+
+  /**
+   * Encode a ZigZag-encoded 64-bit value. ZigZag encodes signed integers into values that can be
+   * efficiently encoded with varint. (Otherwise, negative values must be sign-extended to 64 bits
+   * to be varint encoded, thus always taking 10 bytes on the wire.)
+   *
+   * @param n A signed 64-bit integer.
+   * @return An unsigned 64-bit integer, stored in a signed int because Java has no explicit
+   *     unsigned support.
+   */
+  static long encodeZigZag64(final long n) {
+    // Note:  the right-shift must be arithmetic
+    return (n << 1) ^ (n >> 63);
+  }
+
+  // =================================================================
+
+  /**
+   * Flushes the stream and forces any buffered bytes to be written. This does not flush the
+   * underlying OutputStream.
+   */
+  abstract void flush() throws IOException;
+
+  /**
+   * If writing to a flat array, return the space left in the array. Otherwise, throws {@code
+   * UnsupportedOperationException}.
+   */
+  abstract int spaceLeft();
+
+  /**
+   * Verifies that {@link #spaceLeft()} returns zero. It's common to create a byte array that is
+   * exactly big enough to hold a message, then write to it with a {@code CodedOutputStream}.
+   * Calling {@code checkNoSpaceLeft()} after writing verifies that the message was actually as big
+   * as expected, which can help catch bugs.
+   */
+  final void checkNoSpaceLeft() {
+    if (spaceLeft() != 0) {
+      throw new IllegalStateException("Did not write as much data as expected.");
+    }
+  }
+
+  /**
+   * If you create a CodedOutputStream around a simple flat array, you must not attempt to write
+   * more bytes than the array has space. Otherwise, this exception will be thrown.
+   */
+  static class OutOfSpaceException extends IOException {
+    private static final long serialVersionUID = -6947486886997889499L;
+
+    private static final String MESSAGE =
+        "CodedOutputStream was writing to a flat byte array and ran out of space.";
+
+    OutOfSpaceException() {
+      super(MESSAGE);
+    }
+
+    OutOfSpaceException(String explanationMessage) {
+      super(MESSAGE + ": " + explanationMessage);
+    }
+
+    OutOfSpaceException(Throwable cause) {
+      super(MESSAGE, cause);
+    }
+
+    OutOfSpaceException(String explanationMessage, Throwable cause) {
+      super(MESSAGE + ": " + explanationMessage, cause);
+    }
+  }
+
+  /**
+   * Get the total number of bytes successfully written to this stream. The returned value is not
+   * guaranteed to be accurate if exceptions have been found in the middle of writing.
+   */
+  abstract int getTotalBytesWritten();
+
+  // =================================================================
+
+  /** Write a {@code bytes} field to the stream. */
+  abstract void writeByteArrayNoTag(final byte[] value, final int offset, final int length)
+      throws IOException;
+
+  final void inefficientWriteStringNoTag(String value, Utf8.UnpairedSurrogateException cause)
+      throws IOException {
+    logger.log(
+        Level.WARNING,
+        "Converting ill-formed UTF-16. Your Protocol Buffer will not round trip correctly!",
+        cause);
+
+    // Unfortunately there does not appear to be any way to tell Java to encode
+    // UTF-8 directly into our buffer, so we have to let it create its own byte
+    // array and then copy.
+    final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+    try {
+      writeUInt32NoTag(bytes.length);
+      writeLazy(bytes, 0, bytes.length);
+    } catch (IndexOutOfBoundsException e) {
+      throw new OutOfSpaceException(e);
+    } catch (OutOfSpaceException e) {
+      throw e;
+    }
+  }
+
+  // =================================================================
+
+  /**
+   * Encode and write a varint. {@code value} is treated as unsigned, so it won't be sign-extended
+   * if negative.
+   *
+   * @deprecated use {@link #writeUInt32NoTag} instead.
+   */
+  @Deprecated
+  final void writeRawVarint32(int value) throws IOException {
+    writeUInt32NoTag(value);
+  }
+
+  /**
+   * Encode and write a varint.
+   *
+   * @deprecated use {@link #writeUInt64NoTag} instead.
+   */
+  @Deprecated
+  final void writeRawVarint64(long value) throws IOException {
+    writeUInt64NoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a varint. {@code value} is treated
+   * as unsigned, so it won't be sign-extended if negative.
+   *
+   * @deprecated use {@link #computeUInt32SizeNoTag(int)} instead.
+   */
+  @Deprecated
+  static int computeRawVarint32Size(final int value) {
+    return computeUInt32SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a varint.
+   *
+   * @deprecated use {@link #computeUInt64SizeNoTag(long)} instead.
+   */
+  @Deprecated
+  static int computeRawVarint64Size(long value) {
+    return computeUInt64SizeNoTag(value);
+  }
+
+  /**
+   * Write a little-endian 32-bit integer.
+   *
+   * @deprecated Use {@link #writeFixed32NoTag} instead.
+   */
+  @Deprecated
+  final void writeRawLittleEndian32(final int value) throws IOException {
+    writeFixed32NoTag(value);
+  }
+
+  /**
+   * Write a little-endian 64-bit integer.
+   *
+   * @deprecated Use {@link #writeFixed64NoTag} instead.
+   */
+  @Deprecated
+  final void writeRawLittleEndian64(final long value) throws IOException {
+    writeFixed64NoTag(value);
+  }
+
+  // =================================================================
+
+  /** Abstract base class for buffered encoders. */
+  private abstract static class AbstractBufferedEncoder extends CodedOutputStream {
+    final byte[] buffer;
+    final int limit;
+    int position;
+    int totalBytesWritten;
+
+    AbstractBufferedEncoder(int bufferSize) {
+      if (bufferSize < 0) {
+        throw new IllegalArgumentException("bufferSize must be >= 0");
+      }
+      // As an optimization, we require that the buffer be able to store at least 2
+      // varints so that we can buffer any integer write (tag + value). This reduces the
+      // number of range checks for a single write to 1 (i.e. if there is not enough space
+      // to buffer the tag+value, flush and then buffer it).
+      this.buffer = new byte[Math.max(bufferSize, MAX_VARINT_SIZE * 2)];
+      this.limit = buffer.length;
+    }
+
+    @Override
+    final int spaceLeft() {
+      throw new UnsupportedOperationException(
+          "spaceLeft() can only be called on CodedOutputStreams that are "
+              + "writing to a flat array or ByteBuffer.");
+    }
+
+    @Override
+    final int getTotalBytesWritten() {
+      return totalBytesWritten;
+    }
+
+    /**
+     * This method does not perform bounds checking on the array. Checking array bounds is the
+     * responsibility of the caller.
+     */
+    final void buffer(byte value) {
+      buffer[position++] = value;
+      totalBytesWritten++;
+    }
+
+    /**
+     * This method does not perform bounds checking on the array. Checking array bounds is the
+     * responsibility of the caller.
+     */
+    final void bufferTag(final int fieldNumber, final int wireType) {
+      bufferUInt32NoTag(WireFormat.makeTag(fieldNumber, wireType));
+    }
+
+    /**
+     * This method does not perform bounds checking on the array. Checking array bounds is the
+     * responsibility of the caller.
+     */
+    final void bufferInt32NoTag(final int value) {
+      if (value >= 0) {
+        bufferUInt32NoTag(value);
+      } else {
+        // Must sign-extend.
+        bufferUInt64NoTag(value);
+      }
+    }
+
+    /**
+     * This method does not perform bounds checking on the array. Checking array bounds is the
+     * responsibility of the caller.
+     */
+    final void bufferUInt32NoTag(int value) {
+      while (true) {
+        if ((value & ~0x7F) == 0) {
+          buffer[position++] = (byte) value;
+          totalBytesWritten++;
+          return;
+        } else {
+          buffer[position++] = (byte) ((value & 0x7F) | 0x80);
+          totalBytesWritten++;
+          value >>>= 7;
+        }
+      }
+    }
+
+    /**
+     * This method does not perform bounds checking on the array. Checking array bounds is the
+     * responsibility of the caller.
+     */
+    final void bufferUInt64NoTag(long value) {
+      while (true) {
+        if ((value & ~0x7FL) == 0) {
+          buffer[position++] = (byte) value;
+          totalBytesWritten++;
+          return;
+        } else {
+          buffer[position++] = (byte) (((int) value & 0x7F) | 0x80);
+          totalBytesWritten++;
+          value >>>= 7;
+        }
+      }
+    }
+
+    /**
+     * This method does not perform bounds checking on the array. Checking array bounds is the
+     * responsibility of the caller.
+     */
+    final void bufferFixed32NoTag(int value) {
+      buffer[position++] = (byte) (value & 0xFF);
+      buffer[position++] = (byte) ((value >> 8) & 0xFF);
+      buffer[position++] = (byte) ((value >> 16) & 0xFF);
+      buffer[position++] = (byte) ((value >> 24) & 0xFF);
+      totalBytesWritten += FIXED32_SIZE;
+    }
+
+    /**
+     * This method does not perform bounds checking on the array. Checking array bounds is the
+     * responsibility of the caller.
+     */
+    final void bufferFixed64NoTag(long value) {
+      buffer[position++] = (byte) (value & 0xFF);
+      buffer[position++] = (byte) ((value >> 8) & 0xFF);
+      buffer[position++] = (byte) ((value >> 16) & 0xFF);
+      buffer[position++] = (byte) ((value >> 24) & 0xFF);
+      buffer[position++] = (byte) ((int) (value >> 32) & 0xFF);
+      buffer[position++] = (byte) ((int) (value >> 40) & 0xFF);
+      buffer[position++] = (byte) ((int) (value >> 48) & 0xFF);
+      buffer[position++] = (byte) ((int) (value >> 56) & 0xFF);
+      totalBytesWritten += FIXED64_SIZE;
+    }
+  }
+
+  /**
+   * An {@link CodedOutputStream} that decorates an {@link OutputStream}. It performs internal
+   * buffering to optimize writes to the {@link OutputStream}.
+   */
+  private static final class OutputStreamEncoder extends AbstractBufferedEncoder {
+    private final OutputStream out;
+
+    OutputStreamEncoder(OutputStream out, int bufferSize) {
+      super(bufferSize);
+      if (out == null) {
+        throw new NullPointerException("out");
+      }
+      this.out = out;
+    }
+
+    @Override
+    void writeTag(final int fieldNumber, final int wireType) throws IOException {
+      writeUInt32NoTag(WireFormat.makeTag(fieldNumber, wireType));
+    }
+
+    @Override
+    void writeInt32(final int fieldNumber, final int value) throws IOException {
+      flushIfNotAvailable(MAX_VARINT_SIZE * 2);
+      bufferTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
+      bufferInt32NoTag(value);
+    }
+
+    @Override
+    void writeUInt32(final int fieldNumber, final int value) throws IOException {
+      flushIfNotAvailable(MAX_VARINT_SIZE * 2);
+      bufferTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
+      bufferUInt32NoTag(value);
+    }
+
+    @Override
+    void writeFixed32(final int fieldNumber, final int value) throws IOException {
+      flushIfNotAvailable(MAX_VARINT_SIZE + FIXED32_SIZE);
+      bufferTag(fieldNumber, WireFormat.WIRETYPE_FIXED32);
+      bufferFixed32NoTag(value);
+    }
+
+    @Override
+    void writeUInt64(final int fieldNumber, final long value) throws IOException {
+      flushIfNotAvailable(MAX_VARINT_SIZE * 2);
+      bufferTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
+      bufferUInt64NoTag(value);
+    }
+
+    @Override
+    void writeFixed64(final int fieldNumber, final long value) throws IOException {
+      flushIfNotAvailable(MAX_VARINT_SIZE + FIXED64_SIZE);
+      bufferTag(fieldNumber, WireFormat.WIRETYPE_FIXED64);
+      bufferFixed64NoTag(value);
+    }
+
+    @Override
+    void writeBool(final int fieldNumber, final boolean value) throws IOException {
+      flushIfNotAvailable(MAX_VARINT_SIZE + 1);
+      bufferTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
+      buffer((byte) (value ? 1 : 0));
+    }
+
+    @Override
+    void writeString(final int fieldNumber, final String value) throws IOException {
+      writeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+      writeStringNoTag(value);
+    }
+
+    @Override
+    void writeByteArray(final int fieldNumber, final byte[] value) throws IOException {
+      writeByteArray(fieldNumber, value, 0, value.length);
+    }
+
+    @Override
+    void writeByteArray(
+        final int fieldNumber, final byte[] value, final int offset, final int length)
+        throws IOException {
+      writeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+      writeByteArrayNoTag(value, offset, length);
+    }
+
+    @Override
+    void writeByteArrayNoTag(final byte[] value, int offset, int length) throws IOException {
+      writeUInt32NoTag(length);
+      write(value, offset, length);
+    }
+
+    @Override
+    void write(byte value) throws IOException {
+      if (position == limit) {
+        doFlush();
+      }
+
+      buffer(value);
+    }
+
+    @Override
+    void writeInt32NoTag(int value) throws IOException {
+      if (value >= 0) {
+        writeUInt32NoTag(value);
+      } else {
+        // Must sign-extend.
+        writeUInt64NoTag(value);
+      }
+    }
+
+    @Override
+    void writeUInt32NoTag(int value) throws IOException {
+      flushIfNotAvailable(MAX_VARINT32_SIZE);
+      bufferUInt32NoTag(value);
+    }
+
+    @Override
+    void writeFixed32NoTag(final int value) throws IOException {
+      flushIfNotAvailable(FIXED32_SIZE);
+      bufferFixed32NoTag(value);
+    }
+
+    @Override
+    void writeUInt64NoTag(long value) throws IOException {
+      flushIfNotAvailable(MAX_VARINT_SIZE);
+      bufferUInt64NoTag(value);
+    }
+
+    @Override
+    void writeFixed64NoTag(final long value) throws IOException {
+      flushIfNotAvailable(FIXED64_SIZE);
+      bufferFixed64NoTag(value);
+    }
+
+    @Override
+    void writeStringNoTag(String value) throws IOException {
+      try {
+        // UTF-8 byte length of the string is at least its UTF-16 code unit length (value.length()),
+        // and at most 3 times of it. We take advantage of this in both branches below.
+        final int maxLength = value.length() * Utf8.MAX_BYTES_PER_CHAR;
+        final int maxLengthVarIntSize = computeUInt32SizeNoTag(maxLength);
+
+        // If we are streaming and the potential length is too big to fit in our buffer, we take the
+        // slower path.
+        if (maxLengthVarIntSize + maxLength > limit) {
+          // Allocate a byte[] that we know can fit the string and encode into it. String.getBytes()
+          // does the same internally and then does *another copy* to return a byte[] of exactly the
+          // right size. We can skip that copy and just writeRawBytes up to the actualLength of the
+          // UTF-8 encoded bytes.
+          final byte[] encodedBytes = new byte[maxLength];
+          int actualLength = Utf8.encode(value, encodedBytes, 0, maxLength);
+          writeUInt32NoTag(actualLength);
+          writeLazy(encodedBytes, 0, actualLength);
+          return;
+        }
+
+        // Fast path: we have enough space available in our buffer for the string...
+        if (maxLengthVarIntSize + maxLength > limit - position) {
+          // Flush to free up space.
+          doFlush();
+        }
+
+        // Optimize for the case where we know this length results in a constant varint length as
+        // this saves a pass for measuring the length of the string.
+        final int minLengthVarIntSize = computeUInt32SizeNoTag(value.length());
+        int oldPosition = position;
+        final int length;
+        try {
+          if (minLengthVarIntSize == maxLengthVarIntSize) {
+            position = oldPosition + minLengthVarIntSize;
+            int newPosition = Utf8.encode(value, buffer, position, limit - position);
+            // Since this class is stateful and tracks the position, we rewind and store the
+            // state, prepend the length, then reset it back to the end of the string.
+            position = oldPosition;
+            length = newPosition - oldPosition - minLengthVarIntSize;
+            bufferUInt32NoTag(length);
+            position = newPosition;
+          } else {
+            length = Utf8.encodedLength(value);
+            bufferUInt32NoTag(length);
+            position = Utf8.encode(value, buffer, position, length);
+          }
+          totalBytesWritten += length;
+        } catch (Utf8.UnpairedSurrogateException e) {
+          // Be extra careful and restore the original position for retrying the write with the
+          // less efficient path.
+          totalBytesWritten -= position - oldPosition;
+          position = oldPosition;
+          throw e;
+        } catch (ArrayIndexOutOfBoundsException e) {
+          throw new OutOfSpaceException(e);
+        }
+      } catch (Utf8.UnpairedSurrogateException e) {
+        inefficientWriteStringNoTag(value, e);
+      }
+    }
+
+    @Override
+    void flush() throws IOException {
+      if (position > 0) {
+        // Flush the buffer.
+        doFlush();
+      }
+    }
+
+    @Override
+    void write(byte[] value, int offset, int length) throws IOException {
+      if (limit - position >= length) {
+        // We have room in the current buffer.
+        System.arraycopy(value, offset, buffer, position, length);
+        position += length;
+        totalBytesWritten += length;
+      } else {
+        // Write extends past current buffer.  Fill the rest of this buffer and
+        // flush.
+        final int bytesWritten = limit - position;
+        System.arraycopy(value, offset, buffer, position, bytesWritten);
+        offset += bytesWritten;
+        length -= bytesWritten;
+        position = limit;
+        totalBytesWritten += bytesWritten;
+        doFlush();
+
+        // Now deal with the rest.
+        // Since we have an output stream, this is our buffer
+        // and buffer offset == 0
+        if (length <= limit) {
+          // Fits in new buffer.
+          System.arraycopy(value, offset, buffer, 0, length);
+          position = length;
+        } else {
+          // Write is very big.  Let's do it all at once.
+          out.write(value, offset, length);
+        }
+        totalBytesWritten += length;
+      }
+    }
+
+    @Override
+    void writeLazy(byte[] value, int offset, int length) throws IOException {
+      write(value, offset, length);
+    }
+
+    private void flushIfNotAvailable(int requiredSize) throws IOException {
+      if (limit - position < requiredSize) {
+        doFlush();
+      }
+    }
+
+    private void doFlush() throws IOException {
+      out.write(buffer, 0, position);
+      position = 0;
+    }
+  }
+}

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/CodedOutputStream.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/CodedOutputStream.java
@@ -3,6 +3,37 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Includes work from:
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 package io.opentelemetry.exporter.otlp.trace;
 
 import static io.opentelemetry.exporter.otlp.trace.WireFormat.FIXED32_SIZE;

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/InstrumentationLibraryMarshaler.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/InstrumentationLibraryMarshaler.java
@@ -36,7 +36,9 @@ final class InstrumentationLibraryMarshaler extends MarshalerWithSize {
   private InstrumentationLibraryMarshaler(byte[] name, byte[] version) {
     super(computeSize(name, version));
     ByteArrayOutputStream bos = new ByteArrayOutputStream(getSerializedSize());
-    CodedOutputStream output = CodedOutputStream.newInstance(bos);
+    CodedOutputStream output =
+        CodedOutputStream.newInstance(
+            bos, CodedOutputStream.computePreferredBufferSize(getSerializedSize()));
     try {
       MarshalerUtil.marshalBytes(InstrumentationLibrary.NAME_FIELD_NUMBER, name, output);
       MarshalerUtil.marshalBytes(InstrumentationLibrary.VERSION_FIELD_NUMBER, version, output);

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/Marshaler.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/Marshaler.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.exporter.otlp.trace;
 
-import com.google.protobuf.CodedOutputStream;
 import java.io.IOException;
 
 interface Marshaler {

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/MarshalerInputStream.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/MarshalerInputStream.java
@@ -3,6 +3,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Includes work from:
+/*
+ * Copyright 2014 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.opentelemetry.exporter.otlp.trace;
 
 import com.google.common.io.ByteStreams;

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/MarshalerUtil.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/MarshalerUtil.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.exporter.otlp.trace;
 
-import com.google.protobuf.CodedOutputStream;
-import com.google.protobuf.WireFormat;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/ResourceMarshaler.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/ResourceMarshaler.java
@@ -5,9 +5,9 @@
 
 package io.opentelemetry.exporter.otlp.trace;
 
-import com.google.protobuf.CodedOutputStream;
 import io.opentelemetry.context.internal.shaded.WeakConcurrentMap;
 import io.opentelemetry.proto.resource.v1.internal.Resource;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
@@ -31,8 +31,8 @@ final class ResourceMarshaler extends MarshalerWithSize {
 
   private ResourceMarshaler(AttributeMarshaler[] attributeMarshalers) {
     super(calculateSize(attributeMarshalers));
-    serializedResource = new byte[getSerializedSize()];
-    CodedOutputStream output = CodedOutputStream.newInstance(serializedResource);
+    ByteArrayOutputStream bos = new ByteArrayOutputStream(getSerializedSize());
+    CodedOutputStream output = CodedOutputStream.newInstance(bos);
     try {
       MarshalerUtil.marshalRepeatedMessage(
           Resource.ATTRIBUTES_FIELD_NUMBER, attributeMarshalers, output);
@@ -41,6 +41,7 @@ final class ResourceMarshaler extends MarshalerWithSize {
       // Presized so can't happen (we would have already thrown OutOfMemoryError)
       throw new UncheckedIOException(e);
     }
+    serializedResource = bos.toByteArray();
   }
 
   @Override

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/ResourceMarshaler.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/ResourceMarshaler.java
@@ -32,7 +32,9 @@ final class ResourceMarshaler extends MarshalerWithSize {
   private ResourceMarshaler(AttributeMarshaler[] attributeMarshalers) {
     super(calculateSize(attributeMarshalers));
     ByteArrayOutputStream bos = new ByteArrayOutputStream(getSerializedSize());
-    CodedOutputStream output = CodedOutputStream.newInstance(bos);
+    CodedOutputStream output =
+        CodedOutputStream.newInstance(
+            bos, CodedOutputStream.computePreferredBufferSize(getSerializedSize()));
     try {
       MarshalerUtil.marshalRepeatedMessage(
           Resource.ATTRIBUTES_FIELD_NUMBER, attributeMarshalers, output);

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/TraceMarshaler.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/TraceMarshaler.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.exporter.otlp.trace;
 
-import com.google.protobuf.CodedOutputStream;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/Utf8.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/Utf8.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.trace;
+
+import static java.lang.Character.MAX_SURROGATE;
+import static java.lang.Character.MIN_SUPPLEMENTARY_CODE_POINT;
+import static java.lang.Character.MIN_SURROGATE;
+import static java.lang.Character.isSurrogatePair;
+import static java.lang.Character.toCodePoint;
+
+// Copied from
+// https://github.com/protocolbuffers/protobuf/blob/master/java/core/src/main/java/com/google/protobuf/Utf8.java
+//
+// Removed support for ByteBuffer, decoding, and Unsafe.
+//
+// Unneeded lines of code are deleted as is, without any modifications otherwise.
+final class Utf8 {
+
+  /**
+   * UTF-8 is a runtime hot spot so we attempt to provide heavily optimized implementations
+   * depending on what is available on the platform. The processor is the platform-optimized
+   * delegate for which all methods are delegated directly to.
+   */
+  private static final Processor processor = new SafeProcessor();
+
+  /**
+   * Maximum number of bytes per Java UTF-16 char in UTF-8.
+   *
+   * @see java.nio.charset.CharsetEncoder#maxBytesPerChar()
+   */
+  static final int MAX_BYTES_PER_CHAR = 3;
+
+  // These UTF-8 handling methods are copied from Guava's Utf8 class with a modification to throw
+  // a protocol buffer local exception. This exception is then caught in CodedOutputStream so it can
+  // fallback to more lenient behavior.
+
+  static class UnpairedSurrogateException extends IllegalArgumentException {
+
+    private static final long serialVersionUID = 3903874482406618982L;
+
+    UnpairedSurrogateException(int index, int length) {
+      super("Unpaired surrogate at index " + index + " of " + length);
+    }
+  }
+
+  /**
+   * Returns the number of bytes in the UTF-8-encoded form of {@code sequence}. For a string, this
+   * method is equivalent to {@code string.getBytes(UTF_8).length}, but is more efficient in both
+   * time and space.
+   *
+   * @throws IllegalArgumentException if {@code sequence} contains ill-formed UTF-16 (unpaired
+   *     surrogates)
+   */
+  static int encodedLength(CharSequence sequence) {
+    // Warning to maintainers: this implementation is highly optimized.
+    int utf16Length = sequence.length();
+    int utf8Length = utf16Length;
+    int i = 0;
+
+    // This loop optimizes for pure ASCII.
+    while (i < utf16Length && sequence.charAt(i) < 0x80) {
+      i++;
+    }
+
+    // This loop optimizes for chars less than 0x800.
+    for (; i < utf16Length; i++) {
+      char c = sequence.charAt(i);
+      if (c < 0x800) {
+        utf8Length += ((0x7f - c) >>> 31); // branch free!
+      } else {
+        utf8Length += encodedLengthGeneral(sequence, i);
+        break;
+      }
+    }
+
+    if (utf8Length < utf16Length) {
+      // Necessary and sufficient condition for overflow because of maximum 3x expansion
+      throw new IllegalArgumentException(
+          "UTF-8 length does not fit in int: " + (utf8Length + (1L << 32)));
+    }
+    return utf8Length;
+  }
+
+  private static int encodedLengthGeneral(CharSequence sequence, int start) {
+    int utf16Length = sequence.length();
+    int utf8Length = 0;
+    for (int i = start; i < utf16Length; i++) {
+      char c = sequence.charAt(i);
+      if (c < 0x800) {
+        utf8Length += (0x7f - c) >>> 31; // branch free!
+      } else {
+        utf8Length += 2;
+        // jdk7+: if (Character.isSurrogate(c)) {
+        if (MIN_SURROGATE <= c && c <= MAX_SURROGATE) {
+          // Check that we have a well-formed surrogate pair.
+          int cp = Character.codePointAt(sequence, i);
+          if (cp < MIN_SUPPLEMENTARY_CODE_POINT) {
+            throw new UnpairedSurrogateException(i, utf16Length);
+          }
+          i++;
+        }
+      }
+    }
+    return utf8Length;
+  }
+
+  static int encode(CharSequence in, byte[] out, int offset, int length) {
+    return processor.encodeUtf8(in, out, offset, length);
+  }
+  // End Guava UTF-8 methods.
+
+  /** A processor of UTF-8 strings, providing methods for checking validity and encoding. */
+  // TODO(nathanmittler): Add support for Memory/MemoryBlock on Android.
+  abstract static class Processor {
+
+    abstract int encodeUtf8(CharSequence in, byte[] out, int offset, int length);
+  }
+
+  /** {@link Processor} implementation that does not use any {@code sun.misc.Unsafe} methods. */
+  static final class SafeProcessor extends Processor {
+
+    @Override
+    int encodeUtf8(CharSequence in, byte[] out, int offset, int length) {
+      int utf16Length = in.length();
+      int j = offset;
+      int i = 0;
+      int limit = offset + length;
+      // Designed to take advantage of
+      // https://wiki.openjdk.java.net/display/HotSpotInternals/RangeCheckElimination
+      for (char c; i < utf16Length && i + j < limit && (c = in.charAt(i)) < 0x80; i++) {
+        out[j + i] = (byte) c;
+      }
+      if (i == utf16Length) {
+        return j + utf16Length;
+      }
+      j += i;
+      for (char c; i < utf16Length; i++) {
+        c = in.charAt(i);
+        if (c < 0x80 && j < limit) {
+          out[j++] = (byte) c;
+        } else if (c < 0x800 && j <= limit - 2) { // 11 bits, two UTF-8 bytes
+          out[j++] = (byte) ((0xF << 6) | (c >>> 6));
+          out[j++] = (byte) (0x80 | (0x3F & c));
+        } else if ((c < MIN_SURROGATE || MAX_SURROGATE < c) && j <= limit - 3) {
+          // Maximum single-char code point is 0xFFFF, 16 bits, three UTF-8 bytes
+          out[j++] = (byte) ((0xF << 5) | (c >>> 12));
+          out[j++] = (byte) (0x80 | (0x3F & (c >>> 6)));
+          out[j++] = (byte) (0x80 | (0x3F & c));
+        } else if (j <= limit - 4) {
+          // Minimum code point represented by a surrogate pair is 0x10000, 17 bits,
+          // four UTF-8 bytes
+          final char low;
+          if (i + 1 == in.length() || !isSurrogatePair(c, (low = in.charAt(++i)))) {
+            throw new UnpairedSurrogateException((i - 1), utf16Length);
+          }
+          int codePoint = toCodePoint(c, low);
+          out[j++] = (byte) ((0xF << 4) | (codePoint >>> 18));
+          out[j++] = (byte) (0x80 | (0x3F & (codePoint >>> 12)));
+          out[j++] = (byte) (0x80 | (0x3F & (codePoint >>> 6)));
+          out[j++] = (byte) (0x80 | (0x3F & codePoint));
+        } else {
+          // If we are surrogates and we're not a surrogate pair, always throw an
+          // UnpairedSurrogateException instead of an ArrayOutOfBoundsException.
+          if ((MIN_SURROGATE <= c && c <= MAX_SURROGATE)
+              && (i + 1 == in.length() || !isSurrogatePair(c, in.charAt(i + 1)))) {
+            throw new UnpairedSurrogateException(i, utf16Length);
+          }
+          throw new ArrayIndexOutOfBoundsException("Failed writing " + c + " at index " + j);
+        }
+      }
+      return j;
+    }
+  }
+
+  private Utf8() {}
+}

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/Utf8.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/Utf8.java
@@ -3,6 +3,37 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Includes work from:
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 package io.opentelemetry.exporter.otlp.trace;
 
 import static java.lang.Character.MAX_SURROGATE;

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/WireFormat.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/WireFormat.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.trace;
+
+// Copied from
+// https://github.com/protocolbuffers/protobuf/blob/master/java/core/src/main/java/com/google/protobuf/WireFormat.java
+//
+// Unneeded lines of code are deleted as is, without any modifications otherwise.
+final class WireFormat {
+
+  static final int FIXED32_SIZE = 4;
+  static final int FIXED64_SIZE = 8;
+  static final int MAX_VARINT32_SIZE = 5;
+  static final int MAX_VARINT64_SIZE = 10;
+  static final int MAX_VARINT_SIZE = 10;
+
+  static final int WIRETYPE_VARINT = 0;
+  static final int WIRETYPE_FIXED64 = 1;
+  static final int WIRETYPE_LENGTH_DELIMITED = 2;
+  static final int WIRETYPE_FIXED32 = 5;
+
+  static final int TAG_TYPE_BITS = 3;
+  static final int TAG_TYPE_MASK = (1 << TAG_TYPE_BITS) - 1;
+
+  /** Makes a tag value given a field number and wire type. */
+  static int makeTag(final int fieldNumber, final int wireType) {
+    return (fieldNumber << TAG_TYPE_BITS) | wireType;
+  }
+
+  private WireFormat() {}
+}

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/WireFormat.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/WireFormat.java
@@ -3,6 +3,37 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Includes work from:
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 package io.opentelemetry.exporter.otlp.trace;
 
 // Copied from


### PR DESCRIPTION
… dependency

Because we only use the version of CodedOutputStream that writes to an OutputStream in both gRPC and okhttp marshalers, this only vendors in that version. We end up with about 1300 loc for the coder - by saying goodbye to the 700KB protobuflite or 1.5MB protobuf libraries, I think this is worth it as binary size will not be a reason to avoid the proto serializer. Checking the class files locally, it's about 23KB of uncompressed code. This is a lot smaller than jackson-core too for reference which would likely be our dependency for a JSON encoding approach. The code is 99.9% copied as-is, just with much deletion, and one line with a boolean check on unsafe removed.

@jsuereth called it that removing the buffering slowed things down (the approach I took was to remove the `AbstractBuffered` and replacing writes to the buffer with `out.write`). So didn't write anything custom, the code is as-is. Will follow up with some ideas for actually making changes to improve the performance, for example threadlocal reused CodedOutputStream and checking the varint encoding.

I removed support for Unsafe to reduce the amount of code vendored and because it performs significantly better without it :O I guess Unsafe is really for the byte buffers, byte arrays are very fast on the JVM already.

After
```
Benchmark                                                                         (numSpans)  Mode  Cnt      Score      Error   Units
MarshalerInputStreamBenchmarks.marshalToByteArray                                         16  avgt   10     13.004 ±    0.346   us/op
MarshalerInputStreamBenchmarks.marshalToByteArray:·gc.alloc.rate                          16  avgt   10   1432.026 ±   36.460  MB/sec
MarshalerInputStreamBenchmarks.marshalToByteArray:·gc.alloc.rate.norm                     16  avgt   10  29304.005 ±    0.001    B/op
MarshalerInputStreamBenchmarks.marshalToByteArray:·gc.churn.G1_Eden_Space                 16  avgt   10   1434.033 ±   78.589  MB/sec
MarshalerInputStreamBenchmarks.marshalToByteArray:·gc.churn.G1_Eden_Space.norm            16  avgt   10  29341.737 ± 1246.071    B/op
MarshalerInputStreamBenchmarks.marshalToByteArray:·gc.churn.G1_Old_Gen                    16  avgt   10      0.008 ±    0.007  MB/sec
MarshalerInputStreamBenchmarks.marshalToByteArray:·gc.churn.G1_Old_Gen.norm               16  avgt   10      0.171 ±    0.147    B/op
MarshalerInputStreamBenchmarks.marshalToByteArray:·gc.count                               16  avgt   10    118.000             counts
MarshalerInputStreamBenchmarks.marshalToByteArray:·gc.time                                16  avgt   10     50.000                 ms
MarshalerInputStreamBenchmarks.marshalToNettyBuffer                                       16  avgt   10     12.745 ±    0.264   us/op
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.alloc.rate                        16  avgt   10   1174.283 ±   23.607  MB/sec
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.alloc.rate.norm                   16  avgt   10  23574.688 ±    0.334    B/op
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.churn.G1_Eden_Space               16  avgt   10   1187.772 ±  126.440  MB/sec
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.churn.G1_Eden_Space.norm          16  avgt   10  23833.664 ± 2205.844    B/op
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.churn.G1_Old_Gen                  16  avgt   10      0.017 ±    0.008  MB/sec
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.churn.G1_Old_Gen.norm             16  avgt   10      0.339 ±    0.157    B/op
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.count                             16  avgt   10     81.000             counts
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.time                              16  avgt   10     37.000                 ms
```

Before
```
Benchmark                                                                         (numSpans)  Mode  Cnt      Score     Error   Units
MarshalerInputStreamBenchmarks.marshalToByteArray                                         16  avgt   10     15.420 ±   0.251   us/op
MarshalerInputStreamBenchmarks.marshalToByteArray:·gc.alloc.rate                          16  avgt   10   1208.283 ±  18.331  MB/sec
MarshalerInputStreamBenchmarks.marshalToByteArray:·gc.alloc.rate.norm                     16  avgt   10  29344.006 ±   0.001    B/op
MarshalerInputStreamBenchmarks.marshalToByteArray:·gc.churn.G1_Eden_Space                 16  avgt   10   1214.766 ±   2.780  MB/sec
MarshalerInputStreamBenchmarks.marshalToByteArray:·gc.churn.G1_Eden_Space.norm            16  avgt   10  29504.403 ± 496.366    B/op
MarshalerInputStreamBenchmarks.marshalToByteArray:·gc.churn.G1_Old_Gen                    16  avgt   10      0.032 ±   0.013  MB/sec
MarshalerInputStreamBenchmarks.marshalToByteArray:·gc.churn.G1_Old_Gen.norm               16  avgt   10      0.769 ±   0.312    B/op
MarshalerInputStreamBenchmarks.marshalToByteArray:·gc.count                               16  avgt   10    100.000            counts
MarshalerInputStreamBenchmarks.marshalToByteArray:·gc.time                                16  avgt   10     43.000                ms
MarshalerInputStreamBenchmarks.marshalToNettyBuffer                                       16  avgt   10     15.537 ±   0.564   us/op
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.alloc.rate                        16  avgt   10    965.034 ±  34.576  MB/sec
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.alloc.rate.norm                   16  avgt   10  23606.519 ±   0.279    B/op
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.churn.G1_Eden_Space               16  avgt   10    972.034 ±   2.482  MB/sec
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.churn.G1_Eden_Space.norm          16  avgt   10  23789.728 ± 850.649    B/op
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.churn.G1_Old_Gen                  16  avgt   10      0.015 ±   0.007  MB/sec
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.churn.G1_Old_Gen.norm             16  avgt   10      0.368 ±   0.161    B/op
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.count                             16  avgt   10     80.000            counts
MarshalerInputStreamBenchmarks.marshalToNettyBuffer:·gc.time                              16  avgt   10     32.000                ms
```