### PR TITLE
Restore @Immutable annotation on MetricData

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/MetricData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/MetricData.java
@@ -7,11 +7,13 @@ package io.opentelemetry.sdk.metrics.data;
 
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
+import javax.annotation.concurrent.Immutable;
 
 /**
  * A {@link MetricDataImpl} represents the data exported as part of aggregating one {@code
  * Instrument}.
  */
+@Immutable
 public interface MetricData {
 
   /**


### PR DESCRIPTION
The `@Immutable` annotation was recently removed from `MetricData`, I believe accidentally. This restores it. 