### PR TITLE
Exclude okhttp dependency from grpc-okhttp tests

### DIFF
--- a/exporters/otlp/logs/build.gradle.kts
+++ b/exporters/otlp/logs/build.gradle.kts
@@ -48,7 +48,9 @@ dependencies {
 
   add("testGrpcOkhttpImplementation", "com.linecorp.armeria:armeria-grpc")
   add("testGrpcOkhttpImplementation", "com.linecorp.armeria:armeria-junit5")
-  add("testGrpcOkhttpRuntimeOnly", "io.grpc:grpc-okhttp")
+  add("testGrpcOkhttpRuntimeOnly", "io.grpc:grpc-okhttp") {
+    exclude("com.squareup.okhttp", "okhttp")
+  }
   add("testGrpcOkhttpRuntimeOnly", "org.bouncycastle:bcpkix-jdk15on")
 }
 

--- a/exporters/otlp/metrics/build.gradle.kts
+++ b/exporters/otlp/metrics/build.gradle.kts
@@ -42,7 +42,9 @@ dependencies {
 
   add("testGrpcOkhttpImplementation", "com.linecorp.armeria:armeria-grpc")
   add("testGrpcOkhttpImplementation", "com.linecorp.armeria:armeria-junit5")
-  add("testGrpcOkhttpRuntimeOnly", "io.grpc:grpc-okhttp")
+  add("testGrpcOkhttpRuntimeOnly", "io.grpc:grpc-okhttp") {
+    exclude("com.squareup.okhttp", "okhttp")
+  }
   add("testGrpcOkhttpRuntimeOnly", "org.bouncycastle:bcpkix-jdk15on")
 }
 

--- a/exporters/otlp/trace/build.gradle.kts
+++ b/exporters/otlp/trace/build.gradle.kts
@@ -54,7 +54,9 @@ dependencies {
 
   add("testGrpcOkhttpImplementation", "com.linecorp.armeria:armeria-grpc")
   add("testGrpcOkhttpImplementation", "com.linecorp.armeria:armeria-junit5")
-  add("testGrpcOkhttpRuntimeOnly", "io.grpc:grpc-okhttp")
+  add("testGrpcOkhttpRuntimeOnly", "io.grpc:grpc-okhttp") {
+    exclude("com.squareup.okhttp", "okhttp")
+  }
   add("testGrpcOkhttpRuntimeOnly", "org.bouncycastle:bcpkix-jdk15on")
 
   add("testSpanPipeline", project(":proto"))


### PR DESCRIPTION
`grpc-okhttp` actually bundles in okhttp - they also have a few API knobs that use real okhttp classes, but we don't actually use these knobs. The tests passing with this change seem to confirm that we don't need to actually bring in the ancient okhttp version into downstream builds.

For reference:
https://github.com/grpc/grpc-java/issues/6119