### PR TITLE
Remove dependency on okhttp-tls

### DIFF
--- a/exporters/otlp-http/metrics/build.gradle.kts
+++ b/exporters/otlp-http/metrics/build.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
   implementation(project(":exporters:otlp:common"))
 
   implementation("com.squareup.okhttp3:okhttp")
-  implementation("com.squareup.okhttp3:okhttp-tls")
   implementation("com.squareup.okio:okio")
 
   testImplementation(project(":proto"))
@@ -22,4 +21,5 @@ dependencies {
 
   testImplementation("com.google.api.grpc:proto-google-common-protos")
   testImplementation("com.linecorp.armeria:armeria-junit5")
+  testImplementation("com.squareup.okhttp3:okhttp-tls")
 }

--- a/exporters/otlp-http/metrics/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp-http/metrics/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -8,18 +8,16 @@ package io.opentelemetry.exporter.otlp.http.metrics;
 import static io.opentelemetry.api.internal.Utils.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-import java.io.ByteArrayInputStream;
+import io.opentelemetry.exporter.otlp.internal.TlsUtil;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.X509TrustManager;
 import okhttp3.Headers;
 import okhttp3.OkHttpClient;
-import okhttp3.tls.HandshakeCertificates;
 
 /** Builder utility for {@link OtlpHttpMetricExporter}. */
 public final class OtlpHttpMetricExporterBuilder {
@@ -120,11 +118,9 @@ public final class OtlpHttpMetricExporterBuilder {
 
     if (trustedCertificatesPem != null) {
       try {
-        HandshakeCertificates handshakeCertificates =
-            toHandshakeCertificates(trustedCertificatesPem);
-        clientBuilder.sslSocketFactory(
-            handshakeCertificates.sslSocketFactory(), handshakeCertificates.trustManager());
-      } catch (CertificateException e) {
+        X509TrustManager trustManager = TlsUtil.trustManager(trustedCertificatesPem);
+        clientBuilder.sslSocketFactory(TlsUtil.sslSocketFactory(trustManager), trustManager);
+      } catch (SSLException e) {
         throw new IllegalStateException(
             "Could not set trusted certificate for OTLP HTTP connection, are they valid X.509 in PEM format?",
             e);
@@ -134,25 +130,6 @@ public final class OtlpHttpMetricExporterBuilder {
     Headers headers = headersBuilder == null ? null : headersBuilder.build();
 
     return new OtlpHttpMetricExporter(clientBuilder.build(), endpoint, headers, compressionEnabled);
-  }
-
-  /**
-   * Extract X.509 certificates from the bytes.
-   *
-   * @param trustedCertificatesPem bytes containing an X.509 certificate collection in PEM format.
-   * @return a HandshakeCertificates with the certificates
-   * @throws CertificateException if an error occurs extracting certificates
-   */
-  private static HandshakeCertificates toHandshakeCertificates(byte[] trustedCertificatesPem)
-      throws CertificateException {
-    ByteArrayInputStream is = new ByteArrayInputStream(trustedCertificatesPem);
-    CertificateFactory factory = CertificateFactory.getInstance("X.509");
-    HandshakeCertificates.Builder certBuilder = new HandshakeCertificates.Builder();
-    while (is.available() > 0) {
-      X509Certificate cert = (X509Certificate) factory.generateCertificate(is);
-      certBuilder.addTrustedCertificate(cert);
-    }
-    return certBuilder.build();
   }
 
   OtlpHttpMetricExporterBuilder() {}

--- a/exporters/otlp-http/trace/build.gradle.kts
+++ b/exporters/otlp-http/trace/build.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
   implementation(project(":exporters:otlp:common"))
 
   implementation("com.squareup.okhttp3:okhttp")
-  implementation("com.squareup.okhttp3:okhttp-tls")
   implementation("com.squareup.okio:okio")
 
   testImplementation(project(":proto"))
@@ -22,4 +21,5 @@ dependencies {
 
   testImplementation("com.google.api.grpc:proto-google-common-protos")
   testImplementation("com.linecorp.armeria:armeria-junit5")
+  testImplementation("com.squareup.okhttp3:okhttp-tls")
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/TlsUtil.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/TlsUtil.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * Utilities for working with TLS.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class TlsUtil {
+
+  /** Returns a {@link SSLSocketFactory} configured to use the given trust manager. */
+  public static SSLSocketFactory sslSocketFactory(TrustManager trustManager) throws SSLException {
+
+    SSLContext sslContext;
+    try {
+      sslContext = SSLContext.getInstance("TLS");
+      sslContext.init(null, new TrustManager[] {trustManager}, null);
+    } catch (NoSuchAlgorithmException | KeyManagementException e) {
+      throw new SSLException(
+          "Could not set trusted certificates for TLS connection, are they valid "
+              + "X.509 in PEM format?",
+          e);
+    }
+    return sslContext.getSocketFactory();
+  }
+
+  /** Returns a {@link TrustManager} for the given trusted certificates. */
+  public static X509TrustManager trustManager(byte[] trustedCertificatesPem) throws SSLException {
+    requireNonNull(trustedCertificatesPem, "trustedCertificatesPem");
+    try {
+      KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+      ks.load(null);
+
+      ByteArrayInputStream is = new ByteArrayInputStream(trustedCertificatesPem);
+      CertificateFactory factory = CertificateFactory.getInstance("X.509");
+      int i = 0;
+      while (is.available() > 0) {
+        X509Certificate cert = (X509Certificate) factory.generateCertificate(is);
+        ks.setCertificateEntry("cert_" + i, cert);
+        i++;
+      }
+
+      TrustManagerFactory tmf =
+          TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+      tmf.init(ks);
+      return (X509TrustManager) tmf.getTrustManagers()[0];
+    } catch (CertificateException | KeyStoreException | IOException | NoSuchAlgorithmException e) {
+      throw new SSLException("Could not build TrustManagerFactory from trustedCertificatesPem.", e);
+    }
+  }
+
+  private TlsUtil() {}
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/grpc/ManagedChannelUtil.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/grpc/ManagedChannelUtil.java
@@ -11,22 +11,13 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
+import io.opentelemetry.exporter.otlp.internal.TlsUtil;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.security.KeyManagementException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
-import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
 
 /**
  * Utilities for working with gRPC channels.
@@ -50,7 +41,7 @@ public final class ManagedChannelUtil {
     requireNonNull(managedChannelBuilder, "managedChannelBuilder");
     requireNonNull(trustedCertificatesPem, "trustedCertificatesPem");
 
-    TrustManagerFactory tmf = trustManagerFactory(trustedCertificatesPem);
+    X509TrustManager tmf = TlsUtil.trustManager(trustedCertificatesPem);
 
     // gRPC does not abstract TLS configuration so we need to check the implementation and act
     // accordingly.
@@ -71,43 +62,11 @@ public final class ManagedChannelUtil {
         .equals("io.grpc.okhttp.OkHttpChannelBuilder")) {
       io.grpc.okhttp.OkHttpChannelBuilder okHttpBuilder =
           (io.grpc.okhttp.OkHttpChannelBuilder) managedChannelBuilder;
-      SSLContext sslContext;
-      try {
-        sslContext = SSLContext.getInstance("TLS");
-        sslContext.init(null, tmf.getTrustManagers(), null);
-      } catch (NoSuchAlgorithmException | KeyManagementException e) {
-        throw new SSLException("Could not build SSLContext.", e);
-      }
-      okHttpBuilder.sslSocketFactory(sslContext.getSocketFactory());
+      okHttpBuilder.sslSocketFactory(TlsUtil.sslSocketFactory(tmf));
     } else {
       throw new SSLException(
           "TLS certificate configuration not supported for unrecognized ManagedChannelBuilder "
               + managedChannelBuilder.getClass().getName());
-    }
-  }
-
-  private static TrustManagerFactory trustManagerFactory(byte[] trustedCertificatesPem)
-      throws SSLException {
-    requireNonNull(trustedCertificatesPem, "trustedCertificatesPem");
-    try {
-      KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-      ks.load(null);
-
-      ByteArrayInputStream is = new ByteArrayInputStream(trustedCertificatesPem);
-      CertificateFactory factory = CertificateFactory.getInstance("X.509");
-      int i = 0;
-      while (is.available() > 0) {
-        X509Certificate cert = (X509Certificate) factory.generateCertificate(is);
-        ks.setCertificateEntry("cert_" + i, cert);
-        i++;
-      }
-
-      TrustManagerFactory tmf =
-          TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-      tmf.init(ks);
-      return tmf;
-    } catch (CertificateException | KeyStoreException | IOException | NoSuchAlgorithmException e) {
-      throw new SSLException("Could not build TrustManagerFactory from trustedCertificatesPem.", e);
     }
   }
 


### PR DESCRIPTION
okhttp-tls has a dependency on the fairly large bouncycastle for certificate generation. We don't actually need it's generation so the thought of excluding bouncycastle came to mind - but I realized we already had all the relevant code here anyways.