### PR TITLE
Allow attribute values to be null explicitly

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedAttributesBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedAttributesBuilder.java
@@ -8,6 +8,7 @@ package io.opentelemetry.api.common;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import javax.annotation.Nullable;
 
 class ArrayBackedAttributesBuilder implements AttributesBuilder {
   private final List<Object> data;
@@ -34,7 +35,7 @@ class ArrayBackedAttributesBuilder implements AttributesBuilder {
   }
 
   @Override
-  public <T> AttributesBuilder put(AttributeKey<T> key, T value) {
+  public <T> AttributesBuilder put(AttributeKey<T> key, @Nullable T value) {
     if (key == null || key.getKey().isEmpty() || value == null) {
       return this;
     }

--- a/api/all/src/main/java/io/opentelemetry/api/common/AttributesBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/AttributesBuilder.java
@@ -16,6 +16,7 @@ import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 import java.util.Arrays;
+import javax.annotation.Nullable;
 
 /** A builder of {@link Attributes} supporting an arbitrary number of key-value pairs. */
 public interface AttributesBuilder {
@@ -34,7 +35,7 @@ public interface AttributesBuilder {
   <T> AttributesBuilder put(AttributeKey<Long> key, int value);
 
   /** Puts a {@link AttributeKey} with associated value into this. */
-  <T> AttributesBuilder put(AttributeKey<T> key, T value);
+  <T> AttributesBuilder put(AttributeKey<T> key, @Nullable T value);
 
   /**
    * Puts a String attribute into this.
@@ -44,7 +45,7 @@ public interface AttributesBuilder {
    *
    * @return this Builder
    */
-  default AttributesBuilder put(String key, String value) {
+  default AttributesBuilder put(String key, @Nullable String value) {
     return put(stringKey(key), value);
   }
 

--- a/api/all/src/main/java/io/opentelemetry/api/trace/DefaultTracer.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/DefaultTracer.java
@@ -72,7 +72,7 @@ final class DefaultTracer implements Tracer {
     }
 
     @Override
-    public NoopSpanBuilder setAttribute(String key, String value) {
+    public NoopSpanBuilder setAttribute(String key, @Nullable String value) {
       return this;
     }
 
@@ -92,7 +92,7 @@ final class DefaultTracer implements Tracer {
     }
 
     @Override
-    public <T> NoopSpanBuilder setAttribute(AttributeKey<T> key, T value) {
+    public <T> NoopSpanBuilder setAttribute(AttributeKey<T> key, @Nullable T value) {
       return this;
     }
 

--- a/api/all/src/main/java/io/opentelemetry/api/trace/PropagatedSpan.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/PropagatedSpan.java
@@ -8,6 +8,7 @@ package io.opentelemetry.api.trace;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -42,7 +43,7 @@ final class PropagatedSpan implements Span {
   }
 
   @Override
-  public Span setAttribute(String key, String value) {
+  public Span setAttribute(String key, @Nullable String value) {
     return this;
   }
 
@@ -62,7 +63,7 @@ final class PropagatedSpan implements Span {
   }
 
   @Override
-  public <T> Span setAttribute(AttributeKey<T> key, T value) {
+  public <T> Span setAttribute(AttributeKey<T> key, @Nullable T value) {
     return this;
   }
 

--- a/api/all/src/main/java/io/opentelemetry/api/trace/Span.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/Span.java
@@ -94,7 +94,7 @@ public interface Span extends ImplicitContextKeyed {
    * @param value the value for this attribute.
    * @return this.
    */
-  default Span setAttribute(String key, String value) {
+  default Span setAttribute(String key, @Nullable String value) {
     return setAttribute(AttributeKey.stringKey(key), value);
   }
 
@@ -153,7 +153,7 @@ public interface Span extends ImplicitContextKeyed {
    * @param value the value for this attribute.
    * @return this.
    */
-  <T> Span setAttribute(AttributeKey<T> key, T value);
+  <T> Span setAttribute(AttributeKey<T> key, @Nullable T value);
 
   /**
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for

--- a/api/all/src/main/java/io/opentelemetry/api/trace/SpanBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/SpanBuilder.java
@@ -13,6 +13,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.context.Context;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 /**
  * {@link SpanBuilder} is used to construct {@link Span} instances which define arbitrary scopes of
@@ -175,7 +176,7 @@ public interface SpanBuilder {
    * @param value the value for this attribute.
    * @return this.
    */
-  SpanBuilder setAttribute(String key, String value);
+  SpanBuilder setAttribute(String key, @Nullable String value);
 
   /**
    * Sets an attribute to the newly created {@code Span}. If {@code SpanBuilder} previously
@@ -226,7 +227,7 @@ public interface SpanBuilder {
    * @param value the value for this attribute.
    * @return this.
    */
-  <T> SpanBuilder setAttribute(AttributeKey<T> key, T value);
+  <T> SpanBuilder setAttribute(AttributeKey<T> key, @Nullable T value);
 
   /**
    * Sets attributes to the {@link SpanBuilder}. If the {@link SpanBuilder} previously contained a

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
@@ -3,7 +3,7 @@ Comparing source compatibility of  against
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW INTERFACE: io.opentelemetry.sdk.trace.data.SpanData
 	+++  NEW SUPERCLASS: java.lang.Object
-	+++  NEW METHOD: PUBLIC(+) FINAL(+) boolean equals(java.lang.Object)
+	+++  NEW METHOD: PUBLIC(+) boolean equals(java.lang.Object)
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.common.Attributes getAttributes()
 	+++  NEW METHOD: PUBLIC(+) long getEndEpochNanos()
 	+++  NEW METHOD: PUBLIC(+) java.util.List getEvents()

--- a/extensions/noop-api/src/main/java/io/opentelemetry/extension/noopapi/NoopTracerProvider.java
+++ b/extensions/noop-api/src/main/java/io/opentelemetry/extension/noopapi/NoopTracerProvider.java
@@ -15,6 +15,7 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.Context;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 enum NoopTracerProvider implements TracerProvider {
   INSTANCE;
@@ -62,7 +63,7 @@ enum NoopTracerProvider implements TracerProvider {
     }
 
     @Override
-    public SpanBuilder setAttribute(String key, String value) {
+    public SpanBuilder setAttribute(String key, @Nullable String value) {
       return this;
     }
 
@@ -82,7 +83,7 @@ enum NoopTracerProvider implements TracerProvider {
     }
 
     @Override
-    public <T> SpanBuilder setAttribute(AttributeKey<T> key, T value) {
+    public <T> SpanBuilder setAttribute(AttributeKey<T> key, @Nullable T value) {
       return this;
     }
 

--- a/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/OpenTelemetryNoRecordEventsSpanImpl.java
+++ b/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/OpenTelemetryNoRecordEventsSpanImpl.java
@@ -37,7 +37,7 @@ import io.opentelemetry.api.trace.StatusCode;
 import java.util.EnumSet;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 class OpenTelemetryNoRecordEventsSpanImpl extends Span implements io.opentelemetry.api.trace.Span {
   private static final EnumSet<Options> NOT_RECORD_EVENTS_SPAN_OPTIONS =
@@ -109,7 +109,7 @@ class OpenTelemetryNoRecordEventsSpanImpl extends Span implements io.opentelemet
   }
 
   @Override
-  public io.opentelemetry.api.trace.Span setAttribute(String key, @Nonnull String value) {
+  public io.opentelemetry.api.trace.Span setAttribute(String key, @Nullable String value) {
     return this;
   }
 
@@ -129,7 +129,7 @@ class OpenTelemetryNoRecordEventsSpanImpl extends Span implements io.opentelemet
   }
 
   @Override
-  public <T> io.opentelemetry.api.trace.Span setAttribute(AttributeKey<T> key, @Nonnull T value) {
+  public <T> io.opentelemetry.api.trace.Span setAttribute(AttributeKey<T> key, @Nullable T value) {
     return this;
   }
 

--- a/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/OpenTelemetrySpanImpl.java
+++ b/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/OpenTelemetrySpanImpl.java
@@ -48,7 +48,7 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
-import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 class OpenTelemetrySpanImpl extends Span implements io.opentelemetry.api.trace.Span {
   private static final Logger LOGGER = Logger.getLogger(OpenTelemetrySpanImpl.class.getName());
@@ -135,7 +135,7 @@ class OpenTelemetrySpanImpl extends Span implements io.opentelemetry.api.trace.S
   }
 
   @Override
-  public <T> io.opentelemetry.api.trace.Span setAttribute(AttributeKey<T> key, @Nonnull T value) {
+  public <T> io.opentelemetry.api.trace.Span setAttribute(AttributeKey<T> key, @Nullable T value) {
     return otelSpan.setAttribute(key, value);
   }
 

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/resources/ResourceBuilder.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/resources/ResourceBuilder.java
@@ -29,7 +29,7 @@ public class ResourceBuilder {
    *
    * @return this Builder
    */
-  public ResourceBuilder put(String key, String value) {
+  public ResourceBuilder put(String key, @Nullable String value) {
     if (key != null && value != null) {
       attributesBuilder.put(key, value);
     }
@@ -142,7 +142,7 @@ public class ResourceBuilder {
   }
 
   /** Puts a {@link AttributeKey} with associated value into this. */
-  public <T> ResourceBuilder put(AttributeKey<T> key, T value) {
+  public <T> ResourceBuilder put(AttributeKey<T> key, @Nullable T value) {
     if (key != null && key.getKey() != null && !key.getKey().isEmpty() && value != null) {
       attributesBuilder.put(key, value);
     }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java
@@ -278,7 +278,7 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
   }
 
   @Override
-  public <T> ReadWriteSpan setAttribute(AttributeKey<T> key, T value) {
+  public <T> ReadWriteSpan setAttribute(AttributeKey<T> key, @Nullable T value) {
     if (key == null || key.getKey().isEmpty() || value == null) {
       return this;
     }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java
@@ -124,7 +124,7 @@ final class SdkSpanBuilder implements SpanBuilder {
   }
 
   @Override
-  public SpanBuilder setAttribute(String key, String value) {
+  public SpanBuilder setAttribute(String key, @Nullable String value) {
     return setAttribute(stringKey(key), value);
   }
 
@@ -144,7 +144,7 @@ final class SdkSpanBuilder implements SpanBuilder {
   }
 
   @Override
-  public <T> SpanBuilder setAttribute(AttributeKey<T> key, T value) {
+  public <T> SpanBuilder setAttribute(AttributeKey<T> key, @Nullable T value) {
     if (key == null || key.getKey().isEmpty() || value == null) {
       return this;
     }


### PR DESCRIPTION
In instrumentation, we've found it's very common to need to populate attributes that may or may not be there, depending on the type of request or conditions such as network failure. The attributes are applied generically, often through some interceptor type of mechanism, so all requests flow through despite populating different set of attributes.

Currently, we expect users of the attributes API to always check for null before sending in but I think this use case is common enough that we can explicitly support it, even though we prefer to reduce Nullable in our API where possible.