### PR TITLE
Add @IgnoreJRERequirement to JreDoubleAdder

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/concurrent/JreDoubleAdder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/concurrent/JreDoubleAdder.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.sdk.metrics.internal.concurrent;
 
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
+
+@IgnoreJRERequirement
 final class JreDoubleAdder implements DoubleAdder {
 
   private final java.util.concurrent.atomic.DoubleAdder delegate;


### PR DESCRIPTION
We omitted `@IgnoreJRERequirement` on one class in #3945.