### PR TITLE
Prototype batch api

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/metrics/BatchRecorder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/BatchRecorder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.metrics;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+
+public interface BatchRecorder {
+
+  /** Record the value to the instruments when record is called. */
+  default BatchRecorder addMeasurements(long value, LongInstrument... instruments) {
+    return this;
+  }
+
+  /** Record the value to the instruments when record is called. */
+  default BatchRecorder addMeasurements(double value, DoubleInstrument... instruments) {
+    return this;
+  }
+
+  /** Record the measurements. */
+  default void record(Attributes attributes) {
+    record(attributes, Context.current());
+  }
+
+  /** Record the measurements. */
+  default void record(Attributes attributes, Context context) {}
+}

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DefaultMeter.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DefaultMeter.java
@@ -61,7 +61,28 @@ class DefaultMeter implements Meter {
     return new NoopDoubleObservableInstrumentBuilder();
   }
 
+  @Override
+  public BatchRecorder batch() {
+    return new NoopBatchRecord();
+  }
+
   private DefaultMeter() {}
+
+  private static class NoopBatchRecord implements BatchRecorder {
+
+    @Override
+    public BatchRecorder addMeasurements(long value, LongInstrument... instruments) {
+      return this;
+    }
+
+    @Override
+    public BatchRecorder addMeasurements(double value, DoubleInstrument... instruments) {
+      return this;
+    }
+
+    @Override
+    public void record(Attributes attributes, Context context) {}
+  }
 
   private static class NoopLongCounter implements LongCounter {
     @Override

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleCounter.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleCounter.java
@@ -11,7 +11,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /** A counter instrument that records {@code double} values. */
 @ThreadSafe
-public interface DoubleCounter {
+public interface DoubleCounter extends DoubleInstrument {
   /**
    * Records a value.
    *

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleHistogram.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleHistogram.java
@@ -11,7 +11,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /** A histogram instrument that records {@code long} values. */
 @ThreadSafe
-public interface DoubleHistogram {
+public interface DoubleHistogram extends DoubleInstrument {
 
   /**
    * Records a value.

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleInstrument.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleInstrument.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.metrics;
+
+public interface DoubleInstrument {}

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleUpDownCounter.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleUpDownCounter.java
@@ -11,7 +11,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /** An up-down-counter instrument that records {@code double} values. */
 @ThreadSafe
-public interface DoubleUpDownCounter {
+public interface DoubleUpDownCounter extends DoubleInstrument {
   /**
    * Records a value.
    *

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/LongCounter.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/LongCounter.java
@@ -16,7 +16,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * always-increasing monotonic sums.
  */
 @ThreadSafe
-public interface LongCounter {
+public interface LongCounter extends LongInstrument {
 
   /**
    * Records a value.

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/LongHistogram.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/LongHistogram.java
@@ -11,7 +11,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /** A histogram instrument that records {@code long} values. */
 @ThreadSafe
-public interface LongHistogram {
+public interface LongHistogram extends LongInstrument {
 
   /**
    * Records a value.

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/LongInstrument.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/LongInstrument.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.metrics;
+
+public interface LongInstrument {}

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/LongUpDownCounter.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/LongUpDownCounter.java
@@ -11,7 +11,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /** An up-down-counter instrument that records {@code long} values. */
 @ThreadSafe
-public interface LongUpDownCounter {
+public interface LongUpDownCounter extends LongInstrument {
   /**
    * Records a value.
    *

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/Meter.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/Meter.java
@@ -75,4 +75,9 @@ public interface Meter {
    * @return a builder used for configuring how to report gauge measurements on demand.
    */
   DoubleGaugeBuilder gaugeBuilder(String name);
+
+  /** Returns a batch recorder. */
+  default BatchRecorder batch() {
+    return DefaultMeter.getInstance().batch();
+  }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkBatchRecorder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkBatchRecorder.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.BatchRecorder;
+import io.opentelemetry.api.metrics.DoubleInstrument;
+import io.opentelemetry.api.metrics.LongInstrument;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.internal.ThrottlingLogger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/** {@link SdkBatchRecorder} is SDK implementation of {@link BatchRecorder}. */
+final class SdkBatchRecorder implements BatchRecorder {
+
+  private static final Logger logger = Logger.getLogger(SdkBatchRecorder.class.getName());
+
+  private final ThrottlingLogger throttlingLogger = new ThrottlingLogger(logger);
+  private final List<Object> measurements = new ArrayList<>();
+  private final SdkMeter.BatchLatch batchLatch;
+  private volatile boolean recorded = false;
+
+  SdkBatchRecorder(SdkMeter.BatchLatch batchLatch) {
+    this.batchLatch = batchLatch;
+  }
+
+  @Override
+  public BatchRecorder addMeasurements(long value, LongInstrument... instruments) {
+    if (!isRecorded()) {
+      measurements.add(new LongMeasurement(value, instruments));
+    }
+    return this;
+  }
+
+  @Override
+  public BatchRecorder addMeasurements(double value, DoubleInstrument... instruments) {
+    if (!isRecorded()) {
+      measurements.add(new DoubleMeasurement(value, instruments));
+    }
+    return this;
+  }
+
+  @Override
+  public void record(Attributes attributes, Context context) {
+    if (isRecorded()) {
+      return;
+    }
+    recorded = true;
+
+    batchLatch.startBatchRecord();
+    try {
+      for (Object measurement : measurements) {
+        if (measurement instanceof DoubleMeasurement) {
+          DoubleMeasurement doubleMeasurement = (DoubleMeasurement) measurement;
+          double value = doubleMeasurement.value;
+          for (DoubleInstrument instrument : doubleMeasurement.instruments) {
+            if (instrument instanceof SdkDoubleHistogram) {
+              ((SdkDoubleHistogram) instrument).record(value, attributes, context);
+            } else if (instrument instanceof SdkDoubleCounter) {
+              ((SdkDoubleCounter) instrument).add(value, attributes, context);
+            } else if (instrument instanceof SdkDoubleUpDownCounter) {
+              ((SdkDoubleUpDownCounter) instrument).add(value, attributes, context);
+            } else {
+              unrecognizedInstrument(instrument);
+            }
+          }
+        }
+        if (measurement instanceof LongMeasurement) {
+          LongMeasurement longMeasurement = (LongMeasurement) measurement;
+          long value = longMeasurement.value;
+          for (LongInstrument instrument : longMeasurement.instruments) {
+            if (instrument instanceof SdkLongHistogram) {
+              ((SdkLongHistogram) instrument).record(value, attributes, context);
+            } else if (instrument instanceof SdkLongCounter) {
+              ((SdkLongCounter) instrument).add(value, attributes, context);
+            } else if (instrument instanceof SdkLongUpDownCounter) {
+              ((SdkLongUpDownCounter) instrument).add(value, attributes, context);
+            } else {
+              unrecognizedInstrument(instrument);
+            }
+          }
+        }
+      }
+    } finally {
+      batchLatch.finishBatchRecord();
+    }
+  }
+
+  private void unrecognizedInstrument(Object instrument) {
+    throttlingLogger.log(
+        Level.WARNING,
+        "Unrecognized instrument in batch recording: " + instrument.getClass().getName());
+  }
+
+  private boolean isRecorded() {
+    if (recorded) {
+      throttlingLogger.log(Level.WARNING, "Batch has already recorded.");
+      return true;
+    }
+    return false;
+  }
+
+  private static class DoubleMeasurement {
+    private final double value;
+    private final List<DoubleInstrument> instruments;
+
+    private DoubleMeasurement(double value, DoubleInstrument... instruments) {
+      this.value = value;
+      this.instruments = Arrays.asList(instruments);
+    }
+  }
+
+  private static class LongMeasurement {
+    private final long value;
+    private final List<LongInstrument> instruments;
+
+    private LongMeasurement(long value, LongInstrument... instruments) {
+      this.value = value;
+      this.instruments = Arrays.asList(instruments);
+    }
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import io.opentelemetry.api.metrics.BatchRecorder;
 import io.opentelemetry.api.metrics.DoubleGaugeBuilder;
 import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.LongCounterBuilder;
@@ -16,11 +17,14 @@ import io.opentelemetry.sdk.metrics.internal.export.CollectionInfo;
 import io.opentelemetry.sdk.metrics.internal.state.MeterProviderSharedState;
 import io.opentelemetry.sdk.metrics.internal.state.MeterSharedState;
 import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
 
 /** {@link SdkMeter} is SDK implementation of {@link Meter}. */
 final class SdkMeter implements Meter {
   private final MeterProviderSharedState meterProviderSharedState;
   private final MeterSharedState meterSharedState;
+  private final BatchLatch batchLatch = new BatchLatch();
 
   SdkMeter(
       MeterProviderSharedState meterProviderSharedState,
@@ -37,8 +41,13 @@ final class SdkMeter implements Meter {
   /** Collects all the metric recordings that changed since the previous call. */
   Collection<MetricData> collectAll(
       CollectionInfo collectionInfo, long epochNanos, boolean suppressSynchronousCollection) {
-    return meterSharedState.collectAll(
-        collectionInfo, meterProviderSharedState, epochNanos, suppressSynchronousCollection);
+    batchLatch.startCollect();
+    try {
+      return meterSharedState.collectAll(
+          collectionInfo, meterProviderSharedState, epochNanos, suppressSynchronousCollection);
+    } finally {
+      batchLatch.finishCollect();
+    }
   }
 
   @Override
@@ -59,5 +68,45 @@ final class SdkMeter implements Meter {
   @Override
   public DoubleGaugeBuilder gaugeBuilder(String name) {
     return new SdkDoubleGaugeBuilder(meterProviderSharedState, meterSharedState, name);
+  }
+
+  @Override
+  public BatchRecorder batch() {
+    return new SdkBatchRecorder(batchLatch);
+  }
+
+  static class BatchLatch {
+
+    private static final int batchSlots = 64;
+
+    private volatile CountDownLatch collectLatch = new CountDownLatch(0);
+    private final Semaphore batchSemaphore = new Semaphore(batchSlots);
+
+    void startBatchRecord() {
+      try {
+        collectLatch.await();
+        batchSemaphore.acquire();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+
+    void finishBatchRecord() {
+      batchSemaphore.release();
+    }
+
+    private void startCollect() {
+      collectLatch = new CountDownLatch(1);
+      try {
+        batchSemaphore.acquire(batchSlots);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+
+    private void finishCollect() {
+      collectLatch.countDown();
+      batchSemaphore.release(batchSlots);
+    }
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/BatchTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/BatchTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleCounter;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.DoubleUpDownCounter;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.LongUpDownCounter;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.testing.InMemoryMetricReader;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BatchTest {
+
+  private final InMemoryMetricReader reader = InMemoryMetricReader.create();
+
+  @BeforeEach
+  void setup() {
+    GlobalOpenTelemetry.resetForTest();
+    GlobalOpenTelemetry.set(
+        OpenTelemetrySdk.builder()
+            .setMeterProvider(
+                SdkMeterProvider.builder()
+                    .setMinimumCollectionInterval(Duration.ZERO)
+                    .registerMetricReader(reader)
+                    .build())
+            .build());
+  }
+
+  @AfterEach
+  void cleanup() {
+    GlobalOpenTelemetry.resetForTest();
+  }
+
+  @Test
+  void batch() {
+    Meter meter = GlobalOpenTelemetry.get().getMeterProvider().get("meter");
+
+    DoubleHistogram doubleHistogram = meter.histogramBuilder("double-histogram").build();
+    LongHistogram longHistogram = meter.histogramBuilder("long-histogram").ofLongs().build();
+
+    DoubleCounter doubleCounter = meter.counterBuilder("double-counter").ofDoubles().build();
+    LongCounter longCounter = meter.counterBuilder("long-counter").build();
+
+    DoubleUpDownCounter doubleUpDownCounter =
+        meter.upDownCounterBuilder("double-up-down-counter").ofDoubles().build();
+    LongUpDownCounter longUpDownCounter =
+        meter.upDownCounterBuilder("long-up-down-counter").build();
+
+    // Recording through existing API
+    Attributes attributes = Attributes.builder().put("foo", "bar").build();
+    longHistogram.record(10, attributes);
+    longCounter.add(10, attributes);
+    longUpDownCounter.add(10, attributes);
+    doubleHistogram.record(10.0, attributes);
+    doubleCounter.add(10.0, attributes);
+    doubleUpDownCounter.add(10.0, attributes);
+
+    collectAndPrint();
+
+    // Recording through batch api
+    meter
+        .batch()
+        .addMeasurements(10L, longHistogram, longCounter, longUpDownCounter)
+        .addMeasurements(10.0, doubleHistogram, doubleCounter, doubleUpDownCounter)
+        .record(Attributes.builder().put("foo", "bar").build(), Context.current());
+
+    collectAndPrint();
+  }
+
+  @SuppressWarnings("SystemOut")
+  private void collectAndPrint() {
+    reader
+        .collectAllMetrics()
+        .forEach(
+            metricData -> {
+              System.out.println();
+              System.out.println(metricData);
+            });
+  }
+}


### PR DESCRIPTION
A few weeks ago in the java SIG we discussed that it might be valuable to prototype what a batch API. IIRC, the thought was that prototyping a batch API might find some intersection with the bind API we recently dropped. I dug through the spec and found this old API reference to a [batch API](https://github.com/bogdandrutu/opentelemetry-specification/blob/a7ce40d787c12aaec9cc2548c8e14dc813176fcb/specification/metrics/api-user.md#recordbatch-calling-convention), and used some of the notes as inspiration. 

The idea is that you can "atomically" record values for several instruments using the same attributes. I interpreted atomic as guaranteeing that either all or none of the recordings make it into a particular collection. This seems only somewhat useful to me. However, the API experience of recording a batch of measurements does feel a bit improved. 

The naive implementation I put together in this PR has worse performance than if you were record the instruments using the existing API. This is because the implementation doesn't get to take advantage of acquiring fewer locks by recording in a batch, and actually does some additional synchronization to ensure that all the recordings occur atomically for a collection. There's likely some room for improvement, but is always going to take extra work to guarantee the atomicity. 