### PR TITLE
Disable kotlin incremental compilation to work around compiler warnin…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,8 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m \
   --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+
+# Workaround https://youtrack.jetbrains.com/issue/KT-47152
+# We don't have enough kotlin code to care about incremental compilation anyways.
+kotlin.incremental=false


### PR DESCRIPTION
…g message.

We don't need it, and works around this warning when running build on Java 17

```
Compilation with Kotlin compile daemon was not successful
java.rmi.ServerError: Error occurred in server thread; nested exception is:
        java.lang.NoClassDefFoundError: Could not initialize class org.jetbrains.kotlin.com.intellij.util.io.FileChannelUtil
        at java.rmi/sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:386)
        at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:200)
        at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:197)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:691)
        at java.rmi/sun.rmi.transport.Transport.serviceCall(Transport.java:196)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:587)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:828)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:705)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:391)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:704)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
        at java.base/java.lang.Thread.run(Thread.java:831)
```