### PR TITLE
Lower codecov patch target.

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -24,4 +24,4 @@ coverage:
           - "sdk-extensions/zpages/"
     patch:
       default:
-        target: 90%
+        target: 80%


### PR DESCRIPTION
I guess it's pretty common to have patch diffs with less than 90% coverage that don't strongly affect the coverage of the build.