### PR TITLE
OTLP retry

### DIFF
--- a/exporters/otlp/common/build.gradle.kts
+++ b/exporters/otlp/common/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
   compileOnly("io.grpc:grpc-netty-shaded")
   compileOnly("io.grpc:grpc-okhttp")
   compileOnly("io.grpc:grpc-stub")
+  compileOnly("net.jodah:failsafe:2.4.3")
 
   annotationProcessor("com.google.auto.value:auto-value")
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/RetryConfig.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/RetryConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry;
+
+import io.opentelemetry.exporter.otlp.internal.ExponentialBackoffConfig;
+import java.time.Duration;
+
+@SuppressWarnings("InterfaceWithOnlyStatics")
+public interface RetryConfig {
+
+  /**
+   * Create a retry config representing an exponential backoff policy.
+   *
+   * @param maxAttempts the max number of retries
+   * @param initialBackoff the wait period before attempting the first retry
+   * @param maxBackoff the maximum wait period before retry attempts
+   * @param backoffMultiplier the multiplication factor used to compute the delay between successive
+   *     failures
+   * @param jitter the duration to randomly vary retry delays by
+   */
+  static RetryConfig exponentialBackoff(
+      long maxAttempts,
+      Duration initialBackoff,
+      Duration maxBackoff,
+      double backoffMultiplier,
+      Duration jitter) {
+    return ExponentialBackoffConfig.create(
+        maxAttempts, initialBackoff, maxBackoff, backoffMultiplier, jitter);
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ExponentialBackoffConfig.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ExponentialBackoffConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.RetryConfig;
+import java.time.Duration;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+@AutoValue
+@Immutable
+public abstract class ExponentialBackoffConfig implements RetryConfig {
+
+  public static ExponentialBackoffConfig create(
+      long maxRetries,
+      Duration initialBackoff,
+      Duration maxBackoff,
+      double backoffMultiplier,
+      Duration jitter) {
+    return new AutoValue_ExponentialBackoffConfig(
+        maxRetries, initialBackoff, maxBackoff, backoffMultiplier, jitter);
+  }
+
+  /** The maximum number of retries. */
+  abstract long getMaxRetries();
+
+  /** The wait period before attempting the first retry. */
+  abstract Duration getInitialBackoff();
+
+  /** The maximum wait period before retry attempts. */
+  abstract Duration getMaxBackoff();
+
+  /** The multiplication factor used to compute the delay between successive failures. */
+  abstract double getBackoffMultiplier();
+
+  /** The duration to randomly vary retry delays by. */
+  abstract Duration getJitter();
+
+  ExponentialBackoffConfig() {}
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/RetryUtil.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/RetryUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal;
+
+import static io.grpc.Status.Code.ABORTED;
+import static io.grpc.Status.Code.CANCELLED;
+import static io.grpc.Status.Code.DATA_LOSS;
+import static io.grpc.Status.Code.DEADLINE_EXCEEDED;
+import static io.grpc.Status.Code.OUT_OF_RANGE;
+import static io.grpc.Status.Code.RESOURCE_EXHAUSTED;
+import static io.grpc.Status.Code.UNAVAILABLE;
+
+import io.grpc.Status;
+import io.opentelemetry.RetryConfig;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import net.jodah.failsafe.RetryPolicy;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class RetryUtil {
+
+  private static final Set<Status.Code> RETRYABLE_CODES =
+      Collections.unmodifiableSet(
+          new HashSet<>(
+              Arrays.asList(
+                  CANCELLED,
+                  DEADLINE_EXCEEDED,
+                  RESOURCE_EXHAUSTED,
+                  ABORTED,
+                  OUT_OF_RANGE,
+                  UNAVAILABLE,
+                  DATA_LOSS)));
+
+  public static Set<Status.Code> retryableStatusCodes() {
+    return RETRYABLE_CODES;
+  }
+
+  public static boolean hasRetryableStatusCode(Throwable throwable) {
+    return RETRYABLE_CODES.contains(Status.fromThrowable(throwable).getCode());
+  }
+
+  /** Convert the retry config to a retry policy. */
+  public static <T> RetryPolicy<T> toRetryPolicy(RetryConfig retryConfig) {
+    ExponentialBackoffConfig exponentialBackoffConfig = (ExponentialBackoffConfig) retryConfig;
+    return new RetryPolicy<T>()
+        .withBackoff(
+            exponentialBackoffConfig.getInitialBackoff().toMillis(),
+            exponentialBackoffConfig.getMaxBackoff().toMillis(),
+            ChronoUnit.MILLIS,
+            exponentialBackoffConfig.getBackoffMultiplier())
+        .withMaxRetries((int) exponentialBackoffConfig.getMaxRetries())
+        .withJitter(exponentialBackoffConfig.getJitter());
+  }
+
+  private RetryUtil() {}
+}

--- a/exporters/otlp/trace/build.gradle.kts
+++ b/exporters/otlp/trace/build.gradle.kts
@@ -34,6 +34,8 @@ dependencies {
   api("io.grpc:grpc-stub")
   implementation("io.grpc:grpc-api")
 
+  implementation("net.jodah:failsafe:2.4.3")
+
   testImplementation(project(":proto"))
   testImplementation(project(":sdk:testing"))
 

--- a/exporters/otlp/trace/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/trace/ExportTest.java
+++ b/exporters/otlp/trace/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/trace/ExportTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.exporter.otlp.trace;
 
+import static io.opentelemetry.exporter.otlp.internal.RetryUtil.retryableStatusCodes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -12,19 +13,26 @@ import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import io.opentelemetry.RetryConfig;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
+import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.testing.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -48,28 +56,12 @@ class ExportTest {
 
   @RegisterExtension
   @Order(2)
-  public static ServerExtension server =
-      new ServerExtension() {
-        @Override
-        protected void configure(ServerBuilder sb) {
-          sb.service(
-              GrpcService.builder()
-                  .addService(
-                      new TraceServiceGrpc.TraceServiceImplBase() {
-                        @Override
-                        public void export(
-                            ExportTraceServiceRequest request,
-                            StreamObserver<ExportTraceServiceResponse> responseObserver) {
-                          responseObserver.onNext(ExportTraceServiceResponse.getDefaultInstance());
-                          responseObserver.onCompleted();
-                        }
-                      })
-                  .build());
-          sb.http(0);
-          sb.https(0);
-          sb.tls(certificate.certificateFile(), certificate.privateKeyFile());
-        }
-      };
+  public static GrpcServer server = new GrpcServer(certificate);
+
+  @AfterEach
+  void afterEach() {
+    server.reset();
+  }
 
   @Test
   void gzipCompressionExport() {
@@ -125,5 +117,80 @@ class ExportTest {
                     .build())
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("Could not set trusted certificates");
+  }
+
+  @Test
+  void testRetryPolicy() {
+    OtlpGrpcSpanExporter exporter =
+        OtlpGrpcSpanExporter.builder()
+            .setEndpoint("http://localhost:" + server.httpPort())
+            .setTimeout(Duration.ofSeconds(5))
+            .setRetryConfig(
+                RetryConfig.exponentialBackoff(
+                    5, Duration.ofMillis(500), Duration.ofSeconds(30), 2, Duration.ofMillis(20)))
+            .build();
+
+    for (Status.Code code : Status.Code.values()) {
+      server.reset();
+
+      server.returnStatuses.add(Status.fromCode(code));
+      server.returnStatuses.add(Status.OK);
+
+      CompletableResultCode resultCode = exporter.export(SPANS).join(10, TimeUnit.SECONDS);
+      boolean retryable = retryableStatusCodes().contains(code);
+      boolean expectedResult = retryable || code == Status.Code.OK;
+      assertThat(resultCode.isSuccess())
+          .as(
+              "status code %s should export %s",
+              code, expectedResult ? "successfully" : "unsuccessfully")
+          .isEqualTo(expectedResult);
+      int expectedRequests = retryable ? 2 : 1;
+      assertThat(server.requests.size())
+          .as("status code %s should make %s requests", code, expectedRequests)
+          .isEqualTo(expectedRequests);
+    }
+  }
+
+  private static class GrpcServer extends ServerExtension {
+
+    private final SelfSignedCertificateExtension certificate;
+    private final Deque<ExportTraceServiceRequest> requests = new ArrayDeque<>();
+    private final Deque<Status> returnStatuses = new ArrayDeque<>();
+
+    private GrpcServer(SelfSignedCertificateExtension certificate) {
+      this.certificate = certificate;
+    }
+
+    @Override
+    protected void configure(ServerBuilder sb) {
+      sb.service(
+          GrpcService.builder()
+              .addService(
+                  new TraceServiceGrpc.TraceServiceImplBase() {
+                    @Override
+                    public void export(
+                        ExportTraceServiceRequest request,
+                        StreamObserver<ExportTraceServiceResponse> responseObserver) {
+                      requests.offer(request);
+                      Status returnStatus =
+                          returnStatuses.peek() != null ? returnStatuses.poll() : Status.OK;
+                      if (returnStatus.isOk()) {
+                        responseObserver.onNext(ExportTraceServiceResponse.getDefaultInstance());
+                        responseObserver.onCompleted();
+                        return;
+                      }
+                      responseObserver.onError(returnStatus.asRuntimeException());
+                    }
+                  })
+              .build());
+      sb.http(0);
+      sb.https(0);
+      sb.tls(certificate.certificateFile(), certificate.privateKeyFile());
+    }
+
+    public void reset() {
+      requests.clear();
+      returnStatuses.clear();
+    }
   }
 }


### PR DESCRIPTION
There's an outstanding [issue](https://github.com/open-telemetry/opentelemetry-java/issues/3271) related to supporting this in java, but the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#retry) is unambiguous about the need for retry strategy in SDKs:

> Transient errors MUST be handled with a retry strategy. This retry strategy MUST implement an exponential back-off with jitter to avoid overwhelming the destination until the network is restored or the destination has recovered.

While I think the spec could use clarity about the default retry strategy, there's enough prior art that we should be able to at least provide a mechanism for users to configure a retry strategy if they choose. 

I put together this branch to demonstrate what a retry implementation might look like. Along the way I learned:
- gRPC's built in [retry functionality](https://github.com/grpc/proposal/blob/master/A6-client-retries.md#retry-policy-capabilities) is insufficient. It doesn't support jitter, which is required by the spec. And it wouldn't be applicable for our otlp/http exporters.
- Not clear we can use an off the shelf retry library. This branch uses [failsafe](https://failsafe.dev/), which is great but I learned is littered with usages of `CompletableFuture` (which I learned today is available in the version of android we target). Another popular library called [resilience4j](https://github.com/resilience4j/resilience4j) also uses `CompletableFuture`. There's also [guava-retrying](https://github.com/rholder/guava-retrying) and [retry4j](https://github.com/elennick/retry4j), which haven't been updated in a couple of years.

Wanted to propose this to help the discussion move forward. 