### PR TITLE
Cache AttributeKey hashCode

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/common/AttributeKeyImpl.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/AttributeKeyImpl.java
@@ -5,12 +5,26 @@
 
 package io.opentelemetry.api.common;
 
-import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
 
 @SuppressWarnings("rawtypes")
-@AutoValue
-abstract class AttributeKeyImpl<T> implements AttributeKey<T> {
+final class AttributeKeyImpl<T> implements AttributeKey<T> {
+
+  private final AttributeType type;
+  private final String key;
+  private final int hashCode;
+
+  private AttributeKeyImpl(AttributeType type, String key) {
+    if (type == null) {
+      throw new NullPointerException("Null type");
+    }
+    this.type = type;
+    if (key == null) {
+      throw new NullPointerException("Null key");
+    }
+    this.key = key;
+    this.hashCode = buildHashCode();
+  }
 
   // Used by auto-instrumentation agent. Check with auto-instrumentation before making changes to
   // this method.
@@ -25,14 +39,47 @@ abstract class AttributeKeyImpl<T> implements AttributeKey<T> {
   // Context, which would be the same class (interface) being instrumented at that time,
   // which would lead to the JVM throwing a LinkageError "attempted duplicate interface definition"
   static <T> AttributeKey<T> create(@Nullable String key, AttributeType type) {
-    return new AutoValue_AttributeKeyImpl<>(type, key != null ? key : "");
+    return new AttributeKeyImpl<>(type, key != null ? key : "");
   }
 
   @Override
-  public abstract String getKey();
+  public AttributeType getType() {
+    return type;
+  }
 
   @Override
-  public final String toString() {
-    return getKey();
+  public String getKey() {
+    return key;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof AttributeKeyImpl) {
+      AttributeKeyImpl<?> that = (AttributeKeyImpl<?>) o;
+      return this.type.equals(that.getType()) && this.key.equals(that.getKey());
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return hashCode;
+  }
+
+  @Override
+  public String toString() {
+    return key;
+  }
+
+  private int buildHashCode() {
+    int result = 1;
+    result *= 1000003;
+    result ^= type.hashCode();
+    result *= 1000003;
+    result ^= key.hashCode();
+    return result;
   }
 }

--- a/api/all/src/main/java/io/opentelemetry/api/common/AttributeKeyImpl.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/AttributeKeyImpl.java
@@ -23,7 +23,7 @@ final class AttributeKeyImpl<T> implements AttributeKey<T> {
       throw new NullPointerException("Null key");
     }
     this.key = key;
-    this.hashCode = buildHashCode();
+    this.hashCode = buildHashCode(type, key);
   }
 
   // Used by auto-instrumentation agent. Check with auto-instrumentation before making changes to
@@ -74,7 +74,13 @@ final class AttributeKeyImpl<T> implements AttributeKey<T> {
     return key;
   }
 
+  // this method exists to make EqualsVerifier happy
+  @SuppressWarnings("unused")
   private int buildHashCode() {
+    return buildHashCode(type, key);
+  }
+
+  private static int buildHashCode(AttributeType type, String key) {
     int result = 1;
     result *= 1000003;
     result ^= type.hashCode();

--- a/api/all/src/test/java/io/opentelemetry/api/common/AttributeKeyTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/common/AttributeKeyTest.java
@@ -13,9 +13,11 @@ import org.junit.jupiter.api.Test;
 class AttributeKeyTest {
 
   @Test
-  @SuppressWarnings("AutoValueSubclassLeaked")
   void equalsVerifier() {
-    EqualsVerifier.forClass(AutoValue_AttributeKeyImpl.class).verify();
+    EqualsVerifier.forClass(AttributeKeyImpl.class)
+        .withCachedHashCode(
+            "hashCode", "buildHashCode", (AttributeKeyImpl<?>) AttributeKey.stringKey("test"))
+        .verify();
   }
 
   @Test


### PR DESCRIPTION
This turns out to be very helpful when looking up attribute keys in an attributes map.

I thought about using AutoValue's `@Memoize`, but the implementation for that is lazy double-checked lock (i.e. a volatile read), which seems unnecessary overhead in this case.