### PR TITLE
 Disable Metrics SDK by default in autoconfigure.

### DIFF
--- a/sdk-extensions/autoconfigure/build.gradle.kts
+++ b/sdk-extensions/autoconfigure/build.gradle.kts
@@ -13,8 +13,8 @@ testSets {
   create("testFullConfig")
   create("testInitializeRegistersGlobal")
   create("testJaeger")
-  create("testPrometheus")
   create("testOtlp")
+  create("testPrometheus")
   create("testResourceDisabledByProperty")
   create("testResourceDisabledByEnv")
   create("testZipkin")
@@ -89,6 +89,7 @@ tasks {
   val testConfigError by existing(Test::class)
 
   val testFullConfig by existing(Test::class) {
+    environment("OTEL_METRICS_EXPORTER", "otlp")
     environment("OTEL_RESOURCE_ATTRIBUTES", "service.name=test,cat=meow")
     environment("OTEL_PROPAGATORS", "tracecontext,baggage,b3,b3multi,jaeger,ottrace,xray,test")
     environment("OTEL_BSP_SCHEDULE_DELAY", "10")
@@ -100,20 +101,19 @@ tasks {
 
   val testInitializeRegistersGlobal by existing(Test::class) {
     environment("OTEL_TRACES_EXPORTER", "none")
-    environment("OTEL_METRICS_EXPORTER", "none")
   }
 
   val testJaeger by existing(Test::class) {
     environment("OTEL_TRACES_EXPORTER", "jaeger")
-    environment("OTEL_METRICS_EXPORTER", "none")
     environment("OTEL_BSP_SCHEDULE_DELAY", "10")
   }
 
-  val testOtlp by existing(Test::class)
+  val testOtlp by existing(Test::class) {
+    environment("OTEL_METRICS_EXPORTER", "otlp")
+  }
 
   val testZipkin by existing(Test::class) {
     environment("OTEL_TRACES_EXPORTER", "zipkin")
-    environment("OTEL_METRICS_EXPORTER", "none")
     environment("OTEL_BSP_SCHEDULE_DELAY", "10")
   }
 
@@ -137,7 +137,7 @@ tasks {
     environment("OTEL_METRICS_EXPORTER", "none")
   }
 
-  val check by existing {
+  check {
     dependsOn(
       testConfigError,
       testFullConfig,

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySdkAutoConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySdkAutoConfiguration.java
@@ -75,6 +75,18 @@ public final class OpenTelemetrySdkAutoConfiguration {
   }
 
   private static void configureMeterProvider(Resource resource, ConfigProperties config) {
+    String exporterName = config.getString("otel.metrics.exporter");
+    if (exporterName == null) {
+      exporterName = "none";
+    }
+
+    if (exporterName.equals("none")) {
+      // No possiblity of having any metrics exported so no need to have the SDK installed at all.
+      // NB: If a user wants to add an exporter programatically using SdkMeterProviderConfigurer,
+      // they will need to use ConfigurableMetricExporter instead.
+      return;
+    }
+
     SdkMeterProviderBuilder meterProviderBuilder = SdkMeterProvider.builder().setResource(resource);
 
     for (SdkMeterProviderConfigurer configurer :
@@ -84,10 +96,6 @@ public final class OpenTelemetrySdkAutoConfiguration {
 
     SdkMeterProvider meterProvider = meterProviderBuilder.buildAndRegisterGlobal();
 
-    String exporterName = config.getString("otel.metrics.exporter");
-    if (exporterName == null) {
-      exporterName = "otlp";
-    }
     MetricExporterConfiguration.configureExporter(exporterName, config, meterProvider);
   }
 

--- a/sdk-extensions/autoconfigure/src/testInitializeRegistersGlobal/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySdkAutoConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testInitializeRegistersGlobal/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySdkAutoConfigurationTest.java
@@ -8,6 +8,8 @@ package io.opentelemetry.sdk.autoconfigure;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.metrics.GlobalMeterProvider;
+import io.opentelemetry.api.metrics.internal.NoopMeterProvider;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,5 +37,11 @@ class OpenTelemetrySdkAutoConfigurationTest {
     // SDK; in that case the get() method will return OpenTelemetrySdk and not
     // ObfuscatedOpenTelemetry
     assertThat(GlobalOpenTelemetry.get()).isNotSameAs(sdk);
+  }
+
+  @Test
+  void noMetricsSdk() {
+    // OTEL_METRICS_EXPORTER=none so the metrics SDK should be completely disabled.
+    assertThat(GlobalMeterProvider.get()).isSameAs(NoopMeterProvider.getInstance());
   }
 }


### PR DESCRIPTION
Also disable the metrics API if there is no exporter configured.

We're seeing a memory leak in https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3962 which I think happens when we collect metrics but have no exporter to trigger aggregation. I don't know if this PR is the correct long term solution to this issue, but if it is, or if it's a reasonable short term one, then we should probably get it out as a patch.