### PR TITLE
OTLP exporter - oneof primtives must have their default values serialized.

### DIFF
--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MarshalerUtil.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MarshalerUtil.java
@@ -177,25 +177,25 @@ public final class MarshalerUtil {
 
   /** Returns the size of a double field. */
   public static int sizeDouble(ProtoFieldInfo field, double value) {
-    return sizeDouble(field, value, /* force= */ false);
-  }
-  /** Returns the size of a double field. */
-  public static int sizeDouble(ProtoFieldInfo field, double value, boolean force) {
-    if (!force && value == 0D) {
+    if (value == 0D) {
       return 0;
     }
+    return sizeDoubleOptional(field, value);
+  }
+  /** Returns the size of a double field. */
+  public static int sizeDoubleOptional(ProtoFieldInfo field, double value) {
     return field.getTagSize() + CodedOutputStream.computeDoubleSizeNoTag(value);
   }
 
   /** Returns the size of a fixed64 field. */
   public static int sizeFixed64(ProtoFieldInfo field, long value) {
-    return sizeFixed64(field, value, /* force= */ false);
-  }
-  /** Returns the size of a fixed64 field. */
-  public static int sizeFixed64(ProtoFieldInfo field, long value, boolean force) {
-    if (!force && value == 0L) {
+    if (value == 0L) {
       return 0;
     }
+    return sizeFixed64Optional(field, value);
+  }
+  /** Returns the size of a fixed64 field. */
+  public static int sizeFixed64Optional(ProtoFieldInfo field, long value) {
     return field.getTagSize() + CodedOutputStream.computeFixed64SizeNoTag(value);
   }
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MarshalerUtil.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/MarshalerUtil.java
@@ -177,18 +177,26 @@ public final class MarshalerUtil {
 
   /** Returns the size of a double field. */
   public static int sizeDouble(ProtoFieldInfo field, double value) {
-    if (value == 0D) {
+    return sizeDouble(field, value, /* force= */ false);
+  }
+  /** Returns the size of a double field. */
+  public static int sizeDouble(ProtoFieldInfo field, double value, boolean force) {
+    if (!force && value == 0D) {
       return 0;
     }
     return field.getTagSize() + CodedOutputStream.computeDoubleSizeNoTag(value);
   }
 
   /** Returns the size of a fixed64 field. */
-  public static int sizeFixed64(ProtoFieldInfo field, long message) {
-    if (message == 0L) {
+  public static int sizeFixed64(ProtoFieldInfo field, long value) {
+    return sizeFixed64(field, value, /* force= */ false);
+  }
+  /** Returns the size of a fixed64 field. */
+  public static int sizeFixed64(ProtoFieldInfo field, long value, boolean force) {
+    if (!force && value == 0L) {
       return 0;
     }
-    return field.getTagSize() + CodedOutputStream.computeFixed64SizeNoTag(message);
+    return field.getTagSize() + CodedOutputStream.computeFixed64SizeNoTag(value);
   }
 
   /** Returns the size of a fixed32 field. */

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Serializer.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Serializer.java
@@ -95,14 +95,14 @@ public abstract class Serializer implements AutoCloseable {
 
   /** Serializes a protobuf {@code fixed64} field. */
   public void serializeFixed64(ProtoFieldInfo field, long value) throws IOException {
-    serializeFixed64(field, value, /* force= */ false);
+    if (value == 0) {
+      return;
+    }
+    writeFixed64(field, value);
   }
 
   /** Serializes a protobuf {@code fixed64} field. */
-  public void serializeFixed64(ProtoFieldInfo field, long value, boolean force) throws IOException {
-    if (!force && value == 0) {
-      return;
-    }
+  public void serializeFixed64Optional(ProtoFieldInfo field, long value) throws IOException {
     writeFixed64(field, value);
   }
 
@@ -112,12 +112,7 @@ public abstract class Serializer implements AutoCloseable {
 
   /** Serializes a protobuf {@code fixed32} field. */
   public void serializeFixed32(ProtoFieldInfo field, int value) throws IOException {
-    serializeFixed32(field, value, /* force= */ false);
-  }
-
-  /** Serializes a protobuf {@code fixed32} field. */
-  public void serializeFixed32(ProtoFieldInfo field, int value, boolean force) throws IOException {
-    if (!force && value == 0) {
+    if (value == 0) {
       return;
     }
     writeFixed32(field, value);
@@ -127,14 +122,13 @@ public abstract class Serializer implements AutoCloseable {
 
   /** Serializes a proto buf {@code double} field. */
   public void serializeDouble(ProtoFieldInfo field, double value) throws IOException {
-    serializeDouble(field, value, /* force= */ false);
-  }
-  /** Serializes a proto buf {@code double} field. */
-  public void serializeDouble(ProtoFieldInfo field, double value, boolean force)
-      throws IOException {
-    if (!force && value == 0D) {
+    if (value == 0D) {
       return;
     }
+    writeDouble(field, value);
+  }
+  /** Serializes a proto buf {@code double} field. */
+  public void serializeDoubleOptional(ProtoFieldInfo field, double value) throws IOException {
     writeDouble(field, value);
   }
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Serializer.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Serializer.java
@@ -95,7 +95,12 @@ public abstract class Serializer implements AutoCloseable {
 
   /** Serializes a protobuf {@code fixed64} field. */
   public void serializeFixed64(ProtoFieldInfo field, long value) throws IOException {
-    if (value == 0) {
+    serializeFixed64(field, value, /* force= */ false);
+  }
+
+  /** Serializes a protobuf {@code fixed64} field. */
+  public void serializeFixed64(ProtoFieldInfo field, long value, boolean force) throws IOException {
+    if (!force && value == 0) {
       return;
     }
     writeFixed64(field, value);
@@ -107,7 +112,12 @@ public abstract class Serializer implements AutoCloseable {
 
   /** Serializes a protobuf {@code fixed32} field. */
   public void serializeFixed32(ProtoFieldInfo field, int value) throws IOException {
-    if (value == 0) {
+    serializeFixed32(field, value, /* force= */ false);
+  }
+
+  /** Serializes a protobuf {@code fixed32} field. */
+  public void serializeFixed32(ProtoFieldInfo field, int value, boolean force) throws IOException {
+    if (!force && value == 0) {
       return;
     }
     writeFixed32(field, value);
@@ -117,7 +127,12 @@ public abstract class Serializer implements AutoCloseable {
 
   /** Serializes a proto buf {@code double} field. */
   public void serializeDouble(ProtoFieldInfo field, double value) throws IOException {
-    if (value == 0D) {
+    serializeDouble(field, value, /* force= */ false);
+  }
+  /** Serializes a proto buf {@code double} field. */
+  public void serializeDouble(ProtoFieldInfo field, double value, boolean force)
+      throws IOException {
+    if (!force && value == 0D) {
       return;
     }
     writeDouble(field, value);

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/metrics/NumberDataPointMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/metrics/NumberDataPointMarshaler.java
@@ -80,9 +80,9 @@ final class NumberDataPointMarshaler extends MarshalerWithSize {
     output.serializeFixed64(NumberDataPoint.START_TIME_UNIX_NANO, startTimeUnixNano);
     output.serializeFixed64(NumberDataPoint.TIME_UNIX_NANO, timeUnixNano);
     if (valueField == NumberDataPoint.AS_INT) {
-      output.serializeFixed64(valueField, ((LongPointData) value).getValue());
+      output.serializeFixed64(valueField, ((LongPointData) value).getValue(), /* force= */ true);
     } else {
-      output.serializeDouble(valueField, ((DoublePointData) value).getValue());
+      output.serializeDouble(valueField, ((DoublePointData) value).getValue(), /* force= */ true);
     }
     output.serializeRepeatedMessage(NumberDataPoint.EXEMPLARS, exemplars);
     output.serializeRepeatedMessage(NumberDataPoint.ATTRIBUTES, attributes);

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/metrics/NumberDataPointMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/metrics/NumberDataPointMarshaler.java
@@ -80,9 +80,9 @@ final class NumberDataPointMarshaler extends MarshalerWithSize {
     output.serializeFixed64(NumberDataPoint.START_TIME_UNIX_NANO, startTimeUnixNano);
     output.serializeFixed64(NumberDataPoint.TIME_UNIX_NANO, timeUnixNano);
     if (valueField == NumberDataPoint.AS_INT) {
-      output.serializeFixed64(valueField, ((LongPointData) value).getValue(), /* force= */ true);
+      output.serializeFixed64Optional(valueField, ((LongPointData) value).getValue());
     } else {
-      output.serializeDouble(valueField, ((DoublePointData) value).getValue(), /* force= */ true);
+      output.serializeDoubleOptional(valueField, ((DoublePointData) value).getValue());
     }
     output.serializeRepeatedMessage(NumberDataPoint.EXEMPLARS, exemplars);
     output.serializeRepeatedMessage(NumberDataPoint.ATTRIBUTES, attributes);
@@ -99,13 +99,9 @@ final class NumberDataPointMarshaler extends MarshalerWithSize {
     size += MarshalerUtil.sizeFixed64(NumberDataPoint.START_TIME_UNIX_NANO, startTimeUnixNano);
     size += MarshalerUtil.sizeFixed64(NumberDataPoint.TIME_UNIX_NANO, timeUnixNano);
     if (valueField == NumberDataPoint.AS_INT) {
-      size +=
-          MarshalerUtil.sizeFixed64(
-              valueField, ((LongPointData) value).getValue(), /* force= */ true);
+      size += MarshalerUtil.sizeFixed64Optional(valueField, ((LongPointData) value).getValue());
     } else {
-      size +=
-          MarshalerUtil.sizeDouble(
-              valueField, ((DoublePointData) value).getValue(), /* force= */ true);
+      size += MarshalerUtil.sizeDoubleOptional(valueField, ((DoublePointData) value).getValue());
     }
     size += MarshalerUtil.sizeRepeatedMessage(NumberDataPoint.EXEMPLARS, exemplars);
     size += MarshalerUtil.sizeRepeatedMessage(NumberDataPoint.ATTRIBUTES, attributes);

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/metrics/NumberDataPointMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/metrics/NumberDataPointMarshaler.java
@@ -99,9 +99,13 @@ final class NumberDataPointMarshaler extends MarshalerWithSize {
     size += MarshalerUtil.sizeFixed64(NumberDataPoint.START_TIME_UNIX_NANO, startTimeUnixNano);
     size += MarshalerUtil.sizeFixed64(NumberDataPoint.TIME_UNIX_NANO, timeUnixNano);
     if (valueField == NumberDataPoint.AS_INT) {
-      size += MarshalerUtil.sizeFixed64(valueField, ((LongPointData) value).getValue());
+      size +=
+          MarshalerUtil.sizeFixed64(
+              valueField, ((LongPointData) value).getValue(), /* force= */ true);
     } else {
-      size += MarshalerUtil.sizeDouble(valueField, ((DoublePointData) value).getValue());
+      size +=
+          MarshalerUtil.sizeDouble(
+              valueField, ((DoublePointData) value).getValue(), /* force= */ true);
     }
     size += MarshalerUtil.sizeRepeatedMessage(NumberDataPoint.EXEMPLARS, exemplars);
     size += MarshalerUtil.sizeRepeatedMessage(NumberDataPoint.ATTRIBUTES, attributes);

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/metrics/MetricsRequestMarshalerTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/metrics/MetricsRequestMarshalerTest.java
@@ -74,6 +74,59 @@ class MetricsRequestMarshalerTest {
   }
 
   @Test
+  void longDataPoint_withDefaultValues() {
+    assertThat(
+            toNumberDataPoints(
+                singletonList(
+                    LongPointData.create(
+                        123,
+                        456,
+                        KV_ATTR,
+                        0,
+                        singletonList(
+                            LongExemplarData.create(
+                                Attributes.of(stringKey("test"), "value"),
+                                2,
+                                /*spanId=*/ "0000000000000002",
+                                /*traceId=*/ "00000000000000000000000000000001",
+                                1))))))
+        .containsExactly(
+            NumberDataPoint.newBuilder()
+                .setStartTimeUnixNano(123)
+                .setTimeUnixNano(456)
+                .addAllAttributes(
+                    singletonList(
+                        KeyValue.newBuilder().setKey("k").setValue(stringValue("v")).build()))
+                .setAsInt(0)
+                .addExemplars(
+                    Exemplar.newBuilder()
+                        .setTimeUnixNano(2)
+                        .addFilteredAttributes(
+                            KeyValue.newBuilder()
+                                .setKey("test")
+                                .setValue(stringValue("value"))
+                                .build())
+                        .setSpanId(ByteString.copyFrom(new byte[] {0, 0, 0, 0, 0, 0, 0, 2}))
+                        .setTraceId(
+                            ByteString.copyFrom(
+                                new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}))
+                        .setAsInt(1)
+                        .build())
+                .build());
+
+    assertThat(toNumberDataPoints(singletonList(DoublePointData.create(123, 456, KV_ATTR, 0))))
+        .containsExactly(
+            NumberDataPoint.newBuilder()
+                .setStartTimeUnixNano(123)
+                .setTimeUnixNano(456)
+                .addAllAttributes(
+                    singletonList(
+                        KeyValue.newBuilder().setKey("k").setValue(stringValue("v")).build()))
+                .setAsDouble(0)
+                .build());
+  }
+
+  @Test
   void longDataPoints() {
     assertThat(toNumberDataPoints(Collections.emptyList())).isEmpty();
     assertThat(


### PR DESCRIPTION
Fix #3889 

There may be more instances of this, just fixing the obvious ones.