### PR TITLE
Retain accumulation history when reporting cumulative aggregation for async instruments

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageUtils.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageUtils.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.metrics.internal.state;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
 import java.util.Map;
+import java.util.Set;
 
 /** Utilities to help deal w/ {@code Map<Attributes, Accumulation>} in metric storage. */
 final class MetricStorageUtils {
@@ -31,6 +32,8 @@ final class MetricStorageUtils {
    *
    * <p>If no prior value is found, then the value from {@code toDiff} is used.
    *
+   * <p>Removes accumulations from {@code result} that don't appear in {@code toMerge}.
+   *
    * <p>Note: This mutates the result map.
    */
   static <T> void diffInPlace(
@@ -39,5 +42,8 @@ final class MetricStorageUtils {
         (k, v) -> {
           result.compute(k, (k2, v2) -> (v2 != null) ? aggregator.diff(v2, v) : v);
         });
+    // Remove keys from result that don't appear in toDiff
+    Set<Attributes> toDiffKeys = toDiff.keySet();
+    result.entrySet().removeIf(entry -> !toDiffKeys.contains(entry.getKey()));
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorage.java
@@ -67,7 +67,8 @@ class TemporalMetricStorage<T> {
       //    Here we diff with last cumulative to get a delta.
       // 2. Cumulative Aggregation + Delta recording (sync instrument).
       //    Here we merge with our last record to get a cumulative aggregation.
-      // 3. Cumulative Aggregation + Cumulative recording - do nothing
+      // 3. Cumulative Aggregation + Cumulative recording
+      //    Here we copy last accumulations into current if they don't exist to retain history.
       // 4. Delta Aggregation + Delta recording - do nothing.
       if (temporality == AggregationTemporality.DELTA && !isSynchronous) {
         MetricStorageUtils.diffInPlace(last.getAccumlation(), currentAccumulation, aggregator);
@@ -77,6 +78,8 @@ class TemporalMetricStorage<T> {
         // for the next cumulative measurement.
         MetricStorageUtils.mergeInPlace(last.getAccumlation(), currentAccumulation, aggregator);
         result = last.getAccumlation();
+      } else if (temporality == AggregationTemporality.CUMULATIVE) { // && !isSynchronous
+        last.getAccumlation().forEach(currentAccumulation::putIfAbsent);
       }
     }
     // Update last reported (cumulative) accumulation.

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AsyncResetTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AsyncResetTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics;
+
+import static io.opentelemetry.sdk.testing.assertj.metrics.MetricAssertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+import io.opentelemetry.sdk.metrics.testing.InMemoryMetricReader;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+class AsyncResetTest {
+
+  @Test
+  void demonstrateAsyncCumulativeRetentionBug() {
+    InMemoryMetricReader reader = InMemoryMetricReader.create();
+    SdkMeterProvider sdkMeterProvider =
+        SdkMeterProvider.builder().registerMetricReader(reader).build();
+    sdkMeterProvider
+        .get("my-meter")
+        .counterBuilder("my-counter")
+        .buildWithCallback(
+            new Consumer<ObservableLongMeasurement>() {
+              private final AtomicLong counter = new AtomicLong();
+
+              @Override
+              public void accept(ObservableLongMeasurement observableLongMeasurement) {
+                observableLongMeasurement.observe(
+                    10,
+                    Attributes.builder().put("key", "value" + counter.incrementAndGet()).build());
+              }
+            });
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasName("my-counter")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(
+                        point ->
+                            assertThat(point)
+                                .hasValue(10)
+                                .hasAttributes(Attributes.builder().put("key", "value1").build())));
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasName("my-counter")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactlyInAnyOrder(
+                        point ->
+                            assertThat(point)
+                                .hasValue(10)
+                                .hasAttributes(Attributes.builder().put("key", "value1").build()),
+                        point ->
+                            assertThat(point)
+                                .hasValue(10)
+                                .hasAttributes(Attributes.builder().put("key", "value2").build())));
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorageTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorageTest.java
@@ -12,6 +12,7 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.DoubleAccumulation;
@@ -544,5 +545,56 @@ class TemporalMetricStorageTest {
         .isNotEmpty()
         .satisfiesExactly(
             point -> assertThat(point).hasStartEpochNanos(0).hasEpochNanos(60).hasValue(5));
+  }
+
+  @Test
+  void asynchronous_CumulativeRetainsHistory() {
+    TemporalMetricStorage<DoubleAccumulation> storage =
+        new TemporalMetricStorage<>(ASYNC_SUM, /* isSynchronous= */ false);
+
+    Attributes attr1 = Attributes.builder().put("key", "value1").build();
+    Attributes attr2 = Attributes.builder().put("key", "value2").build();
+
+    // Send in new measurement at time 10 for collector 1, with attr1
+    Map<Attributes, DoubleAccumulation> measurement1 = new HashMap<>();
+    measurement1.put(attr1, DoubleAccumulation.create(3));
+    assertThat(
+            storage.buildMetricFor(
+                collector1,
+                Resource.empty(),
+                InstrumentationLibraryInfo.empty(),
+                METRIC_DESCRIPTOR,
+                AggregationTemporality.CUMULATIVE,
+                measurement1,
+                0,
+                10))
+        .hasDoubleSum()
+        .isCumulative()
+        .points()
+        .hasSize(1)
+        .isNotEmpty()
+        .contains(DoublePointData.create(0, 10, attr1, 3));
+
+    // Send in new measurement at time 20 for collector 1, with attr2
+    // Result should include accumulations for attr1 and attr2
+    Map<Attributes, DoubleAccumulation> measurement2 = new HashMap<>();
+    measurement2.put(attr2, DoubleAccumulation.create(7));
+    assertThat(
+            storage.buildMetricFor(
+                collector1,
+                Resource.empty(),
+                InstrumentationLibraryInfo.empty(),
+                METRIC_DESCRIPTOR,
+                AggregationTemporality.CUMULATIVE,
+                measurement2,
+                0,
+                20))
+        .hasDoubleSum()
+        .isCumulative()
+        .points()
+        .hasSize(2)
+        .isNotEmpty()
+        .containsExactlyInAnyOrder(
+            DoublePointData.create(0, 20, attr1, 3), DoublePointData.create(0, 20, attr2, 7));
   }
 }


### PR DESCRIPTION
If I'm exporting cumulative metrics, and have an async instrument that records one set of attributes on the first collection:
```
...
observableLongMeasurement.observe(10, Attributes.builder().put("key", "value1").build())
```
.. then on the next collection records another set of attributes:
```
...
observableLongMeasurement.observe(10, Attributes.builder().put("key", "value2").build())
```
Then I expect that the second export contains data points for both sets of attributes. Accumulations should be retained even if they don't appear in the most recent collection.

Currently, they do not. For async instruments and cumulative temporality, only the accumulations in the current collection appear.

This PR fixes that. 