### PR TITLE
Remove AggregationTemporality from View configuration API

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorage.java
@@ -38,7 +38,6 @@ public final class AsynchronousMetricStorage<T> implements MetricStorage {
   private final AsyncAccumulator<T> asyncAccumulator;
   private final TemporalMetricStorage<T> storage;
   private final Runnable metricUpdater;
-  @Nullable private final AggregationTemporality configuredTemporality;
 
   /** Constructs asynchronous metric storage which stores nothing. */
   public static MetricStorage empty() {
@@ -78,11 +77,7 @@ public final class AsynchronousMetricStorage<T> implements MetricStorage {
           }
         };
     return new AsynchronousMetricStorage<>(
-        metricDescriptor,
-        aggregator,
-        measurementAccumulator,
-        () -> metricUpdater.accept(result),
-        view.getAggregation().getConfiguredTemporality());
+        metricDescriptor, aggregator, measurementAccumulator, () -> metricUpdater.accept(result));
   }
 
   /** Constructs storage for {@code long} valued instruments. */
@@ -114,24 +109,18 @@ public final class AsynchronousMetricStorage<T> implements MetricStorage {
           }
         };
     return new AsynchronousMetricStorage<>(
-        metricDescriptor,
-        aggregator,
-        measurementAccumulator,
-        () -> metricUpdater.accept(result),
-        view.getAggregation().getConfiguredTemporality());
+        metricDescriptor, aggregator, measurementAccumulator, () -> metricUpdater.accept(result));
   }
 
   private AsynchronousMetricStorage(
       MetricDescriptor metricDescriptor,
       Aggregator<T> aggregator,
       AsyncAccumulator<T> asyncAccumulator,
-      Runnable metricUpdater,
-      @Nullable AggregationTemporality configuredTemporality) {
+      Runnable metricUpdater) {
     this.metricDescriptor = metricDescriptor;
     this.asyncAccumulator = asyncAccumulator;
     this.metricUpdater = metricUpdater;
     this.storage = new TemporalMetricStorage<>(aggregator, /* isSynchronous= */ false);
-    this.configuredTemporality = configuredTemporality;
   }
 
   @Override
@@ -145,9 +134,7 @@ public final class AsynchronousMetricStorage<T> implements MetricStorage {
       boolean suppressSynchronousCollection) {
     AggregationTemporality temporality =
         TemporalityUtils.resolveTemporality(
-            collectionInfo.getSupportedAggregation(),
-            collectionInfo.getPreferredAggregation(),
-            configuredTemporality);
+            collectionInfo.getSupportedAggregation(), collectionInfo.getPreferredAggregation());
     collectLock.lock();
     try {
       metricUpdater.run();

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java
@@ -30,18 +30,15 @@ public final class DefaultSynchronousMetricStorage<T> implements SynchronousMetr
   private final DeltaMetricStorage<T> deltaMetricStorage;
   private final TemporalMetricStorage<T> temporalMetricStorage;
   private final AttributesProcessor attributesProcessor;
-  @Nullable private final AggregationTemporality configuredTemporality;
 
   DefaultSynchronousMetricStorage(
       MetricDescriptor metricDescriptor,
       Aggregator<T> aggregator,
-      AttributesProcessor attributesProcessor,
-      @Nullable AggregationTemporality configuredTemporality) {
+      AttributesProcessor attributesProcessor) {
     this.attributesProcessor = attributesProcessor;
     this.metricDescriptor = metricDescriptor;
     this.deltaMetricStorage = new DeltaMetricStorage<>(aggregator);
     this.temporalMetricStorage = new TemporalMetricStorage<>(aggregator, /* isSynchronous= */ true);
-    this.configuredTemporality = configuredTemporality;
   }
 
   // This is a storage handle to use when the attributes processor requires
@@ -108,9 +105,7 @@ public final class DefaultSynchronousMetricStorage<T> implements SynchronousMetr
       boolean suppressSynchronousCollection) {
     AggregationTemporality temporality =
         TemporalityUtils.resolveTemporality(
-            collectionInfo.getSupportedAggregation(),
-            collectionInfo.getPreferredAggregation(),
-            configuredTemporality);
+            collectionInfo.getSupportedAggregation(), collectionInfo.getPreferredAggregation());
     Map<Attributes, T> result =
         deltaMetricStorage.collectFor(
             collectionInfo.getCollector(),

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorage.java
@@ -46,9 +46,6 @@ public interface SynchronousMetricStorage extends MetricStorage, WriteableMetric
       return empty();
     }
     return new DefaultSynchronousMetricStorage<>(
-        metricDescriptor,
-        aggregator,
-        view.getAttributesProcessor(),
-        view.getAggregation().getConfiguredTemporality());
+        metricDescriptor, aggregator, view.getAttributesProcessor());
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/TemporalityUtils.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/TemporalityUtils.java
@@ -17,16 +17,9 @@ final class TemporalityUtils {
    *
    * @param supported All aggregation temporalities supported by the exporter.
    * @param preferred The preferred temporality of the exporter.
-   * @param configured The aggregation temporality configured via the View interface.
    */
   static AggregationTemporality resolveTemporality(
-      EnumSet<AggregationTemporality> supported,
-      @Nullable AggregationTemporality preferred,
-      @Nullable AggregationTemporality configured) {
-    // Return the configured temporality, if it exists and is supported.
-    if (configured != null && supported.contains(configured)) {
-      return configured;
-    }
+      EnumSet<AggregationTemporality> supported, @Nullable AggregationTemporality preferred) {
     // Next assume preferred should always win.
     if (preferred != null) {
       return preferred;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/Aggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/Aggregation.java
@@ -6,10 +6,8 @@
 package io.opentelemetry.sdk.metrics.view;
 
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
-import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
-import io.opentelemetry.sdk.metrics.internal.aggregator.ExplicitBucketHistogramUtils;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -33,16 +31,6 @@ public abstract class Aggregation {
   public abstract <T> Aggregator<T> createAggregator(
       InstrumentDescriptor instrumentDescriptor, ExemplarFilter exemplarFilter);
 
-  /**
-   * Returns the user-configured {@link AggregationTemporality} for this aggregation.
-   *
-   * @return the temporality, or {code null} if no temporality was specified.
-   */
-  @Nullable
-  public AggregationTemporality getConfiguredTemporality() {
-    return null;
-  }
-
   /** The None Aggregation will ignore/drop all Instrument Measurements. */
   public static Aggregation none() {
     return NoAggregation.INSTANCE;
@@ -51,11 +39,6 @@ public abstract class Aggregation {
   /** The default aggregation for an instrument will be chosen. */
   public static Aggregation defaultAggregation() {
     return DefaultAggregation.INSTANCE;
-  }
-
-  /** Instrument measurements will be combined into a metric Sum. */
-  public static Aggregation sum(AggregationTemporality temporality) {
-    return new SumAggregation(temporality);
   }
 
   /** Instrument measurements will be combined into a metric Sum. */
@@ -76,35 +59,13 @@ public abstract class Aggregation {
   }
 
   /**
-   * Aggregates measurements into an explicit bucket histogram using the default bucket boundaries.
-   *
-   * @param temporality Whether to report DELTA or CUMULATIVE metrics.
-   */
-  public static Aggregation explicitBucketHistogram(AggregationTemporality temporality) {
-    return explicitBucketHistogram(
-        temporality, ExplicitBucketHistogramUtils.DEFAULT_HISTOGRAM_BUCKET_BOUNDARIES);
-  }
-
-  /**
    * Aggregates measurements into an explicit bucket histogram.
    *
    * @param bucketBoundaries A list of (inclusive) upper bounds for the histogram. Should be in
    *     order from lowest to highest.
    */
   public static Aggregation explicitBucketHistogram(List<Double> bucketBoundaries) {
-    return new ExplicitBucketHistogramAggregation(null, bucketBoundaries);
-  }
-
-  /**
-   * Aggregates measurements into an explicit bucket histogram.
-   *
-   * @param temporality Whether to report DELTA or CUMULATIVE metrics.
-   * @param bucketBoundaries A list of (inclusive) upper bounds for the histogram. Should be in
-   *     order from lowest to highest.
-   */
-  public static Aggregation explicitBucketHistogram(
-      AggregationTemporality temporality, List<Double> bucketBoundaries) {
-    return new ExplicitBucketHistogramAggregation(temporality, bucketBoundaries);
+    return new ExplicitBucketHistogramAggregation(bucketBoundaries);
   }
 
   /** Aggregates measurements using the best available Histogram. */

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/ExplicitBucketHistogramAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/ExplicitBucketHistogramAggregation.java
@@ -7,29 +7,24 @@ package io.opentelemetry.sdk.metrics.view;
 
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
-import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarReservoir;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.DoubleHistogramAggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.ExplicitBucketHistogramUtils;
 import java.util.List;
-import javax.annotation.Nullable;
 
 /** Explicit bucket histogram aggregation configuration. */
 class ExplicitBucketHistogramAggregation extends Aggregation {
 
   static final Aggregation DEFAULT =
       new ExplicitBucketHistogramAggregation(
-          null, ExplicitBucketHistogramUtils.DEFAULT_HISTOGRAM_BUCKET_BOUNDARIES);
+          ExplicitBucketHistogramUtils.DEFAULT_HISTOGRAM_BUCKET_BOUNDARIES);
 
-  @Nullable private final AggregationTemporality temporality;
   private final List<Double> bucketBoundaries;
   private final double[] bucketBoundaryArray;
 
-  ExplicitBucketHistogramAggregation(
-      @Nullable AggregationTemporality temporality, List<Double> bucketBoundaries) {
-    this.temporality = temporality;
+  ExplicitBucketHistogramAggregation(List<Double> bucketBoundaries) {
     this.bucketBoundaries = bucketBoundaries;
     // We need to fail here if our bucket boundaries are ill-configured.
     this.bucketBoundaryArray = ExplicitBucketHistogramUtils.createBoundaryArray(bucketBoundaries);
@@ -38,12 +33,6 @@ class ExplicitBucketHistogramAggregation extends Aggregation {
   /** Returns the configured bucket boundaries for the histogram aggregation. */
   public List<Double> getBucketBoundaries() {
     return bucketBoundaries;
-  }
-
-  @Override
-  @Nullable
-  public AggregationTemporality getConfiguredTemporality() {
-    return temporality;
   }
 
   @Override
@@ -62,6 +51,6 @@ class ExplicitBucketHistogramAggregation extends Aggregation {
 
   @Override
   public String toString() {
-    return "ExplicitBucketHistogramAggregation(" + temporality + ")";
+    return "ExplicitBucketHistogramAggregation(" + bucketBoundaries.toString() + ")";
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/SumAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/SumAggregation.java
@@ -8,29 +8,18 @@ package io.opentelemetry.sdk.metrics.view;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.internal.RandomSupplier;
 import io.opentelemetry.sdk.metrics.common.InstrumentDescriptor;
-import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarReservoir;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.DoubleSumAggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.LongSumAggregator;
 import java.util.function.Supplier;
-import javax.annotation.Nullable;
 
 /** A sum aggregation configuration. */
 class SumAggregation extends Aggregation {
-  static final SumAggregation DEFAULT = new SumAggregation(null);
+  static final SumAggregation DEFAULT = new SumAggregation();
 
-  @Nullable private final AggregationTemporality temporality;
-
-  SumAggregation(@Nullable AggregationTemporality temporality) {
-    this.temporality = temporality;
-  }
-
-  @Override
-  public AggregationTemporality getConfiguredTemporality() {
-    return temporality;
-  }
+  private SumAggregation() {}
 
   @Override
   @SuppressWarnings("unchecked")
@@ -55,6 +44,6 @@ class SumAggregation extends Aggregation {
 
   @Override
   public String toString() {
-    return "SumAggregation(" + temporality + ")";
+    return "SumAggregation";
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleSumObserverTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleSumObserverTest.java
@@ -11,7 +11,6 @@ import static io.opentelemetry.sdk.testing.assertj.metrics.MetricAssertions.asse
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
-import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.testing.InMemoryMetricReader;
 import io.opentelemetry.sdk.metrics.view.Aggregation;
 import io.opentelemetry.sdk.metrics.view.InstrumentSelector;
@@ -110,7 +109,7 @@ class SdkDoubleSumObserverTest {
   @Test
   @SuppressWarnings("unchecked")
   void collectMetrics_DeltaSumAggregator() {
-    InMemoryMetricReader sdkMeterReader = InMemoryMetricReader.create();
+    InMemoryMetricReader sdkMeterReader = InMemoryMetricReader.createDelta();
     SdkMeterProvider sdkMeterProvider =
         sdkMeterProviderBuilder
             .registerMetricReader(sdkMeterReader)
@@ -118,9 +117,7 @@ class SdkDoubleSumObserverTest {
                 InstrumentSelector.builder()
                     .setInstrumentType(InstrumentType.OBSERVABLE_SUM)
                     .build(),
-                View.builder()
-                    .setAggregation(Aggregation.sum(AggregationTemporality.DELTA))
-                    .build())
+                View.builder().setAggregation(Aggregation.sum()).build())
             .build();
     sdkMeterProvider
         .get(getClass().getName())

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleUpDownSumObserverTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleUpDownSumObserverTest.java
@@ -11,7 +11,6 @@ import static io.opentelemetry.sdk.testing.assertj.metrics.MetricAssertions.asse
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
-import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.testing.InMemoryMetricReader;
 import io.opentelemetry.sdk.metrics.view.Aggregation;
 import io.opentelemetry.sdk.metrics.view.InstrumentSelector;
@@ -106,7 +105,7 @@ class SdkDoubleUpDownSumObserverTest {
   @Test
   @SuppressWarnings("unchecked")
   void collectMetrics_DeltaSumAggregator() {
-    InMemoryMetricReader sdkMeterReader = InMemoryMetricReader.create();
+    InMemoryMetricReader sdkMeterReader = InMemoryMetricReader.createDelta();
     SdkMeterProvider sdkMeterProvider =
         sdkMeterProviderBuilder
             .registerMetricReader(sdkMeterReader)
@@ -114,9 +113,7 @@ class SdkDoubleUpDownSumObserverTest {
                 InstrumentSelector.builder()
                     .setInstrumentType(InstrumentType.OBSERVABLE_UP_DOWN_SUM)
                     .build(),
-                View.builder()
-                    .setAggregation(Aggregation.sum(AggregationTemporality.DELTA))
-                    .build())
+                View.builder().setAggregation(Aggregation.sum()).build())
             .build();
     sdkMeterProvider
         .get(getClass().getName())

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkLongSumObserverTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkLongSumObserverTest.java
@@ -11,7 +11,6 @@ import static io.opentelemetry.sdk.testing.assertj.metrics.MetricAssertions.asse
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
-import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.testing.InMemoryMetricReader;
 import io.opentelemetry.sdk.metrics.view.Aggregation;
 import io.opentelemetry.sdk.metrics.view.InstrumentSelector;
@@ -104,7 +103,7 @@ class SdkLongSumObserverTest {
   @Test
   @SuppressWarnings("unchecked")
   void collectMetrics_DeltaSumAggregator() {
-    InMemoryMetricReader sdkMeterReader = InMemoryMetricReader.create();
+    InMemoryMetricReader sdkMeterReader = InMemoryMetricReader.createDelta();
     SdkMeterProvider sdkMeterProvider =
         sdkMeterProviderBuilder
             .registerMetricReader(sdkMeterReader)
@@ -112,9 +111,7 @@ class SdkLongSumObserverTest {
                 InstrumentSelector.builder()
                     .setInstrumentType(InstrumentType.OBSERVABLE_SUM)
                     .build(),
-                View.builder()
-                    .setAggregation(Aggregation.sum(AggregationTemporality.DELTA))
-                    .build())
+                View.builder().setAggregation(Aggregation.sum()).build())
             .build();
     sdkMeterProvider
         .get(getClass().getName())

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkLongUpDownSumObserverTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkLongUpDownSumObserverTest.java
@@ -11,7 +11,6 @@ import static io.opentelemetry.sdk.testing.assertj.metrics.MetricAssertions.asse
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
-import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.testing.InMemoryMetricReader;
 import io.opentelemetry.sdk.metrics.view.Aggregation;
 import io.opentelemetry.sdk.metrics.view.InstrumentSelector;
@@ -104,7 +103,7 @@ class SdkLongUpDownSumObserverTest {
   @Test
   @SuppressWarnings("unchecked")
   void collectMetrics_DeltaSumAggregator() {
-    InMemoryMetricReader sdkMeterReader = InMemoryMetricReader.create();
+    InMemoryMetricReader sdkMeterReader = InMemoryMetricReader.createDelta();
     SdkMeterProvider sdkMeterProvider =
         sdkMeterProviderBuilder
             .registerMetricReader(sdkMeterReader)
@@ -112,9 +111,7 @@ class SdkLongUpDownSumObserverTest {
                 InstrumentSelector.builder()
                     .setInstrumentType(InstrumentType.OBSERVABLE_UP_DOWN_SUM)
                     .build(),
-                View.builder()
-                    .setAggregation(Aggregation.sum(AggregationTemporality.DELTA))
-                    .build())
+                View.builder().setAggregation(Aggregation.sum()).build())
             .build();
     sdkMeterProvider
         .get(getClass().getName())

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderTest.java
@@ -23,7 +23,6 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
-import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.export.MetricReader;
 import io.opentelemetry.sdk.metrics.testing.InMemoryMetricReader;
 import io.opentelemetry.sdk.metrics.view.Aggregation;
@@ -182,11 +181,9 @@ class SdkMeterProviderTest {
     sdkMeterProviderBuilder.registerView(
         InstrumentSelector.builder().setInstrumentType(InstrumentType.COUNTER).build(),
         View.builder()
-            .setAggregation(
-                Aggregation.explicitBucketHistogram(
-                    AggregationTemporality.DELTA, Collections.emptyList()))
+            .setAggregation(Aggregation.explicitBucketHistogram(Collections.emptyList()))
             .build());
-    InMemoryMetricReader sdkMeterReader = InMemoryMetricReader.create();
+    InMemoryMetricReader sdkMeterReader = InMemoryMetricReader.createDelta();
     SdkMeterProvider sdkMeterProvider =
         sdkMeterProviderBuilder.registerMetricReader(sdkMeterReader).build();
     Meter sdkMeter = sdkMeterProvider.get(SdkMeterProviderTest.class.getName());
@@ -238,9 +235,8 @@ class SdkMeterProviderTest {
   @SuppressWarnings("unchecked")
   void collectAllSyncInstruments_DeltaHistogram() {
     registerViewForAllTypes(
-        sdkMeterProviderBuilder,
-        Aggregation.explicitBucketHistogram(AggregationTemporality.DELTA, Collections.emptyList()));
-    InMemoryMetricReader sdkMeterReader = InMemoryMetricReader.create();
+        sdkMeterProviderBuilder, Aggregation.explicitBucketHistogram(Collections.emptyList()));
+    InMemoryMetricReader sdkMeterReader = InMemoryMetricReader.createDelta();
     SdkMeterProvider sdkMeterProvider =
         sdkMeterProviderBuilder.registerMetricReader(sdkMeterReader).build();
     Meter sdkMeter = sdkMeterProvider.get(SdkMeterProviderTest.class.getName());
@@ -508,7 +504,7 @@ class SdkMeterProviderTest {
                 View.builder()
                     .setName("not_test_2")
                     .setDescription("not_desc_2")
-                    .setAggregation(Aggregation.sum(AggregationTemporality.CUMULATIVE))
+                    .setAggregation(Aggregation.sum())
                     .build())
             .build();
     Meter meter = provider.get(SdkMeterProviderTest.class.getName());
@@ -556,7 +552,7 @@ class SdkMeterProviderTest {
                 View.builder()
                     .setName("not_test_2")
                     .setDescription("not_desc_2")
-                    .setAggregation(Aggregation.sum(AggregationTemporality.CUMULATIVE))
+                    .setAggregation(Aggregation.sum())
                     .build())
             .build();
     Meter meter = provider.get(SdkMeterProviderTest.class.getName());
@@ -595,7 +591,7 @@ class SdkMeterProviderTest {
             .registerView(
                 selector,
                 View.builder()
-                    .setAggregation(Aggregation.sum(AggregationTemporality.CUMULATIVE))
+                    .setAggregation(Aggregation.sum())
                     .appendAllBaggageAttributes()
                     .build())
             .build();
@@ -798,8 +794,8 @@ class SdkMeterProviderTest {
   void sdkMeterProvider_supportsMultipleCollectorsDelta() {
     // Note: we use a view to do delta aggregation, but any view ALWAYS uses double-precision right
     // now.
-    InMemoryMetricReader collector1 = InMemoryMetricReader.create();
-    InMemoryMetricReader collector2 = InMemoryMetricReader.create();
+    InMemoryMetricReader collector1 = InMemoryMetricReader.createDelta();
+    InMemoryMetricReader collector2 = InMemoryMetricReader.createDelta();
     SdkMeterProvider meterProvider =
         sdkMeterProviderBuilder
             .registerMetricReader(collector1)
@@ -809,9 +805,7 @@ class SdkMeterProviderTest {
                     .setInstrumentType(InstrumentType.COUNTER)
                     .setInstrumentName("testSum")
                     .build(),
-                View.builder()
-                    .setAggregation(Aggregation.sum(AggregationTemporality.DELTA))
-                    .build())
+                View.builder().setAggregation(Aggregation.sum()).build())
             .build();
     Meter sdkMeter = meterProvider.get(SdkMeterProviderTest.class.getName());
     final LongCounter counter = sdkMeter.counterBuilder("testSum").build();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorageTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorageTest.java
@@ -66,7 +66,7 @@ public class SynchronousMetricStorageTest {
     AttributesProcessor spyAttributesProcessor = Mockito.spy(this.attributesProcessor);
     SynchronousMetricStorage accumulator =
         new DefaultSynchronousMetricStorage<>(
-            METRIC_DESCRIPTOR, aggregator, spyAttributesProcessor, null);
+            METRIC_DESCRIPTOR, aggregator, spyAttributesProcessor);
     accumulator.bind(Attributes.empty());
     Mockito.verify(spyAttributesProcessor).process(Attributes.empty(), Context.current());
   }
@@ -78,8 +78,7 @@ public class SynchronousMetricStorageTest {
         AttributesProcessor.append(Attributes.builder().put("modifiedK", "modifiedV").build());
     AttributesProcessor spyLabelsProcessor = Mockito.spy(attributesProcessor);
     SynchronousMetricStorage accumulator =
-        new DefaultSynchronousMetricStorage<>(
-            METRIC_DESCRIPTOR, aggregator, spyLabelsProcessor, null);
+        new DefaultSynchronousMetricStorage<>(METRIC_DESCRIPTOR, aggregator, spyLabelsProcessor);
     BoundStorageHandle handle = accumulator.bind(labels);
     handle.recordDouble(1, labels, Context.root());
     Mockito.when(reader.getSupportedTemporality())
@@ -107,8 +106,7 @@ public class SynchronousMetricStorageTest {
   @Test
   void sameAggregator_ForSameAttributes() {
     SynchronousMetricStorage accumulator =
-        new DefaultSynchronousMetricStorage<>(
-            METRIC_DESCRIPTOR, aggregator, attributesProcessor, null);
+        new DefaultSynchronousMetricStorage<>(METRIC_DESCRIPTOR, aggregator, attributesProcessor);
     BoundStorageHandle handle = accumulator.bind(Attributes.builder().put("K", "V").build());
     BoundStorageHandle duplicateHandle =
         accumulator.bind(Attributes.builder().put("K", "V").build());

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/TemporalityUtilsTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/TemporalityUtilsTest.java
@@ -13,59 +13,33 @@ import java.util.EnumSet;
 import org.junit.jupiter.api.Test;
 
 class TemporalityUtilsTest {
-  @Test
-  void testUseConfigured() {
-    assertThat(
-            resolveTemporality(
-                EnumSet.allOf(AggregationTemporality.class),
-                AggregationTemporality.CUMULATIVE,
-                /* configured= */ AggregationTemporality.DELTA))
-        .isEqualTo(AggregationTemporality.DELTA);
-    assertThat(
-            resolveTemporality(
-                EnumSet.allOf(AggregationTemporality.class),
-                null,
-                /* configured= */ AggregationTemporality.DELTA))
-        .isEqualTo(AggregationTemporality.DELTA);
-    // If configured is not supported, we choose a different temporality.
-    assertThat(
-            resolveTemporality(
-                EnumSet.of(AggregationTemporality.CUMULATIVE),
-                null,
-                /* configured= */ AggregationTemporality.DELTA))
-        .isEqualTo(AggregationTemporality.CUMULATIVE);
-  }
 
   @Test
   void testUsePreferred() {
     assertThat(
             resolveTemporality(
-                EnumSet.allOf(AggregationTemporality.class),
-                AggregationTemporality.CUMULATIVE,
-                /* configured= */ null))
+                EnumSet.allOf(AggregationTemporality.class), AggregationTemporality.CUMULATIVE))
         .isEqualTo(AggregationTemporality.CUMULATIVE);
     assertThat(
             resolveTemporality(
-                EnumSet.allOf(AggregationTemporality.class), AggregationTemporality.DELTA, null))
+                EnumSet.allOf(AggregationTemporality.class), AggregationTemporality.DELTA))
         .isEqualTo(AggregationTemporality.DELTA);
   }
 
   @Test
   void testDefaultToCumulativeIfAble() {
-    assertThat(resolveTemporality(EnumSet.allOf(AggregationTemporality.class), null, null))
+    assertThat(resolveTemporality(EnumSet.allOf(AggregationTemporality.class), null))
         .isEqualTo(AggregationTemporality.CUMULATIVE);
-    assertThat(resolveTemporality(EnumSet.of(AggregationTemporality.CUMULATIVE), null, null))
+    assertThat(resolveTemporality(EnumSet.of(AggregationTemporality.CUMULATIVE), null))
         .isEqualTo(AggregationTemporality.CUMULATIVE);
-    assertThat(resolveTemporality(EnumSet.of(AggregationTemporality.DELTA), null, null))
+    assertThat(resolveTemporality(EnumSet.of(AggregationTemporality.DELTA), null))
         .isEqualTo(AggregationTemporality.DELTA);
   }
 
   @Test
   void testHandleErrorScenarios() {
-    // Default to cumulative if preferred is empty.
-    assertThat(
-            resolveTemporality(
-                EnumSet.noneOf(AggregationTemporality.class), null, AggregationTemporality.DELTA))
+    // Default to cumulative if preferred/supported is empty.
+    assertThat(resolveTemporality(EnumSet.noneOf(AggregationTemporality.class), null))
         .isEqualTo(AggregationTemporality.CUMULATIVE);
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/view/ExplicitBucketHistogramTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/view/ExplicitBucketHistogramTest.java
@@ -8,7 +8,6 @@ package io.opentelemetry.sdk.metrics.internal.view;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.view.Aggregation;
 import java.util.Arrays;
 import java.util.Collections;
@@ -19,11 +18,7 @@ class ExplicitBucketHistogramTest {
 
   @Test
   void goodConfig() {
-    assertThat(Aggregation.explicitBucketHistogram().getConfiguredTemporality()).isNull();
-    assertThat(
-            Aggregation.explicitBucketHistogram(AggregationTemporality.DELTA)
-                .getConfiguredTemporality())
-        .isEqualTo(AggregationTemporality.DELTA);
+    assertThat(Aggregation.explicitBucketHistogram()).isNotNull();
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/view/AggregationTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/view/AggregationTest.java
@@ -7,7 +7,6 @@ package io.opentelemetry.sdk.metrics.view;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
@@ -20,48 +19,12 @@ class AggregationTest {
     assertThat(Aggregation.defaultAggregation()).asString().contains("Default");
     assertThat(Aggregation.lastValue()).asString().contains("LastValue");
     assertThat(Aggregation.sum()).asString().contains("Sum");
-    assertThat(Aggregation.sum(AggregationTemporality.DELTA)).asString().contains("Sum");
     assertThat(Aggregation.explicitBucketHistogram())
-        .asString()
-        .contains("ExplicitBucketHistogram");
-    assertThat(Aggregation.explicitBucketHistogram(AggregationTemporality.DELTA))
-        .asString()
-        .contains("ExplicitBucketHistogram");
-    assertThat(
-            Aggregation.explicitBucketHistogram(
-                AggregationTemporality.CUMULATIVE, Arrays.asList(1.0d)))
         .asString()
         .contains("ExplicitBucketHistogram");
     assertThat(Aggregation.explicitBucketHistogram(Arrays.asList(1.0d)))
         .asString()
         .contains("ExplicitBucketHistogram");
-  }
-
-  @Test
-  void noTemporalityIsNullTemporality() {
-    assertThat(Aggregation.none()).extracting(Aggregation::getConfiguredTemporality).isNull();
-    assertThat(Aggregation.defaultAggregation())
-        .extracting(Aggregation::getConfiguredTemporality)
-        .isNull();
-    assertThat(Aggregation.lastValue()).extracting(Aggregation::getConfiguredTemporality).isNull();
-    assertThat(Aggregation.sum()).extracting(Aggregation::getConfiguredTemporality).isNull();
-    assertThat(Aggregation.histogram()).extracting(Aggregation::getConfiguredTemporality).isNull();
-    assertThat(Aggregation.explicitBucketHistogram())
-        .extracting(Aggregation::getConfiguredTemporality)
-        .isNull();
-    assertThat(Aggregation.explicitBucketHistogram(Arrays.asList(1d)))
-        .extracting(Aggregation::getConfiguredTemporality)
-        .isNull();
-  }
-
-  @Test
-  void returnsConfiguredTemporality() {
-    assertThat(Aggregation.sum(AggregationTemporality.CUMULATIVE))
-        .extracting(Aggregation::getConfiguredTemporality)
-        .isEqualTo(AggregationTemporality.CUMULATIVE);
-    assertThat(Aggregation.explicitBucketHistogram(AggregationTemporality.DELTA))
-        .extracting(Aggregation::getConfiguredTemporality)
-        .isEqualTo(AggregationTemporality.DELTA);
   }
 
   @Test


### PR DESCRIPTION
Update all tests / use cases to leverage exporter-based configuration.