### PR TITLE
Add port mapping to example docker-compose.yaml

### DIFF
--- a/examples/otlp/docker/docker-compose.yaml
+++ b/examples/otlp/docker/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     ports:
       - "16686:16686"
       - "14268"
-      - "14250"
+      - "14250:14250"
 
   # Zipkin
   zipkin-all-in-one:


### PR DESCRIPTION
Without this it choses an ephemeral port and so the default Jaeger exporter configuration doesn't work.