### PR TITLE
Update the semantic conventions to 1.6.0

### DIFF
--- a/buildscripts/semantic-convention/generate.sh
+++ b/buildscripts/semantic-convention/generate.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../../"
 
 # freeze the spec & generator tools versions to make SemanticAttributes generation reproducible
-SEMCONV_VERSION=1.5.0
+SEMCONV_VERSION=1.6.0
 SPEC_VERSION=v$SEMCONV_VERSION
 SCHEMA_URL=https://opentelemetry.io/schemas/$SEMCONV_VERSION
 GENERATOR_VERSION=0.4.1

--- a/buildscripts/semantic-convention/templates/SemanticAttributes.java.j2
+++ b/buildscripts/semantic-convention/templates/SemanticAttributes.java.j2
@@ -89,7 +89,7 @@ public final class {{class}} {
   public static final class {{class_name}} {
     {%- for member in attribute.attr_type.members %}
       /** {% filter escape %}{{member.brief | to_doc_brief}}.{% endfilter %} */
-      public static final {{ type }} {{ member.member_id | to_const_name }} = {{ print_value(type, member.value) }};
+      public static final {{ type }} {{ member.member_id | to_const_name | regex_replace(" ", "_") | regex_replace("^([0-9])","_$1") }} = {{ print_value(type, member.value) }};
     {%- endfor %}
       private {{ class_name }}() {}
   }

--- a/semconv/src/main/java/io/opentelemetry/semconv/resource/attributes/ResourceAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/resource/attributes/ResourceAttributes.java
@@ -16,7 +16,7 @@ import java.util.List;
 // buildscripts/semantic-convention/templates/SemanticAttributes.java.j2
 public final class ResourceAttributes {
   /** The URL of the OpenTelemetry schema for these keys and values. */
-  public static final String SCHEMA_URL = "https://opentelemetry.io/schemas/1.5.0";
+  public static final String SCHEMA_URL = "https://opentelemetry.io/schemas/1.6.0";
 
   /** Name of the cloud provider. */
   public static final AttributeKey<String> CLOUD_PROVIDER = stringKey("cloud.provider");
@@ -27,6 +27,7 @@ public final class ResourceAttributes {
   /**
    * The geographical region the resource is running. Refer to your provider's docs to see the
    * available regions, for example <a
+   * href="https://www.alibabacloud.com/help/doc-detail/40654.htm">Alibaba Cloud regions</a>, <a
    * href="https://aws.amazon.com/about-aws/global-infrastructure/regions_az/">AWS regions</a>, <a
    * href="https://azure.microsoft.com/en-us/global-infrastructure/geographies/">Azure regions</a>,
    * or <a href="https://cloud.google.com/about/locations">Google Cloud regions</a>.
@@ -40,7 +41,7 @@ public final class ResourceAttributes {
    * <p>Notes:
    *
    * <ul>
-   *   <li>Availability zones are called &quot;zones&quot; on Google Cloud.
+   *   <li>Availability zones are called &quot;zones&quot; on Alibaba Cloud and Google Cloud.
    * </ul>
    */
   public static final AttributeKey<String> CLOUD_AVAILABILITY_ZONE =
@@ -548,6 +549,8 @@ public final class ResourceAttributes {
 
   // Enum definitions
   public static final class CloudProviderValues {
+    /** Alibaba Cloud. */
+    public static final String ALIBABA_CLOUD = "alibaba_cloud";
     /** Amazon Web Services. */
     public static final String AWS = "aws";
     /** Microsoft Azure. */
@@ -559,6 +562,10 @@ public final class ResourceAttributes {
   }
 
   public static final class CloudPlatformValues {
+    /** Alibaba Cloud Elastic Compute Service. */
+    public static final String ALIBABA_CLOUD_ECS = "alibaba_cloud_ecs";
+    /** Alibaba Cloud Function Compute. */
+    public static final String ALIBABA_CLOUD_FC = "alibaba_cloud_fc";
     /** AWS Elastic Compute Cloud. */
     public static final String AWS_EC2 = "aws_ec2";
     /** AWS Elastic Container Service. */

--- a/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/SemanticAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/SemanticAttributes.java
@@ -18,7 +18,7 @@ import java.util.List;
 // buildscripts/semantic-convention/templates/SemanticAttributes.java.j2
 public final class SemanticAttributes {
   /** The URL of the OpenTelemetry schema for these keys and values. */
-  public static final String SCHEMA_URL = "https://opentelemetry.io/schemas/1.5.0";
+  public static final String SCHEMA_URL = "https://opentelemetry.io/schemas/1.6.0";
 
   /**
    * The full invoked ARN as provided on the {@code Context} passed to the function ({@code
@@ -343,6 +343,30 @@ public final class SemanticAttributes {
 
   /** Local hostname or similar, see note below. */
   public static final AttributeKey<String> NET_HOST_NAME = stringKey("net.host.name");
+
+  /** The internet connection type currently being used by the host. */
+  public static final AttributeKey<String> NET_HOST_CONNECTION_TYPE =
+      stringKey("net.host.connection.type");
+
+  /**
+   * This describes more details regarding the connection.type. It may be the type of cell
+   * technology connection, but it could be used for describing details about a wifi connection.
+   */
+  public static final AttributeKey<String> NET_HOST_CONNECTION_SUBTYPE =
+      stringKey("net.host.connection.subtype");
+
+  /** The name of the mobile carrier. */
+  public static final AttributeKey<String> NET_HOST_CARRIER_NAME =
+      stringKey("net.host.carrier.name");
+
+  /** The mobile carrier country code. */
+  public static final AttributeKey<String> NET_HOST_CARRIER_MCC = stringKey("net.host.carrier.mcc");
+
+  /** The mobile carrier network code. */
+  public static final AttributeKey<String> NET_HOST_CARRIER_MNC = stringKey("net.host.carrier.mnc");
+
+  /** The ISO 3166-1 alpha-2 2-character country code associated with the mobile carrier network. */
+  public static final AttributeKey<String> NET_HOST_CARRIER_ICC = stringKey("net.host.carrier.icc");
 
   /**
    * The <a href="../../resource/semantic_conventions/README.md#service">{@code service.name}</a> of
@@ -917,6 +941,8 @@ public final class SemanticAttributes {
   }
 
   public static final class FaasInvokedProviderValues {
+    /** Alibaba Cloud. */
+    public static final String ALIBABA_CLOUD = "alibaba_cloud";
     /** Amazon Web Services. */
     public static final String AWS = "aws";
     /** Microsoft Azure. */
@@ -944,6 +970,68 @@ public final class SemanticAttributes {
     public static final String OTHER = "other";
 
     private NetTransportValues() {}
+  }
+
+  public static final class NetHostConnectionTypeValues {
+    /** wifi. */
+    public static final String WIFI = "wifi";
+    /** wired. */
+    public static final String WIRED = "wired";
+    /** cell. */
+    public static final String CELL = "cell";
+    /** unavailable. */
+    public static final String UNAVAILABLE = "unavailable";
+    /** unknown. */
+    public static final String UNKNOWN = "unknown";
+
+    private NetHostConnectionTypeValues() {}
+  }
+
+  public static final class NetHostConnectionSubtypeValues {
+    /** GPRS. */
+    public static final String GPRS = "GPRS";
+    /** EDGE. */
+    public static final String EDGE = "EDGE";
+    /** UMTS. */
+    public static final String UMTS = "UMTS";
+    /** CDMA. */
+    public static final String CDMA = "CDMA";
+    /** EVDO_0. */
+    public static final String EVDO_0 = "EVDO_0";
+    /** EVDO_A. */
+    public static final String EVDO_A = "EVDO_A";
+    /** 1xRTT. */
+    public static final String _1XRTT = "1xRTT";
+    /** HSDPA. */
+    public static final String HSDPA = "HSDPA";
+    /** HSUPA. */
+    public static final String HSUPA = "HSUPA";
+    /** HSPA. */
+    public static final String HSPA = "HSPA";
+    /** IDEN. */
+    public static final String IDEN = "IDEN";
+    /** EVDO_B. */
+    public static final String EVDO_B = "EVDO_B";
+    /** LTE. */
+    public static final String LTE = "LTE";
+    /** EHRPD. */
+    public static final String EHRPD = "EHRPD";
+    /** HSPAP. */
+    public static final String HSPAP = "HSPAP";
+    /** GSM. */
+    public static final String GSM = "GSM";
+    /** TD_SCDMA. */
+    public static final String TD_SCDMA = "TD_SCDMA";
+    /** IWLAN. */
+    public static final String IWLAN = "IWLAN";
+    /** NR. */
+    public static final String NR = "NR";
+    /** NRNSA. */
+    public static final String NRNSA = "NRNSA";
+    /** LTE_CA. */
+    public static final String LTE_CA = "LTE_CA";
+
+    private NetHostConnectionSubtypeValues() {}
   }
 
   public static final class HttpFlavorValues {


### PR DESCRIPTION
I had to tweak the generator template a bit to account for some new constants that didn't map to java constant names.