### PR TITLE
Don't crash on null spans in BSP

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -91,7 +91,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
 
   @Override
   public void onEnd(ReadableSpan span) {
-    if (!span.getSpanContext().isSampled()) {
+    if (span == null || !span.getSpanContext().isSampled()) {
       return;
     }
     worker.addSpan(span);

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.trace.export;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
@@ -306,6 +307,21 @@ class BatchSpanProcessorTest {
     exported = waitingSpanExporter.waitForExport();
     assertThat(exported).isNotNull();
     assertThat(exported).containsExactlyElementsOf(spansToExport);
+  }
+
+  @Test
+  void ignoresNullSpans() {
+    BatchSpanProcessor processor = BatchSpanProcessor.builder(mockSpanExporter).build();
+    try {
+      assertThatCode(
+              () -> {
+                processor.onStart(null, null);
+                processor.onEnd(null);
+              })
+          .doesNotThrowAnyException();
+    } finally {
+      processor.shutdown();
+    }
   }
 
   @Test


### PR DESCRIPTION
Noticed this in #3655 - since this is on the hot path in the user's app it can't have a chance of crashing