### PR TITLE
Configure periodic metric reader interval with otel.metric.export.interval

### DIFF
--- a/sdk-extensions/autoconfigure/README.md
+++ b/sdk-extensions/autoconfigure/README.md
@@ -221,11 +221,12 @@ These properties can be used to control the maximum size of recordings per span.
 |--------------------------|--------------------------|-----------------------------------------------------------------------------------|
 | otel.metrics.exemplar.filter | OTEL_METRICS_EXEMPLAR_FILTER | The filter for exemplar sampling.  Can be `NONE`, `ALL` or `WITH_SAMPLED_TRACE`. Default is `WITH_SAMPLED_TRACE`.|
 
-## Interval metric reader
+## Periodic Metric Reader
 
 | System property          | Environment variable     | Description                                                                       |
 |--------------------------|--------------------------|-----------------------------------------------------------------------------------|
-| otel.imr.export.interval | OTEL_IMR_EXPORT_INTERVAL | The interval, in milliseconds, between pushes to the exporter. Default is `60000`.|
+| otel.metric.export.interval | OTEL_METRIC_EXPORT_INTERVAL | The interval, in milliseconds, between the start of two export attempts. Default is `60000`.|
+| otel.imr.export.interval | OTEL_IMR_EXPORT_INTERVAL | **DEPRECATED for removal in 1.10.0.** The interval, in milliseconds, between the start of two export attempts. Default is `60000`.|
 
 ## Customizing the OpenTelemetry SDK
 
@@ -233,5 +234,5 @@ Autoconfiguration exposes SPI [hooks](../autoconfigure-spi/src/main/java/io/open
 It's recommended to use the above configuration properties where possible, only implementing the SPI to add functionality not found in the
 SDK by default.
 
-[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure.svg
+[javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry- sdk-extension-autoconfigure.svg
 [javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
@@ -139,7 +139,10 @@ final class MetricExporterConfiguration {
       SdkMeterProviderBuilder sdkMeterProviderBuilder,
       MetricExporter exporter) {
 
-    Duration exportInterval = config.getDuration("otel.imr.export.interval");
+    Duration exportInterval = config.getDuration("otel.metric.export.interval");
+    if (exportInterval == null) {
+      exportInterval = config.getDuration("otel.imr.export.interval");
+    }
     if (exportInterval == null) {
       exportInterval = Duration.ofMinutes(1);
     }

--- a/sdk-extensions/autoconfigure/src/testOtlpGrpc/java/io/opentelemetry/sdk/autoconfigure/OtlpGrpcConfigTest.java
+++ b/sdk-extensions/autoconfigure/src/testOtlpGrpc/java/io/opentelemetry/sdk/autoconfigure/OtlpGrpcConfigTest.java
@@ -311,7 +311,7 @@ class OtlpGrpcConfigTest {
     System.setProperty("otel.exporter.otlp.endpoint", "https://localhost:" + server.httpsPort());
     System.setProperty(
         "otel.exporter.otlp.certificate", certificate.certificateFile().getAbsolutePath());
-    System.setProperty("otel.imr.export.interval", "1s");
+    System.setProperty("otel.metric.export.interval", "1s");
 
     GlobalOpenTelemetry.get().getTracer("test").spanBuilder("test").startSpan().end();
 

--- a/sdk-extensions/autoconfigure/src/testOtlpHttp/java/io/opentelemetry/sdk/autoconfigure/OtlpHttpConfigTest.java
+++ b/sdk-extensions/autoconfigure/src/testOtlpHttp/java/io/opentelemetry/sdk/autoconfigure/OtlpHttpConfigTest.java
@@ -363,7 +363,7 @@ class OtlpHttpConfigTest {
         "otel.exporter.otlp.endpoint",
         "https://" + canonicalHostName + ":" + server.httpsPort() + "/");
     System.setProperty("otel.exporter.otlp.certificate", certificateExtension.filePath);
-    System.setProperty("otel.imr.export.interval", "1s");
+    System.setProperty("otel.metric.export.interval", "1s");
 
     GlobalOpenTelemetry.get().getTracer("test").spanBuilder("test").startSpan().end();
 


### PR DESCRIPTION
Updating autoconfigure configuration of the periodic metric reader to be based off `otel.metric.export.interval`, and deprecating `otel.imr.export.interval`. 

This system property was introduced in spec [PR 2038](https://github.com/open-telemetry/opentelemetry-specification/pull/2038).

The spec also introduced another property, `OTEL_METRIC_EXPORT_TIMEOUT`, but `PeriodicMetricReader` doesn't yet have a configurable export timeout. 

