### PR TITLE
Deprecate async-processor which was added to contrib.

### DIFF
--- a/sdk-extensions/async-processor/src/main/java/io/opentelemetry/sdk/extension/trace/export/DisruptorAsyncSpanProcessor.java
+++ b/sdk-extensions/async-processor/src/main/java/io/opentelemetry/sdk/extension/trace/export/DisruptorAsyncSpanProcessor.java
@@ -16,8 +16,13 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * A {@link SpanProcessor} implementation that uses {@code Disruptor} to execute all the hooks on an
  * async thread.
+ *
+ * @deprecated It is recommended to use the {@link
+ *     io.opentelemetry.sdk.trace.export.BatchSpanProcessor}. If you know you need to use disruptor,
+ *     switch to the {@code io.opentelemetry.contrib:disruptor-processor} artifact.
  */
 @ThreadSafe
+@Deprecated
 public final class DisruptorAsyncSpanProcessor implements SpanProcessor {
 
   private final DisruptorEventQueue disruptorEventQueue;
@@ -68,7 +73,11 @@ public final class DisruptorAsyncSpanProcessor implements SpanProcessor {
    * @param spanProcessor the {@code List<SpanProcessor>} to where the Span's events are pushed.
    * @return a new {@link DisruptorAsyncSpanProcessor}.
    * @throws NullPointerException if the {@code spanProcessor} is {@code null}.
+   * @deprecated It is recommended to use the {@link
+   *     io.opentelemetry.sdk.trace.export.BatchSpanProcessor}. If you know you need to use
+   *     disruptor, switch to the {@code io.opentelemetry.contrib:disruptor-processor} artifact.
    */
+  @Deprecated
   public static DisruptorAsyncSpanProcessorBuilder builder(SpanProcessor spanProcessor) {
     return new DisruptorAsyncSpanProcessorBuilder(Objects.requireNonNull(spanProcessor));
   }

--- a/sdk-extensions/async-processor/src/main/java/io/opentelemetry/sdk/extension/trace/export/DisruptorAsyncSpanProcessorBuilder.java
+++ b/sdk-extensions/async-processor/src/main/java/io/opentelemetry/sdk/extension/trace/export/DisruptorAsyncSpanProcessorBuilder.java
@@ -9,7 +9,14 @@ import com.lmax.disruptor.SleepingWaitStrategy;
 import com.lmax.disruptor.WaitStrategy;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 
-/** Builder for {@link DisruptorAsyncSpanProcessor}. */
+/**
+ * Builder for {@link DisruptorAsyncSpanProcessor}.
+ *
+ * @deprecated It is recommended to use the {@link
+ *     io.opentelemetry.sdk.trace.export.BatchSpanProcessor}. If you know you need to use disruptor,
+ *     switch to the {@code io.opentelemetry.contrib:disruptor-processor} artifact.
+ */
+@Deprecated
 public final class DisruptorAsyncSpanProcessorBuilder {
 
   // Number of events that can be enqueued at any one time. If more than this are enqueued,

--- a/sdk-extensions/async-processor/src/test/java/io/opentelemetry/sdk/extension/trace/export/DisruptorAsyncSpanProcessorTest.java
+++ b/sdk-extensions/async-processor/src/test/java/io/opentelemetry/sdk/extension/trace/export/DisruptorAsyncSpanProcessorTest.java
@@ -22,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 /** Unit tests for {@link DisruptorAsyncSpanProcessor}. */
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("deprecation")
 class DisruptorAsyncSpanProcessorTest {
   private static final boolean REQUIRED = true;
   private static final boolean NOT_REQUIRED = false;


### PR DESCRIPTION
This may cause a couple of days of awkwardness where this is deprecated but the contrib artifact hasn't had it's first published version yet. I think it's ok since it should be a small number of days and we're not actually removing the code.