### PR TITLE
Make proto dependency in otlp-common compileOnly.

### DIFF
--- a/exporters/logging-otlp/build.gradle.kts
+++ b/exporters/logging-otlp/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
   compileOnly(project(":sdk:metrics"))
 
   implementation(project(":exporters:otlp:common"))
+  implementation(project(":proto"))
 
   implementation("org.curioswitch.curiostack:protobuf-jackson")
 

--- a/exporters/otlp-http/metrics/build.gradle.kts
+++ b/exporters/otlp-http/metrics/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
   api(project(":sdk:metrics"))
 
   implementation(project(":exporters:otlp:common"))
+  implementation(project(":proto"))
 
   implementation("com.squareup.okhttp3:okhttp")
   implementation("com.squareup.okhttp3:okhttp-tls")

--- a/exporters/otlp-http/trace/build.gradle.kts
+++ b/exporters/otlp-http/trace/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
   api(project(":sdk:trace"))
 
   implementation(project(":exporters:otlp:common"))
+  implementation(project(":proto"))
 
   implementation("com.squareup.okhttp3:okhttp")
   implementation("com.squareup.okhttp3:okhttp-tls")

--- a/exporters/otlp/common/build.gradle.kts
+++ b/exporters/otlp/common/build.gradle.kts
@@ -11,17 +11,24 @@ otelJava.moduleName.set("io.opentelemetry.exporter.otlp.internal")
 
 dependencies {
   api(project(":api:all"))
-  api(project(":proto"))
   api(project(":sdk:all"))
   api(project(":sdk:metrics"))
 
+  // We only use the protos for HTTP, logging-otlp, and metric export for now. Let them expose the
+  // proto dependency in their POMs instead of here. This is fine because this artifact only
+  // contains internal code.
+  compileOnly(project(":proto"))
+
   implementation("com.google.protobuf:protobuf-java")
 
+  // Similar to above note about :proto, we include a helper shared by the gRPC exporters but do not
+  // want to impose the gRPC dependency on all of our consumers.
   compileOnly("io.grpc:grpc-netty")
   compileOnly("io.grpc:grpc-netty-shaded")
   compileOnly("io.grpc:grpc-okhttp")
   compileOnly("io.grpc:grpc-stub")
 
+  testImplementation(project(":proto"))
   testImplementation(project(":sdk:testing"))
 
   testImplementation("com.google.api.grpc:proto-google-common-protos")

--- a/exporters/otlp/metrics/build.gradle.kts
+++ b/exporters/otlp/metrics/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
   api(project(":sdk:metrics"))
 
   implementation(project(":exporters:otlp:common"))
+  implementation(project(":proto"))
 
   api("io.grpc:grpc-stub")
   implementation("io.grpc:grpc-api")

--- a/exporters/otlp/trace/build.gradle.kts
+++ b/exporters/otlp/trace/build.gradle.kts
@@ -25,9 +25,7 @@ dependencies {
 
   implementation(project(":api:metrics"))
 
-  implementation(project(":exporters:otlp:common")) {
-    exclude(mapOf("module" to "proto"))
-  }
+  implementation(project(":exporters:otlp:common"))
 
   implementation("com.google.protobuf:protobuf-java")
 


### PR DESCRIPTION
This is a bit of a mess but will get cleaned up after 1) migrating HTTP exporter to TraceMarshaler (coming soon after #3519) and 2) Adding a MetricMarshaler (coming eventually). On the bright side, forgetting to add `:proto` where it's needed results in a quick compile failure.