### PR TITLE
Pass a cause to ConfigurationException somewhere.

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/DefaultConfigProperties.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/DefaultConfigProperties.java
@@ -135,7 +135,8 @@ final class DefaultConfigProperties implements ConfigProperties {
               + "="
               + value
               + ". Expected number, found: "
-              + numberString);
+              + numberString,
+          ex);
     } catch (ConfigurationException ex) {
       throw new ConfigurationException(
           "Invalid duration property " + name + "=" + value + ". " + ex.getMessage());


### PR DESCRIPTION
It's no big deal but it's a bit annoying to see the opentelemetry-spi package in codecov have 50% coverage as it just looks like a project with low coverage even though it isn't really. The simple fix is to pass and then ignore this NumberFormatException as a cause (the other location we were calling the constructor that has a cause is an invalid cert exception that is tedious to verify)