### PR TITLE
Add missing none compression support to OtlpHttpLogExporter

### DIFF
--- a/exporters/otlp-http/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogExporterBuilder.java
+++ b/exporters/otlp-http/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogExporterBuilder.java
@@ -76,15 +76,17 @@ public final class OtlpHttpLogExporterBuilder {
   }
 
   /**
-   * Sets the method used to compress payloads. If unset, compression is disabled. Currently the
-   * only supported compression method is "gzip".
+   * Sets the method used to compress payloads. If unset, compression is disabled. Currently
+   * supported compression methods include "gzip" and "none".
    */
   public OtlpHttpLogExporterBuilder setCompression(String compressionMethod) {
     requireNonNull(compressionMethod, "compressionMethod");
     checkArgument(
-        compressionMethod.equals("gzip"),
-        "Unsupported compression method. Supported compression methods include: gzip.");
-    this.compressionEnabled = true;
+        compressionMethod.equals("gzip") || compressionMethod.equals("none"),
+        "Unsupported compression method. Supported compression methods include: gzip, none.");
+    if (compressionMethod.equals("gzip")) {
+      this.compressionEnabled = true;
+    }
     return this;
   }
 


### PR DESCRIPTION
[PR #3682](https://github.com/open-telemetry/opentelemetry-java/pull/3682) and [PR #3687](https://github.com/open-telemetry/opentelemetry-java/pull/3687) were outstanding at the same time and support for `none` compression for the `OtlpHttpLogExporter` didn't make it in. This fixes that. 