### PR TITLE
Temurin JDK

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Java 17
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 17
 
       - name: Autobuild

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -31,20 +31,20 @@ jobs:
         name: Setup Java 8 for tests
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 8
           java-package: jre
       - id: setup-java-11
         name: Setup Java 11 for tests
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
       - id: setup-java-17
         name: Setup Java 17
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 17
       - uses: gradle/gradle-build-action@v2
         with:
@@ -74,7 +74,7 @@ jobs:
         name: Setup Java 11
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 17
       - uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -51,7 +51,7 @@ jobs:
           ref: ${{ needs.prepare-release-branch.outputs.release-branch-name }}
       - uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 17
       - name: Setup git name
         run: |

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -32,20 +32,20 @@ jobs:
         name: Setup Java 8 for tests
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 8
           java-package: jre
       - id: setup-java-11
         name: Setup Java 11 for tests
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
       - id: setup-java-17
         name: Setup Java 17
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 17
       - uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/pr-examples-build.yml
+++ b/.github/workflows/pr-examples-build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Java 17
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 17
       - uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2.4.0
       - uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 17
       - uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
Temurin JDK

https://github.com/actions/setup-java/blob/main/README.md

NOTE: Adopt OpenJDK got moved to Eclipse Temurin and won't
be updated anymore. It is highly recommended to migrate
workflows from adopt to temurin to keep receiving software
and security updates.