### PR TITLE
Fix typos in metrics-testing package

### DIFF
--- a/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/metrics/AbstractSumDataAssert.java
+++ b/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/metrics/AbstractSumDataAssert.java
@@ -22,7 +22,7 @@ public class AbstractSumDataAssert<
     isNotNull();
     if (!actual.isMonotonic()) {
       failWithActualExpectedAndMessage(
-          actual, "montonic: true", "Exepcted Sum to be monotonic", true, actual.isMonotonic());
+          actual, "monotonic: true", "Expected Sum to be monotonic", true, actual.isMonotonic());
     }
     return myself;
   }
@@ -33,7 +33,7 @@ public class AbstractSumDataAssert<
     if (actual.isMonotonic()) {
       failWithActualExpectedAndMessage(
           actual,
-          "montonic: fail",
+          "monotonic: fail",
           "Expected Sum to be non-monotonic, found: %s",
           actual.isMonotonic());
     }

--- a/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/metrics/DoubleHistogramAssert.java
+++ b/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/metrics/DoubleHistogramAssert.java
@@ -27,7 +27,7 @@ public class DoubleHistogramAssert
       failWithActualExpectedAndMessage(
           actual,
           "aggregationTemporality: CUMULATIVE",
-          "Exepcted Histgram to have cumulative aggregation but found <%s>",
+          "Expected Histogram to have cumulative aggregation but found <%s>",
           AggregationTemporality.CUMULATIVE,
           actual.getAggregationTemporality());
     }
@@ -41,7 +41,7 @@ public class DoubleHistogramAssert
       failWithActualExpectedAndMessage(
           actual,
           "aggregationTemporality: DELTA",
-          "Exepcted Histgram to have cumulative aggregation but found <%s>",
+          "Expected Histgram to have cumulative aggregation but found <%s>",
           AggregationTemporality.DELTA,
           actual.getAggregationTemporality());
     }

--- a/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/metrics/DoubleHistogramPointDataAssert.java
+++ b/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/metrics/DoubleHistogramPointDataAssert.java
@@ -38,8 +38,7 @@ public class DoubleHistogramPointDataAssert
    */
   public DoubleHistogramPointDataAssert hasBucketBoundaries(double... boundaries) {
     isNotNull();
-    Double[] bigBoundaries =
-        Arrays.stream(boundaries).mapToObj(Double::valueOf).toArray(idx -> new Double[idx]);
+    Double[] bigBoundaries = Arrays.stream(boundaries).boxed().toArray(Double[]::new);
     Assertions.assertThat(actual.getBoundaries()).as("boundaries").containsExactly(bigBoundaries);
     return this;
   }
@@ -51,7 +50,7 @@ public class DoubleHistogramPointDataAssert
    */
   public DoubleHistogramPointDataAssert hasBucketCounts(long... counts) {
     isNotNull();
-    Long[] bigCounts = Arrays.stream(counts).mapToObj(Long::valueOf).toArray(idx -> new Long[idx]);
+    Long[] bigCounts = Arrays.stream(counts).boxed().toArray(Long[]::new);
     Assertions.assertThat(actual.getCounts()).as("bucketCounts").containsExactly(bigCounts);
     return this;
   }

--- a/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/metrics/ExponentialHistogramAssert.java
+++ b/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/metrics/ExponentialHistogramAssert.java
@@ -40,7 +40,7 @@ public class ExponentialHistogramAssert
       failWithActualExpectedAndMessage(
           actual,
           "aggregationTemporality: DELTA",
-          "Exepcted Histogram to have cumulative aggregation but found <%s>",
+          "Expected Histogram to have cumulative aggregation but found <%s>",
           AggregationTemporality.DELTA,
           actual.getAggregationTemporality());
     }

--- a/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/metrics/MetricDataAssert.java
+++ b/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/metrics/MetricDataAssert.java
@@ -24,7 +24,7 @@ public class MetricDataAssert extends AbstractAssert<MetricDataAssert, MetricDat
       failWithActualExpectedAndMessage(
           actual,
           "resource: " + resource,
-          "Exepcted MetricData to have resource <%s> but found <%s>",
+          "Expected MetricData to have resource <%s> but found <%s>",
           resource,
           actual.getResource());
     }
@@ -42,7 +42,7 @@ public class MetricDataAssert extends AbstractAssert<MetricDataAssert, MetricDat
       failWithActualExpectedAndMessage(
           actual,
           "instrumentation library: " + instrumentationLibrary,
-          "Exepcted MetricData to have resource <%s> but found <%s>",
+          "Expected MetricData to have resource <%s> but found <%s>",
           instrumentationLibrary,
           actual.getInstrumentationLibraryInfo());
     }
@@ -56,7 +56,7 @@ public class MetricDataAssert extends AbstractAssert<MetricDataAssert, MetricDat
       failWithActualExpectedAndMessage(
           actual,
           "name: " + name,
-          "Exepcted MetricData to have name <%s> but found <%s>",
+          "Expected MetricData to have name <%s> but found <%s>",
           name,
           actual.getName());
     }
@@ -70,7 +70,7 @@ public class MetricDataAssert extends AbstractAssert<MetricDataAssert, MetricDat
       failWithActualExpectedAndMessage(
           actual,
           "description: " + description,
-          "Exepcted MetricData to have description <%s> but found <%s>",
+          "Expected MetricData to have description <%s> but found <%s>",
           description,
           actual.getDescription());
     }
@@ -84,7 +84,7 @@ public class MetricDataAssert extends AbstractAssert<MetricDataAssert, MetricDat
       failWithActualExpectedAndMessage(
           actual,
           "unit: " + unit,
-          "Exepcted MetricData to have unit <%s> but found <%s>",
+          "Expected MetricData to have unit <%s> but found <%s>",
           unit,
           actual.getUnit());
     }
@@ -102,7 +102,7 @@ public class MetricDataAssert extends AbstractAssert<MetricDataAssert, MetricDat
       failWithActualExpectedAndMessage(
           actual,
           "type: HISTOGRAM",
-          "Exepcted MetricData to have type <%s> but found <%s>",
+          "Expected MetricData to have type <%s> but found <%s>",
           MetricDataType.HISTOGRAM,
           actual.getType());
     }
@@ -112,7 +112,7 @@ public class MetricDataAssert extends AbstractAssert<MetricDataAssert, MetricDat
   /**
    * Ensures this {@link MetricData} is a {@code ExponentialHistogram}.
    *
-   * @return convenience API to assert agains the {@code ExponentialHistogram}.
+   * @return convenience API to assert against the {@code ExponentialHistogram}.
    */
   public ExponentialHistogramAssert hasExponentialHistogram() {
     isNotNull();
@@ -138,7 +138,7 @@ public class MetricDataAssert extends AbstractAssert<MetricDataAssert, MetricDat
       failWithActualExpectedAndMessage(
           actual,
           "type: DOUBLE_GAUGE",
-          "Exepcted MetricData to have type <%s> but found <%s>",
+          "Expected MetricData to have type <%s> but found <%s>",
           MetricDataType.DOUBLE_GAUGE,
           actual.getType());
     }
@@ -156,7 +156,7 @@ public class MetricDataAssert extends AbstractAssert<MetricDataAssert, MetricDat
       failWithActualExpectedAndMessage(
           actual,
           "type: DOUBLE_SUM",
-          "Exepcted MetricData to have type <%s> but found <%s>",
+          "Expected MetricData to have type <%s> but found <%s>",
           MetricDataType.DOUBLE_SUM,
           actual.getType());
     }
@@ -174,7 +174,7 @@ public class MetricDataAssert extends AbstractAssert<MetricDataAssert, MetricDat
       failWithActualExpectedAndMessage(
           actual,
           "type: LONG_GAUGE",
-          "Exepcted MetricData to have type <%s> but found <%s>",
+          "Expected MetricData to have type <%s> but found <%s>",
           MetricDataType.LONG_GAUGE,
           actual.getType());
     }
@@ -192,7 +192,7 @@ public class MetricDataAssert extends AbstractAssert<MetricDataAssert, MetricDat
       failWithActualExpectedAndMessage(
           actual,
           "type: LONG_SUM",
-          "Exepcted MetricData to have type <%s> but found <%s>",
+          "Expected MetricData to have type <%s> but found <%s>",
           MetricDataType.LONG_SUM,
           actual.getType());
     }
@@ -210,7 +210,7 @@ public class MetricDataAssert extends AbstractAssert<MetricDataAssert, MetricDat
       failWithActualExpectedAndMessage(
           actual,
           "type: SUMMARY",
-          "Exepcted MetricData to have type <%s> but found <%s>",
+          "Expected MetricData to have type <%s> but found <%s>",
           MetricDataType.SUMMARY,
           actual.getType());
     }


### PR DESCRIPTION
Came across a handful of typos in the `:sdk:metrics-testing` module and felt compelled to fix them. 