### PR TITLE
make W3CTraceContextPropagator.extractContextFromTraceParent public

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagator.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/propagation/W3CTraceContextPropagator.java
@@ -190,7 +190,7 @@ public final class W3CTraceContextPropagator implements TextMapPropagator {
     }
   }
 
-  private static SpanContext extractContextFromTraceParent(String traceparent) {
+  public static SpanContext extractContextFromTraceParent(String traceparent) {
     // TODO(bdrutu): Do we need to verify that version is hex and that
     // for the version the length is the expected one?
     boolean isValid =


### PR DESCRIPTION
In order to propagate a distributed trace in a lambda invocation, we needed to pass along the `traceparent` value to the lambda and create the invocation `Span` from that `traceparent` (if provided).

We didn't want to write our own parsing logic, so looking at how this repository does it we ended up copying / pasting the code.

This PR exposes `W3CTraceContextPropagator.extractContextFromTraceParent` as `public static` rather than `private static` so we can just use that.