### PR TITLE
Remove experimental prefix from otlp protocol config properties

### DIFF
--- a/sdk-extensions/autoconfigure/README.md
+++ b/sdk-extensions/autoconfigure/README.md
@@ -65,9 +65,9 @@ The [OpenTelemetry Protocol (OTLP)](https://github.com/open-telemetry/openteleme
 | otel.exporter.otlp.timeout   | OTEL_EXPORTER_OTLP_TIMEOUT  | The maximum waiting time, in milliseconds, allowed to send each OTLP trace and metric batch. Default is `10000`.  |
 | otel.exporter.otlp.traces.timeout   | OTEL_EXPORTER_OTLP_TRACES_TIMEOUT  | The maximum waiting time, in milliseconds, allowed to send each OTLP trace batch. Default is `10000`.  |
 | otel.exporter.otlp.metrics.timeout   | OTEL_EXPORTER_OTLP_METRICS_TIMEOUT  | The maximum waiting time, in milliseconds, allowed to send each OTLP metric batch. Default is `10000`.  |
-| otel.experimental.exporter.otlp.protocol | OTEL_EXPERIMENTAL_EXPORTER_OTLP_PROTOCOL | The transport protocol to use on OTLP trace and metrics requests. Options include `grpc` and `http/protobuf`. Default is `grpc`. |
-| otel.experimental.exporter.otlp.traces.protocol | OTEL_EXPERIMENTAL_EXPORTER_OTLP_TRACES_PROTOCOL | The transport protocol to use on OTLP trace requests. Options include `grpc` and `http/protobuf`. Default is `grpc`. |
-| otel.experimental.exporter.otlp.metrics.protocol | OTEL_EXPERIMENTAL_EXPORTER_OTLP_METRICS_PROTOCOL | The transport protocol to use on OTLP metrics requests. Options include `grpc` and `http/protobuf`. Default is `grpc`. |
+| otel.exporter.otlp.protocol | OTEL_EXPORTER_OTLP_PROTOCOL | The transport protocol to use on OTLP trace and metrics requests. Options include `grpc` and `http/protobuf`. Default is `grpc`. |
+| otel.exporter.otlp.traces.protocol | OTEL_EXPORTER_OTLP_TRACES_PROTOCOL | The transport protocol to use on OTLP trace requests. Options include `grpc` and `http/protobuf`. Default is `grpc`. |
+| otel.exporter.otlp.metrics.protocol | OTEL_EXPORTER_OTLP_METRICS_PROTOCOL | The transport protocol to use on OTLP metrics requests. Options include `grpc` and `http/protobuf`. Default is `grpc`. |
 
 To configure the service name for the OTLP exporter, add the `service.name` key
 to the OpenTelemetry Resource ([see below](#opentelemetry-resource)), e.g. `OTEL_RESOURCE_ATTRIBUTES=service.name=myservice`.

--- a/sdk-extensions/autoconfigure/README.md
+++ b/sdk-extensions/autoconfigure/README.md
@@ -68,6 +68,9 @@ The [OpenTelemetry Protocol (OTLP)](https://github.com/open-telemetry/openteleme
 | otel.exporter.otlp.protocol | OTEL_EXPORTER_OTLP_PROTOCOL | The transport protocol to use on OTLP trace and metrics requests. Options include `grpc` and `http/protobuf`. Default is `grpc`. |
 | otel.exporter.otlp.traces.protocol | OTEL_EXPORTER_OTLP_TRACES_PROTOCOL | The transport protocol to use on OTLP trace requests. Options include `grpc` and `http/protobuf`. Default is `grpc`. |
 | otel.exporter.otlp.metrics.protocol | OTEL_EXPORTER_OTLP_METRICS_PROTOCOL | The transport protocol to use on OTLP metrics requests. Options include `grpc` and `http/protobuf`. Default is `grpc`. |
+| otel.experimental.exporter.otlp.protocol | OTEL_EXPERIMENTAL_EXPORTER_OTLP_PROTOCOL | **DEPRECATED for removal in 1.8.0.** The transport protocol to use on OTLP trace and metrics requests. Options include `grpc` and `http/protobuf`. Default is `grpc`. |
+| otel.experimental.exporter.otlp.traces.protocol | OTEL_EXPERIMENTAL_EXPORTER_OTLP_TRACES_PROTOCOL | **DEPRECATED for removal in 1.8.0.** The transport protocol to use on OTLP trace requests. Options include `grpc` and `http/protobuf`. Default is `grpc`. |
+| otel.experimental.exporter.otlp.metrics.protocol | OTEL_EXPERIMENTAL_EXPORTER_OTLP_METRICS_PROTOCOL | **DEPRECATED for removal in 1.8.0.** The transport protocol to use on OTLP metrics requests. Options include `grpc` and `http/protobuf`. Default is `grpc`. |
 
 To configure the service name for the OTLP exporter, add the `service.name` key
 to the OpenTelemetry Resource ([see below](#opentelemetry-resource)), e.g. `OTEL_RESOURCE_ATTRIBUTES=service.name=myservice`.

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtil.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtil.java
@@ -22,9 +22,9 @@ final class OtlpConfigUtil {
   static final String DATA_TYPE_METRICS = "metrics";
 
   static String getOtlpProtocol(String dataType, ConfigProperties config) {
-    String protocol = config.getString("otel.experimental.exporter.otlp." + dataType + ".protocol");
+    String protocol = config.getString("otel.exporter.otlp." + dataType + ".protocol");
     if (protocol == null) {
-      protocol = config.getString("otel.experimental.exporter.otlp.protocol");
+      protocol = config.getString("otel.exporter.otlp.protocol");
     }
     return (protocol == null) ? "grpc" : protocol;
   }

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtil.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtil.java
@@ -26,6 +26,12 @@ final class OtlpConfigUtil {
     if (protocol == null) {
       protocol = config.getString("otel.exporter.otlp.protocol");
     }
+    if (protocol == null) {
+      protocol = config.getString("otel.experimental.exporter.otlp." + dataType + ".protocol");
+    }
+    if (protocol == null) {
+      protocol = config.getString("otel.experimental.exporter.otlp.protocol");
+    }
     return (protocol == null) ? "grpc" : protocol;
   }
 

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/NotOnClasspathTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/NotOnClasspathTest.java
@@ -34,7 +34,7 @@ class NotOnClasspathTest {
   void otlpHttpSpans() {
     ConfigProperties config =
         DefaultConfigProperties.createForTest(
-            Collections.singletonMap("otel.experimental.exporter.otlp.protocol", "http/protobuf"));
+            Collections.singletonMap("otel.exporter.otlp.protocol", "http/protobuf"));
     assertThatThrownBy(
             () ->
                 SpanExporterConfiguration.configureExporter("otlp", config, Collections.emptyMap()))
@@ -104,7 +104,7 @@ class NotOnClasspathTest {
   void otlpHttpMetrics() {
     ConfigProperties config =
         DefaultConfigProperties.createForTest(
-            Collections.singletonMap("otel.experimental.exporter.otlp.protocol", "http/protobuf"));
+            Collections.singletonMap("otel.exporter.otlp.protocol", "http/protobuf"));
     assertThatCode(
             () ->
                 MetricExporterConfiguration.configureExporter(

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtilTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtilTest.java
@@ -25,7 +25,7 @@ class OtlpConfigUtilTest {
             OtlpConfigUtil.getOtlpProtocol(
                 DATA_TYPE_TRACES,
                 DefaultConfigProperties.createForTest(
-                    ImmutableMap.of("otel.exporter.otlp.protocol", "foo"))))
+                    ImmutableMap.of("otel.experimental.exporter.otlp.protocol", "foo"))))
         .isEqualTo("foo");
 
     assertThat(
@@ -33,10 +33,29 @@ class OtlpConfigUtilTest {
                 DATA_TYPE_TRACES,
                 DefaultConfigProperties.createForTest(
                     ImmutableMap.of(
-                        "otel.exporter.otlp.protocol",
-                        "foo",
-                        "otel.exporter.otlp.traces.protocol",
-                        "bar"))))
+                        "otel.experimental.exporter.otlp.protocol", "foo",
+                        "otel.experimental.exporter.otlp.traces.protocol", "bar"))))
         .isEqualTo("bar");
+
+    assertThat(
+            OtlpConfigUtil.getOtlpProtocol(
+                DATA_TYPE_TRACES,
+                DefaultConfigProperties.createForTest(
+                    ImmutableMap.of(
+                        "otel.experimental.exporter.otlp.protocol", "foo",
+                        "otel.experimental.exporter.otlp.traces.protocol", "bar",
+                        "otel.exporter.otlp.protocol", "baz"))))
+        .isEqualTo("baz");
+
+    assertThat(
+            OtlpConfigUtil.getOtlpProtocol(
+                DATA_TYPE_TRACES,
+                DefaultConfigProperties.createForTest(
+                    ImmutableMap.of(
+                        "otel.experimental.exporter.otlp.protocol", "foo",
+                        "otel.experimental.exporter.otlp.traces.protocol", "bar",
+                        "otel.exporter.otlp.protocol", "baz",
+                        "otel.exporter.otlp.traces.protocol", "qux"))))
+        .isEqualTo("qux");
   }
 }

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtilTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtilTest.java
@@ -25,7 +25,7 @@ class OtlpConfigUtilTest {
             OtlpConfigUtil.getOtlpProtocol(
                 DATA_TYPE_TRACES,
                 DefaultConfigProperties.createForTest(
-                    ImmutableMap.of("otel.experimental.exporter.otlp.protocol", "foo"))))
+                    ImmutableMap.of("otel.exporter.otlp.protocol", "foo"))))
         .isEqualTo("foo");
 
     assertThat(
@@ -33,9 +33,9 @@ class OtlpConfigUtilTest {
                 DATA_TYPE_TRACES,
                 DefaultConfigProperties.createForTest(
                     ImmutableMap.of(
-                        "otel.experimental.exporter.otlp.protocol",
+                        "otel.exporter.otlp.protocol",
                         "foo",
-                        "otel.experimental.exporter.otlp.traces.protocol",
+                        "otel.exporter.otlp.traces.protocol",
                         "bar"))))
         .isEqualTo("bar");
   }

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfigurationTest.java
@@ -20,7 +20,7 @@ public class MetricExporterConfigurationTest {
             () ->
                 MetricExporterConfiguration.configureOtlpMetrics(
                     DefaultConfigProperties.createForTest(
-                        ImmutableMap.of("otel.experimental.exporter.otlp.protocol", "foo")),
+                        ImmutableMap.of("otel.exporter.otlp.protocol", "foo")),
                     SdkMeterProvider.builder().build()))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("Unsupported OTLP metrics protocol: foo");

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfigurationTest.java
@@ -25,7 +25,7 @@ class SpanExporterConfigurationTest {
             () ->
                 SpanExporterConfiguration.configureOtlp(
                     DefaultConfigProperties.createForTest(
-                        ImmutableMap.of("otel.experimental.exporter.otlp.protocol", "foo"))))
+                        ImmutableMap.of("otel.exporter.otlp.protocol", "foo"))))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("Unsupported OTLP traces protocol: foo");
   }

--- a/sdk-extensions/autoconfigure/src/testOtlpHttp/java/io/opentelemetry/sdk/autoconfigure/OtlpHttpConfigTest.java
+++ b/sdk-extensions/autoconfigure/src/testOtlpHttp/java/io/opentelemetry/sdk/autoconfigure/OtlpHttpConfigTest.java
@@ -163,7 +163,7 @@ class OtlpHttpConfigTest {
   @Test
   void configureExportersGeneral() {
     Map<String, String> props = new HashMap<>();
-    props.put("otel.experimental.exporter.otlp.protocol", "http/protobuf");
+    props.put("otel.exporter.otlp.protocol", "http/protobuf");
     props.put("otel.exporter.otlp.traces.endpoint", traceEndpoint());
     props.put("otel.exporter.otlp.metrics.endpoint", metricEndpoint());
     props.put("otel.exporter.otlp.certificate", certificateExtension.filePath);
@@ -219,8 +219,8 @@ class OtlpHttpConfigTest {
     // Set values for general and signal specific properties. Signal specific should override
     // general.
     Map<String, String> props = new HashMap<>();
-    props.put("otel.experimental.exporter.otlp.protocol", "grpc");
-    props.put("otel.experimental.exporter.otlp.traces.protocol", "http/protobuf");
+    props.put("otel.exporter.otlp.protocol", "grpc");
+    props.put("otel.exporter.otlp.traces.protocol", "http/protobuf");
     props.put("otel.exporter.otlp.endpoint", "http://foo.bar");
     props.put("otel.exporter.otlp.certificate", Paths.get("foo", "bar", "baz").toString());
     props.put("otel.exporter.otlp.headers", "header-key=dummy-value");
@@ -259,8 +259,8 @@ class OtlpHttpConfigTest {
     // Set values for general and signal specific properties. Signal specific should override
     // general.
     Map<String, String> props = new HashMap<>();
-    props.put("otel.experimental.exporter.otlp.protocol", "grpc");
-    props.put("otel.experimental.exporter.otlp.metrics.protocol", "http/protobuf");
+    props.put("otel.exporter.otlp.protocol", "grpc");
+    props.put("otel.exporter.otlp.metrics.protocol", "http/protobuf");
     props.put("otel.exporter.otlp.endpoint", "http://foo.bar");
     props.put("otel.exporter.otlp.certificate", Paths.get("foo", "bar", "baz").toString());
     props.put("otel.exporter.otlp.headers", "header-key=dummy-value");
@@ -296,7 +296,7 @@ class OtlpHttpConfigTest {
   @Test
   void configureTlsInvalidCertificatePath() {
     Map<String, String> props = new HashMap<>();
-    props.put("otel.experimental.exporter.otlp.protocol", "http/protobuf");
+    props.put("otel.exporter.otlp.protocol", "http/protobuf");
     props.put("otel.exporter.otlp.certificate", Paths.get("foo", "bar", "baz").toString());
     ConfigProperties properties = DefaultConfigProperties.createForTest(props);
 
@@ -348,7 +348,7 @@ class OtlpHttpConfigTest {
 
   @Test
   void configuresGlobal() {
-    System.setProperty("otel.experimental.exporter.otlp.protocol", "http/protobuf");
+    System.setProperty("otel.exporter.otlp.protocol", "http/protobuf");
     System.setProperty("otel.exporter.otlp.traces.endpoint", traceEndpoint());
     System.setProperty("otel.exporter.otlp.metrics.endpoint", metricEndpoint());
     System.setProperty("otel.exporter.otlp.certificate", certificateExtension.filePath);


### PR DESCRIPTION
Updating the config properties for protocol now that they're official in the [spec](https://github.com/open-telemetry/opentelemetry-specification/pull/1880).