### PR TITLE
Add a PropertySource SPI to allow autoconfigure to have defaults defi…

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
@@ -1,2 +1,5 @@
 Comparing source compatibility of  against 
-No changes.
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.autoconfigure.spi.PropertySource  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) java.util.Map getProperties()

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/PropertySource.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/PropertySource.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure.spi;
+
+import java.util.Map;
+
+/**
+ * A service provider interface (SPI) for providing default values for use in {@link
+ * ConfigProperties}. The order of precedence of properties is system properties > environment
+ * variables > PropertySource.
+ */
+public interface PropertySource {
+  /**
+   * Returns a string map containing the properties to be included in {@link ConfigProperties}. The
+   * keys should correspond to recognized system properties.
+   */
+  Map<String, String> getProperties();
+}

--- a/sdk-extensions/autoconfigure/build.gradle.kts
+++ b/sdk-extensions/autoconfigure/build.gradle.kts
@@ -53,10 +53,11 @@ dependencies {
   add("testFullConfigImplementation", project(":exporters:logging"))
   add("testFullConfigImplementation", project(":exporters:otlp:all"))
   add("testFullConfigImplementation", project(":exporters:otlp:metrics"))
-  add("testFullConfigImplementation", project(":exporters:prometheus"))
-  add("testFullConfigImplementation", "io.prometheus:simpleclient_httpserver")
   add("testFullConfigImplementation", project(":exporters:zipkin"))
+  add("testFullConfigImplementation", project(":exporters:prometheus"))
   add("testFullConfigImplementation", project(":sdk-extensions:resources"))
+  add("testFullConfigImplementation", "io.prometheus:simpleclient_httpserver")
+  add("testFullConfigImplementation", "org.junit-pioneer:junit-pioneer")
 
   add("testOtlpGrpcImplementation", project(":exporters:otlp:all"))
   add("testOtlpGrpcImplementation", project(":exporters:otlp:metrics"))

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/DefaultConfigPropertiesTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/DefaultConfigPropertiesTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.PropertySource;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+import org.junitpioneer.jupiter.SetSystemProperty;
+
+class DefaultConfigPropertiesTest {
+
+  @Test
+  void readsPropertySource() {
+    ConfigProperties config = DefaultConfigProperties.get();
+    assertThat(config.getString("animal")).isEqualTo("cat");
+    assertThat(config.getString("programming.language")).isEqualTo("java");
+    assertThat(config.getString("unknown")).isNull();
+  }
+
+  @Test
+  @SetEnvironmentVariable(key = "PROGRAMMING_LANGUAGE", value = "cobol")
+  void envOverrides() {
+    ConfigProperties config = DefaultConfigProperties.get();
+    assertThat(config.getString("animal")).isEqualTo("cat");
+    assertThat(config.getString("programming.language")).isEqualTo("cobol");
+    assertThat(config.getString("unknown")).isNull();
+  }
+
+  @Test
+  @SetSystemProperty(key = "programming-language", value = "cobol")
+  void propOverrides() {
+    ConfigProperties config = DefaultConfigProperties.get();
+    assertThat(config.getString("animal")).isEqualTo("cat");
+    assertThat(config.getString("programming.language")).isEqualTo("cobol");
+    assertThat(config.getString("unknown")).isNull();
+  }
+
+  public static class TestPropertySource implements PropertySource {
+    @Override
+    public Map<String, String> getProperties() {
+      Map<String, String> props = new HashMap<>();
+      props.put("animal", "cat");
+      props.put("programming-language", "java");
+      return props;
+    }
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.PropertySource
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.PropertySource
@@ -1,0 +1,1 @@
+io.opentelemetry.sdk.autoconfigure.DefaultConfigPropertiesTest$TestPropertySource


### PR DESCRIPTION
…ned.

The desire for the ability to tweak autoconfiguration config has come up in several situations

- Defining different defaults for a vendor distro of an autoconfiguration-based wrapper such as the AWS Lambda wrapper
- Falling back to sane defaults when user doesn't provide e.g., for service.name in the maven extension. A maven extension isn't a "service" in the traditional sense and unknown_service is a worse default than it could be
- The javaagent's file-based properties, which currently require the javaagent to reimplement the entire DefaultConfigProperties

I think more too - rule of three says this can be a good addition.