### PR TITLE
Apply dependencyManagement also to unresolvable configurations for composite build

### DIFF
--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -175,6 +175,12 @@ dependencies {
   dependencyManagement(platform(project(":dependencyManagement")))
   afterEvaluate {
     configurations.configureEach {
+      // Normally, we configure the maven publication such that all the dependencies have the right
+      // version. However, a composite build does not consume the included builds via maven
+      // publications, so these settings are ignored. Thus we need to apply the dependencyManagement
+      // also to configurations such as "api" there, otherwise the including build will have any
+      // external dependencies of the included project without version, causing dependency
+      // resolution to fail.
       val isIncludedBuild = project.gradle.parent != null
       if (!isCanBeConsumed && (isIncludedBuild || isCanBeResolved) && this != dependencyManagement) {
         extendsFrom(dependencyManagement)

--- a/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 publishing {
+  // We can't publish from an included build, see java-conventions.
   val isIncludedBuild = rootProject.gradle.parent != null
   if (isIncludedBuild) {
     tasks.withType(AbstractPublishToMaven::class).configureEach {


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-java/pull/3603#discussion_r707370823

This should only make a difference when used in composite builds.
Without this, the dependency management versions won't be applied
when the ultimate user is a project outside this build. E.g. if
a project in a composite build uses
:odin-java:exporters:opentelemetry-exporter-zipkin,
it will indirectly depend on io.zipkin.reporter2:zipkin-reporter
without version.

Theoretically, this could be fixed in the using project by adding
a version constraint, but that is rather awkward.

With this change, including build usually work out of the box, but
they are forced to use a version compatible with the dependency
constraints from our dependency management.
This is especially annoying because we only have a single big dependencyManagement
configuration with production and test dependencies,
so e.g. our JUnit version constraint will be forced on the including build.