### PR TITLE
Don't use hashmap for zpage buckets since the keys are constant.

### DIFF
--- a/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/TracezSpanBuckets.java
+++ b/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/TracezSpanBuckets.java
@@ -10,24 +10,12 @@ import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import java.util.ArrayList;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 final class TracezSpanBuckets {
-  private final Map<LatencyBoundary, SpanBucket> latencyBuckets = new HashMap<>();
-  private final Map<StatusCode, SpanBucket> errorBuckets = new HashMap<>();
-
-  TracezSpanBuckets() {
-    for (LatencyBoundary bucket : LatencyBoundary.values()) {
-      latencyBuckets.put(bucket, new SpanBucket(/* isLatencyBucket= */ true));
-    }
-    for (StatusCode code : StatusCode.values()) {
-      if (code == StatusCode.ERROR) {
-        errorBuckets.put(code, new SpanBucket(/* isLatencyBucket= */ false));
-      }
-    }
-  }
+  private final LatencyBuckets latencyBuckets = new LatencyBuckets();
+  private final SpanBucket errors = new SpanBucket(/* isLatencyBucket= */ false);
 
   void addToBucket(ReadableSpan span) {
     StatusData status = span.toSpanData().getStatus();
@@ -35,7 +23,7 @@ final class TracezSpanBuckets {
       latencyBuckets.get(LatencyBoundary.getBoundary(span.getLatencyNanos())).add(span);
       return;
     }
-    errorBuckets.get(status.getStatusCode()).add(span);
+    errors.add(span);
   }
 
   Map<LatencyBoundary, Integer> getLatencyBoundaryToCountMap() {
@@ -48,17 +36,13 @@ final class TracezSpanBuckets {
 
   List<ReadableSpan> getOkSpans() {
     List<ReadableSpan> okSpans = new ArrayList<>();
-    for (SpanBucket latencyBucket : latencyBuckets.values()) {
-      latencyBucket.addTo(okSpans);
-    }
+    latencyBuckets.addTo(okSpans);
     return okSpans;
   }
 
   List<ReadableSpan> getErrorSpans() {
     List<ReadableSpan> errorSpans = new ArrayList<>();
-    for (SpanBucket errorBucket : errorBuckets.values()) {
-      errorBucket.addTo(errorSpans);
-    }
+    errors.addTo(errorSpans);
     return errorSpans;
   }
 
@@ -67,5 +51,54 @@ final class TracezSpanBuckets {
     spans.addAll(getOkSpans());
     spans.addAll(getErrorSpans());
     return spans;
+  }
+
+  private static class LatencyBuckets {
+    final SpanBucket zeroToTenMicros = new SpanBucket(/* isLatencyBucket= */ true);
+    final SpanBucket tenMicrosToHundredMicros = new SpanBucket(/* isLatencyBucket= */ true);
+    final SpanBucket hundredMicrosToOneMilli = new SpanBucket(/* isLatencyBucket= */ true);
+    final SpanBucket oneMilliToTenMillis = new SpanBucket(/* isLatencyBucket= */ true);
+    final SpanBucket tenMillisToHundredMillis = new SpanBucket(/* isLatencyBucket= */ true);
+    final SpanBucket hundredMillisToOneSecond = new SpanBucket(/* isLatencyBucket= */ true);
+    final SpanBucket oneSecondToTenSeconds = new SpanBucket(/* isLatencyBucket= */ true);
+    final SpanBucket tenSecondsToHundredSeconds = new SpanBucket(/* isLatencyBucket= */ true);
+    final SpanBucket hundredSecondsToMax = new SpanBucket(/* isLatencyBucket= */ true);
+
+    void addTo(List<ReadableSpan> spans) {
+      zeroToTenMicros.addTo(spans);
+      tenMicrosToHundredMicros.addTo(spans);
+      hundredMicrosToOneMilli.addTo(spans);
+      oneMilliToTenMillis.addTo(spans);
+      tenMillisToHundredMillis.addTo(spans);
+      hundredMillisToOneSecond.addTo(spans);
+      oneSecondToTenSeconds.addTo(spans);
+      tenSecondsToHundredSeconds.addTo(spans);
+      hundredSecondsToMax.addTo(spans);
+    }
+
+    SpanBucket get(LatencyBoundary boundary) {
+      switch (boundary) {
+        case ZERO_MICROSx10:
+          return zeroToTenMicros;
+        case MICROSx10_MICROSx100:
+          return tenMicrosToHundredMicros;
+        case MICROSx100_MILLIx1:
+          return hundredMicrosToOneMilli;
+        case MILLIx1_MILLIx10:
+          return oneMilliToTenMillis;
+        case MILLIx10_MILLIx100:
+          return tenMillisToHundredMillis;
+        case MILLIx100_SECONDx1:
+          return hundredMillisToOneSecond;
+        case SECONDx1_SECONDx10:
+          return oneSecondToTenSeconds;
+        case SECONDx10_SECONDx100:
+          return tenSecondsToHundredSeconds;
+        case SECONDx100_MAX:
+          return hundredSecondsToMax;
+      }
+      // Can't happen with aligned versions, just pick an arbitrary one to compile.
+      return hundredSecondsToMax;
+    }
   }
 }


### PR DESCRIPTION
Nullness checker found the usage of `Map.get()` without null check, which in practice wasn't an issue since we prepopulate the map with all values of an enum. So in other words the keys to the maps were constant (well one of them only had one item inside). This made me think we should just use constants instead.

We can expect a significant performance improvement since complete enumswitch is just a single jump (though switching from HashMap to EnumMap would have gotten very similar improvement, but still require adding nullness casts)