### PR TITLE
Stop throwing an exception when ScopeManagerShim activate a null Span

### DIFF
--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/ScopeManagerShim.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/ScopeManagerShim.java
@@ -44,7 +44,12 @@ final class ScopeManagerShim extends BaseShimObject implements ScopeManager {
 
   @Override
   @SuppressWarnings("MustBeClosedChecker")
-  public Scope activate(Span span) {
+  public Scope activate(@Nullable Span span) {
+    if (span == null) {
+      SpanShim spanShim = new SpanShim(telemetryInfo(),
+          io.opentelemetry.api.trace.Span.getInvalid());
+      return new ScopeShim(Context.current().with(spanShim).makeCurrent());
+    }
     if (!(span instanceof SpanShim)) {
       throw new IllegalArgumentException("span is not a valid SpanShim object");
     }

--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/ScopeManagerShim.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/ScopeManagerShim.java
@@ -16,8 +16,7 @@ final class ScopeManagerShim extends BaseShimObject implements ScopeManager {
   private static final SpanShim NOOP_SPANSHIM =
       new SpanShim(
           new TelemetryInfo(
-              OpenTelemetry.noop().getTracer("noop"),
-              OpenTracingPropagators.builder().build()),
+              OpenTelemetry.noop().getTracer("noop"), OpenTracingPropagators.builder().build()),
           io.opentelemetry.api.trace.Span.getInvalid());
 
   public ScopeManagerShim(TelemetryInfo telemetryInfo) {

--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/ScopeManagerShim.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/ScopeManagerShim.java
@@ -46,8 +46,8 @@ final class ScopeManagerShim extends BaseShimObject implements ScopeManager {
   @SuppressWarnings("MustBeClosedChecker")
   public Scope activate(@Nullable Span span) {
     if (span == null) {
-      SpanShim spanShim = new SpanShim(telemetryInfo(),
-          io.opentelemetry.api.trace.Span.getInvalid());
+      SpanShim spanShim =
+          new SpanShim(telemetryInfo(), io.opentelemetry.api.trace.Span.getInvalid());
       return new ScopeShim(Context.current().with(spanShim).makeCurrent());
     }
     if (!(span instanceof SpanShim)) {

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/TracerShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/TracerShimTest.java
@@ -81,6 +81,25 @@ class TracerShimTest {
   }
 
   @Test
+  void activateNullSpan() {
+    assertThat(tracerShim.activeSpan()).isNull();
+    assertThat(tracerShim.scopeManager().activeSpan()).isNull();
+    assertThat(io.opentelemetry.api.trace.Span.current()).isSameAs(INVALID_SPAN);
+    assertThat(io.opentelemetry.api.baggage.Baggage.current()).isSameAs(EMPTY_BAGGAGE);
+
+    try (Scope scope = tracerShim.activateSpan(null)) {
+      assertThat(tracerShim.activeSpan()).isNull();
+      assertThat(tracerShim.scopeManager().activeSpan()).isNull();
+      assertThat(io.opentelemetry.api.trace.Span.current()).isSameAs(INVALID_SPAN);
+    }
+
+    assertThat(tracerShim.activeSpan()).isNull();
+    assertThat(tracerShim.scopeManager().activeSpan()).isNull();
+    assertThat(io.opentelemetry.api.trace.Span.current()).isSameAs(INVALID_SPAN);
+    assertThat(io.opentelemetry.api.baggage.Baggage.current()).isSameAs(EMPTY_BAGGAGE);
+  }
+
+  @Test
   void activateSpan_withBaggage() {
     Span otSpan = tracerShim.buildSpan("one").start();
     otSpan.setBaggageItem("foo", "bar");


### PR DESCRIPTION
Details are described in: https://github.com/open-telemetry/opentelemetry-java/issues/3952

A scope is returned to make sure the context is restored.