### PR TITLE
Add SdkLogEmitterProvider#get(String)

### DIFF
--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogEmitterProvider.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogEmitterProvider.java
@@ -42,6 +42,16 @@ public final class SdkLogEmitterProvider implements Closeable {
   }
 
   /**
+   * Gets or creates a named log emitter instance.
+   *
+   * @param instrumentationName the name of the instrumentation library
+   * @return a log emitter instance
+   */
+  public LogEmitter get(String instrumentationName) {
+    return logEmitterBuilder(instrumentationName).build();
+  }
+
+  /**
    * Creates a {@link LogEmitterBuilder} instance.
    *
    * @param instrumentationName the name of the instrumentation library

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLogEmitterProviderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLogEmitterProviderTest.java
@@ -93,6 +93,7 @@ class SdkLogEmitterProviderTest {
   @Test
   void logEmitterBuilder_SameName() {
     assertThat(sdkLogEmitterProvider.logEmitterBuilder("test").build())
+        .isSameAs(sdkLogEmitterProvider.get("test"))
         .isSameAs(sdkLogEmitterProvider.logEmitterBuilder("test").build())
         .isNotSameAs(
             sdkLogEmitterProvider


### PR DESCRIPTION
For symmetry with TracerProvider and MeterProvider. 