### PR TITLE
Add javac params per errorprone docs.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,9 +8,14 @@ org.gradle.priority=low
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m \
   --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
 
 # Workaround https://youtrack.jetbrains.com/issue/KT-47152
 # We don't have enough kotlin code to care about incremental compilation anyways.


### PR DESCRIPTION
I think this only can cause a problem depending in certain situations, depending on which specific error prone check fails. Figure may as well follow the doc

https://errorprone.info/docs/installation