### PR TITLE
use Eclipse Temurin JDK docker image

### DIFF
--- a/.github/workflows/docker-test-containers.yml
+++ b/.github/workflows/docker-test-containers.yml
@@ -16,7 +16,7 @@ jobs:
             target_image: otel-collector
           - source: shopify/toxiproxy:latest
             target_image: toxiproxy
-          - source: adoptopenjdk/openjdk8:latest
+          - source: eclipse-temurin:8-jdk
             target_image: openjdk8
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
https://hub.docker.com/_/eclipse-temurin

https://www.infoq.com/news/2021/10/adoptium-releases-temurin-jdk/