### PR TITLE
Refactor package to io.opentelemetry.exporter.otlp.http.metrics for c…

### DIFF
--- a/exporters/otlp-http/metrics/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporter.java
+++ b/exporters/otlp-http/metrics/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporter.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.exporter.otlp.http.metric;
+package io.opentelemetry.exporter.otlp.http.metrics;
 
 import io.opentelemetry.exporter.otlp.internal.GrpcStatusUtil;
 import io.opentelemetry.exporter.otlp.internal.MetricAdapter;

--- a/exporters/otlp-http/metrics/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp-http/metrics/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.exporter.otlp.http.metric;
+package io.opentelemetry.exporter.otlp.http.metrics;
 
 import static io.opentelemetry.api.internal.Utils.checkArgument;
 import static java.util.Objects.requireNonNull;

--- a/exporters/otlp-http/metrics/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/package-info.java
+++ b/exporters/otlp-http/metrics/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/package-info.java
@@ -5,6 +5,6 @@
 
 /** OpenTelemetry exporter which sends metric data to OpenTelemetry collector via OTLP HTTP. */
 @ParametersAreNonnullByDefault
-package io.opentelemetry.exporter.otlp.http.metric;
+package io.opentelemetry.exporter.otlp.http.metrics;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/otlp-http/metrics/src/test/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterTest.java
+++ b/exporters/otlp-http/metrics/src/test/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.exporter.otlp.http.metric;
+package io.opentelemetry.exporter.otlp.http.metrics;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
@@ -8,8 +8,8 @@ package io.opentelemetry.sdk.autoconfigure;
 import static io.opentelemetry.sdk.autoconfigure.OtlpConfigUtil.DATA_TYPE_METRICS;
 
 import io.opentelemetry.exporter.logging.LoggingMetricExporter;
-import io.opentelemetry.exporter.otlp.http.metric.OtlpHttpMetricExporter;
-import io.opentelemetry.exporter.otlp.http.metric.OtlpHttpMetricExporterBuilder;
+import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
+import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder;
 import io.opentelemetry.exporter.prometheus.PrometheusCollector;
@@ -87,7 +87,7 @@ final class MetricExporterConfiguration {
     if (protocol.equals("http/protobuf")) {
       try {
         ClasspathUtil.checkClassExists(
-            "io.opentelemetry.exporter.otlp.http.metric.OtlpHttpMetricExporter",
+            "io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter",
             "OTLP HTTP Metrics Exporter",
             "opentelemetry-exporter-otlp-http-metrics");
       } catch (ConfigurationException e) {


### PR DESCRIPTION
The other metrics packages in the project are plural. This makes `:exporters:otlp-http:metrics` consistent. 

Better to make the change now while the number of consumers is small. Plus, this package is still in alpha. 