### PR TITLE
Add LogData interface

### DIFF
--- a/exporters/otlp-http/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogExporter.java
+++ b/exporters/otlp-http/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogExporter.java
@@ -15,7 +15,7 @@ import io.opentelemetry.exporter.otlp.internal.grpc.GrpcStatusUtil;
 import io.opentelemetry.exporter.otlp.internal.logs.LogsRequestMarshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.internal.ThrottlingLogger;
-import io.opentelemetry.sdk.logging.data.LogRecord;
+import io.opentelemetry.sdk.logging.data.LogData;
 import io.opentelemetry.sdk.logging.export.LogExporter;
 import java.io.IOException;
 import java.util.Collection;
@@ -83,7 +83,7 @@ public final class OtlpHttpLogExporter implements LogExporter {
    * @return the result of the operation
    */
   @Override
-  public CompletableResultCode export(Collection<LogRecord> logs) {
+  public CompletableResultCode export(Collection<LogData> logs) {
     logsSeen.add(logs.size());
 
     LogsRequestMarshaler exportRequest = LogsRequestMarshaler.create(logs);

--- a/exporters/otlp-http/logs/src/test/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogExporterTest.java
+++ b/exporters/otlp-http/logs/src/test/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogExporterTest.java
@@ -29,7 +29,9 @@ import io.opentelemetry.proto.logs.v1.ResourceLogs;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.logging.data.Body;
+import io.opentelemetry.sdk.logging.data.LogData;
 import io.opentelemetry.sdk.logging.data.LogRecord;
+import io.opentelemetry.sdk.logging.data.Severity;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.IdGenerator;
 import java.io.ByteArrayOutputStream;
@@ -271,7 +273,7 @@ class OtlpHttpLogExporterTest {
 
   private static ExportLogsServiceRequest exportAndAssertResult(
       OtlpHttpLogExporter otlpHttpLogExporter, boolean expectedResult) {
-    List<LogRecord> logs = Collections.singletonList(generateFakeLog());
+    List<LogData> logs = Collections.singletonList(generateFakeLog());
     CompletableResultCode resultCode = otlpHttpLogExporter.export(logs);
     resultCode.join(10, TimeUnit.SECONDS);
     assertThat(resultCode.isSuccess()).isEqualTo(expectedResult);
@@ -301,18 +303,18 @@ class OtlpHttpLogExporterTest {
     return HttpResponse.of(httpStatus, APPLICATION_PROTOBUF, message.toByteArray());
   }
 
-  private static LogRecord generateFakeLog() {
+  private static LogData generateFakeLog() {
     return LogRecord.builder(
             Resource.getDefault(),
             InstrumentationLibraryInfo.create("testLib", "1.0", "http://url"))
         .setName("log-name")
         .setBody(Body.stringBody("log body"))
         .setAttributes(Attributes.builder().put("key", "value").build())
-        .setSeverity(LogRecord.Severity.INFO)
-        .setSeverityText(LogRecord.Severity.INFO.name())
+        .setSeverity(Severity.INFO)
+        .setSeverityText(Severity.INFO.name())
         .setTraceId(IdGenerator.random().generateTraceId())
         .setSpanId(IdGenerator.random().generateSpanId())
-        .setUnixTimeNano(TimeUnit.MILLISECONDS.toNanos(Instant.now().toEpochMilli()))
+        .setEpochNanos(TimeUnit.MILLISECONDS.toNanos(Instant.now().toEpochMilli()))
         .setFlags(0)
         .build();
   }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/logs/LogMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/logs/LogMarshaler.java
@@ -13,7 +13,7 @@ import io.opentelemetry.exporter.otlp.internal.Serializer;
 import io.opentelemetry.exporter.otlp.internal.StringAnyValueMarshaler;
 import io.opentelemetry.proto.logs.v1.internal.LogRecord;
 import io.opentelemetry.proto.logs.v1.internal.SeverityNumber;
-import io.opentelemetry.sdk.logging.data.LogRecord.Severity;
+import io.opentelemetry.sdk.logging.data.Severity;
 import java.io.IOException;
 
 final class LogMarshaler extends MarshalerWithSize {
@@ -28,26 +28,26 @@ final class LogMarshaler extends MarshalerWithSize {
   private final String traceId;
   private final String spanId;
 
-  static LogMarshaler create(io.opentelemetry.sdk.logging.data.LogRecord logRecord) {
+  static LogMarshaler create(io.opentelemetry.sdk.logging.data.LogData logData) {
     KeyValueMarshaler[] attributeMarshalers =
-        KeyValueMarshaler.createRepeated(logRecord.getAttributes());
+        KeyValueMarshaler.createRepeated(logData.getAttributes());
 
     // For now, map all the bodies to String AnyValue.
     StringAnyValueMarshaler anyValueMarshaler =
-        new StringAnyValueMarshaler(MarshalerUtil.toBytes(logRecord.getBody().asString()));
+        new StringAnyValueMarshaler(MarshalerUtil.toBytes(logData.getBody().asString()));
 
     return new LogMarshaler(
-        logRecord.getTimeUnixNano(),
-        toProtoSeverityNumber(logRecord.getSeverity()),
-        MarshalerUtil.toBytes(logRecord.getSeverityText()),
-        MarshalerUtil.toBytes(logRecord.getName()),
+        logData.getEpochNanos(),
+        toProtoSeverityNumber(logData.getSeverity()),
+        MarshalerUtil.toBytes(logData.getSeverityText()),
+        MarshalerUtil.toBytes(logData.getName()),
         anyValueMarshaler,
         attributeMarshalers,
         // TODO (trask) implement droppedAttributesCount in LogRecord
         0,
-        logRecord.getFlags(),
-        logRecord.getTraceId(),
-        logRecord.getSpanId());
+        logData.getFlags(),
+        logData.getTraceId(),
+        logData.getSpanId());
   }
 
   private LogMarshaler(

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/logs/LogsRequestMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/logs/LogsRequestMarshaler.java
@@ -10,6 +10,7 @@ import io.opentelemetry.exporter.otlp.internal.MarshalerUtil;
 import io.opentelemetry.exporter.otlp.internal.MarshalerWithSize;
 import io.opentelemetry.exporter.otlp.internal.Serializer;
 import io.opentelemetry.proto.collector.logs.v1.internal.ExportLogsServiceRequest;
+import io.opentelemetry.sdk.logging.data.LogData;
 import io.opentelemetry.sdk.logging.data.LogRecord;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.io.IOException;
@@ -29,8 +30,8 @@ public final class LogsRequestMarshaler extends MarshalerWithSize {
    * Returns a {@link LogsRequestMarshaler} that can be used to convert the provided {@link
    * SpanData} into a serialized OTLP ExportLogsServiceRequest.
    */
-  public static LogsRequestMarshaler create(Collection<LogRecord> logsList) {
-    return new LogsRequestMarshaler(ResourceLogsMarshaler.create(logsList));
+  public static LogsRequestMarshaler create(Collection<LogData> logs) {
+    return new LogsRequestMarshaler(ResourceLogsMarshaler.create(logs));
   }
 
   private LogsRequestMarshaler(ResourceLogsMarshaler[] resourceLogsMarshalers) {

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/logs/ResourceLogsMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/logs/ResourceLogsMarshaler.java
@@ -13,7 +13,7 @@ import io.opentelemetry.exporter.otlp.internal.ResourceMarshaler;
 import io.opentelemetry.exporter.otlp.internal.Serializer;
 import io.opentelemetry.proto.logs.v1.internal.ResourceLogs;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.logging.data.LogRecord;
+import io.opentelemetry.sdk.logging.data.LogData;
 import io.opentelemetry.sdk.resources.Resource;
 import java.io.IOException;
 import java.util.Collection;
@@ -32,9 +32,9 @@ public final class ResourceLogsMarshaler extends MarshalerWithSize {
   private final InstrumentationLibraryLogsMarshaler[] instrumentationLibraryLogsMarshalers;
 
   /** Returns Marshalers of ResourceLogs created by grouping the provided logRecords. */
-  public static ResourceLogsMarshaler[] create(Collection<LogRecord> logRecords) {
+  public static ResourceLogsMarshaler[] create(Collection<LogData> logs) {
     Map<Resource, Map<InstrumentationLibraryInfo, List<Marshaler>>> resourceAndLibraryMap =
-        groupByResourceAndLibrary(logRecords);
+        groupByResourceAndLibrary(logs);
 
     ResourceLogsMarshaler[] resourceLogsMarshalers =
         new ResourceLogsMarshaler[resourceAndLibraryMap.size()];
@@ -94,13 +94,13 @@ public final class ResourceLogsMarshaler extends MarshalerWithSize {
   }
 
   private static Map<Resource, Map<InstrumentationLibraryInfo, List<Marshaler>>>
-      groupByResourceAndLibrary(Collection<LogRecord> logRecords) {
+      groupByResourceAndLibrary(Collection<LogData> logs) {
     return MarshalerUtil.groupByResourceAndLibrary(
-        logRecords,
+        logs,
         // TODO(anuraaga): Replace with an internal SdkData type of interface that exposes these
         // two.
-        LogRecord::getResource,
-        LogRecord::getInstrumentationLibraryInfo,
+        LogData::getResource,
+        LogData::getInstrumentationLibraryInfo,
         LogMarshaler::create);
   }
 }

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/logs/LogsRequestMarshalerTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/logs/LogsRequestMarshalerTest.java
@@ -24,6 +24,7 @@ import io.opentelemetry.proto.logs.v1.InstrumentationLibraryLogs;
 import io.opentelemetry.proto.logs.v1.LogRecord;
 import io.opentelemetry.proto.logs.v1.ResourceLogs;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.logging.data.Severity;
 import io.opentelemetry.sdk.resources.Resource;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -53,12 +54,12 @@ class LogsRequestMarshalerTest {
                         InstrumentationLibraryInfo.create("testLib", "1.0", "http://url"))
                     .setName(NAME)
                     .setBody(BODY)
-                    .setSeverity(io.opentelemetry.sdk.logging.data.LogRecord.Severity.INFO)
+                    .setSeverity(Severity.INFO)
                     .setSeverityText("INFO")
                     .setTraceId(TRACE_ID)
                     .setSpanId(SPAN_ID)
                     .setAttributes(Attributes.of(AttributeKey.booleanKey("key"), true))
-                    .setUnixTimeNano(12345)
+                    .setEpochNanos(12345)
                     .build()));
 
     assertThat(resourceLogsMarshalers).hasSize(1);
@@ -86,12 +87,12 @@ class LogsRequestMarshalerTest {
                         InstrumentationLibraryInfo.create("instrumentation", "1"))
                     .setName(NAME)
                     .setBody(BODY)
-                    .setSeverity(io.opentelemetry.sdk.logging.data.LogRecord.Severity.INFO)
+                    .setSeverity(Severity.INFO)
                     .setSeverityText("INFO")
                     .setTraceId(TRACE_ID)
                     .setSpanId(SPAN_ID)
                     .setAttributes(Attributes.of(AttributeKey.booleanKey("key"), true))
-                    .setUnixTimeNano(12345)
+                    .setEpochNanos(12345)
                     .build()));
 
     assertThat(logRecord.getTraceId().toByteArray()).isEqualTo(TRACE_ID_BYTES);

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogExporter.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogExporter.java
@@ -8,7 +8,7 @@ package io.opentelemetry.exporter.otlp.logs;
 import io.opentelemetry.exporter.otlp.internal.grpc.GrpcExporter;
 import io.opentelemetry.exporter.otlp.internal.logs.LogsRequestMarshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.logging.data.LogRecord;
+import io.opentelemetry.sdk.logging.data.LogData;
 import io.opentelemetry.sdk.logging.export.LogExporter;
 import java.util.Collection;
 import javax.annotation.concurrent.ThreadSafe;
@@ -50,7 +50,7 @@ public final class OtlpGrpcLogExporter implements LogExporter {
    * @return the result of the operation
    */
   @Override
-  public CompletableResultCode export(Collection<LogRecord> logs) {
+  public CompletableResultCode export(Collection<LogData> logs) {
     LogsRequestMarshaler request = LogsRequestMarshaler.create(logs);
     return delegate.export(request, logs.size());
   }

--- a/exporters/otlp/logs/src/test/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogsExporterTest.java
+++ b/exporters/otlp/logs/src/test/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogsExporterTest.java
@@ -31,7 +31,9 @@ import io.opentelemetry.proto.collector.logs.v1.LogsServiceGrpc;
 import io.opentelemetry.proto.logs.v1.ResourceLogs;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.logging.data.LogData;
 import io.opentelemetry.sdk.logging.data.LogRecord;
+import io.opentelemetry.sdk.logging.data.Severity;
 import io.opentelemetry.sdk.resources.Resource;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -154,7 +156,7 @@ class OtlpGrpcLogsExporterTest {
 
   @Test
   void testExport() {
-    LogRecord log = generateFakeLog();
+    LogData log = generateFakeLog();
     OtlpGrpcLogExporter exporter =
         OtlpGrpcLogExporter.builder().setChannel(inProcessChannel).build();
     try {
@@ -168,7 +170,7 @@ class OtlpGrpcLogsExporterTest {
 
   @Test
   void testExport_MultipleLogs() {
-    List<LogRecord> logs = new ArrayList<>();
+    List<LogData> logs = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
       logs.add(generateFakeLog());
     }
@@ -182,7 +184,7 @@ class OtlpGrpcLogsExporterTest {
     }
   }
 
-  private static List<ResourceLogs> toResourceLogs(List<LogRecord> logs) {
+  private static List<ResourceLogs> toResourceLogs(List<LogData> logs) {
     return Arrays.stream(ResourceLogsMarshaler.create(logs))
         .map(
             marshaler -> {
@@ -216,7 +218,7 @@ class OtlpGrpcLogsExporterTest {
 
   @Test
   void testExport_AfterShutdown() {
-    LogRecord log = generateFakeLog();
+    LogData log = generateFakeLog();
     OtlpGrpcLogExporter exporter =
         OtlpGrpcLogExporter.builder().setChannel(inProcessChannel).build();
     exporter.shutdown();
@@ -354,15 +356,15 @@ class OtlpGrpcLogsExporterTest {
         .isInstanceOf(DefaultGrpcExporterBuilder.class);
   }
 
-  private static LogRecord generateFakeLog() {
+  private static LogData generateFakeLog() {
     return LogRecord.builder(
             Resource.create(Attributes.builder().put("testKey", "testValue").build()),
             InstrumentationLibraryInfo.create("instrumentation", "1"))
-        .setUnixTimeMillis(System.currentTimeMillis())
+        .setEpochMillis(System.currentTimeMillis())
         .setTraceId(TraceId.getInvalid())
         .setSpanId(SpanId.getInvalid())
         .setFlags(TraceFlags.getDefault().asByte())
-        .setSeverity(LogRecord.Severity.ERROR)
+        .setSeverity(Severity.ERROR)
         .setSeverityText("really severe")
         .setName("log1")
         .setBody("message")

--- a/exporters/otlp/logs/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/logs/ExportTest.java
+++ b/exporters/otlp/logs/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/logs/ExportTest.java
@@ -22,7 +22,9 @@ import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceResponse;
 import io.opentelemetry.proto.collector.logs.v1.LogsServiceGrpc;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.logging.data.LogData;
 import io.opentelemetry.sdk.logging.data.LogRecord;
+import io.opentelemetry.sdk.logging.data.Severity;
 import io.opentelemetry.sdk.resources.Resource;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -35,16 +37,16 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 class ExportTest {
 
-  private static final List<LogRecord> LOGS =
+  private static final List<LogData> LOGS =
       Collections.singletonList(
           LogRecord.builder(
                   Resource.create(Attributes.builder().put("testKey", "testValue").build()),
                   InstrumentationLibraryInfo.create("instrumentation", "1"))
-              .setUnixTimeMillis(System.currentTimeMillis())
+              .setEpochMillis(System.currentTimeMillis())
               .setTraceId(TraceId.getInvalid())
               .setSpanId(SpanId.getInvalid())
               .setFlags(TraceFlags.getDefault().asByte())
-              .setSeverity(LogRecord.Severity.ERROR)
+              .setSeverity(Severity.ERROR)
               .setSeverityText("really severe")
               .setName("log1")
               .setBody("message")

--- a/exporters/otlp/logs/src/testGrpcNettyShaded/java/io/opentelemetry/exporter/otlp/logs/ExportTest.java
+++ b/exporters/otlp/logs/src/testGrpcNettyShaded/java/io/opentelemetry/exporter/otlp/logs/ExportTest.java
@@ -22,7 +22,9 @@ import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceResponse;
 import io.opentelemetry.proto.collector.logs.v1.LogsServiceGrpc;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.logging.data.LogData;
 import io.opentelemetry.sdk.logging.data.LogRecord;
+import io.opentelemetry.sdk.logging.data.Severity;
 import io.opentelemetry.sdk.resources.Resource;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -35,16 +37,16 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 class ExportTest {
 
-  private static final List<LogRecord> LOGS =
+  private static final List<LogData> LOGS =
       Collections.singletonList(
           LogRecord.builder(
                   Resource.create(Attributes.builder().put("testKey", "testValue").build()),
                   InstrumentationLibraryInfo.create("instrumentation", "1"))
-              .setUnixTimeMillis(System.currentTimeMillis())
+              .setEpochMillis(System.currentTimeMillis())
               .setTraceId(TraceId.getInvalid())
               .setSpanId(SpanId.getInvalid())
               .setFlags(TraceFlags.getDefault().asByte())
-              .setSeverity(LogRecord.Severity.ERROR)
+              .setSeverity(Severity.ERROR)
               .setSeverityText("really severe")
               .setName("log1")
               .setBody("message")

--- a/exporters/otlp/logs/src/testGrpcOkhttp/java/io/opentelemetry/exporter/otlp/logs/ExportTest.java
+++ b/exporters/otlp/logs/src/testGrpcOkhttp/java/io/opentelemetry/exporter/otlp/logs/ExportTest.java
@@ -22,7 +22,9 @@ import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceResponse;
 import io.opentelemetry.proto.collector.logs.v1.LogsServiceGrpc;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.logging.data.LogData;
 import io.opentelemetry.sdk.logging.data.LogRecord;
+import io.opentelemetry.sdk.logging.data.Severity;
 import io.opentelemetry.sdk.resources.Resource;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -35,16 +37,16 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 class ExportTest {
 
-  private static final List<LogRecord> LOGS =
+  private static final List<LogData> LOGS =
       Collections.singletonList(
           LogRecord.builder(
                   Resource.create(Attributes.builder().put("testKey", "testValue").build()),
                   InstrumentationLibraryInfo.create("instrumentation", "1"))
-              .setUnixTimeMillis(System.currentTimeMillis())
+              .setEpochMillis(System.currentTimeMillis())
               .setTraceId(TraceId.getInvalid())
               .setSpanId(SpanId.getInvalid())
               .setFlags(TraceFlags.getDefault().asByte())
-              .setSeverity(LogRecord.Severity.ERROR)
+              .setSeverity(Severity.ERROR)
               .setSeverityText("really severe")
               .setName("log1")
               .setBody("message")

--- a/exporters/otlp/logs/src/testOkHttpOnly/java/io/opentelemetry/exporter/otlp/logs/OkHttpOnlyExportTest.java
+++ b/exporters/otlp/logs/src/testOkHttpOnly/java/io/opentelemetry/exporter/otlp/logs/OkHttpOnlyExportTest.java
@@ -19,7 +19,9 @@ import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.exporter.otlp.internal.grpc.OkHttpGrpcExporterBuilder;
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceResponse;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.logging.data.LogData;
 import io.opentelemetry.sdk.logging.data.LogRecord;
+import io.opentelemetry.sdk.logging.data.Severity;
 import io.opentelemetry.sdk.resources.Resource;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -36,16 +38,16 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 class OkHttpOnlyExportTest {
 
-  private static final List<LogRecord> LOGS =
+  private static final List<LogData> LOGS =
       Collections.singletonList(
           LogRecord.builder(
                   Resource.create(Attributes.builder().put("testKey", "testValue").build()),
                   InstrumentationLibraryInfo.create("instrumentation", "1"))
-              .setUnixTimeMillis(System.currentTimeMillis())
+              .setEpochMillis(System.currentTimeMillis())
               .setTraceId(TraceId.getInvalid())
               .setSpanId(SpanId.getInvalid())
               .setFlags(TraceFlags.getDefault().asByte())
-              .setSeverity(LogRecord.Severity.ERROR)
+              .setSeverity(Severity.ERROR)
               .setSeverityText("really severe")
               .setName("log1")
               .setBody("message")

--- a/integration-tests/src/testOtlpCommon/java/io/opentelemetry/integrationtest/OtlpExporterIntegrationTest.java
+++ b/integration-tests/src/testOtlpCommon/java/io/opentelemetry/integrationtest/OtlpExporterIntegrationTest.java
@@ -53,6 +53,7 @@ import io.opentelemetry.proto.trace.v1.Span.Link;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.logging.data.Body;
 import io.opentelemetry.sdk.logging.data.LogRecord;
+import io.opentelemetry.sdk.logging.data.Severity;
 import io.opentelemetry.sdk.logging.export.LogExporter;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
@@ -379,11 +380,11 @@ abstract class OtlpExporterIntegrationTest {
             .setName("log-name")
             .setBody(Body.stringBody("log body"))
             .setAttributes(Attributes.builder().put("key", "value").build())
-            .setSeverity(LogRecord.Severity.DEBUG)
+            .setSeverity(Severity.DEBUG)
             .setSeverityText("DEBUG")
             .setTraceId(IdGenerator.random().generateTraceId())
             .setSpanId(IdGenerator.random().generateSpanId())
-            .setUnixTimeNano(TimeUnit.MILLISECONDS.toNanos(Instant.now().toEpochMilli()))
+            .setEpochNanos(TimeUnit.MILLISECONDS.toNanos(Instant.now().toEpochMilli()))
             .setFlags(0)
             .build();
 
@@ -427,7 +428,7 @@ abstract class OtlpExporterIntegrationTest {
         .isEqualTo(logRecord.getTraceId());
     assertThat(SpanId.fromBytes(protoLog.getSpanId().toByteArray()))
         .isEqualTo(logRecord.getSpanId());
-    assertThat(protoLog.getTimeUnixNano()).isEqualTo(logRecord.getTimeUnixNano());
+    assertThat(protoLog.getTimeUnixNano()).isEqualTo(logRecord.getEpochNanos());
     assertThat(protoLog.getFlags()).isEqualTo(logRecord.getFlags());
   }
 

--- a/sdk-extensions/logging/src/main/java/io/opentelemetry/sdk/logging/data/LogData.java
+++ b/sdk-extensions/logging/src/main/java/io/opentelemetry/sdk/logging/data/LogData.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.logging.data;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * The interface for a log as defined in the <a
+ * href="https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/logs/data-model.md">OpenTelemetry
+ * logging model</a>.
+ */
+@Immutable
+public interface LogData {
+
+  /**
+   * Returns the resource of this log.
+   *
+   * @return the resource.
+   */
+  Resource getResource();
+
+  /**
+   * Returns the instrumentation library that generated this log.
+   *
+   * @return an instance of {@link InstrumentationLibraryInfo}.
+   */
+  InstrumentationLibraryInfo getInstrumentationLibraryInfo();
+
+  /**
+   * Returns the epoch timestamp in nanos when the log was recorded.
+   *
+   * @return the epoch timestamp in nanos.
+   */
+  long getEpochNanos();
+
+  /**
+   * Returns the trace id for this log.
+   *
+   * @return the trace id.
+   */
+  String getTraceId();
+
+  /**
+   * Returns the span id for this log.
+   *
+   * @return the span id.
+   */
+  String getSpanId();
+
+  /**
+   * Returns the flags for this log.
+   *
+   * @return the flags.
+   */
+  int getFlags();
+
+  /**
+   * Returns the severity for this log.
+   *
+   * @return the severity.
+   */
+  Severity getSeverity();
+
+  /**
+   * Returns the severity text for this log.
+   *
+   * @return the severity text.
+   */
+  @Nullable
+  String getSeverityText();
+
+  /**
+   * Returns the name for this log.
+   *
+   * @return the name.
+   */
+  @Nullable
+  String getName();
+
+  /**
+   * Returns the body for this log.
+   *
+   * @return the body.
+   */
+  Body getBody();
+
+  /**
+   * Returns the attributes for this log.
+   *
+   * @return the attributes.
+   */
+  Attributes getAttributes();
+}

--- a/sdk-extensions/logging/src/main/java/io/opentelemetry/sdk/logging/data/LogRecord.java
+++ b/sdk-extensions/logging/src/main/java/io/opentelemetry/sdk/logging/data/LogRecord.java
@@ -10,14 +10,13 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
 
-/**
- * A LogRecord is an implementation of the <a
- * href="https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/logs/data-model.md">
- * OpenTelemetry logging model</a>.
- */
+@Immutable
 @AutoValue
-public abstract class LogRecord {
+public abstract class LogRecord implements LogData {
+
+  LogRecord() {}
 
   public static LogRecordBuilder builder(
       Resource resource, InstrumentationLibraryInfo instrumentationLibraryInfo) {
@@ -27,7 +26,7 @@ public abstract class LogRecord {
   static LogRecord create(
       Resource resource,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
-      long timeUnixNano,
+      long epochNanos,
       String traceId,
       String spanId,
       int flags,
@@ -39,7 +38,7 @@ public abstract class LogRecord {
     return new AutoValue_LogRecord(
         resource,
         instrumentationLibraryInfo,
-        timeUnixNano,
+        epochNanos,
         traceId,
         spanId,
         flags,
@@ -48,68 +47,5 @@ public abstract class LogRecord {
         name,
         body,
         attributes);
-  }
-
-  public abstract Resource getResource();
-
-  public abstract InstrumentationLibraryInfo getInstrumentationLibraryInfo();
-
-  public abstract long getTimeUnixNano();
-
-  public abstract String getTraceId();
-
-  public abstract String getSpanId();
-
-  public abstract int getFlags();
-
-  public abstract Severity getSeverity();
-
-  @Nullable
-  public abstract String getSeverityText();
-
-  @Nullable
-  public abstract String getName();
-
-  public abstract Body getBody();
-
-  public abstract Attributes getAttributes();
-
-  public enum Severity {
-    UNDEFINED_SEVERITY_NUMBER(0),
-    TRACE(1),
-    TRACE2(2),
-    TRACE3(3),
-    TRACE4(4),
-    DEBUG(5),
-    DEBUG2(6),
-    DEBUG3(7),
-    DEBUG4(8),
-    INFO(9),
-    INFO2(10),
-    INFO3(11),
-    INFO4(12),
-    WARN(13),
-    WARN2(14),
-    WARN3(15),
-    WARN4(16),
-    ERROR(17),
-    ERROR2(18),
-    ERROR3(19),
-    ERROR4(20),
-    FATAL(21),
-    FATAL2(22),
-    FATAL3(23),
-    FATAL4(24),
-    ;
-
-    private final int severityNumber;
-
-    Severity(int severityNumber) {
-      this.severityNumber = severityNumber;
-    }
-
-    public int getSeverityNumber() {
-      return severityNumber;
-    }
   }
 }

--- a/sdk-extensions/logging/src/main/java/io/opentelemetry/sdk/logging/data/LogRecordBuilder.java
+++ b/sdk-extensions/logging/src/main/java/io/opentelemetry/sdk/logging/data/LogRecordBuilder.java
@@ -12,15 +12,16 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
+/** Builder for {@link LogRecord}. */
 public final class LogRecordBuilder {
   private final Resource resource;
   private final InstrumentationLibraryInfo instrumentationLibraryInfo;
 
-  private long timeUnixNano;
+  private long epochNanos;
   private String traceId = "";
   private String spanId = "";
   private int flags;
-  private LogRecord.Severity severity = LogRecord.Severity.UNDEFINED_SEVERITY_NUMBER;
+  private Severity severity = Severity.UNDEFINED_SEVERITY_NUMBER;
   @Nullable private String severityText;
   @Nullable private String name;
   private Body body = Body.stringBody("");
@@ -31,13 +32,13 @@ public final class LogRecordBuilder {
     this.instrumentationLibraryInfo = instrumentationLibraryInfo;
   }
 
-  public LogRecordBuilder setUnixTimeNano(long timestamp) {
-    this.timeUnixNano = timestamp;
+  public LogRecordBuilder setEpochNanos(long timestamp) {
+    this.epochNanos = timestamp;
     return this;
   }
 
-  public LogRecordBuilder setUnixTimeMillis(long timestamp) {
-    return setUnixTimeNano(TimeUnit.MILLISECONDS.toNanos(timestamp));
+  public LogRecordBuilder setEpochMillis(long timestamp) {
+    return setEpochNanos(TimeUnit.MILLISECONDS.toNanos(timestamp));
   }
 
   public LogRecordBuilder setTraceId(String traceId) {
@@ -55,7 +56,7 @@ public final class LogRecordBuilder {
     return this;
   }
 
-  public LogRecordBuilder setSeverity(LogRecord.Severity severity) {
+  public LogRecordBuilder setSeverity(Severity severity) {
     this.severity = severity;
     return this;
   }
@@ -90,13 +91,13 @@ public final class LogRecordBuilder {
    * @return value object being built
    */
   public LogRecord build() {
-    if (timeUnixNano == 0) {
-      timeUnixNano = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
+    if (epochNanos == 0) {
+      epochNanos = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
     }
     return LogRecord.create(
         resource,
         instrumentationLibraryInfo,
-        timeUnixNano,
+        epochNanos,
         traceId,
         spanId,
         flags,

--- a/sdk-extensions/logging/src/main/java/io/opentelemetry/sdk/logging/data/Severity.java
+++ b/sdk-extensions/logging/src/main/java/io/opentelemetry/sdk/logging/data/Severity.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.logging.data;
+
+public enum Severity {
+  UNDEFINED_SEVERITY_NUMBER(0),
+  TRACE(1),
+  TRACE2(2),
+  TRACE3(3),
+  TRACE4(4),
+  DEBUG(5),
+  DEBUG2(6),
+  DEBUG3(7),
+  DEBUG4(8),
+  INFO(9),
+  INFO2(10),
+  INFO3(11),
+  INFO4(12),
+  WARN(13),
+  WARN2(14),
+  WARN3(15),
+  WARN4(16),
+  ERROR(17),
+  ERROR2(18),
+  ERROR3(19),
+  ERROR4(20),
+  FATAL(21),
+  FATAL2(22),
+  FATAL3(23),
+  FATAL4(24),
+  ;
+
+  private final int severityNumber;
+
+  Severity(int severityNumber) {
+    this.severityNumber = severityNumber;
+  }
+
+  public int getSeverityNumber() {
+    return severityNumber;
+  }
+}

--- a/sdk-extensions/logging/src/main/java/io/opentelemetry/sdk/logging/export/LogExporter.java
+++ b/sdk-extensions/logging/src/main/java/io/opentelemetry/sdk/logging/export/LogExporter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.logging.export;
 
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.logging.data.LogData;
 import io.opentelemetry.sdk.logging.data.LogRecord;
 import java.util.Collection;
 
@@ -14,7 +15,7 @@ import java.util.Collection;
  * ultimate destination.
  */
 public interface LogExporter {
-  CompletableResultCode export(Collection<LogRecord> records);
+  CompletableResultCode export(Collection<LogData> logs);
 
   CompletableResultCode shutdown();
 }

--- a/sdk-extensions/logging/src/test/java/io/opentelemetry/sdk/logging/sdk/BatchLogProcessorTest.java
+++ b/sdk-extensions/logging/src/test/java/io/opentelemetry/sdk/logging/sdk/BatchLogProcessorTest.java
@@ -14,6 +14,7 @@ import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.logging.data.LogRecord;
+import io.opentelemetry.sdk.logging.data.Severity;
 import io.opentelemetry.sdk.logging.export.BatchLogProcessor;
 import io.opentelemetry.sdk.logging.util.TestLogExporter;
 import io.opentelemetry.sdk.resources.Resource;
@@ -22,11 +23,11 @@ import org.junit.jupiter.api.Test;
 
 class BatchLogProcessorTest {
 
-  private static LogRecord createLog(LogRecord.Severity severity, String message) {
+  private static LogRecord createLog(Severity severity, String message) {
     return LogRecord.builder(
             Resource.create(Attributes.builder().put("testKey", "testValue").build()),
             InstrumentationLibraryInfo.create("instrumentation", "1"))
-        .setUnixTimeMillis(System.currentTimeMillis())
+        .setEpochMillis(System.currentTimeMillis())
         .setTraceId(TraceId.getInvalid())
         .setSpanId(SpanId.getInvalid())
         .setFlags(TraceFlags.getDefault().asByte())
@@ -50,7 +51,7 @@ class BatchLogProcessorTest {
             .setScheduleDelayMillis(2000) // longer than test
             .build();
     for (int i = 0; i < 17; i++) {
-      LogRecord record = createLog(LogRecord.Severity.INFO, Integer.toString(i));
+      LogRecord record = createLog(Severity.INFO, Integer.toString(i));
       processor.addLogRecord(record);
     }
     await().until(() -> exporter.getCallCount() > 0);

--- a/sdk-extensions/logging/src/test/java/io/opentelemetry/sdk/logging/util/TestLogExporter.java
+++ b/sdk-extensions/logging/src/test/java/io/opentelemetry/sdk/logging/util/TestLogExporter.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.logging.util;
 
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.logging.data.LogRecord;
+import io.opentelemetry.sdk.logging.data.LogData;
 import io.opentelemetry.sdk.logging.export.LogExporter;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -14,12 +14,12 @@ import javax.annotation.Nullable;
 
 public class TestLogExporter implements LogExporter {
 
-  private final ArrayList<LogRecord> records = new ArrayList<>();
+  private final ArrayList<LogData> records = new ArrayList<>();
   @Nullable private Runnable onCall = null;
   private int callCount = 0;
 
   @Override
-  public synchronized CompletableResultCode export(Collection<LogRecord> records) {
+  public synchronized CompletableResultCode export(Collection<LogData> records) {
     this.records.addAll(records);
     callCount++;
     if (onCall != null) {
@@ -33,7 +33,7 @@ public class TestLogExporter implements LogExporter {
     return new CompletableResultCode().succeed();
   }
 
-  public synchronized ArrayList<LogRecord> getRecords() {
+  public synchronized ArrayList<LogData> getRecords() {
     return records;
   }
 


### PR DESCRIPTION
Adds a `LogData` interface, implemented by `LogRecord`. Also elevates `Severity` to a top level class. 

This PR is in response to this [convo](https://github.com/open-telemetry/opentelemetry-java/pull/3685#discussion_r725338939).

The goal of this is to continue to mature the logging SDK. It seems like the [json log exporter](https://github.com/open-telemetry/opentelemetry-java/pull/3685) PR is blocked because it a dependency on the alpha `:sdk-extensions:logging` module. The logging [data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md) is still experimental. The logging otlp protos are [beta](https://github.com/open-telemetry/opentelemetry-proto). Once the proto reaches stability, the separation of the interface / implementation would potentially allow the stable release of a limited set of log functionality while the data model / sdk spec mature. 