### PR TITLE
Handle multiple hyphens in container prefix when parsing cgroups

### DIFF
--- a/sdk-extensions/resources/src/main/java/io/opentelemetry/sdk/extension/resources/ContainerResource.java
+++ b/sdk-extensions/resources/src/main/java/io/opentelemetry/sdk/extension/resources/ContainerResource.java
@@ -67,7 +67,7 @@ public final class ContainerResource {
       Optional<String> value =
           lines
               .filter(line -> !line.isEmpty())
-              .map(line -> getIdFromLine(line))
+              .map(ContainerResource::getIdFromLine)
               .filter(Objects::nonNull)
               .findFirst();
       if (value.isPresent()) {
@@ -82,14 +82,14 @@ public final class ContainerResource {
   @Nullable
   private static String getIdFromLine(String line) {
     // This cgroup output line should have the container id in it
-    int lastSlashIdx = line.lastIndexOf("/");
+    int lastSlashIdx = line.lastIndexOf('/');
     if (lastSlashIdx < 0) {
       return null;
     }
 
     String lastSection = line.substring(lastSlashIdx + 1);
-    int startIdx = lastSection.indexOf("-");
-    int endIdx = lastSection.lastIndexOf(".");
+    int startIdx = lastSection.lastIndexOf('-');
+    int endIdx = lastSection.lastIndexOf('.');
 
     String containerId =
         lastSection.substring(

--- a/sdk-extensions/resources/src/test/java/io/opentelemetry/sdk/extension/resources/ContainerResourceTest.java
+++ b/sdk-extensions/resources/src/test/java/io/opentelemetry/sdk/extension/resources/ContainerResourceTest.java
@@ -48,6 +48,12 @@ public class ContainerResourceTest {
 
   private static final String EXPECTED_CGROUP_4 = "dc579f8a8319c8cf7d38e1adf263bc08d23";
 
+  // with two dashes in prefix
+  private static final String CGROUP_LINE_5 =
+      "11:perf_event:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod4415fd05_2c0f_4533_909b_f2180dca8d7c.slice/cri-containerd-713a77a26fe2a38ebebd5709604a048c3d380db1eb16aa43aca0b2499e54733c.scope";
+  private static final String EXPECTED_CGROUP_5 =
+      "713a77a26fe2a38ebebd5709604a048c3d380db1eb16aa43aca0b2499e54733c";
+
   @Test
   public void testNegativeCases(@TempDir Path tempFolder) throws IOException {
     // invalid containerId (non-hex)
@@ -72,6 +78,9 @@ public class ContainerResourceTest {
 
     Path cgroup4 = createCGroup(tempFolder.resolve("cgroup4"), CGROUP_LINE_4);
     assertThat(getContainerId(buildResource(cgroup4))).isEqualTo(EXPECTED_CGROUP_4);
+
+    Path cgroup5 = createCGroup(tempFolder.resolve("cgroup5"), CGROUP_LINE_5);
+    assertThat(getContainerId(buildResource(cgroup5))).isEqualTo(EXPECTED_CGROUP_5);
   }
 
   private static String getContainerId(Resource resource) {


### PR DESCRIPTION
resolves #3832 