### PR TITLE
Update Gradle plugins

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,17 +9,17 @@ repositories {
 }
 
 dependencies {
-  implementation("com.diffplug.spotless:spotless-plugin-gradle:5.14.3")
+  implementation("com.diffplug.spotless:spotless-plugin-gradle:5.15.2")
   // Needed for japicmp but not automatically brought in for some reason.
-  implementation("com.google.guava:guava:30.1-jre")
+  implementation("com.google.guava:guava:30.1.1-jre")
   implementation("com.squareup:javapoet:1.13.0")
   implementation("com.squareup.wire:wire-compiler:3.7.0")
   implementation("com.squareup.wire:wire-gradle-plugin:3.7.0")
-  implementation("gradle.plugin.com.google.protobuf:protobuf-gradle-plugin:0.8.16")
+  implementation("gradle.plugin.com.google.protobuf:protobuf-gradle-plugin:0.8.17")
   implementation("gradle.plugin.io.morethan.jmhreport:gradle-jmh-report:0.9.0")
-  implementation("me.champeau.gradle:japicmp-gradle-plugin:0.2.9")
-  implementation("me.champeau.jmh:jmh-gradle-plugin:0.6.5")
-  implementation("net.ltgt.gradle:gradle-errorprone-plugin:2.0.1")
+  implementation("me.champeau.gradle:japicmp-gradle-plugin:0.3.0")
+  implementation("me.champeau.jmh:jmh-gradle-plugin:0.6.6")
+  implementation("net.ltgt.gradle:gradle-errorprone-plugin:2.0.2")
   implementation("net.ltgt.gradle:gradle-nullaway-plugin:1.1.0")
   implementation("ru.vyarus:gradle-animalsniffer-plugin:1.5.3")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,12 +2,11 @@ pluginManagement {
   plugins {
     id("com.github.ben-manes.versions") version "0.39.0"
     id("com.github.johnrengelman.shadow") version "7.0.0"
-    id("com.gradle.enterprise") version "3.6"
-    id("de.undercouch.download") version "4.1.1"
+    id("com.gradle.enterprise") version "3.7"
+    id("de.undercouch.download") version "4.1.2"
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
     id("nebula.release") version "16.0.0"
-    id("org.checkerframework") version "0.5.20"
-    id("org.jetbrains.kotlin.jvm") version "1.5.30"
+    id("org.jetbrains.kotlin.jvm") version "1.5.31"
     id("org.unbroken-dome.test-sets") version "4.0.0"
   }
 }


### PR DESCRIPTION
I mainly wanted to update Kotlin to possibly avoid this weird warning on newer Java but seems to have not been fixed, hopefully next time.

```
Compilation with Kotlin compile daemon was not successful
java.rmi.ServerError: Error occurred in server thread; nested exception is:
        java.lang.NoClassDefFoundError: Could not initialize class org.jetbrains.kotlin.com.intellij.util.io.FileChannelUtil
        at java.rmi/sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:386)
        at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:200)
        at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:197)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:691)
        at java.rmi/sun.rmi.transport.Transport.serviceCall(Transport.java:196)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:587)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:828)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:705)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:391)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:704)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
```