### PR TITLE
Demonstrate async metrics not reseting properly

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageUtils.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageUtils.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.metrics.internal.state;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
 import java.util.Map;
+import java.util.Set;
 
 /** Utilities to help deal w/ {@code Map<Attributes, Accumulation>} in metric storage. */
 final class MetricStorageUtils {
@@ -31,6 +32,8 @@ final class MetricStorageUtils {
    *
    * <p>If no prior value is found, then the value from {@code toDiff} is used.
    *
+   * <p>Removes accumulations from {@code result} that don't appear in {@code toMerge}.
+   *
    * <p>Note: This mutates the result map.
    */
   static <T> void diffInPlace(
@@ -39,5 +42,8 @@ final class MetricStorageUtils {
         (k, v) -> {
           result.compute(k, (k2, v2) -> (v2 != null) ? aggregator.diff(v2, v) : v);
         });
+    // Remove keys from result that don't appear in toDiff
+    Set<Attributes> toDiffKeys = toDiff.keySet();
+    result.entrySet().removeIf(entry -> !toDiffKeys.contains(entry.getKey()));
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AsyncResetTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AsyncResetTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics;
+
+import static io.opentelemetry.sdk.testing.assertj.metrics.MetricAssertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+import io.opentelemetry.sdk.metrics.testing.InMemoryMetricReader;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+class AsyncResetTest {
+
+  @Test
+  void demonstrateAsyncResetBug() {
+    InMemoryMetricReader reader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider sdkMeterProvider =
+        SdkMeterProvider.builder().registerMetricReader(reader).build();
+    sdkMeterProvider
+        .get("my-meter")
+        .counterBuilder("my-counter")
+        .buildWithCallback(
+            new Consumer<ObservableLongMeasurement>() {
+              private final AtomicLong counter = new AtomicLong();
+
+              @Override
+              public void accept(ObservableLongMeasurement observableLongMeasurement) {
+                observableLongMeasurement.observe(
+                    10,
+                    Attributes.builder().put("key", "value" + counter.incrementAndGet()).build());
+              }
+            });
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasName("my-counter")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(
+                        point ->
+                            assertThat(point)
+                                .hasValue(10)
+                                .hasAttributes(Attributes.builder().put("key", "value1").build())));
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasName("my-counter")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(
+                        point ->
+                            assertThat(point)
+                                .hasValue(10)
+                                .hasAttributes(Attributes.builder().put("key", "value2").build())));
+  }
+}


### PR DESCRIPTION
I noticed that async metrics aren't properly reseting when reporting to a delta reader. The issue is that accumulations (i.e. unique attributes) that don't appear in the most recent collection still get sent to the reader.

This results in double counting of the last reported value for a unique set of attributes. 