### PR TITLE
Fix flaky ThrottlingLogger test

### DIFF
--- a/sdk/common/src/test/java/io/opentelemetry/sdk/internal/ThrottlingLoggerTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/internal/ThrottlingLoggerTest.java
@@ -20,13 +20,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class ThrottlingLoggerTest {
+
+  private static final Logger realLogger = Logger.getLogger(ThrottlingLoggerTest.class.getName());
+
   @RegisterExtension
   LogCapturer logs = LogCapturer.create().captureForType(ThrottlingLoggerTest.class);
 
   @Test
   void delegation() {
-    ThrottlingLogger logger =
-        new ThrottlingLogger(Logger.getLogger(ThrottlingLoggerTest.class.getName()));
+    ThrottlingLogger logger = new ThrottlingLogger(realLogger);
 
     logger.log(Level.WARNING, "oh no!");
     logger.log(Level.INFO, "oh yes!");
@@ -58,8 +60,7 @@ class ThrottlingLoggerTest {
   @Test
   void fiveInAMinuteTriggersLimiting() {
     Clock clock = TestClock.create();
-    ThrottlingLogger logger =
-        new ThrottlingLogger(Logger.getLogger(ThrottlingLoggerTest.class.getName()), clock);
+    ThrottlingLogger logger = new ThrottlingLogger(realLogger, clock);
 
     logger.log(Level.WARNING, "oh no!");
     logger.log(Level.WARNING, "oh no!");
@@ -80,8 +81,7 @@ class ThrottlingLoggerTest {
   @Test
   void allowsTrickleOfMessages() {
     TestClock clock = TestClock.create();
-    ThrottlingLogger logger =
-        new ThrottlingLogger(Logger.getLogger(ThrottlingLoggerTest.class.getName()), clock);
+    ThrottlingLogger logger = new ThrottlingLogger(realLogger, clock);
     logger.log(Level.WARNING, "oh no!");
     assertThat(logs.size()).isEqualTo(1);
     logger.log(Level.WARNING, "oh no!");
@@ -113,8 +113,7 @@ class ThrottlingLoggerTest {
   @Test
   void afterAMinuteLetOneThrough() {
     TestClock clock = TestClock.create();
-    ThrottlingLogger logger =
-        new ThrottlingLogger(Logger.getLogger(ThrottlingLoggerTest.class.getName()), clock);
+    ThrottlingLogger logger = new ThrottlingLogger(realLogger, clock);
 
     logger.log(Level.WARNING, "oh no!");
     logger.log(Level.WARNING, "oh no!");


### PR DESCRIPTION
The one we've seen elsewhere for not keeping a static reference to the actual logger and having it GC'd before being captured

```
> Task :sdk:common:test

ThrottlingLoggerTest > delegation() FAILED
    org.opentest4j.AssertionFailedError: oh no! ==> None of the 0 captured log events matched the filter predicate
        at app//org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:39)
        at app//org.junit.jupiter.api.Assertions.fail(Assertions.java:134)
        at app//io.github.netmikey.logunit.api.LogCapturer.lambda$assertContains$3(LogCapturer.java:174)
        at java.base@11.0.11/java.util.Optional.orElseGet(Optional.java:369)
        at app//io.github.netmikey.logunit.api.LogCapturer.assertContains(LogCapturer.java:173)
        at app//io.opentelemetry.sdk.internal.ThrottlingLoggerTest.delegation(ThrottlingLoggerTest.java:36)
```