### PR TITLE
Metric cardinality limits

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorage.java
@@ -162,6 +162,10 @@ public final class AsynchronousMetricStorage<T> implements MetricStorage {
     private Map<Attributes, T> currentAccumulation = new HashMap<>();
 
     public void record(Attributes attributes, T accumulation) {
+      if (currentAccumulation.size() >= MAX_ACCUMULATIONS) {
+        // TODO: provide useful diagnostics when max accumulations has been reached
+        return;
+      }
       // TODO: error on metric overwrites
       currentAccumulation.put(attributes, accumulation);
     }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorage.java
@@ -10,6 +10,7 @@ import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.internal.ThrottlingLogger;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarFilter;
@@ -24,6 +25,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
@@ -33,6 +36,8 @@ import javax.annotation.Nullable;
  * at any time.
  */
 public final class AsynchronousMetricStorage<T> implements MetricStorage {
+  private static final ThrottlingLogger logger =
+      new ThrottlingLogger(Logger.getLogger(DeltaMetricStorage.class.getName()));
   private final MetricDescriptor metricDescriptor;
   private final ReentrantLock collectLock = new ReentrantLock();
   private final AsyncAccumulator<T> asyncAccumulator;
@@ -56,7 +61,7 @@ public final class AsynchronousMetricStorage<T> implements MetricStorage {
     Aggregator<T> aggregator =
         view.getAggregation().createAggregator(instrument, ExemplarFilter.neverSample());
 
-    final AsyncAccumulator<T> measurementAccumulator = new AsyncAccumulator<>();
+    final AsyncAccumulator<T> measurementAccumulator = new AsyncAccumulator<>(instrument);
     if (Aggregator.empty() == aggregator) {
       return empty();
     }
@@ -90,7 +95,7 @@ public final class AsynchronousMetricStorage<T> implements MetricStorage {
     final MetricDescriptor metricDescriptor = MetricDescriptor.create(view, instrument);
     Aggregator<T> aggregator =
         view.getAggregation().createAggregator(instrument, ExemplarFilter.neverSample());
-    final AsyncAccumulator<T> measurementAccumulator = new AsyncAccumulator<>();
+    final AsyncAccumulator<T> measurementAccumulator = new AsyncAccumulator<>(instrument);
     final AttributesProcessor attributesProcessor = view.getAttributesProcessor();
     // TODO: Find a way to grab the measurement JUST ONCE for all async metrics.
     final ObservableLongMeasurement result =
@@ -159,11 +164,22 @@ public final class AsynchronousMetricStorage<T> implements MetricStorage {
 
   /** Helper class to record async measurements on demand. */
   private static final class AsyncAccumulator<T> {
+    private final InstrumentDescriptor instrument;
     private Map<Attributes, T> currentAccumulation = new HashMap<>();
 
+    AsyncAccumulator(InstrumentDescriptor instrument) {
+      this.instrument = instrument;
+    }
+
     public void record(Attributes attributes, T accumulation) {
-      if (currentAccumulation.size() >= MAX_ACCUMULATIONS) {
-        // TODO: provide useful diagnostics when max accumulations has been reached
+      if (currentAccumulation.size() >= MetricStorageUtils.MAX_ACCUMULATIONS) {
+        logger.log(
+            Level.WARNING,
+            "Instrument "
+                + instrument.getName()
+                + " has exceeded the maximum allowed accumulations ("
+                + MetricStorageUtils.MAX_ACCUMULATIONS
+                + ").");
         return;
       }
       // TODO: error on metric overwrites

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java
@@ -37,7 +37,8 @@ public final class DefaultSynchronousMetricStorage<T> implements SynchronousMetr
       AttributesProcessor attributesProcessor) {
     this.attributesProcessor = attributesProcessor;
     this.metricDescriptor = metricDescriptor;
-    this.deltaMetricStorage = new DeltaMetricStorage<>(aggregator);
+    this.deltaMetricStorage =
+        new DeltaMetricStorage<>(aggregator, metricDescriptor.getSourceInstrument());
     this.temporalMetricStorage = new TemporalMetricStorage<>(aggregator, /* isSynchronous= */ true);
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorage.java
@@ -20,6 +20,9 @@ import javax.annotation.Nullable;
  */
 public interface MetricStorage {
 
+  /** The max number of metric accumulations for a particular {@link MetricStorage}. */
+  Integer MAX_ACCUMULATIONS = 2000;
+
   /** Returns a description of the metric produced in this storage. */
   MetricDescriptor getMetricDescriptor();
   /**

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorage.java
@@ -20,9 +20,6 @@ import javax.annotation.Nullable;
  */
 public interface MetricStorage {
 
-  /** The max number of metric accumulations for a particular {@link MetricStorage}. */
-  Integer MAX_ACCUMULATIONS = 2000;
-
   /** Returns a description of the metric produced in this storage. */
   MetricDescriptor getMetricDescriptor();
   /**

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageUtils.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageUtils.java
@@ -20,6 +20,7 @@ final class MetricStorageUtils {
    */
   static <T> void mergeInPlace(
       Map<Attributes, T> result, Map<Attributes, T> toMerge, Aggregator<T> aggregator) {
+    result.entrySet().removeIf(entry -> !toMerge.containsKey(entry.getKey()));
     toMerge.forEach(
         (k, v) -> {
           result.compute(k, (k2, v2) -> (v2 != null) ? aggregator.merge(v2, v) : v);
@@ -35,6 +36,7 @@ final class MetricStorageUtils {
    */
   static <T> void diffInPlace(
       Map<Attributes, T> result, Map<Attributes, T> toDiff, Aggregator<T> aggregator) {
+    result.entrySet().removeIf(entry -> !toDiff.containsKey(entry.getKey()));
     toDiff.forEach(
         (k, v) -> {
           result.compute(k, (k2, v2) -> (v2 != null) ? aggregator.diff(v2, v) : v);

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageUtils.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageUtils.java
@@ -11,10 +11,14 @@ import java.util.Map;
 
 /** Utilities to help deal w/ {@code Map<Attributes, Accumulation>} in metric storage. */
 final class MetricStorageUtils {
+  /** The max number of metric accumulations for a particular {@link MetricStorage}. */
+  static final int MAX_ACCUMULATIONS = 2000;
+
   private MetricStorageUtils() {}
 
   /**
-   * Merges accumulations from {@code toMerge} into {@code result}.
+   * Merges accumulations from {@code toMerge} into {@code result}. Keys from {@code result} which
+   * don't appear in {@code toMerge} are removed.
    *
    * <p>Note: This mutates the result map.
    */
@@ -28,7 +32,8 @@ final class MetricStorageUtils {
   }
 
   /**
-   * Diffs accumulations from {@code toMerge} into {@code result}.
+   * Diffs accumulations from {@code toMerge} into {@code result}. Keys from {@code result} which
+   * don't appear in {@code toMerge} are removed.
    *
    * <p>If no prior value is found, then the value from {@code toDiff} is used.
    *

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorage.java
@@ -81,7 +81,7 @@ class TemporalMetricStorage<T> {
     }
     // Update last reported (cumulative) accumulation.
     // For synchronous instruments, we need the merge result.
-    // For asynchronous isntruments, we need the recorded value.
+    // For asynchronous instruments, we need the recorded value.
     // This assumes aggregation remains consistent for the lifetime of a collector, and
     // could be optimised to not record results for cases 3+4 listed above.
     if (isSynchronous) {
@@ -107,17 +107,16 @@ class TemporalMetricStorage<T> {
 
   /** Remembers what was presented to a specific exporter. */
   private static class LastReportedAccumulation<T> {
-    @Nullable private final Map<Attributes, T> accumulation;
+    private final Map<Attributes, T> accumulation;
     private final long epochNanos;
 
     /**
      * Constructs a new reporting record.
      *
-     * @param accumulation The last accumulation of metric data or {@code null} if the accumulator
-     *     is not stateful.
+     * @param accumulation The last accumulation of metric data.
      * @param epochNanos The timestamp the data was reported.
      */
-    LastReportedAccumulation(@Nullable Map<Attributes, T> accumulation, long epochNanos) {
+    LastReportedAccumulation(Map<Attributes, T> accumulation, long epochNanos) {
       this.accumulation = accumulation;
       this.epochNanos = epochNanos;
     }
@@ -126,7 +125,6 @@ class TemporalMetricStorage<T> {
       return epochNanos;
     }
 
-    @Nullable
     Map<Attributes, T> getAccumlation() {
       return accumulation;
     }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/CardinalityTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/CardinalityTest.java
@@ -5,14 +5,12 @@
 
 package io.opentelemetry.sdk.metrics;
 
-import static io.opentelemetry.sdk.metrics.internal.state.MetricStorage.MAX_ACCUMULATIONS;
 import static io.opentelemetry.sdk.testing.assertj.metrics.MetricAssertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
-import io.opentelemetry.sdk.metrics.internal.state.MetricStorage;
 import io.opentelemetry.sdk.metrics.testing.InMemoryMetricReader;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
@@ -21,6 +19,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class CardinalityTest {
+
+  /** Traces {@code MetricStorageUtils#MAX_ACCUMULATIONS}. */
+  private static final int MAX_ACCUMULATIONS = 2000;
 
   private InMemoryMetricReader deltaReader;
   private InMemoryMetricReader cumulativeReader;
@@ -120,8 +121,8 @@ class CardinalityTest {
   }
 
   /**
-   * Records to sync instruments, many distinct attributes. Validates that the {@link
-   * MetricStorage#MAX_ACCUMULATIONS} is enforced for each instrument.
+   * Records to sync instruments, many distinct attributes. Validates that the {@code
+   * MetricStorageUtils#MAX_ACCUMULATIONS} is enforced for each instrument.
    */
   @Test
   void cardinalityLimits_synchronousInstrument() {
@@ -172,8 +173,8 @@ class CardinalityTest {
   }
 
   /**
-   * Records to sync instruments, many distinct attributes. Validates that the {@link
-   * MetricStorage#MAX_ACCUMULATIONS} is enforced for each instrument.
+   * Records to sync instruments, many distinct attributes. Validates that the {@code
+   * MetricStorageUtils#MAX_ACCUMULATIONS} is enforced for each instrument.
    */
   @Test
   void cardinalityLimits_asynchronousInstrument() {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/CardinalityTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/CardinalityTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics;
+
+import static io.opentelemetry.sdk.testing.assertj.metrics.MetricAssertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.sdk.metrics.testing.InMemoryMetricReader;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+class CardinalityTest {
+
+  /**
+   * Records to sync and async instruments, with distinct attributes each time. Validates that stale
+   * metrics are dropped for delta and cumulative readers, sync and async instruments. Stale metrics
+   * are those with attributes that did not receive recordings in the most recent collection.
+   */
+  @Test
+  void staleMetricsDropped() {
+    InMemoryMetricReader deltaReader = InMemoryMetricReader.createDelta();
+    InMemoryMetricReader cumulativeReader = InMemoryMetricReader.create();
+    SdkMeterProvider sdkMeterProvider =
+        SdkMeterProvider.builder()
+            .registerMetricReader(deltaReader)
+            .registerMetricReader(cumulativeReader)
+            .setMinimumCollectionInterval(Duration.ofSeconds(0))
+            .build();
+    Meter meter = sdkMeterProvider.get(CardinalityTest.class.getName());
+
+    AtomicLong count = new AtomicLong();
+    meter
+        .counterBuilder("async-counter")
+        .buildWithCallback(
+            measurement ->
+                measurement.observe(
+                    1, Attributes.builder().put("key", "num_" + count.incrementAndGet()).build()));
+    LongCounter syncCounter = meter.counterBuilder("sync-counter").build();
+
+    for (int i = 1; i <= 5; i++) {
+      syncCounter.add(1, Attributes.builder().put("key", "num_" + count.incrementAndGet()).build());
+
+      assertThat(deltaReader.collectAllMetrics())
+          .as("Delta collection " + i)
+          .hasSize(2)
+          .satisfiesExactlyInAnyOrder(
+              metricData ->
+                  assertThat(metricData)
+                      .hasName("async-counter")
+                      .hasLongSum()
+                      .isDelta()
+                      .points()
+                      .hasSize(1),
+              metricData ->
+                  assertThat(metricData)
+                      .hasName("sync-counter")
+                      .hasLongSum()
+                      .isDelta()
+                      .points()
+                      .hasSize(1));
+
+      assertThat(cumulativeReader.collectAllMetrics())
+          .as("Cumulative collection " + i)
+          .hasSize(2)
+          .satisfiesExactlyInAnyOrder(
+              metricData ->
+                  assertThat(metricData)
+                      .hasName("async-counter")
+                      .hasLongSum()
+                      .isCumulative()
+                      .points()
+                      .hasSize(1),
+              metricData ->
+                  assertThat(metricData)
+                      .hasName("sync-counter")
+                      .hasLongSum()
+                      .isCumulative()
+                      .points()
+                      .hasSize(1));
+    }
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/CardinalityTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/CardinalityTest.java
@@ -5,58 +5,55 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import static io.opentelemetry.sdk.metrics.internal.state.MetricStorage.MAX_ACCUMULATIONS;
 import static io.opentelemetry.sdk.testing.assertj.metrics.MetricAssertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+import io.opentelemetry.sdk.metrics.internal.state.MetricStorage;
 import io.opentelemetry.sdk.metrics.testing.InMemoryMetricReader;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class CardinalityTest {
 
-  /**
-   * Records to sync and async instruments, with distinct attributes each time. Validates that stale
-   * metrics are dropped for delta and cumulative readers, sync and async instruments. Stale metrics
-   * are those with attributes that did not receive recordings in the most recent collection.
-   */
-  @Test
-  void staleMetricsDropped() {
-    InMemoryMetricReader deltaReader = InMemoryMetricReader.createDelta();
-    InMemoryMetricReader cumulativeReader = InMemoryMetricReader.create();
+  private InMemoryMetricReader deltaReader;
+  private InMemoryMetricReader cumulativeReader;
+  private Meter meter;
+
+  @BeforeEach
+  void setup() {
+    deltaReader = InMemoryMetricReader.createDelta();
+    cumulativeReader = InMemoryMetricReader.create();
     SdkMeterProvider sdkMeterProvider =
         SdkMeterProvider.builder()
             .registerMetricReader(deltaReader)
             .registerMetricReader(cumulativeReader)
             .setMinimumCollectionInterval(Duration.ofSeconds(0))
             .build();
-    Meter meter = sdkMeterProvider.get(CardinalityTest.class.getName());
+    meter = sdkMeterProvider.get(CardinalityTest.class.getName());
+  }
 
-    AtomicLong count = new AtomicLong();
-    meter
-        .counterBuilder("async-counter")
-        .buildWithCallback(
-            measurement ->
-                measurement.observe(
-                    1, Attributes.builder().put("key", "num_" + count.incrementAndGet()).build()));
+  /**
+   * Records to sync instruments, with distinct attributes each time. Validates that stale metrics
+   * are dropped for delta and cumulative readers. Stale metrics are those with attributes that did
+   * not receive recordings in the most recent collection.
+   */
+  @Test
+  void staleMetricsDropped_synchronousInstrument() {
     LongCounter syncCounter = meter.counterBuilder("sync-counter").build();
-
     for (int i = 1; i <= 5; i++) {
-      syncCounter.add(1, Attributes.builder().put("key", "num_" + count.incrementAndGet()).build());
+      syncCounter.add(1, Attributes.builder().put("key", "num_" + i).build());
 
       assertThat(deltaReader.collectAllMetrics())
           .as("Delta collection " + i)
-          .hasSize(2)
-          .satisfiesExactlyInAnyOrder(
-              metricData ->
-                  assertThat(metricData)
-                      .hasName("async-counter")
-                      .hasLongSum()
-                      .isDelta()
-                      .points()
-                      .hasSize(1),
+          .hasSize(1)
+          .satisfiesExactly(
               metricData ->
                   assertThat(metricData)
                       .hasName("sync-counter")
@@ -67,15 +64,8 @@ class CardinalityTest {
 
       assertThat(cumulativeReader.collectAllMetrics())
           .as("Cumulative collection " + i)
-          .hasSize(2)
-          .satisfiesExactlyInAnyOrder(
-              metricData ->
-                  assertThat(metricData)
-                      .hasName("async-counter")
-                      .hasLongSum()
-                      .isCumulative()
-                      .points()
-                      .hasSize(1),
+          .hasSize(1)
+          .satisfiesExactly(
               metricData ->
                   assertThat(metricData)
                       .hasName("sync-counter")
@@ -84,5 +74,154 @@ class CardinalityTest {
                       .points()
                       .hasSize(1));
     }
+  }
+
+  /**
+   * Records to async instruments, with distinct attributes each time. Validates that stale metrics
+   * are dropped for delta and cumulative readers. Stale metrics are those with attributes that did
+   * not receive recordings in the most recent collection.
+   */
+  @Test
+  void staleMetricsDropped_asynchronousInstrument() {
+    AtomicLong count = new AtomicLong();
+
+    meter
+        .counterBuilder("async-counter")
+        .buildWithCallback(
+            measurement ->
+                measurement.observe(
+                    1, Attributes.builder().put("key", "num_" + count.incrementAndGet()).build()));
+
+    for (int i = 1; i <= 5; i++) {
+      assertThat(deltaReader.collectAllMetrics())
+          .as("Delta collection " + i)
+          .hasSize(1)
+          .satisfiesExactlyInAnyOrder(
+              metricData ->
+                  assertThat(metricData)
+                      .hasName("async-counter")
+                      .hasLongSum()
+                      .isDelta()
+                      .points()
+                      .hasSize(1));
+
+      assertThat(cumulativeReader.collectAllMetrics())
+          .as("Cumulative collection " + i)
+          .hasSize(1)
+          .satisfiesExactlyInAnyOrder(
+              metricData ->
+                  assertThat(metricData)
+                      .hasName("async-counter")
+                      .hasLongSum()
+                      .isCumulative()
+                      .points()
+                      .hasSize(1));
+    }
+  }
+
+  /**
+   * Records to sync instruments, many distinct attributes. Validates that the {@link
+   * MetricStorage#MAX_ACCUMULATIONS} is enforced for each instrument.
+   */
+  @Test
+  void cardinalityLimits_synchronousInstrument() {
+    LongCounter syncCounter1 = meter.counterBuilder("sync-counter1").build();
+    LongCounter syncCounter2 = meter.counterBuilder("sync-counter2").build();
+    for (int i = 0; i < MAX_ACCUMULATIONS + 1; i++) {
+      syncCounter1.add(1, Attributes.builder().put("key", "value" + i).build());
+      syncCounter2.add(1, Attributes.builder().put("key", "value" + i).build());
+    }
+
+    assertThat(deltaReader.collectAllMetrics())
+        .as("Delta collection")
+        .hasSize(2)
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasName("sync-counter1")
+                    .hasLongSum()
+                    .isDelta()
+                    .points()
+                    .hasSize(MAX_ACCUMULATIONS),
+            metricData ->
+                assertThat(metricData)
+                    .hasName("sync-counter2")
+                    .hasLongSum()
+                    .isDelta()
+                    .points()
+                    .hasSize(MAX_ACCUMULATIONS));
+
+    assertThat(cumulativeReader.collectAllMetrics())
+        .as("Cumulative collection")
+        .hasSize(2)
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasName("sync-counter1")
+                    .hasLongSum()
+                    .isCumulative()
+                    .points()
+                    .hasSize(MAX_ACCUMULATIONS),
+            metricData ->
+                assertThat(metricData)
+                    .hasName("sync-counter2")
+                    .hasLongSum()
+                    .isCumulative()
+                    .points()
+                    .hasSize(MAX_ACCUMULATIONS));
+  }
+
+  /**
+   * Records to sync instruments, many distinct attributes. Validates that the {@link
+   * MetricStorage#MAX_ACCUMULATIONS} is enforced for each instrument.
+   */
+  @Test
+  void cardinalityLimits_asynchronousInstrument() {
+    Consumer<ObservableLongMeasurement> callback =
+        measurement -> {
+          for (int i = 0; i < MAX_ACCUMULATIONS + 1; i++) {
+            measurement.observe(1, Attributes.builder().put("key", "value" + i).build());
+          }
+        };
+    meter.counterBuilder("async-counter1").buildWithCallback(callback);
+    meter.counterBuilder("async-counter2").buildWithCallback(callback);
+
+    assertThat(deltaReader.collectAllMetrics())
+        .as("Delta collection")
+        .hasSize(2)
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasName("async-counter1")
+                    .hasLongSum()
+                    .isDelta()
+                    .points()
+                    .hasSize(MAX_ACCUMULATIONS),
+            metricData ->
+                assertThat(metricData)
+                    .hasName("async-counter2")
+                    .hasLongSum()
+                    .isDelta()
+                    .points()
+                    .hasSize(MAX_ACCUMULATIONS));
+
+    assertThat(cumulativeReader.collectAllMetrics())
+        .as("Cumulative collection")
+        .hasSize(2)
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasName("async-counter1")
+                    .hasLongSum()
+                    .isCumulative()
+                    .points()
+                    .hasSize(MAX_ACCUMULATIONS),
+            metricData ->
+                assertThat(metricData)
+                    .hasName("async-counter2")
+                    .hasLongSum()
+                    .isCumulative()
+                    .points()
+                    .hasSize(MAX_ACCUMULATIONS));
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/DeltaMetricStorageTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/DeltaMetricStorageTest.java
@@ -41,7 +41,8 @@ class DeltaMetricStorageTest {
     allCollectors.add(collector2);
     storage =
         new DeltaMetricStorage<>(
-            Aggregation.sum().createAggregator(DESCRIPTOR, ExemplarFilter.neverSample()));
+            Aggregation.sum().createAggregator(DESCRIPTOR, ExemplarFilter.neverSample()),
+            DESCRIPTOR);
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorageTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorageTest.java
@@ -197,15 +197,15 @@ class TemporalMetricStorageTest {
     Attributes attr1 = Attributes.builder().put("key", "value1").build();
     measurement1.put(attr1, DoubleAccumulation.create(3));
     assertThat(
-        storage.buildMetricFor(
-            collector1,
-            Resource.empty(),
-            InstrumentationLibraryInfo.empty(),
-            METRIC_DESCRIPTOR,
-            AggregationTemporality.DELTA,
-            measurement1,
-            0,
-            10))
+            storage.buildMetricFor(
+                collector1,
+                Resource.empty(),
+                InstrumentationLibraryInfo.empty(),
+                METRIC_DESCRIPTOR,
+                AggregationTemporality.DELTA,
+                measurement1,
+                0,
+                10))
         .hasDoubleSum()
         .isDelta()
         .points()
@@ -219,15 +219,15 @@ class TemporalMetricStorageTest {
     Attributes attr2 = Attributes.builder().put("key", "value2").build();
     measurement2.put(attr2, DoubleAccumulation.create(7));
     assertThat(
-        storage.buildMetricFor(
-            collector1,
-            Resource.empty(),
-            InstrumentationLibraryInfo.empty(),
-            METRIC_DESCRIPTOR,
-            AggregationTemporality.DELTA,
-            measurement2,
-            0,
-            20))
+            storage.buildMetricFor(
+                collector1,
+                Resource.empty(),
+                InstrumentationLibraryInfo.empty(),
+                METRIC_DESCRIPTOR,
+                AggregationTemporality.DELTA,
+                measurement2,
+                0,
+                20))
         .hasDoubleSum()
         .isDelta()
         .points()
@@ -536,15 +536,15 @@ class TemporalMetricStorageTest {
     Attributes attr1 = Attributes.builder().put("key", "value1").build();
     measurement1.put(attr1, DoubleAccumulation.create(3));
     assertThat(
-        storage.buildMetricFor(
-            collector1,
-            Resource.empty(),
-            InstrumentationLibraryInfo.empty(),
-            METRIC_DESCRIPTOR,
-            AggregationTemporality.DELTA,
-            measurement1,
-            0,
-            10))
+            storage.buildMetricFor(
+                collector1,
+                Resource.empty(),
+                InstrumentationLibraryInfo.empty(),
+                METRIC_DESCRIPTOR,
+                AggregationTemporality.DELTA,
+                measurement1,
+                0,
+                10))
         .hasDoubleSum()
         .isDelta()
         .points()
@@ -558,15 +558,15 @@ class TemporalMetricStorageTest {
     Attributes attr2 = Attributes.builder().put("key", "value2").build();
     measurement2.put(attr2, DoubleAccumulation.create(7));
     assertThat(
-        storage.buildMetricFor(
-            collector1,
-            Resource.empty(),
-            InstrumentationLibraryInfo.empty(),
-            METRIC_DESCRIPTOR,
-            AggregationTemporality.DELTA,
-            measurement2,
-            0,
-            20))
+            storage.buildMetricFor(
+                collector1,
+                Resource.empty(),
+                InstrumentationLibraryInfo.empty(),
+                METRIC_DESCRIPTOR,
+                AggregationTemporality.DELTA,
+                measurement2,
+                0,
+                20))
         .hasDoubleSum()
         .isDelta()
         .points()

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorageTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorageTest.java
@@ -12,6 +12,7 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.DoubleAccumulation;
@@ -135,6 +136,104 @@ class TemporalMetricStorageTest {
         .isNotEmpty()
         .satisfiesExactly(
             point -> assertThat(point).hasStartEpochNanos(0).hasEpochNanos(35).hasValue(8));
+  }
+
+  @Test
+  void synchronousCumulative_dropsStale() {
+    TemporalMetricStorage<DoubleAccumulation> storage =
+        new TemporalMetricStorage<>(SUM, /* isSynchronous= */ true);
+
+    // Send in new measurement at time 10 for collector 1, with attr1
+    Map<Attributes, DoubleAccumulation> measurement1 = new HashMap<>();
+    Attributes attr1 = Attributes.builder().put("key", "value1").build();
+    measurement1.put(attr1, DoubleAccumulation.create(3));
+    assertThat(
+            storage.buildMetricFor(
+                collector1,
+                Resource.empty(),
+                InstrumentationLibraryInfo.empty(),
+                METRIC_DESCRIPTOR,
+                AggregationTemporality.CUMULATIVE,
+                measurement1,
+                0,
+                10))
+        .hasDoubleSum()
+        .isCumulative()
+        .points()
+        .hasSize(1)
+        .isNotEmpty()
+        .contains(DoublePointData.create(0, 10, attr1, 3));
+
+    // Send in new measurement at time 20 for collector 1, with attr2
+    // Result should drop accumulation for attr1, only reporting accumulation for attr2
+    Map<Attributes, DoubleAccumulation> measurement2 = new HashMap<>();
+    Attributes attr2 = Attributes.builder().put("key", "value2").build();
+    measurement2.put(attr2, DoubleAccumulation.create(7));
+    assertThat(
+            storage.buildMetricFor(
+                collector1,
+                Resource.empty(),
+                InstrumentationLibraryInfo.empty(),
+                METRIC_DESCRIPTOR,
+                AggregationTemporality.CUMULATIVE,
+                measurement2,
+                0,
+                20))
+        .hasDoubleSum()
+        .isCumulative()
+        .points()
+        .hasSize(1)
+        .isNotEmpty()
+        .containsExactly(DoublePointData.create(0, 20, attr2, 7));
+  }
+
+  @Test
+  void synchronousDelta_dropsStale() {
+    TemporalMetricStorage<DoubleAccumulation> storage =
+        new TemporalMetricStorage<>(SUM, /* isSynchronous= */ true);
+
+    // Send in new measurement at time 10 for collector 1, with attr1
+    Map<Attributes, DoubleAccumulation> measurement1 = new HashMap<>();
+    Attributes attr1 = Attributes.builder().put("key", "value1").build();
+    measurement1.put(attr1, DoubleAccumulation.create(3));
+    assertThat(
+        storage.buildMetricFor(
+            collector1,
+            Resource.empty(),
+            InstrumentationLibraryInfo.empty(),
+            METRIC_DESCRIPTOR,
+            AggregationTemporality.DELTA,
+            measurement1,
+            0,
+            10))
+        .hasDoubleSum()
+        .isDelta()
+        .points()
+        .hasSize(1)
+        .isNotEmpty()
+        .contains(DoublePointData.create(0, 10, attr1, 3));
+
+    // Send in new measurement at time 20 for collector 1, with attr2
+    // Result should drop accumulation for attr1, only reporting accumulation for attr2
+    Map<Attributes, DoubleAccumulation> measurement2 = new HashMap<>();
+    Attributes attr2 = Attributes.builder().put("key", "value2").build();
+    measurement2.put(attr2, DoubleAccumulation.create(7));
+    assertThat(
+        storage.buildMetricFor(
+            collector1,
+            Resource.empty(),
+            InstrumentationLibraryInfo.empty(),
+            METRIC_DESCRIPTOR,
+            AggregationTemporality.DELTA,
+            measurement2,
+            0,
+            20))
+        .hasDoubleSum()
+        .isDelta()
+        .points()
+        .hasSize(1)
+        .isNotEmpty()
+        .containsExactly(DoublePointData.create(10, 20, attr2, 7));
   }
 
   @Test
@@ -376,6 +475,104 @@ class TemporalMetricStorageTest {
         .isNotEmpty()
         .satisfiesExactly(
             point -> assertThat(point).hasStartEpochNanos(0).hasEpochNanos(35).hasValue(2));
+  }
+
+  @Test
+  void asynchronousCumulative_dropsStale() {
+    TemporalMetricStorage<DoubleAccumulation> storage =
+        new TemporalMetricStorage<>(ASYNC_SUM, /* isSynchronous= */ false);
+
+    // Send in new measurement at time 10 for collector 1, with attr1
+    Map<Attributes, DoubleAccumulation> measurement1 = new HashMap<>();
+    Attributes attr1 = Attributes.builder().put("key", "value1").build();
+    measurement1.put(attr1, DoubleAccumulation.create(3));
+    assertThat(
+            storage.buildMetricFor(
+                collector1,
+                Resource.empty(),
+                InstrumentationLibraryInfo.empty(),
+                METRIC_DESCRIPTOR,
+                AggregationTemporality.CUMULATIVE,
+                measurement1,
+                0,
+                10))
+        .hasDoubleSum()
+        .isCumulative()
+        .points()
+        .hasSize(1)
+        .isNotEmpty()
+        .contains(DoublePointData.create(0, 10, attr1, 3));
+
+    // Send in new measurement at time 20 for collector 1, with attr2
+    // Result should drop accumulation for attr1, only reporting accumulation for attr2
+    Map<Attributes, DoubleAccumulation> measurement2 = new HashMap<>();
+    Attributes attr2 = Attributes.builder().put("key", "value2").build();
+    measurement2.put(attr2, DoubleAccumulation.create(7));
+    assertThat(
+            storage.buildMetricFor(
+                collector1,
+                Resource.empty(),
+                InstrumentationLibraryInfo.empty(),
+                METRIC_DESCRIPTOR,
+                AggregationTemporality.CUMULATIVE,
+                measurement2,
+                0,
+                20))
+        .hasDoubleSum()
+        .isCumulative()
+        .points()
+        .hasSize(1)
+        .isNotEmpty()
+        .containsExactly(DoublePointData.create(0, 20, attr2, 7));
+  }
+
+  @Test
+  void asynchronousDelta_dropsStale() {
+    TemporalMetricStorage<DoubleAccumulation> storage =
+        new TemporalMetricStorage<>(ASYNC_SUM, /* isSynchronous= */ false);
+
+    // Send in new measurement at time 10 for collector 1, with attr1
+    Map<Attributes, DoubleAccumulation> measurement1 = new HashMap<>();
+    Attributes attr1 = Attributes.builder().put("key", "value1").build();
+    measurement1.put(attr1, DoubleAccumulation.create(3));
+    assertThat(
+        storage.buildMetricFor(
+            collector1,
+            Resource.empty(),
+            InstrumentationLibraryInfo.empty(),
+            METRIC_DESCRIPTOR,
+            AggregationTemporality.DELTA,
+            measurement1,
+            0,
+            10))
+        .hasDoubleSum()
+        .isDelta()
+        .points()
+        .hasSize(1)
+        .isNotEmpty()
+        .contains(DoublePointData.create(0, 10, attr1, 3));
+
+    // Send in new measurement at time 20 for collector 1, with attr2
+    // Result should drop accumulation for attr1, only reporting accumulation for attr2
+    Map<Attributes, DoubleAccumulation> measurement2 = new HashMap<>();
+    Attributes attr2 = Attributes.builder().put("key", "value2").build();
+    measurement2.put(attr2, DoubleAccumulation.create(7));
+    assertThat(
+        storage.buildMetricFor(
+            collector1,
+            Resource.empty(),
+            InstrumentationLibraryInfo.empty(),
+            METRIC_DESCRIPTOR,
+            AggregationTemporality.DELTA,
+            measurement2,
+            0,
+            20))
+        .hasDoubleSum()
+        .isDelta()
+        .points()
+        .hasSize(1)
+        .isNotEmpty()
+        .containsExactly(DoublePointData.create(10, 20, attr2, 7));
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/testing/InMemoryMetricReaderCumulativeTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/testing/InMemoryMetricReaderCumulativeTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.metrics.testing;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +20,11 @@ class InMemoryMetricReaderCumulativeTest {
   @BeforeEach
   void setup() {
     reader = InMemoryMetricReader.create();
-    provider = SdkMeterProvider.builder().registerMetricReader(reader).build();
+    provider =
+        SdkMeterProvider.builder()
+            .setMinimumCollectionInterval(Duration.ofSeconds(0))
+            .registerMetricReader(reader)
+            .build();
   }
 
   private void generateFakeMetric(int index) {
@@ -45,7 +50,7 @@ class InMemoryMetricReaderCumulativeTest {
 
     // Add more data, should join.
     generateFakeMetric(1);
-    assertThat(reader.collectAllMetrics()).hasSize(3);
+    assertThat(reader.collectAllMetrics()).hasSize(1);
   }
 
   @Test
@@ -55,7 +60,7 @@ class InMemoryMetricReaderCumulativeTest {
     generateFakeMetric(3);
     // TODO: Better assertions for CompletableResultCode.
     assertThat(reader.flush()).isNotNull();
-    assertThat(reader.collectAllMetrics()).hasSize(3);
+    assertThat(reader.collectAllMetrics()).hasSize(0);
   }
 
   @Test


### PR DESCRIPTION
This PR adds some naive protections for metrics cardinality:

- It aggressively forgets metric streams when temporality is cumulative. Currently, if temporality is cumulative and async instruments stop recording for a metric stream for an export, that stream is removed. The PR changes sync instruments to have the same behavior. This is the most conservative thing we can do from a memory management perspective. In the past we've talked about having TTL, where if a stream isn't recorded for the TTL, it's removed. This is a more aggressive, and simpler to implement removal policy that I think is a good start.
- It caps the number of metric streams for each `MetricStorage`. There is one metric storage per view, so each view has a cap number of metric streams. I set the number to 2000, which I believe is consistent with the behavior of dotnet. Arguably this should be much lower. It should also (eventually) be configurable. 
- It makes the `SdkMeterProvider` minimum collection interval configurable. This was an outstanding TODO in the code. Allowing this to be set to 0 made for simpler tests. 