### PR TITLE
Implement JsonSerializer

### DIFF
--- a/exporters/otlp/common/build.gradle.kts
+++ b/exporters/otlp/common/build.gradle.kts
@@ -23,6 +23,8 @@ dependencies {
   // contains internal code.
   compileOnly(project(":proto"))
 
+  compileOnly("com.fasterxml.jackson.core:jackson-core")
+
   // Similar to above note about :proto, we include helpers shared by gRPC or okhttp exporters but
   // do not want to impose these dependency on all of our consumers.
   compileOnly("com.squareup.okhttp3:okhttp")
@@ -36,6 +38,9 @@ dependencies {
   testImplementation(project(":proto"))
   testImplementation(project(":sdk:testing"))
 
+  testImplementation("com.fasterxml.jackson.core:jackson-core")
+  testImplementation("com.google.protobuf:protobuf-java-util")
+
   testImplementation("org.jeasy:easy-random-randomizers")
 
   testImplementation("com.google.api.grpc:proto-google-common-protos")
@@ -45,6 +50,10 @@ dependencies {
   jmhImplementation(project(":proto"))
   jmhImplementation(project(":sdk:testing"))
   jmhImplementation(project(":sdk-extensions:resources"))
+  jmhImplementation("com.fasterxml.jackson.core:jackson-core")
+  jmhImplementation("org.curioswitch.curiostack:protobuf-jackson")
+  jmhImplementation("com.google.protobuf:protobuf-java-util")
+  jmhRuntimeOnly("io.grpc:grpc-netty")
 }
 
 wire {

--- a/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/otlp/internal/MarshalerInputStreamBenchmarks.java
+++ b/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/otlp/internal/MarshalerInputStreamBenchmarks.java
@@ -3,12 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.exporter.otlp.trace;
+package io.opentelemetry.exporter.otlp.internal;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.buffer.PooledByteBufAllocator;
-import io.opentelemetry.exporter.otlp.internal.TraceRequestMarshaler;
 import io.opentelemetry.exporter.otlp.internal.grpc.MarshalerInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/otlp/internal/RequestMarshalBenchmarks.java
+++ b/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/otlp/internal/RequestMarshalBenchmarks.java
@@ -3,14 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.exporter.otlp.trace;
+package io.opentelemetry.exporter.otlp.internal;
 
-import io.opentelemetry.exporter.otlp.internal.SpanAdapter;
-import io.opentelemetry.exporter.otlp.internal.TraceRequestMarshaler;
+import com.google.protobuf.util.JsonFormat;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
+import org.curioswitch.common.protobuf.json.MessageMarshaller;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -26,6 +28,12 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 10, time = 1)
 @Fork(1)
 public class RequestMarshalBenchmarks {
+
+  private static final MessageMarshaller BYTEBUDDY_MARSHALLER =
+      MessageMarshaller.builder()
+          .register(ExportTraceServiceRequest.class)
+          .omittingInsignificantWhitespace(true)
+          .build();
 
   @Benchmark
   @Threads(1)
@@ -63,6 +71,43 @@ public class RequestMarshalBenchmarks {
     ByteArrayOutputStream customOutput =
         new ByteArrayOutputStream(requestMarshaler.getBinarySerializedSize());
     requestMarshaler.writeBinaryTo(customOutput);
+    return customOutput;
+  }
+
+  @Benchmark
+  @Threads(1)
+  public ByteArrayOutputStream marshalJson(RequestMarshalState state) throws IOException {
+    TraceRequestMarshaler requestMarshaler = TraceRequestMarshaler.create(state.spanDataList);
+    ByteArrayOutputStream customOutput = new ByteArrayOutputStream();
+    requestMarshaler.writeJsonTo(customOutput);
+    return customOutput;
+  }
+
+  @Benchmark
+  @Threads(1)
+  public ByteArrayOutputStream marshalJsonProtoByteBuddy(RequestMarshalState state)
+      throws IOException {
+    ExportTraceServiceRequest protoRequest =
+        ExportTraceServiceRequest.newBuilder()
+            .addAllResourceSpans(SpanAdapter.toProtoResourceSpans(state.spanDataList))
+            .build();
+    ByteArrayOutputStream customOutput = new ByteArrayOutputStream();
+    BYTEBUDDY_MARSHALLER.writeValue(protoRequest, customOutput);
+    return customOutput;
+  }
+
+  @Benchmark
+  @Threads(1)
+  public ByteArrayOutputStream marshalJsonProtoReflection(RequestMarshalState state)
+      throws IOException {
+    ExportTraceServiceRequest protoRequest =
+        ExportTraceServiceRequest.newBuilder()
+            .addAllResourceSpans(SpanAdapter.toProtoResourceSpans(state.spanDataList))
+            .build();
+    ByteArrayOutputStream customOutput = new ByteArrayOutputStream();
+    JsonFormat.printer()
+        .omittingInsignificantWhitespace()
+        .appendTo(protoRequest, new OutputStreamWriter(customOutput, StandardCharsets.UTF_8));
     return customOutput;
   }
 }

--- a/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/otlp/internal/RequestMarshalState.java
+++ b/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/otlp/internal/RequestMarshalState.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.exporter.otlp.trace;
+package io.opentelemetry.exporter.otlp.internal;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/InstrumentationLibraryMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/InstrumentationLibraryMarshaler.java
@@ -36,12 +36,9 @@ final class InstrumentationLibraryMarshaler extends MarshalerWithSize {
   private InstrumentationLibraryMarshaler(byte[] name, byte[] version) {
     super(computeSize(name, version));
     ByteArrayOutputStream bos = new ByteArrayOutputStream(getBinarySerializedSize());
-    CodedOutputStream output = CodedOutputStream.newInstance(bos);
-    Serializer serializer = new ProtoSerializer(output);
-    try {
+    try (ProtoSerializer serializer = new ProtoSerializer(bos)) {
       serializer.serializeString(InstrumentationLibrary.NAME, name);
       serializer.serializeString(InstrumentationLibrary.VERSION, version);
-      output.flush();
     } catch (IOException e) {
       // Presized so can't happen (we would have already thrown OutOfMemoryError)
       throw new UncheckedIOException(e);

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/JsonSerializer.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/JsonSerializer.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+
+final class JsonSerializer extends Serializer {
+
+  private static final JsonFactory JSON_FACTORY = new JsonFactory();
+
+  private final JsonGenerator generator;
+
+  JsonSerializer(OutputStream output) throws IOException {
+    generator = JSON_FACTORY.createGenerator(output);
+  }
+
+  @Override
+  protected void writeTraceId(ProtoFieldInfo field, String traceId) throws IOException {
+    generator.writeStringField(field.getJsonName(), traceId);
+  }
+
+  @Override
+  protected void writeSpanId(ProtoFieldInfo field, String spanId) throws IOException {
+    generator.writeStringField(field.getJsonName(), spanId);
+  }
+
+  @Override
+  protected void writeBool(ProtoFieldInfo field, boolean value) throws IOException {
+    generator.writeBooleanField(field.getJsonName(), value);
+  }
+
+  @Override
+  protected void writeEnum(ProtoFieldInfo field, int enumNumber) throws IOException {
+    generator.writeNumberField(field.getJsonName(), enumNumber);
+  }
+
+  @Override
+  protected void writeUint32(ProtoFieldInfo field, int value) throws IOException {
+    generator.writeNumberField(field.getJsonName(), value);
+  }
+
+  @Override
+  protected void writeInt64(ProtoFieldInfo field, long value) throws IOException {
+    generator.writeStringField(field.getJsonName(), Long.toString(value));
+  }
+
+  @Override
+  protected void writeFixed64(ProtoFieldInfo field, long value) throws IOException {
+    generator.writeStringField(field.getJsonName(), Long.toString(value));
+  }
+
+  @Override
+  protected void writeFixed64Value(long value) throws IOException {
+    generator.writeString(Long.toString(value));
+  }
+
+  @Override
+  protected void writeDouble(ProtoFieldInfo field, double value) throws IOException {
+    generator.writeNumberField(field.getJsonName(), value);
+  }
+
+  @Override
+  protected void writeDoubleValue(double value) throws IOException {
+    generator.writeNumber(value);
+  }
+
+  @Override
+  protected void writeString(ProtoFieldInfo field, byte[] utf8Bytes) throws IOException {
+    generator.writeFieldName(field.getJsonName());
+    generator.writeUTF8String(utf8Bytes, 0, utf8Bytes.length);
+  }
+
+  @Override
+  protected void writeBytes(ProtoFieldInfo field, byte[] value) throws IOException {
+    generator.writeBinaryField(field.getJsonName(), value);
+  }
+
+  @Override
+  protected void writeStartMessage(ProtoFieldInfo field, int protoMessageSize) throws IOException {
+    generator.writeObjectFieldStart(field.getJsonName());
+  }
+
+  @Override
+  protected void writeEndMessage() throws IOException {
+    generator.writeEndObject();
+  }
+
+  @Override
+  protected void writeStartRepeatedPrimitive(
+      ProtoFieldInfo field, int protoSizePerElement, int numElements) throws IOException {
+    generator.writeArrayFieldStart(field.getJsonName());
+  }
+
+  @Override
+  protected void writeEndRepeatedPrimitive() throws IOException {
+    generator.writeEndArray();
+  }
+
+  @Override
+  public void serializeRepeatedMessage(ProtoFieldInfo field, Marshaler[] repeatedMessage)
+      throws IOException {
+    generator.writeArrayFieldStart(field.getJsonName());
+    for (Marshaler marshaler : repeatedMessage) {
+      writeMessageValue(marshaler);
+    }
+    generator.writeEndArray();
+  }
+
+  @Override
+  public void serializeRepeatedMessage(
+      ProtoFieldInfo field, List<? extends Marshaler> repeatedMessage) throws IOException {
+    generator.writeArrayFieldStart(field.getJsonName());
+    for (Marshaler marshaler : repeatedMessage) {
+      writeMessageValue(marshaler);
+    }
+    generator.writeEndArray();
+  }
+
+  // Not a field.
+  void writeMessageValue(Marshaler message) throws IOException {
+    generator.writeStartObject();
+    message.writeTo(this);
+    generator.writeEndObject();
+  }
+
+  @Override
+  public void writeSerializedMessage(byte[] protoSerialized, String jsonSerialized)
+      throws IOException {
+    generator.writeRaw(jsonSerialized);
+  }
+
+  @Override
+  public void close() throws IOException {
+    generator.close();
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Marshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Marshaler.java
@@ -18,9 +18,9 @@ public abstract class Marshaler {
 
   /** Marshals into the {@link OutputStream} in proto binary format. */
   public final void writeBinaryTo(OutputStream output) throws IOException {
-    CodedOutputStream cos = CodedOutputStream.newInstance(output);
-    writeTo(new ProtoSerializer(cos));
-    cos.flush();
+    try (ProtoSerializer serializer = new ProtoSerializer(output)) {
+      writeTo(serializer);
+    }
   }
 
   /** Returns the number of bytes this Marshaler will write in proto binary format. */

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Marshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Marshaler.java
@@ -18,8 +18,15 @@ public abstract class Marshaler {
 
   /** Marshals into the {@link OutputStream} in proto binary format. */
   public final void writeBinaryTo(OutputStream output) throws IOException {
-    try (ProtoSerializer serializer = new ProtoSerializer(output)) {
+    try (Serializer serializer = new ProtoSerializer(output)) {
       writeTo(serializer);
+    }
+  }
+
+  /** Marshals into the {@link OutputStream} in proto JSON format. */
+  public final void writeJsonTo(OutputStream output) throws IOException {
+    try (JsonSerializer serializer = new JsonSerializer(output)) {
+      serializer.writeMessageValue(this);
     }
   }
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MarshalerUtil.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MarshalerUtil.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.exporter.otlp.internal;
 
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import java.nio.charset.StandardCharsets;
@@ -17,6 +19,11 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 
 final class MarshalerUtil {
+  private static final int TRACE_ID_VALUE_SIZE =
+      CodedOutputStream.computeLengthDelimitedFieldSize(TraceId.getLength() / 2);
+  private static final int SPAN_ID_VALUE_SIZE =
+      CodedOutputStream.computeLengthDelimitedFieldSize(SpanId.getLength() / 2);
+
   static final byte[] EMPTY_BYTES = new byte[0];
 
   static <T, U> Map<Resource, Map<InstrumentationLibraryInfo, List<U>>> groupByResourceAndLibrary(
@@ -124,6 +131,20 @@ final class MarshalerUtil {
       return 0;
     }
     return field.getTagSize() + CodedOutputStream.computeEnumSizeNoTag(value);
+  }
+
+  static int sizeTraceId(ProtoFieldInfo field, @Nullable String traceId) {
+    if (traceId == null) {
+      return 0;
+    }
+    return field.getTagSize() + TRACE_ID_VALUE_SIZE;
+  }
+
+  static int sizeSpanId(ProtoFieldInfo field, @Nullable String spanId) {
+    if (spanId == null) {
+      return 0;
+    }
+    return field.getTagSize() + SPAN_ID_VALUE_SIZE;
   }
 
   static byte[] toBytes(@Nullable String value) {

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MarshalerUtil.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MarshalerUtil.java
@@ -9,6 +9,9 @@ import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -23,6 +26,19 @@ final class MarshalerUtil {
       CodedOutputStream.computeLengthDelimitedFieldSize(TraceId.getLength() / 2);
   private static final int SPAN_ID_VALUE_SIZE =
       CodedOutputStream.computeLengthDelimitedFieldSize(SpanId.getLength() / 2);
+
+  static final boolean JSON_AVAILABLE;
+
+  static {
+    boolean jsonAvailable = false;
+    try {
+      Class.forName("com.fasterxml.jackson.core.JsonFactory");
+      jsonAvailable = true;
+    } catch (ClassNotFoundException e) {
+      // Not available
+    }
+    JSON_AVAILABLE = jsonAvailable;
+  }
 
   static final byte[] EMPTY_BYTES = new byte[0];
 
@@ -43,6 +59,28 @@ final class MarshalerUtil {
       marshalerList.add(createMarshaler.apply(data));
     }
     return result;
+  }
+
+  static String preserializeJsonFields(Marshaler marshaler) {
+    if (!MarshalerUtil.JSON_AVAILABLE) {
+      return "";
+    }
+
+    ByteArrayOutputStream jsonBos = new ByteArrayOutputStream();
+    try {
+      marshaler.writeJsonTo(jsonBos);
+    } catch (IOException e) {
+      throw new UncheckedIOException(
+          "Serialization error, this is likely a bug in OpenTelemetry.", e);
+    }
+
+    // We effectively cache `writeTo`, however Jackson would not allow us to only write out
+    // fields
+    // which is what writeTo does. So we need to write to an object but skip the object start
+    // /
+    // end.
+    byte[] jsonBytes = jsonBos.toByteArray();
+    return new String(jsonBytes, 1, jsonBytes.length - 2, StandardCharsets.UTF_8);
   }
 
   static int sizeRepeatedFixed64(ProtoFieldInfo field, List<Long> values) {

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MetricsRequestMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MetricsRequestMarshaler.java
@@ -621,8 +621,7 @@ public final class MetricsRequestMarshaler extends MarshalerWithSize {
     private final long startTimeUnixNano;
     private final long timeUnixNano;
 
-    // Always fixed64, for a double it's the bits themselves.
-    private final long value;
+    private final PointData value;
     private final ProtoFieldInfo valueField;
 
     private final ExemplarMarshaler[] exemplars;
@@ -644,21 +643,18 @@ public final class MetricsRequestMarshaler extends MarshalerWithSize {
       KeyValueMarshaler[] attributeMarshalers =
           KeyValueMarshaler.createRepeated(point.getAttributes());
 
-      final long value;
       final ProtoFieldInfo valueField;
       if (point instanceof LongPointData) {
-        value = ((LongPointData) point).getValue();
         valueField = NumberDataPoint.AS_INT;
       } else {
         assert point instanceof DoublePointData;
-        value = Double.doubleToRawLongBits(((DoublePointData) point).getValue());
         valueField = NumberDataPoint.AS_DOUBLE;
       }
 
       return new NumberDataPointMarshaler(
           point.getStartEpochNanos(),
           point.getEpochNanos(),
-          value,
+          point,
           valueField,
           exemplarMarshalers,
           attributeMarshalers);
@@ -667,12 +663,12 @@ public final class MetricsRequestMarshaler extends MarshalerWithSize {
     private NumberDataPointMarshaler(
         long startTimeUnixNano,
         long timeUnixNano,
-        long value,
+        PointData value,
         ProtoFieldInfo valueField,
         ExemplarMarshaler[] exemplars,
         KeyValueMarshaler[] attributes) {
       super(
-          calculateSize(startTimeUnixNano, timeUnixNano, value, valueField, exemplars, attributes));
+          calculateSize(startTimeUnixNano, timeUnixNano, valueField, value, exemplars, attributes));
       this.startTimeUnixNano = startTimeUnixNano;
       this.timeUnixNano = timeUnixNano;
       this.value = value;
@@ -685,7 +681,11 @@ public final class MetricsRequestMarshaler extends MarshalerWithSize {
     public void writeTo(Serializer output) throws IOException {
       output.serializeFixed64(NumberDataPoint.START_TIME_UNIX_NANO, startTimeUnixNano);
       output.serializeFixed64(NumberDataPoint.TIME_UNIX_NANO, timeUnixNano);
-      output.serializeFixed64(valueField, value);
+      if (valueField == NumberDataPoint.AS_INT) {
+        output.serializeFixed64(valueField, ((LongPointData) value).getValue());
+      } else {
+        output.serializeDouble(valueField, ((DoublePointData) value).getValue());
+      }
       output.serializeRepeatedMessage(NumberDataPoint.EXEMPLARS, exemplars);
       output.serializeRepeatedMessage(NumberDataPoint.ATTRIBUTES, attributes);
     }
@@ -693,14 +693,19 @@ public final class MetricsRequestMarshaler extends MarshalerWithSize {
     private static int calculateSize(
         long startTimeUnixNano,
         long timeUnixNano,
-        long value,
         ProtoFieldInfo valueField,
+        PointData value,
         ExemplarMarshaler[] exemplars,
         KeyValueMarshaler[] attributes) {
       int size = 0;
       size += MarshalerUtil.sizeFixed64(NumberDataPoint.START_TIME_UNIX_NANO, startTimeUnixNano);
       size += MarshalerUtil.sizeFixed64(NumberDataPoint.TIME_UNIX_NANO, timeUnixNano);
-      size += MarshalerUtil.sizeFixed64(valueField, value);
+      // Value doesn't matter when sizing
+      if (valueField == NumberDataPoint.AS_INT) {
+        size += MarshalerUtil.sizeFixed64(valueField, ((LongPointData) value).getValue());
+      } else {
+        size += MarshalerUtil.sizeDouble(valueField, ((DoublePointData) value).getValue());
+      }
       size += MarshalerUtil.sizeRepeatedMessage(NumberDataPoint.EXEMPLARS, exemplars);
       size += MarshalerUtil.sizeRepeatedMessage(NumberDataPoint.ATTRIBUTES, attributes);
       return size;
@@ -711,8 +716,7 @@ public final class MetricsRequestMarshaler extends MarshalerWithSize {
 
     private final long timeUnixNano;
 
-    // Always fixed64, for a double it's the bits themselves.
-    private final long value;
+    private final Exemplar value;
     private final ProtoFieldInfo valueField;
 
     @Nullable private final String spanId;
@@ -733,20 +737,17 @@ public final class MetricsRequestMarshaler extends MarshalerWithSize {
       KeyValueMarshaler[] attributeMarshalers =
           KeyValueMarshaler.createRepeated(exemplar.getFilteredAttributes());
 
-      final long value;
       final ProtoFieldInfo valueField;
       if (exemplar instanceof LongExemplar) {
-        value = ((LongExemplar) exemplar).getValue();
         valueField = io.opentelemetry.proto.metrics.v1.internal.Exemplar.AS_INT;
       } else {
         assert exemplar instanceof DoubleExemplar;
-        value = Double.doubleToRawLongBits(((DoubleExemplar) exemplar).getValue());
         valueField = io.opentelemetry.proto.metrics.v1.internal.Exemplar.AS_DOUBLE;
       }
 
       return new ExemplarMarshaler(
           exemplar.getEpochNanos(),
-          value,
+          exemplar,
           valueField,
           exemplar.getSpanId(),
           exemplar.getTraceId(),
@@ -755,14 +756,14 @@ public final class MetricsRequestMarshaler extends MarshalerWithSize {
 
     private ExemplarMarshaler(
         long timeUnixNano,
-        long value,
+        Exemplar value,
         ProtoFieldInfo valueField,
         @Nullable String spanId,
         @Nullable String traceId,
         KeyValueMarshaler[] filteredAttributeMarshalers) {
       super(
           calculateSize(
-              timeUnixNano, value, valueField, spanId, traceId, filteredAttributeMarshalers));
+              timeUnixNano, valueField, value, spanId, traceId, filteredAttributeMarshalers));
       this.timeUnixNano = timeUnixNano;
       this.value = value;
       this.valueField = valueField;
@@ -775,7 +776,11 @@ public final class MetricsRequestMarshaler extends MarshalerWithSize {
     public void writeTo(Serializer output) throws IOException {
       output.serializeFixed64(
           io.opentelemetry.proto.metrics.v1.internal.Exemplar.TIME_UNIX_NANO, timeUnixNano);
-      output.serializeFixed64(valueField, value);
+      if (valueField == io.opentelemetry.proto.metrics.v1.internal.Exemplar.AS_INT) {
+        output.serializeFixed64(valueField, ((LongExemplar) value).getValue());
+      } else {
+        output.serializeDouble(valueField, ((DoubleExemplar) value).getValue());
+      }
       output.serializeSpanId(io.opentelemetry.proto.metrics.v1.internal.Exemplar.SPAN_ID, spanId);
       output.serializeTraceId(
           io.opentelemetry.proto.metrics.v1.internal.Exemplar.TRACE_ID, traceId);
@@ -786,8 +791,8 @@ public final class MetricsRequestMarshaler extends MarshalerWithSize {
 
     private static int calculateSize(
         long timeUnixNano,
-        long value,
         ProtoFieldInfo valueField,
+        Exemplar value,
         @Nullable String spanId,
         @Nullable String traceId,
         KeyValueMarshaler[] filteredAttributeMarshalers) {
@@ -795,7 +800,12 @@ public final class MetricsRequestMarshaler extends MarshalerWithSize {
       size +=
           MarshalerUtil.sizeFixed64(
               io.opentelemetry.proto.metrics.v1.internal.Exemplar.TIME_UNIX_NANO, timeUnixNano);
-      size += MarshalerUtil.sizeFixed64(valueField, value);
+      // Value doesn't matter for sizing
+      if (valueField == io.opentelemetry.proto.metrics.v1.internal.Exemplar.AS_INT) {
+        size += MarshalerUtil.sizeFixed64(valueField, ((LongExemplar) value).getValue());
+      } else {
+        size += MarshalerUtil.sizeDouble(valueField, ((DoubleExemplar) value).getValue());
+      }
       size +=
           MarshalerUtil.sizeSpanId(
               io.opentelemetry.proto.metrics.v1.internal.Exemplar.SPAN_ID, spanId);

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MetricsRequestMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MetricsRequestMarshaler.java
@@ -700,7 +700,6 @@ public final class MetricsRequestMarshaler extends MarshalerWithSize {
       int size = 0;
       size += MarshalerUtil.sizeFixed64(NumberDataPoint.START_TIME_UNIX_NANO, startTimeUnixNano);
       size += MarshalerUtil.sizeFixed64(NumberDataPoint.TIME_UNIX_NANO, timeUnixNano);
-      // Value doesn't matter when sizing
       if (valueField == NumberDataPoint.AS_INT) {
         size += MarshalerUtil.sizeFixed64(valueField, ((LongPointData) value).getValue());
       } else {
@@ -800,7 +799,6 @@ public final class MetricsRequestMarshaler extends MarshalerWithSize {
       size +=
           MarshalerUtil.sizeFixed64(
               io.opentelemetry.proto.metrics.v1.internal.Exemplar.TIME_UNIX_NANO, timeUnixNano);
-      // Value doesn't matter for sizing
       if (valueField == io.opentelemetry.proto.metrics.v1.internal.Exemplar.AS_INT) {
         size += MarshalerUtil.sizeFixed64(valueField, ((LongExemplar) value).getValue());
       } else {

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ProtoSerializer.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ProtoSerializer.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 /** Serializer for the protobuf binary wire format. */
-final class ProtoSerializer extends Serializer implements AutoCloseable {
+final class ProtoSerializer extends Serializer {
 
   // Cache ID conversion to bytes since we know it's common to use the same ID multiple times within
   // a single export (trace ID and parent span ID).
@@ -145,7 +145,7 @@ final class ProtoSerializer extends Serializer implements AutoCloseable {
   }
 
   @Override
-  public void writeSerializedMessage(byte[] protoSerialized, byte[] jsonSerialized)
+  public void writeSerializedMessage(byte[] protoSerialized, String jsonSerialized)
       throws IOException {
     output.writeRawBytes(protoSerialized);
   }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ProtoSerializer.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ProtoSerializer.java
@@ -5,16 +5,47 @@
 
 package io.opentelemetry.exporter.otlp.internal;
 
+import io.opentelemetry.api.internal.OtelEncodingUtils;
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.TraceId;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /** Serializer for the protobuf binary wire format. */
-final class ProtoSerializer extends Serializer {
+final class ProtoSerializer extends Serializer implements AutoCloseable {
+
+  // Cache ID conversion to bytes since we know it's common to use the same ID multiple times within
+  // a single export (trace ID and parent span ID).
+  // In practice, there is often only one thread that calls this code in the BatchSpanProcessor so
+  // reusing buffers for the thread is almost free. Even with multiple threads, it should still be
+  // worth it and is common practice in serialization libraries such as Jackson.
+  private static final ThreadLocal<Map<String, byte[]>> THREAD_LOCAL_ID_CACHE = new ThreadLocal<>();
 
   private final CodedOutputStream output;
+  private final Map<String, byte[]> idCache;
 
-  ProtoSerializer(CodedOutputStream output) {
-    this.output = output;
+  ProtoSerializer(OutputStream output) {
+    this.output = CodedOutputStream.newInstance(output);
+    idCache = getIdCache();
+  }
+
+  @Override
+  protected void writeTraceId(ProtoFieldInfo field, String traceId) throws IOException {
+    byte[] traceIdBytes =
+        idCache.computeIfAbsent(
+            traceId, id -> OtelEncodingUtils.bytesFromBase16(id, TraceId.getLength()));
+    writeBytes(field, traceIdBytes);
+  }
+
+  @Override
+  protected void writeSpanId(ProtoFieldInfo field, String spanId) throws IOException {
+    byte[] spanIdBytes =
+        idCache.computeIfAbsent(
+            spanId, id -> OtelEncodingUtils.bytesFromBase16(id, SpanId.getLength()));
+    writeBytes(field, spanIdBytes);
   }
 
   @Override
@@ -119,9 +150,18 @@ final class ProtoSerializer extends Serializer {
     output.writeRawBytes(protoSerialized);
   }
 
-  // TODO(anuraaga): Remove after moving protobuf Value serialization from AttributeMarshaler to
-  // here.
-  CodedOutputStream getCodedOutputStream() {
-    return output;
+  @Override
+  public void close() throws IOException {
+    output.flush();
+    idCache.clear();
+  }
+
+  private static Map<String, byte[]> getIdCache() {
+    Map<String, byte[]> result = THREAD_LOCAL_ID_CACHE.get();
+    if (result == null) {
+      result = new HashMap<>();
+      THREAD_LOCAL_ID_CACHE.set(result);
+    }
+    return result;
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ResourceMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ResourceMarshaler.java
@@ -32,11 +32,8 @@ final class ResourceMarshaler extends MarshalerWithSize {
   private ResourceMarshaler(KeyValueMarshaler[] attributeMarshalers) {
     super(calculateSize(attributeMarshalers));
     ByteArrayOutputStream bos = new ByteArrayOutputStream(getBinarySerializedSize());
-    CodedOutputStream output = CodedOutputStream.newInstance(bos);
-    ProtoSerializer serializer = new ProtoSerializer(output);
-    try {
+    try (ProtoSerializer serializer = new ProtoSerializer(bos)) {
       serializer.serializeRepeatedMessage(Resource.ATTRIBUTES, attributeMarshalers);
-      output.flush();
     } catch (IOException e) {
       // Presized so can't happen (we would have already thrown OutOfMemoryError)
       throw new UncheckedIOException(e);

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Serializer.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Serializer.java
@@ -7,6 +7,7 @@ package io.opentelemetry.exporter.otlp.internal;
 
 import java.io.IOException;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Serializer to use when converting from an SDK data object into a protobuf output format. Unlike
@@ -20,6 +21,26 @@ import java.util.List;
 public abstract class Serializer {
 
   Serializer() {}
+
+  /** Serializes a trace ID field. */
+  public void serializeTraceId(ProtoFieldInfo field, @Nullable String traceId) throws IOException {
+    if (traceId == null) {
+      return;
+    }
+    writeTraceId(field, traceId);
+  }
+
+  protected abstract void writeTraceId(ProtoFieldInfo field, String traceId) throws IOException;
+
+  /** Serializes a span ID field. */
+  public void serializeSpanId(ProtoFieldInfo field, @Nullable String spanId) throws IOException {
+    if (spanId == null) {
+      return;
+    }
+    writeSpanId(field, spanId);
+  }
+
+  protected abstract void writeSpanId(ProtoFieldInfo field, String traceId) throws IOException;
 
   /** Serializes a protobuf {@code bool} field. */
   public void serializeBool(ProtoFieldInfo field, boolean value) throws IOException {

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Serializer.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Serializer.java
@@ -18,7 +18,7 @@ import javax.annotation.Nullable;
  *   <li>Can be implemented to serialize into protobuf JSON format (not binary)
  * </ul>
  */
-public abstract class Serializer {
+public abstract class Serializer implements AutoCloseable {
 
   Serializer() {}
 
@@ -40,7 +40,7 @@ public abstract class Serializer {
     writeSpanId(field, spanId);
   }
 
-  protected abstract void writeSpanId(ProtoFieldInfo field, String traceId) throws IOException;
+  protected abstract void writeSpanId(ProtoFieldInfo field, String spanId) throws IOException;
 
   /** Serializes a protobuf {@code bool} field. */
   public void serializeBool(ProtoFieldInfo field, boolean value) throws IOException {
@@ -172,6 +172,9 @@ public abstract class Serializer {
       ProtoFieldInfo field, List<? extends Marshaler> repeatedMessage) throws IOException;
 
   /** Writes the value for a message field that has been pre-serialized. */
-  public abstract void writeSerializedMessage(byte[] protoSerialized, byte[] jsonSerialized)
+  public abstract void writeSerializedMessage(byte[] protoSerialized, String jsonSerialized)
       throws IOException;
+
+  @Override
+  public abstract void close() throws IOException;
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/TraceRequestMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/TraceRequestMarshaler.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.exporter.otlp.internal;
 
-import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.proto.collector.trace.v1.internal.ExportTraceServiceRequest;
@@ -21,9 +20,9 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * {@link Marshaler} to convert SDK {@link SpanData} to OTLP ExportTraceServiceRequest.
@@ -32,11 +31,6 @@ import java.util.Map;
  * at any time.
  */
 public final class TraceRequestMarshaler extends MarshalerWithSize {
-
-  // In practice, there is often only one thread that calls this code in the BatchSpanProcessor so
-  // reusing buffers for the thread is almost free. Even with multiple threads, it should still be
-  // worth it and is common practice in serialization libraries such as Jackson.
-  private static final ThreadLocal<ThreadLocalCache> THREAD_LOCAL_CACHE = new ThreadLocal<>();
 
   private final ResourceSpansMarshaler[] resourceSpansMarshalers;
 
@@ -162,9 +156,9 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
   }
 
   private static final class SpanMarshaler extends MarshalerWithSize {
-    private final byte[] traceId;
-    private final byte[] spanId;
-    private final byte[] parentSpanId;
+    private final String traceId;
+    private final String spanId;
+    @Nullable private final String parentSpanId;
     private final byte[] nameUtf8;
     private final int spanKind;
     private final long startEpochNanos;
@@ -178,35 +172,20 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
     private final SpanStatusMarshaler spanStatusMarshaler;
 
     // Because SpanMarshaler is always part of a repeated field, it cannot return "null".
-    static SpanMarshaler create(SpanData spanData, ThreadLocalCache threadLocalCache) {
+    static SpanMarshaler create(SpanData spanData) {
       KeyValueMarshaler[] attributeMarshalers =
           KeyValueMarshaler.createRepeated(spanData.getAttributes());
       SpanEventMarshaler[] spanEventMarshalers = SpanEventMarshaler.create(spanData.getEvents());
-      SpanLinkMarshaler[] spanLinkMarshalers =
-          SpanLinkMarshaler.create(spanData.getLinks(), threadLocalCache);
-      Map<String, byte[]> idBytesCache = threadLocalCache.idBytesCache;
+      SpanLinkMarshaler[] spanLinkMarshalers = SpanLinkMarshaler.create(spanData.getLinks());
 
-      byte[] traceId =
-          idBytesCache.computeIfAbsent(
-              spanData.getSpanContext().getTraceId(),
-              unused -> spanData.getSpanContext().getTraceIdBytes());
-      byte[] spanId =
-          idBytesCache.computeIfAbsent(
-              spanData.getSpanContext().getSpanId(),
-              unused -> spanData.getSpanContext().getSpanIdBytes());
-
-      byte[] parentSpanId = MarshalerUtil.EMPTY_BYTES;
-      SpanContext parentSpanContext = spanData.getParentSpanContext();
-      if (parentSpanContext.isValid()) {
-        parentSpanId =
-            idBytesCache.computeIfAbsent(
-                spanData.getParentSpanContext().getSpanId(),
-                unused -> spanData.getParentSpanContext().getSpanIdBytes());
-      }
+      String parentSpanId =
+          spanData.getParentSpanContext().isValid()
+              ? spanData.getParentSpanContext().getSpanId()
+              : null;
 
       return new SpanMarshaler(
-          traceId,
-          spanId,
+          spanData.getSpanContext().getTraceId(),
+          spanData.getSpanContext().getSpanId(),
           parentSpanId,
           MarshalerUtil.toBytes(spanData.getName()),
           toProtoSpanKind(spanData.getKind()),
@@ -222,9 +201,9 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
     }
 
     private SpanMarshaler(
-        byte[] traceId,
-        byte[] spanId,
-        byte[] parentSpanId,
+        String traceId,
+        String spanId,
+        @Nullable String parentSpanId,
         byte[] nameUtf8,
         int spanKind,
         long startEpochNanos,
@@ -270,10 +249,10 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
 
     @Override
     public void writeTo(Serializer output) throws IOException {
-      output.serializeBytes(Span.TRACE_ID, traceId);
-      output.serializeBytes(Span.SPAN_ID, spanId);
+      output.serializeTraceId(Span.TRACE_ID, traceId);
+      output.serializeSpanId(Span.SPAN_ID, spanId);
       // TODO: Set TraceState;
-      output.serializeBytes(Span.PARENT_SPAN_ID, parentSpanId);
+      output.serializeSpanId(Span.PARENT_SPAN_ID, parentSpanId);
       output.serializeString(Span.NAME, nameUtf8);
 
       output.serializeEnum(Span.KIND, spanKind);
@@ -294,9 +273,9 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
     }
 
     private static int calculateSize(
-        byte[] traceId,
-        byte[] spanId,
-        byte[] parentSpanId,
+        String traceId,
+        String spanId,
+        @Nullable String parentSpanId,
         byte[] nameUtf8,
         int spanKind,
         long startEpochNanos,
@@ -309,10 +288,10 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
         int droppedLinksCount,
         SpanStatusMarshaler spanStatusMarshaler) {
       int size = 0;
-      size += MarshalerUtil.sizeBytes(Span.TRACE_ID, traceId);
-      size += MarshalerUtil.sizeBytes(Span.SPAN_ID, spanId);
+      size += MarshalerUtil.sizeTraceId(Span.TRACE_ID, traceId);
+      size += MarshalerUtil.sizeSpanId(Span.SPAN_ID, spanId);
       // TODO: Set TraceState;
-      size += MarshalerUtil.sizeBytes(Span.PARENT_SPAN_ID, parentSpanId);
+      size += MarshalerUtil.sizeSpanId(Span.PARENT_SPAN_ID, parentSpanId);
       size += MarshalerUtil.sizeBytes(Span.NAME, nameUtf8);
 
       size += MarshalerUtil.sizeEnum(Span.KIND, spanKind);
@@ -396,28 +375,23 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
 
   private static final class SpanLinkMarshaler extends MarshalerWithSize {
     private static final SpanLinkMarshaler[] EMPTY = new SpanLinkMarshaler[0];
-    private final byte[] traceId;
-    private final byte[] spanId;
+    private final String traceId;
+    private final String spanId;
     private final KeyValueMarshaler[] attributeMarshalers;
     private final int droppedAttributesCount;
 
-    static SpanLinkMarshaler[] create(List<LinkData> links, ThreadLocalCache threadLocalCache) {
+    static SpanLinkMarshaler[] create(List<LinkData> links) {
       if (links.isEmpty()) {
         return EMPTY;
       }
-      Map<String, byte[]> idBytesCache = threadLocalCache.idBytesCache;
 
       SpanLinkMarshaler[] result = new SpanLinkMarshaler[links.size()];
       int pos = 0;
       for (LinkData link : links) {
         result[pos++] =
             new SpanLinkMarshaler(
-                idBytesCache.computeIfAbsent(
-                    link.getSpanContext().getTraceId(),
-                    unused -> link.getSpanContext().getTraceIdBytes()),
-                idBytesCache.computeIfAbsent(
-                    link.getSpanContext().getSpanId(),
-                    unused -> link.getSpanContext().getSpanIdBytes()),
+                link.getSpanContext().getTraceId(),
+                link.getSpanContext().getSpanId(),
                 KeyValueMarshaler.createRepeated(link.getAttributes()),
                 link.getTotalAttributeCount() - link.getAttributes().size());
       }
@@ -426,8 +400,8 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
     }
 
     private SpanLinkMarshaler(
-        byte[] traceId,
-        byte[] spanId,
+        String traceId,
+        String spanId,
         KeyValueMarshaler[] attributeMarshalers,
         int droppedAttributesCount) {
       super(calculateSize(traceId, spanId, attributeMarshalers, droppedAttributesCount));
@@ -439,21 +413,21 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
 
     @Override
     public void writeTo(Serializer output) throws IOException {
-      output.serializeBytes(Span.Link.TRACE_ID, traceId);
-      output.serializeBytes(Span.Link.SPAN_ID, spanId);
+      output.serializeTraceId(Span.Link.TRACE_ID, traceId);
+      output.serializeSpanId(Span.Link.SPAN_ID, spanId);
       // TODO: Set TraceState;
       output.serializeRepeatedMessage(Span.Link.ATTRIBUTES, attributeMarshalers);
       output.serializeUInt32(Span.Link.DROPPED_ATTRIBUTES_COUNT, droppedAttributesCount);
     }
 
     private static int calculateSize(
-        byte[] traceId,
-        byte[] spanId,
+        String traceId,
+        String spanId,
         KeyValueMarshaler[] attributeMarshalers,
         int droppedAttributesCount) {
       int size = 0;
-      size += MarshalerUtil.sizeBytes(Span.Link.TRACE_ID, traceId);
-      size += MarshalerUtil.sizeBytes(Span.Link.SPAN_ID, spanId);
+      size += MarshalerUtil.sizeTraceId(Span.Link.TRACE_ID, traceId);
+      size += MarshalerUtil.sizeSpanId(Span.Link.SPAN_ID, spanId);
       // TODO: Set TraceState;
       size += MarshalerUtil.sizeRepeatedMessage(Span.Link.ATTRIBUTES, attributeMarshalers);
       size += MarshalerUtil.sizeUInt32(Span.Link.DROPPED_ATTRIBUTES_COUNT, droppedAttributesCount);
@@ -507,18 +481,13 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
 
   private static Map<Resource, Map<InstrumentationLibraryInfo, List<SpanMarshaler>>>
       groupByResourceAndLibrary(Collection<SpanData> spanDataList) {
-    ThreadLocalCache threadLocalCache = getThreadLocalCache();
-    try {
-      return MarshalerUtil.groupByResourceAndLibrary(
-          spanDataList,
-          // TODO(anuraaga): Replace with an internal SdkData type of interface that exposes these
-          // two.
-          SpanData::getResource,
-          SpanData::getInstrumentationLibraryInfo,
-          data -> SpanMarshaler.create(data, threadLocalCache));
-    } finally {
-      threadLocalCache.idBytesCache.clear();
-    }
+    return MarshalerUtil.groupByResourceAndLibrary(
+        spanDataList,
+        // TODO(anuraaga): Replace with an internal SdkData type of interface that exposes these
+        // two.
+        SpanData::getResource,
+        SpanData::getInstrumentationLibraryInfo,
+        data -> SpanMarshaler.create(data));
   }
 
   private static int toProtoSpanKind(SpanKind kind) {
@@ -535,18 +504,5 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
         return Span.SpanKind.SPAN_KIND_CONSUMER_VALUE;
     }
     return -1;
-  }
-
-  private static ThreadLocalCache getThreadLocalCache() {
-    ThreadLocalCache result = THREAD_LOCAL_CACHE.get();
-    if (result == null) {
-      result = new ThreadLocalCache();
-      THREAD_LOCAL_CACHE.set(result);
-    }
-    return result;
-  }
-
-  private static final class ThreadLocalCache {
-    final Map<String, byte[]> idBytesCache = new HashMap<>();
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/TraceRequestMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/TraceRequestMarshaler.java
@@ -354,7 +354,7 @@ public final class TraceRequestMarshaler extends MarshalerWithSize {
     @Override
     public void writeTo(Serializer output) throws IOException {
       output.serializeFixed64(Span.Event.TIME_UNIX_NANO, epochNanos);
-      output.serializeBytes(Span.Event.NAME, name);
+      output.serializeString(Span.Event.NAME, name);
       output.serializeRepeatedMessage(Span.Event.ATTRIBUTES, attributeMarshalers);
       output.serializeUInt32(Span.Event.DROPPED_ATTRIBUTES_COUNT, droppedAttributesCount);
     }

--- a/exporters/otlp/trace/build.gradle.kts
+++ b/exporters/otlp/trace/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
   id("otel.java-conventions")
   id("otel.publish-conventions")
 
-  id("otel.jmh-conventions")
   id("otel.animalsniffer-conventions")
 
   id("org.unbroken-dome.test-sets")
@@ -57,11 +56,6 @@ dependencies {
   add("testGrpcOkhttpImplementation", "com.linecorp.armeria:armeria-junit5")
   add("testGrpcOkhttpRuntimeOnly", "io.grpc:grpc-okhttp")
   add("testGrpcOkhttpRuntimeOnly", "org.bouncycastle:bcpkix-jdk15on")
-
-  jmhImplementation(project(":proto"))
-  jmhImplementation(project(":sdk:testing"))
-  jmhRuntimeOnly("io.grpc:grpc-netty")
-  jmhImplementation("io.grpc:grpc-testing")
 
   add("testSpanPipeline", project(":proto"))
   add("testSpanPipeline", "io.grpc:grpc-protobuf")


### PR DESCRIPTION
Depends on #3586

JSON serialization without any real change to the Marshalers :) (aside from the preserialized which are rare)

The performance matches our current byte-buddy generated marshalers - this is because protobuf-jackson is awesome :-) In particular, I suspect the main reason is that it is preserializing the field names which are constant. We can do similar without too much effort, but luckily it doesn't regress so that can come later. Also added what the upstream JSON serializer looks like for kicks.

And for reference binary is about 13 for the 16-cnt case. This was my original objective with protobuf-jackson, to make sure JSON is within an order of magnitude, which upstream isn't. But we do see the significant benefit binary still gets us over it.

```
Benchmark                                                                             (numSpans)  Mode  Cnt         Score         Error   Units
RequestMarshalBenchmarks.marshalJson                                                          16  avgt   10        49.695 ±       0.251   us/op
RequestMarshalBenchmarks.marshalJson:·gc.alloc.rate                                           16  avgt   10      1049.935 ±       5.796  MB/sec
RequestMarshalBenchmarks.marshalJson:·gc.alloc.rate.norm                                      16  avgt   10     82203.230 ±       1.077    B/op
RequestMarshalBenchmarks.marshalJson:·gc.churn.G1_Eden_Space                                  16  avgt   10      1062.041 ±      88.910  MB/sec
RequestMarshalBenchmarks.marshalJson:·gc.churn.G1_Eden_Space.norm                             16  avgt   10     83159.494 ±    7187.573    B/op
RequestMarshalBenchmarks.marshalJson:·gc.churn.G1_Survivor_Space                              16  avgt   10         0.008 ±       0.005  MB/sec
RequestMarshalBenchmarks.marshalJson:·gc.churn.G1_Survivor_Space.norm                         16  avgt   10         0.613 ±       0.399    B/op
RequestMarshalBenchmarks.marshalJson:·gc.count                                                16  avgt   10        87.000                counts
RequestMarshalBenchmarks.marshalJson:·gc.time                                                 16  avgt   10        59.000                    ms
RequestMarshalBenchmarks.marshalJson                                                         512  avgt   10      1585.927 ±      37.346   us/op
RequestMarshalBenchmarks.marshalJson:·gc.alloc.rate                                          512  avgt   10       702.583 ±      16.857  MB/sec
RequestMarshalBenchmarks.marshalJson:·gc.alloc.rate.norm                                     512  avgt   10   1753456.319 ±      19.782    B/op
RequestMarshalBenchmarks.marshalJson:·gc.churn.G1_Eden_Space                                 512  avgt   10       697.028 ±      47.524  MB/sec
RequestMarshalBenchmarks.marshalJson:·gc.churn.G1_Eden_Space.norm                            512  avgt   10   1739799.409 ±  118063.445    B/op
RequestMarshalBenchmarks.marshalJson:·gc.churn.G1_Survivor_Space                             512  avgt   10         0.823 ±       0.235  MB/sec
RequestMarshalBenchmarks.marshalJson:·gc.churn.G1_Survivor_Space.norm                        512  avgt   10      2054.812 ±     587.739    B/op
RequestMarshalBenchmarks.marshalJson:·gc.count                                               512  avgt   10        71.000                counts
RequestMarshalBenchmarks.marshalJson:·gc.time                                                512  avgt   10        55.000                    ms
RequestMarshalBenchmarks.marshalJsonProtoByteBuddy                                            16  avgt   10        50.305 ±       1.694   us/op
RequestMarshalBenchmarks.marshalJsonProtoByteBuddy:·gc.alloc.rate                             16  avgt   10       771.487 ±      25.044  MB/sec
RequestMarshalBenchmarks.marshalJsonProtoByteBuddy:·gc.alloc.rate.norm                        16  avgt   10     61087.908 ±       1.874    B/op
RequestMarshalBenchmarks.marshalJsonProtoByteBuddy:·gc.churn.G1_Eden_Space                    16  avgt   10       770.078 ±      89.304  MB/sec
RequestMarshalBenchmarks.marshalJsonProtoByteBuddy:·gc.churn.G1_Eden_Space.norm               16  avgt   10     60981.430 ±    6850.953    B/op
RequestMarshalBenchmarks.marshalJsonProtoByteBuddy:·gc.churn.G1_Survivor_Space                16  avgt   10         0.032 ±       0.010  MB/sec
RequestMarshalBenchmarks.marshalJsonProtoByteBuddy:·gc.churn.G1_Survivor_Space.norm           16  avgt   10         2.508 ±       0.790    B/op
RequestMarshalBenchmarks.marshalJsonProtoByteBuddy:·gc.count                                  16  avgt   10        63.000                counts
RequestMarshalBenchmarks.marshalJsonProtoByteBuddy:·gc.time                                   16  avgt   10        44.000                    ms
RequestMarshalBenchmarks.marshalJsonProtoByteBuddy                                           512  avgt   10      1623.671 ±      19.109   us/op
RequestMarshalBenchmarks.marshalJsonProtoByteBuddy:·gc.alloc.rate                            512  avgt   10       840.978 ±      10.161  MB/sec
RequestMarshalBenchmarks.marshalJsonProtoByteBuddy:·gc.alloc.rate.norm                       512  avgt   10   2149575.583 ±      21.297    B/op
RequestMarshalBenchmarks.marshalJsonProtoByteBuddy:·gc.churn.G1_Eden_Space                   512  avgt   10       833.232 ±      58.650  MB/sec
RequestMarshalBenchmarks.marshalJsonProtoByteBuddy:·gc.churn.G1_Eden_Space.norm              512  avgt   10   2129854.786 ±  150704.058    B/op
RequestMarshalBenchmarks.marshalJsonProtoByteBuddy:·gc.churn.G1_Survivor_Space               512  avgt   10         1.026 ±       0.269  MB/sec
RequestMarshalBenchmarks.marshalJsonProtoByteBuddy:·gc.churn.G1_Survivor_Space.norm          512  avgt   10      2623.900 ±     687.404    B/op
RequestMarshalBenchmarks.marshalJsonProtoByteBuddy:·gc.count                                 512  avgt   10        69.000                counts
RequestMarshalBenchmarks.marshalJsonProtoByteBuddy:·gc.time                                  512  avgt   10        57.000                    ms
RequestMarshalBenchmarks.marshalJsonProtoReflection                                           16  avgt   10       318.368 ±       3.615   us/op
RequestMarshalBenchmarks.marshalJsonProtoReflection:·gc.alloc.rate                            16  avgt   10      1341.946 ±      13.986  MB/sec
RequestMarshalBenchmarks.marshalJsonProtoReflection:·gc.alloc.rate.norm                       16  avgt   10    672842.893 ±       5.861    B/op
RequestMarshalBenchmarks.marshalJsonProtoReflection:·gc.churn.G1_Eden_Space                   16  avgt   10      1340.415 ±      69.469  MB/sec
RequestMarshalBenchmarks.marshalJsonProtoReflection:·gc.churn.G1_Eden_Space.norm              16  avgt   10    672139.114 ±   37291.364    B/op
RequestMarshalBenchmarks.marshalJsonProtoReflection:·gc.churn.G1_Survivor_Space               16  avgt   10         0.024 ±       0.010  MB/sec
RequestMarshalBenchmarks.marshalJsonProtoReflection:·gc.churn.G1_Survivor_Space.norm          16  avgt   10        12.016 ±       5.046    B/op
RequestMarshalBenchmarks.marshalJsonProtoReflection:·gc.count                                 16  avgt   10        91.000                counts
RequestMarshalBenchmarks.marshalJsonProtoReflection:·gc.time                                  16  avgt   10        66.000                    ms
RequestMarshalBenchmarks.marshalJsonProtoReflection                                          512  avgt   10     11080.765 ±     163.395   us/op
RequestMarshalBenchmarks.marshalJsonProtoReflection:·gc.alloc.rate                           512  avgt   10      1263.414 ±      19.001  MB/sec
RequestMarshalBenchmarks.marshalJsonProtoReflection:·gc.alloc.rate.norm                      512  avgt   10  22010972.357 ±     201.203    B/op
RequestMarshalBenchmarks.marshalJsonProtoReflection:·gc.churn.G1_Eden_Space                  512  avgt   10      1277.433 ±     107.175  MB/sec
RequestMarshalBenchmarks.marshalJsonProtoReflection:·gc.churn.G1_Eden_Space.norm             512  avgt   10  22251656.078 ± 1731121.506    B/op
RequestMarshalBenchmarks.marshalJsonProtoReflection:·gc.churn.G1_Survivor_Space              512  avgt   10         0.897 ±       0.126  MB/sec
RequestMarshalBenchmarks.marshalJsonProtoReflection:·gc.churn.G1_Survivor_Space.norm         512  avgt   10     15633.659 ±    2281.130    B/op
RequestMarshalBenchmarks.marshalJsonProtoReflection:·gc.count                                512  avgt   10        87.000                counts
RequestMarshalBenchmarks.marshalJsonProtoReflection:·gc.time                                 512  avgt   10        80.000                    ms
```