### PR TITLE
Use constants for AttributeKeys in JMH

### DIFF
--- a/exporters/otlp/trace/src/jmh/java/io/opentelemetry/exporter/otlp/trace/RequestMarshalState.java
+++ b/exporters/otlp/trace/src/jmh/java/io/opentelemetry/exporter/otlp/trace/RequestMarshalState.java
@@ -28,19 +28,32 @@ import org.openjdk.jmh.annotations.State;
 
 @State(Scope.Benchmark)
 public class RequestMarshalState {
+
+  private static final AttributeKey<Boolean> KEY_BOOL = AttributeKey.booleanKey("key_bool");
+  private static final AttributeKey<String> KEY_STRING = AttributeKey.stringKey("key_string");
+  private static final AttributeKey<Long> KEY_INT = AttributeKey.longKey("key_int");
+  private static final AttributeKey<Double> KEY_DOUBLE = AttributeKey.doubleKey("key_double");
+  private static final AttributeKey<List<String>> KEY_STRING_ARRAY =
+      AttributeKey.stringArrayKey("key_string_array");
+  private static final AttributeKey<List<Long>> KEY_LONG_ARRAY =
+      AttributeKey.longArrayKey("key_long_array");
+  private static final AttributeKey<List<Double>> KEY_DOUBLE_ARRAY =
+      AttributeKey.doubleArrayKey("key_double_array");
+  private static final AttributeKey<List<Boolean>> KEY_BOOLEAN_ARRAY =
+      AttributeKey.booleanArrayKey("key_boolean_array");
+  private static final AttributeKey<String> LINK_ATTR_KEY = AttributeKey.stringKey("link_attr_key");
+
   private static final Resource RESOURCE =
       Resource.create(
           Attributes.builder()
-              .put(AttributeKey.booleanKey("key_bool"), true)
-              .put(AttributeKey.stringKey("key_string"), "string")
-              .put(AttributeKey.longKey("key_int"), 100L)
-              .put(AttributeKey.doubleKey("key_double"), 100.3)
-              .put(
-                  AttributeKey.stringArrayKey("key_string_array"),
-                  Arrays.asList("string", "string"))
-              .put(AttributeKey.longArrayKey("key_long_array"), Arrays.asList(12L, 23L))
-              .put(AttributeKey.doubleArrayKey("key_double_array"), Arrays.asList(12.3, 23.1))
-              .put(AttributeKey.booleanArrayKey("key_boolean_array"), Arrays.asList(true, false))
+              .put(KEY_BOOL, true)
+              .put(KEY_STRING, "string")
+              .put(KEY_INT, 100L)
+              .put(KEY_DOUBLE, 100.3)
+              .put(KEY_STRING_ARRAY, Arrays.asList("string", "string"))
+              .put(KEY_LONG_ARRAY, Arrays.asList(12L, 23L))
+              .put(KEY_DOUBLE_ARRAY, Arrays.asList(12.3, 23.1))
+              .put(KEY_BOOLEAN_ARRAY, Arrays.asList(true, false))
               .build());
 
   private static final InstrumentationLibraryInfo INSTRUMENTATION_LIBRARY_INFO =
@@ -76,26 +89,22 @@ public class RequestMarshalState {
         .setEndEpochNanos(12349)
         .setAttributes(
             Attributes.builder()
-                .put(AttributeKey.booleanKey("key_bool"), true)
-                .put(AttributeKey.stringKey("key_string"), "string")
-                .put(AttributeKey.longKey("key_int"), 100L)
-                .put(AttributeKey.doubleKey("key_double"), 100.3)
+                .put(KEY_BOOL, true)
+                .put(KEY_STRING, "string")
+                .put(KEY_INT, 100L)
+                .put(KEY_DOUBLE, 100.3)
                 .build())
         .setTotalAttributeCount(2)
         .setEvents(
             Arrays.asList(
                 EventData.create(12347, "my_event_1", Attributes.empty()),
-                EventData.create(
-                    12348,
-                    "my_event_2",
-                    Attributes.of(AttributeKey.longKey("event_attr_key"), 1234L)),
+                EventData.create(12348, "my_event_2", Attributes.of(KEY_INT, 1234L)),
                 EventData.create(12349, "my_event_3", Attributes.empty())))
         .setTotalRecordedEvents(4)
         .setLinks(
             Arrays.asList(
                 LinkData.create(SPAN_CONTEXT),
-                LinkData.create(
-                    SPAN_CONTEXT, Attributes.of(AttributeKey.stringKey("link_attr_key"), "value"))))
+                LinkData.create(SPAN_CONTEXT, Attributes.of(LINK_ATTR_KEY, "value"))))
         .setTotalRecordedLinks(3)
         .setStatus(StatusData.ok())
         .build();


### PR DESCRIPTION
We expect AttributeKey to always be singleton for performance - on the flip side, attributes added without creating constants can be considered non-performance-sensitive code I think. So our benchmark should reflect the actual performance-sensitive case to possibly, in the future, add optimizations that benefit it at the expense of some slowdown in non-performance-sensitive code.