### PR TITLE
Use default spotless googleJavaFormat version

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -42,7 +42,7 @@ subprojects {
     spotless {
         java {
             targetExclude '**/generated/**'
-            googleJavaFormat("1.9")
+            googleJavaFormat()
         }
     }
 }


### PR DESCRIPTION
I noticed this when sync'ing #3554 back into the instrumentation repo. Based on @anuraaga's https://github.com/open-telemetry/opentelemetry-java/pull/3554#discussion_r696309005.