### PR TITLE
Migrate Zipkin integration test from junit4 to junit5 + testcontainers

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -85,7 +85,6 @@ val DEPENDENCIES = listOf(
   "io.github.netmikey.logunit:logunit-jul:1.1.0",
   "io.jaegertracing:jaeger-client:1.6.0",
   "io.opentracing:opentracing-api:0.33.0",
-  "io.zipkin.zipkin2:zipkin-junit:2.23.4",
   "junit:junit:4.13.2",
   "nl.jqno.equalsverifier:equalsverifier:3.7.1",
   "org.assertj:assertj-core:3.20.2",

--- a/exporters/zipkin/build.gradle.kts
+++ b/exporters/zipkin/build.gradle.kts
@@ -9,13 +9,9 @@ description = "OpenTelemetry - Zipkin Exporter"
 otelJava.moduleName.set("io.opentelemetry.exporter.zipkin")
 
 dependencies {
-  compileOnly("com.google.auto.value:auto-value")
-
   api(project(":sdk:all"))
 
   api("io.zipkin.reporter2:zipkin-reporter")
-
-  annotationProcessor("com.google.auto.value:auto-value")
 
   implementation(project(":semconv"))
 
@@ -23,5 +19,6 @@ dependencies {
 
   testImplementation(project(":sdk:testing"))
 
-  testImplementation("io.zipkin.zipkin2:zipkin-junit")
+  testImplementation("com.linecorp.armeria:armeria")
+  testImplementation("org.testcontainers:junit-jupiter")
 }


### PR DESCRIPTION
This is the last junit4 test in the repo aside from our explicit junit4 rule test in sdk-testing