### PR TITLE
Make LogRecord required parameters final.

### DIFF
--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/LogAdapterTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/LogAdapterTest.java
@@ -36,7 +36,9 @@ class LogAdapterTest {
     List<ResourceLogs> resourceLogs =
         LogAdapter.toProtoResourceLogs(
             Collections.singleton(
-                io.opentelemetry.sdk.logging.data.LogRecord.builder()
+                io.opentelemetry.sdk.logging.data.LogRecord.builder(
+                        Resource.builder().put("one", 1).setSchemaUrl("http://url").build(),
+                        InstrumentationLibraryInfo.create("testLib", "1.0", "http://url"))
                     .setName(NAME)
                     .setBody(BODY)
                     .setSeverity(io.opentelemetry.sdk.logging.data.LogRecord.Severity.INFO)
@@ -45,10 +47,6 @@ class LogAdapterTest {
                     .setSpanId(SPAN_ID)
                     .setAttributes(Attributes.of(AttributeKey.booleanKey("key"), true))
                     .setUnixTimeNano(12345)
-                    .setResource(
-                        Resource.builder().put("one", 1).setSchemaUrl("http://url").build())
-                    .setInstrumentationLibraryInfo(
-                        InstrumentationLibraryInfo.create("testLib", "1.0", "http://url"))
                     .build()));
 
     assertThat(resourceLogs).hasSize(1);
@@ -67,7 +65,9 @@ class LogAdapterTest {
   void toProtoLogRecord() {
     io.opentelemetry.proto.logs.v1.LogRecord logRecord =
         LogAdapter.toProtoLogRecord(
-            io.opentelemetry.sdk.logging.data.LogRecord.builder()
+            io.opentelemetry.sdk.logging.data.LogRecord.builder(
+                    Resource.create(Attributes.builder().put("testKey", "testValue").build()),
+                    InstrumentationLibraryInfo.create("instrumentation", "1"))
                 .setName(NAME)
                 .setBody(BODY)
                 .setSeverity(io.opentelemetry.sdk.logging.data.LogRecord.Severity.INFO)
@@ -76,10 +76,6 @@ class LogAdapterTest {
                 .setSpanId(SPAN_ID)
                 .setAttributes(Attributes.of(AttributeKey.booleanKey("key"), true))
                 .setUnixTimeNano(12345)
-                .setResource(
-                    Resource.create(Attributes.builder().put("testKey", "testValue").build()))
-                .setInstrumentationLibraryInfo(
-                    InstrumentationLibraryInfo.create("instrumentation", "1"))
                 .build());
 
     assertThat(logRecord.getTraceId().toByteArray()).isEqualTo(TRACE_ID_BYTES);

--- a/sdk-extensions/logging/src/main/java/io/opentelemetry/sdk/logging/data/LogRecord.java
+++ b/sdk-extensions/logging/src/main/java/io/opentelemetry/sdk/logging/data/LogRecord.java
@@ -19,8 +19,9 @@ import javax.annotation.Nullable;
 @AutoValue
 public abstract class LogRecord {
 
-  public static LogRecordBuilder builder() {
-    return new LogRecordBuilder();
+  public static LogRecordBuilder builder(
+      Resource resource, InstrumentationLibraryInfo instrumentationLibraryInfo) {
+    return new LogRecordBuilder(resource, instrumentationLibraryInfo);
   }
 
   static LogRecord create(

--- a/sdk-extensions/logging/src/main/java/io/opentelemetry/sdk/logging/data/LogRecordBuilder.java
+++ b/sdk-extensions/logging/src/main/java/io/opentelemetry/sdk/logging/data/LogRecordBuilder.java
@@ -12,8 +12,9 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.util.concurrent.TimeUnit;
 
 public final class LogRecordBuilder {
-  private Resource resource;
-  private InstrumentationLibraryInfo instrumentationLibraryInfo;
+  private final Resource resource;
+  private final InstrumentationLibraryInfo instrumentationLibraryInfo;
+
   private long timeUnixNano;
   private String traceId = "";
   private String spanId = "";
@@ -24,17 +25,9 @@ public final class LogRecordBuilder {
   private Body body = Body.stringBody("");
   private final AttributesBuilder attributeBuilder = Attributes.builder();
 
-  LogRecordBuilder() {}
-
-  public LogRecordBuilder setResource(Resource resource) {
+  LogRecordBuilder(Resource resource, InstrumentationLibraryInfo instrumentationLibraryInfo) {
     this.resource = resource;
-    return this;
-  }
-
-  public LogRecordBuilder setInstrumentationLibraryInfo(
-      InstrumentationLibraryInfo instrumentationLibraryInfo) {
     this.instrumentationLibraryInfo = instrumentationLibraryInfo;
-    return this;
   }
 
   public LogRecordBuilder setUnixTimeNano(long timestamp) {

--- a/sdk-extensions/logging/src/test/java/io/opentelemetry/sdk/logging/LogSinkSdkProviderTest.java
+++ b/sdk-extensions/logging/src/test/java/io/opentelemetry/sdk/logging/LogSinkSdkProviderTest.java
@@ -28,9 +28,9 @@ import org.junit.jupiter.api.Test;
 class LogSinkSdkProviderTest {
 
   private static LogRecord createLog(LogRecord.Severity severity, String message) {
-    return LogRecord.builder()
-        .setResource(Resource.create(Attributes.builder().put("testKey", "testValue").build()))
-        .setInstrumentationLibraryInfo(InstrumentationLibraryInfo.create("instrumentation", "1"))
+    return LogRecord.builder(
+            Resource.create(Attributes.builder().put("testKey", "testValue").build()),
+            InstrumentationLibraryInfo.create("instrumentation", "1"))
         .setUnixTimeMillis(System.currentTimeMillis())
         .setTraceId(TraceId.getInvalid())
         .setSpanId(SpanId.getInvalid())

--- a/sdk-extensions/logging/src/test/java/io/opentelemetry/sdk/logging/sdk/BatchLogProcessorTest.java
+++ b/sdk-extensions/logging/src/test/java/io/opentelemetry/sdk/logging/sdk/BatchLogProcessorTest.java
@@ -23,9 +23,9 @@ import org.junit.jupiter.api.Test;
 class BatchLogProcessorTest {
 
   private static LogRecord createLog(LogRecord.Severity severity, String message) {
-    return LogRecord.builder()
-        .setResource(Resource.create(Attributes.builder().put("testKey", "testValue").build()))
-        .setInstrumentationLibraryInfo(InstrumentationLibraryInfo.create("instrumentation", "1"))
+    return LogRecord.builder(
+            Resource.create(Attributes.builder().put("testKey", "testValue").build()),
+            InstrumentationLibraryInfo.create("instrumentation", "1"))
         .setUnixTimeMillis(System.currentTimeMillis())
         .setTraceId(TraceId.getInvalid())
         .setSpanId(SpanId.getInvalid())


### PR DESCRIPTION
I think this is our convention - it solves a nullness issue which is why I found it.