### PR TITLE
Make method private

### DIFF
--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
@@ -130,10 +130,6 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message, V>
     this.resourceTelemetryInstance = resourceTelemetryInstance;
   }
 
-  protected void setGrpcError(int code, @Nullable String message) {
-    grpcError = new ArmeriaStatusException(code, message);
-  }
-
   @BeforeAll
   void setUp() {
     exporter = createExporter(server.httpUri().toString());
@@ -316,5 +312,9 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message, V>
               }
             })
         .collect(Collectors.toList());
+  }
+
+  private static void setGrpcError(int code, @Nullable String message) {
+    grpcError = new ArmeriaStatusException(code, message);
   }
 }


### PR DESCRIPTION
This wasn't meant to be callable from subclasses - making private to reduce @jkwatson's worries about spaghetti :)