### PR TITLE
Fix metric descriptor compatibility check

### DIFF
--- a/sdk/metrics/src/debugEnabledTest/java/io/opentelemetry/testing/TestSourceInfo.java
+++ b/sdk/metrics/src/debugEnabledTest/java/io/opentelemetry/testing/TestSourceInfo.java
@@ -44,17 +44,16 @@ class TestSourceInfo {
         MetricDescriptor.create(
             View.builder().build(),
             InstrumentDescriptor.create(
-                "name",
-                "description2",
-                "unit2",
-                InstrumentType.HISTOGRAM,
-                InstrumentValueType.DOUBLE));
+                "name", "description2", "unit2", InstrumentType.COUNTER, InstrumentValueType.LONG));
     assertThat(DebugUtils.duplicateMetricErrorMessage(simple, simpleWithNewDescription))
         .contains("Found duplicate metric definition: name")
         .contains("- Unit [unit2] does not match [unit]")
         .contains("- Description [description2] does not match [description]")
+        .contains("- InstrumentType [COUNTER] does not match [HISTOGRAM]")
+        .contains("- InstrumentValueType [LONG] does not match [DOUBLE]")
         .contains(simple.getSourceInstrument().getSourceInfo().multiLineDebugString())
-        .contains("Original instrument registered with same name but different description or unit")
+        .contains(
+            "Original instrument registered with same name but different description, unit, instrument type, or instrument value type.")
         .contains(
             simpleWithNewDescription.getSourceInstrument().getSourceInfo().multiLineDebugString());
   }
@@ -119,7 +118,8 @@ class TestSourceInfo {
         .contains("FROM instrument name2")
         .contains(simple.getSourceInstrument().getSourceInfo().multiLineDebugString())
         .contains("- Unit [unit] does not match [unit2]")
-        .contains("Original instrument registered with same name but different description or unit")
+        .contains(
+            "Original instrument registered with same name but different description, unit, instrument type, or instrument value type.")
         .contains(
             simpleWithNewDescription.getSourceInstrument().getSourceInfo().multiLineDebugString());
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/descriptor/MetricDescriptor.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/descriptor/MetricDescriptor.java
@@ -65,10 +65,25 @@ public abstract class MetricDescriptor {
   @Override
   public abstract int hashCode();
 
-  /** Returns true if another metric descriptor is compatible with this one. */
+  /**
+   * Returns true if another metric descriptor is compatible with this one.
+   *
+   * <p>A metric descriptor is compatible with another if the following are true:
+   *
+   * <ul>
+   *   <li>{@link #getName()} is equal
+   *   <li>{@link #getDescription()} is equal
+   *   <li>{@link #getUnit()} is equal
+   *   <li>{@link InstrumentDescriptor#getType()} is equal
+   *   <li>{@link InstrumentDescriptor#getValueType()} is equal
+   * </ul>
+   */
   public boolean isCompatibleWith(MetricDescriptor other) {
     return Objects.equals(getName(), other.getName())
         && Objects.equals(getDescription(), other.getDescription())
-        && Objects.equals(getUnit(), other.getUnit());
+        && Objects.equals(getUnit(), other.getUnit())
+        && Objects.equals(getSourceInstrument().getType(), other.getSourceInstrument().getType())
+        && Objects.equals(
+            getSourceInstrument().getValueType(), other.getSourceInstrument().getValueType());
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DebugUtils.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DebugUtils.java
@@ -74,13 +74,35 @@ public final class DebugUtils {
           .append(existing.getUnit())
           .append("]\n");
     }
+    if (!existing
+        .getSourceInstrument()
+        .getType()
+        .equals(conflict.getSourceInstrument().getType())) {
+      result
+          .append("- InstrumentType [")
+          .append(conflict.getSourceInstrument().getType())
+          .append("] does not match [")
+          .append(existing.getSourceInstrument().getType())
+          .append("]\n");
+    }
+    if (!existing
+        .getSourceInstrument()
+        .getValueType()
+        .equals(conflict.getSourceInstrument().getValueType())) {
+      result
+          .append("- InstrumentValueType [")
+          .append(conflict.getSourceInstrument().getValueType())
+          .append("] does not match [")
+          .append(existing.getSourceInstrument().getValueType())
+          .append("]\n");
+    }
 
-    // Next we write out where the existing metric deescriptor came from, either a raw instrument
+    // Next we write out where the existing metric descriptor came from, either a raw instrument
     // or a view on a raw instrument.
     if (existing.getName().equals(existing.getSourceInstrument().getName())) {
       result
           .append(
-              "Original instrument registered with same name but different description or unit.\n")
+              "Original instrument registered with same name but different description, unit, instrument type, or instrument value type.\n")
           .append(existing.getSourceInstrument().getSourceInfo().multiLineDebugString())
           .append("\n");
     } else {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorage.java
@@ -28,7 +28,8 @@ public interface SynchronousMetricStorage extends MetricStorage, WriteableMetric
   /**
    * Constructs metric storage for a given synchronous instrument and view.
    *
-   * @return The storage, or {@code null} if the instrument should not be recorded.
+   * @return The storage, or {@link EmptyMetricStorage#empty()} if the instrument should not be
+   *     recorded.
    */
   static <T> SynchronousMetricStorage create(
       View view, InstrumentDescriptor instrumentDescriptor, ExemplarFilter exemplarFilter) {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/descriptor/MetricDescriptorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/descriptor/MetricDescriptorTest.java
@@ -41,4 +41,86 @@ class MetricDescriptorTest {
     assertThat(simple.getSourceInstrument()).isEqualTo(instrument);
     assertThat(simple.getSourceView()).contains(view);
   }
+
+  @Test
+  void metricDescriptor_isCompatible() {
+    View view = View.builder().build();
+    MetricDescriptor descriptor =
+        MetricDescriptor.create(
+            view,
+            InstrumentDescriptor.create(
+                "name", "description", "unit", InstrumentType.COUNTER, InstrumentValueType.DOUBLE));
+    // Same name, description, unit, instrument type, and value type is compatible
+    assertThat(
+            descriptor.isCompatibleWith(
+                MetricDescriptor.create(
+                    view,
+                    InstrumentDescriptor.create(
+                        "name",
+                        "description",
+                        "unit",
+                        InstrumentType.COUNTER,
+                        InstrumentValueType.DOUBLE))))
+        .isTrue();
+    // Different name is not compatible
+    assertThat(
+            descriptor.isCompatibleWith(
+                MetricDescriptor.create(
+                    view,
+                    InstrumentDescriptor.create(
+                        "foo",
+                        "description",
+                        "unit",
+                        InstrumentType.COUNTER,
+                        InstrumentValueType.DOUBLE))))
+        .isFalse();
+    // Different description is not compatible
+    assertThat(
+            descriptor.isCompatibleWith(
+                MetricDescriptor.create(
+                    view,
+                    InstrumentDescriptor.create(
+                        "name",
+                        "foo",
+                        "unit",
+                        InstrumentType.COUNTER,
+                        InstrumentValueType.DOUBLE))))
+        .isFalse();
+    // Different unit is not compatible
+    assertThat(
+            descriptor.isCompatibleWith(
+                MetricDescriptor.create(
+                    view,
+                    InstrumentDescriptor.create(
+                        "name",
+                        "description",
+                        "foo",
+                        InstrumentType.COUNTER,
+                        InstrumentValueType.DOUBLE))))
+        .isFalse();
+    // Different instrument type is not compatible
+    assertThat(
+            descriptor.isCompatibleWith(
+                MetricDescriptor.create(
+                    view,
+                    InstrumentDescriptor.create(
+                        "name",
+                        "description",
+                        "unit",
+                        InstrumentType.HISTOGRAM,
+                        InstrumentValueType.DOUBLE))))
+        .isFalse();
+    // Different instrument value type is not compatible
+    assertThat(
+            descriptor.isCompatibleWith(
+                MetricDescriptor.create(
+                    view,
+                    InstrumentDescriptor.create(
+                        "name",
+                        "description",
+                        "unit",
+                        InstrumentType.COUNTER,
+                        InstrumentValueType.LONG))))
+        .isFalse();
+  }
 }


### PR DESCRIPTION
The metric descriptor compatibility check currently ignores instrument type and instrument value type. This leads to confusing errors when conflicts occur. For example, the following code:
```
SdkMeterProvider sdkMeterProvider = SdkMeterProvider.builder().build();
Meter meter = sdkMeterProvider.get(CardinalityTest.class.getName());
meter.counterBuilder("foo").build().add(1);
meter.histogramBuilder("foo").build().record(1);
```
Produces:
```
This aggregator does not support recording double values.
java.lang.UnsupportedOperationException: This aggregator does not support recording double values.
```

This PR strengthens the compatibility check so that in addition to name, description, and unit, instruments must also match instrument type and and instrument value type. 

After this change, the same code produces useful debugging information:
```
WARNING: Found duplicate metric definition: foo
	at unknown source
		To enable better debugging, run your JVM with -Dotel.experimental.sdk.metrics.debug=true
Causes
- InstrumentType [HISTOGRAM] does not match [COUNTER]
- InstrumentValueType [DOUBLE] does not match [LONG]
Original instrument registered with same name but different description, unit, instrument type, or instrument value type.
	at unknown source
		To enable better debugging, run your JVM with -Dotel.experimental.sdk.metrics.debug=true
```