### PR TITLE
Add OTLP protocol configurability to autoconfigure

### DIFF
--- a/exporters/otlp-http/build.gradle.kts
+++ b/exporters/otlp-http/build.gradle.kts
@@ -1,8 +1,10 @@
 subprojects {
-    val proj = this
-    plugins.withId("java") {
-        configure<BasePluginConvention> {
-            archivesBaseName = "opentelemetry-exporter-otlp-http-${proj.name}"
-        }
-    }
+  // Workaround https://github.com/gradle/gradle/issues/847
+  group = "io.opentelemetry.exporter.otlp.http"
+  val proj = this
+  plugins.withId("java") {
+      configure<BasePluginConvention> {
+          archivesBaseName = "opentelemetry-exporter-otlp-http-${proj.name}"
+      }
+  }
 }

--- a/exporters/otlp/build.gradle.kts
+++ b/exporters/otlp/build.gradle.kts
@@ -1,4 +1,6 @@
 subprojects {
+  // Workaround https://github.com/gradle/gradle/issues/847
+  group = "io.opentelemetry.exporter.otlp"
   val proj = this
   plugins.withId("java") {
     configure<BasePluginConvention> {

--- a/sdk-extensions/autoconfigure/README.md
+++ b/sdk-extensions/autoconfigure/README.md
@@ -62,6 +62,9 @@ The [OpenTelemetry Protocol (OTLP)](https://github.com/open-telemetry/openteleme
 | otel.exporter.otlp.timeout   | OTEL_EXPORTER_OTLP_TIMEOUT  | The maximum waiting time, in milliseconds, allowed to send each OTLP trace and metric batch. Default is `10000`.  |
 | otel.exporter.otlp.traces.timeout   | OTEL_EXPORTER_OTLP_TRACES_TIMEOUT  | The maximum waiting time, in milliseconds, allowed to send each OTLP trace batch. Default is `10000`.  |
 | otel.exporter.otlp.metrics.timeout   | OTEL_EXPORTER_OTLP_METRICS_TIMEOUT  | The maximum waiting time, in milliseconds, allowed to send each OTLP metric batch. Default is `10000`.  |
+| otel.experimental.exporter.otlp.protocol | OTEL_EXPERIMENTAL_EXPORTER_OTLP_PROTOCOL | The transport protocol to use on OTLP trace and metrics requests. Options include `grpc` and `http/protobuf`. Default is `grpc`. |
+| otel.experimental.exporter.otlp.traces.protocol | OTEL_EXPERIMENTAL_EXPORTER_OTLP_TRACES_PROTOCOL | The transport protocol to use on OTLP trace requests. Options include `grpc` and `http/protobuf`. Default is `grpc`. |
+| otel.experimental.exporter.otlp.metrics.protocol | OTEL_EXPERIMENTAL_EXPORTER_OTLP_METRICS_PROTOCOL | The transport protocol to use on OTLP metrics requests. Options include `grpc` and `http/protobuf`. Default is `grpc`. |
 
 To configure the service name for the OTLP exporter, add the `service.name` key
 to the OpenTelemetry Resource ([see below](#opentelemetry-resource)), e.g. `OTEL_RESOURCE_ATTRIBUTES=service.name=myservice`.

--- a/sdk-extensions/autoconfigure/build.gradle.kts
+++ b/sdk-extensions/autoconfigure/build.gradle.kts
@@ -30,6 +30,8 @@ dependencies {
   compileOnly(project(":exporters:logging"))
   compileOnly(project(":exporters:otlp:all"))
   compileOnly(project(":exporters:otlp:metrics"))
+  compileOnly(project(":exporters:otlp-http:trace"))
+  compileOnly(project(":exporters:otlp-http:metrics"))
   compileOnly(project(":exporters:prometheus"))
   compileOnly("io.prometheus:simpleclient_httpserver")
   compileOnly(project(":exporters:zipkin"))
@@ -56,6 +58,10 @@ dependencies {
 
   add("testOtlpImplementation", project(":exporters:otlp:all"))
   add("testOtlpImplementation", project(":exporters:otlp:metrics"))
+  add("testOtlpImplementation", project(":exporters:otlp-http:trace"))
+  add("testOtlpImplementation", project(":exporters:otlp-http:metrics"))
+  add("testOtlpImplementation", "com.squareup.okhttp3:okhttp")
+  add("testOtlpImplementation", "com.squareup.okhttp3:okhttp-tls")
   add("testOtlpImplementation", "org.bouncycastle:bcpkix-jdk15on")
 
   add("testJaegerImplementation", project(":exporters:jaeger"))

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
@@ -8,6 +8,8 @@ package io.opentelemetry.sdk.autoconfigure;
 import static io.opentelemetry.sdk.autoconfigure.OtlpConfigUtil.DATA_TYPE_METRICS;
 
 import io.opentelemetry.exporter.logging.LoggingMetricExporter;
+import io.opentelemetry.exporter.otlp.http.metric.OtlpHttpMetricExporter;
+import io.opentelemetry.exporter.otlp.http.metric.OtlpHttpMetricExporterBuilder;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder;
 import io.opentelemetry.exporter.prometheus.PrometheusCollector;
@@ -77,29 +79,58 @@ final class MetricExporterConfiguration {
 
   // Visible for testing
   @Nullable
-  static OtlpGrpcMetricExporter configureOtlpMetrics(
+  static MetricExporter configureOtlpMetrics(
       ConfigProperties config, SdkMeterProvider meterProvider) {
-    try {
-      ClasspathUtil.checkClassExists(
-          "io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter",
-          "OTLP Metrics Exporter",
-          "opentelemetry-exporter-otlp-metrics");
-    } catch (ConfigurationException e) {
-      // Squash this for now, until metrics are stable and included in the `exporter-otlp` artifact
-      // by default,
-      return null;
+    String protocol = OtlpConfigUtil.getOtlpProtocol(DATA_TYPE_METRICS, config);
+
+    MetricExporter exporter;
+    if (protocol.equals("http/protobuf")) {
+      try {
+        ClasspathUtil.checkClassExists(
+            "io.opentelemetry.exporter.otlp.http.metric.OtlpHttpMetricExporter",
+            "OTLP HTTP Metrics Exporter",
+            "opentelemetry-exporter-otlp-http-metrics");
+      } catch (ConfigurationException e) {
+        // Squash this for now, until metrics are stable
+        return null;
+      }
+      OtlpHttpMetricExporterBuilder builder = OtlpHttpMetricExporter.builder();
+
+      OtlpConfigUtil.configureOtlpExporterBuilder(
+          DATA_TYPE_METRICS,
+          config,
+          builder::setEndpoint,
+          builder::addHeader,
+          builder::setTimeout,
+          builder::setTrustedCertificates);
+
+      exporter = builder.build();
+    } else if (protocol.equals("grpc")) {
+      try {
+        ClasspathUtil.checkClassExists(
+            "io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter",
+            "OTLP gRPC Metrics Exporter",
+            "opentelemetry-exporter-otlp-metrics");
+      } catch (ConfigurationException e) {
+        // Squash this for now, until metrics are stable and included in the `exporter-otlp`
+        // artifact
+        // by default,
+        return null;
+      }
+      OtlpGrpcMetricExporterBuilder builder = OtlpGrpcMetricExporter.builder();
+
+      OtlpConfigUtil.configureOtlpExporterBuilder(
+          DATA_TYPE_METRICS,
+          config,
+          builder::setEndpoint,
+          builder::addHeader,
+          builder::setTimeout,
+          builder::setTrustedCertificates);
+
+      exporter = builder.build();
+    } else {
+      throw new ConfigurationException("Unsupported OTLP metrics protocol: " + protocol);
     }
-    OtlpGrpcMetricExporterBuilder builder = OtlpGrpcMetricExporter.builder();
-
-    OtlpConfigUtil.configureOtlpExporterBuilder(
-        DATA_TYPE_METRICS,
-        config,
-        builder::setEndpoint,
-        builder::addHeader,
-        builder::setTimeout,
-        builder::setTrustedCertificates);
-
-    OtlpGrpcMetricExporter exporter = builder.build();
 
     configureIntervalMetricReader(config, meterProvider, exporter);
 

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtil.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtil.java
@@ -19,6 +19,14 @@ final class OtlpConfigUtil {
   static final String DATA_TYPE_TRACES = "traces";
   static final String DATA_TYPE_METRICS = "metrics";
 
+  static String getOtlpProtocol(String dataType, ConfigProperties config) {
+    String protocol = config.getString("otel.experimental.exporter.otlp." + dataType + ".protocol");
+    if (protocol == null) {
+      protocol = config.getString("otel.experimental.exporter.otlp.protocol");
+    }
+    return (protocol == null) ? "grpc" : protocol;
+  }
+
   static void configureOtlpExporterBuilder(
       String dataType,
       ConfigProperties config,
@@ -26,7 +34,7 @@ final class OtlpConfigUtil {
       BiConsumer<String, String> addHeader,
       Consumer<Duration> setTimeout,
       Consumer<byte[]> setTrustedCertificates) {
-    String endpoint = config.getString(String.format("otel.exporter.otlp.%s.endpoint", dataType));
+    String endpoint = config.getString("otel.exporter.otlp." + dataType + ".endpoint");
     if (endpoint == null) {
       endpoint = config.getString("otel.exporter.otlp.endpoint");
     }
@@ -35,13 +43,13 @@ final class OtlpConfigUtil {
     }
 
     Map<String, String> headers =
-        config.getCommaSeparatedMap(String.format("otel.exporter.otlp.%s.headers", dataType));
+        config.getCommaSeparatedMap("otel.exporter.otlp." + dataType + ".headers");
     if (headers.isEmpty()) {
       headers = config.getCommaSeparatedMap("otel.exporter.otlp.headers");
     }
     headers.forEach(addHeader);
 
-    Duration timeout = config.getDuration(String.format("otel.exporter.otlp.%s.timeout", dataType));
+    Duration timeout = config.getDuration("otel.exporter.otlp." + dataType + ".timeout");
     if (timeout == null) {
       timeout = config.getDuration("otel.exporter.otlp.timeout");
     }
@@ -49,8 +57,7 @@ final class OtlpConfigUtil {
       setTimeout.accept(timeout);
     }
 
-    String certificate =
-        config.getString(String.format("otel.exporter.otlp.%s.certificate", dataType));
+    String certificate = config.getString("otel.exporter.otlp." + dataType + ".certificate");
     if (certificate == null) {
       certificate = config.getString("otel.exporter.otlp.certificate");
     }

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/NotOnClasspathTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/NotOnClasspathTest.java
@@ -18,11 +18,23 @@ class NotOnClasspathTest {
       DefaultConfigProperties.createForTest(Collections.emptyMap());
 
   @Test
-  void otlpSpans() {
+  void otlpGrpcSpans() {
     assertThatThrownBy(() -> SpanExporterConfiguration.configureExporter("otlp", EMPTY))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining(
-            "OTLP Trace Exporter enabled but opentelemetry-exporter-otlp not found on "
+            "OTLP gRPC Trace Exporter enabled but opentelemetry-exporter-otlp not found on "
+                + "classpath");
+  }
+
+  @Test
+  void otlpHttpSpans() {
+    ConfigProperties config =
+        DefaultConfigProperties.createForTest(
+            Collections.singletonMap("otel.experimental.exporter.otlp.protocol", "http/protobuf"));
+    assertThatThrownBy(() -> SpanExporterConfiguration.configureExporter("otlp", config))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining(
+            "OTLP HTTP Trace Exporter enabled but opentelemetry-exporter-otlp-http-trace not found on "
                 + "classpath");
   }
 
@@ -65,11 +77,23 @@ class NotOnClasspathTest {
   }
 
   @Test
-  void otlpMetrics() {
+  void otlpGrpcMetrics() {
     assertThatCode(
             () ->
                 MetricExporterConfiguration.configureExporter(
                     "otlp", EMPTY, SdkMeterProvider.builder().build()))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void otlpHttpMetrics() {
+    ConfigProperties config =
+        DefaultConfigProperties.createForTest(
+            Collections.singletonMap("otel.experimental.exporter.otlp.protocol", "http/protobuf"));
+    assertThatCode(
+            () ->
+                MetricExporterConfiguration.configureExporter(
+                    "otlp", config, SdkMeterProvider.builder().build()))
         .doesNotThrowAnyException();
   }
 

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtilTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtilTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import static io.opentelemetry.sdk.autoconfigure.OtlpConfigUtil.DATA_TYPE_TRACES;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class OtlpConfigUtilTest {
+
+  @Test
+  void getOtlpProtocolDefault() {
+    assertThat(
+            OtlpConfigUtil.getOtlpProtocol(
+                DATA_TYPE_TRACES, DefaultConfigProperties.createForTest(Collections.emptyMap())))
+        .isEqualTo("grpc");
+
+    assertThat(
+            OtlpConfigUtil.getOtlpProtocol(
+                DATA_TYPE_TRACES,
+                DefaultConfigProperties.createForTest(
+                    ImmutableMap.of("otel.experimental.exporter.otlp.protocol", "foo"))))
+        .isEqualTo("foo");
+
+    assertThat(
+            OtlpConfigUtil.getOtlpProtocol(
+                DATA_TYPE_TRACES,
+                DefaultConfigProperties.createForTest(
+                    ImmutableMap.of(
+                        "otel.experimental.exporter.otlp.protocol",
+                        "foo",
+                        "otel.experimental.exporter.otlp.traces.protocol",
+                        "bar"))))
+        .isEqualTo("bar");
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfigurationTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import org.junit.jupiter.api.Test;
+
+public class MetricExporterConfigurationTest {
+
+  @Test
+  void configureOtlpMetricsUnsupportedProtocol() {
+    assertThatThrownBy(
+            () ->
+                MetricExporterConfiguration.configureOtlpMetrics(
+                    DefaultConfigProperties.createForTest(
+                        ImmutableMap.of("otel.experimental.exporter.otlp.protocol", "foo")),
+                    SdkMeterProvider.builder().build()))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("Unsupported OTLP metrics protocol: foo");
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfigurationTest.java
@@ -6,7 +6,9 @@
 package io.opentelemetry.sdk.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
@@ -15,6 +17,17 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 class SpanExporterConfigurationTest {
+
+  @Test
+  void configureOtlpSpansUnsupportedProtocol() {
+    assertThatThrownBy(
+            () ->
+                SpanExporterConfiguration.configureOtlp(
+                    DefaultConfigProperties.createForTest(
+                        ImmutableMap.of("otel.experimental.exporter.otlp.protocol", "foo"))))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("Unsupported OTLP traces protocol: foo");
+  }
 
   // Timeout difficult to test using real exports so just check implementation detail here.
   @Test

--- a/sdk-extensions/autoconfigure/src/testOtlp/java/io/opentelemetry/sdk/autoconfigure/OtlpGrpcConfigTest.java
+++ b/sdk-extensions/autoconfigure/src/testOtlp/java/io/opentelemetry/sdk/autoconfigure/OtlpGrpcConfigTest.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import com.google.common.collect.Lists;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import io.grpc.stub.StreamObserver;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
+import io.opentelemetry.proto.collector.metrics.v1.MetricsServiceGrpc;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.LongSumData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.IntervalMetricReader;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.testing.trace.TestSpanData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class OtlpGrpcConfigTest {
+
+  private static final BlockingQueue<ExportTraceServiceRequest> traceRequests =
+      new LinkedBlockingDeque<>();
+  private static final BlockingQueue<ExportMetricsServiceRequest> metricRequests =
+      new LinkedBlockingDeque<>();
+  private static final BlockingQueue<RequestHeaders> requestHeaders = new LinkedBlockingDeque<>();
+
+  @RegisterExtension
+  @Order(1)
+  public static final SelfSignedCertificateExtension certificate =
+      new SelfSignedCertificateExtension();
+
+  @RegisterExtension
+  @Order(2)
+  public static final ServerExtension server =
+      new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+          sb.service(
+              GrpcService.builder()
+                  // OTLP spans
+                  .addService(
+                      new TraceServiceGrpc.TraceServiceImplBase() {
+                        @Override
+                        public void export(
+                            ExportTraceServiceRequest request,
+                            StreamObserver<ExportTraceServiceResponse> responseObserver) {
+                          traceRequests.add(request);
+                          responseObserver.onNext(ExportTraceServiceResponse.getDefaultInstance());
+                          responseObserver.onCompleted();
+                        }
+                      })
+                  // OTLP metrics
+                  .addService(
+                      new MetricsServiceGrpc.MetricsServiceImplBase() {
+                        @Override
+                        public void export(
+                            ExportMetricsServiceRequest request,
+                            StreamObserver<ExportMetricsServiceResponse> responseObserver) {
+                          if (request.getResourceMetricsCount() > 0) {
+                            metricRequests.add(request);
+                          }
+                          responseObserver.onNext(
+                              ExportMetricsServiceResponse.getDefaultInstance());
+                          responseObserver.onCompleted();
+                        }
+                      })
+                  .useBlockingTaskExecutor(true)
+                  .build());
+          sb.decorator(
+              (delegate, ctx, req) -> {
+                requestHeaders.add(req.headers());
+                return delegate.serve(ctx, req);
+              });
+          sb.tls(certificate.certificateFile(), certificate.privateKeyFile());
+        }
+      };
+
+  @BeforeEach
+  void setUp() {
+    traceRequests.clear();
+    metricRequests.clear();
+    requestHeaders.clear();
+    GlobalOpenTelemetry.resetForTest();
+    IntervalMetricReader.resetGlobalForTest();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    GlobalOpenTelemetry.resetForTest();
+    IntervalMetricReader.resetGlobalForTest();
+  }
+
+  @Test
+  void configureExportersGeneral() {
+    Map<String, String> props = new HashMap<>();
+    props.put("otel.exporter.otlp.endpoint", "https://localhost:" + server.httpsPort());
+    props.put("otel.exporter.otlp.certificate", certificate.certificateFile().getAbsolutePath());
+    props.put("otel.exporter.otlp.headers", "header-key=header-value");
+    props.put("otel.exporter.otlp.timeout", "15s");
+    ConfigProperties properties = DefaultConfigProperties.createForTest(props);
+    SpanExporter spanExporter = SpanExporterConfiguration.configureExporter("otlp", properties);
+    MetricExporter metricExporter =
+        MetricExporterConfiguration.configureOtlpMetrics(
+            properties, SdkMeterProvider.builder().build());
+
+    assertThat(spanExporter).extracting("timeoutNanos").isEqualTo(TimeUnit.SECONDS.toNanos(15));
+    assertThat(
+            spanExporter
+                .export(Lists.newArrayList(generateFakeSpan()))
+                .join(15, TimeUnit.SECONDS)
+                .isSuccess())
+        .isTrue();
+    assertThat(traceRequests).hasSize(1);
+    assertThat(requestHeaders)
+        .anyMatch(
+            headers ->
+                headers.contains(
+                        ":path", "/opentelemetry.proto.collector.trace.v1.TraceService/Export")
+                    && headers.contains("header-key", "header-value"));
+
+    assertThat(metricExporter).extracting("timeoutNanos").isEqualTo(TimeUnit.SECONDS.toNanos(15));
+    assertThat(
+            metricExporter
+                .export(Lists.newArrayList(generateFakeMetric()))
+                .join(15, TimeUnit.SECONDS)
+                .isSuccess())
+        .isTrue();
+    assertThat(metricRequests).hasSize(1);
+    assertThat(requestHeaders)
+        .anyMatch(
+            headers ->
+                headers.contains(
+                        ":path", "/opentelemetry.proto.collector.metrics.v1.MetricsService/Export")
+                    && headers.contains("header-key", "header-value"));
+  }
+
+  @Test
+  void configureSpanExporter() {
+    // Set values for general and signal specific properties. Signal specific should override
+    // general.
+    Map<String, String> props = new HashMap<>();
+    props.put("otel.exporter.otlp.endpoint", "http://foo.bar");
+    props.put("otel.exporter.otlp.certificate", Paths.get("foo", "bar", "baz").toString());
+    props.put("otel.exporter.otlp.headers", "header-key=dummy-value");
+    props.put("otel.exporter.otlp.timeout", "10s");
+    props.put("otel.exporter.otlp.traces.endpoint", "https://localhost:" + server.httpsPort());
+    props.put(
+        "otel.exporter.otlp.traces.certificate", certificate.certificateFile().getAbsolutePath());
+    props.put("otel.exporter.otlp.traces.headers", "header-key=header-value");
+    props.put("otel.exporter.otlp.traces.timeout", "15s");
+    SpanExporter spanExporter =
+        SpanExporterConfiguration.configureExporter(
+            "otlp", DefaultConfigProperties.createForTest(props));
+
+    assertThat(spanExporter).extracting("timeoutNanos").isEqualTo(TimeUnit.SECONDS.toNanos(15));
+    assertThat(
+            spanExporter
+                .export(Lists.newArrayList(generateFakeSpan()))
+                .join(10, TimeUnit.SECONDS)
+                .isSuccess())
+        .isTrue();
+    assertThat(traceRequests).hasSize(1);
+    assertThat(requestHeaders)
+        .anyMatch(
+            headers ->
+                headers.contains(
+                        ":path", "/opentelemetry.proto.collector.trace.v1.TraceService/Export")
+                    && headers.contains("header-key", "header-value"));
+  }
+
+  @Test
+  public void configureMetricExporter() {
+    // Set values for general and signal specific properties. Signal specific should override
+    // general.
+    Map<String, String> props = new HashMap<>();
+    props.put("otel.exporter.otlp.endpoint", "http://foo.bar");
+    props.put("otel.exporter.otlp.certificate", Paths.get("foo", "bar", "baz").toString());
+    props.put("otel.exporter.otlp.headers", "header-key=dummy-value");
+    props.put("otel.exporter.otlp.timeout", "10s");
+    props.put("otel.exporter.otlp.metrics.endpoint", "https://localhost:" + server.httpsPort());
+    props.put(
+        "otel.exporter.otlp.metrics.certificate", certificate.certificateFile().getAbsolutePath());
+    props.put("otel.exporter.otlp.metrics.headers", "header-key=header-value");
+    props.put("otel.exporter.otlp.metrics.timeout", "15s");
+    MetricExporter metricExporter =
+        MetricExporterConfiguration.configureOtlpMetrics(
+            DefaultConfigProperties.createForTest(props), SdkMeterProvider.builder().build());
+
+    assertThat(metricExporter).extracting("timeoutNanos").isEqualTo(TimeUnit.SECONDS.toNanos(15));
+    assertThat(
+            metricExporter
+                .export(Lists.newArrayList(generateFakeMetric()))
+                .join(15, TimeUnit.SECONDS)
+                .isSuccess())
+        .isTrue();
+    assertThat(metricRequests).hasSize(1);
+    assertThat(requestHeaders)
+        .anyMatch(
+            headers ->
+                headers.contains(
+                        ":path", "/opentelemetry.proto.collector.metrics.v1.MetricsService/Export")
+                    && headers.contains("header-key", "header-value"));
+  }
+
+  @Test
+  void configureTlsInvalidCertificatePath() {
+    Map<String, String> props = new HashMap<>();
+    props.put("otel.exporter.otlp.certificate", Paths.get("foo", "bar", "baz").toString());
+    ConfigProperties properties = DefaultConfigProperties.createForTest(props);
+
+    assertThatThrownBy(() -> SpanExporterConfiguration.configureExporter("otlp", properties))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("Invalid OTLP certificate path:");
+
+    assertThatThrownBy(
+            () ->
+                MetricExporterConfiguration.configureOtlpMetrics(
+                    properties, SdkMeterProvider.builder().build()))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("Invalid OTLP certificate path:");
+  }
+
+  private static SpanData generateFakeSpan() {
+    return TestSpanData.builder()
+        .setHasEnded(true)
+        .setName("name")
+        .setStartEpochNanos(MILLISECONDS.toNanos(System.currentTimeMillis()))
+        .setEndEpochNanos(MILLISECONDS.toNanos(System.currentTimeMillis()))
+        .setKind(SpanKind.SERVER)
+        .setStatus(StatusData.error())
+        .setTotalRecordedEvents(0)
+        .setTotalRecordedLinks(0)
+        .build();
+  }
+
+  private static MetricData generateFakeMetric() {
+    return MetricData.createLongSum(
+        Resource.empty(),
+        InstrumentationLibraryInfo.empty(),
+        "metric_name",
+        "metric_description",
+        "ms",
+        LongSumData.create(
+            false,
+            AggregationTemporality.CUMULATIVE,
+            Collections.singletonList(
+                LongPointData.create(
+                    MILLISECONDS.toNanos(System.currentTimeMillis()),
+                    MILLISECONDS.toNanos(System.currentTimeMillis()),
+                    Attributes.of(stringKey("key"), "value"),
+                    10))));
+  }
+
+  @Test
+  void configuresGlobal() {
+    // Protocol defaults to grpc but other tests may set system property to change it
+    System.setProperty("otel.experimental.exporter.otlp.protocol", "grpc");
+    System.setProperty("otel.exporter.otlp.endpoint", "https://localhost:" + server.httpsPort());
+    System.setProperty(
+        "otel.exporter.otlp.certificate", certificate.certificateFile().getAbsolutePath());
+    System.setProperty("otel.imr.export.interval", "1s");
+
+    GlobalOpenTelemetry.get().getTracer("test").spanBuilder("test").startSpan().end();
+
+    await()
+        .untilAsserted(
+            () -> {
+              assertThat(traceRequests).hasSize(1);
+
+              // Not well defined how many metric exports would have happened by now, check that
+              // any did. Metrics are recorded by OtlpGrpcSpanExporter, BatchSpanProcessor, and
+              // potentially others.
+              assertThat(metricRequests).isNotEmpty();
+            });
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testOtlp/java/io/opentelemetry/sdk/autoconfigure/OtlpHttpConfigTest.java
+++ b/sdk-extensions/autoconfigure/src/testOtlp/java/io/opentelemetry/sdk/autoconfigure/OtlpHttpConfigTest.java
@@ -7,26 +7,25 @@ package io.opentelemetry.sdk.autoconfigure;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 import com.google.common.collect.Lists;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.server.grpc.GrpcService;
-import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
-import io.grpc.stub.StreamObserver;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
-import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
-import io.opentelemetry.proto.collector.metrics.v1.MetricsServiceGrpc;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
-import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
-import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
@@ -40,6 +39,10 @@ import io.opentelemetry.sdk.testing.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
@@ -47,24 +50,45 @@ import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
+import okhttp3.OkHttpClient;
+import okhttp3.tls.HeldCertificate;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-class OtlpConfigTest {
+class OtlpHttpConfigTest {
 
-  private static final BlockingQueue<ExportTraceServiceRequest> otlpTraceRequests =
+  private static final BlockingQueue<ExportTraceServiceRequest> traceRequests =
       new LinkedBlockingDeque<>();
-  private static final BlockingQueue<ExportMetricsServiceRequest> otlpMetricsRequests =
+  private static final BlockingQueue<ExportMetricsServiceRequest> metricRequests =
       new LinkedBlockingDeque<>();
   private static final BlockingQueue<RequestHeaders> requestHeaders = new LinkedBlockingDeque<>();
 
   @RegisterExtension
   @Order(1)
-  public static final SelfSignedCertificateExtension certificate =
-      new SelfSignedCertificateExtension();
+  public static final CertificateExtension certificateExtension = new CertificateExtension();
+
+  private static class CertificateExtension implements BeforeAllCallback {
+    private HeldCertificate heldCertificate;
+    private String filePath;
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+      heldCertificate =
+          new HeldCertificate.Builder()
+              .commonName("localhost")
+              .addSubjectAlternativeName(InetAddress.getByName("localhost").getCanonicalHostName())
+              .build();
+      Path file = Files.createTempFile("test-cert", ".pem");
+      Files.write(file, heldCertificate.certificatePem().getBytes(StandardCharsets.UTF_8));
+      filePath = file.toAbsolutePath().toString();
+    }
+  }
 
   @RegisterExtension
   @Order(2)
@@ -73,49 +97,43 @@ class OtlpConfigTest {
         @Override
         protected void configure(ServerBuilder sb) {
           sb.service(
-              GrpcService.builder()
-                  // OTLP spans
-                  .addService(
-                      new TraceServiceGrpc.TraceServiceImplBase() {
-                        @Override
-                        public void export(
-                            ExportTraceServiceRequest request,
-                            StreamObserver<ExportTraceServiceResponse> responseObserver) {
-                          otlpTraceRequests.add(request);
-                          responseObserver.onNext(ExportTraceServiceResponse.getDefaultInstance());
-                          responseObserver.onCompleted();
-                        }
-                      })
-                  // OTLP metrics
-                  .addService(
-                      new MetricsServiceGrpc.MetricsServiceImplBase() {
-                        @Override
-                        public void export(
-                            ExportMetricsServiceRequest request,
-                            StreamObserver<ExportMetricsServiceResponse> responseObserver) {
-                          if (request.getResourceMetricsCount() > 0) {
-                            otlpMetricsRequests.add(request);
-                          }
-                          responseObserver.onNext(
-                              ExportMetricsServiceResponse.getDefaultInstance());
-                          responseObserver.onCompleted();
-                        }
-                      })
-                  .useBlockingTaskExecutor(true)
-                  .build());
-          sb.decorator(
-              (delegate, ctx, req) -> {
-                requestHeaders.add(req.headers());
-                return delegate.serve(ctx, req);
-              });
-          sb.tls(certificate.certificateFile(), certificate.privateKeyFile());
+                  "/v1/traces",
+                  httpService(traceRequests, ExportTraceServiceRequest.getDefaultInstance()))
+              .service(
+                  "/v1/metrics",
+                  httpService(metricRequests, ExportMetricsServiceRequest.getDefaultInstance()));
+          sb.tls(
+              certificateExtension.heldCertificate.keyPair().getPrivate(),
+              certificateExtension.heldCertificate.certificate());
         }
       };
 
+  @SuppressWarnings("unchecked")
+  private static <T extends Message> HttpService httpService(
+      BlockingQueue<T> queue, T defaultMessage) {
+    return (ctx, req) ->
+        HttpResponse.from(
+            req.aggregate()
+                .thenApply(
+                    aggReq -> {
+                      requestHeaders.add(aggReq.headers());
+                      try {
+                        queue.add(
+                            (T)
+                                defaultMessage
+                                    .getParserForType()
+                                    .parseFrom(aggReq.content().array()));
+                      } catch (InvalidProtocolBufferException e) {
+                        return HttpResponse.of(HttpStatus.BAD_REQUEST);
+                      }
+                      return HttpResponse.of(HttpStatus.OK);
+                    }));
+  }
+
   @BeforeEach
   void setUp() {
-    otlpTraceRequests.clear();
-    otlpMetricsRequests.clear();
+    traceRequests.clear();
+    metricRequests.clear();
     requestHeaders.clear();
     GlobalOpenTelemetry.resetForTest();
     IntervalMetricReader.resetGlobalForTest();
@@ -130,8 +148,10 @@ class OtlpConfigTest {
   @Test
   void configureExportersGeneral() {
     Map<String, String> props = new HashMap<>();
-    props.put("otel.exporter.otlp.endpoint", "https://localhost:" + server.httpsPort());
-    props.put("otel.exporter.otlp.certificate", certificate.certificateFile().getAbsolutePath());
+    props.put("otel.experimental.exporter.otlp.protocol", "http/protobuf");
+    props.put("otel.exporter.otlp.traces.endpoint", traceEndpoint());
+    props.put("otel.exporter.otlp.metrics.endpoint", metricEndpoint());
+    props.put("otel.exporter.otlp.certificate", certificateExtension.filePath);
     props.put("otel.exporter.otlp.headers", "header-key=header-value");
     props.put("otel.exporter.otlp.timeout", "15s");
     ConfigProperties properties = DefaultConfigProperties.createForTest(props);
@@ -140,34 +160,38 @@ class OtlpConfigTest {
         MetricExporterConfiguration.configureOtlpMetrics(
             properties, SdkMeterProvider.builder().build());
 
-    assertThat(spanExporter).extracting("timeoutNanos").isEqualTo(TimeUnit.SECONDS.toNanos(15));
+    assertThat(spanExporter)
+        .extracting("client", as(InstanceOfAssertFactories.type(OkHttpClient.class)))
+        .extracting(OkHttpClient::callTimeoutMillis)
+        .isEqualTo((int) TimeUnit.SECONDS.toMillis(15));
     assertThat(
             spanExporter
                 .export(Lists.newArrayList(generateFakeSpan()))
                 .join(15, TimeUnit.SECONDS)
                 .isSuccess())
         .isTrue();
-    assertThat(otlpTraceRequests).hasSize(1);
+    assertThat(traceRequests).hasSize(1);
     assertThat(requestHeaders)
         .anyMatch(
             headers ->
-                headers.contains(
-                        ":path", "/opentelemetry.proto.collector.trace.v1.TraceService/Export")
+                headers.contains(":path", "/v1/traces")
                     && headers.contains("header-key", "header-value"));
 
-    assertThat(metricExporter).extracting("timeoutNanos").isEqualTo(TimeUnit.SECONDS.toNanos(15));
+    assertThat(metricExporter)
+        .extracting("client", as(InstanceOfAssertFactories.type(OkHttpClient.class)))
+        .extracting(OkHttpClient::callTimeoutMillis)
+        .isEqualTo((int) TimeUnit.SECONDS.toMillis(15));
     assertThat(
             metricExporter
                 .export(Lists.newArrayList(generateFakeMetric()))
                 .join(15, TimeUnit.SECONDS)
                 .isSuccess())
         .isTrue();
-    assertThat(otlpMetricsRequests).hasSize(1);
+    assertThat(metricRequests).hasSize(1);
     assertThat(requestHeaders)
         .anyMatch(
             headers ->
-                headers.contains(
-                        ":path", "/opentelemetry.proto.collector.metrics.v1.MetricsService/Export")
+                headers.contains(":path", "/v1/metrics")
                     && headers.contains("header-key", "header-value"));
   }
 
@@ -176,32 +200,35 @@ class OtlpConfigTest {
     // Set values for general and signal specific properties. Signal specific should override
     // general.
     Map<String, String> props = new HashMap<>();
+    props.put("otel.experimental.exporter.otlp.protocol", "grpc");
+    props.put("otel.experimental.exporter.otlp.traces.protocol", "http/protobuf");
     props.put("otel.exporter.otlp.endpoint", "http://foo.bar");
     props.put("otel.exporter.otlp.certificate", Paths.get("foo", "bar", "baz").toString());
     props.put("otel.exporter.otlp.headers", "header-key=dummy-value");
     props.put("otel.exporter.otlp.timeout", "10s");
-    props.put("otel.exporter.otlp.traces.endpoint", "https://localhost:" + server.httpsPort());
-    props.put(
-        "otel.exporter.otlp.traces.certificate", certificate.certificateFile().getAbsolutePath());
+    props.put("otel.exporter.otlp.traces.endpoint", traceEndpoint());
+    props.put("otel.exporter.otlp.traces.certificate", certificateExtension.filePath);
     props.put("otel.exporter.otlp.traces.headers", "header-key=header-value");
     props.put("otel.exporter.otlp.traces.timeout", "15s");
     SpanExporter spanExporter =
         SpanExporterConfiguration.configureExporter(
             "otlp", DefaultConfigProperties.createForTest(props));
 
-    assertThat(spanExporter).extracting("timeoutNanos").isEqualTo(TimeUnit.SECONDS.toNanos(15));
+    assertThat(spanExporter)
+        .extracting("client", as(InstanceOfAssertFactories.type(OkHttpClient.class)))
+        .extracting(OkHttpClient::callTimeoutMillis)
+        .isEqualTo((int) TimeUnit.SECONDS.toMillis(15));
     assertThat(
             spanExporter
                 .export(Lists.newArrayList(generateFakeSpan()))
                 .join(10, TimeUnit.SECONDS)
                 .isSuccess())
         .isTrue();
-    assertThat(otlpTraceRequests).hasSize(1);
+    assertThat(traceRequests).hasSize(1);
     assertThat(requestHeaders)
         .anyMatch(
             headers ->
-                headers.contains(
-                        ":path", "/opentelemetry.proto.collector.trace.v1.TraceService/Export")
+                headers.contains(":path", "/v1/traces")
                     && headers.contains("header-key", "header-value"));
   }
 
@@ -210,38 +237,42 @@ class OtlpConfigTest {
     // Set values for general and signal specific properties. Signal specific should override
     // general.
     Map<String, String> props = new HashMap<>();
+    props.put("otel.experimental.exporter.otlp.protocol", "grpc");
+    props.put("otel.experimental.exporter.otlp.metrics.protocol", "http/protobuf");
     props.put("otel.exporter.otlp.endpoint", "http://foo.bar");
     props.put("otel.exporter.otlp.certificate", Paths.get("foo", "bar", "baz").toString());
     props.put("otel.exporter.otlp.headers", "header-key=dummy-value");
     props.put("otel.exporter.otlp.timeout", "10s");
-    props.put("otel.exporter.otlp.metrics.endpoint", "https://localhost:" + server.httpsPort());
-    props.put(
-        "otel.exporter.otlp.metrics.certificate", certificate.certificateFile().getAbsolutePath());
+    props.put("otel.exporter.otlp.metrics.endpoint", metricEndpoint());
+    props.put("otel.exporter.otlp.metrics.certificate", certificateExtension.filePath);
     props.put("otel.exporter.otlp.metrics.headers", "header-key=header-value");
     props.put("otel.exporter.otlp.metrics.timeout", "15s");
     MetricExporter metricExporter =
         MetricExporterConfiguration.configureOtlpMetrics(
             DefaultConfigProperties.createForTest(props), SdkMeterProvider.builder().build());
 
-    assertThat(metricExporter).extracting("timeoutNanos").isEqualTo(TimeUnit.SECONDS.toNanos(15));
+    assertThat(metricExporter)
+        .extracting("client", as(InstanceOfAssertFactories.type(OkHttpClient.class)))
+        .extracting(OkHttpClient::callTimeoutMillis)
+        .isEqualTo((int) TimeUnit.SECONDS.toMillis(15));
     assertThat(
             metricExporter
                 .export(Lists.newArrayList(generateFakeMetric()))
                 .join(15, TimeUnit.SECONDS)
                 .isSuccess())
         .isTrue();
-    assertThat(otlpMetricsRequests).hasSize(1);
+    assertThat(metricRequests).hasSize(1);
     assertThat(requestHeaders)
         .anyMatch(
             headers ->
-                headers.contains(
-                        ":path", "/opentelemetry.proto.collector.metrics.v1.MetricsService/Export")
+                headers.contains(":path", "/v1/metrics")
                     && headers.contains("header-key", "header-value"));
   }
 
   @Test
   void configureTlsInvalidCertificatePath() {
     Map<String, String> props = new HashMap<>();
+    props.put("otel.experimental.exporter.otlp.protocol", "http/protobuf");
     props.put("otel.exporter.otlp.certificate", Paths.get("foo", "bar", "baz").toString());
     ConfigProperties properties = DefaultConfigProperties.createForTest(props);
 
@@ -290,9 +321,10 @@ class OtlpConfigTest {
 
   @Test
   void configuresGlobal() {
-    System.setProperty("otel.exporter.otlp.endpoint", "https://localhost:" + server.httpsPort());
-    System.setProperty(
-        "otel.exporter.otlp.certificate", certificate.certificateFile().getAbsolutePath());
+    System.setProperty("otel.experimental.exporter.otlp.protocol", "http/protobuf");
+    System.setProperty("otel.exporter.otlp.traces.endpoint", traceEndpoint());
+    System.setProperty("otel.exporter.otlp.metrics.endpoint", metricEndpoint());
+    System.setProperty("otel.exporter.otlp.certificate", certificateExtension.filePath);
     System.setProperty("otel.imr.export.interval", "1s");
 
     GlobalOpenTelemetry.get().getTracer("test").spanBuilder("test").startSpan().end();
@@ -300,12 +332,20 @@ class OtlpConfigTest {
     await()
         .untilAsserted(
             () -> {
-              assertThat(otlpTraceRequests).hasSize(1);
+              assertThat(traceRequests).hasSize(1);
 
               // Not well defined how many metric exports would have happened by now, check that
-              // any did. Metrics are recorded by OtlpGrpcSpanExporter, BatchSpanProcessor, and
+              // any did. Metrics are recorded by OtlpHttpSpanExporter, BatchSpanProcessor, and
               // potentially others.
-              assertThat(otlpMetricsRequests).isNotEmpty();
+              assertThat(metricRequests).isNotEmpty();
             });
+  }
+
+  private static String traceEndpoint() {
+    return String.format("https://localhost:%s/v1/traces", server.httpsPort());
+  }
+
+  private static String metricEndpoint() {
+    return String.format("https://localhost:%s/v1/metrics", server.httpsPort());
   }
 }


### PR DESCRIPTION
Related to this [open spec issue](https://github.com/open-telemetry/opentelemetry-specification/issues/1879).

A note on the implementation: I was getting annoyed with how repetitive the configuration was for OTLP exporters. The extraction of config properties for OTLP grpc traces / metrics exporters is mostly the same. Adding support for protocol configurability of protocol means more copy / pasta or adding some abstraction. Went with adding an abstraction. 

I initially added a `OtlpExporterBuilder` interface located in `:exporters:otlp:common` with methods common across all the OTLP exporters, but ran into all sorts of `NoClassDefFoundError` errors I couldn't get past. The solution I landed is to have a method that accepts a bunch of consumers which are invoked after config properties are extracted. Its pretty clean IMO, with one downside being a method that accepts 6 arguments. 