### PR TITLE
Remove branches from isValidBase16

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/internal/OtelEncodingUtils.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/OtelEncodingUtils.java
@@ -17,6 +17,7 @@ public final class OtelEncodingUtils {
   private static final int NUM_ASCII_CHARACTERS = 128;
   private static final char[] ENCODING = buildEncodingArray();
   private static final byte[] DECODING = buildDecodingArray();
+  private static final boolean[] VALID_HEX = buildValidHexArray();
 
   private static char[] buildEncodingArray() {
     char[] encoding = new char[512];
@@ -35,6 +36,14 @@ public final class OtelEncodingUtils {
       decoding[c] = (byte) i;
     }
     return decoding;
+  }
+
+  private static boolean[] buildValidHexArray() {
+    boolean[] validHex = new boolean[Character.MAX_VALUE];
+    for (int i = 0; i < Character.MAX_VALUE; i++) {
+      validHex[i] = (48 <= i && i <= 57) || (97 <= i && i <= 102);
+    }
+    return validHex;
   }
 
   /**
@@ -122,7 +131,8 @@ public final class OtelEncodingUtils {
 
   /** Returns whether the {@link CharSequence} is a valid hex string. */
   public static boolean isValidBase16String(CharSequence value) {
-    for (int i = 0; i < value.length(); i++) {
+    int len = value.length();
+    for (int i = 0; i < len; i++) {
       char b = value.charAt(i);
       if (!isValidBase16Character(b)) {
         return false;
@@ -133,8 +143,7 @@ public final class OtelEncodingUtils {
 
   /** Returns whether the given {@code char} is a valid hex character. */
   public static boolean isValidBase16Character(char b) {
-    // 48..57 && 97..102 are valid
-    return (48 <= b && b <= 57) || (97 <= b && b <= 102);
+    return VALID_HEX[b];
   }
 
   private OtelEncodingUtils() {}


### PR DESCRIPTION
@trask This changed the flamegraphs quite a bit to not have a dominant base16 validation in them. 0 is still better than non-0 but maybe this changes the importance of the other PR (though I left a comment on that which could allow us to eat the cake).

After
```
Benchmark                                                          Mode  Cnt     Score    Error   Units
FillSpanBenchmark.setFourAttributes                               thrpt   60  3208.277 ± 48.574  ops/ms
FillSpanBenchmark.setFourAttributes:·gc.alloc.rate                thrpt   60  1205.990 ± 18.235  MB/sec
FillSpanBenchmark.setFourAttributes:·gc.alloc.rate.norm           thrpt   60   592.000 ±  0.001    B/op
FillSpanBenchmark.setFourAttributes:·gc.churn.G1_Eden_Space       thrpt   60  1206.781 ± 33.014  MB/sec
FillSpanBenchmark.setFourAttributes:·gc.churn.G1_Eden_Space.norm  thrpt   60   592.359 ± 13.208    B/op
FillSpanBenchmark.setFourAttributes:·gc.churn.G1_Old_Gen          thrpt   60     0.002 ±  0.001  MB/sec
FillSpanBenchmark.setFourAttributes:·gc.churn.G1_Old_Gen.norm     thrpt   60     0.001 ±  0.001    B/op
FillSpanBenchmark.setFourAttributes:·gc.count                     thrpt   60   561.000           counts
FillSpanBenchmark.setFourAttributes:·gc.time                      thrpt   60   232.000               ms
```

Before
```
Benchmark                                                          Mode  Cnt     Score    Error   Units
FillSpanBenchmark.setFourAttributes                               thrpt   60  2029.646 ± 25.532  ops/ms
FillSpanBenchmark.setFourAttributes:·gc.alloc.rate                thrpt   60   763.105 ±  9.714  MB/sec
FillSpanBenchmark.setFourAttributes:·gc.alloc.rate.norm           thrpt   60   592.000 ±  0.001    B/op
FillSpanBenchmark.setFourAttributes:·gc.churn.G1_Eden_Space       thrpt   60   762.296 ± 25.178  MB/sec
FillSpanBenchmark.setFourAttributes:·gc.churn.G1_Eden_Space.norm  thrpt   60   591.415 ± 18.165    B/op
FillSpanBenchmark.setFourAttributes:·gc.churn.G1_Old_Gen          thrpt   60     0.002 ±  0.001  MB/sec
FillSpanBenchmark.setFourAttributes:·gc.churn.G1_Old_Gen.norm     thrpt   60     0.002 ±  0.001    B/op
FillSpanBenchmark.setFourAttributes:·gc.count                     thrpt   60   427.000           counts
FillSpanBenchmark.setFourAttributes:·gc.time                      thrpt   60   164.000               ms
```