### PR TITLE
Fix DelegatingSpanData#toString() typo

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/DelegatingSpanData.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/DelegatingSpanData.java
@@ -197,7 +197,7 @@ public abstract class DelegatingSpanData implements SpanData {
 
   @Override
   public String toString() {
-    return "SpanDataImpl{"
+    return "DelegatingSpanData{"
         + "spanContext="
         + getSpanContext()
         + ", "


### PR DESCRIPTION
Noticed this typo while working on something else. 