### PR TITLE
Fix up cumulatives to be preserved in more scenarios. 

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageUtils.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageUtils.java
@@ -34,7 +34,7 @@ final class MetricStorageUtils {
    *
    * <p>Note: This mutates the result map.
    */
-  static <T> void mergeAndPerserveInPlace(
+  static <T> void mergeAndPreserveInPlace(
       Map<Attributes, T> result, Map<Attributes, T> toMerge, Aggregator<T> aggregator) {
     blend(result, toMerge, /* preserve= */ true, aggregator::merge);
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageUtils.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageUtils.java
@@ -25,7 +25,18 @@ final class MetricStorageUtils {
    */
   static <T> void mergeInPlace(
       Map<Attributes, T> result, Map<Attributes, T> toMerge, Aggregator<T> aggregator) {
-    blend(result, toMerge, aggregator::merge);
+    blend(result, toMerge, /* preserve= */ false, aggregator::merge);
+  }
+
+  /**
+   * Merges accumulations from {@code toMerge} into {@code result}. Keys from {@code result} which
+   * don't appear in {@code toMerge} are preserved as-is.
+   *
+   * <p>Note: This mutates the result map.
+   */
+  static <T> void mergeAndPerserveInPlace(
+      Map<Attributes, T> result, Map<Attributes, T> toMerge, Aggregator<T> aggregator) {
+    blend(result, toMerge, /* preserve= */ true, aggregator::merge);
   }
 
   /**
@@ -38,13 +49,27 @@ final class MetricStorageUtils {
    */
   static <T> void diffInPlace(
       Map<Attributes, T> result, Map<Attributes, T> toDiff, Aggregator<T> aggregator) {
-    blend(result, toDiff, aggregator::diff);
+    blend(result, toDiff, /* preserve= */ false, aggregator::diff);
   }
 
   private static <T> void blend(
-      Map<Attributes, T> result, Map<Attributes, T> toMerge, BiFunction<T, T, T> blendFunction) {
-    result.entrySet().removeIf(entry -> !toMerge.containsKey(entry.getKey()));
+      Map<Attributes, T> result,
+      Map<Attributes, T> toMerge,
+      boolean preserve,
+      BiFunction<T, T, T> blendFunction) {
+    if (!preserve) {
+      removeUnseen(result, toMerge);
+    }
     toMerge.forEach(
         (k, v) -> result.compute(k, (k2, v2) -> (v2 != null) ? blendFunction.apply(v2, v) : v));
+  }
+
+  /**
+   * Removes all keys in {@code result} that do not exist in {@code latest}.
+   *
+   * <p>Note: This mutates the result map.
+   */
+  public static <T> void removeUnseen(Map<Attributes, T> result, Map<Attributes, T> latest) {
+    result.entrySet().removeIf(entry -> !latest.containsKey(entry.getKey()));
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorage.java
@@ -74,19 +74,12 @@ class TemporalMetricStorage<T> {
       } else if (temporality == AggregationTemporality.CUMULATIVE && isSynchronous) {
         // We need to make sure the current delta recording gets merged into the previous cumulative
         // for the next cumulative measurement.
-
-        // We select whether we "clean" un-seen measurements based on how many we had in the last
-        // cycle.
-        if (last.getAccumulation().size() >= MetricStorageUtils.MAX_ACCUMULATIONS) {
-          MetricStorageUtils.mergeInPlace(last.getAccumulation(), currentAccumulation, aggregator);
-        } else {
-          MetricStorageUtils.mergeAndPerserveInPlace(
-              last.getAccumulation(), currentAccumulation, aggregator);
-          // Note: We allow going over our hard limit on attribute streams when first merging, but
-          // preserve agter this point.
-          if (last.getAccumulation().size() > MetricStorageUtils.MAX_ACCUMULATIONS) {
-            MetricStorageUtils.removeUnseen(last.getAccumulation(), currentAccumulation);
-          }
+        MetricStorageUtils.mergeAndPreserveInPlace(
+            last.getAccumulation(), currentAccumulation, aggregator);
+        // Note: We allow going over our hard limit on attribute streams when first merging, but
+        // preserve after this point.
+        if (last.getAccumulation().size() > MetricStorageUtils.MAX_ACCUMULATIONS) {
+          MetricStorageUtils.removeUnseen(last.getAccumulation(), currentAccumulation);
         }
         result = last.getAccumulation();
       }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorage.java
@@ -74,7 +74,20 @@ class TemporalMetricStorage<T> {
       } else if (temporality == AggregationTemporality.CUMULATIVE && isSynchronous) {
         // We need to make sure the current delta recording gets merged into the previous cumulative
         // for the next cumulative measurement.
-        MetricStorageUtils.mergeInPlace(last.getAccumulation(), currentAccumulation, aggregator);
+
+        // We select whether we "clean" un-seen measurements based on how many we had in the last
+        // cycle.
+        if (last.getAccumulation().size() >= MetricStorageUtils.MAX_ACCUMULATIONS) {
+          MetricStorageUtils.mergeInPlace(last.getAccumulation(), currentAccumulation, aggregator);
+        } else {
+          MetricStorageUtils.mergeAndPerserveInPlace(
+              last.getAccumulation(), currentAccumulation, aggregator);
+          // Note: We allow going over our hard limit on attribute streams when first merging, but
+          // preserve agter this point.
+          if (last.getAccumulation().size() > MetricStorageUtils.MAX_ACCUMULATIONS) {
+            MetricStorageUtils.removeUnseen(last.getAccumulation(), currentAccumulation);
+          }
+        }
         result = last.getAccumulation();
       }
     }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/CardinalityTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/CardinalityTest.java
@@ -44,13 +44,18 @@ class CardinalityTest {
    * Records to sync instruments, with distinct attributes each time. Validates that stale metrics
    * are dropped for delta and cumulative readers. Stale metrics are those with attributes that did
    * not receive recordings in the most recent collection.
+   *
+   * <p>Effectively, we make sure we cap-out at attribute size = 2000 (constant in
+   * MetricStorageutils).
    */
   @Test
   void staleMetricsDropped_synchronousInstrument() {
     LongCounter syncCounter = meter.counterBuilder("sync-counter").build();
-    for (int i = 1; i <= 5; i++) {
+    // Note: This constant comes from MetricStorageUtils, but it's package-private.
+    for (int i = 1; i <= 2000; i++) {
       syncCounter.add(1, Attributes.builder().put("key", "num_" + i).build());
 
+      // DELTA reader only has latest
       assertThat(deltaReader.collectAllMetrics())
           .as("Delta collection " + i)
           .hasSize(1)
@@ -63,6 +68,8 @@ class CardinalityTest {
                       .points()
                       .hasSize(1));
 
+      // Make sure we preserve previous cumulatives
+      final int currentSize = i;
       assertThat(cumulativeReader.collectAllMetrics())
           .as("Cumulative collection " + i)
           .hasSize(1)
@@ -73,8 +80,35 @@ class CardinalityTest {
                       .hasLongSum()
                       .isCumulative()
                       .points()
-                      .hasSize(1));
+                      .hasSize(currentSize));
     }
+    // Now punch the limit and ONLY metrics we just recorded stay, due to simplistic GC.
+    for (int i = 2001; i <= 2010; i++) {
+      syncCounter.add(1, Attributes.builder().put("key", "num_" + i).build());
+    }
+    assertThat(deltaReader.collectAllMetrics())
+        .as("Delta collection - post limit @ 10")
+        .hasSize(1)
+        .satisfiesExactly(
+            metricData ->
+                assertThat(metricData)
+                    .hasName("sync-counter")
+                    .hasLongSum()
+                    .isDelta()
+                    .points()
+                    .hasSize(10));
+
+    assertThat(cumulativeReader.collectAllMetrics())
+        .as("Cumulative collection - post limit @ 10")
+        .hasSize(1)
+        .satisfiesExactly(
+            metricData ->
+                assertThat(metricData)
+                    .hasName("sync-counter")
+                    .hasLongSum()
+                    .isCumulative()
+                    .points()
+                    .hasSize(10));
   }
 
   /**

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/testing/InMemoryMetricReaderCumulativeTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/testing/InMemoryMetricReaderCumulativeTest.java
@@ -50,7 +50,7 @@ class InMemoryMetricReaderCumulativeTest {
 
     // Add more data, should join.
     generateFakeMetric(1);
-    assertThat(reader.collectAllMetrics()).hasSize(1);
+    assertThat(reader.collectAllMetrics()).hasSize(3);
   }
 
   @Test
@@ -60,7 +60,7 @@ class InMemoryMetricReaderCumulativeTest {
     generateFakeMetric(3);
     // TODO: Better assertions for CompletableResultCode.
     assertThat(reader.flush()).isNotNull();
-    assertThat(reader.collectAllMetrics()).hasSize(0);
+    assertThat(reader.collectAllMetrics()).hasSize(3);
   }
 
   @Test


### PR DESCRIPTION
 Expand testing…/expectations to match cumulative user expecations.


- Cumulatives are now preserved until at/near limits
- We drop all but latest attributes once we reach limit (aggressive GC vs. LRU)

We can improve this more in the future.