### PR TITLE
Add autoconfigure for span attribute value length limits

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
@@ -10,4 +10,4 @@ Comparing source compatibility of  against
 	+++  NEW METHOD: PUBLIC(+) int getMaxAttributeValueLength()
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.SpanLimitsBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.SpanLimitsBuilder setMaxAttributeLength(int)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.SpanLimitsBuilder setMaxAttributeValueLength(int)

--- a/sdk-extensions/autoconfigure/README.md
+++ b/sdk-extensions/autoconfigure/README.md
@@ -181,11 +181,12 @@ Supported values for `otel.traces.sampler` are
 
 These properties can be used to control the maximum size of recordings per span.
 
-| System property                 | Environment variable            | Description                                                  |
-|---------------------------------|---------------------------------|--------------------------------------------------------------|
-| otel.span.attribute.count.limit | OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT | The maximum number of attributes per span. Default is `128`.  |
-| otel.span.event.count.limit     | OTEL_SPAN_EVENT_COUNT_LIMIT     | The maximum number of events per span. Default is `128`.     |
-| otel.span.link.count.limit      | OTEL_SPAN_LINK_COUNT_LIMIT      | The maximum number of links per span. Default is `128`        |
+| System property                        | Environment variable                   | Description                                                            |
+|----------------------------------------|----------------------------------------|------------------------------------------------------------------------|
+| otel.span.attribute.value.length.limit | OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT | The maximum length of attribute values. By default there is no limit.  |
+| otel.span.attribute.count.limit        | OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT        | The maximum number of attributes per span. Default is `128`.           |
+| otel.span.event.count.limit            | OTEL_SPAN_EVENT_COUNT_LIMIT            | The maximum number of events per span. Default is `128`.               |
+| otel.span.link.count.limit             | OTEL_SPAN_LINK_COUNT_LIMIT             | The maximum number of links per span. Default is `128`                 |
 
 ## Interval metric reader
 

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
@@ -109,6 +109,11 @@ final class TracerProviderConfiguration {
   static SpanLimits configureSpanLimits(ConfigProperties config) {
     SpanLimitsBuilder builder = SpanLimits.builder();
 
+    Integer maxLength = config.getInt("otel.span.attribute.value.length.limit");
+    if (maxLength != null) {
+      builder.setMaxAttributeValueLength(maxLength);
+    }
+
     Integer maxAttrs = config.getInt("otel.span.attribute.count.limit");
     if (maxAttrs != null) {
       builder.setMaxNumberOfAttributes(maxAttrs);

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
@@ -154,6 +154,7 @@ class TracerProviderConfigurationTest {
 
     Map<String, String> properties = new HashMap<>();
     properties.put("otel.traces.sampler", "always_off");
+    properties.put("otel.span.attribute.value.length.limit", "100");
     properties.put("otel.span.attribute.count.limit", "5");
     properties.put("otel.span.event.count.limit", "4");
     properties.put("otel.span.link.count.limit", "3");
@@ -161,6 +162,7 @@ class TracerProviderConfigurationTest {
     SpanLimits config =
         TracerProviderConfiguration.configureSpanLimits(
             DefaultConfigProperties.createForTest(properties));
+    assertThat(config.getMaxAttributeValueLength()).isEqualTo(100);
     assertThat(config.getMaxNumberOfAttributes()).isEqualTo(5);
     assertThat(config.getMaxNumberOfEvents()).isEqualTo(4);
     assertThat(config.getMaxNumberOfLinks()).isEqualTo(3);

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SpanLimits.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SpanLimits.java
@@ -93,7 +93,7 @@ public abstract class SpanLimits {
   public abstract int getMaxNumberOfAttributesPerLink();
 
   /**
-   * Returns the max number of characters for string attribute values. For string array attributes
+   * Returns the max number of characters for string attribute values. For string array attribute
    * values, applies to each entry individually.
    *
    * @return the max number of characters for attribute strings.
@@ -116,7 +116,7 @@ public abstract class SpanLimits {
         .setMaxNumberOfLinks(getMaxNumberOfLinks())
         .setMaxNumberOfAttributesPerEvent(getMaxNumberOfAttributesPerEvent())
         .setMaxNumberOfAttributesPerLink(getMaxNumberOfAttributesPerLink())
-        .setMaxAttributeLength(getMaxAttributeValueLength());
+        .setMaxAttributeValueLength(getMaxAttributeValueLength());
   }
 
   @AutoValue

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SpanLimitsBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SpanLimitsBuilder.java
@@ -22,7 +22,7 @@ public final class SpanLimitsBuilder {
   private int maxNumLinks = DEFAULT_SPAN_MAX_NUM_LINKS;
   private int maxNumAttributesPerEvent = DEFAULT_SPAN_MAX_NUM_ATTRIBUTES_PER_EVENT;
   private int maxNumAttributesPerLink = DEFAULT_SPAN_MAX_NUM_ATTRIBUTES_PER_LINK;
-  private int maxAttributeLength = SpanLimits.DEFAULT_SPAN_MAX_ATTRIBUTE_LENGTH;
+  private int maxAttributeValueLength = SpanLimits.DEFAULT_SPAN_MAX_ATTRIBUTE_LENGTH;
 
   SpanLimitsBuilder() {}
 
@@ -94,16 +94,16 @@ public final class SpanLimitsBuilder {
   }
 
   /**
-   * Sets the max number of characters for string attribute values. For string array attributes
+   * Sets the max number of characters for string attribute values. For string array attribute
    * values, applies to each entry individually.
    *
-   * @param maxAttributeLength the max characters for string attribute values. Must not be negative.
+   * @param maxAttributeValueLength the max number of characters for attribute strings. Must not be negative.
    * @return this.
-   * @throws IllegalArgumentException if {@code maxAttributeLength} is negative.
+   * @throws IllegalArgumentException if {@code maxAttributeValueLength} is negative.
    */
-  public SpanLimitsBuilder setMaxAttributeLength(int maxAttributeLength) {
-    Utils.checkArgument(maxAttributeLength > -1, "maxAttributeLength must be non-negative");
-    this.maxAttributeLength = maxAttributeLength;
+  public SpanLimitsBuilder setMaxAttributeValueLength(int maxAttributeValueLength) {
+    Utils.checkArgument(maxAttributeValueLength > -1, "maxAttributeValueLength must be non-negative");
+    this.maxAttributeValueLength = maxAttributeValueLength;
     return this;
   }
 
@@ -115,6 +115,6 @@ public final class SpanLimitsBuilder {
         maxNumLinks,
         maxNumAttributesPerEvent,
         maxNumAttributesPerLink,
-        maxAttributeLength);
+        maxAttributeValueLength);
   }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SpanLimitsBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SpanLimitsBuilder.java
@@ -97,12 +97,14 @@ public final class SpanLimitsBuilder {
    * Sets the max number of characters for string attribute values. For string array attribute
    * values, applies to each entry individually.
    *
-   * @param maxAttributeValueLength the max number of characters for attribute strings. Must not be negative.
+   * @param maxAttributeValueLength the max number of characters for attribute strings. Must not be
+   *     negative.
    * @return this.
    * @throws IllegalArgumentException if {@code maxAttributeValueLength} is negative.
    */
   public SpanLimitsBuilder setMaxAttributeValueLength(int maxAttributeValueLength) {
-    Utils.checkArgument(maxAttributeValueLength > -1, "maxAttributeValueLength must be non-negative");
+    Utils.checkArgument(
+        maxAttributeValueLength > -1, "maxAttributeValueLength must be non-negative");
     this.maxAttributeValueLength = maxAttributeValueLength;
     return this;
   }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -693,7 +693,7 @@ class RecordEventsReadableSpanTest {
   void attributeLength() {
     int maxLength = 25;
     RecordEventsReadableSpan span =
-        createTestSpan(SpanLimits.builder().setMaxAttributeLength(maxLength).build());
+        createTestSpan(SpanLimits.builder().setMaxAttributeValueLength(maxLength).build());
     try {
       String strVal = IntStream.range(0, maxLength).mapToObj(i -> "a").collect(joining());
       String tooLongStrVal = strVal + strVal;
@@ -731,7 +731,7 @@ class RecordEventsReadableSpanTest {
   void eventAttributeLength() {
     int maxLength = 25;
     RecordEventsReadableSpan span =
-        createTestSpan(SpanLimits.builder().setMaxAttributeLength(maxLength).build());
+        createTestSpan(SpanLimits.builder().setMaxAttributeValueLength(maxLength).build());
     try {
       String strVal = IntStream.range(0, maxLength).mapToObj(i -> "a").collect(joining());
       String tooLongStrVal = strVal + strVal;

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
@@ -159,7 +159,7 @@ class SdkSpanBuilderTest {
     int maxLength = 25;
     TracerProvider tracerProvider =
         SdkTracerProvider.builder()
-            .setSpanLimits(SpanLimits.builder().setMaxAttributeLength(maxLength).build())
+            .setSpanLimits(SpanLimits.builder().setMaxAttributeValueLength(maxLength).build())
             .build();
     SpanBuilder spanBuilder = tracerProvider.get("test").spanBuilder(SPAN_NAME);
     String strVal = IntStream.range(0, maxLength).mapToObj(i -> "a").collect(joining());


### PR DESCRIPTION
Followup to Issue #3551.

Also noticed an inconsistency between the name of the new span attribute value length setter and getter so I've fixed that as well. Will be good to get that aligned before the release 😬!