### PR TITLE
Use same pattern of compileOnly SDK dependencies in exporter-common

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
@@ -3,7 +3,7 @@ Comparing source compatibility of  against
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW INTERFACE: io.opentelemetry.sdk.trace.data.SpanData
 	+++  NEW SUPERCLASS: java.lang.Object
-	+++  NEW METHOD: PUBLIC(+) FINAL(+) boolean equals(java.lang.Object)
+	+++  NEW METHOD: PUBLIC(+) boolean equals(java.lang.Object)
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.common.Attributes getAttributes()
 	+++  NEW METHOD: PUBLIC(+) long getEndEpochNanos()
 	+++  NEW METHOD: PUBLIC(+) java.util.List getEvents()

--- a/exporters/logging-otlp/build.gradle.kts
+++ b/exporters/logging-otlp/build.gradle.kts
@@ -19,6 +19,8 @@ dependencies {
 
   testImplementation(project(":sdk:testing"))
   testImplementation(project(":sdk:logs"))
+  testImplementation(project(":sdk:metrics"))
+  testImplementation(project(":sdk:trace"))
 
   testImplementation("org.skyscreamer:jsonassert")
 }

--- a/exporters/otlp/common/build.gradle.kts
+++ b/exporters/otlp/common/build.gradle.kts
@@ -16,14 +16,15 @@ dependencies {
   protoSource("io.opentelemetry.proto:opentelemetry-proto:${versions["io.opentelemetry.proto"]}")
 
   api(project(":api:all"))
-  api(project(":sdk:all"))
-  api(project(":sdk:metrics"))
+  api(project(":api:metrics"))
+
+  compileOnly(project(":sdk:metrics"))
+  compileOnly(project(":sdk:trace"))
   compileOnly(project(":sdk:logs"))
 
+  // We include helpers shared by gRPC or okhttp exporters but do not want to impose these
+  // dependency on all of our consumers.
   compileOnly("com.fasterxml.jackson.core:jackson-core")
-
-  // Similar to above note about :proto, we include helpers shared by gRPC or okhttp exporters but
-  // do not want to impose these dependency on all of our consumers.
   compileOnly("com.squareup.okhttp3:okhttp")
   compileOnly("io.grpc:grpc-netty")
   compileOnly("io.grpc:grpc-netty-shaded")
@@ -32,6 +33,8 @@ dependencies {
 
   annotationProcessor("com.google.auto.value:auto-value")
 
+  testImplementation(project(":sdk:metrics"))
+  testImplementation(project(":sdk:trace"))
   testImplementation(project(":sdk:logs"))
   testImplementation(project(":sdk:testing"))
 


### PR DESCRIPTION
Notably, currently metrics SDK leaks into every exporter