### PR TITLE
Only compute nanoTime once for a root span.

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/AnchoredClock.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/AnchoredClock.java
@@ -51,4 +51,9 @@ final class AnchoredClock {
     long deltaNanos = clock.nanoTime() - this.nanoTime;
     return epochNanos + deltaNanos;
   }
+
+  /** Returns the start time in nanos of this {@link AnchoredClock}. */
+  long startTime() {
+    return epochNanos;
+  }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -14,6 +14,7 @@ import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.EventData;
@@ -124,11 +125,11 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
    * @param context supplies the trace_id and span_id for the newly started span.
    * @param name the displayed name for the new span.
    * @param kind the span kind.
-   * @param parentSpanContext the parent span context, or {@link SpanContext#getInvalid()} if this
-   *     span is a root span.
+   * @param parentSpan the parent span, or {@link Span#getInvalid()} if this span is a root span.
    * @param spanLimits trace parameters like sampler and probability.
    * @param spanProcessor handler called when the span starts and ends.
-   * @param clock the clock used to get the time.
+   * @param parentSpan the parent span
+   * @param tracerClock the tracer's clock
    * @param resource the resource associated with this span.
    * @param attributes the attributes set during span creation.
    * @param links the links set during span creation, may be truncated. The list MUST be immutable.
@@ -139,23 +140,46 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
       String name,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
       SpanKind kind,
-      SpanContext parentSpanContext,
+      Span parentSpan,
       Context parentContext,
       SpanLimits spanLimits,
       SpanProcessor spanProcessor,
-      AnchoredClock clock,
+      Clock tracerClock,
       Resource resource,
       @Nullable AttributesMap attributes,
       List<LinkData> links,
       int totalRecordedLinks,
-      long startEpochNanos) {
+      long userStartEpochNanos) {
+    final boolean createdAnchoredClock;
+    final AnchoredClock clock;
+    if (parentSpan instanceof RecordEventsReadableSpan) {
+      RecordEventsReadableSpan parentRecordEventsSpan = (RecordEventsReadableSpan) parentSpan;
+      clock = parentRecordEventsSpan.clock;
+      createdAnchoredClock = false;
+    } else {
+      clock = AnchoredClock.create(tracerClock);
+      createdAnchoredClock = true;
+    }
+
+    final long startEpochNanos;
+    if (userStartEpochNanos != 0) {
+      startEpochNanos = userStartEpochNanos;
+    } else if (createdAnchoredClock) {
+      // If this is a new AnchoredClock, the start time is now, so just use it to avoid
+      // recoputing current time.
+      startEpochNanos = clock.startTime();
+    } else {
+      // AnchoredClock created in the past, so need to compute now.
+      startEpochNanos = clock.now();
+    }
+
     RecordEventsReadableSpan span =
         new RecordEventsReadableSpan(
             context,
             name,
             instrumentationLibraryInfo,
             kind,
-            parentSpanContext,
+            parentSpan.getSpanContext(),
             spanLimits,
             spanProcessor,
             clock,
@@ -163,7 +187,7 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
             attributes,
             links,
             totalRecordedLinks,
-            startEpochNanos == 0 ? clock.now() : startEpochNanos);
+            startEpochNanos);
     // Call onStart here instead of calling in the constructor to make sure the span is completely
     // initialized.
     spanProcessor.onStart(parentContext, span);

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -128,7 +128,6 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
    * @param parentSpan the parent span, or {@link Span#getInvalid()} if this span is a root span.
    * @param spanLimits trace parameters like sampler and probability.
    * @param spanProcessor handler called when the span starts and ends.
-   * @param parentSpan the parent span
    * @param tracerClock the tracer's clock
    * @param resource the resource associated with this span.
    * @param attributes the attributes set during span creation.

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -166,7 +166,7 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
       startEpochNanos = userStartEpochNanos;
     } else if (createdAnchoredClock) {
       // If this is a new AnchoredClock, the start time is now, so just use it to avoid
-      // recoputing current time.
+      // recomputing current time.
       startEpochNanos = clock.startTime();
     } else {
       // AnchoredClock created in the past, so need to compute now.

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java
@@ -19,7 +19,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
@@ -215,11 +214,11 @@ final class SdkSpanBuilder implements SpanBuilder {
         spanName,
         instrumentationLibraryInfo,
         spanKind,
-        parentSpanContext,
+        parentSpan,
         parentContext,
         spanLimits,
         tracerSharedState.getActiveSpanProcessor(),
-        getClock(parentSpan, tracerSharedState.getClock()),
+        tracerSharedState.getClock(),
         tracerSharedState.getResource(),
         recordedAttributes,
         immutableLinks,
@@ -234,15 +233,6 @@ final class SdkSpanBuilder implements SpanBuilder {
       attributes = this.attributes;
     }
     return attributes;
-  }
-
-  private static AnchoredClock getClock(Span parent, Clock clock) {
-    if (parent instanceof RecordEventsReadableSpan) {
-      RecordEventsReadableSpan parentRecordEventsSpan = (RecordEventsReadableSpan) parent;
-      return parentRecordEventsSpan.getClock();
-    } else {
-      return AnchoredClock.create(clock);
-    }
   }
 
   // Visible for testing

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.SpanKind;
@@ -958,13 +959,14 @@ class RecordEventsReadableSpanTest {
             instrumentationLibraryInfo,
             kind,
             parentSpanId != null
-                ? SpanContext.create(
-                    traceId, parentSpanId, TraceFlags.getDefault(), TraceState.getDefault())
-                : SpanContext.getInvalid(),
+                ? Span.wrap(
+                    SpanContext.create(
+                        traceId, parentSpanId, TraceFlags.getDefault(), TraceState.getDefault()))
+                : Span.getInvalid(),
             Context.root(),
             config,
             spanProcessor,
-            AnchoredClock.create(testClock),
+            testClock,
             resource,
             attributes,
             links,
@@ -1046,13 +1048,14 @@ class RecordEventsReadableSpanTest {
             instrumentationLibraryInfo,
             kind,
             parentSpanId != null
-                ? SpanContext.create(
-                    traceId, parentSpanId, TraceFlags.getDefault(), TraceState.getDefault())
-                : SpanContext.getInvalid(),
+                ? Span.wrap(
+                    SpanContext.create(
+                        traceId, parentSpanId, TraceFlags.getDefault(), TraceState.getDefault()))
+                : Span.getInvalid(),
             Context.root(),
             spanLimits,
             spanProcessor,
-            AnchoredClock.create(clock),
+            clock,
             resource,
             attributesWithCapacity,
             Collections.singletonList(link1),


### PR DESCRIPTION
Currently we compute current `nanoTime` twice for a root span unnecessarily. `nanoTime` calls into the OS so it's not the fastest API out there and this does end up showing up on flame graphs. It's not so difficult to avoid this.

After
```
Benchmark                                                          Mode  Cnt     Score    Error   Units
FillSpanBenchmark.setFourAttributes                               thrpt   60  2164.882 ± 28.919  ops/ms
FillSpanBenchmark.setFourAttributes:·gc.alloc.rate                thrpt   60   813.621 ± 10.910  MB/sec
FillSpanBenchmark.setFourAttributes:·gc.alloc.rate.norm           thrpt   60   592.000 ±  0.001    B/op
FillSpanBenchmark.setFourAttributes:·gc.churn.G1_Eden_Space       thrpt   60   813.659 ± 24.409  MB/sec
FillSpanBenchmark.setFourAttributes:·gc.churn.G1_Eden_Space.norm  thrpt   60   591.916 ± 15.074    B/op
FillSpanBenchmark.setFourAttributes:·gc.churn.G1_Old_Gen          thrpt   60     0.002 ±  0.001  MB/sec
FillSpanBenchmark.setFourAttributes:·gc.churn.G1_Old_Gen.norm     thrpt   60     0.001 ±  0.001    B/op
FillSpanBenchmark.setFourAttributes:·gc.count                     thrpt   60   457.000           counts
FillSpanBenchmark.setFourAttributes:·gc.time                      thrpt   60   174.000               ms
```

Before
```
Benchmark                                                          Mode  Cnt     Score    Error   Units
FillSpanBenchmark.setFourAttributes                               thrpt   60  2029.646 ± 25.532  ops/ms
FillSpanBenchmark.setFourAttributes:·gc.alloc.rate                thrpt   60   763.105 ±  9.714  MB/sec
FillSpanBenchmark.setFourAttributes:·gc.alloc.rate.norm           thrpt   60   592.000 ±  0.001    B/op
FillSpanBenchmark.setFourAttributes:·gc.churn.G1_Eden_Space       thrpt   60   762.296 ± 25.178  MB/sec
FillSpanBenchmark.setFourAttributes:·gc.churn.G1_Eden_Space.norm  thrpt   60   591.415 ± 18.165    B/op
FillSpanBenchmark.setFourAttributes:·gc.churn.G1_Old_Gen          thrpt   60     0.002 ±  0.001  MB/sec
FillSpanBenchmark.setFourAttributes:·gc.churn.G1_Old_Gen.norm     thrpt   60     0.002 ±  0.001    B/op
FillSpanBenchmark.setFourAttributes:·gc.count                     thrpt   60   427.000           counts
FillSpanBenchmark.setFourAttributes:·gc.time                      thrpt   60   164.000               ms
```