### PR TITLE
Build with Java 17

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,11 +18,11 @@ jobs:
         with:
           languages: java
 
-      - name: Setup Java 11
+      - name: Setup Java 17
         uses: actions/setup-java@v2
         with:
           distribution: adopt
-          java-version: 11
+          java-version: 17
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v1

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -18,11 +18,10 @@ jobs:
         test-java-version:
           - 8
           - 11
-          - 16
           - 17
         include:
           - os: ubuntu-20.04
-            test-java-version: 11
+            test-java-version: 17
             coverage: true
     steps:
       - uses: actions/checkout@v2.3.4
@@ -35,25 +34,18 @@ jobs:
           distribution: adopt
           java-version: 8
           java-package: jre
-      - id: setup-java-16
-        name: Setup Java 16 for tests
-        uses: actions/setup-java@v2
-        with:
-          distribution: adopt
-          java-version: 16
-      - id: setup-java-17
-        name: Setup Java 17 for tests
-        uses: actions/setup-java@v2
-        with:
-          # TODO(anuraaga): Switch to adopt when they release 17-ea
-          distribution: zulu
-          java-version: 17-ea
       - id: setup-java-11
-        name: Setup Java 11
+        name: Setup Java 11 for tests
         uses: actions/setup-java@v2
         with:
           distribution: adopt
           java-version: 11
+      - id: setup-java-17
+        name: Setup Java 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 17
       - uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: jdk${{ matrix.test-java-version }}
@@ -83,10 +75,10 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: adopt
-          java-version: 11
+          java-version: 17
       - uses: burrunan/gradle-cache-action@v1.10
         with:
-          job-id: jdk11
+          job-id: jdk17
           remote-build-cache-proxy-enabled: false
           arguments: snapshot --stacktrace
         env:

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: adopt
-          java-version: 11
+          java-version: 17
       - name: Setup git name
         run: |
           git config user.name github-actions
@@ -67,7 +67,7 @@ jobs:
           done
       - uses: burrunan/gradle-cache-action@v1.10
         with:
-          job-id: jdk11
+          job-id: jdk17
           remote-build-cache-proxy-enabled: false
           arguments: build --stacktrace -Prelease.version=${{ github.event.inputs.version }}
       - name: Publish artifacts

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -18,7 +18,6 @@ jobs:
         test-java-version:
           - 8
           - 11
-          - 16
           - 17
         include:
           - os: ubuntu-20.04
@@ -35,25 +34,18 @@ jobs:
           distribution: adopt
           java-version: 8
           java-package: jre
-      - id: setup-java-16
-        name: Setup Java 16 for tests
-        uses: actions/setup-java@v2
-        with:
-          distribution: adopt
-          java-version: 16
-      - id: setup-java-17
-        name: Setup Java 17 for tests
-        uses: actions/setup-java@v2
-        with:
-          # TODO(anuraaga): Switch to adopt when they release 17-ea
-          distribution: zulu
-          java-version: 17-ea
       - id: setup-java-11
-        name: Setup Java 11
+        name: Setup Java 11 for tests
         uses: actions/setup-java@v2
         with:
           distribution: adopt
           java-version: 11
+      - id: setup-java-17
+        name: Setup Java 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 17
       - uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: jdk${{ matrix.test-java-version }}

--- a/.github/workflows/pr-examples-build.yml
+++ b/.github/workflows/pr-examples-build.yml
@@ -17,12 +17,11 @@ jobs:
           - ubuntu-20.04
     steps:
       - uses: actions/checkout@v2.3.4
-      - id: setup-java-11
-        name: Setup Java 11
+      - name: Setup Java 17
         uses: actions/setup-java@v2
         with:
           distribution: adopt
-          java-version: 11
+          java-version: 17
       - uses: burrunan/gradle-cache-action@v1.10
         with:
           remote-build-cache-proxy-enabled: false

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -16,10 +16,10 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: adopt
-          java-version: 11
+          java-version: 17
       - uses: burrunan/gradle-cache-action@v1.10
         with:
-          job-id: jdk11
+          job-id: jdk17
           remote-build-cache-proxy-enabled: false
           arguments: build --stacktrace -Prelease.version=${{ github.event.inputs.version }}
       - name: Publish artifacts

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -25,7 +25,7 @@ base {
 
 java {
   toolchain {
-    languageVersion.set(JavaLanguageVersion.of(11))
+    languageVersion.set(JavaLanguageVersion.of(17))
   }
 
   withJavadocJar()

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,10 @@ org.gradle.caching=true
 org.gradle.priority=low
 
 # Gradle default is 256m which causes issues with our build - https://docs.gradle.org/current/userguide/build_environment.html#sec:configuring_jvm_memory
-org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
+# Also workaround https://github.com/diffplug/spotless/issues/834
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m \
+  --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \


### PR DESCRIPTION
Doesn't change the target compatibility to 17.

Does still build fine if Gradle is run with Java 11. Now it can also be run with Java 17 (with the gradle.properties workaround)