### PR TITLE
Extract trace / span ID serialization logic to Serializer to allow ch…

### DIFF
--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/InstrumentationLibraryMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/InstrumentationLibraryMarshaler.java
@@ -36,12 +36,9 @@ final class InstrumentationLibraryMarshaler extends MarshalerWithSize {
   private InstrumentationLibraryMarshaler(byte[] name, byte[] version) {
     super(computeSize(name, version));
     ByteArrayOutputStream bos = new ByteArrayOutputStream(getBinarySerializedSize());
-    CodedOutputStream output = CodedOutputStream.newInstance(bos);
-    Serializer serializer = new ProtoSerializer(output);
-    try {
+    try (ProtoSerializer serializer = new ProtoSerializer(bos)) {
       serializer.serializeString(InstrumentationLibrary.NAME, name);
       serializer.serializeString(InstrumentationLibrary.VERSION, version);
-      output.flush();
     } catch (IOException e) {
       // Presized so can't happen (we would have already thrown OutOfMemoryError)
       throw new UncheckedIOException(e);

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Marshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Marshaler.java
@@ -18,9 +18,9 @@ public abstract class Marshaler {
 
   /** Marshals into the {@link OutputStream} in proto binary format. */
   public final void writeBinaryTo(OutputStream output) throws IOException {
-    CodedOutputStream cos = CodedOutputStream.newInstance(output);
-    writeTo(new ProtoSerializer(cos));
-    cos.flush();
+    try (ProtoSerializer serializer = new ProtoSerializer(output)) {
+      writeTo(serializer);
+    }
   }
 
   /** Returns the number of bytes this Marshaler will write in proto binary format. */

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MarshalerUtil.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MarshalerUtil.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.exporter.otlp.internal;
 
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import java.nio.charset.StandardCharsets;
@@ -17,6 +19,11 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 
 final class MarshalerUtil {
+  private static final int TRACE_ID_VALUE_SIZE =
+      CodedOutputStream.computeLengthDelimitedFieldSize(TraceId.getLength() / 2);
+  private static final int SPAN_ID_VALUE_SIZE =
+      CodedOutputStream.computeLengthDelimitedFieldSize(SpanId.getLength() / 2);
+
   static final byte[] EMPTY_BYTES = new byte[0];
 
   static <T, U> Map<Resource, Map<InstrumentationLibraryInfo, List<U>>> groupByResourceAndLibrary(
@@ -124,6 +131,20 @@ final class MarshalerUtil {
       return 0;
     }
     return field.getTagSize() + CodedOutputStream.computeEnumSizeNoTag(value);
+  }
+
+  static int sizeTraceId(ProtoFieldInfo field, @Nullable String traceId) {
+    if (traceId == null) {
+      return 0;
+    }
+    return field.getTagSize() + TRACE_ID_VALUE_SIZE;
+  }
+
+  static int sizeSpanId(ProtoFieldInfo field, @Nullable String spanId) {
+    if (spanId == null) {
+      return 0;
+    }
+    return field.getTagSize() + SPAN_ID_VALUE_SIZE;
   }
 
   static byte[] toBytes(@Nullable String value) {

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ProtoSerializer.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ProtoSerializer.java
@@ -5,16 +5,47 @@
 
 package io.opentelemetry.exporter.otlp.internal;
 
+import io.opentelemetry.api.internal.OtelEncodingUtils;
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.TraceId;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /** Serializer for the protobuf binary wire format. */
-final class ProtoSerializer extends Serializer {
+final class ProtoSerializer extends Serializer implements AutoCloseable {
+
+  // Cache ID conversion to bytes since we know it's common to use the same ID multiple times within
+  // a single export (trace ID and parent span ID).
+  // In practice, there is often only one thread that calls this code in the BatchSpanProcessor so
+  // reusing buffers for the thread is almost free. Even with multiple threads, it should still be
+  // worth it and is common practice in serialization libraries such as Jackson.
+  private static final ThreadLocal<Map<String, byte[]>> THREAD_LOCAL_ID_CACHE = new ThreadLocal<>();
 
   private final CodedOutputStream output;
+  private final Map<String, byte[]> idCache;
 
-  ProtoSerializer(CodedOutputStream output) {
-    this.output = output;
+  ProtoSerializer(OutputStream output) {
+    this.output = CodedOutputStream.newInstance(output);
+    idCache = getIdCache();
+  }
+
+  @Override
+  protected void writeTraceId(ProtoFieldInfo field, String traceId) throws IOException {
+    byte[] traceIdBytes =
+        idCache.computeIfAbsent(
+            traceId, id -> OtelEncodingUtils.bytesFromBase16(id, TraceId.getLength()));
+    writeBytes(field, traceIdBytes);
+  }
+
+  @Override
+  protected void writeSpanId(ProtoFieldInfo field, String spanId) throws IOException {
+    byte[] spanIdBytes =
+        idCache.computeIfAbsent(
+            spanId, id -> OtelEncodingUtils.bytesFromBase16(id, SpanId.getLength()));
+    writeBytes(field, spanIdBytes);
   }
 
   @Override
@@ -119,9 +150,18 @@ final class ProtoSerializer extends Serializer {
     output.writeRawBytes(protoSerialized);
   }
 
-  // TODO(anuraaga): Remove after moving protobuf Value serialization from AttributeMarshaler to
-  // here.
-  CodedOutputStream getCodedOutputStream() {
-    return output;
+  @Override
+  public void close() throws IOException {
+    output.flush();
+    idCache.clear();
+  }
+
+  private static Map<String, byte[]> getIdCache() {
+    Map<String, byte[]> result = THREAD_LOCAL_ID_CACHE.get();
+    if (result == null) {
+      result = new HashMap<>();
+      THREAD_LOCAL_ID_CACHE.set(result);
+    }
+    return result;
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ResourceMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ResourceMarshaler.java
@@ -32,11 +32,8 @@ final class ResourceMarshaler extends MarshalerWithSize {
   private ResourceMarshaler(KeyValueMarshaler[] attributeMarshalers) {
     super(calculateSize(attributeMarshalers));
     ByteArrayOutputStream bos = new ByteArrayOutputStream(getBinarySerializedSize());
-    CodedOutputStream output = CodedOutputStream.newInstance(bos);
-    ProtoSerializer serializer = new ProtoSerializer(output);
-    try {
+    try (ProtoSerializer serializer = new ProtoSerializer(bos)) {
       serializer.serializeRepeatedMessage(Resource.ATTRIBUTES, attributeMarshalers);
-      output.flush();
     } catch (IOException e) {
       // Presized so can't happen (we would have already thrown OutOfMemoryError)
       throw new UncheckedIOException(e);

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Serializer.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Serializer.java
@@ -7,6 +7,7 @@ package io.opentelemetry.exporter.otlp.internal;
 
 import java.io.IOException;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Serializer to use when converting from an SDK data object into a protobuf output format. Unlike
@@ -20,6 +21,26 @@ import java.util.List;
 public abstract class Serializer {
 
   Serializer() {}
+
+  /** Serializes a trace ID field. */
+  public void serializeTraceId(ProtoFieldInfo field, @Nullable String traceId) throws IOException {
+    if (traceId == null) {
+      return;
+    }
+    writeTraceId(field, traceId);
+  }
+
+  protected abstract void writeTraceId(ProtoFieldInfo field, String traceId) throws IOException;
+
+  /** Serializes a span ID field. */
+  public void serializeSpanId(ProtoFieldInfo field, @Nullable String spanId) throws IOException {
+    if (spanId == null) {
+      return;
+    }
+    writeSpanId(field, spanId);
+  }
+
+  protected abstract void writeSpanId(ProtoFieldInfo field, String traceId) throws IOException;
 
   /** Serializes a protobuf {@code bool} field. */
   public void serializeBool(ProtoFieldInfo field, boolean value) throws IOException {

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/TraceRequestMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/TraceRequestMarshaler.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.exporter.otlp.internal;
 
-import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.proto.collector.trace.v1.internal.ExportTraceServiceRequest;
@@ -21,9 +20,9 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * {@link Marshaler} to convert SDK {@link SpanData} to OTLP ExportTraceServiceRequest.
@@ -32,11 +31,6 @@ import java.util.Map;
  * at any time.
  */
 public final class TraceRequestMarshaler extends MarshalerWithSize {
-
-  // In practice, there is often only one thread that calls this code in the BatchSpanProcessor so
-  // reusing buffers for the thread is almost free. Even with multiple threads, it should still be
-  // worth it and is common practice in serialization libraries such as Jackson.
-  private static final ThreadLocal<ThreadLocalCache> THREAD_LOCAL_CACHE = new ThreadLocal<>();
 
   private final ResourceSpansMarshaler[] resourceSpansMarshalers;
 
@@ -162,9 +156,9 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
   }
 
   private static final class SpanMarshaler extends MarshalerWithSize {
-    private final byte[] traceId;
-    private final byte[] spanId;
-    private final byte[] parentSpanId;
+    private final String traceId;
+    private final String spanId;
+    @Nullable private final String parentSpanId;
     private final byte[] nameUtf8;
     private final int spanKind;
     private final long startEpochNanos;
@@ -178,35 +172,20 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
     private final SpanStatusMarshaler spanStatusMarshaler;
 
     // Because SpanMarshaler is always part of a repeated field, it cannot return "null".
-    static SpanMarshaler create(SpanData spanData, ThreadLocalCache threadLocalCache) {
+    static SpanMarshaler create(SpanData spanData) {
       KeyValueMarshaler[] attributeMarshalers =
           KeyValueMarshaler.createRepeated(spanData.getAttributes());
       SpanEventMarshaler[] spanEventMarshalers = SpanEventMarshaler.create(spanData.getEvents());
-      SpanLinkMarshaler[] spanLinkMarshalers =
-          SpanLinkMarshaler.create(spanData.getLinks(), threadLocalCache);
-      Map<String, byte[]> idBytesCache = threadLocalCache.idBytesCache;
+      SpanLinkMarshaler[] spanLinkMarshalers = SpanLinkMarshaler.create(spanData.getLinks());
 
-      byte[] traceId =
-          idBytesCache.computeIfAbsent(
-              spanData.getSpanContext().getTraceId(),
-              unused -> spanData.getSpanContext().getTraceIdBytes());
-      byte[] spanId =
-          idBytesCache.computeIfAbsent(
-              spanData.getSpanContext().getSpanId(),
-              unused -> spanData.getSpanContext().getSpanIdBytes());
-
-      byte[] parentSpanId = MarshalerUtil.EMPTY_BYTES;
-      SpanContext parentSpanContext = spanData.getParentSpanContext();
-      if (parentSpanContext.isValid()) {
-        parentSpanId =
-            idBytesCache.computeIfAbsent(
-                spanData.getParentSpanContext().getSpanId(),
-                unused -> spanData.getParentSpanContext().getSpanIdBytes());
-      }
+      String parentSpanId =
+          spanData.getParentSpanContext().isValid()
+              ? spanData.getParentSpanContext().getSpanId()
+              : null;
 
       return new SpanMarshaler(
-          traceId,
-          spanId,
+          spanData.getSpanContext().getTraceId(),
+          spanData.getSpanContext().getSpanId(),
           parentSpanId,
           MarshalerUtil.toBytes(spanData.getName()),
           toProtoSpanKind(spanData.getKind()),
@@ -222,9 +201,9 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
     }
 
     private SpanMarshaler(
-        byte[] traceId,
-        byte[] spanId,
-        byte[] parentSpanId,
+        String traceId,
+        String spanId,
+        @Nullable String parentSpanId,
         byte[] nameUtf8,
         int spanKind,
         long startEpochNanos,
@@ -270,10 +249,10 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
 
     @Override
     public void writeTo(Serializer output) throws IOException {
-      output.serializeBytes(Span.TRACE_ID, traceId);
-      output.serializeBytes(Span.SPAN_ID, spanId);
+      output.serializeTraceId(Span.TRACE_ID, traceId);
+      output.serializeSpanId(Span.SPAN_ID, spanId);
       // TODO: Set TraceState;
-      output.serializeBytes(Span.PARENT_SPAN_ID, parentSpanId);
+      output.serializeSpanId(Span.PARENT_SPAN_ID, parentSpanId);
       output.serializeString(Span.NAME, nameUtf8);
 
       output.serializeEnum(Span.KIND, spanKind);
@@ -294,9 +273,9 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
     }
 
     private static int calculateSize(
-        byte[] traceId,
-        byte[] spanId,
-        byte[] parentSpanId,
+        String traceId,
+        String spanId,
+        @Nullable String parentSpanId,
         byte[] nameUtf8,
         int spanKind,
         long startEpochNanos,
@@ -309,10 +288,10 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
         int droppedLinksCount,
         SpanStatusMarshaler spanStatusMarshaler) {
       int size = 0;
-      size += MarshalerUtil.sizeBytes(Span.TRACE_ID, traceId);
-      size += MarshalerUtil.sizeBytes(Span.SPAN_ID, spanId);
+      size += MarshalerUtil.sizeTraceId(Span.TRACE_ID, traceId);
+      size += MarshalerUtil.sizeSpanId(Span.SPAN_ID, spanId);
       // TODO: Set TraceState;
-      size += MarshalerUtil.sizeBytes(Span.PARENT_SPAN_ID, parentSpanId);
+      size += MarshalerUtil.sizeSpanId(Span.PARENT_SPAN_ID, parentSpanId);
       size += MarshalerUtil.sizeBytes(Span.NAME, nameUtf8);
 
       size += MarshalerUtil.sizeEnum(Span.KIND, spanKind);
@@ -396,28 +375,23 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
 
   private static final class SpanLinkMarshaler extends MarshalerWithSize {
     private static final SpanLinkMarshaler[] EMPTY = new SpanLinkMarshaler[0];
-    private final byte[] traceId;
-    private final byte[] spanId;
+    private final String traceId;
+    private final String spanId;
     private final KeyValueMarshaler[] attributeMarshalers;
     private final int droppedAttributesCount;
 
-    static SpanLinkMarshaler[] create(List<LinkData> links, ThreadLocalCache threadLocalCache) {
+    static SpanLinkMarshaler[] create(List<LinkData> links) {
       if (links.isEmpty()) {
         return EMPTY;
       }
-      Map<String, byte[]> idBytesCache = threadLocalCache.idBytesCache;
 
       SpanLinkMarshaler[] result = new SpanLinkMarshaler[links.size()];
       int pos = 0;
       for (LinkData link : links) {
         result[pos++] =
             new SpanLinkMarshaler(
-                idBytesCache.computeIfAbsent(
-                    link.getSpanContext().getTraceId(),
-                    unused -> link.getSpanContext().getTraceIdBytes()),
-                idBytesCache.computeIfAbsent(
-                    link.getSpanContext().getSpanId(),
-                    unused -> link.getSpanContext().getSpanIdBytes()),
+                link.getSpanContext().getTraceId(),
+                link.getSpanContext().getSpanId(),
                 KeyValueMarshaler.createRepeated(link.getAttributes()),
                 link.getTotalAttributeCount() - link.getAttributes().size());
       }
@@ -426,8 +400,8 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
     }
 
     private SpanLinkMarshaler(
-        byte[] traceId,
-        byte[] spanId,
+        String traceId,
+        String spanId,
         KeyValueMarshaler[] attributeMarshalers,
         int droppedAttributesCount) {
       super(calculateSize(traceId, spanId, attributeMarshalers, droppedAttributesCount));
@@ -439,21 +413,21 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
 
     @Override
     public void writeTo(Serializer output) throws IOException {
-      output.serializeBytes(Span.Link.TRACE_ID, traceId);
-      output.serializeBytes(Span.Link.SPAN_ID, spanId);
+      output.serializeTraceId(Span.Link.TRACE_ID, traceId);
+      output.serializeSpanId(Span.Link.SPAN_ID, spanId);
       // TODO: Set TraceState;
       output.serializeRepeatedMessage(Span.Link.ATTRIBUTES, attributeMarshalers);
       output.serializeUInt32(Span.Link.DROPPED_ATTRIBUTES_COUNT, droppedAttributesCount);
     }
 
     private static int calculateSize(
-        byte[] traceId,
-        byte[] spanId,
+        String traceId,
+        String spanId,
         KeyValueMarshaler[] attributeMarshalers,
         int droppedAttributesCount) {
       int size = 0;
-      size += MarshalerUtil.sizeBytes(Span.Link.TRACE_ID, traceId);
-      size += MarshalerUtil.sizeBytes(Span.Link.SPAN_ID, spanId);
+      size += MarshalerUtil.sizeTraceId(Span.Link.TRACE_ID, traceId);
+      size += MarshalerUtil.sizeSpanId(Span.Link.SPAN_ID, spanId);
       // TODO: Set TraceState;
       size += MarshalerUtil.sizeRepeatedMessage(Span.Link.ATTRIBUTES, attributeMarshalers);
       size += MarshalerUtil.sizeUInt32(Span.Link.DROPPED_ATTRIBUTES_COUNT, droppedAttributesCount);
@@ -507,18 +481,13 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
 
   private static Map<Resource, Map<InstrumentationLibraryInfo, List<SpanMarshaler>>>
       groupByResourceAndLibrary(Collection<SpanData> spanDataList) {
-    ThreadLocalCache threadLocalCache = getThreadLocalCache();
-    try {
-      return MarshalerUtil.groupByResourceAndLibrary(
-          spanDataList,
-          // TODO(anuraaga): Replace with an internal SdkData type of interface that exposes these
-          // two.
-          SpanData::getResource,
-          SpanData::getInstrumentationLibraryInfo,
-          data -> SpanMarshaler.create(data, threadLocalCache));
-    } finally {
-      threadLocalCache.idBytesCache.clear();
-    }
+    return MarshalerUtil.groupByResourceAndLibrary(
+        spanDataList,
+        // TODO(anuraaga): Replace with an internal SdkData type of interface that exposes these
+        // two.
+        SpanData::getResource,
+        SpanData::getInstrumentationLibraryInfo,
+        data -> SpanMarshaler.create(data));
   }
 
   private static int toProtoSpanKind(SpanKind kind) {
@@ -535,18 +504,5 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
         return Span.SpanKind.SPAN_KIND_CONSUMER_VALUE;
     }
     return -1;
-  }
-
-  private static ThreadLocalCache getThreadLocalCache() {
-    ThreadLocalCache result = THREAD_LOCAL_CACHE.get();
-    if (result == null) {
-      result = new ThreadLocalCache();
-      THREAD_LOCAL_CACHE.set(result);
-    }
-    return result;
-  }
-
-  private static final class ThreadLocalCache {
-    final Map<String, byte[]> idBytesCache = new HashMap<>();
   }
 }


### PR DESCRIPTION
…anging for JSON.

Since trace / span ID don't follow protobuf conventions in OTLP, we can't just have a single `serializeBytes` method handling them so added them to the `Serializer`. By moving the byte cache into that layer, it seems to have actually simplified the code quite a bit too, and given metrics the caching automatically.

No change in performance. I initially tried using invalid IDs instead of `null` as currently in this PR but that tanked performance.