### PR TITLE
Add gradle ktfmt spotless config to all projects

### DIFF
--- a/all/build.gradle.kts
+++ b/all/build.gradle.kts
@@ -1,8 +1,7 @@
-plugins {
-  id("otel.java-conventions")
-}
+plugins { id("otel.java-conventions") }
 
 description = "OpenTelemetry All"
+
 otelJava.moduleName.set("io.opentelemetry.all")
 
 tasks {
@@ -10,15 +9,11 @@ tasks {
   // aggregating jacoco reports and it doesn't work if this isn't at least as high as the
   // highest supported Java version in any of our projects. Most of our projects target
   // Java 8, except for jfr-events.
-  withType(JavaCompile::class) {
-    options.release.set(11)
-  }
+  withType(JavaCompile::class) { options.release.set(11) }
 
   val testJavaVersion: String? by project
   if (testJavaVersion == "8") {
-    test {
-      enabled = false
-    }
+    test { enabled = false }
   }
 }
 
@@ -27,9 +22,7 @@ dependencies {
     // Generate aggregate coverage report for published modules that enable jacoco.
     subproject.plugins.withId("jacoco") {
       subproject.plugins.withId("maven-publish") {
-        implementation(project(subproject.path)) {
-          isTransitive = false
-        }
+        implementation(project(subproject.path)) { isTransitive = false }
       }
     }
   }
@@ -66,21 +59,25 @@ tasks.named<JacocoReport>("jacocoTestReport") {
   enabled = true
 
   configurations.runtimeClasspath.get().forEach {
-    additionalClassDirs(zipTree(it).filter {
-      // Exclude mrjar (jacoco complains), shaded, and generated code
-      !it.absolutePath.contains("META-INF/versions/") &&
-        !it.absolutePath.contains("/internal/shaded/") &&
-        !it.absolutePath.contains("io/opentelemetry/proto/") &&
-        !it.absolutePath.contains("io/opentelemetry/exporter/jaeger/proto/") &&
-        !it.absolutePath.contains("io/opentelemetry/sdk/extension/trace/jaeger/proto/") &&
-        !it.absolutePath.contains("io/opentelemetry/semconv/trace/attributes/") &&
-        !it.absolutePath.contains("AutoValue_") &&
-        // TODO(anuraaga): Remove exclusion after enabling coverage for jfr-events
-        !it.absolutePath.contains("io/opentelemetry/sdk/extension/jfr")
-    })
+    additionalClassDirs(
+      zipTree(it).filter {
+        // Exclude mrjar (jacoco complains), shaded, and generated code
+        !it.absolutePath.contains("META-INF/versions/") &&
+          !it.absolutePath.contains("/internal/shaded/") &&
+          !it.absolutePath.contains("io/opentelemetry/proto/") &&
+          !it.absolutePath.contains("io/opentelemetry/exporter/jaeger/proto/") &&
+          !it.absolutePath.contains("io/opentelemetry/sdk/extension/trace/jaeger/proto/") &&
+          !it.absolutePath.contains("io/opentelemetry/semconv/trace/attributes/") &&
+          !it.absolutePath.contains("AutoValue_") &&
+          // TODO(anuraaga): Remove exclusion after enabling coverage for jfr-events
+          !it.absolutePath.contains("io/opentelemetry/sdk/extension/jfr")
+      }
+    )
   }
   additionalSourceDirs(sourcesPath.incoming.artifactView { lenient(true) }.files)
-  executionData(coverageDataPath.incoming.artifactView { lenient(true) }.files.filter { it.exists() })
+  executionData(
+    coverageDataPath.incoming.artifactView { lenient(true) }.files.filter { it.exists() }
+  )
 
   reports {
     // xml is usually used to integrate code coverage with

--- a/api/all/build.gradle.kts
+++ b/api/all/build.gradle.kts
@@ -7,7 +7,9 @@ plugins {
 }
 
 description = "OpenTelemetry API"
+
 otelJava.moduleName.set("io.opentelemetry.api")
+
 base.archivesBaseName = "opentelemetry-api"
 
 dependencies {

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -3,8 +3,6 @@ subprojects {
   group = "io.opentelemetry.api"
   val proj = this
   plugins.withId("java") {
-    configure<BasePluginConvention> {
-      archivesBaseName = "opentelemetry-api-${proj.name}"
-    }
+    configure<BasePluginConvention> { archivesBaseName = "opentelemetry-api-${proj.name}" }
   }
 }

--- a/api/metrics/build.gradle.kts
+++ b/api/metrics/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 }
 
 description = "OpenTelemetry API"
+
 otelJava.moduleName.set("io.opentelemetry.api.metrics")
 
 dependencies {

--- a/bom-alpha/build.gradle.kts
+++ b/bom-alpha/build.gradle.kts
@@ -4,7 +4,9 @@ plugins {
 }
 
 description = "OpenTelemetry Bill of Materials (Alpha)"
+
 group = "io.opentelemetry"
+
 base.archivesBaseName = "opentelemetry-bom-alpha"
 
 rootProject.subprojects.forEach { subproject ->
@@ -16,15 +18,12 @@ rootProject.subprojects.forEach { subproject ->
 afterEvaluate {
   dependencies {
     constraints {
-      rootProject.subprojects
+      rootProject
+        .subprojects
         .sortedBy { it.findProperty("archivesBaseName") as String? }
         .filter { !it.name.startsWith("bom") }
         .filter { it.findProperty("otel.release") == "alpha" }
-        .forEach { project ->
-          project.plugins.withId("maven-publish") {
-            api(project)
-          }
-        }
+        .forEach { project -> project.plugins.withId("maven-publish") { api(project) } }
     }
   }
 }

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -4,7 +4,9 @@ plugins {
 }
 
 description = "OpenTelemetry Bill of Materials"
+
 group = "io.opentelemetry"
+
 base.archivesBaseName = "opentelemetry-bom"
 
 rootProject.subprojects.forEach { subproject ->
@@ -16,15 +18,12 @@ rootProject.subprojects.forEach { subproject ->
 afterEvaluate {
   dependencies {
     constraints {
-      rootProject.subprojects
+      rootProject
+        .subprojects
         .sortedBy { it.findProperty("archivesBaseName") as String? }
         .filter { !it.name.startsWith("bom") }
         .filter { !it.hasProperty("otel.release") }
-        .forEach { project ->
-          project.plugins.withId("maven-publish") {
-            api(project)
-          }
-        }
+        .forEach { project -> project.plugins.withId("maven-publish") { api(project) } }
     }
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
-import nebula.plugin.release.git.opinion.Strategies
 import java.time.Duration
+import nebula.plugin.release.git.opinion.Strategies
 
 plugins {
   id("com.diffplug.spotless")
@@ -9,28 +9,25 @@ plugins {
 }
 
 if (!JavaVersion.current().isJava11Compatible()) {
-  throw GradleException("JDK 11 or higher is required to build. " +
-    "One option is to download it from https://adoptopenjdk.net/. If you believe you already " +
-    "have it, please check that the JAVA_HOME environment variable is pointing at the " +
-    "JDK 11 installation.")
+  throw GradleException(
+    "JDK 11 or higher is required to build. " +
+      "One option is to download it from https://adoptopenjdk.net/. If you believe you already " +
+      "have it, please check that the JAVA_HOME environment variable is pointing at the " +
+      "JDK 11 installation."
+  )
 }
 
 // Nebula plugin will not configure if .git doesn't exist, let's allow building on it by stubbing it
 // out. This supports building from the zip archive downloaded from GitHub.
 var releaseTask: TaskProvider<Task>
-if (file(".git").exists()) {
-  release {
-    defaultVersionStrategy = Strategies.getSNAPSHOT()
-  }
 
-  nebulaRelease {
-    addReleaseBranchPattern("""v\d+\.\d+\.x""")
-  }
+if (file(".git").exists()) {
+  release { defaultVersionStrategy = Strategies.getSNAPSHOT() }
+
+  nebulaRelease { addReleaseBranchPattern("""v\d+\.\d+\.x""") }
 
   releaseTask = tasks.named("release")
-  releaseTask.configure {
-    mustRunAfter("snapshotSetup", "finalSetup")
-  }
+  releaseTask.configure { mustRunAfter("snapshotSetup", "finalSetup") }
 } else {
   releaseTask = tasks.register("release")
 }
@@ -56,6 +53,10 @@ nexusPublishing {
   }
 }
 
-subprojects {
-  group = "io.opentelemetry"
+allprojects {
+  apply(plugin = "com.diffplug.spotless")
+
+  spotless { kotlinGradle { ktfmt().googleStyle() } }
 }
+
+subprojects { group = "io.opentelemetry" }

--- a/context/build.gradle.kts
+++ b/context/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 }
 
 description = "OpenTelemetry Context (Incubator)"
+
 otelJava.moduleName.set("io.opentelemetry.context")
 
 testSets {
@@ -47,8 +48,14 @@ tasks {
   }
 
   named("check") {
-    dependsOn("grpcInOtelTest", "otelInGrpcTest", "braveInOtelTest", "otelInBraveTest",
-      "otelAsBraveTest", "storageWrappersTest", "strictContextEnabledTest")
+    dependsOn(
+      "grpcInOtelTest",
+      "otelInGrpcTest",
+      "braveInOtelTest",
+      "otelInBraveTest",
+      "otelAsBraveTest",
+      "storageWrappersTest",
+      "strictContextEnabledTest"
+    )
   }
 }
-

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -9,102 +9,84 @@ plugins {
 data class DependencySet(val group: String, val version: String, val modules: List<String>)
 
 val dependencyVersions = hashMapOf<String, String>()
+
 rootProject.extra["versions"] = dependencyVersions
 
-val DEPENDENCY_BOMS = listOf(
-  "com.fasterxml.jackson:jackson-bom:2.12.4",
-  "com.google.guava:guava-bom:30.1.1-jre",
-  "com.google.protobuf:protobuf-bom:3.17.3",
-  "com.linecorp.armeria:armeria-bom:1.9.2",
-  "com.squareup.okhttp3:okhttp-bom:4.9.1",
-  "io.grpc:grpc-bom:1.39.0",
-  "io.zipkin.brave:brave-bom:5.13.3",
-  "io.zipkin.reporter2:zipkin-reporter-bom:2.16.3",
-  "org.junit:junit-bom:5.7.2",
-  "org.testcontainers:testcontainers-bom:1.16.0"
-)
-
-val DEPENDENCY_SETS = listOf(
-  DependencySet(
-    "com.google.auto.value",
-    "1.8.2",
-    listOf("auto-value", "auto-value-annotations")
-  ),
-  DependencySet(
-    "com.google.errorprone",
-    "2.8.1",
-    listOf("error_prone_annotations", "error_prone_core")
-  ),
-  DependencySet(
-    "io.opencensus",
-    "0.28.3",
-    listOf(
-      "opencensus-api",
-      "opencensus-impl-core",
-      "opencensus-impl",
-      "opencensus-exporter-metrics-util"
-    )
-  ),
-  DependencySet(
-    "io.prometheus",
-    "0.11.0",
-    listOf("simpleclient", "simpleclient_common", "simpleclient_httpserver")
-  ),
-  DependencySet(
-    "javax.annotation",
-    "1.3.2",
-    listOf("javax.annotation-api")
-  ),
-  DependencySet(
-    "org.openjdk.jmh",
-    "1.33",
-    listOf("jmh-core", "jmh-generator-bytecode")
-  ),
-  DependencySet(
-    "org.jeasy",
-    "4.3.0",
-    listOf("easy-random-core", "easy-random-randomizers")
-  ),
-  DependencySet(
-    "org.mockito",
-    "3.11.2",
-    listOf("mockito-core", "mockito-junit-jupiter")
+val DEPENDENCY_BOMS =
+  listOf(
+    "com.fasterxml.jackson:jackson-bom:2.12.4",
+    "com.google.guava:guava-bom:30.1.1-jre",
+    "com.google.protobuf:protobuf-bom:3.17.3",
+    "com.linecorp.armeria:armeria-bom:1.9.2",
+    "com.squareup.okhttp3:okhttp-bom:4.9.1",
+    "io.grpc:grpc-bom:1.39.0",
+    "io.zipkin.brave:brave-bom:5.13.3",
+    "io.zipkin.reporter2:zipkin-reporter-bom:2.16.3",
+    "org.junit:junit-bom:5.7.2",
+    "org.testcontainers:testcontainers-bom:1.16.0"
   )
-)
 
-val DEPENDENCIES = listOf(
-  "com.github.stefanbirkner:system-rules:1.19.0",
-  "com.google.api.grpc:proto-google-common-protos:2.3.2",
-  "com.google.code.findbugs:jsr305:3.0.2",
-  "com.google.code.gson:gson:2.8.7",
-  "com.google.guava:guava-beta-checker:1.0",
-  "com.lmax:disruptor:3.4.4",
-  "com.squareup.okhttp3:okhttp:4.9.1",
-  "com.sun.net.httpserver:http:20070405",
-  "com.tngtech.archunit:archunit-junit4:0.20.1",
-  "com.uber.nullaway:nullaway:0.9.2",
-  "edu.berkeley.cs.jqf:jqf-fuzz:1.7",
-  "eu.rekawek.toxiproxy:toxiproxy-java:2.1.4",
-  "io.github.netmikey.logunit:logunit-jul:1.1.0",
-  "io.jaegertracing:jaeger-client:1.6.0",
-  "io.opentracing:opentracing-api:0.33.0",
-  "io.zipkin.zipkin2:zipkin-junit:2.23.2",
-  "junit:junit:4.13.2",
-  "nl.jqno.equalsverifier:equalsverifier:3.7.1",
-  "org.assertj:assertj-core:3.20.2",
-  "org.awaitility:awaitility:4.1.0",
-  "org.bouncycastle:bcpkix-jdk15on:1.69",
-  "org.codehaus.mojo:animal-sniffer-annotations:1.20",
-  "org.curioswitch.curiostack:protobuf-jackson:1.2.0",
-  "org.jctools:jctools-core:3.3.0",
-  "org.junit-pioneer:junit-pioneer:1.4.2",
-  "org.skyscreamer:jsonassert:1.5.0",
-  "org.slf4j:slf4j-simple:1.7.32"
-)
+val DEPENDENCY_SETS =
+  listOf(
+    DependencySet("com.google.auto.value", "1.8.2", listOf("auto-value", "auto-value-annotations")),
+    DependencySet(
+      "com.google.errorprone",
+      "2.8.1",
+      listOf("error_prone_annotations", "error_prone_core")
+    ),
+    DependencySet(
+      "io.opencensus",
+      "0.28.3",
+      listOf(
+        "opencensus-api",
+        "opencensus-impl-core",
+        "opencensus-impl",
+        "opencensus-exporter-metrics-util"
+      )
+    ),
+    DependencySet(
+      "io.prometheus",
+      "0.11.0",
+      listOf("simpleclient", "simpleclient_common", "simpleclient_httpserver")
+    ),
+    DependencySet("javax.annotation", "1.3.2", listOf("javax.annotation-api")),
+    DependencySet("org.openjdk.jmh", "1.33", listOf("jmh-core", "jmh-generator-bytecode")),
+    DependencySet("org.jeasy", "4.3.0", listOf("easy-random-core", "easy-random-randomizers")),
+    DependencySet("org.mockito", "3.11.2", listOf("mockito-core", "mockito-junit-jupiter"))
+  )
 
-javaPlatform {
-  allowDependencies()
-}
+val DEPENDENCIES =
+  listOf(
+    "com.github.stefanbirkner:system-rules:1.19.0",
+    "com.google.api.grpc:proto-google-common-protos:2.3.2",
+    "com.google.code.findbugs:jsr305:3.0.2",
+    "com.google.code.gson:gson:2.8.7",
+    "com.google.guava:guava-beta-checker:1.0",
+    "com.lmax:disruptor:3.4.4",
+    "com.squareup.okhttp3:okhttp:4.9.1",
+    "com.sun.net.httpserver:http:20070405",
+    "com.tngtech.archunit:archunit-junit4:0.20.1",
+    "com.uber.nullaway:nullaway:0.9.2",
+    "edu.berkeley.cs.jqf:jqf-fuzz:1.7",
+    "eu.rekawek.toxiproxy:toxiproxy-java:2.1.4",
+    "io.github.netmikey.logunit:logunit-jul:1.1.0",
+    "io.jaegertracing:jaeger-client:1.6.0",
+    "io.opentracing:opentracing-api:0.33.0",
+    "io.zipkin.zipkin2:zipkin-junit:2.23.2",
+    "junit:junit:4.13.2",
+    "nl.jqno.equalsverifier:equalsverifier:3.7.1",
+    "org.assertj:assertj-core:3.20.2",
+    "org.awaitility:awaitility:4.1.0",
+    "org.bouncycastle:bcpkix-jdk15on:1.69",
+    "org.codehaus.mojo:animal-sniffer-annotations:1.20",
+    "org.curioswitch.curiostack:protobuf-jackson:1.2.0",
+    "org.jctools:jctools-core:3.3.0",
+    "org.junit-pioneer:junit-pioneer:1.4.2",
+    "org.skyscreamer:jsonassert:1.5.0",
+    "org.slf4j:slf4j-simple:1.7.32"
+  )
+
+javaPlatform { allowDependencies() }
 
 dependencies {
   for (bom in DEPENDENCY_BOMS) {
@@ -140,8 +122,6 @@ tasks {
     revision = "release"
     checkConstraints = true
 
-    rejectVersionIf {
-      isNonStable(candidate.version)
-    }
+    rejectVersionIf { isNonStable(candidate.version) }
   }
 }

--- a/exporters/build.gradle.kts
+++ b/exporters/build.gradle.kts
@@ -3,8 +3,6 @@ subprojects {
   group = "io.opentelemetry.exporters"
   val proj = this
   plugins.withId("java") {
-    configure<BasePluginConvention> {
-      archivesBaseName = "opentelemetry-exporter-${proj.name}"
-    }
+    configure<BasePluginConvention> { archivesBaseName = "opentelemetry-exporter-${proj.name}" }
   }
 }

--- a/exporters/jaeger-thrift/build.gradle.kts
+++ b/exporters/jaeger-thrift/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry - Jaeger Thrift Exporter"
+
 otelJava.moduleName.set("io.opentelemetry.exporter.jaeger.thrift")
 
 dependencies {

--- a/exporters/jaeger/build.gradle.kts
+++ b/exporters/jaeger/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry - Jaeger Exporter"
+
 otelJava.moduleName.set("io.opentelemetry.exporter.jaeger")
 
 dependencies {

--- a/exporters/logging-otlp/build.gradle.kts
+++ b/exporters/logging-otlp/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry Protocol JSON Logging Exporters"
+
 otelJava.moduleName.set("io.opentelemetry.exporter.logging.otlp")
 
 dependencies {

--- a/exporters/logging/build.gradle.kts
+++ b/exporters/logging/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry - Logging Exporter"
+
 otelJava.moduleName.set("io.opentelemetry.exporter.logging")
 
 dependencies {

--- a/exporters/otlp-http/build.gradle.kts
+++ b/exporters/otlp-http/build.gradle.kts
@@ -1,8 +1,8 @@
 subprojects {
-    val proj = this
-    plugins.withId("java") {
-        configure<BasePluginConvention> {
-            archivesBaseName = "opentelemetry-exporter-otlp-http-${proj.name}"
-        }
+  val proj = this
+  plugins.withId("java") {
+    configure<BasePluginConvention> {
+      archivesBaseName = "opentelemetry-exporter-otlp-http-${proj.name}"
     }
+  }
 }

--- a/exporters/otlp-http/metrics/build.gradle.kts
+++ b/exporters/otlp-http/metrics/build.gradle.kts
@@ -1,11 +1,12 @@
 plugins {
-    id("otel.java-conventions")
-    id("otel.publish-conventions")
+  id("otel.java-conventions")
+  id("otel.publish-conventions")
 
-    id("otel.animalsniffer-conventions")
+  id("otel.animalsniffer-conventions")
 }
 
 description = "OpenTelemetry Protocol HTTP Metrics Exporter"
+
 otelJava.moduleName.set("io.opentelemetry.exporter.otlp.http.metrics")
 
 dependencies {

--- a/exporters/otlp-http/trace/build.gradle.kts
+++ b/exporters/otlp-http/trace/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 }
 
 description = "OpenTelemetry Protocol HTTP Trace Exporter"
+
 otelJava.moduleName.set("io.opentelemetry.exporter.otlp.http.trace")
 
 dependencies {

--- a/exporters/otlp/all/build.gradle.kts
+++ b/exporters/otlp/all/build.gradle.kts
@@ -7,9 +7,9 @@ plugins {
 }
 
 description = "OpenTelemetry Protocol Exporters"
+
 otelJava.moduleName.set("io.opentelemetry.exporter.otlp")
+
 base.archivesBaseName = "opentelemetry-exporter-otlp"
 
-dependencies {
-  api(project(":exporters:otlp:trace"))
-}
+dependencies { api(project(":exporters:otlp:trace")) }

--- a/exporters/otlp/common/build.gradle.kts
+++ b/exporters/otlp/common/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 }
 
 description = "OpenTelemetry Protocol Exporter"
+
 otelJava.moduleName.set("io.opentelemetry.exporter.otlp.internal")
 
 dependencies {

--- a/exporters/otlp/metrics/build.gradle.kts
+++ b/exporters/otlp/metrics/build.gradle.kts
@@ -7,12 +7,13 @@ plugins {
 }
 
 description = "OpenTelemetry Protocol Metrics Exporter"
+
 otelJava.moduleName.set("io.opentelemetry.exporter.otlp.metrics")
 
 testSets {
-    create("testGrpcNetty")
-    create("testGrpcNettyShaded")
-    create("testGrpcOkhttp")
+  create("testGrpcNetty")
+  create("testGrpcNettyShaded")
+  create("testGrpcOkhttp")
 }
 
 dependencies {
@@ -48,8 +49,4 @@ dependencies {
   add("testGrpcOkhttpRuntimeOnly", "org.bouncycastle:bcpkix-jdk15on")
 }
 
-tasks {
-  named("check") {
-    dependsOn("testGrpcNetty", "testGrpcNettyShaded", "testGrpcOkhttp")
-  }
-}
+tasks { named("check") { dependsOn("testGrpcNetty", "testGrpcNettyShaded", "testGrpcOkhttp") } }

--- a/exporters/otlp/trace/build.gradle.kts
+++ b/exporters/otlp/trace/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 }
 
 description = "OpenTelemetry Protocol Trace Exporter"
+
 otelJava.moduleName.set("io.opentelemetry.exporter.otlp.trace")
 
 testSets {
@@ -64,16 +65,10 @@ dependencies {
   jmh("io.grpc:grpc-netty")
 }
 
-tasks {
-  named("check") {
-    dependsOn("testGrpcNetty", "testGrpcNettyShaded", "testGrpcOkhttp")
-  }
-}
+tasks { named("check") { dependsOn("testGrpcNetty", "testGrpcNettyShaded", "testGrpcOkhttp") } }
 
 wire {
   root("opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest")
 
-  custom {
-    customHandlerClass = "io.opentelemetry.gradle.ProtoFieldsWireHandler"
-  }
+  custom { customHandlerClass = "io.opentelemetry.gradle.ProtoFieldsWireHandler" }
 }

--- a/exporters/prometheus/build.gradle.kts
+++ b/exporters/prometheus/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry Prometheus Exporter"
+
 otelJava.moduleName.set("io.opentelemetry.exporter.prometheus")
 
 dependencies {

--- a/exporters/zipkin/build.gradle.kts
+++ b/exporters/zipkin/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry - Zipkin Exporter"
+
 otelJava.moduleName.set("io.opentelemetry.exporter.zipkin")
 
 dependencies {

--- a/extensions/annotations/build.gradle.kts
+++ b/extensions/annotations/build.gradle.kts
@@ -6,8 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry Extension Annotations"
+
 otelJava.moduleName.set("io.opentelemetry.extension.annotations")
 
-dependencies {
-  api(project(":api:all"))
-}
+dependencies { api(project(":api:all")) }

--- a/extensions/aws/build.gradle.kts
+++ b/extensions/aws/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry API Extensions for AWS"
+
 otelJava.moduleName.set("io.opentelemetry.extension.aws")
 
 dependencies {

--- a/extensions/build.gradle.kts
+++ b/extensions/build.gradle.kts
@@ -1,8 +1,6 @@
 subprojects {
   val proj = this
   plugins.withId("java") {
-    configure<BasePluginConvention> {
-      archivesBaseName = "opentelemetry-extension-${proj.name}"
-    }
+    configure<BasePluginConvention> { archivesBaseName = "opentelemetry-extension-${proj.name}" }
   }
 }

--- a/extensions/incubator/build.gradle.kts
+++ b/extensions/incubator/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 }
 
 description = "OpenTelemetry API Incubator"
+
 otelJava.moduleName.set("io.opentelemetry.extension.incubator")
 
 dependencies {

--- a/extensions/kotlin/build.gradle.kts
+++ b/extensions/kotlin/build.gradle.kts
@@ -11,11 +11,10 @@ plugins {
 }
 
 description = "OpenTelemetry Kotlin Extensions"
+
 otelJava.moduleName.set("io.opentelemetry.extension.kotlin")
 
-testSets {
-  create("testStrictContext")
-}
+testSets { create("testStrictContext") }
 
 dependencies {
   implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
@@ -31,16 +30,10 @@ dependencies {
 }
 
 tasks {
-  withType(KotlinCompile::class) {
-    kotlinOptions {
-      jvmTarget = "1.8"
-    }
-  }
+  withType(KotlinCompile::class) { kotlinOptions { jvmTarget = "1.8" } }
 
   // We don't have any public Java classes
-  named("javadoc") {
-    enabled = false
-  }
+  named("javadoc") { enabled = false }
 
   named<Test>("testStrictContext") {
     jvmArgs("-Dio.opentelemetry.context.enableStrictContext=true")

--- a/extensions/noop-api/build.gradle.kts
+++ b/extensions/noop-api/build.gradle.kts
@@ -6,8 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry Noop API"
+
 otelJava.moduleName.set("io.opentelemetry.extension.noopapi")
 
-dependencies {
-  api(project(":api:all"))
-}
+dependencies { api(project(":api:all")) }

--- a/extensions/trace-propagators/build.gradle.kts
+++ b/extensions/trace-propagators/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 }
 
 description = "OpenTelemetry Extension : Trace Propagators"
+
 otelJava.moduleName.set("io.opentelemetry.extension.trace.propagation")
 
 dependencies {

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -1,8 +1,7 @@
-plugins {
-  id("otel.java-conventions")
-}
+plugins { id("otel.java-conventions") }
 
 description = "OpenTelemetry Integration Tests"
+
 otelJava.moduleName.set("io.opentelemetry.integration.tests")
 
 dependencies {

--- a/integration-tests/tracecontext/build.gradle.kts
+++ b/integration-tests/tracecontext/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 }
 
 description = "OpenTelemetry W3C Context Propagation Integration Tests"
+
 otelJava.moduleName.set("io.opentelemetry.tracecontext.integration.tests")
 
 dependencies {
@@ -21,14 +22,14 @@ tasks {
   val shadowJar by existing(Jar::class) {
     archiveFileName.set("tracecontext-tests.jar")
 
-    manifest {
-      attributes("Main-Class" to "io.opentelemetry.Application")
-    }
+    manifest { attributes("Main-Class" to "io.opentelemetry.Application") }
   }
 
   withType(Test::class) {
     dependsOn(shadowJar)
 
-    jvmArgs("-Dio.opentelemetry.testArchive=${shadowJar.get().archiveFile.get().asFile.absolutePath}")
+    jvmArgs(
+      "-Dio.opentelemetry.testArchive=${shadowJar.get().archiveFile.get().asFile.absolutePath}"
+    )
   }
 }

--- a/opencensus-shim/build.gradle.kts
+++ b/opencensus-shim/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 description = "OpenTelemetry OpenCensus Shim"
+
 otelJava.moduleName.set("io.opentelemetry.opencensusshim")
 
 dependencies {

--- a/opentracing-shim/build.gradle.kts
+++ b/opentracing-shim/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 description = "OpenTelemetry OpenTracing Bridge"
+
 otelJava.moduleName.set("io.opentelemetry.opentracingshim")
 
 dependencies {
@@ -17,10 +18,4 @@ dependencies {
   testImplementation("org.slf4j:slf4j-simple")
 }
 
-tasks {
-  withType(Test::class) {
-    testLogging {
-      showStandardStreams = true
-    }
-  }
-}
+tasks { withType(Test::class) { testLogging { showStandardStreams = true } } }

--- a/perf-harness/build.gradle.kts
+++ b/perf-harness/build.gradle.kts
@@ -1,8 +1,7 @@
-plugins {
-  id("otel.java-conventions")
-}
+plugins { id("otel.java-conventions") }
 
 description = "Performance Testing Harness"
+
 otelJava.moduleName.set("io.opentelemetry.perf-harness")
 
 dependencies {

--- a/proto/build.gradle.kts
+++ b/proto/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 }
 
 description = "OpenTelemetry Proto"
+
 otelJava.moduleName.set("io.opentelemetry.proto")
 
 dependencies {
@@ -45,17 +46,7 @@ tasks {
     into("$buildDir/protos")
   }
 
-  afterEvaluate {
-    named("generateProto") {
-      dependsOn(unzipProtoArchive)
-    }
-  }
+  afterEvaluate { named("generateProto") { dependsOn(unzipProtoArchive) } }
 }
 
-sourceSets {
-  main {
-    proto {
-      srcDir("$buildDir/protos/opentelemetry-proto-${protoVersion}")
-    }
-  }
-}
+sourceSets { main { proto { srcDir("$buildDir/protos/opentelemetry-proto-${protoVersion}") } } }

--- a/sdk-extensions/async-processor/build.gradle.kts
+++ b/sdk-extensions/async-processor/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry SDK Extension: Async SpanProcessor"
+
 otelJava.moduleName.set("io.opentelemetry.sdk.extension.trace.export")
 
 dependencies {

--- a/sdk-extensions/autoconfigure/build.gradle.kts
+++ b/sdk-extensions/autoconfigure/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry SDK Auto-configuration"
+
 otelJava.moduleName.set("io.opentelemetry.sdk.autoconfigure")
 
 testSets {
@@ -118,15 +119,23 @@ tasks {
   }
 
   val testResourceDisabledByProperty by existing(Test::class) {
-    jvmArgs("-Dotel.java.disabled.resource-providers=io.opentelemetry.sdk.extension.resources.OsResourceProvider,io.opentelemetry.sdk.extension.resources.ProcessResourceProvider")
+    jvmArgs(
+      "-Dotel.java.disabled.resource-providers=io.opentelemetry.sdk.extension.resources.OsResourceProvider,io.opentelemetry.sdk.extension.resources.ProcessResourceProvider"
+    )
     // Properties win, this is ignored.
-    environment("OTEL_JAVA_DISABLED_RESOURCE_PROVIDERS", "io.opentelemetry.sdk.extension.resources.ProcessRuntimeResourceProvider")
+    environment(
+      "OTEL_JAVA_DISABLED_RESOURCE_PROVIDERS",
+      "io.opentelemetry.sdk.extension.resources.ProcessRuntimeResourceProvider"
+    )
     environment("OTEL_TRACES_EXPORTER", "none")
     environment("OTEL_METRICS_EXPORTER", "none")
   }
 
   val testResourceDisabledByEnv by existing(Test::class) {
-    environment("OTEL_JAVA_DISABLED_RESOURCE_PROVIDERS", "io.opentelemetry.sdk.extension.resources.OsResourceProvider,io.opentelemetry.sdk.extension.resources.ProcessResourceProvider")
+    environment(
+      "OTEL_JAVA_DISABLED_RESOURCE_PROVIDERS",
+      "io.opentelemetry.sdk.extension.resources.OsResourceProvider,io.opentelemetry.sdk.extension.resources.ProcessResourceProvider"
+    )
     environment("OTEL_TRACES_EXPORTER", "none")
     environment("OTEL_METRICS_EXPORTER", "none")
   }

--- a/sdk-extensions/aws/build.gradle.kts
+++ b/sdk-extensions/aws/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry SDK AWS Instrumentation Support"
+
 otelJava.moduleName.set("io.opentelemetry.sdk.extension.trace.aws")
 
 dependencies {

--- a/sdk-extensions/jaeger-remote-sampler/build.gradle.kts
+++ b/sdk-extensions/jaeger-remote-sampler/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry - Jaeger Remote sampler"
+
 otelJava.moduleName.set("io.opentelemetry.sdk.extension.trace.jaeger")
 
 dependencies {

--- a/sdk-extensions/jfr-events/build.gradle.kts
+++ b/sdk-extensions/jfr-events/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 description = "OpenTelemetry SDK Extension JFR"
+
 otelJava.moduleName.set("io.opentelemetry.sdk.extension.jfr")
 
 dependencies {
@@ -12,9 +13,7 @@ dependencies {
 }
 
 tasks {
-  withType(JavaCompile::class) {
-    options.release.set(11)
-  }
+  withType(JavaCompile::class) { options.release.set(11) }
 
   test {
     val testJavaVersion: String? by project
@@ -23,8 +22,6 @@ tasks {
     }
 
     // Disabled due to https://bugs.openjdk.java.net/browse/JDK-8245283
-    configure<JacocoTaskExtension> {
-      enabled = false
-    }
+    configure<JacocoTaskExtension> { enabled = false }
   }
 }

--- a/sdk-extensions/logging/build.gradle.kts
+++ b/sdk-extensions/logging/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry Contrib Logging Support"
+
 otelJava.moduleName.set("io.opentelemetry.sdk.extension.logging")
 
 dependencies {

--- a/sdk-extensions/resources/build.gradle.kts
+++ b/sdk-extensions/resources/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry SDK Resource Providers"
+
 otelJava.moduleName.set("io.opentelemetry.sdk.extension.resources")
 
 val mrJarVersions = listOf(11)
@@ -23,13 +24,7 @@ dependencies {
 }
 
 for (version in mrJarVersions) {
-  sourceSets {
-    create("java${version}") {
-      java {
-        setSrcDirs(listOf("src/main/java${version}"))
-      }
-    }
-  }
+  sourceSets { create("java${version}") { java { setSrcDirs(listOf("src/main/java${version}")) } } }
 
   tasks {
     named<JavaCompile>("compileJava${version}Java") {
@@ -40,16 +35,13 @@ for (version in mrJarVersions) {
   }
 
   configurations {
-    named("java${version}Implementation") {
-      extendsFrom(configurations["implementation"])
-    }
-    named("java${version}CompileOnly") {
-      extendsFrom(configurations["compileOnly"])
-    }
+    named("java${version}Implementation") { extendsFrom(configurations["implementation"]) }
+    named("java${version}CompileOnly") { extendsFrom(configurations["compileOnly"]) }
   }
 
   dependencies {
-    // Common to reference classes in main sourceset from Java 9 one (e.g., to return a common interface)
+    // Common to reference classes in main sourceset from Java 9 one (e.g., to return a common
+    // interface)
     add("java${version}Implementation", files(sourceSets.main.get().output.classesDirs))
   }
 }
@@ -57,12 +49,8 @@ for (version in mrJarVersions) {
 tasks {
   withType(Jar::class) {
     for (version in mrJarVersions) {
-      into("META-INF/versions/${version}") {
-        from(sourceSets["java${version}"].output)
-      }
+      into("META-INF/versions/${version}") { from(sourceSets["java${version}"].output) }
     }
-    manifest.attributes(
-      "Multi-Release" to "true"
-    )
+    manifest.attributes("Multi-Release" to "true")
   }
 }

--- a/sdk-extensions/tracing-incubator/build.gradle.kts
+++ b/sdk-extensions/tracing-incubator/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 // SDK modules that are still being developed.
 
 description = "OpenTelemetry SDK Tracing Incubator"
+
 otelJava.moduleName.set("io.opentelemetry.sdk.extension.trace.incubator")
 
 dependencies {
@@ -36,9 +37,7 @@ dependencies {
     isTransitive = false
   }
   // explicitly adding the opentelemetry-exporter-otlp dependencies
-  jmh(project(":exporters:otlp:common")) {
-    isTransitive = false
-  }
+  jmh(project(":exporters:otlp:common")) { isTransitive = false }
   jmh(project(":proto"))
 
   jmh("com.google.guava:guava")

--- a/sdk-extensions/zpages/build.gradle.kts
+++ b/sdk-extensions/zpages/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry - zPages"
+
 otelJava.moduleName.set("io.opentelemetry.sdk.extension.zpages")
 
 dependencies {

--- a/sdk/all/build.gradle.kts
+++ b/sdk/all/build.gradle.kts
@@ -7,7 +7,9 @@ plugins {
 }
 
 description = "OpenTelemetry SDK"
+
 otelJava.moduleName.set("io.opentelemetry.sdk")
+
 base.archivesName.set("opentelemetry-sdk")
 
 dependencies {

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -3,8 +3,6 @@ subprojects {
   group = "io.opentelemetry.sdk"
   val proj = this
   plugins.withId("java") {
-    configure<BasePluginConvention> {
-      archivesBaseName = "opentelemetry-sdk-${proj.name}"
-    }
+    configure<BasePluginConvention> { archivesBaseName = "opentelemetry-sdk-${proj.name}" }
   }
 }

--- a/sdk/common/build.gradle.kts
+++ b/sdk/common/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 }
 
 description = "OpenTelemetry SDK Common"
+
 otelJava.moduleName.set("io.opentelemetry.sdk.common")
 
 val mrJarVersions = listOf(9)
@@ -31,13 +32,7 @@ dependencies {
 }
 
 for (version in mrJarVersions) {
-  sourceSets {
-    create("java${version}") {
-      java {
-        setSrcDirs(listOf("src/main/java${version}"))
-      }
-    }
-  }
+  sourceSets { create("java${version}") { java { setSrcDirs(listOf("src/main/java${version}")) } } }
 
   tasks {
     named<JavaCompile>("compileJava${version}Java") {
@@ -48,13 +43,12 @@ for (version in mrJarVersions) {
   }
 
   configurations {
-    named("java${version}Implementation") {
-      extendsFrom(configurations["implementation"])
-    }
+    named("java${version}Implementation") { extendsFrom(configurations["implementation"]) }
   }
 
   dependencies {
-    // Common to reference classes in main sourceset from Java 9 one (e.g., to return a common interface)
+    // Common to reference classes in main sourceset from Java 9 one (e.g., to return a common
+    // interface)
     add("java${version}Implementation", files(sourceSets.main.get().output.classesDirs))
   }
 }
@@ -62,13 +56,9 @@ for (version in mrJarVersions) {
 tasks {
   withType(Jar::class) {
     for (version in mrJarVersions) {
-      into("META-INF/versions/${version}") {
-        from(sourceSets["java${version}"].output)
-      }
+      into("META-INF/versions/${version}") { from(sourceSets["java${version}"].output) }
     }
-    manifest.attributes(
-      "Multi-Release" to "true"
-    )
+    manifest.attributes("Multi-Release" to "true")
   }
 
   test {

--- a/sdk/metrics-testing/build.gradle.kts
+++ b/sdk/metrics-testing/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 description = "OpenTelemetry Metrics SDK Testing utilities"
+
 otelJava.moduleName.set("io.opentelemetry.sdk.metrics-testing")
 
 dependencies {

--- a/sdk/metrics/build.gradle.kts
+++ b/sdk/metrics/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 }
 
 description = "OpenTelemetry SDK Metrics"
+
 otelJava.moduleName.set("io.opentelemetry.sdk.metrics")
 
 dependencies {

--- a/sdk/testing/build.gradle.kts
+++ b/sdk/testing/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 description = "OpenTelemetry SDK Testing utilities"
+
 otelJava.moduleName.set("io.opentelemetry.sdk.testing")
 
 dependencies {

--- a/sdk/trace-shaded-deps/build.gradle.kts
+++ b/sdk/trace-shaded-deps/build.gradle.kts
@@ -7,11 +7,10 @@ plugins {
 // This project is not published, it is bundled into :sdk:trace
 
 description = "Internal use only - shaded dependencies of OpenTelemetry SDK for Tracing"
+
 otelJava.moduleName.set("io.opentelemetry.sdk.trace.internal")
 
-dependencies {
-  implementation("org.jctools:jctools-core")
-}
+dependencies { implementation("org.jctools:jctools-core") }
 
 tasks {
   shadowJar {

--- a/sdk/trace/build.gradle.kts
+++ b/sdk/trace/build.gradle.kts
@@ -9,12 +9,16 @@ plugins {
 }
 
 description = "OpenTelemetry SDK For Tracing"
+
 otelJava.moduleName.set("io.opentelemetry.sdk.trace")
 
 sourceSets {
   main {
     val traceShadedDeps = project(":sdk:trace-shaded-deps")
-    output.dir(traceShadedDeps.file("build/extracted/shadow"), "builtBy" to ":sdk:trace-shaded-deps:extractShadowJar")
+    output.dir(
+      traceShadedDeps.file("build/extracted/shadow"),
+      "builtBy" to ":sdk:trace-shaded-deps:extractShadowJar"
+    )
   }
 }
 
@@ -48,9 +52,7 @@ dependencies {
     isTransitive = false
   }
   // explicitly adding the opentelemetry-exporter-otlp dependencies
-  jmh(project(":exporters:otlp:common")) {
-    isTransitive = false
-  }
+  jmh(project(":exporters:otlp:common")) { isTransitive = false }
   jmh(project(":proto"))
 
   jmh("com.google.guava:guava")

--- a/semconv/build.gradle.kts
+++ b/semconv/build.gradle.kts
@@ -6,8 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry Semantic Conventions"
+
 otelJava.moduleName.set("io.opentelemetry.semconv")
 
-dependencies {
-  api(project(":api:all"))
-}
+dependencies { api(project(":api:all")) }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,9 +12,7 @@ pluginManagement {
   }
 }
 
-plugins {
-  id("com.gradle.enterprise")
-}
+plugins { id("com.gradle.enterprise") }
 
 dependencyResolutionManagement {
   repositories {
@@ -24,56 +22,105 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "opentelemetry-java"
+
 include(":all")
+
 include(":api:all")
+
 include(":api:metrics")
+
 include(":semconv")
+
 include(":bom")
+
 include(":bom-alpha")
+
 include(":context")
+
 include(":dependencyManagement")
+
 include(":extensions:annotations")
+
 include(":extensions:incubator")
+
 include(":extensions:aws")
+
 include(":extensions:kotlin")
+
 include(":extensions:noop-api")
+
 include(":extensions:trace-propagators")
+
 include(":exporters:jaeger")
+
 include(":exporters:jaeger-thrift")
+
 include(":exporters:logging")
+
 include(":exporters:logging-otlp")
+
 include(":exporters:otlp:all")
+
 include(":exporters:otlp:common")
+
 include(":exporters:otlp:metrics")
+
 include(":exporters:otlp:trace")
+
 include(":exporters:otlp-http:metrics")
+
 include(":exporters:otlp-http:trace")
+
 include(":exporters:prometheus")
+
 include(":exporters:zipkin")
+
 include(":integration-tests")
+
 include(":integration-tests:tracecontext")
+
 include(":opencensus-shim")
+
 include(":opentracing-shim")
+
 include(":perf-harness")
+
 include(":proto")
+
 include(":sdk:all")
+
 include(":sdk:common")
+
 include(":sdk:metrics")
+
 include(":sdk:metrics-testing")
+
 include(":sdk:testing")
+
 include(":sdk:trace")
+
 include(":sdk:trace-shaded-deps")
+
 include(":sdk-extensions:async-processor")
+
 include(":sdk-extensions:autoconfigure")
+
 include(":sdk-extensions:aws")
+
 include(":sdk-extensions:logging")
+
 include(":sdk-extensions:resources")
+
 include(":sdk-extensions:tracing-incubator")
+
 include(":sdk-extensions:jaeger-remote-sampler")
+
 include(":sdk-extensions:jfr-events")
+
 include(":sdk-extensions:zpages")
 
 val isCI = System.getenv("CI") != null
+
 gradleEnterprise {
   buildScan {
     termsOfServiceUrl = "https://gradle.com/terms-of-service"


### PR DESCRIPTION
Resolves #3435. 

Uses [ktfmt](https://github.com/facebookincubator/ktfmt) to apply `google-java-format` style to all `*.gradle.kts` build files.

Opening as a draft to gauge interest in the approach and the resultant style. 

See [kotlin spotless config](https://github.com/diffplug/spotless/tree/main/plugin-gradle#kotlin) docs for additional configuration options. 