### PR TITLE
Add test tasks as dependencies to test report.

### DIFF
--- a/all/build.gradle.kts
+++ b/all/build.gradle.kts
@@ -22,6 +22,8 @@ tasks {
   }
 }
 
+val testTasks = mutableListOf<Task>()
+
 dependencies {
   rootProject.subprojects.forEach { subproject ->
     // Generate aggregate coverage report for published modules that enable jacoco.
@@ -29,6 +31,9 @@ dependencies {
       subproject.plugins.withId("maven-publish") {
         implementation(project(subproject.path)) {
           isTransitive = false
+        }
+        subproject.tasks.withType<Test>().configureEach {
+          testTasks.add(this)
         }
       }
     }
@@ -64,6 +69,8 @@ val coverageDataPath by configurations.creating {
 
 tasks.named<JacocoReport>("jacocoTestReport") {
   enabled = true
+
+  dependsOn(testTasks)
 
   configurations.runtimeClasspath.get().forEach {
     additionalClassDirs(


### PR DESCRIPTION
Without dependencies, we get deprecation warnings like this one

```
 - Gradle detected a problem with the following location: '/Users/aanuraag/git/opentelemetry-java/sdk-extensions/logging/build/jacoco/test.exec'. Reason: Task ':all:codeCoverageReport' uses this output of task ':sdk-extensions:logging:test' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```

This pattern isn't mentioned in the docs https://docs.gradle.org/current/samples/sample_jvm_multi_project_with_code_coverage.html but seems to have solved the warning.