### PR TITLE
Exclude internal Time protos used by jaeger marshaling from coverage

### DIFF
--- a/all/build.gradle.kts
+++ b/all/build.gradle.kts
@@ -73,6 +73,7 @@ tasks.named<JacocoReport>("jacocoTestReport") {
           !it.absolutePath.contains("/internal/shaded/") &&
           !it.absolutePath.contains("io/opentelemetry/proto/") &&
           !it.absolutePath.contains("io/opentelemetry/exporter/jaeger/proto/") &&
+          !it.absolutePath.contains("io/opentelemetry/exporter/jaeger/internal/protobuf/") &&
           !it.absolutePath.contains("io/opentelemetry/sdk/extension/trace/jaeger/proto/") &&
           !it.absolutePath.contains("io/opentelemetry/semconv/trace/attributes/") &&
           !it.absolutePath.contains("AutoValue_") &&


### PR DESCRIPTION
Recently introduced these to this new internal package so need to exclude