### PR TITLE
Add getAttribute() to SpanData and EventData

### DIFF
--- a/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/InteroperabilityTest.java
+++ b/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/InteroperabilityTest.java
@@ -219,9 +219,9 @@ class InteroperabilityTest {
         .isEqualTo(parentLinkSpan.getContext().getSpanId().toLowerBase16());
     assertThat(spanData3.getKind()).isEqualTo(SpanKind.SERVER);
     assertThat(spanData3.getStatus()).isEqualTo(StatusData.ok());
-    assertThat(spanData3.getAttributes().get(AttributeKey.doubleKey("testKey"))).isEqualTo(2.5);
-    assertThat(spanData3.getAttributes().get(AttributeKey.booleanKey("testKey2"))).isEqualTo(false);
-    assertThat(spanData3.getAttributes().get(AttributeKey.longKey("testKey3"))).isEqualTo(3);
+    assertThat(spanData3.getAttribute(AttributeKey.doubleKey("testKey"))).isEqualTo(2.5);
+    assertThat(spanData3.getAttribute(AttributeKey.booleanKey("testKey2"))).isEqualTo(false);
+    assertThat(spanData3.getAttribute(AttributeKey.longKey("testKey3"))).isEqualTo(3);
     assertThat(spanData3.getTotalRecordedEvents()).isEqualTo(3);
     assertThat(spanData3.getEvents().get(0).getName()).isEqualTo("12345");
     assertThat(
@@ -246,10 +246,9 @@ class InteroperabilityTest {
                 .get(AttributeKey.stringKey("message.event.type")))
         .isEqualTo("SENT");
     assertThat(spanData3.getEvents().get(1).getName()).isEqualTo("OpenCensus: Event 1");
-    assertThat(spanData3.getEvents().get(1).getAttributes().get(AttributeKey.doubleKey("testKey")))
+    assertThat(spanData3.getEvents().get(1).getAttribute(AttributeKey.doubleKey("testKey")))
         .isEqualTo(123);
-    assertThat(
-            spanData3.getEvents().get(1).getAttributes().get(AttributeKey.booleanKey("testKey2")))
+    assertThat(spanData3.getEvents().get(1).getAttribute(AttributeKey.booleanKey("testKey2")))
         .isEqualTo(true);
     assertThat(spanData3.getEvents().get(2).getName()).isEqualTo("OpenCensus: Event 2");
 
@@ -293,16 +292,15 @@ class InteroperabilityTest {
     assertThat(spanData1.getTotalRecordedEvents()).isEqualTo(4);
     assertThat(spanData1.getEvents().get(0).getName()).isEqualTo("OpenCensus span: Event 1");
     assertThat(spanData1.getEvents().get(1).getName()).isEqualTo("OpenCensus span: Event 2");
-    assertThat(spanData1.getEvents().get(1).getAttributes().get(AttributeKey.doubleKey("key2")))
+    assertThat(spanData1.getEvents().get(1).getAttribute(AttributeKey.doubleKey("key2")))
         .isEqualTo(3.5);
     assertThat(spanData1.getEvents().get(1).getEpochNanos()).isEqualTo(0);
     assertThat(spanData1.getEvents().get(2).getName()).isEqualTo("OpenCensus span: Event 3");
     assertThat(spanData1.getEvents().get(2).getEpochNanos()).isEqualTo((long) 5e6);
     assertThat(spanData1.getEvents().get(3).getName()).isEqualTo("OpenCensus span: Event 4");
-    assertThat(spanData1.getEvents().get(3).getAttributes().get(AttributeKey.longKey("key3")))
+    assertThat(spanData1.getEvents().get(3).getAttribute(AttributeKey.longKey("key3")))
         .isEqualTo(4L);
-    assertThat(spanData1.getAttributes().get(AttributeKey.stringKey("testKey")))
-        .isEqualTo("testValue");
+    assertThat(spanData1.getAttribute(AttributeKey.stringKey("testKey"))).isEqualTo("testValue");
   }
 
   @Test

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
@@ -252,11 +252,9 @@ class SpanShimTest {
   }
 
   private static void verifyAttributes(EventData eventData) {
-    assertThat(eventData.getAttributes().get(AttributeKey.stringKey("keyForString")))
-        .isEqualTo("value");
-    assertThat(eventData.getAttributes().get(AttributeKey.longKey("keyForInt"))).isEqualTo(1);
-    assertThat(eventData.getAttributes().get(AttributeKey.doubleKey("keyForDouble")))
-        .isEqualTo(1.0);
-    assertThat(eventData.getAttributes().get(AttributeKey.booleanKey("keyForBoolean"))).isTrue();
+    assertThat(eventData.getAttribute(AttributeKey.stringKey("keyForString"))).isEqualTo("value");
+    assertThat(eventData.getAttribute(AttributeKey.longKey("keyForInt"))).isEqualTo(1);
+    assertThat(eventData.getAttribute(AttributeKey.doubleKey("keyForDouble"))).isEqualTo(1.0);
+    assertThat(eventData.getAttribute(AttributeKey.booleanKey("keyForBoolean"))).isTrue();
   }
 }

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/TestUtils.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/TestUtils.java
@@ -33,7 +33,7 @@ public final class TestUtils {
     return getByCondition(
         spans,
         spanData -> {
-          T attrValue = spanData.getAttributes().get(key);
+          T attrValue = spanData.getAttribute(key);
           if (attrValue == null) {
             return false;
           }

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/nestedcallbacks/NestedCallbacksTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/nestedcallbacks/NestedCallbacksTest.java
@@ -48,8 +48,7 @@ public final class NestedCallbacksTest {
     Attributes attrs = spans.get(0).getAttributes();
     assertThat(attrs.size()).isEqualTo(3);
     for (int i = 1; i <= 3; i++) {
-      assertThat(spans.get(0).getAttributes().get(stringKey("key" + i)))
-          .isEqualTo(Integer.toString(i));
+      assertThat(spans.get(0).getAttribute(stringKey("key" + i))).isEqualTo(Integer.toString(i));
     }
 
     assertThat(tracer.scopeManager().activeSpan()).isNull();

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/RateLimitingSamplerTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/RateLimitingSamplerTest.java
@@ -56,8 +56,8 @@ class RateLimitingSamplerTest {
                 .getDecision())
         .isEqualTo(SamplingDecision.DROP);
     assertThat(samplingResult.getAttributes().size()).isEqualTo(2);
-    assertThat(samplingResult.getAttributes().get(RateLimitingSampler.SAMPLER_PARAM)).isEqualTo(1d);
-    assertThat(samplingResult.getAttributes().get(RateLimitingSampler.SAMPLER_TYPE))
+    assertThat(samplingResult.getAttribute(RateLimitingSampler.SAMPLER_PARAM)).isEqualTo(1d);
+    assertThat(samplingResult.getAttribute(RateLimitingSampler.SAMPLER_TYPE))
         .isEqualTo(RateLimitingSampler.TYPE);
   }
 

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/RateLimitingSamplerTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/RateLimitingSamplerTest.java
@@ -56,8 +56,8 @@ class RateLimitingSamplerTest {
                 .getDecision())
         .isEqualTo(SamplingDecision.DROP);
     assertThat(samplingResult.getAttributes().size()).isEqualTo(2);
-    assertThat(samplingResult.getAttribute(RateLimitingSampler.SAMPLER_PARAM)).isEqualTo(1d);
-    assertThat(samplingResult.getAttribute(RateLimitingSampler.SAMPLER_TYPE))
+    assertThat(samplingResult.getAttributes().get(RateLimitingSampler.SAMPLER_PARAM)).isEqualTo(1d);
+    assertThat(samplingResult.getAttributes().get(RateLimitingSampler.SAMPLER_TYPE))
         .isEqualTo(RateLimitingSampler.TYPE);
   }
 

--- a/sdk-extensions/tracing-incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/trace/data/DelegatingSpanDataTest.java
+++ b/sdk-extensions/tracing-incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/trace/data/DelegatingSpanDataTest.java
@@ -38,7 +38,7 @@ class DelegatingSpanDataTest {
     private SpanDataWithClientType(SpanData delegate) {
       super(delegate);
       final String clientType;
-      String userAgent = delegate.getAttributes().get(SemanticAttributes.HTTP_USER_AGENT);
+      String userAgent = delegate.getAttribute(SemanticAttributes.HTTP_USER_AGENT);
       if (userAgent != null) {
         clientType = parseUserAgent(userAgent);
       } else {
@@ -81,7 +81,7 @@ class DelegatingSpanDataTest {
   void overrideDelegate() {
     SpanData spanData = createBasicSpanBuilder().build();
     SpanData spanDataWithClientType = new SpanDataWithClientType(spanData);
-    assertThat(spanDataWithClientType.getAttributes().get(CLIENT_TYPE_KEY)).isEqualTo("unknown");
+    assertThat(spanDataWithClientType.getAttribute(CLIENT_TYPE_KEY)).isEqualTo("unknown");
   }
 
   @Test
@@ -100,7 +100,7 @@ class DelegatingSpanDataTest {
         .addEqualityGroup(noopWrapper)
         .addEqualityGroup(spanDataWithClientType)
         .testEquals();
-    assertThat(spanDataWithClientType.getAttributes().get(CLIENT_TYPE_KEY)).isEqualTo("unknown");
+    assertThat(spanDataWithClientType.getAttribute(CLIENT_TYPE_KEY)).isEqualTo("unknown");
   }
 
   private static TestSpanData.Builder createBasicSpanBuilder() {

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SpanDataAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SpanDataAssert.java
@@ -302,7 +302,7 @@ public final class SpanDataAssert extends AbstractAssert<SpanDataAssert, SpanDat
 
     // Exceptions used in assertions always have a different stack trace, just confirm it was
     // recorded.
-    String stackTrace = exceptionEvent.getAttributes().get(SemanticAttributes.EXCEPTION_STACKTRACE);
+    String stackTrace = exceptionEvent.getAttribute(SemanticAttributes.EXCEPTION_STACKTRACE);
     assertThat(stackTrace).as("exception.stacktrace").isNotNull();
 
     return this;

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/EventData.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/EventData.java
@@ -5,8 +5,10 @@
 
 package io.opentelemetry.sdk.trace.data;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.trace.SpanLimits;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /** Data representation of a event. */
@@ -52,6 +54,16 @@ public interface EventData {
    * @return the attributes of the {@link EventData}.
    */
   Attributes getAttributes();
+
+  /**
+   * Returns the value for a given attribute key.
+   *
+   * @return the value of the attribute with the given key
+   */
+  @Nullable
+  default <T> T getAttribute(AttributeKey<T> key) {
+    return getAttributes().get(key);
+  }
 
   /**
    * Returns the epoch time in nanos of this event.

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.trace.data;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
@@ -12,6 +13,7 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SpanLimits;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -92,6 +94,16 @@ public interface SpanData {
    * @return the attributes recorded for this {@code Span}.
    */
   Attributes getAttributes();
+
+  /**
+   * Returns the value for a given attribute key.
+   *
+   * @return the value of the attribute with the given key
+   */
+  @Nullable
+  default <T> T getAttribute(AttributeKey<T> key) {
+    return getAttributes().get(key);
+  }
 
   /**
    * Returns the timed events recorded for this {@code Span}.

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpanTest.java
@@ -264,7 +264,7 @@ class RecordEventsReadableSpanTest {
     // Assert that the snapshot does not reflect the modified state, but the state of the time when
     // toSpanData was called.
     assertThat(spanData.getAttributes().size()).isEqualTo(attributes.size());
-    assertThat(spanData.getAttributes().get(stringKey("anotherKey"))).isNull();
+    assertThat(spanData.getAttribute(stringKey("anotherKey"))).isNull();
     assertThat(spanData.hasEnded()).isFalse();
     assertThat(spanData.getEndEpochNanos()).isEqualTo(0);
     assertThat(spanData.getName()).isEqualTo(SPAN_NAME);
@@ -274,7 +274,7 @@ class RecordEventsReadableSpanTest {
     // state.
     spanData = span.toSpanData();
     assertThat(spanData.getAttributes().size()).isEqualTo(attributes.size() + 1);
-    assertThat(spanData.getAttributes().get(stringKey("anotherKey"))).isEqualTo("anotherValue");
+    assertThat(spanData.getAttribute(stringKey("anotherKey"))).isEqualTo("anotherValue");
     assertThat(spanData.hasEnded()).isTrue();
     assertThat(spanData.getEndEpochNanos()).isGreaterThan(0);
     assertThat(spanData.getName()).isEqualTo("changedName");
@@ -413,28 +413,26 @@ class RecordEventsReadableSpanTest {
     }
     SpanData spanData = span.toSpanData();
     assertThat(spanData.getAttributes().size()).isEqualTo(16);
-    assertThat(spanData.getAttributes().get(stringKey("StringKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(stringKey("EmptyStringKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(stringKey("EmptyStringAttributeValue"))).isNotNull();
-    assertThat(spanData.getAttributes().get(longKey("LongKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(longKey("LongKey2"))).isEqualTo(5L);
-    assertThat(spanData.getAttributes().get(longKey("LongKey3"))).isEqualTo(6L);
-    assertThat(spanData.getAttributes().get(doubleKey("DoubleKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(booleanKey("BooleanKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(stringArrayKey("ArrayStringKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(longArrayKey("ArrayLongKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(doubleArrayKey("ArrayDoubleKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(booleanArrayKey("ArrayBooleanKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(longArrayKey("ArrayWithNullLongKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(stringArrayKey("ArrayWithNullStringKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(doubleArrayKey("ArrayWithNullDoubleKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(booleanArrayKey("ArrayWithNullBooleanKey")))
-        .isNotNull();
-    assertThat(spanData.getAttributes().get(stringArrayKey("ArrayStringKey")).size()).isEqualTo(4);
-    assertThat(spanData.getAttributes().get(longArrayKey("ArrayLongKey")).size()).isEqualTo(5);
-    assertThat(spanData.getAttributes().get(doubleArrayKey("ArrayDoubleKey")).size()).isEqualTo(5);
-    assertThat(spanData.getAttributes().get(booleanArrayKey("ArrayBooleanKey")).size())
-        .isEqualTo(4);
+    assertThat(spanData.getAttribute(stringKey("StringKey"))).isNotNull();
+    assertThat(spanData.getAttribute(stringKey("EmptyStringKey"))).isNotNull();
+    assertThat(spanData.getAttribute(stringKey("EmptyStringAttributeValue"))).isNotNull();
+    assertThat(spanData.getAttribute(longKey("LongKey"))).isNotNull();
+    assertThat(spanData.getAttribute(longKey("LongKey2"))).isEqualTo(5L);
+    assertThat(spanData.getAttribute(longKey("LongKey3"))).isEqualTo(6L);
+    assertThat(spanData.getAttribute(doubleKey("DoubleKey"))).isNotNull();
+    assertThat(spanData.getAttribute(booleanKey("BooleanKey"))).isNotNull();
+    assertThat(spanData.getAttribute(stringArrayKey("ArrayStringKey"))).isNotNull();
+    assertThat(spanData.getAttribute(longArrayKey("ArrayLongKey"))).isNotNull();
+    assertThat(spanData.getAttribute(doubleArrayKey("ArrayDoubleKey"))).isNotNull();
+    assertThat(spanData.getAttribute(booleanArrayKey("ArrayBooleanKey"))).isNotNull();
+    assertThat(spanData.getAttribute(longArrayKey("ArrayWithNullLongKey"))).isNotNull();
+    assertThat(spanData.getAttribute(stringArrayKey("ArrayWithNullStringKey"))).isNotNull();
+    assertThat(spanData.getAttribute(doubleArrayKey("ArrayWithNullDoubleKey"))).isNotNull();
+    assertThat(spanData.getAttribute(booleanArrayKey("ArrayWithNullBooleanKey"))).isNotNull();
+    assertThat(spanData.getAttribute(stringArrayKey("ArrayStringKey")).size()).isEqualTo(4);
+    assertThat(spanData.getAttribute(longArrayKey("ArrayLongKey")).size()).isEqualTo(5);
+    assertThat(spanData.getAttribute(doubleArrayKey("ArrayDoubleKey")).size()).isEqualTo(5);
+    assertThat(spanData.getAttribute(booleanArrayKey("ArrayBooleanKey")).size()).isEqualTo(4);
   }
 
   @Test
@@ -554,28 +552,26 @@ class RecordEventsReadableSpanTest {
 
     SpanData spanData = span.toSpanData();
     assertThat(spanData.getAttributes().size()).isEqualTo(16);
-    assertThat(spanData.getAttributes().get(stringKey("StringKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(stringKey("EmptyStringKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(stringKey("EmptyStringAttributeValue"))).isNotNull();
-    assertThat(spanData.getAttributes().get(longKey("LongKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(longKey("LongKey2"))).isEqualTo(5L);
-    assertThat(spanData.getAttributes().get(longKey("LongKey3"))).isEqualTo(6L);
-    assertThat(spanData.getAttributes().get(doubleKey("DoubleKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(booleanKey("BooleanKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(stringArrayKey("ArrayStringKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(longArrayKey("ArrayLongKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(doubleArrayKey("ArrayDoubleKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(booleanArrayKey("ArrayBooleanKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(longArrayKey("ArrayWithNullLongKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(stringArrayKey("ArrayWithNullStringKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(doubleArrayKey("ArrayWithNullDoubleKey"))).isNotNull();
-    assertThat(spanData.getAttributes().get(booleanArrayKey("ArrayWithNullBooleanKey")))
-        .isNotNull();
-    assertThat(spanData.getAttributes().get(stringArrayKey("ArrayStringKey")).size()).isEqualTo(4);
-    assertThat(spanData.getAttributes().get(longArrayKey("ArrayLongKey")).size()).isEqualTo(5);
-    assertThat(spanData.getAttributes().get(doubleArrayKey("ArrayDoubleKey")).size()).isEqualTo(5);
-    assertThat(spanData.getAttributes().get(booleanArrayKey("ArrayBooleanKey")).size())
-        .isEqualTo(4);
+    assertThat(spanData.getAttribute(stringKey("StringKey"))).isNotNull();
+    assertThat(spanData.getAttribute(stringKey("EmptyStringKey"))).isNotNull();
+    assertThat(spanData.getAttribute(stringKey("EmptyStringAttributeValue"))).isNotNull();
+    assertThat(spanData.getAttribute(longKey("LongKey"))).isNotNull();
+    assertThat(spanData.getAttribute(longKey("LongKey2"))).isEqualTo(5L);
+    assertThat(spanData.getAttribute(longKey("LongKey3"))).isEqualTo(6L);
+    assertThat(spanData.getAttribute(doubleKey("DoubleKey"))).isNotNull();
+    assertThat(spanData.getAttribute(booleanKey("BooleanKey"))).isNotNull();
+    assertThat(spanData.getAttribute(stringArrayKey("ArrayStringKey"))).isNotNull();
+    assertThat(spanData.getAttribute(longArrayKey("ArrayLongKey"))).isNotNull();
+    assertThat(spanData.getAttribute(doubleArrayKey("ArrayDoubleKey"))).isNotNull();
+    assertThat(spanData.getAttribute(booleanArrayKey("ArrayBooleanKey"))).isNotNull();
+    assertThat(spanData.getAttribute(longArrayKey("ArrayWithNullLongKey"))).isNotNull();
+    assertThat(spanData.getAttribute(stringArrayKey("ArrayWithNullStringKey"))).isNotNull();
+    assertThat(spanData.getAttribute(doubleArrayKey("ArrayWithNullDoubleKey"))).isNotNull();
+    assertThat(spanData.getAttribute(booleanArrayKey("ArrayWithNullBooleanKey"))).isNotNull();
+    assertThat(spanData.getAttribute(stringArrayKey("ArrayStringKey")).size()).isEqualTo(4);
+    assertThat(spanData.getAttribute(longArrayKey("ArrayLongKey")).size()).isEqualTo(5);
+    assertThat(spanData.getAttribute(doubleArrayKey("ArrayDoubleKey")).size()).isEqualTo(5);
+    assertThat(spanData.getAttribute(booleanArrayKey("ArrayBooleanKey")).size()).isEqualTo(4);
   }
 
   @Test
@@ -600,15 +596,13 @@ class RecordEventsReadableSpanTest {
 
     SpanData spanData = span.toSpanData();
     assertThat(spanData.getAttributes().size()).isEqualTo(5);
-    assertThat(spanData.getAttributes().get(stringKey("StringKey")))
-        .isNotNull()
-        .isEqualTo("StringVal");
-    assertThat(spanData.getAttributes().get(stringKey("ExistingStringKey")))
+    assertThat(spanData.getAttribute(stringKey("StringKey"))).isNotNull().isEqualTo("StringVal");
+    assertThat(spanData.getAttribute(stringKey("ExistingStringKey")))
         .isNotNull()
         .isEqualTo("ExistingStringVal");
-    assertThat(spanData.getAttributes().get(longKey("LongKey"))).isNotNull().isEqualTo(1000L);
-    assertThat(spanData.getAttributes().get(doubleKey("DoubleKey"))).isNotNull().isEqualTo(10.0);
-    assertThat(spanData.getAttributes().get(booleanKey("BooleanKey"))).isNotNull().isEqualTo(false);
+    assertThat(spanData.getAttribute(longKey("LongKey"))).isNotNull().isEqualTo(1000L);
+    assertThat(spanData.getAttribute(doubleKey("DoubleKey"))).isNotNull().isEqualTo(10.0);
+    assertThat(spanData.getAttribute(booleanKey("BooleanKey"))).isNotNull().isEqualTo(false);
   }
 
   @Test
@@ -823,12 +817,11 @@ class RecordEventsReadableSpanTest {
       // Test that we still have in the attributes map the latest maxNumberOfAttributes / 2 entries.
       for (int i = 0; i < maxNumberOfAttributes / 2; i++) {
         int val = i + maxNumberOfAttributes * 3 / 2;
-        assertThat(spanData.getAttributes().get(longKey("MyStringAttributeKey" + i)))
-            .isEqualTo(val);
+        assertThat(spanData.getAttribute(longKey("MyStringAttributeKey" + i))).isEqualTo(val);
       }
       // Test that we have the newest re-added initial entries.
       for (int i = maxNumberOfAttributes / 2; i < maxNumberOfAttributes; i++) {
-        assertThat(spanData.getAttributes().get(longKey("MyStringAttributeKey" + i))).isEqualTo(i);
+        assertThat(spanData.getAttribute(longKey("MyStringAttributeKey" + i))).isEqualTo(i);
       }
     } finally {
       span.end();
@@ -906,7 +899,7 @@ class RecordEventsReadableSpanTest {
     List<EventData> events = span.toSpanData().getEvents();
     assertThat(events).hasSize(1);
     EventData event = events.get(0);
-    assertThat(event.getAttributes().get(SemanticAttributes.EXCEPTION_MESSAGE)).isNull();
+    assertThat(event.getAttribute(SemanticAttributes.EXCEPTION_MESSAGE)).isNull();
   }
 
   private static class InnerClassException extends Exception {}
@@ -921,7 +914,7 @@ class RecordEventsReadableSpanTest {
     List<EventData> events = span.toSpanData().getEvents();
     assertThat(events).hasSize(1);
     EventData event = events.get(0);
-    assertThat(event.getAttributes().get(SemanticAttributes.EXCEPTION_TYPE))
+    assertThat(event.getAttribute(SemanticAttributes.EXCEPTION_TYPE))
         .isEqualTo("io.opentelemetry.sdk.trace.RecordEventsReadableSpanTest.InnerClassException");
   }
 

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
@@ -447,7 +447,7 @@ class SdkSpanBuilderTest {
     RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
     span.end();
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(1);
-    assertThat(span.toSpanData().getAttributes().get(stringKey("cat"))).isEqualTo("meow");
+    assertThat(span.toSpanData().getAttribute(stringKey("cat"))).isEqualTo("meow");
   }
 
   @Test
@@ -637,7 +637,7 @@ class SdkSpanBuilderTest {
                 .startSpan();
     try {
       assertThat(span.getSpanContext().isSampled()).isTrue();
-      assertThat(span.toSpanData().getAttributes().get(samplerAttributeKey)).isNotNull();
+      assertThat(span.toSpanData().getAttribute(samplerAttributeKey)).isNotNull();
       assertThat(span.toSpanData().getSpanContext().getTraceState())
           .isEqualTo(TraceState.getDefault());
     } finally {
@@ -692,7 +692,7 @@ class SdkSpanBuilderTest {
                 .startSpan();
     try {
       assertThat(span.getSpanContext().isSampled()).isTrue();
-      assertThat(span.toSpanData().getAttributes().get(samplerAttributeKey)).isNotNull();
+      assertThat(span.toSpanData().getAttribute(samplerAttributeKey)).isNotNull();
       assertThat(span.toSpanData().getSpanContext().getTraceState())
           .isEqualTo(TraceState.builder().put("newkey", "newValue").build());
     } finally {

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/data/DelegatingSpanDataTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/data/DelegatingSpanDataTest.java
@@ -35,7 +35,7 @@ class DelegatingSpanDataTest {
     private SpanDataWithClientType(SpanData delegate) {
       super(delegate);
       final String clientType;
-      String userAgent = delegate.getAttributes().get(SemanticAttributes.HTTP_USER_AGENT);
+      String userAgent = delegate.getAttribute(SemanticAttributes.HTTP_USER_AGENT);
       if (userAgent != null) {
         clientType = parseUserAgent(userAgent);
       } else {
@@ -78,7 +78,7 @@ class DelegatingSpanDataTest {
   void overrideDelegate() {
     SpanData spanData = createBasicSpanBuilder().build();
     SpanData spanDataWithClientType = new SpanDataWithClientType(spanData);
-    assertThat(spanDataWithClientType.getAttributes().get(CLIENT_TYPE_KEY)).isEqualTo("unknown");
+    assertThat(spanDataWithClientType.getAttribute(CLIENT_TYPE_KEY)).isEqualTo("unknown");
   }
 
   @Test
@@ -97,7 +97,7 @@ class DelegatingSpanDataTest {
         .addEqualityGroup(noopWrapper)
         .addEqualityGroup(spanDataWithClientType)
         .testEquals();
-    assertThat(spanDataWithClientType.getAttributes().get(CLIENT_TYPE_KEY)).isEqualTo("unknown");
+    assertThat(spanDataWithClientType.getAttribute(CLIENT_TYPE_KEY)).isEqualTo("unknown");
   }
 
   private static TestSpanData.Builder createBasicSpanBuilder() {

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/testbed/TestUtils.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/testbed/TestUtils.java
@@ -35,7 +35,7 @@ public final class TestUtils {
     return getByCondition(
         spans,
         span -> {
-          T attrValue = span.getAttributes().get(key);
+          T attrValue = span.getAttribute(key);
           if (attrValue == null) {
             return false;
           }


### PR DESCRIPTION
Quite a few places where we call `getAttributes().get(key)` on `SpanData` (and spans) and also `EventData`. This adds the singular `getAttribute()` to simplify it a bit and fix a small law of Demeter violation (technicality).