### PR TITLE
Catch exceptions when loading a configurable SPI.

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
@@ -25,9 +25,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
-import java.util.ServiceLoader;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 
 final class MetricExporterConfiguration {
@@ -63,13 +60,11 @@ final class MetricExporterConfiguration {
   @Nullable
   static MetricExporter configureSpiExporter(String name, ConfigProperties config) {
     Map<String, MetricExporter> spiExporters =
-        StreamSupport.stream(
-                ServiceLoader.load(ConfigurableMetricExporterProvider.class).spliterator(), false)
-            .collect(
-                Collectors.toMap(
-                    ConfigurableMetricExporterProvider::getName,
-                    configurableSpanExporterProvider ->
-                        configurableSpanExporterProvider.createExporter(config)));
+        SpiUtil.loadConfigurable(
+            ConfigurableMetricExporterProvider.class,
+            ConfigurableMetricExporterProvider::getName,
+            ConfigurableMetricExporterProvider::createExporter,
+            config);
     return spiExporters.get(name);
   }
 

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
@@ -62,6 +62,7 @@ final class MetricExporterConfiguration {
     Map<String, MetricExporter> spiExporters =
         SpiUtil.loadConfigurable(
             ConfigurableMetricExporterProvider.class,
+            Collections.singletonList(name),
             ConfigurableMetricExporterProvider::getName,
             ConfigurableMetricExporterProvider::createExporter,
             config);

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/PropagatorConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/PropagatorConfiguration.java
@@ -16,22 +16,17 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 final class PropagatorConfiguration {
 
   static ContextPropagators configurePropagators(ConfigProperties config) {
     Map<String, TextMapPropagator> spiPropagators =
-        StreamSupport.stream(
-                ServiceLoader.load(ConfigurablePropagatorProvider.class).spliterator(), false)
-            .collect(
-                Collectors.toMap(
-                    ConfigurablePropagatorProvider::getName,
-                    configurablePropagatorProvider ->
-                        configurablePropagatorProvider.getPropagator(config)));
+        SpiUtil.loadConfigurable(
+            ConfigurablePropagatorProvider.class,
+            ConfigurablePropagatorProvider::getName,
+            ConfigurablePropagatorProvider::getPropagator,
+            config);
 
     Set<TextMapPropagator> propagators = new LinkedHashSet<>();
     List<String> requestedPropagators = config.getCommaSeparatedValues("otel.propagators");

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/PropagatorConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/PropagatorConfiguration.java
@@ -21,18 +21,20 @@ import java.util.Set;
 final class PropagatorConfiguration {
 
   static ContextPropagators configurePropagators(ConfigProperties config) {
-    Map<String, TextMapPropagator> spiPropagators =
-        SpiUtil.loadConfigurable(
-            ConfigurablePropagatorProvider.class,
-            ConfigurablePropagatorProvider::getName,
-            ConfigurablePropagatorProvider::getPropagator,
-            config);
-
     Set<TextMapPropagator> propagators = new LinkedHashSet<>();
     List<String> requestedPropagators = config.getCommaSeparatedValues("otel.propagators");
     if (requestedPropagators.isEmpty()) {
       requestedPropagators = Arrays.asList("tracecontext", "baggage");
     }
+
+    Map<String, TextMapPropagator> spiPropagators =
+        SpiUtil.loadConfigurable(
+            ConfigurablePropagatorProvider.class,
+            requestedPropagators,
+            ConfigurablePropagatorProvider::getName,
+            ConfigurablePropagatorProvider::getPropagator,
+            config);
+
     for (String propagatorName : requestedPropagators) {
       propagators.add(getPropagator(propagatorName, spiPropagators));
     }

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfiguration.java
@@ -66,6 +66,7 @@ final class SpanExporterConfiguration {
     Map<String, SpanExporter> spiExporters =
         SpiUtil.loadConfigurable(
             ConfigurableSpanExporterProvider.class,
+            exporterNamesList,
             ConfigurableSpanExporterProvider::getName,
             ConfigurableSpanExporterProvider::createExporter,
             config);

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfiguration.java
@@ -29,10 +29,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.StreamSupport;
 
 final class SpanExporterConfiguration {
 
@@ -66,13 +64,11 @@ final class SpanExporterConfiguration {
     }
 
     Map<String, SpanExporter> spiExporters =
-        StreamSupport.stream(
-                ServiceLoader.load(ConfigurableSpanExporterProvider.class).spliterator(), false)
-            .collect(
-                toMap(
-                    ConfigurableSpanExporterProvider::getName,
-                    configurableSpanExporterProvider ->
-                        configurableSpanExporterProvider.createExporter(config)));
+        SpiUtil.loadConfigurable(
+            ConfigurableSpanExporterProvider.class,
+            ConfigurableSpanExporterProvider::getName,
+            ConfigurableSpanExporterProvider::createExporter,
+            config);
 
     return exporterNames.stream()
         .collect(

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/SpiUtil.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/SpiUtil.java
@@ -21,7 +21,7 @@ final class SpiUtil {
 
   static <T, U> Map<String, T> loadConfigurable(
       Class<U> spiClass,
-      List<String> requested,
+      List<String> requestedNames,
       Function<U, String> getName,
       BiFunction<U, ConfigProperties, T> getConfigurable,
       ConfigProperties config) {
@@ -32,7 +32,7 @@ final class SpiUtil {
       try {
         configurable = getConfigurable.apply(provider, config);
       } catch (Throwable t) {
-        Level level = requested.contains(name) ? Level.WARNING : Level.FINE;
+        Level level = requestedNames.contains(name) ? Level.WARNING : Level.FINE;
         logger.log(
             level, "Error initializing " + spiClass.getSimpleName() + " with name " + name, t);
         continue;

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/SpiUtil.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/SpiUtil.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.autoconfigure;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.function.BiFunction;
@@ -20,6 +21,7 @@ final class SpiUtil {
 
   static <T, U> Map<String, T> loadConfigurable(
       Class<U> spiClass,
+      List<String> requested,
       Function<U, String> getName,
       BiFunction<U, ConfigProperties, T> getConfigurable,
       ConfigProperties config) {
@@ -30,8 +32,9 @@ final class SpiUtil {
       try {
         configurable = getConfigurable.apply(provider, config);
       } catch (Throwable t) {
+        Level level = requested.contains(name) ? Level.WARNING : Level.FINE;
         logger.log(
-            Level.FINE, "Error initializing " + spiClass.getSimpleName() + " with name " + name, t);
+            level, "Error initializing " + spiClass.getSimpleName() + " with name " + name, t);
         continue;
       }
       result.put(name, configurable);

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/SpiUtil.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/SpiUtil.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+final class SpiUtil {
+
+  private static final Logger logger = Logger.getLogger(SpiUtil.class.getName());
+
+  static <T, U> Map<String, T> loadConfigurable(
+      Class<U> spiClass,
+      Function<U, String> getName,
+      BiFunction<U, ConfigProperties, T> getConfigurable,
+      ConfigProperties config) {
+    Map<String, T> result = new HashMap<>();
+    for (U provider : ServiceLoader.load(spiClass)) {
+      String name = getName.apply(provider);
+      final T configurable;
+      try {
+        configurable = getConfigurable.apply(provider, config);
+      } catch (Throwable t) {
+        logger.log(
+            Level.FINE, "Error initializing " + spiClass.getSimpleName() + " with name " + name, t);
+        continue;
+      }
+      result.put(name, configurable);
+    }
+    return result;
+  }
+
+  private SpiUtil() {}
+}

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
@@ -22,6 +22,7 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -131,6 +132,7 @@ final class TracerProviderConfiguration {
     Map<String, Sampler> spiSamplers =
         SpiUtil.loadConfigurable(
             ConfigurableSamplerProvider.class,
+            Collections.singletonList(sampler),
             ConfigurableSamplerProvider::getName,
             ConfigurableSamplerProvider::createSampler,
             config);

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
@@ -26,8 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 final class TracerProviderConfiguration {
 
@@ -131,12 +129,11 @@ final class TracerProviderConfiguration {
   // Visible for testing
   static Sampler configureSampler(String sampler, ConfigProperties config) {
     Map<String, Sampler> spiSamplers =
-        StreamSupport.stream(
-                ServiceLoader.load(ConfigurableSamplerProvider.class).spliterator(), false)
-            .collect(
-                Collectors.toMap(
-                    ConfigurableSamplerProvider::getName,
-                    provider -> provider.createSampler(config)));
+        SpiUtil.loadConfigurable(
+            ConfigurableSamplerProvider.class,
+            ConfigurableSamplerProvider::getName,
+            ConfigurableSamplerProvider::createSampler,
+            config);
 
     switch (sampler) {
       case "always_on":

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ThrowingConfigurableMetricExporterProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ThrowingConfigurableMetricExporterProvider.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+
+public class ThrowingConfigurableMetricExporterProvider
+    implements ConfigurableMetricExporterProvider {
+  @Override
+  public MetricExporter createExporter(ConfigProperties config) {
+    throw new IllegalStateException("always throws");
+  }
+
+  @Override
+  public String getName() {
+    return "throwing";
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ThrowingConfigurablePropagatorProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ThrowingConfigurablePropagatorProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
+
+public class ThrowingConfigurablePropagatorProvider implements ConfigurablePropagatorProvider {
+  @Override
+  public TextMapPropagator getPropagator(ConfigProperties config) {
+    throw new IllegalStateException("always throws");
+  }
+
+  @Override
+  public String getName() {
+    return "throwing";
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ThrowingConfigurableSamplerProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ThrowingConfigurableSamplerProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+
+public class ThrowingConfigurableSamplerProvider implements ConfigurableSamplerProvider {
+  @Override
+  public Sampler createSampler(ConfigProperties config) {
+    throw new IllegalStateException("always throws");
+  }
+
+  @Override
+  public String getName() {
+    return "throwing";
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ThrowingConfigurableSpanExporterProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ThrowingConfigurableSpanExporterProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+
+public class ThrowingConfigurableSpanExporterProvider implements ConfigurableSpanExporterProvider {
+  @Override
+  public SpanExporter createExporter(ConfigProperties config) {
+    throw new IllegalStateException("always throws");
+  }
+
+  @Override
+  public String getName() {
+    return "throwing";
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider
@@ -1,1 +1,2 @@
 io.opentelemetry.sdk.autoconfigure.TestConfigurablePropagatorProvider
+io.opentelemetry.sdk.autoconfigure.ThrowingConfigurablePropagatorProvider

--- a/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider
@@ -1,1 +1,2 @@
 io.opentelemetry.sdk.autoconfigure.TestConfigurableMetricExporterProvider
+io.opentelemetry.sdk.autoconfigure.ThrowingConfigurableMetricExporterProvider

--- a/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider
@@ -1,1 +1,2 @@
 io.opentelemetry.sdk.autoconfigure.TestConfigurableSamplerProvider
+io.opentelemetry.sdk.autoconfigure.ThrowingConfigurableSamplerProvider

--- a/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider
@@ -1,1 +1,2 @@
 io.opentelemetry.sdk.autoconfigure.TestConfigurableSpanExporterProvider
+io.opentelemetry.sdk.autoconfigure.ThrowingConfigurableSpanExporterProvider


### PR DESCRIPTION
In https://github.com/aws-observability/aws-otel-java-instrumentation/issues/77 I noticed that it's possible for a bad SPI implementation to prevent others from being usable since we load them eagerly without catching exceptions. I think it's worth making sure that one bad SPI doesn't remove the flag completely so this catches and logs a failure. If the bad SPI was actually specified for the flag, it would result in a ConfigurationException still as we'd want.

I think for the non-configurable SPIs (*ProviderConfigurer) it seemed still fine to bubble the exception as they are not just an option out of many but code that needs to be executed.