### PR TITLE
Add a manually run stress test from SDK through OTLP via BSP.

### DIFF
--- a/exporters/otlp/trace/build.gradle.kts
+++ b/exporters/otlp/trace/build.gradle.kts
@@ -15,6 +15,10 @@ testSets {
   create("testGrpcNetty")
   create("testGrpcNettyShaded")
   create("testGrpcOkhttp")
+
+  // Mainly to conveniently profile through IDEA. Don't add to check task, it's for
+  // manual invocation.
+  create("testSpanPipeline")
 }
 
 dependencies {
@@ -54,9 +58,14 @@ dependencies {
   add("testGrpcOkhttpRuntimeOnly", "io.grpc:grpc-okhttp")
   add("testGrpcOkhttpRuntimeOnly", "org.bouncycastle:bcpkix-jdk15on")
 
-  jmh(project(":proto"))
-  jmh(project(":sdk:testing"))
-  jmh("io.grpc:grpc-netty")
+  jmhImplementation(project(":proto"))
+  jmhImplementation(project(":sdk:testing"))
+  jmhRuntimeOnly("io.grpc:grpc-netty")
+  jmhImplementation("io.grpc:grpc-testing")
+
+  add("testSpanPipeline", project(":proto"))
+  add("testSpanPipeline", "io.grpc:grpc-protobuf")
+  add("testSpanPipeline", "io.grpc:grpc-testing")
 }
 
 tasks {

--- a/exporters/otlp/trace/src/testSpanPipeline/java/io/opentelemetry/exporter/otlp/trace/SpanPipelineOtlpBenchmark.java
+++ b/exporters/otlp/trace/src/testSpanPipeline/java/io/opentelemetry/exporter/otlp/trace/SpanPipelineOtlpBenchmark.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.trace;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+public class SpanPipelineOtlpBenchmark {
+  private static final Resource RESOURCE =
+      Resource.create(
+          Attributes.builder()
+              .put(AttributeKey.booleanKey("key_bool"), true)
+              .put(AttributeKey.stringKey("key_string"), "string")
+              .put(AttributeKey.longKey("key_int"), 100L)
+              .put(AttributeKey.doubleKey("key_double"), 100.3)
+              .put(
+                  AttributeKey.stringArrayKey("key_string_array"),
+                  Arrays.asList("string", "string"))
+              .put(AttributeKey.longArrayKey("key_long_array"), Arrays.asList(12L, 23L))
+              .put(AttributeKey.doubleArrayKey("key_double_array"), Arrays.asList(12.3, 23.1))
+              .put(AttributeKey.booleanArrayKey("key_boolean_array"), Arrays.asList(true, false))
+              .build());
+
+  private static final Attributes SPAN_ATTRIBUTES =
+      Attributes.builder()
+          .put(AttributeKey.booleanKey("key_bool"), true)
+          .put(AttributeKey.stringKey("key_string"), "string")
+          .put(AttributeKey.longKey("key_int"), 100L)
+          .put(AttributeKey.doubleKey("key_double"), 100.3)
+          .build();
+
+  private static final NoopCollector collector = new NoopCollector();
+  private static final String serverName = InProcessServerBuilder.generateName();
+  private static final ManagedChannel inProcessChannel =
+      InProcessChannelBuilder.forName(serverName).directExecutor().build();
+  private static final Server server;
+
+  static {
+    try {
+      server =
+          InProcessServerBuilder.forName(serverName)
+              .directExecutor()
+              .addService(collector)
+              .build()
+              .start();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private static final SdkTracerProvider tracerProvider =
+      SdkTracerProvider.builder()
+          .setResource(RESOURCE)
+          .addSpanProcessor(
+              BatchSpanProcessor.builder(
+                      OtlpGrpcSpanExporter.builder().setChannel(inProcessChannel).build())
+                  .setScheduleDelay(Duration.ofMillis(500))
+                  .build())
+          .build();
+
+  private static final Tracer tracer = tracerProvider.get("benchmark");
+
+  private static void tearDown() {
+    tracerProvider.close();
+    server.shutdownNow();
+    inProcessChannel.shutdownNow();
+  }
+
+  private static void createSpan() {
+    Span span = tracer.spanBuilder("POST /search").startSpan();
+    try (Scope ignored = span.makeCurrent()) {
+      span.setAllAttributes(SPAN_ATTRIBUTES);
+    }
+    span.end();
+  }
+
+  // Convenient to run in IDE with profiling
+  @Test
+  void runPipeline() {
+    long startTimeNanos = System.nanoTime();
+    long endTimeNanos = startTimeNanos + TimeUnit.SECONDS.toNanos(60);
+    try {
+      while (System.nanoTime() < endTimeNanos) {
+        SpanPipelineOtlpBenchmark.createSpan();
+      }
+    } finally {
+      SpanPipelineOtlpBenchmark.tearDown();
+    }
+  }
+
+  private static class NoopCollector extends TraceServiceGrpc.TraceServiceImplBase {
+    @Override
+    public void export(
+        ExportTraceServiceRequest request,
+        StreamObserver<ExportTraceServiceResponse> responseObserver) {
+      responseObserver.onNext(ExportTraceServiceResponse.getDefaultInstance());
+      responseObserver.onCompleted();
+    }
+  }
+}


### PR DESCRIPTION
Now adays it's just one button to run some code with async profiler attached from within IDEA. I originally tried to just add a `public static void main` to a JMH benchmark, so the benchmark method could be run either via JMH or via a simple loop (triggered by the IDEA button) but presumably due to an IDEA bug, it would never resolve `jmhRuntime` type of dependencies correctly. Run would work fine, but Run with profiler would fail of ClassNotFound.

So just added a separate test set instead, and this worked fine. Got a couple of insights from the flame graphs, one is to add `bytesFromBase16` which fills a byte[] without allocating. And our encoder would use a threadlocal to not need to ever allocate for base16 conversion.