### PR TITLE
Remove deprecated methods from ObservableMeasurement

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/metrics/ObservableDoubleMeasurement.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/ObservableDoubleMeasurement.java
@@ -9,28 +9,6 @@ import io.opentelemetry.api.common.Attributes;
 
 /** An interface for observing measurements with {@code double} values. */
 public interface ObservableDoubleMeasurement extends ObservableMeasurement {
-  /**
-   * Records a measurement.
-   *
-   * @param value The measurement amount.
-   * @deprecated Use {@link #record(double)}.
-   */
-  @Deprecated
-  default void observe(double value) {
-    record(value);
-  }
-
-  /**
-   * Records a measurement with a set of attributes.
-   *
-   * @param value The measurement amount.
-   * @param attributes A set of attributes to associate with the count.
-   * @deprecated Use {@link #record(double, Attributes)}.
-   */
-  @Deprecated
-  default void observe(double value, Attributes attributes) {
-    record(value, attributes);
-  }
 
   /**
    * Records a measurement.

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/ObservableLongMeasurement.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/ObservableLongMeasurement.java
@@ -9,28 +9,6 @@ import io.opentelemetry.api.common.Attributes;
 
 /** An interface for observing measurements with {@code long} values. */
 public interface ObservableLongMeasurement extends ObservableMeasurement {
-  /**
-   * Records a measurement.
-   *
-   * @param value The measurement amount.
-   * @deprecated Use {@link #record(long)}.
-   */
-  @Deprecated
-  default void observe(long value) {
-    record(value);
-  }
-
-  /**
-   * Records a measurement with a set of attributes.
-   *
-   * @param value The measurement amount.
-   * @param attributes A set of attributes to associate with the count.
-   * @deprecated Use {@link #record(long, Attributes)}.
-   */
-  @Deprecated
-  default void observe(long value, Attributes attributes) {
-    record(value, attributes);
-  }
 
   /**
    * Records a measurement.

--- a/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
@@ -21,6 +21,10 @@ plugins {
  * The latest *released* version of the project. Evaluated lazily so the work is only done if necessary.
  */
 val latestReleasedVersion: String by lazy {
+  // TODO(anuraaga): Restore code after 1.10.0 is released
+  val moduleVersion = "1.9.1"
+  moduleVersion
+  /*
   // hack to find the current released version of the project
   val temp: Configuration = configurations.create("tempConfig")
   // pick the api, since it's always there.
@@ -29,6 +33,7 @@ val latestReleasedVersion: String by lazy {
   configurations.remove(temp)
   logger.debug("Discovered latest release version: " + moduleVersion)
   moduleVersion
+  */
 }
 
 

--- a/docs/apidiffs/current_vs_latest/opentelemetry-api.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-api.txt
@@ -1,2 +1,180 @@
 Comparing source compatibility of  against 
-No changes.
++++  NEW CLASS: PUBLIC(+) STATIC(+) io.opentelemetry.api.metrics.DefaultMeter$NoopDoubleHistogram  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: io.opentelemetry.api.metrics.DoubleHistogram
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW CONSTRUCTOR: PUBLIC(+) DefaultMeter$NoopDoubleHistogram()
+	+++  NEW METHOD: PUBLIC(+) void record(double, io.opentelemetry.api.common.Attributes, io.opentelemetry.context.Context)
+	+++  NEW METHOD: PUBLIC(+) void record(double, io.opentelemetry.api.common.Attributes)
+	+++  NEW METHOD: PUBLIC(+) void record(double)
++++  NEW CLASS: PUBLIC(+) STATIC(+) io.opentelemetry.api.metrics.DefaultMeter$NoopDoubleHistogramBuilder  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: io.opentelemetry.api.metrics.DoubleHistogramBuilder
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW CONSTRUCTOR: PUBLIC(+) DefaultMeter$NoopDoubleHistogramBuilder()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.metrics.DoubleHistogram build()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.metrics.LongHistogramBuilder ofLongs()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.metrics.DoubleHistogramBuilder setDescription(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.metrics.DoubleHistogramBuilder setUnit(java.lang.String)
++++  NEW CLASS: PUBLIC(+) STATIC(+) io.opentelemetry.api.metrics.DefaultMeter$NoopDoubleObservableInstrumentBuilder  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: io.opentelemetry.api.metrics.DoubleGaugeBuilder
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW CONSTRUCTOR: PUBLIC(+) DefaultMeter$NoopDoubleObservableInstrumentBuilder()
+	+++  NEW METHOD: PUBLIC(+) void buildWithCallback(java.util.function.Consumer)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.metrics.LongGaugeBuilder ofLongs()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.metrics.DoubleGaugeBuilder setDescription(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.metrics.DoubleGaugeBuilder setUnit(java.lang.String)
++++  NEW CLASS: PUBLIC(+) STATIC(+) io.opentelemetry.api.metrics.DefaultMeter$NoopLongHistogram  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: io.opentelemetry.api.metrics.LongHistogram
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW CONSTRUCTOR: PUBLIC(+) DefaultMeter$NoopLongHistogram()
+	+++  NEW METHOD: PUBLIC(+) void record(long, io.opentelemetry.api.common.Attributes, io.opentelemetry.context.Context)
+	+++  NEW METHOD: PUBLIC(+) void record(long, io.opentelemetry.api.common.Attributes)
+	+++  NEW METHOD: PUBLIC(+) void record(long)
++++  NEW CLASS: PUBLIC(+) STATIC(+) io.opentelemetry.api.metrics.DefaultMeter$NoopLongHistogramBuilder  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: io.opentelemetry.api.metrics.LongHistogramBuilder
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW CONSTRUCTOR: PUBLIC(+) DefaultMeter$NoopLongHistogramBuilder()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.metrics.LongHistogram build()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.metrics.LongHistogramBuilder setDescription(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.metrics.LongHistogramBuilder setUnit(java.lang.String)
++++  NEW CLASS: PUBLIC(+) STATIC(+) io.opentelemetry.api.metrics.DefaultMeter$NoopLongObservableInstrumentBuilder  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: io.opentelemetry.api.metrics.LongGaugeBuilder
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW CONSTRUCTOR: PUBLIC(+) DefaultMeter$NoopLongObservableInstrumentBuilder()
+	+++  NEW METHOD: PUBLIC(+) void buildWithCallback(java.util.function.Consumer)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.metrics.LongGaugeBuilder setDescription(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.metrics.LongGaugeBuilder setUnit(java.lang.String)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleCounter  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void add(double)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void add(double, io.opentelemetry.api.common.Attributes)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void add(double, io.opentelemetry.api.common.Attributes, io.opentelemetry.context.Context)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleCounterBuilder  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleCounter build()
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void buildWithCallback(java.util.function.Consumer)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleCounterBuilder setDescription(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleCounterBuilder setUnit(java.lang.String)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleGaugeBuilder  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void buildWithCallback(java.util.function.Consumer)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongGaugeBuilder ofLongs()
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleGaugeBuilder setDescription(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleGaugeBuilder setUnit(java.lang.String)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleHistogram  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void record(double)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void record(double, io.opentelemetry.api.common.Attributes)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void record(double, io.opentelemetry.api.common.Attributes, io.opentelemetry.context.Context)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleHistogramBuilder  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleHistogram build()
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongHistogramBuilder ofLongs()
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleHistogramBuilder setDescription(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleHistogramBuilder setUnit(java.lang.String)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleUpDownCounter  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void add(double)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void add(double, io.opentelemetry.api.common.Attributes)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void add(double, io.opentelemetry.api.common.Attributes, io.opentelemetry.context.Context)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleUpDownCounterBuilder  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleUpDownCounter build()
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void buildWithCallback(java.util.function.Consumer)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleUpDownCounterBuilder setDescription(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleUpDownCounterBuilder setUnit(java.lang.String)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongCounter  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void add(long)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void add(long, io.opentelemetry.api.common.Attributes)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void add(long, io.opentelemetry.api.common.Attributes, io.opentelemetry.context.Context)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongCounterBuilder  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongCounter build()
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void buildWithCallback(java.util.function.Consumer)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleCounterBuilder ofDoubles()
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongCounterBuilder setDescription(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongCounterBuilder setUnit(java.lang.String)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongGaugeBuilder  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void buildWithCallback(java.util.function.Consumer)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongGaugeBuilder setDescription(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongGaugeBuilder setUnit(java.lang.String)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongHistogram  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void record(long)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void record(long, io.opentelemetry.api.common.Attributes)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void record(long, io.opentelemetry.api.common.Attributes, io.opentelemetry.context.Context)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongHistogramBuilder  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongHistogram build()
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongHistogramBuilder setDescription(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongHistogramBuilder setUnit(java.lang.String)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongUpDownCounter  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void add(long)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void add(long, io.opentelemetry.api.common.Attributes)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void add(long, io.opentelemetry.api.common.Attributes, io.opentelemetry.context.Context)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongUpDownCounterBuilder  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongUpDownCounter build()
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void buildWithCallback(java.util.function.Consumer)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleUpDownCounterBuilder ofDoubles()
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongUpDownCounterBuilder setDescription(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongUpDownCounterBuilder setUnit(java.lang.String)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.Meter  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongCounterBuilder counterBuilder(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleGaugeBuilder gaugeBuilder(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleHistogramBuilder histogramBuilder(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.LongUpDownCounterBuilder upDownCounterBuilder(java.lang.String)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.MeterBuilder  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.Meter build()
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.MeterBuilder setInstrumentationVersion(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.MeterBuilder setSchemaUrl(java.lang.String)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.MeterProvider  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.metrics.Meter get(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.MeterBuilder meterBuilder(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.api.metrics.MeterProvider noop()
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.ObservableDoubleMeasurement  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: io.opentelemetry.api.metrics.ObservableMeasurement
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void record(double)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void record(double, io.opentelemetry.api.common.Attributes)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.ObservableLongMeasurement  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: io.opentelemetry.api.metrics.ObservableMeasurement
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void record(long)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void record(long, io.opentelemetry.api.common.Attributes)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.ObservableMeasurement  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+***! MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.api.OpenTelemetry  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++! NEW METHOD: PUBLIC(+) io.opentelemetry.api.metrics.MeterProvider getMeterProvider()

--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-logging-otlp.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-logging-otlp.txt
@@ -1,2 +1,8 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingLogExporter  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.common.CompletableResultCode flush()
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingMetricExporter  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.export.MetricExporter create(io.opentelemetry.sdk.metrics.data.AggregationTemporality)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.metrics.data.AggregationTemporality getPreferredTemporality()

--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-logging.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-logging.txt
@@ -1,2 +1,19 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.logging.LoggingMetricExporter  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	===  UNCHANGED CONSTRUCTOR: PUBLIC LoggingMetricExporter()
+		+++  NEW ANNOTATION: java.lang.Deprecated
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.exporter.logging.LoggingMetricExporter create()
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.exporter.logging.LoggingMetricExporter create(io.opentelemetry.sdk.metrics.data.AggregationTemporality)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.metrics.data.AggregationTemporality getPreferredTemporality()
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.logging.LoggingSpanExporter  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	===  UNCHANGED CONSTRUCTOR: PUBLIC LoggingSpanExporter()
+		+++  NEW ANNOTATION: java.lang.Deprecated
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.exporter.logging.LoggingSpanExporter create()
+***  MODIFIED CLASS: PUBLIC io.opentelemetry.exporter.logging.SystemOutLogExporter  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	===  UNCHANGED CONSTRUCTOR: PUBLIC SystemOutLogExporter()
+		+++  NEW ANNOTATION: java.lang.Deprecated
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.exporter.logging.SystemOutLogExporter create()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.common.CompletableResultCode flush()

--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp-http-trace.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp-http-trace.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder setMeterProvider(io.opentelemetry.api.metrics.MeterProvider)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp-trace.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp-trace.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder setMeterProvider(io.opentelemetry.api.metrics.MeterProvider)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.export.BatchSpanProcessorBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.BatchSpanProcessorBuilder setMeterProvider(io.opentelemetry.api.metrics.MeterProvider)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk.txt
@@ -1,2 +1,10 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.OpenTelemetrySdk  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.metrics.MeterProvider getMeterProvider()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.logs.SdkLogEmitterProvider getSdkLogEmitterProvider()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.metrics.SdkMeterProvider getSdkMeterProvider()
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.OpenTelemetrySdkBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.OpenTelemetrySdkBuilder setLogEmitterProvider(io.opentelemetry.sdk.logs.SdkLogEmitterProvider)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.OpenTelemetrySdkBuilder setMeterProvider(io.opentelemetry.sdk.metrics.SdkMeterProvider)


### PR DESCRIPTION
Forgot these in a previous PR