### PR TITLE
Remove protobuf-java-util / gson dependency from jaeger exporter in f…

### DIFF
--- a/exporters/jaeger/build.gradle.kts
+++ b/exporters/jaeger/build.gradle.kts
@@ -17,12 +17,13 @@ dependencies {
 
   implementation("io.grpc:grpc-protobuf")
   implementation("io.grpc:grpc-stub")
+  implementation("com.fasterxml.jackson.jr:jackson-jr-objects")
   implementation("com.google.protobuf:protobuf-java")
-  implementation("com.google.protobuf:protobuf-java-util")
 
+  testImplementation("com.fasterxml.jackson.jr:jackson-jr-stree")
   testImplementation("io.grpc:grpc-testing")
-  testImplementation("com.fasterxml.jackson.core:jackson-databind")
   testImplementation("org.testcontainers:junit-jupiter")
+  testImplementation("com.google.protobuf:protobuf-java-util")
   testImplementation("com.squareup.okhttp3:okhttp")
 
   testImplementation(project(":sdk:testing"))

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/AdapterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/AdapterTest.java
@@ -64,6 +64,7 @@ class AdapterTest {
   }
 
   @Test
+  @SuppressWarnings({"ProtoTimestampGetSecondsGetNano", "ProtoDurationGetSecondsGetNano"})
   void testProtoSpan() {
     long duration = 900; // ms
     long startMs = System.currentTimeMillis();
@@ -78,7 +79,7 @@ class AdapterTest {
     assertThat(SpanId.fromBytes(jaegerSpan.getSpanId().toByteArray())).isEqualTo(span.getSpanId());
     assertThat(jaegerSpan.getOperationName()).isEqualTo("GET /api/endpoint");
     assertThat(jaegerSpan.getStartTime()).isEqualTo(Timestamps.fromMillis(startMs));
-    assertThat(Durations.toMillis(jaegerSpan.getDuration())).isEqualTo(duration);
+    assertThat(jaegerSpan.getDuration()).isEqualTo(Durations.fromMillis(duration));
 
     assertThat(jaegerSpan.getTagsCount()).isEqualTo(6);
     Model.KeyValue keyValue = getValue(jaegerSpan.getTagsList(), Adapter.KEY_SPAN_KIND);


### PR DESCRIPTION
…avor of Jackson.

We use Jackson in several other places and I think it's good to be consistent on the JSON library we're using so switching from gson for the jaeger artifacts, the only ones that use it.