### PR TITLE
Add SdkLogEmitterProvider to OpenTelemetrySdk

### DIFF
--- a/sdk/all/build.gradle.kts
+++ b/sdk/all/build.gradle.kts
@@ -18,6 +18,9 @@ dependencies {
   // implementation dependency to require users to add the artifact directly to their build to use
   // SdkMeterProviderBuilder.
   implementation(project(":sdk:metrics"))
+  // implementation dependency to require users to add the artifact directly to their build to use
+  // SdkLogEmitterProvider.
+  implementation(project(":sdk:logs"))
 
   annotationProcessor("com.google.auto.value:auto-value")
 

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -12,6 +12,7 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerBuilder;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.logs.SdkLogEmitterProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import javax.annotation.concurrent.ThreadSafe;
@@ -21,14 +22,17 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class OpenTelemetrySdk implements OpenTelemetry {
   private final ObfuscatedTracerProvider tracerProvider;
   private final ObfuscatedMeterProvider meterProvider;
+  private final SdkLogEmitterProvider logEmitterProvider;
   private final ContextPropagators propagators;
 
   OpenTelemetrySdk(
       SdkTracerProvider tracerProvider,
       SdkMeterProvider meterProvider,
+      SdkLogEmitterProvider logEmitterProvider,
       ContextPropagators propagators) {
     this.tracerProvider = new ObfuscatedTracerProvider(tracerProvider);
     this.meterProvider = new ObfuscatedMeterProvider(meterProvider);
+    this.logEmitterProvider = logEmitterProvider;
     this.propagators = propagators;
   }
 
@@ -58,6 +62,11 @@ public final class OpenTelemetrySdk implements OpenTelemetry {
   /** Returns the {@link SdkMeterProvider} for this {@link OpenTelemetrySdk}. */
   public SdkMeterProvider getSdkMeterProvider() {
     return meterProvider.unobfuscate();
+  }
+
+  /** Returns the {@link SdkLogEmitterProvider} for this {@link OpenTelemetrySdk}. */
+  public SdkLogEmitterProvider getSdkLogEmitterProvider() {
+    return logEmitterProvider;
   }
 
   @Override

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdkBuilder.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdkBuilder.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.logs.SdkLogEmitterProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
@@ -18,6 +19,7 @@ public final class OpenTelemetrySdkBuilder {
   private ContextPropagators propagators = ContextPropagators.noop();
   @Nullable private SdkTracerProvider tracerProvider;
   @Nullable private SdkMeterProvider meterProvider;
+  @Nullable private SdkLogEmitterProvider logEmitterProvider;
 
   /**
    * Package protected to disallow direct initialization.
@@ -46,6 +48,18 @@ public final class OpenTelemetrySdkBuilder {
    */
   public OpenTelemetrySdkBuilder setMeterProvider(SdkMeterProvider meterProvider) {
     this.meterProvider = meterProvider;
+    return this;
+  }
+
+  /**
+   * Sets the {@link SdkLogEmitterProvider} to use. This can be used to configure log settings by
+   * returning the instance created by a {@link
+   * io.opentelemetry.sdk.logs.SdkLogEmitterProviderBuilder}.
+   *
+   * @see SdkLogEmitterProvider#builder()
+   */
+  public OpenTelemetrySdkBuilder setLogEmitterProvider(SdkLogEmitterProvider logEmitterProvider) {
+    this.logEmitterProvider = logEmitterProvider;
     return this;
   }
 
@@ -91,6 +105,11 @@ public final class OpenTelemetrySdkBuilder {
       meterProvider = SdkMeterProvider.builder().build();
     }
 
-    return new OpenTelemetrySdk(tracerProvider, meterProvider, propagators);
+    SdkLogEmitterProvider logEmitterProvider = this.logEmitterProvider;
+    if (logEmitterProvider == null) {
+      logEmitterProvider = SdkLogEmitterProvider.builder().build();
+    }
+
+    return new OpenTelemetrySdk(tracerProvider, meterProvider, logEmitterProvider, propagators);
   }
 }

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -17,6 +17,7 @@ import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.sdk.common.Clock;
+import io.opentelemetry.sdk.logs.SdkLogEmitterProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.IdGenerator;
@@ -36,6 +37,7 @@ class OpenTelemetrySdkTest {
 
   @Mock private SdkTracerProvider tracerProvider;
   @Mock private SdkMeterProvider meterProvider;
+  @Mock private SdkLogEmitterProvider logEmitterProvider;
   @Mock private ContextPropagators propagators;
   @Mock private Clock clock;
 
@@ -115,6 +117,7 @@ class OpenTelemetrySdkTest {
         OpenTelemetrySdk.builder()
             .setTracerProvider(tracerProvider)
             .setMeterProvider(meterProvider)
+            .setLogEmitterProvider(logEmitterProvider)
             .setPropagators(propagators)
             .build();
     assertThat(
@@ -126,7 +129,7 @@ class OpenTelemetrySdkTest {
             ((OpenTelemetrySdk.ObfuscatedMeterProvider) openTelemetry.getMeterProvider())
                 .unobfuscate())
         .isEqualTo(meterProvider);
-    assertThat(openTelemetry.getSdkMeterProvider()).isEqualTo(meterProvider);
+    assertThat(openTelemetry.getSdkLogEmitterProvider()).isEqualTo(logEmitterProvider);
     assertThat(openTelemetry.getPropagators()).isEqualTo(propagators);
   }
 


### PR DESCRIPTION
Preparing to add autoconfigure support for logs.

First step is extending `OpenTelemetrySdk` to include `SdkLogEmitterProvider`. 