### PR TITLE
Reuse a threadlocal CodedOutputStream for marshaling.

### DIFF
--- a/exporters/otlp-http/trace/src/main/java/io/opentelemetry/exporter/otlp/http/trace/ProtoRequestBody.java
+++ b/exporters/otlp-http/trace/src/main/java/io/opentelemetry/exporter/otlp/http/trace/ProtoRequestBody.java
@@ -37,8 +37,7 @@ final class ProtoRequestBody extends RequestBody {
 
   @Override
   public void writeTo(@NotNull BufferedSink bufferedSink) throws IOException {
-    CodedOutputStream cos =
-        CodedOutputStream.newInstance(bufferedSink.outputStream(), contentLength);
+    CodedOutputStream cos = CodedOutputStream.newInstance(bufferedSink.outputStream());
     marshaler.writeTo(cos);
     cos.flush();
   }

--- a/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/otlp/internal/MetricsRequestMarshalerBenchmark.java
+++ b/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/otlp/internal/MetricsRequestMarshalerBenchmark.java
@@ -128,9 +128,7 @@ public class MetricsRequestMarshalerBenchmark {
   public ByteArrayOutputStream marshaler() throws IOException {
     MetricsRequestMarshaler marshaler = MetricsRequestMarshaler.create(METRICS);
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    CodedOutputStream cos =
-        CodedOutputStream.newInstance(
-            bos, CodedOutputStream.computePreferredBufferSize(marshaler.getSerializedSize()));
+    CodedOutputStream cos = CodedOutputStream.newInstance(bos);
     marshaler.writeTo(cos);
     cos.flush();
     return bos;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/InstrumentationLibraryMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/InstrumentationLibraryMarshaler.java
@@ -36,9 +36,7 @@ final class InstrumentationLibraryMarshaler extends MarshalerWithSize {
   private InstrumentationLibraryMarshaler(byte[] name, byte[] version) {
     super(computeSize(name, version));
     ByteArrayOutputStream bos = new ByteArrayOutputStream(getSerializedSize());
-    CodedOutputStream output =
-        CodedOutputStream.newInstance(
-            bos, CodedOutputStream.computePreferredBufferSize(getSerializedSize()));
+    CodedOutputStream output = CodedOutputStream.newInstance(bos);
     try {
       MarshalerUtil.marshalBytes(InstrumentationLibrary.NAME_FIELD_NUMBER, name, output);
       MarshalerUtil.marshalBytes(InstrumentationLibrary.VERSION_FIELD_NUMBER, version, output);

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ResourceMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ResourceMarshaler.java
@@ -32,9 +32,7 @@ final class ResourceMarshaler extends MarshalerWithSize {
   private ResourceMarshaler(AttributeMarshaler[] attributeMarshalers) {
     super(calculateSize(attributeMarshalers));
     ByteArrayOutputStream bos = new ByteArrayOutputStream(getSerializedSize());
-    CodedOutputStream output =
-        CodedOutputStream.newInstance(
-            bos, CodedOutputStream.computePreferredBufferSize(getSerializedSize()));
+    CodedOutputStream output = CodedOutputStream.newInstance(bos);
     try {
       MarshalerUtil.marshalRepeatedMessage(
           Resource.ATTRIBUTES_FIELD_NUMBER, attributeMarshalers, output);

--- a/exporters/otlp/trace/src/jmh/java/io/opentelemetry/exporter/otlp/trace/RequestMarshalBenchmarks.java
+++ b/exporters/otlp/trace/src/jmh/java/io/opentelemetry/exporter/otlp/trace/RequestMarshalBenchmarks.java
@@ -22,7 +22,7 @@ import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode({Mode.AverageTime})
-@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 10, time = 1)
 @Fork(1)
@@ -63,10 +63,7 @@ public class RequestMarshalBenchmarks {
     TraceRequestMarshaler requestMarshaler = TraceRequestMarshaler.create(state.spanDataList);
     ByteArrayOutputStream customOutput =
         new ByteArrayOutputStream(requestMarshaler.getSerializedSize());
-    CodedOutputStream cos =
-        CodedOutputStream.newInstance(
-            customOutput,
-            CodedOutputStream.computePreferredBufferSize(requestMarshaler.getSerializedSize()));
+    CodedOutputStream cos = CodedOutputStream.newInstance(customOutput);
     requestMarshaler.writeTo(cos);
     cos.flush();
     return customOutput;

--- a/exporters/otlp/trace/src/jmh/java/io/opentelemetry/exporter/otlp/trace/RequestMarshalState.java
+++ b/exporters/otlp/trace/src/jmh/java/io/opentelemetry/exporter/otlp/trace/RequestMarshalState.java
@@ -50,7 +50,7 @@ public class RequestMarshalState {
   private static final SpanContext SPAN_CONTEXT =
       SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault());
 
-  @Param({"16"})
+  @Param({"16", "512"})
   int numSpans;
 
   List<SpanData> spanDataList;

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/MarshalerInputStream.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/MarshalerInputStream.java
@@ -50,9 +50,7 @@ final class MarshalerInputStream extends InputStream implements Drainable, Known
     int written;
     if (message != null) {
       written = message.getSerializedSize();
-      CodedOutputStream cos =
-          CodedOutputStream.newInstance(
-              target, CodedOutputStream.computePreferredBufferSize(message.getSerializedSize()));
+      CodedOutputStream cos = CodedOutputStream.newInstance(target);
       message.writeTo(cos);
       cos.flush();
       message = null;
@@ -103,9 +101,7 @@ final class MarshalerInputStream extends InputStream implements Drainable, Known
 
   private static byte[] toByteArray(Marshaler message) throws IOException {
     ByteArrayOutputStream bos = new ByteArrayOutputStream(message.getSerializedSize());
-    CodedOutputStream cos =
-        CodedOutputStream.newInstance(
-            bos, CodedOutputStream.computePreferredBufferSize(message.getSerializedSize()));
+    CodedOutputStream cos = CodedOutputStream.newInstance(bos);
     message.writeTo(cos);
     cos.flush();
     return bos.toByteArray();


### PR DESCRIPTION
Also raises the buffer size from 4K to 50K. We only expect a single thread exporting in 99% of apps, so the overall overhead is 50K. Some event-loop driven apps may avoid the BatchSpanProcessor, they will still generally only have 2 * num CPU threads, 64 threads would be about 3MB of overhead which seems OK. 1000 threads would be 50MB which is probably not OK, but not using the BatchSpanProcessor when processing requests with 1000 threads is not going to have good performance anyways and I think we can accept this. For reference, Jackson reuses a 8K buffer, while Jackson does not have any expectation on the number of threads 

There is an escape hatch flag (which I don't think we need to document until anyone happens to complain about it) in case this is prohibitive for some reason.

Other approaches could be a buffer pool, or not worrying about the async case and passing in a threadlocal from BSP.