### PR TITLE
Add missing API diff.

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-extension-kotlin.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-extension-kotlin.txt
@@ -1,2 +1,10 @@
 Comparing source compatibility of  against 
-No changes.
+===  UNCHANGED CLASS: PUBLIC FINAL io.opentelemetry.extension.kotlin.ContextExtensionsKt  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	***  MODIFIED ANNOTATION: kotlin.Metadata
+		---  REMOVED ELEMENT: xi=48 (-)
+		***  MODIFIED ELEMENT: mv=1,4,0 (<- 1,5,1)
+		===  UNCHANGED ELEMENT: k=2
+		===  UNCHANGED ELEMENT: d1=��&#xA;�&#xA;���&#xA;���&#xA;���&#xA;����&#xA;����0�*�0��&#xA;����0�*�0��&#xA;����0�*�0�¨��
+		===  UNCHANGED ELEMENT: d2=asContextElement,Lkotlin/coroutines/CoroutineContext;,Lio/opentelemetry/context/Context;,Lio/opentelemetry/context/ImplicitContextKeyed;,getOpenTelemetryContext,opentelemetry-extension-kotlin
+		+++  NEW ELEMENT: bv=1,0,3 (+)


### PR DESCRIPTION
A change was made to `:extensions:kotlin` without running the apidiff script.