### PR TITLE
Wire in Exemplar Pre-Filters

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/AlwaysSampleFilter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/AlwaysSampleFilter.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.exemplar;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+
+class AlwaysSampleFilter implements ExemplarFilter {
+  static final ExemplarFilter INSTANCE = new AlwaysSampleFilter();
+
+  private AlwaysSampleFilter() {}
+
+  @Override
+  public boolean shouldSampleMeasurement(long value, Attributes attributes, Context context) {
+    return true;
+  }
+
+  @Override
+  public boolean shouldSampleMeasurement(double value, Attributes attributes, Context context) {
+    return true;
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/ExemplarFilter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/ExemplarFilter.java
@@ -19,14 +19,19 @@ public interface ExemplarFilter {
   /** Returns whether or not a resorvoir should attempt to filter a measurement. */
   boolean shouldSampleMeasurement(double value, Attributes attributes, Context context);
 
-  /** A filter that only allows exemplars with traces. */
+  /**
+   * A filter that only accepts measurements where there is a {@code Span} in {@link Context} that
+   * is being sampled.
+   */
   static ExemplarFilter sampleWithTraces() {
     return WithTraceExemplarFilter.INSTANCE;
   }
+
   /** A filter that accepts any measurement. */
   static ExemplarFilter alwaysSample() {
     return AlwaysSampleFilter.INSTANCE;
   }
+
   /** A filter that accepts no measurements. */
   static ExemplarFilter neverSample() {
     return NeverSampleFilter.INSTANCE;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/ExemplarFilter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/ExemplarFilter.java
@@ -31,22 +31,4 @@ public interface ExemplarFilter {
   static ExemplarFilter neverSample() {
     return NeverSampleFilter.INSTANCE;
   }
-  /** Returns the default exemplar filter, pulling from environment variables. */
-  static ExemplarFilter defaultFilter() {
-    String env = System.getenv("OTEL_METRICS_EXEMPLAR_FILTER");
-
-    if (env != null) {
-      switch (env) {
-        case "NONE":
-          return neverSample();
-        case "ALL":
-          return alwaysSample();
-        case "WITH_SAMPLED_TRACE":
-          return sampleWithTraces();
-        default:
-          // TODO: some kind of error.
-      }
-    }
-    return sampleWithTraces();
-  }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/ExemplarFilter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/ExemplarFilter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.exemplar;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+
+/**
+ * Exemplar filters are used to pre-filter measurements before attempting to store them in a
+ * reservoir.
+ */
+public interface ExemplarFilter {
+  /** Returns whether or not a resorvoir should attempt to filter a measurement. */
+  boolean shouldSampleMeasurement(long value, Attributes attributes, Context context);
+
+  /** Returns whether or not a resorvoir should attempt to filter a measurement. */
+  boolean shouldSampleMeasurement(double value, Attributes attributes, Context context);
+
+  /** A filter that only allows exemplars with traces. */
+  static ExemplarFilter sampleWithTraces() {
+    return WithTraceExemplarFilter.INSTANCE;
+  }
+  /** A filter that accepts any measurement. */
+  static ExemplarFilter alwaysSample() {
+    return AlwaysSampleFilter.INSTANCE;
+  }
+  /** A filter that accepts no measurements. */
+  static ExemplarFilter neverSample() {
+    return NeverSampleFilter.INSTANCE;
+  }
+  /** Returns the default exemplar filter, pulling from environment variables. */
+  static ExemplarFilter defaultFilter() {
+    String env = System.getenv("OTEL_METRICS_EXEMPLAR_FILTER");
+
+    if (env != null) {
+      switch (env) {
+        case "NONE":
+          return neverSample();
+        case "ALL":
+          return alwaysSample();
+        case "WITH_SAMPLED_TRACE":
+          return sampleWithTraces();
+        default:
+          // TODO: some kind of error.
+      }
+    }
+    return sampleWithTraces();
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/ExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/ExemplarReservoir.java
@@ -22,6 +22,11 @@ public interface ExemplarReservoir {
     return NoExemplarReservoir.INSTANCE;
   }
 
+  /** Wraps a {@link ExemplarReservoir} with a measurement pre-filter. */
+  public static ExemplarReservoir filtered(ExemplarFilter filter, ExemplarReservoir original) {
+    return new FilteredExemplarReservoir(filter, original);
+  }
+
   /** Offers a {@code long} measurement to be sampled. */
   void offerMeasurement(long value, Attributes attributes, Context context);
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/ExemplarSampler.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/ExemplarSampler.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.metrics.exemplar;
 
 import com.google.auto.value.AutoValue;
+import io.opentelemetry.sdk.metrics.view.Aggregation;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -25,12 +26,21 @@ public abstract class ExemplarSampler {
   ExemplarSampler() {}
 
   /** Configuration for exemplar storage. */
-  public abstract ExemplarReservoirFactory getFactory();
+  abstract ExemplarReservoirFactory getFactory();
+  
+  /** Configuration for exemplar measurement pre-filter. */
+  abstract ExemplarFilter getFilter();
+
+  /** Creates a new {@link ExemplarReservoir} using the existing aggregation config. */
+  public ExemplarReservoir createReservoir(Aggregation aggregation) {
+    return ExemplarReservoir.filtered(getFilter(), getFactory().createReservoir(aggregation));
+  }
 
   /** Returns a builder with default exemplar sampling configuration. */
   public static Builder builder() {
     return new AutoValue_ExemplarSampler.Builder()
         .setFactory(ignore -> ExemplarReservoir.noSamples());
+        .setFilter(ExemplarFilter.defaultFilter());
   }
 
   /** Builder for exemplar sampling. */
@@ -38,6 +48,9 @@ public abstract class ExemplarSampler {
   public abstract static class Builder {
     /** Sets the factory used to provide {@link ExemplarReservoir}s for metric streams. */
     public abstract Builder setFactory(ExemplarReservoirFactory storageStrategy);
+
+    /** Sets the pre-filter on which measurements can be sampled. */
+    public abstract Builder setFilter(ExemplarFilter filter);
 
     /** Returns the configured {@link ExemplarSampler}. */
     public abstract ExemplarSampler build();

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/ExemplarSampler.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/ExemplarSampler.java
@@ -27,7 +27,7 @@ public abstract class ExemplarSampler {
 
   /** Configuration for exemplar storage. */
   abstract ExemplarReservoirFactory getFactory();
-  
+
   /** Configuration for exemplar measurement pre-filter. */
   abstract ExemplarFilter getFilter();
 
@@ -39,8 +39,8 @@ public abstract class ExemplarSampler {
   /** Returns a builder with default exemplar sampling configuration. */
   public static Builder builder() {
     return new AutoValue_ExemplarSampler.Builder()
-        .setFactory(ignore -> ExemplarReservoir.noSamples());
-        .setFilter(ExemplarFilter.defaultFilter());
+        .setFactory(ignore -> ExemplarReservoir.noSamples())
+        .setFilter(ExemplarFilter.sampleWithTraces());
   }
 
   /** Builder for exemplar sampling. */

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/FilteredExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/FilteredExemplarReservoir.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.exemplar;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.metrics.data.Exemplar;
+import java.util.List;
+
+/** Implementation of a reservoir that has a pre-filter on measurements. */
+class FilteredExemplarReservoir implements ExemplarReservoir {
+  private final ExemplarFilter filter;
+  private final ExemplarReservoir reservoir;
+
+  FilteredExemplarReservoir(ExemplarFilter filter, ExemplarReservoir reservoir) {
+    this.filter = filter;
+    this.reservoir = reservoir;
+  }
+
+  @Override
+  public void offerMeasurement(long value, Attributes attributes, Context context) {
+    if (filter.shouldSampleMeasurement(value, attributes, context)) {
+      reservoir.offerMeasurement(value, attributes, context);
+    }
+  }
+
+  @Override
+  public void offerMeasurement(double value, Attributes attributes, Context context) {
+    if (filter.shouldSampleMeasurement(value, attributes, context)) {
+      reservoir.offerMeasurement(value, attributes, context);
+    }
+  }
+
+  @Override
+  public List<Exemplar> collectAndReset(Attributes pointAttributes) {
+    return reservoir.collectAndReset(pointAttributes);
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/NeverSampleFilter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/NeverSampleFilter.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.exemplar;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+
+class NeverSampleFilter implements ExemplarFilter {
+  static final ExemplarFilter INSTANCE = new NeverSampleFilter();
+
+  private NeverSampleFilter() {}
+
+  @Override
+  public boolean shouldSampleMeasurement(long value, Attributes attributes, Context context) {
+    return false;
+  }
+
+  @Override
+  public boolean shouldSampleMeasurement(double value, Attributes attributes, Context context) {
+    return false;
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/WithTraceExemplarFilter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/WithTraceExemplarFilter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.exemplar;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+
+/** Exemplar sampler that only samples measurements with associated sampled traces. */
+final class WithTraceExemplarFilter implements ExemplarFilter {
+
+  static final ExemplarFilter INSTANCE = new WithTraceExemplarFilter();
+
+  private WithTraceExemplarFilter() {}
+
+  @Override
+  public boolean shouldSampleMeasurement(long value, Attributes attributes, Context context) {
+    return hasSampledTrace(context);
+  }
+
+  @Override
+  public boolean shouldSampleMeasurement(double value, Attributes attributes, Context context) {
+    return hasSampledTrace(context);
+  }
+
+  private static boolean hasSampledTrace(Context context) {
+    return Span.fromContext(context).getSpanContext().isSampled();
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorage.java
@@ -53,7 +53,7 @@ public final class SynchronousMetricStorage<T> implements MetricStorage, Writeab
                 instrumentationLibraryInfo,
                 instrumentDescriptor,
                 metricDescriptor,
-                () -> sampler.getFactory().createReservoir(view.getAggregation()));
+                () -> sampler.createReservoir(view.getAggregation()));
     return new SynchronousMetricStorage<>(
         metricDescriptor,
         aggregator,

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/exemplar/ExemplarFilterTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/exemplar/ExemplarFilterTest.java
@@ -15,7 +15,7 @@ import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import org.junit.jupiter.api.Test;
 
-public class ExemplarFilterTest {
+class ExemplarFilterTest {
   private static final String TRACE_ID = "ff000000000000000000000000000041";
   private static final String SPAN_ID = "ff00000000000041";
 

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/exemplar/ExemplarFilterTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/exemplar/ExemplarFilterTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.exemplar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Context;
+import org.junit.jupiter.api.Test;
+
+public class ExemplarFilterTest {
+  private static final String TRACE_ID = "ff000000000000000000000000000041";
+  private static final String SPAN_ID = "ff00000000000041";
+
+  @Test
+  void never_NeverReturnsTrue() {
+    assertThat(
+            ExemplarFilter.neverSample()
+                .shouldSampleMeasurement(1, Attributes.empty(), Context.root()))
+        .isFalse();
+  }
+
+  @Test
+  void withSampledTrace_ReturnsFalseOnNoContext() {
+    assertThat(
+            ExemplarFilter.sampleWithTraces()
+                .shouldSampleMeasurement(1, Attributes.empty(), Context.root()))
+        .isFalse();
+  }
+
+  @Test
+  void withSampledTrace_sampleWithTrace() {
+    final Context context =
+        Context.root()
+            .with(
+                Span.wrap(
+                    SpanContext.createFromRemoteParent(
+                        TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault())));
+    assertThat(
+            ExemplarFilter.sampleWithTraces()
+                .shouldSampleMeasurement(1, Attributes.empty(), context))
+        .isTrue();
+  }
+
+  @Test
+  void withSampledTrace_notSampleUnsampledTrace() {
+    final Context context =
+        Context.root()
+            .with(
+                Span.wrap(
+                    SpanContext.createFromRemoteParent(
+                        TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault())));
+    assertThat(
+            ExemplarFilter.sampleWithTraces()
+                .shouldSampleMeasurement(1, Attributes.empty(), context))
+        .isFalse();
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/exemplar/ExemplarFilterTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/exemplar/ExemplarFilterTest.java
@@ -28,6 +28,14 @@ public class ExemplarFilterTest {
   }
 
   @Test
+  void always_AlwaysReturnsTrue() {
+    assertThat(
+            ExemplarFilter.alwaysSample()
+                .shouldSampleMeasurement(1, Attributes.empty(), Context.root()))
+        .isTrue();
+  }
+
+  @Test
   void withSampledTrace_ReturnsFalseOnNoContext() {
     assertThat(
             ExemplarFilter.sampleWithTraces()

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/exemplar/FilteredExemplarReservoirTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/exemplar/FilteredExemplarReservoirTest.java
@@ -21,7 +21,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class FilteredExemplarReservoirTest {
+class FilteredExemplarReservoirTest {
   @Mock ExemplarReservoir reservoir;
   @Mock ExemplarFilter filter;
 

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/exemplar/FilteredExemplarReservoirTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/exemplar/FilteredExemplarReservoirTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.exemplar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class FilteredExemplarReservoirTest {
+  @Mock ExemplarReservoir reservoir;
+  @Mock ExemplarFilter filter;
+
+  @Test
+  void testFilter_preventsSamplingDoubles() {
+    when(filter.shouldSampleMeasurement(anyDouble(), any(), any())).thenReturn(false);
+    ExemplarReservoir filtered = new FilteredExemplarReservoir(filter, reservoir);
+    filtered.offerMeasurement(1.0, Attributes.empty(), Context.root());
+  }
+
+  @Test
+  void testFilter_allowsSamplingDoubles() {
+    when(filter.shouldSampleMeasurement(anyDouble(), any(), any())).thenReturn(true);
+    ExemplarReservoir filtered = new FilteredExemplarReservoir(filter, reservoir);
+    filtered.offerMeasurement(1.0, Attributes.empty(), Context.root());
+    verify(reservoir).offerMeasurement(1.0, Attributes.empty(), Context.root());
+  }
+
+  @Test
+  void testFilter_preventsSamplingLongs() {
+    when(filter.shouldSampleMeasurement(anyLong(), any(), any())).thenReturn(false);
+    ExemplarReservoir filtered = new FilteredExemplarReservoir(filter, reservoir);
+    filtered.offerMeasurement(1L, Attributes.empty(), Context.root());
+  }
+
+  @Test
+  void testFilter_allowsSamplingLongs() {
+    when(filter.shouldSampleMeasurement(anyLong(), any(), any())).thenReturn(true);
+    ExemplarReservoir filtered = new FilteredExemplarReservoir(filter, reservoir);
+    filtered.offerMeasurement(1L, Attributes.empty(), Context.root());
+    verify(reservoir).offerMeasurement(1L, Attributes.empty(), Context.root());
+  }
+
+  @Test
+  void reservoir_collectsUnderlying() {
+    when(reservoir.collectAndReset(Attributes.empty())).thenReturn(Collections.emptyList());
+    ExemplarReservoir filtered = new FilteredExemplarReservoir(filter, reservoir);
+    assertThat(filtered.collectAndReset(Attributes.empty())).isEmpty();
+  }
+}


### PR DESCRIPTION
Depends on #3583

- Add `ExemplarFitler` interface
- Add three default impelementaitons (with traces, none and all)
- Create `FilteredExemplarReservoir` that allows pre-filtering measurements prior to actual reservoir sampling.