### PR TITLE
Support comma separated list for exporters for otel.traces.exporter.

### DIFF
--- a/sdk-extensions/autoconfigure/README.md
+++ b/sdk-extensions/autoconfigure/README.md
@@ -39,7 +39,7 @@ The following configuration properties are common to all exporters:
 
 | System property | Environment variable | Purpose                                                                                                                                                 |
 |-----------------|----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
-| otel.traces.exporter   | OTEL_TRACES_EXPORTER        | The exporter to be used for tracing. Default is `otlp`. `none` means no autoconfigured exporter. |
+| otel.traces.exporter   | OTEL_TRACES_EXPORTER        | List of exporters to be used for tracing, separated by commas. Default is `otlp`. `none` means no autoconfigured exporter. |
 | otel.metrics.exporter   | OTEL_METRICS_EXPORTER        | The exporter to be used for metrics. Default is `otlp`. `none` means no autoconfigured exporter. |
 
 ### OTLP exporter (both span and metric exporters)

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/NotOnClasspathTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/NotOnClasspathTest.java
@@ -19,7 +19,9 @@ class NotOnClasspathTest {
 
   @Test
   void otlpSpans() {
-    assertThatThrownBy(() -> SpanExporterConfiguration.configureExporter("otlp", EMPTY))
+    assertThatThrownBy(
+            () ->
+                SpanExporterConfiguration.configureExporter("otlp", EMPTY, Collections.emptyMap()))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining(
             "OTLP Trace Exporter enabled but opentelemetry-exporter-otlp not found on "
@@ -28,7 +30,10 @@ class NotOnClasspathTest {
 
   @Test
   void jaeger() {
-    assertThatThrownBy(() -> SpanExporterConfiguration.configureExporter("jaeger", EMPTY))
+    assertThatThrownBy(
+            () ->
+                SpanExporterConfiguration.configureExporter(
+                    "jaeger", EMPTY, Collections.emptyMap()))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining(
             "Jaeger gRPC Exporter enabled but opentelemetry-exporter-jaeger not found on "
@@ -37,7 +42,10 @@ class NotOnClasspathTest {
 
   @Test
   void zipkin() {
-    assertThatThrownBy(() -> SpanExporterConfiguration.configureExporter("zipkin", EMPTY))
+    assertThatThrownBy(
+            () ->
+                SpanExporterConfiguration.configureExporter(
+                    "zipkin", EMPTY, Collections.emptyMap()))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining(
             "Zipkin Exporter enabled but opentelemetry-exporter-zipkin not found on classpath");
@@ -45,7 +53,10 @@ class NotOnClasspathTest {
 
   @Test
   void logging() {
-    assertThatThrownBy(() -> SpanExporterConfiguration.configureExporter("logging", EMPTY))
+    assertThatThrownBy(
+            () ->
+                SpanExporterConfiguration.configureExporter(
+                    "logging", EMPTY, Collections.emptyMap()))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining(
             "Logging Trace Exporter enabled but opentelemetry-exporter-logging not found on "

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
@@ -79,9 +79,9 @@ class TracerProviderConfigurationTest {
   }
 
   @Test
-  void configureSpanProcessor_empty() {
+  void configureBatchSpanProcessor_empty() {
     BatchSpanProcessor processor =
-        TracerProviderConfiguration.configureSpanProcessor(EMPTY, mockSpanExporter);
+        TracerProviderConfiguration.configureBatchSpanProcessor(EMPTY, mockSpanExporter);
 
     try {
       assertThat(processor)
@@ -107,7 +107,7 @@ class TracerProviderConfigurationTest {
   }
 
   @Test
-  void configureSpanProcessor_configured() {
+  void configureBatchSpanProcessor_configured() {
     Map<String, String> properties = new HashMap<>();
     properties.put("otel.bsp.schedule.delay", "100000");
     properties.put("otel.bsp.max.queue.size", "2");
@@ -115,7 +115,7 @@ class TracerProviderConfigurationTest {
     properties.put("otel.bsp.export.timeout", "4");
 
     BatchSpanProcessor processor =
-        TracerProviderConfiguration.configureSpanProcessor(
+        TracerProviderConfiguration.configureBatchSpanProcessor(
             DefaultConfigProperties.createForTest(properties), mockSpanExporter);
 
     try {

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
@@ -42,11 +42,12 @@ public class ConfigurableSpanExporterTest {
   @Test
   void configureSpanExporters_duplicates() {
     ConfigProperties config =
-        DefaultConfigProperties.createForTest(ImmutableMap.of("otel.traces.exporter", "otlp,otlp"));
+        DefaultConfigProperties.createForTest(
+            ImmutableMap.of("otel.traces.exporter", "otlp,otlp,logging"));
 
     assertThatThrownBy(() -> SpanExporterConfiguration.configureSpanExporters(config))
         .isInstanceOf(ConfigurationException.class)
-        .hasMessageContaining("otel.traces.exporter contains duplicates");
+        .hasMessageContaining("otel.traces.exporter contains duplicates: [otlp]");
   }
 
   @Test

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
@@ -10,26 +10,53 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Collections;
 import java.util.Map;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
 public class ConfigurableSpanExporterTest {
 
   @Test
-  void configuration() {
+  void configureSpanExporters_spiExporter() {
     ConfigProperties config =
-        DefaultConfigProperties.createForTest(ImmutableMap.of("test.option", "true"));
-    SpanExporter spanExporter = SpanExporterConfiguration.configureExporter("testExporter", config);
+        DefaultConfigProperties.createForTest(
+            ImmutableMap.of("test.option", "true", "otel.traces.exporter", "testExporter"));
+    Map<String, SpanExporter> exportersByName =
+        SpanExporterConfiguration.configureSpanExporters(config);
 
-    assertThat(spanExporter)
+    assertThat(exportersByName)
+        .hasSize(1)
+        .containsKey("testExporter")
+        .extracting(map -> map.get("testExporter"))
         .isInstanceOf(TestConfigurableSpanExporterProvider.TestSpanExporter.class)
         .extracting("config")
         .isSameAs(config);
+  }
+
+  @Test
+  void configureSpanExporters_duplicates() {
+    ConfigProperties config =
+        DefaultConfigProperties.createForTest(ImmutableMap.of("otel.traces.exporter", "otlp,otlp"));
+
+    assertThatThrownBy(() -> SpanExporterConfiguration.configureSpanExporters(config))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("otel.traces.exporter contains duplicates");
+  }
+
+  @Test
+  void configureSpanExporters_multipleWithNone() {
+    ConfigProperties config =
+        DefaultConfigProperties.createForTest(ImmutableMap.of("otel.traces.exporter", "otlp,none"));
+
+    assertThatThrownBy(() -> SpanExporterConfiguration.configureSpanExporters(config))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("otel.traces.exporter contains none along with other exporters");
   }
 
   @Test
@@ -37,32 +64,91 @@ public class ConfigurableSpanExporterTest {
     assertThatThrownBy(
             () ->
                 SpanExporterConfiguration.configureExporter(
-                    "catExporter", DefaultConfigProperties.createForTest(Collections.emptyMap())))
+                    "catExporter",
+                    DefaultConfigProperties.createForTest(Collections.emptyMap()),
+                    Collections.emptyMap()))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("catExporter");
   }
 
   @Test
-  void configureSpanProcessor_simpleSpanProcessor() {
+  void configureSpanProcessors_simpleSpanProcessor() {
     String exporterName = "logging";
     Map<String, String> propMap = Collections.singletonMap("otel.traces.exporter", exporterName);
     SpanExporter exporter = new LoggingSpanExporter();
     ConfigProperties properties = DefaultConfigProperties.createForTest(propMap);
 
     assertThat(
-            TracerProviderConfiguration.configureSpanProcessor(properties, exporter, exporterName))
+            TracerProviderConfiguration.configureSpanProcessors(
+                properties, ImmutableMap.of(exporterName, exporter)))
+        .hasSize(1)
+        .first()
         .isInstanceOf(SimpleSpanProcessor.class);
   }
 
   @Test
-  void configureSpanProcessor_batchSpanProcessor() {
+  void configureSpanProcessors_batchSpanProcessor() {
     String exporterName = "zipkin";
     Map<String, String> propMap = Collections.singletonMap("otel.traces.exporter", exporterName);
     SpanExporter exporter = ZipkinSpanExporter.builder().build();
     ConfigProperties properties = DefaultConfigProperties.createForTest(propMap);
 
     assertThat(
-            TracerProviderConfiguration.configureSpanProcessor(properties, exporter, exporterName))
+            TracerProviderConfiguration.configureSpanProcessors(
+                properties, ImmutableMap.of(exporterName, exporter)))
+        .hasSize(1)
+        .first()
         .isInstanceOf(BatchSpanProcessor.class);
+  }
+
+  @Test
+  void configureSpanProcessors_multipleExporters() {
+    SpanExporter otlpExporter = OtlpGrpcSpanExporter.builder().build();
+    SpanExporter zipkinExporter = ZipkinSpanExporter.builder().build();
+    ConfigProperties properties =
+        DefaultConfigProperties.createForTest(
+            Collections.singletonMap("otel.traces.exporter", "otlp,zipkin"));
+
+    assertThat(
+            TracerProviderConfiguration.configureSpanProcessors(
+                properties, ImmutableMap.of("otlp", otlpExporter, "zipkin", zipkinExporter)))
+        .hasSize(1)
+        .hasAtLeastOneElementOfType(BatchSpanProcessor.class)
+        .first()
+        .extracting("worker")
+        .extracting("spanExporter")
+        .asInstanceOf(InstanceOfAssertFactories.type(SpanExporter.class))
+        .satisfies(
+            spanExporter -> {
+              assertThat(spanExporter)
+                  .extracting(spanExporter1 -> spanExporter1.getClass().getSimpleName())
+                  .isEqualTo("MultiSpanExporter");
+              assertThat(spanExporter)
+                  .extracting("spanExporters")
+                  .asInstanceOf(InstanceOfAssertFactories.type(SpanExporter[].class))
+                  .satisfies(
+                      spanExporters -> {
+                        assertThat(spanExporters.length).isEqualTo(2);
+                        assertThat(spanExporters)
+                            .hasAtLeastOneElementOfType(ZipkinSpanExporter.class)
+                            .hasAtLeastOneElementOfType(OtlpGrpcSpanExporter.class);
+                      });
+            });
+  }
+
+  @Test
+  void configureSpanProcessors_multipleExportersWithLogging() {
+    SpanExporter loggingExporter = new LoggingSpanExporter();
+    SpanExporter zipkinExporter = ZipkinSpanExporter.builder().build();
+    ConfigProperties properties =
+        DefaultConfigProperties.createForTest(
+            Collections.singletonMap("otel.traces.exporter", "logging,zipkin"));
+
+    assertThat(
+            TracerProviderConfiguration.configureSpanProcessors(
+                properties, ImmutableMap.of("logging", loggingExporter, "zipkin", zipkinExporter)))
+        .hasSize(2)
+        .hasAtLeastOneElementOfType(SimpleSpanProcessor.class)
+        .hasAtLeastOneElementOfType(BatchSpanProcessor.class);
   }
 }

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfigurationTest.java
@@ -23,7 +23,8 @@ class SpanExporterConfigurationTest {
         SpanExporterConfiguration.configureExporter(
             "otlp",
             DefaultConfigProperties.createForTest(
-                Collections.singletonMap("otel.exporter.otlp.timeout", "10")));
+                Collections.singletonMap("otel.exporter.otlp.timeout", "10")),
+            Collections.emptyMap());
     try {
       assertThat(exporter)
           .isInstanceOfSatisfying(
@@ -44,7 +45,8 @@ class SpanExporterConfigurationTest {
         SpanExporterConfiguration.configureExporter(
             "jaeger",
             DefaultConfigProperties.createForTest(
-                Collections.singletonMap("otel.exporter.jaeger.timeout", "10")));
+                Collections.singletonMap("otel.exporter.jaeger.timeout", "10")),
+            Collections.emptyMap());
     try {
       assertThat(exporter)
           .isInstanceOfSatisfying(
@@ -65,7 +67,8 @@ class SpanExporterConfigurationTest {
         SpanExporterConfiguration.configureExporter(
             "zipkin",
             DefaultConfigProperties.createForTest(
-                Collections.singletonMap("otel.exporter.zipkin.timeout", "5s")));
+                Collections.singletonMap("otel.exporter.zipkin.timeout", "5s")),
+            Collections.emptyMap());
     try {
       assertThat(exporter).isNotNull();
     } finally {

--- a/sdk-extensions/autoconfigure/src/testOtlp/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigTest.java
+++ b/sdk-extensions/autoconfigure/src/testOtlp/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigTest.java
@@ -135,7 +135,8 @@ class OtlpConfigTest {
     props.put("otel.exporter.otlp.headers", "header-key=header-value");
     props.put("otel.exporter.otlp.timeout", "15s");
     ConfigProperties properties = DefaultConfigProperties.createForTest(props);
-    SpanExporter spanExporter = SpanExporterConfiguration.configureExporter("otlp", properties);
+    SpanExporter spanExporter =
+        SpanExporterConfiguration.configureExporter("otlp", properties, Collections.emptyMap());
     MetricExporter metricExporter =
         MetricExporterConfiguration.configureOtlpMetrics(
             properties, SdkMeterProvider.builder().build());
@@ -187,7 +188,7 @@ class OtlpConfigTest {
     props.put("otel.exporter.otlp.traces.timeout", "15s");
     SpanExporter spanExporter =
         SpanExporterConfiguration.configureExporter(
-            "otlp", DefaultConfigProperties.createForTest(props));
+            "otlp", DefaultConfigProperties.createForTest(props), Collections.emptyMap());
 
     assertThat(spanExporter).extracting("timeoutNanos").isEqualTo(TimeUnit.SECONDS.toNanos(15));
     assertThat(
@@ -245,7 +246,10 @@ class OtlpConfigTest {
     props.put("otel.exporter.otlp.certificate", Paths.get("foo", "bar", "baz").toString());
     ConfigProperties properties = DefaultConfigProperties.createForTest(props);
 
-    assertThatThrownBy(() -> SpanExporterConfiguration.configureExporter("otlp", properties))
+    assertThatThrownBy(
+            () ->
+                SpanExporterConfiguration.configureExporter(
+                    "otlp", properties, Collections.emptyMap()))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("Invalid OTLP certificate path:");
 


### PR DESCRIPTION
Resolves Issue #3443 .