### PR TITLE
Switch to archunit junit5

### DIFF
--- a/all/build.gradle.kts
+++ b/all/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
       }
     }
   }
-  testImplementation("com.tngtech.archunit:archunit-junit4")
+  testImplementation("com.tngtech.archunit:archunit-junit5")
 }
 
 // https://docs.gradle.org/current/samples/sample_jvm_multi_project_with_code_coverage.html

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -78,7 +78,7 @@ val DEPENDENCIES = listOf(
   "com.squareup.okhttp3:okhttp:3.12.13",
   "com.squareup.okhttp3:okhttp-tls:3.12.13",
   "com.sun.net.httpserver:http:20070405",
-  "com.tngtech.archunit:archunit-junit4:0.21.0",
+  "com.tngtech.archunit:archunit-junit5:0.21.0",
   "com.uber.nullaway:nullaway:0.9.2",
   "edu.berkeley.cs.jqf:jqf-fuzz:1.7",
   "eu.rekawek.toxiproxy:toxiproxy-java:2.1.4",


### PR DESCRIPTION
The junit4/5 integration for archunit is apparently just a caching mechanism for performance, which is probably why despite our tests being jupiter, they still worked ok. Also, while junit4 requires explicit activation of the caching mechanism (which we weren't doing), junit5 is apparently automatic so this might improve something. But primarily to remove the word junit4 from the build to prevent confusion.