### PR TITLE
Use concatenation instead of stringbuilder in RERS.

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -534,30 +534,28 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
       totalRecordedEvents = this.totalRecordedEvents;
       endEpochNanos = this.endEpochNanos;
     }
-    StringBuilder sb = new StringBuilder();
-    sb.append("RecordEventsReadableSpan{traceId=");
-    sb.append(context.getTraceId());
-    sb.append(", spanId=");
-    sb.append(context.getSpanId());
-    sb.append(", parentSpanContext=");
-    sb.append(parentSpanContext);
-    sb.append(", name=");
-    sb.append(name);
-    sb.append(", kind=");
-    sb.append(kind);
-    sb.append(", attributes=");
-    sb.append(attributes);
-    sb.append(", status=");
-    sb.append(status);
-    sb.append(", totalRecordedEvents=");
-    sb.append(totalRecordedEvents);
-    sb.append(", totalRecordedLinks=");
-    sb.append(totalRecordedLinks);
-    sb.append(", startEpochNanos=");
-    sb.append(startEpochNanos);
-    sb.append(", endEpochNanos=");
-    sb.append(endEpochNanos);
-    sb.append("}");
-    return sb.toString();
+    return "RecordEventsReadableSpan{traceId="
+        + context.getTraceId()
+        + ", spanId="
+        + context.getSpanId()
+        + ", parentSpanContext="
+        + parentSpanContext
+        + ", name="
+        + name
+        + ", kind="
+        + kind
+        + ", attributes="
+        + attributes
+        + ", status="
+        + status
+        + ", totalRecordedEvents="
+        + totalRecordedEvents
+        + ", totalRecordedLinks="
+        + totalRecordedLinks
+        + ", startEpochNanos="
+        + startEpochNanos
+        + ", endEpochNanos="
+        + endEpochNanos
+        + "}";
   }
 }


### PR DESCRIPTION
Randomly found this and let IntelliJ automatically convert this - we generally prefer concatenation since basically same if not better readability and if we ever get to compile against Java 9+ we'll get free performance.