### PR TITLE
Make Marshaler.writeTo private and expose method to write binary into…

### DIFF
--- a/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/otlp/internal/MetricsRequestMarshalerBenchmark.java
+++ b/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/otlp/internal/MetricsRequestMarshalerBenchmark.java
@@ -128,9 +128,7 @@ public class MetricsRequestMarshalerBenchmark {
   public ByteArrayOutputStream marshaler() throws IOException {
     MetricsRequestMarshaler marshaler = MetricsRequestMarshaler.create(METRICS);
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    CodedOutputStream cos = CodedOutputStream.newInstance(bos);
-    marshaler.writeTo(Serializer.createProtoSerializer(cos));
-    cos.flush();
+    marshaler.writeBinaryTo(bos);
     return bos;
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/CodedOutputStream.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/CodedOutputStream.java
@@ -64,7 +64,7 @@ import java.util.logging.Logger;
 // - Allow resetting and use a ThreadLocal instance
 //
 @SuppressWarnings({"UngroupedOverloads", "InlineMeSuggester"})
-public abstract class CodedOutputStream {
+abstract class CodedOutputStream {
   private static final Logger logger = Logger.getLogger(CodedOutputStream.class.getName());
 
   /** The buffer size used in {@link #newInstance(OutputStream)}. */
@@ -90,7 +90,7 @@ public abstract class CodedOutputStream {
    * the provided byte arrays. Doing so may result in corrupted data, which would be difficult to
    * debug.
    */
-  public static CodedOutputStream newInstance(final OutputStream output) {
+  static CodedOutputStream newInstance(final OutputStream output) {
     OutputStreamEncoder cos = THREAD_LOCAL_CODED_OUTPUT_STREAM.get();
     if (cos == null) {
       cos = new OutputStreamEncoder(output);
@@ -617,7 +617,7 @@ public abstract class CodedOutputStream {
    * Flushes the stream and forces any buffered bytes to be written. This does not flush the
    * underlying OutputStream.
    */
-  public abstract void flush() throws IOException;
+  abstract void flush() throws IOException;
 
   /**
    * If writing to a flat array, return the space left in the array. Otherwise, throws {@code
@@ -1079,7 +1079,7 @@ public abstract class CodedOutputStream {
     }
 
     @Override
-    public void flush() throws IOException {
+    void flush() throws IOException {
       if (position > 0) {
         // Flush the buffer.
         doFlush();

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/InstrumentationLibraryMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/InstrumentationLibraryMarshaler.java
@@ -35,9 +35,9 @@ final class InstrumentationLibraryMarshaler extends MarshalerWithSize {
 
   private InstrumentationLibraryMarshaler(byte[] name, byte[] version) {
     super(computeSize(name, version));
-    ByteArrayOutputStream bos = new ByteArrayOutputStream(getProtoSerializedSize());
+    ByteArrayOutputStream bos = new ByteArrayOutputStream(getBinarySerializedSize());
     CodedOutputStream output = CodedOutputStream.newInstance(bos);
-    Serializer serializer = Serializer.createProtoSerializer(output);
+    Serializer serializer = new ProtoSerializer(output);
     try {
       serializer.serializeString(InstrumentationLibrary.NAME, name);
       serializer.serializeString(InstrumentationLibrary.VERSION, version);

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Marshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Marshaler.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.exporter.otlp.internal;
 
 import java.io.IOException;
+import java.io.OutputStream;
 
 /**
  * Marshaler from an SDK structure to protobuf wire format.
@@ -13,8 +14,17 @@ import java.io.IOException;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public interface Marshaler {
-  void writeTo(Serializer output) throws IOException;
+public abstract class Marshaler {
 
-  int getProtoSerializedSize();
+  /** Marshals into the {@link OutputStream} in proto binary format. */
+  public final void writeBinaryTo(OutputStream output) throws IOException {
+    CodedOutputStream cos = CodedOutputStream.newInstance(output);
+    writeTo(new ProtoSerializer(cos));
+    cos.flush();
+  }
+
+  /** Returns the number of bytes this Marshaler will write in proto binary format. */
+  public abstract int getBinarySerializedSize();
+
+  abstract void writeTo(Serializer output) throws IOException;
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MarshalerUtil.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MarshalerUtil.java
@@ -62,7 +62,7 @@ final class MarshalerUtil {
     int size = 0;
     int fieldTagSize = field.getTagSize();
     for (Marshaler message : repeatedMessage) {
-      int fieldSize = message.getProtoSerializedSize();
+      int fieldSize = message.getBinarySerializedSize();
       size += fieldTagSize + CodedOutputStream.computeUInt32SizeNoTag(fieldSize) + fieldSize;
     }
     return size;
@@ -72,14 +72,14 @@ final class MarshalerUtil {
     int size = 0;
     int fieldTagSize = field.getTagSize();
     for (Marshaler message : repeatedMessage) {
-      int fieldSize = message.getProtoSerializedSize();
+      int fieldSize = message.getBinarySerializedSize();
       size += fieldTagSize + CodedOutputStream.computeUInt32SizeNoTag(fieldSize) + fieldSize;
     }
     return size;
   }
 
   static int sizeMessage(ProtoFieldInfo field, Marshaler message) {
-    int fieldSize = message.getProtoSerializedSize();
+    int fieldSize = message.getBinarySerializedSize();
     return field.getTagSize() + CodedOutputStream.computeUInt32SizeNoTag(fieldSize) + fieldSize;
   }
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MarshalerWithSize.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MarshalerWithSize.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.exporter.otlp.internal;
 
-abstract class MarshalerWithSize implements Marshaler {
+abstract class MarshalerWithSize extends Marshaler {
   private final int size;
 
   protected MarshalerWithSize(int size) {
@@ -13,7 +13,7 @@ abstract class MarshalerWithSize implements Marshaler {
   }
 
   @Override
-  public final int getProtoSerializedSize() {
+  public final int getBinarySerializedSize() {
     return size;
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MetricsRequestMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MetricsRequestMarshaler.java
@@ -47,7 +47,7 @@ import java.util.Map;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public final class MetricsRequestMarshaler extends MarshalerWithSize implements Marshaler {
+public final class MetricsRequestMarshaler extends MarshalerWithSize {
 
   private final ResourceMetricsMarshaler[] resourceMetricsMarshalers;
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/NoopMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/NoopMarshaler.java
@@ -5,14 +5,14 @@
 
 package io.opentelemetry.exporter.otlp.internal;
 
-enum NoopMarshaler implements Marshaler {
-  INSTANCE;
+final class NoopMarshaler extends MarshalerWithSize {
+
+  static final NoopMarshaler INSTANCE = new NoopMarshaler();
+
+  private NoopMarshaler() {
+    super(0);
+  }
 
   @Override
   public void writeTo(Serializer output) {}
-
-  @Override
-  public int getProtoSerializedSize() {
-    return 0;
-  }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ProtoRequestBody.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ProtoRequestBody.java
@@ -26,7 +26,7 @@ public final class ProtoRequestBody extends RequestBody {
   /** Creates a new {@link ProtoRequestBody}. */
   public ProtoRequestBody(Marshaler marshaler) {
     this.marshaler = marshaler;
-    contentLength = marshaler.getProtoSerializedSize();
+    contentLength = marshaler.getBinarySerializedSize();
   }
 
   @Override
@@ -41,8 +41,6 @@ public final class ProtoRequestBody extends RequestBody {
 
   @Override
   public void writeTo(BufferedSink bufferedSink) throws IOException {
-    CodedOutputStream cos = CodedOutputStream.newInstance(bufferedSink.outputStream());
-    marshaler.writeTo(Serializer.createProtoSerializer(cos));
-    cos.flush();
+    marshaler.writeBinaryTo(bufferedSink.outputStream());
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ResourceMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ResourceMarshaler.java
@@ -31,7 +31,7 @@ final class ResourceMarshaler extends MarshalerWithSize {
 
   private ResourceMarshaler(AttributeMarshaler[] attributeMarshalers) {
     super(calculateSize(attributeMarshalers));
-    ByteArrayOutputStream bos = new ByteArrayOutputStream(getProtoSerializedSize());
+    ByteArrayOutputStream bos = new ByteArrayOutputStream(getBinarySerializedSize());
     CodedOutputStream output = CodedOutputStream.newInstance(bos);
     ProtoSerializer serializer = new ProtoSerializer(output);
     try {

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Serializer.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Serializer.java
@@ -19,11 +19,6 @@ import java.util.List;
  */
 public abstract class Serializer {
 
-  /** Returns a {@link Serializer} to serialize into protobuf binary format. */
-  public static Serializer createProtoSerializer(CodedOutputStream output) {
-    return new ProtoSerializer(output);
-  }
-
   Serializer() {}
 
   /** Serializes a protobuf {@code bool} field. */
@@ -112,7 +107,7 @@ public abstract class Serializer {
 
   /** Serializes a protobuf embedded {@code message}. */
   public void serializeMessage(ProtoFieldInfo field, Marshaler message) throws IOException {
-    writeStartMessage(field, message.getProtoSerializedSize());
+    writeStartMessage(field, message.getBinarySerializedSize());
     message.writeTo(this);
     writeEndMessage();
   }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/TraceRequestMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/TraceRequestMarshaler.java
@@ -31,7 +31,7 @@ import java.util.Map;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public final class TraceRequestMarshaler extends MarshalerWithSize implements Marshaler {
+public final class TraceRequestMarshaler extends MarshalerWithSize {
 
   // In practice, there is often only one thread that calls this code in the BatchSpanProcessor so
   // reusing buffers for the thread is almost free. Even with multiple threads, it should still be

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/MetricsRequestMarshalerTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/MetricsRequestMarshalerTest.java
@@ -786,10 +786,8 @@ class MetricsRequestMarshalerTest {
 
   private static byte[] toByteArray(Marshaler marshaler) {
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    CodedOutputStream cos = CodedOutputStream.newInstance(bos);
     try {
-      marshaler.writeTo(Serializer.createProtoSerializer(cos));
-      cos.flush();
+      marshaler.writeBinaryTo(bos);
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/TraceRequestMarshalerTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/TraceRequestMarshalerTest.java
@@ -153,10 +153,8 @@ class TraceRequestMarshalerTest {
     byte[] protoOutput = protoRequest.toByteArray();
 
     ByteArrayOutputStream customOutput =
-        new ByteArrayOutputStream(requestMarshaler.getProtoSerializedSize());
-    CodedOutputStream cos = CodedOutputStream.newInstance(customOutput);
-    requestMarshaler.writeTo(Serializer.createProtoSerializer(cos));
-    cos.flush();
+        new ByteArrayOutputStream(requestMarshaler.getBinarySerializedSize());
+    requestMarshaler.writeBinaryTo(customOutput);
     byte[] customOutputBytes = customOutput.toByteArray();
     if (!Arrays.equals(customOutputBytes, protoOutput)) {
       String reverse = "<invalid>";
@@ -197,16 +195,14 @@ class TraceRequestMarshalerTest {
             .build();
     TraceRequestMarshaler requestMarshaler = TraceRequestMarshaler.create(spanDataList);
     int protoSize = protoRequest.getSerializedSize();
-    assertThat(requestMarshaler.getProtoSerializedSize()).isEqualTo(protoSize);
+    assertThat(requestMarshaler.getBinarySerializedSize()).isEqualTo(protoSize);
 
     ByteArrayOutputStream protoOutput = new ByteArrayOutputStream(protoRequest.getSerializedSize());
     protoRequest.writeTo(protoOutput);
 
     ByteArrayOutputStream customOutput =
-        new ByteArrayOutputStream(requestMarshaler.getProtoSerializedSize());
-    CodedOutputStream cos = CodedOutputStream.newInstance(customOutput);
-    requestMarshaler.writeTo(Serializer.createProtoSerializer(cos));
-    cos.flush();
+        new ByteArrayOutputStream(requestMarshaler.getBinarySerializedSize());
+    requestMarshaler.writeBinaryTo(customOutput);
     assertThat(customOutput.toByteArray()).isEqualTo(protoOutput.toByteArray());
   }
 

--- a/exporters/otlp/trace/src/jmh/java/io/opentelemetry/exporter/otlp/trace/RequestMarshalBenchmarks.java
+++ b/exporters/otlp/trace/src/jmh/java/io/opentelemetry/exporter/otlp/trace/RequestMarshalBenchmarks.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.exporter.otlp.trace;
 
-import io.opentelemetry.exporter.otlp.internal.CodedOutputStream;
-import io.opentelemetry.exporter.otlp.internal.Serializer;
 import io.opentelemetry.exporter.otlp.internal.SpanAdapter;
 import io.opentelemetry.exporter.otlp.internal.TraceRequestMarshaler;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
@@ -55,7 +53,7 @@ public class RequestMarshalBenchmarks {
   @Threads(1)
   public ByteArrayOutputStream createCustomMarshal(RequestMarshalState state) {
     TraceRequestMarshaler requestMarshaler = TraceRequestMarshaler.create(state.spanDataList);
-    return new ByteArrayOutputStream(requestMarshaler.getProtoSerializedSize());
+    return new ByteArrayOutputStream(requestMarshaler.getBinarySerializedSize());
   }
 
   @Benchmark
@@ -63,10 +61,8 @@ public class RequestMarshalBenchmarks {
   public ByteArrayOutputStream marshalCustom(RequestMarshalState state) throws IOException {
     TraceRequestMarshaler requestMarshaler = TraceRequestMarshaler.create(state.spanDataList);
     ByteArrayOutputStream customOutput =
-        new ByteArrayOutputStream(requestMarshaler.getProtoSerializedSize());
-    CodedOutputStream cos = CodedOutputStream.newInstance(customOutput);
-    requestMarshaler.writeTo(Serializer.createProtoSerializer(cos));
-    cos.flush();
+        new ByteArrayOutputStream(requestMarshaler.getBinarySerializedSize());
+    requestMarshaler.writeBinaryTo(customOutput);
     return customOutput;
   }
 }


### PR DESCRIPTION
… an OutputStream.

Callers of the Marshaler don't actually need to worry about `CodedOutputstream`, `Serializer`, (or later `JsonGenerator`) if we switch to only exposing an interface that accepts an `OutputStream`. While it's internal code, we do get to see the simplification by the reduction of code in various places that are calling the marshaler and we'll be able to continue to iterate on serialization patterns without larger refactorings.