### PR TITLE
evict okhttp connections on shutdown

### DIFF
--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/grpc/OkHttpGrpcExporter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/grpc/OkHttpGrpcExporter.java
@@ -222,6 +222,7 @@ public final class OkHttpGrpcExporter<T extends Marshaler> implements GrpcExport
   public CompletableResultCode shutdown() {
     client.dispatcher().cancelAll();
     client.dispatcher().executorService().shutdownNow();
+    client.connectionPool().evictAll();
     this.seen.unbind();
     this.success.unbind();
     this.failed.unbind();

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/okhttp/OkHttpExporter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/okhttp/OkHttpExporter.java
@@ -127,6 +127,7 @@ public final class OkHttpExporter<T extends Marshaler> {
     final CompletableResultCode result = CompletableResultCode.ofSuccess();
     client.dispatcher().cancelAll();
     client.dispatcher().executorService().shutdownNow();
+    client.connectionPool().evictAll();
     exporterMetrics.unbind();
     return result;
   }


### PR DESCRIPTION
fixes OkHttp thread not exiting on shutdown:

```
[E] Non-daemon threads currently preventing JVM termination: - 37: Thread[DestroyJavaVM,5,main]
[E]  -  - 27: Thread[OkHttp localhost Writer,5,main]
[E]  -  - 25: Thread[OkHttp localhost,5,main]
```


https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/#shutdown-isnt-necessary

Fixes #3900