### PR TITLE
Actually flush in ExecutorServiceSpanProcessor

### DIFF
--- a/sdk-extensions/tracing-incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/trace/ExecutorServiceSpanProcessor.java
+++ b/sdk-extensions/tracing-incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/trace/ExecutorServiceSpanProcessor.java
@@ -212,7 +212,6 @@ public final class ExecutorServiceSpanProcessor implements SpanProcessor {
 
     @Override
     public void run() {
-      // nextExportTime is set for the first time in the constructor
       if (!running.compareAndSet(false, true)) {
         return;
       }

--- a/sdk-extensions/tracing-incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/trace/ExecutorServiceSpanProcessorTest.java
+++ b/sdk-extensions/tracing-incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/trace/ExecutorServiceSpanProcessorTest.java
@@ -396,6 +396,7 @@ class ExecutorServiceSpanProcessorTest {
     // Still processing new spans.
     CountDownLatch exportedAgain = new CountDownLatch(1);
     reset(mockSpanExporter);
+    when(mockSpanExporter.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
     when(mockSpanExporter.export(
             argThat(
                 spans -> {


### PR DESCRIPTION
The test for forceFlush for this processor is flaky because the processor doesn't actually force a flush. Now it does.

It's pretty complex fix though, I couldn't come up with a better pattern. Let me know with some code if anyone has a better idea.

@Oberon00 Are you still interested in this processor? Wondering if anyone is actually using it.