### PR TITLE
Add MarshalerUtil enum helpers.

### DIFF
--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MarshalerUtil.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MarshalerUtil.java
@@ -127,6 +127,14 @@ final class MarshalerUtil {
     output.writeByteArray(fieldNumber, message);
   }
 
+  // Assumes OTLP always defines the first item in an enum with number 0, which it does and will.
+  static void marshalEnum(int fieldNumber, int value, CodedOutputStream output) throws IOException {
+    if (value == 0) {
+      return;
+    }
+    output.writeEnum(fieldNumber, value);
+  }
+
   static int sizeRepeatedFixed64(int fieldNumber, List<Long> values) {
     return sizeRepeatedFixed64(fieldNumber, values.size());
   }
@@ -207,6 +215,14 @@ final class MarshalerUtil {
       return 0;
     }
     return CodedOutputStream.computeByteArraySize(fieldNumber, message);
+  }
+
+  // Assumes OTLP always defines the first item in an enum with number 0, which it does and will.
+  static int sizeEnum(int fieldNumber, int value) {
+    if (value == 0) {
+      return 0;
+    }
+    return CodedOutputStream.computeEnumSize(fieldNumber, value);
   }
 
   static byte[] toBytes(@Nullable String value) {

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MetricsRequestMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MetricsRequestMarshaler.java
@@ -339,17 +339,16 @@ public final class MetricsRequestMarshaler extends MarshalerWithSize implements 
     @Override
     public void writeTo(CodedOutputStream output) throws IOException {
       MarshalerUtil.marshalRepeatedMessage(Histogram.DATA_POINTS_FIELD_NUMBER, dataPoints, output);
-      // TODO: Make this a MarshalerUtil helper.
-      output.writeEnum(Histogram.AGGREGATION_TEMPORALITY_FIELD_NUMBER, aggregationTemporality);
+      MarshalerUtil.marshalEnum(
+          Histogram.AGGREGATION_TEMPORALITY_FIELD_NUMBER, aggregationTemporality, output);
     }
 
     private static int calculateSize(
         HistogramDataPointMarshaler[] dataPoints, int aggregationTemporality) {
       int size = 0;
       size += MarshalerUtil.sizeRepeatedMessage(Histogram.DATA_POINTS_FIELD_NUMBER, dataPoints);
-      // TODO: Make this a MarshalerUtil helper.
       size +=
-          CodedOutputStream.computeEnumSize(
+          MarshalerUtil.sizeEnum(
               Histogram.AGGREGATION_TEMPORALITY_FIELD_NUMBER, aggregationTemporality);
       return size;
     }
@@ -496,8 +495,8 @@ public final class MetricsRequestMarshaler extends MarshalerWithSize implements 
     @Override
     public void writeTo(CodedOutputStream output) throws IOException {
       MarshalerUtil.marshalRepeatedMessage(Sum.DATA_POINTS_FIELD_NUMBER, dataPoints, output);
-      // TODO: Make this a MarshalerUtil helper.
-      output.writeEnum(Sum.AGGREGATION_TEMPORALITY_FIELD_NUMBER, aggregationTemporality);
+      MarshalerUtil.marshalEnum(
+          Sum.AGGREGATION_TEMPORALITY_FIELD_NUMBER, aggregationTemporality, output);
       MarshalerUtil.marshalBool(Sum.IS_MONOTONIC_FIELD_NUMBER, isMonotonic, output);
     }
 
@@ -505,10 +504,8 @@ public final class MetricsRequestMarshaler extends MarshalerWithSize implements 
         NumberDataPointMarshaler[] dataPoints, int aggregationTemporality, boolean isMonotonic) {
       int size = 0;
       size += MarshalerUtil.sizeRepeatedMessage(Sum.DATA_POINTS_FIELD_NUMBER, dataPoints);
-      // TODO: Make this a MarshalerUtil helper.
       size +=
-          CodedOutputStream.computeEnumSize(
-              Sum.AGGREGATION_TEMPORALITY_FIELD_NUMBER, aggregationTemporality);
+          MarshalerUtil.sizeEnum(Sum.AGGREGATION_TEMPORALITY_FIELD_NUMBER, aggregationTemporality);
       size += MarshalerUtil.sizeBool(Sum.IS_MONOTONIC_FIELD_NUMBER, isMonotonic);
       return size;
     }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/TraceRequestMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/TraceRequestMarshaler.java
@@ -287,8 +287,7 @@ public final class TraceRequestMarshaler extends MarshalerWithSize implements Ma
       MarshalerUtil.marshalBytes(Span.PARENT_SPAN_ID_FIELD_NUMBER, parentSpanId, output);
       MarshalerUtil.marshalBytes(Span.NAME_FIELD_NUMBER, name, output);
 
-      // TODO: Make this a MarshalerUtil helper.
-      output.writeEnum(Span.KIND_FIELD_NUMBER, spanKind);
+      MarshalerUtil.marshalEnum(Span.KIND_FIELD_NUMBER, spanKind, output);
 
       MarshalerUtil.marshalFixed64(Span.START_TIME_UNIX_NANO_FIELD_NUMBER, startEpochNanos, output);
       MarshalerUtil.marshalFixed64(Span.END_TIME_UNIX_NANO_FIELD_NUMBER, endEpochNanos, output);
@@ -330,8 +329,7 @@ public final class TraceRequestMarshaler extends MarshalerWithSize implements Ma
       size += MarshalerUtil.sizeBytes(Span.PARENT_SPAN_ID_FIELD_NUMBER, parentSpanId);
       size += MarshalerUtil.sizeBytes(Span.NAME_FIELD_NUMBER, name);
 
-      // TODO: Make this a MarshalerUtil helper.
-      size += CodedOutputStream.computeEnumSize(Span.KIND_FIELD_NUMBER, spanKind);
+      size += MarshalerUtil.sizeEnum(Span.KIND_FIELD_NUMBER, spanKind);
 
       size += MarshalerUtil.sizeFixed64(Span.START_TIME_UNIX_NANO_FIELD_NUMBER, startEpochNanos);
       size += MarshalerUtil.sizeFixed64(Span.END_TIME_UNIX_NANO_FIELD_NUMBER, endEpochNanos);
@@ -518,31 +516,22 @@ public final class TraceRequestMarshaler extends MarshalerWithSize implements Ma
 
     @Override
     public void writeTo(CodedOutputStream output) throws IOException {
-      // TODO: Make this a MarshalerUtil helper.
       if (deprecatedStatusCode != Status.DeprecatedStatusCode.DEPRECATED_STATUS_CODE_OK_VALUE) {
-        output.writeEnum(Status.DEPRECATED_CODE_FIELD_NUMBER, deprecatedStatusCode);
+        MarshalerUtil.marshalEnum(
+            Status.DEPRECATED_CODE_FIELD_NUMBER, deprecatedStatusCode, output);
       }
       MarshalerUtil.marshalBytes(Status.MESSAGE_FIELD_NUMBER, description, output);
-      // TODO: Make this a MarshalerUtil helper.
       if (protoStatusCode != Status.StatusCode.STATUS_CODE_UNSET_VALUE) {
-        output.writeEnum(Status.CODE_FIELD_NUMBER, protoStatusCode);
+        MarshalerUtil.marshalEnum(Status.CODE_FIELD_NUMBER, protoStatusCode, output);
       }
     }
 
     private static int computeSize(
         int protoStatusCode, int deprecatedStatusCode, byte[] description) {
       int size = 0;
-      // TODO: Make this a MarshalerUtil helper.
-      if (deprecatedStatusCode != Status.DeprecatedStatusCode.DEPRECATED_STATUS_CODE_OK_VALUE) {
-        size +=
-            CodedOutputStream.computeEnumSize(
-                Status.DEPRECATED_CODE_FIELD_NUMBER, deprecatedStatusCode);
-      }
+      size += MarshalerUtil.sizeEnum(Status.DEPRECATED_CODE_FIELD_NUMBER, deprecatedStatusCode);
       size += MarshalerUtil.sizeBytes(Status.MESSAGE_FIELD_NUMBER, description);
-      // TODO: Make this a MarshalerUtil helper.
-      if (protoStatusCode != Status.StatusCode.STATUS_CODE_UNSET_VALUE) {
-        size += CodedOutputStream.computeEnumSize(Status.CODE_FIELD_NUMBER, protoStatusCode);
-      }
+      size += MarshalerUtil.sizeEnum(Status.CODE_FIELD_NUMBER, protoStatusCode);
       return size;
     }
   }


### PR DESCRIPTION
Solves a TODO. I suspect the original implementation didn't include them since they're not 100% correct - you're supposed to compare against the first entry in the `enum`, which may not necessarily be `0`. OTLP will always use `0` following best practices though and I think this is safe enough.