### PR TITLE
Extract common logic for HTTP exporters

### DIFF
--- a/exporters/otlp-http/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogExporter.java
+++ b/exporters/otlp-http/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogExporter.java
@@ -5,154 +5,31 @@
 
 package io.opentelemetry.exporter.otlp.http.logs;
 
-import io.opentelemetry.exporter.otlp.internal.ExporterMetrics;
-import io.opentelemetry.exporter.otlp.internal.ProtoRequestBody;
-import io.opentelemetry.exporter.otlp.internal.grpc.GrpcStatusUtil;
 import io.opentelemetry.exporter.otlp.internal.logs.LogsRequestMarshaler;
+import io.opentelemetry.exporter.otlp.internal.okhttp.OkHttpExporter;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.internal.ThrottlingLogger;
 import io.opentelemetry.sdk.logs.data.LogData;
 import io.opentelemetry.sdk.logs.export.LogExporter;
-import java.io.IOException;
 import java.util.Collection;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-import okhttp3.Call;
-import okhttp3.Callback;
-import okhttp3.Headers;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
-import okio.BufferedSink;
-import okio.GzipSink;
-import okio.Okio;
 
 /** Exports logs using OTLP via HTTP, using OpenTelemetry's protobuf model. */
 @ThreadSafe
 public final class OtlpHttpLogExporter implements LogExporter {
 
-  private static final Logger internalLogger =
-      Logger.getLogger(OtlpHttpLogExporter.class.getName());
+  private final OkHttpExporter<LogsRequestMarshaler> delegate;
 
-  private final ThrottlingLogger logger = new ThrottlingLogger(internalLogger);
-
-  private final ExporterMetrics exporterMetrics;
-  private final OkHttpClient client;
-  private final String endpoint;
-  @Nullable private final Headers headers;
-  private final boolean compressionEnabled;
-
-  OtlpHttpLogExporter(
-      OkHttpClient client, String endpoint, @Nullable Headers headers, boolean compressionEnabled) {
-    this.exporterMetrics = ExporterMetrics.createHttpProtobuf("log");
-    this.client = client;
-    this.endpoint = endpoint;
-    this.headers = headers;
-    this.compressionEnabled = compressionEnabled;
+  OtlpHttpLogExporter(OkHttpExporter<LogsRequestMarshaler> delegate) {
+    this.delegate = delegate;
   }
 
   /**
-   * Submits all the given logs in a single batch to the OpenTelemetry collector.
+   * Returns a new {@link OtlpHttpLogExporter} using the default values.
    *
-   * @param logs the list of sampled Logs to be exported.
-   * @return the result of the operation
+   * @return a new {@link OtlpHttpLogExporter} instance.
    */
-  @Override
-  public CompletableResultCode export(Collection<LogData> logs) {
-    exporterMetrics.addSeen(logs.size());
-
-    LogsRequestMarshaler exportRequest = LogsRequestMarshaler.create(logs);
-
-    Request.Builder requestBuilder = new Request.Builder().url(endpoint);
-    if (headers != null) {
-      requestBuilder.headers(headers);
-    }
-    RequestBody requestBody = new ProtoRequestBody(exportRequest);
-    if (compressionEnabled) {
-      requestBuilder.addHeader("Content-Encoding", "gzip");
-      requestBuilder.post(gzipRequestBody(requestBody));
-    } else {
-      requestBuilder.post(requestBody);
-    }
-
-    CompletableResultCode result = new CompletableResultCode();
-
-    client
-        .newCall(requestBuilder.build())
-        .enqueue(
-            new Callback() {
-              @Override
-              public void onFailure(Call call, IOException e) {
-                exporterMetrics.addFailed(logs.size());
-                logger.log(
-                    Level.SEVERE,
-                    "Failed to export logs. The request could not be executed. Full error message: "
-                        + e.getMessage());
-                result.fail();
-              }
-
-              @Override
-              public void onResponse(Call call, Response response) {
-                if (response.isSuccessful()) {
-                  exporterMetrics.addSuccess(logs.size());
-                  result.succeed();
-                  return;
-                }
-
-                exporterMetrics.addFailed(logs.size());
-                int code = response.code();
-
-                String status = extractErrorStatus(response);
-
-                logger.log(
-                    Level.WARNING,
-                    "Failed to export logs. Server responded with HTTP status code "
-                        + code
-                        + ". Error message: "
-                        + status);
-                result.fail();
-              }
-            });
-
-    return result;
-  }
-
-  private static RequestBody gzipRequestBody(RequestBody requestBody) {
-    return new RequestBody() {
-      @Override
-      public MediaType contentType() {
-        return requestBody.contentType();
-      }
-
-      @Override
-      public long contentLength() {
-        return -1;
-      }
-
-      @Override
-      public void writeTo(BufferedSink bufferedSink) throws IOException {
-        BufferedSink gzipSink = Okio.buffer(new GzipSink(bufferedSink));
-        requestBody.writeTo(gzipSink);
-        gzipSink.close();
-      }
-    };
-  }
-
-  private static String extractErrorStatus(Response response) {
-    ResponseBody responseBody = response.body();
-    if (responseBody == null) {
-      return "Response body missing, HTTP status message: " + response.message();
-    }
-    try {
-      return GrpcStatusUtil.getStatusMessage(responseBody.bytes());
-    } catch (IOException e) {
-      return "Unable to parse response body, HTTP status message: " + response.message();
-    }
+  public static OtlpHttpLogExporter getDefault() {
+    return builder().build();
   }
 
   /**
@@ -165,20 +42,20 @@ public final class OtlpHttpLogExporter implements LogExporter {
   }
 
   /**
-   * Returns a new {@link OtlpHttpLogExporter} using the default values.
+   * Submits all the given logs in a single batch to the OpenTelemetry collector.
    *
-   * @return a new {@link OtlpHttpLogExporter} instance.
+   * @param logs the list of sampled Logs to be exported.
+   * @return the result of the operation
    */
-  public static OtlpHttpLogExporter getDefault() {
-    return builder().build();
+  @Override
+  public CompletableResultCode export(Collection<LogData> logs) {
+    LogsRequestMarshaler exportRequest = LogsRequestMarshaler.create(logs);
+    return delegate.export(exportRequest, logs.size());
   }
 
   /** Shutdown the exporter. */
   @Override
   public CompletableResultCode shutdown() {
-    final CompletableResultCode result = CompletableResultCode.ofSuccess();
-    client.dispatcher().cancelAll();
-    exporterMetrics.unbind();
-    return result;
+    return delegate.shutdown();
   }
 }

--- a/exporters/otlp-http/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogExporterBuilder.java
+++ b/exporters/otlp-http/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogExporterBuilder.java
@@ -8,43 +8,36 @@ package io.opentelemetry.exporter.otlp.http.logs;
 import static io.opentelemetry.api.internal.Utils.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-import io.opentelemetry.exporter.otlp.internal.TlsUtil;
-import java.net.URI;
-import java.net.URISyntaxException;
+import io.opentelemetry.exporter.otlp.internal.logs.LogsRequestMarshaler;
+import io.opentelemetry.exporter.otlp.internal.okhttp.OkHttpExporterBuilder;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
-import javax.net.ssl.SSLException;
-import javax.net.ssl.X509TrustManager;
-import okhttp3.Headers;
-import okhttp3.OkHttpClient;
 
 /** Builder utility for {@link OtlpHttpLogExporter}. */
 public final class OtlpHttpLogExporterBuilder {
 
-  private static final long DEFAULT_TIMEOUT_SECS = 10;
   private static final String DEFAULT_ENDPOINT = "http://localhost:4318/v1/logs";
 
-  private long timeoutNanos = TimeUnit.SECONDS.toNanos(DEFAULT_TIMEOUT_SECS);
-  private String endpoint = DEFAULT_ENDPOINT;
-  private boolean compressionEnabled = false;
-  @Nullable private Headers.Builder headersBuilder;
-  @Nullable private byte[] trustedCertificatesPem;
+  private final OkHttpExporterBuilder<LogsRequestMarshaler> delegate;
+
+  OtlpHttpLogExporterBuilder() {
+    delegate = new OkHttpExporterBuilder<>("log", DEFAULT_ENDPOINT);
+  }
 
   /**
    * Sets the maximum time to wait for the collector to process an exported batch of logs. If unset,
-   * defaults to {@value DEFAULT_TIMEOUT_SECS}s.
+   * defaults to {@value OkHttpExporterBuilder#DEFAULT_TIMEOUT_SECS}s.
    */
   public OtlpHttpLogExporterBuilder setTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
     checkArgument(timeout >= 0, "timeout must be non-negative");
-    timeoutNanos = unit.toNanos(timeout);
+    delegate.setTimeout(timeout, unit);
     return this;
   }
 
   /**
    * Sets the maximum time to wait for the collector to process an exported batch of logs. If unset,
-   * defaults to {@value DEFAULT_TIMEOUT_SECS}s.
+   * defaults to {@value OkHttpExporterBuilder#DEFAULT_TIMEOUT_SECS}s.
    */
   public OtlpHttpLogExporterBuilder setTimeout(Duration timeout) {
     requireNonNull(timeout, "timeout");
@@ -57,21 +50,7 @@ public final class OtlpHttpLogExporterBuilder {
    */
   public OtlpHttpLogExporterBuilder setEndpoint(String endpoint) {
     requireNonNull(endpoint, "endpoint");
-
-    URI uri;
-    try {
-      uri = new URI(endpoint);
-    } catch (URISyntaxException e) {
-      throw new IllegalArgumentException("Invalid endpoint, must be a URL: " + endpoint, e);
-    }
-
-    if (uri.getScheme() == null
-        || (!uri.getScheme().equals("http") && !uri.getScheme().equals("https"))) {
-      throw new IllegalArgumentException(
-          "Invalid endpoint, must start with http:// or https://: " + uri);
-    }
-
-    this.endpoint = endpoint;
+    delegate.setEndpoint(endpoint);
     return this;
   }
 
@@ -84,18 +63,13 @@ public final class OtlpHttpLogExporterBuilder {
     checkArgument(
         compressionMethod.equals("gzip") || compressionMethod.equals("none"),
         "Unsupported compression method. Supported compression methods include: gzip, none.");
-    if (compressionMethod.equals("gzip")) {
-      this.compressionEnabled = true;
-    }
+    delegate.setCompression(compressionMethod);
     return this;
   }
 
   /** Add header to requests. */
   public OtlpHttpLogExporterBuilder addHeader(String key, String value) {
-    if (headersBuilder == null) {
-      headersBuilder = new Headers.Builder();
-    }
-    headersBuilder.add(key, value);
+    delegate.addHeader(key, value);
     return this;
   }
 
@@ -105,7 +79,7 @@ public final class OtlpHttpLogExporterBuilder {
    * use the system default trusted certificates.
    */
   public OtlpHttpLogExporterBuilder setTrustedCertificates(byte[] trustedCertificatesPem) {
-    this.trustedCertificatesPem = trustedCertificatesPem;
+    delegate.setTrustedCertificates(trustedCertificatesPem);
     return this;
   }
 
@@ -115,24 +89,6 @@ public final class OtlpHttpLogExporterBuilder {
    * @return a new exporter's instance
    */
   public OtlpHttpLogExporter build() {
-    OkHttpClient.Builder clientBuilder =
-        new OkHttpClient.Builder().callTimeout(Duration.ofNanos(timeoutNanos));
-
-    if (trustedCertificatesPem != null) {
-      try {
-        X509TrustManager trustManager = TlsUtil.trustManager(trustedCertificatesPem);
-        clientBuilder.sslSocketFactory(TlsUtil.sslSocketFactory(trustManager), trustManager);
-      } catch (SSLException e) {
-        throw new IllegalStateException(
-            "Could not set trusted certificate for OTLP HTTP connection, are they valid X.509 in PEM format?",
-            e);
-      }
-    }
-
-    Headers headers = headersBuilder == null ? null : headersBuilder.build();
-
-    return new OtlpHttpLogExporter(clientBuilder.build(), endpoint, headers, compressionEnabled);
+    return new OtlpHttpLogExporter(delegate.build());
   }
-
-  OtlpHttpLogExporterBuilder() {}
 }

--- a/exporters/otlp-http/logs/src/test/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogExporterTest.java
+++ b/exporters/otlp-http/logs/src/test/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogExporterTest.java
@@ -23,6 +23,7 @@ import com.linecorp.armeria.testing.junit5.server.mock.RecordedRequest;
 import io.github.netmikey.logunit.api.LogCapturer;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.exporter.otlp.internal.logs.ResourceLogsMarshaler;
+import io.opentelemetry.exporter.otlp.internal.okhttp.OkHttpExporter;
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceResponse;
 import io.opentelemetry.proto.logs.v1.ResourceLogs;
@@ -87,8 +88,7 @@ class OtlpHttpLogExporterTest {
         }
       };
 
-  @RegisterExtension
-  LogCapturer logs = LogCapturer.create().captureForType(OtlpHttpLogExporter.class);
+  @RegisterExtension LogCapturer logs = LogCapturer.create().captureForType(OkHttpExporter.class);
 
   private OtlpHttpLogExporterBuilder builder;
 

--- a/exporters/otlp-http/metrics/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporter.java
+++ b/exporters/otlp-http/metrics/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporter.java
@@ -5,164 +5,31 @@
 
 package io.opentelemetry.exporter.otlp.http.metrics;
 
-import io.opentelemetry.exporter.otlp.internal.ExporterMetrics;
-import io.opentelemetry.exporter.otlp.internal.ProtoRequestBody;
-import io.opentelemetry.exporter.otlp.internal.grpc.GrpcStatusUtil;
 import io.opentelemetry.exporter.otlp.internal.metrics.MetricsRequestMarshaler;
+import io.opentelemetry.exporter.otlp.internal.okhttp.OkHttpExporter;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.internal.ThrottlingLogger;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
-import java.io.IOException;
 import java.util.Collection;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-import okhttp3.Call;
-import okhttp3.Callback;
-import okhttp3.Headers;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
-import okio.BufferedSink;
-import okio.GzipSink;
-import okio.Okio;
 
 /** Exports metrics using OTLP via HTTP, using OpenTelemetry's protobuf model. */
 @ThreadSafe
 public final class OtlpHttpMetricExporter implements MetricExporter {
 
-  private static final Logger internalLogger =
-      Logger.getLogger(OtlpHttpMetricExporter.class.getName());
+  private final OkHttpExporter<MetricsRequestMarshaler> delegate;
 
-  private final ThrottlingLogger logger = new ThrottlingLogger(internalLogger);
-
-  private final ExporterMetrics exporterMetrics;
-  private final OkHttpClient client;
-  private final String endpoint;
-  @Nullable private final Headers headers;
-  private final boolean compressionEnabled;
-
-  OtlpHttpMetricExporter(
-      OkHttpClient client, String endpoint, @Nullable Headers headers, boolean compressionEnabled) {
-    this.exporterMetrics = ExporterMetrics.createHttpProtobuf("metric");
-    this.client = client;
-    this.endpoint = endpoint;
-    this.headers = headers;
-    this.compressionEnabled = compressionEnabled;
+  OtlpHttpMetricExporter(OkHttpExporter<MetricsRequestMarshaler> delegate) {
+    this.delegate = delegate;
   }
 
   /**
-   * Submits all the given metrics in a single batch to the OpenTelemetry collector.
+   * Returns a new {@link OtlpHttpMetricExporter} using the default values.
    *
-   * @param metrics the list of Metrics to be exported.
-   * @return the result of the operation
+   * @return a new {@link OtlpHttpMetricExporter} instance.
    */
-  @Override
-  public CompletableResultCode export(Collection<MetricData> metrics) {
-    exporterMetrics.addSeen(metrics.size());
-
-    MetricsRequestMarshaler exportRequest = MetricsRequestMarshaler.create(metrics);
-
-    Request.Builder requestBuilder = new Request.Builder().url(endpoint);
-    if (headers != null) {
-      requestBuilder.headers(headers);
-    }
-    RequestBody requestBody = new ProtoRequestBody(exportRequest);
-    if (compressionEnabled) {
-      requestBuilder.addHeader("Content-Encoding", "gzip");
-      requestBuilder.post(gzipRequestBody(requestBody));
-    } else {
-      requestBuilder.post(requestBody);
-    }
-
-    CompletableResultCode result = new CompletableResultCode();
-
-    client
-        .newCall(requestBuilder.build())
-        .enqueue(
-            new Callback() {
-              @Override
-              public void onFailure(Call call, IOException e) {
-                exporterMetrics.addFailed(metrics.size());
-                logger.log(
-                    Level.SEVERE,
-                    "Failed to export metrics. The request could not be executed. Full error message: "
-                        + e.getMessage());
-                result.fail();
-              }
-
-              @Override
-              public void onResponse(Call call, Response response) {
-                if (response.isSuccessful()) {
-                  exporterMetrics.addSuccess(metrics.size());
-                  result.succeed();
-                  return;
-                }
-
-                exporterMetrics.addFailed(metrics.size());
-                int code = response.code();
-
-                String status = extractErrorStatus(response);
-
-                logger.log(
-                    Level.WARNING,
-                    "Failed to export metrics. Server responded with HTTP status code "
-                        + code
-                        + ". Error message: "
-                        + status);
-                result.fail();
-              }
-            });
-
-    return result;
-  }
-
-  private static RequestBody gzipRequestBody(RequestBody requestBody) {
-    return new RequestBody() {
-      @Override
-      public MediaType contentType() {
-        return requestBody.contentType();
-      }
-
-      @Override
-      public long contentLength() {
-        return -1;
-      }
-
-      @Override
-      public void writeTo(BufferedSink bufferedSink) throws IOException {
-        BufferedSink gzipSink = Okio.buffer(new GzipSink(bufferedSink));
-        requestBody.writeTo(gzipSink);
-        gzipSink.close();
-      }
-    };
-  }
-
-  private static String extractErrorStatus(Response response) {
-    ResponseBody responseBody = response.body();
-    if (responseBody == null) {
-      return "Response body missing, HTTP status message: " + response.message();
-    }
-    try {
-      return GrpcStatusUtil.getStatusMessage(responseBody.bytes());
-    } catch (IOException e) {
-      return "Unable to parse response body, HTTP status message: " + response.message();
-    }
-  }
-
-  /**
-   * The OTLP exporter does not batch metrics, so this method will immediately return with success.
-   *
-   * @return always Success
-   */
-  @Override
-  public CompletableResultCode flush() {
-    return CompletableResultCode.ofSuccess();
+  public static OtlpHttpMetricExporter getDefault() {
+    return builder().build();
   }
 
   /**
@@ -175,20 +42,30 @@ public final class OtlpHttpMetricExporter implements MetricExporter {
   }
 
   /**
-   * Returns a new {@link OtlpHttpMetricExporter} using the default values.
+   * Submits all the given metrics in a single batch to the OpenTelemetry collector.
    *
-   * @return a new {@link OtlpHttpMetricExporter} instance.
+   * @param metrics the list of sampled Metrics to be exported.
+   * @return the result of the operation
    */
-  public static OtlpHttpMetricExporter getDefault() {
-    return builder().build();
+  @Override
+  public CompletableResultCode export(Collection<MetricData> metrics) {
+    MetricsRequestMarshaler exportRequest = MetricsRequestMarshaler.create(metrics);
+    return delegate.export(exportRequest, metrics.size());
+  }
+
+  /**
+   * The OTLP exporter does not batch metrics, so this method will immediately return with success.
+   *
+   * @return always Success
+   */
+  @Override
+  public CompletableResultCode flush() {
+    return CompletableResultCode.ofSuccess();
   }
 
   /** Shutdown the exporter. */
   @Override
   public CompletableResultCode shutdown() {
-    final CompletableResultCode result = CompletableResultCode.ofSuccess();
-    client.dispatcher().cancelAll();
-    exporterMetrics.unbind();
-    return result;
+    return delegate.shutdown();
   }
 }

--- a/exporters/otlp-http/metrics/src/test/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterTest.java
+++ b/exporters/otlp-http/metrics/src/test/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterTest.java
@@ -23,6 +23,7 @@ import com.linecorp.armeria.testing.junit5.server.mock.MockWebServerExtension;
 import io.github.netmikey.logunit.api.LogCapturer;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.exporter.otlp.internal.metrics.ResourceMetricsMarshaler;
+import io.opentelemetry.exporter.otlp.internal.okhttp.OkHttpExporter;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
 import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
@@ -83,8 +84,7 @@ class OtlpHttpMetricExporterTest {
         }
       };
 
-  @RegisterExtension
-  LogCapturer logs = LogCapturer.create().captureForType(OtlpHttpMetricExporter.class);
+  @RegisterExtension LogCapturer logs = LogCapturer.create().captureForType(OkHttpExporter.class);
 
   private OtlpHttpMetricExporterBuilder builder;
 

--- a/exporters/otlp-http/trace/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp-http/trace/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -8,43 +8,36 @@ package io.opentelemetry.exporter.otlp.http.trace;
 import static io.opentelemetry.api.internal.Utils.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-import io.opentelemetry.exporter.otlp.internal.TlsUtil;
-import java.net.URI;
-import java.net.URISyntaxException;
+import io.opentelemetry.exporter.otlp.internal.okhttp.OkHttpExporterBuilder;
+import io.opentelemetry.exporter.otlp.internal.traces.TraceRequestMarshaler;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
-import javax.net.ssl.SSLException;
-import javax.net.ssl.X509TrustManager;
-import okhttp3.Headers;
-import okhttp3.OkHttpClient;
 
 /** Builder utility for {@link OtlpHttpSpanExporter}. */
 public final class OtlpHttpSpanExporterBuilder {
 
-  private static final long DEFAULT_TIMEOUT_SECS = 10;
   private static final String DEFAULT_ENDPOINT = "http://localhost:4318/v1/traces";
 
-  private long timeoutNanos = TimeUnit.SECONDS.toNanos(DEFAULT_TIMEOUT_SECS);
-  private String endpoint = DEFAULT_ENDPOINT;
-  private boolean compressionEnabled = false;
-  @Nullable private Headers.Builder headersBuilder;
-  @Nullable private byte[] trustedCertificatesPem;
+  private final OkHttpExporterBuilder<TraceRequestMarshaler> delegate;
+
+  OtlpHttpSpanExporterBuilder() {
+    delegate = new OkHttpExporterBuilder<>("span", DEFAULT_ENDPOINT);
+  }
 
   /**
    * Sets the maximum time to wait for the collector to process an exported batch of spans. If
-   * unset, defaults to {@value DEFAULT_TIMEOUT_SECS}s.
+   * unset, defaults to {@value OkHttpExporterBuilder#DEFAULT_TIMEOUT_SECS}s.
    */
   public OtlpHttpSpanExporterBuilder setTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
     checkArgument(timeout >= 0, "timeout must be non-negative");
-    timeoutNanos = unit.toNanos(timeout);
+    delegate.setTimeout(timeout, unit);
     return this;
   }
 
   /**
    * Sets the maximum time to wait for the collector to process an exported batch of spans. If
-   * unset, defaults to {@value DEFAULT_TIMEOUT_SECS}s.
+   * unset, defaults to {@value OkHttpExporterBuilder#DEFAULT_TIMEOUT_SECS}s.
    */
   public OtlpHttpSpanExporterBuilder setTimeout(Duration timeout) {
     requireNonNull(timeout, "timeout");
@@ -57,21 +50,7 @@ public final class OtlpHttpSpanExporterBuilder {
    */
   public OtlpHttpSpanExporterBuilder setEndpoint(String endpoint) {
     requireNonNull(endpoint, "endpoint");
-
-    URI uri;
-    try {
-      uri = new URI(endpoint);
-    } catch (URISyntaxException e) {
-      throw new IllegalArgumentException("Invalid endpoint, must be a URL: " + endpoint, e);
-    }
-
-    if (uri.getScheme() == null
-        || (!uri.getScheme().equals("http") && !uri.getScheme().equals("https"))) {
-      throw new IllegalArgumentException(
-          "Invalid endpoint, must start with http:// or https://: " + uri);
-    }
-
-    this.endpoint = endpoint;
+    delegate.setEndpoint(endpoint);
     return this;
   }
 
@@ -84,18 +63,13 @@ public final class OtlpHttpSpanExporterBuilder {
     checkArgument(
         compressionMethod.equals("gzip") || compressionMethod.equals("none"),
         "Unsupported compression method. Supported compression methods include: gzip, none.");
-    if (compressionMethod.equals("gzip")) {
-      this.compressionEnabled = true;
-    }
+    delegate.setCompression(compressionMethod);
     return this;
   }
 
   /** Add header to requests. */
   public OtlpHttpSpanExporterBuilder addHeader(String key, String value) {
-    if (headersBuilder == null) {
-      headersBuilder = new Headers.Builder();
-    }
-    headersBuilder.add(key, value);
+    delegate.addHeader(key, value);
     return this;
   }
 
@@ -105,7 +79,7 @@ public final class OtlpHttpSpanExporterBuilder {
    * use the system default trusted certificates.
    */
   public OtlpHttpSpanExporterBuilder setTrustedCertificates(byte[] trustedCertificatesPem) {
-    this.trustedCertificatesPem = trustedCertificatesPem;
+    delegate.setTrustedCertificates(trustedCertificatesPem);
     return this;
   }
 
@@ -115,24 +89,6 @@ public final class OtlpHttpSpanExporterBuilder {
    * @return a new exporter's instance
    */
   public OtlpHttpSpanExporter build() {
-    OkHttpClient.Builder clientBuilder =
-        new OkHttpClient.Builder().callTimeout(Duration.ofNanos(timeoutNanos));
-
-    if (trustedCertificatesPem != null) {
-      try {
-        X509TrustManager trustManager = TlsUtil.trustManager(trustedCertificatesPem);
-        clientBuilder.sslSocketFactory(TlsUtil.sslSocketFactory(trustManager), trustManager);
-      } catch (SSLException e) {
-        throw new IllegalStateException(
-            "Could not set trusted certificate for OTLP HTTP connection, are they valid X.509 in PEM format?",
-            e);
-      }
-    }
-
-    Headers headers = headersBuilder == null ? null : headersBuilder.build();
-
-    return new OtlpHttpSpanExporter(clientBuilder.build(), endpoint, headers, compressionEnabled);
+    return new OtlpHttpSpanExporter(delegate.build());
   }
-
-  OtlpHttpSpanExporterBuilder() {}
 }

--- a/exporters/otlp-http/trace/src/test/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterTest.java
+++ b/exporters/otlp-http/trace/src/test/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterTest.java
@@ -25,6 +25,7 @@ import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.exporter.otlp.internal.okhttp.OkHttpExporter;
 import io.opentelemetry.exporter.otlp.internal.traces.ResourceSpansMarshaler;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
@@ -86,8 +87,7 @@ class OtlpHttpSpanExporterTest {
         }
       };
 
-  @RegisterExtension
-  LogCapturer logs = LogCapturer.create().captureForType(OtlpHttpSpanExporter.class);
+  @RegisterExtension LogCapturer logs = LogCapturer.create().captureForType(OkHttpExporter.class);
 
   private OtlpHttpSpanExporterBuilder builder;
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/okhttp/OkHttpExporter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/okhttp/OkHttpExporter.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal.okhttp;
+
+import io.opentelemetry.exporter.otlp.internal.ExporterMetrics;
+import io.opentelemetry.exporter.otlp.internal.Marshaler;
+import io.opentelemetry.exporter.otlp.internal.grpc.GrpcStatusUtil;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.internal.ThrottlingLogger;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Headers;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okio.BufferedSink;
+import okio.GzipSink;
+import okio.Okio;
+
+/** An exporter for http/protobuf using a signal-specific Marshaler. */
+@SuppressWarnings("checkstyle:JavadocMethod")
+public final class OkHttpExporter<T extends Marshaler> {
+
+  private static final Logger internalLogger = Logger.getLogger(OkHttpExporter.class.getName());
+
+  private final ThrottlingLogger logger = new ThrottlingLogger(internalLogger);
+
+  private final String type;
+  private final OkHttpClient client;
+  private final String endpoint;
+  @Nullable private final Headers headers;
+  private final boolean compressionEnabled;
+
+  private final ExporterMetrics exporterMetrics;
+
+  OkHttpExporter(
+      String type,
+      OkHttpClient client,
+      String endpoint,
+      @Nullable Headers headers,
+      boolean compressionEnabled) {
+    this.type = type;
+    this.client = client;
+    this.endpoint = endpoint;
+    this.headers = headers;
+    this.compressionEnabled = compressionEnabled;
+
+    this.exporterMetrics = ExporterMetrics.createHttpProtobuf(type);
+  }
+
+  public CompletableResultCode export(T exportRequest, int numItems) {
+    exporterMetrics.addSeen(numItems);
+
+    Request.Builder requestBuilder = new Request.Builder().url(endpoint);
+    if (headers != null) {
+      requestBuilder.headers(headers);
+    }
+    RequestBody requestBody = new ProtoRequestBody(exportRequest);
+    if (compressionEnabled) {
+      requestBuilder.addHeader("Content-Encoding", "gzip");
+      requestBuilder.post(gzipRequestBody(requestBody));
+    } else {
+      requestBuilder.post(requestBody);
+    }
+
+    CompletableResultCode result = new CompletableResultCode();
+
+    client
+        .newCall(requestBuilder.build())
+        .enqueue(
+            new Callback() {
+              @Override
+              public void onFailure(Call call, IOException e) {
+                exporterMetrics.addFailed(numItems);
+                logger.log(
+                    Level.SEVERE,
+                    "Failed to export "
+                        + type
+                        + "s. The request could not be executed. Full error message: "
+                        + e.getMessage());
+                result.fail();
+              }
+
+              @Override
+              public void onResponse(Call call, Response response) {
+                if (response.isSuccessful()) {
+                  exporterMetrics.addSuccess(numItems);
+                  result.succeed();
+                  return;
+                }
+
+                exporterMetrics.addFailed(numItems);
+                int code = response.code();
+
+                String status = extractErrorStatus(response);
+
+                logger.log(
+                    Level.WARNING,
+                    "Failed to export "
+                        + type
+                        + "s. Server responded with HTTP status code "
+                        + code
+                        + ". Error message: "
+                        + status);
+                result.fail();
+              }
+            });
+
+    return result;
+  }
+
+  public CompletableResultCode shutdown() {
+    final CompletableResultCode result = CompletableResultCode.ofSuccess();
+    client.dispatcher().cancelAll();
+    client.dispatcher().executorService().shutdownNow();
+    exporterMetrics.unbind();
+    return result;
+  }
+
+  private static RequestBody gzipRequestBody(RequestBody requestBody) {
+    return new RequestBody() {
+      @Override
+      public MediaType contentType() {
+        return requestBody.contentType();
+      }
+
+      @Override
+      public long contentLength() {
+        return -1;
+      }
+
+      @Override
+      public void writeTo(BufferedSink bufferedSink) throws IOException {
+        BufferedSink gzipSink = Okio.buffer(new GzipSink(bufferedSink));
+        requestBody.writeTo(gzipSink);
+        gzipSink.close();
+      }
+    };
+  }
+
+  private static String extractErrorStatus(Response response) {
+    ResponseBody responseBody = response.body();
+    if (responseBody == null) {
+      return "Response body missing, HTTP status message: " + response.message();
+    }
+    try {
+      return GrpcStatusUtil.getStatusMessage(responseBody.bytes());
+    } catch (IOException e) {
+      return "Unable to parse response body, HTTP status message: " + response.message();
+    }
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/okhttp/OkHttpExporterBuilder.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/okhttp/OkHttpExporterBuilder.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal.okhttp;
+
+import io.opentelemetry.exporter.otlp.internal.Marshaler;
+import io.opentelemetry.exporter.otlp.internal.TlsUtil;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.X509TrustManager;
+import okhttp3.Headers;
+import okhttp3.OkHttpClient;
+
+/** A builder for {@link OkHttpExporter}. */
+@SuppressWarnings("checkstyle:JavadocMethod")
+public final class OkHttpExporterBuilder<T extends Marshaler> {
+  public static final long DEFAULT_TIMEOUT_SECS = 10;
+
+  private final String type;
+
+  private String endpoint;
+
+  private long timeoutNanos = TimeUnit.SECONDS.toNanos(DEFAULT_TIMEOUT_SECS);
+  private boolean compressionEnabled = false;
+  @Nullable private Headers.Builder headersBuilder;
+  @Nullable private byte[] trustedCertificatesPem;
+
+  public OkHttpExporterBuilder(String type, String defaultEndpoint) {
+    this.type = type;
+
+    endpoint = defaultEndpoint;
+  }
+
+  public OkHttpExporterBuilder<T> setTimeout(long timeout, TimeUnit unit) {
+    timeoutNanos = unit.toNanos(timeout);
+    return this;
+  }
+
+  public OkHttpExporterBuilder<T> setTimeout(Duration timeout) {
+    return setTimeout(timeout.toNanos(), TimeUnit.NANOSECONDS);
+  }
+
+  public OkHttpExporterBuilder<T> setEndpoint(String endpoint) {
+    URI uri;
+    try {
+      uri = new URI(endpoint);
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException("Invalid endpoint, must be a URL: " + endpoint, e);
+    }
+
+    if (uri.getScheme() == null
+        || (!uri.getScheme().equals("http") && !uri.getScheme().equals("https"))) {
+      throw new IllegalArgumentException(
+          "Invalid endpoint, must start with http:// or https://: " + uri);
+    }
+
+    this.endpoint = endpoint;
+    return this;
+  }
+
+  public OkHttpExporterBuilder<T> setCompression(String compressionMethod) {
+    if (compressionMethod.equals("gzip")) {
+      this.compressionEnabled = true;
+    }
+    return this;
+  }
+
+  public OkHttpExporterBuilder<T> addHeader(String key, String value) {
+    if (headersBuilder == null) {
+      headersBuilder = new Headers.Builder();
+    }
+    headersBuilder.add(key, value);
+    return this;
+  }
+
+  public OkHttpExporterBuilder<T> setTrustedCertificates(byte[] trustedCertificatesPem) {
+    this.trustedCertificatesPem = trustedCertificatesPem;
+    return this;
+  }
+
+  public OkHttpExporter<T> build() {
+    OkHttpClient.Builder clientBuilder =
+        new OkHttpClient.Builder().callTimeout(Duration.ofNanos(timeoutNanos));
+
+    if (trustedCertificatesPem != null) {
+      try {
+        X509TrustManager trustManager = TlsUtil.trustManager(trustedCertificatesPem);
+        clientBuilder.sslSocketFactory(TlsUtil.sslSocketFactory(trustManager), trustManager);
+      } catch (SSLException e) {
+        throw new IllegalStateException(
+            "Could not set trusted certificate for OTLP HTTP connection, are they valid X.509 in PEM format?",
+            e);
+      }
+    }
+
+    Headers headers = headersBuilder == null ? null : headersBuilder.build();
+
+    return new OkHttpExporter<>(type, clientBuilder.build(), endpoint, headers, compressionEnabled);
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/okhttp/ProtoRequestBody.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/okhttp/ProtoRequestBody.java
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.exporter.otlp.internal;
+package io.opentelemetry.exporter.otlp.internal.okhttp;
 
+import io.opentelemetry.exporter.otlp.internal.Marshaler;
 import java.io.IOException;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/okhttp/package-info.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/okhttp/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** Utilities for HTTP exporters. */
+@ParametersAreNonnullByDefault
+package io.opentelemetry.exporter.otlp.internal.okhttp;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk-extensions/autoconfigure/src/testOtlpHttp/java/io/opentelemetry/sdk/autoconfigure/OtlpHttpConfigTest.java
+++ b/sdk-extensions/autoconfigure/src/testOtlpHttp/java/io/opentelemetry/sdk/autoconfigure/OtlpHttpConfigTest.java
@@ -184,7 +184,7 @@ class OtlpHttpConfigTest {
         MetricExporterConfiguration.configureOtlpMetrics(properties, SdkMeterProvider.builder());
 
     assertThat(spanExporter)
-        .extracting("client", as(InstanceOfAssertFactories.type(OkHttpClient.class)))
+        .extracting("delegate.client", as(InstanceOfAssertFactories.type(OkHttpClient.class)))
         .extracting(OkHttpClient::callTimeoutMillis)
         .isEqualTo((int) TimeUnit.SECONDS.toMillis(15));
     assertThat(
@@ -202,7 +202,7 @@ class OtlpHttpConfigTest {
                     && headers.contains("content-encoding", "gzip"));
 
     assertThat(metricExporter)
-        .extracting("client", as(InstanceOfAssertFactories.type(OkHttpClient.class)))
+        .extracting("delegate.client", as(InstanceOfAssertFactories.type(OkHttpClient.class)))
         .extracting(OkHttpClient::callTimeoutMillis)
         .isEqualTo((int) TimeUnit.SECONDS.toMillis(15));
     assertThat(
@@ -244,7 +244,7 @@ class OtlpHttpConfigTest {
             "otlp", DefaultConfigProperties.createForTest(props), Collections.emptyMap());
 
     assertThat(spanExporter)
-        .extracting("client", as(InstanceOfAssertFactories.type(OkHttpClient.class)))
+        .extracting("delegate.client", as(InstanceOfAssertFactories.type(OkHttpClient.class)))
         .extracting(OkHttpClient::callTimeoutMillis)
         .isEqualTo((int) TimeUnit.SECONDS.toMillis(15));
     assertThat(
@@ -286,7 +286,7 @@ class OtlpHttpConfigTest {
             DefaultConfigProperties.createForTest(props), SdkMeterProvider.builder());
 
     assertThat(metricExporter)
-        .extracting("client", as(InstanceOfAssertFactories.type(OkHttpClient.class)))
+        .extracting("delegate.client", as(InstanceOfAssertFactories.type(OkHttpClient.class)))
         .extracting(OkHttpClient::callTimeoutMillis)
         .isEqualTo((int) TimeUnit.SECONDS.toMillis(15));
     assertThat(


### PR DESCRIPTION
Primarily motivated by being needed for #3786 to have a consistent okhttp in the codebase (shaded). But nice code reduction too :-)