### PR TITLE
Add timeout between delta collection

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java
@@ -99,7 +99,7 @@ public final class DefaultSynchronousMetricStorage<T> implements SynchronousMetr
       Set<CollectionHandle> allCollectors,
       long startEpochNanos,
       long epochNanos) {
-    Map<Attributes, T> result = deltaMetricStorage.collectFor(collector, allCollectors);
+    Map<Attributes, T> result = deltaMetricStorage.collectFor(collector, allCollectors, epochNanos);
     return temporalMetricStorage.buildMetricFor(collector, result, startEpochNanos, epochNanos);
   }
 

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderTest.java
@@ -183,7 +183,7 @@ public class SdkMeterProviderTest {
 
     LongCounter longCounter = sdkMeter.counterBuilder("testLongCounter").build();
     longCounter.add(10, Attributes.empty());
-    testClock.advance(Duration.ofNanos(50));
+    testClock.advance(Duration.ofSeconds(1));
 
     assertThat(sdkMeterReader.collectAllMetrics())
         .satisfiesExactly(
@@ -198,13 +198,13 @@ public class SdkMeterProviderTest {
                     .satisfiesExactly(
                         point ->
                             assertThat(point)
-                                .hasStartEpochNanos(testClock.now() - 50)
+                                .hasStartEpochNanos(testClock.now() - 1000000000)
                                 .hasEpochNanos(testClock.now())
                                 .hasAttributes(Attributes.empty())
                                 .hasBucketCounts(1)));
 
     longCounter.add(10, Attributes.empty());
-    testClock.advance(Duration.ofNanos(50));
+    testClock.advance(Duration.ofSeconds(1));
 
     assertThat(sdkMeterReader.collectAllMetrics())
         .satisfiesExactly(
@@ -218,7 +218,7 @@ public class SdkMeterProviderTest {
                     .satisfiesExactly(
                         point ->
                             assertThat(point)
-                                .hasStartEpochNanos(testClock.now() - 50)
+                                .hasStartEpochNanos(testClock.now() - 1000000000)
                                 .hasEpochNanos(testClock.now())
                                 .hasAttributes(Attributes.empty())
                                 .hasBucketCounts(1)));
@@ -251,7 +251,7 @@ public class SdkMeterProviderTest {
         sdkMeter.histogramBuilder("testDoubleValueRecorder").build();
     doubleValueRecorder.record(10, Attributes.empty());
 
-    testClock.advance(Duration.ofNanos(50));
+    testClock.advance(Duration.ofSeconds(1));
 
     assertThat(sdkMeterReader.collectAllMetrics())
         .allSatisfy(
@@ -267,7 +267,7 @@ public class SdkMeterProviderTest {
                     .satisfiesExactlyInAnyOrder(
                         point ->
                             assertThat(point)
-                                .hasStartEpochNanos(testClock.now() - 50)
+                                .hasStartEpochNanos(testClock.now() - 1000000000)
                                 .hasEpochNanos(testClock.now())
                                 .hasAttributes(Attributes.empty())
                                 .hasBucketCounts(1)))
@@ -280,7 +280,7 @@ public class SdkMeterProviderTest {
             "testLongValueRecorder",
             "testDoubleValueRecorder");
 
-    testClock.advance(Duration.ofNanos(50));
+    testClock.advance(Duration.ofSeconds(1));
 
     longCounter.add(10, Attributes.empty());
     longUpDownCounter.add(10, Attributes.empty());
@@ -303,7 +303,7 @@ public class SdkMeterProviderTest {
                     .satisfiesExactlyInAnyOrder(
                         point ->
                             assertThat(point)
-                                .hasStartEpochNanos(testClock.now() - 50)
+                                .hasStartEpochNanos(testClock.now() - 1000000000)
                                 .hasEpochNanos(testClock.now())
                                 .hasAttributes(Attributes.empty())
                                 .hasBucketCounts(1)))


### PR DESCRIPTION
Avoids a scenario where rapid collection cycles across multiple readers can do funny things.

A few important points:

- This sacrifices some accuracy for better runtime behavior in the presence of a poor-acting / aggressive metric reader
- This helps alleviate *some* concerns around Exemplar sampling when merging deltas.  (We always drop LHS exemplars during merge, which means we only keep latest exemplars from a delta right now).
- I placed some code to deal with clock-resets to avoid issues we saw in OpenCensus.   It's unclear how the whole SDK works in that scenario, or what we should do if we DO detect it.
- The timeout mechanism should be globally configurable eventually.  Just wanted to do a short cleanup for the next Java SDK release.