### PR TITLE
Try disabling codecov report age check.

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -2,6 +2,7 @@ codecov:
   notify:
     require_ci_to_pass: yes
   strict_yaml_branch: main  # only use the latest copy on main branch
+  max_report_age: off
 
 coverage:
   precision: 2


### PR DESCRIPTION
To see if it makes codecov any more stable. One suspicion is if any part of the report is served from cache and having a too old age, the whole report gets dropped. As we always upload as part of the build, there seems to be no way to benefit from this check anyways.