### PR TITLE
Add integration test for otlp http/protobuf log exporter

### DIFF
--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
   testImplementation(project(":exporters:otlp:logs"))
   testImplementation(project(":exporters:otlp-http:trace"))
   testImplementation(project(":exporters:otlp-http:metrics"))
+  testImplementation(project(":exporters:otlp-http:logs"))
   testImplementation(project(":semconv"))
   testImplementation(project(":proto"))
 

--- a/integration-tests/src/test/java/io/opentelemetry/OtlpExporterIntegrationTest.java
+++ b/integration-tests/src/test/java/io/opentelemetry/OtlpExporterIntegrationTest.java
@@ -22,6 +22,7 @@ import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogExporter;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogExporter;
@@ -343,6 +344,22 @@ class OtlpExporterIntegrationTest {
             .build();
 
     testLogExporter(otlpGrpcLogExporter);
+  }
+
+  @Test
+  void testOtlpHttpLogExport() {
+    LogExporter otlpHttpLogExporter =
+        OtlpHttpLogExporter.builder()
+            .setEndpoint(
+                "http://"
+                    + collector.getHost()
+                    + ":"
+                    + collector.getMappedPort(COLLECTOR_OTLP_HTTP_PORT)
+                    + "/v1/logs")
+            .setCompression("gzip")
+            .build();
+
+    testLogExporter(otlpHttpLogExporter);
   }
 
   private static void testLogExporter(LogExporter logExporter) {


### PR DESCRIPTION
Rounding out the otlp integration test with the addition of the [http/protobuf log](https://github.com/open-telemetry/opentelemetry-java/pull/3682) exporter. 