### PR TITLE
Allow multiple views per instrument

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProviderBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProviderBuilder.java
@@ -12,8 +12,6 @@ import io.opentelemetry.sdk.metrics.internal.view.ViewRegistryBuilder;
 import io.opentelemetry.sdk.metrics.view.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.view.View;
 import io.opentelemetry.sdk.resources.Resource;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -24,7 +22,7 @@ public final class SdkMeterProviderBuilder {
 
   private Clock clock = Clock.getDefault();
   private Resource resource = Resource.getDefault();
-  private final Map<InstrumentSelector, View> instrumentSelectorViews = new HashMap<>();
+  private final ViewRegistryBuilder viewRegistryBuilder = ViewRegistry.builder();
 
   SdkMeterProviderBuilder() {}
 
@@ -79,7 +77,7 @@ public final class SdkMeterProviderBuilder {
   public SdkMeterProviderBuilder registerView(InstrumentSelector selector, View view) {
     Objects.requireNonNull(selector, "selector");
     Objects.requireNonNull(view, "view");
-    instrumentSelectorViews.put(selector, view);
+    viewRegistryBuilder.addView(selector, view);
     return this;
   }
 
@@ -107,9 +105,6 @@ public final class SdkMeterProviderBuilder {
    * @see GlobalMeterProvider
    */
   public SdkMeterProvider build() {
-    ViewRegistryBuilder viewRegistryBuilder = ViewRegistry.builder();
-    instrumentSelectorViews.forEach(viewRegistryBuilder::addView);
-    ViewRegistry viewRegistry = viewRegistryBuilder.build();
-    return new SdkMeterProvider(clock, resource, viewRegistry);
+    return new SdkMeterProvider(clock, resource, viewRegistryBuilder.build());
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DuplicateMetricStorageException.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DuplicateMetricStorageException.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.internal.state;
+
+import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
+
+/** There are multiple metrics defined with the same name/identity. */
+class DuplicateMetricStorageException extends IllegalArgumentException {
+
+  DuplicateMetricStorageException(
+      MetricDescriptor existing, MetricDescriptor next, String message) {
+    // TODO: Better error messages including async vs. sync instruments.
+    super(message + " Found: " + existing + ", Want: " + next);
+  }
+
+  private static final long serialVersionUID = 1547329629200005982L;
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MeterSharedState.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MeterSharedState.java
@@ -92,21 +92,22 @@ public abstract class MeterSharedState {
       InstrumentDescriptor instrument,
       MeterProviderSharedState meterProviderSharedState,
       Consumer<ObservableLongMeasurement> metricUpdater) {
-    // TODO - we  need to iterate over all possible views here and register each we find.
-    View view =
+    // TODO - we should avoid registering independent storage that calls observables over and over.
+    List<View> views =
         meterProviderSharedState
             .getViewRegistry()
-            .findView(instrument, getInstrumentationLibraryInfo());
-
-    getMetricStorageRegistry()
-        .register(
-            AsynchronousMetricStorage.longAsynchronousAccumulator(
-                view,
-                instrument,
-                meterProviderSharedState.getResource(),
-                getInstrumentationLibraryInfo(),
-                meterProviderSharedState.getStartEpochNanos(),
-                metricUpdater));
+            .findViews(instrument, getInstrumentationLibraryInfo());
+    for (View view : views) {
+      getMetricStorageRegistry()
+          .register(
+              AsynchronousMetricStorage.longAsynchronousAccumulator(
+                  view,
+                  instrument,
+                  meterProviderSharedState.getResource(),
+                  getInstrumentationLibraryInfo(),
+                  meterProviderSharedState.getStartEpochNanos(),
+                  metricUpdater));
+    }
   }
 
   /** Registers new asynchronous storage associated with a given {@code double} instrument. */
@@ -114,19 +115,21 @@ public abstract class MeterSharedState {
       InstrumentDescriptor instrument,
       MeterProviderSharedState meterProviderSharedState,
       Consumer<ObservableDoubleMeasurement> metricUpdater) {
-    // TODO - we  need to iterate over all possible views here and register each we find.
-    View view =
+    // TODO - we should avoid registering independent storage that calls observables over and over.
+    List<View> views =
         meterProviderSharedState
             .getViewRegistry()
-            .findView(instrument, getInstrumentationLibraryInfo());
-    getMetricStorageRegistry()
-        .register(
-            AsynchronousMetricStorage.doubleAsynchronousAccumulator(
-                view,
-                instrument,
-                meterProviderSharedState.getResource(),
-                getInstrumentationLibraryInfo(),
-                meterProviderSharedState.getStartEpochNanos(),
-                metricUpdater));
+            .findViews(instrument, getInstrumentationLibraryInfo());
+    for (View view : views) {
+      getMetricStorageRegistry()
+          .register(
+              AsynchronousMetricStorage.doubleAsynchronousAccumulator(
+                  view,
+                  instrument,
+                  meterProviderSharedState.getResource(),
+                  getInstrumentationLibraryInfo(),
+                  meterProviderSharedState.getStartEpochNanos(),
+                  metricUpdater));
+    }
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageRegistry.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageRegistry.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ConcurrentMap;
  * at any time.
  */
 public class MetricStorageRegistry {
+  // TODO: Maybe we store metrics *and* instrument interfaces separately here...
   private final ConcurrentMap<String, MetricStorage> registry = new ConcurrentHashMap<>();
 
   /**

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageRegistry.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageRegistry.java
@@ -60,19 +60,17 @@ public class MetricStorageRegistry {
         registry.computeIfAbsent(descriptor.getName().toLowerCase(), key -> storage);
     // Make sure the storage is compatible.
     if (!oldOrNewStorage.getMetricDescriptor().isCompatibleWith(descriptor)) {
-      throw new IllegalArgumentException(
-          "Metric with same name and different descriptor already created.   Found: "
-              + oldOrNewStorage.getMetricDescriptor()
-              + ", Want: "
-              + descriptor);
+      throw new DuplicateMetricStorageException(
+          oldOrNewStorage.getMetricDescriptor(),
+          descriptor,
+          "Metric with same name and different descriptor already created.");
     }
     // Make sure we aren't mixing sync + async.
     if (!storage.getClass().equals(oldOrNewStorage.getClass())) {
-      throw new IllegalArgumentException(
-          "Metric with same name and different instrument already created.   Found: "
-              + oldOrNewStorage.getClass()
-              + ", Want: "
-              + storage.getClass());
+      throw new DuplicateMetricStorageException(
+          oldOrNewStorage.getMetricDescriptor(),
+          descriptor,
+          "Metric with same name and different instrument already created.");
     }
 
     return (I) oldOrNewStorage;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MultiBoundStorageHandle.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MultiBoundStorageHandle.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.internal.state;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import java.util.List;
+
+/** Storage handle that aggregates across several instances. */
+class MultiBoundStorageHandle implements BoundStorageHandle {
+  private final List<BoundStorageHandle> underlyingHandles;
+
+  MultiBoundStorageHandle(List<BoundStorageHandle> handles) {
+    this.underlyingHandles = handles;
+  }
+
+  @Override
+  public void recordLong(long value, Attributes attributes, Context context) {
+    for (BoundStorageHandle handle : underlyingHandles) {
+      handle.recordLong(value, attributes, context);
+    }
+  }
+
+  @Override
+  public void recordDouble(double value, Attributes attributes, Context context) {
+    for (BoundStorageHandle handle : underlyingHandles) {
+      handle.recordDouble(value, attributes, context);
+    }
+  }
+
+  @Override
+  public void release() {
+    for (BoundStorageHandle handle : underlyingHandles) {
+      handle.release();
+    }
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MultiWritableMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MultiWritableMetricStorage.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.internal.state;
+
+import io.opentelemetry.api.common.Attributes;
+import java.util.ArrayList;
+import java.util.List;
+
+class MultiWritableMetricStorage implements WriteableMetricStorage {
+  private final List<WriteableMetricStorage> underlyingMetrics;
+
+  MultiWritableMetricStorage(List<WriteableMetricStorage> metrics) {
+    this.underlyingMetrics = metrics;
+  }
+
+  @Override
+  public BoundStorageHandle bind(Attributes attributes) {
+    List<BoundStorageHandle> handles = new ArrayList<>(underlyingMetrics.size());
+    for (WriteableMetricStorage metric : underlyingMetrics) {
+      handles.add(metric.bind(attributes));
+    }
+    return new MultiBoundStorageHandle(handles);
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorage.java
@@ -27,7 +27,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public final class SynchronousMetricStorage<T> implements WriteableMetricStorage {
+public final class SynchronousMetricStorage<T> implements MetricStorage, WriteableMetricStorage {
   private final MetricDescriptor metricDescriptor;
   private final ConcurrentHashMap<Attributes, AggregatorHandle<T>> aggregatorLabels;
   private final ReentrantLock collectLock;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/WriteableMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/WriteableMetricStorage.java
@@ -14,7 +14,7 @@ import io.opentelemetry.context.Context;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public interface WriteableMetricStorage extends MetricStorage {
+public interface WriteableMetricStorage {
   /** Bind an efficient storage handle for a set of attributes. */
   BoundStorageHandle bind(Attributes attributes);
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/ViewRegistry.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/ViewRegistry.java
@@ -12,6 +12,7 @@ import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.view.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.view.MeterSelector;
 import io.opentelemetry.sdk.metrics.view.View;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -69,6 +70,26 @@ public final class ViewRegistry {
     }
 
     return getDefaultSpecification(descriptor);
+  }
+
+  /**
+   * Returns the metric {@link View} for a given instrument.
+   *
+   * @param descriptor description of the instrument.
+   * @return The list of {@link View}s for this instrument in registered order, or a default
+   *     aggregation view.
+   */
+  public List<View> findViews(InstrumentDescriptor descriptor, InstrumentationLibraryInfo meter) {
+    List<View> result = new ArrayList<>();
+    for (RegisteredView entry : reverseRegistration) {
+      if (matchesSelector(entry.getInstrumentSelector(), descriptor, meter)) {
+        result.add(entry.getView());
+      }
+    }
+    if (result.isEmpty()) {
+      return Collections.singletonList(getDefaultSpecification(descriptor));
+    }
+    return Collections.unmodifiableList(result);
   }
 
   // Matches an instrument selector against an instrument + meter.

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderTest.java
@@ -460,7 +460,7 @@ public class SdkMeterProviderTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  void viewSdk_AllowMulitpleViewsPerInstrument() {
+  void viewSdk_AllowMulitpleViewsPerSynchronousInstrument() {
     InstrumentSelector selector =
         InstrumentSelector.builder()
             // TODO: Make instrument type optional.
@@ -488,6 +488,54 @@ public class SdkMeterProviderTest {
     DoubleHistogram histogram =
         meter.histogramBuilder("test").setDescription("desc").setUnit("unit").build();
     histogram.record(1.0);
+    assertThat(provider.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metric ->
+                assertThat(metric)
+                    .hasName("not_test")
+                    .hasDescription("not_desc")
+                    .hasUnit("unit")
+                    .hasDoubleGauge(),
+            metric ->
+                assertThat(metric)
+                    .hasName("not_test_2")
+                    .hasDescription("not_desc_2")
+                    .hasUnit("unit")
+                    .hasDoubleSum());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void viewSdk_AllowMulitpleViewsPerAsynchronousInstrument() {
+    InstrumentSelector selector =
+        InstrumentSelector.builder()
+            // TODO: Make instrument type optional.
+            .setInstrumentType(InstrumentType.OBSERVABLE_GAUGE)
+            .setInstrumentName("test")
+            .build();
+    SdkMeterProvider provider =
+        sdkMeterProviderBuilder
+            .registerView(
+                selector,
+                View.builder()
+                    .setName("not_test")
+                    .setDescription("not_desc")
+                    .setAggregatorFactory(AggregatorFactory.lastValue())
+                    .build())
+            .registerView(
+                selector,
+                View.builder()
+                    .setName("not_test_2")
+                    .setDescription("not_desc_2")
+                    .setAggregatorFactory(AggregatorFactory.sum(AggregationTemporality.CUMULATIVE))
+                    .build())
+            .build();
+    Meter meter = provider.get(SdkMeterProviderTest.class.getName());
+    meter
+        .gaugeBuilder("test")
+        .setDescription("desc")
+        .setUnit("unit")
+        .buildWithCallback(obs -> obs.observe(1.0));
     assertThat(provider.collectAllMetrics())
         .satisfiesExactlyInAnyOrder(
             metric ->

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageRegistryTest.java
@@ -68,7 +68,7 @@ class MetricStorageRegistryTest {
         .hasMessageContaining("Metric with same name and different instrument already created.");
   }
 
-  private static final class TestMetricStorage implements WriteableMetricStorage {
+  private static final class TestMetricStorage implements MetricStorage, WriteableMetricStorage {
     private final MetricDescriptor descriptor;
 
     TestMetricStorage(MetricDescriptor descriptor) {
@@ -91,7 +91,8 @@ class MetricStorageRegistryTest {
     }
   }
 
-  private static final class OtherTestMetricStorage implements WriteableMetricStorage {
+  private static final class OtherTestMetricStorage
+      implements MetricStorage, WriteableMetricStorage {
     private final MetricDescriptor descriptor;
 
     OtherTestMetricStorage(MetricDescriptor descriptor) {


### PR DESCRIPTION
- Allow multiple views per instrument
- Log on view conflict instead of throwing an exception.
- Update error reporting (slightly)


This does *NOT*

- Attempt to only poll async metrics once-per-instrument (instead once-per-metric for now)
- Give the best error messages