### PR TITLE
Use PrimitiveLongList in ExponentialHistogramBuckets

### DIFF
--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/PrimitiveLongList.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/PrimitiveLongList.java
@@ -6,7 +6,9 @@
 package io.opentelemetry.sdk.internal;
 
 import java.util.AbstractList;
+import java.util.Arrays;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * A list of longs backed by, and exposing, an array of primitives. Values will be boxed on demand
@@ -56,6 +58,19 @@ public final class PrimitiveLongList {
     public Long get(int index) {
       // If out of bounds, the array access will produce a perfectly fine IndexOutOfBoundsException.
       return values[index];
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+      if (!(o instanceof LongListImpl)) {
+        return super.equals(o);
+      }
+      return Arrays.equals(values, ((LongListImpl) o).values);
+    }
+
+    @Override
+    public int hashCode() {
+      return Arrays.hashCode(values);
     }
 
     @Override

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/internal/PrimitiveLongListTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/internal/PrimitiveLongListTest.java
@@ -19,12 +19,16 @@ class PrimitiveLongListTest {
   void wrap() {
     long[] array = new long[] {1, 2};
     List<Long> wrapped = PrimitiveLongList.wrap(array);
+    List<Long> reference = Arrays.asList(1L, 2L);
     // Standard List operations
     assertThat(wrapped).containsExactly(1L, 2L);
     assertThat(wrapped).hasSize(2);
+    assertThat(wrapped.equals(reference)).isTrue();
+    assertThat(wrapped.hashCode()).isEqualTo(reference.hashCode());
+
     // Message can change between Java versions, so instead check it's the same as a normal List's
     // exception.
-    Throwable referenceException = catchThrowable(() -> Arrays.asList(1, 2).get(3));
+    Throwable referenceException = catchThrowable(() -> reference.get(3));
     assertThatThrownBy(() -> wrapped.get(3))
         .isInstanceOf(IndexOutOfBoundsException.class)
         .hasMessage(referenceException.getMessage());

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/internal/PrimitiveLongListTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/internal/PrimitiveLongListTest.java
@@ -25,6 +25,7 @@ class PrimitiveLongListTest {
     assertThat(wrapped).hasSize(2);
     assertThat(wrapped.equals(reference)).isTrue();
     assertThat(wrapped.hashCode()).isEqualTo(reference.hashCode());
+    assertThat(wrapped.equals(PrimitiveLongList.wrap(array))).isTrue();
 
     // Message can change between Java versions, so instead check it's the same as a normal List's
     // exception.

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramBuckets.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramBuckets.java
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.sdk.metrics.internal.aggregator;
 
+import io.opentelemetry.sdk.internal.PrimitiveLongList;
 import io.opentelemetry.sdk.metrics.data.ExponentialHistogramBuckets;
 import io.opentelemetry.sdk.metrics.internal.state.ExponentialCounter;
 import io.opentelemetry.sdk.metrics.internal.state.MapCounter;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -65,11 +65,11 @@ final class DoubleExponentialHistogramBuckets implements ExponentialHistogramBuc
       return Collections.emptyList();
     }
     int length = counts.getIndexEnd() - counts.getIndexStart() + 1;
-    Long[] countsArr = new Long[length];
+    long[] countsArr = new long[length];
     for (int i = 0; i < length; i++) {
       countsArr[i] = counts.get(i + counts.getIndexStart());
     }
-    return Arrays.asList(countsArr);
+    return PrimitiveLongList.wrap(countsArr);
   }
 
   @Override


### PR DESCRIPTION
Also added optimized equals / hashcode since I noticed they're used in ExponentialHistogramBuckets, though there is possibly more optimization possible by avoiding the copy into the array