### PR TITLE
Reduce metrics stress test operations

### DIFF
--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkLongUpDownCounterTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkLongUpDownCounterTest.java
@@ -186,10 +186,10 @@ class SdkLongUpDownCounterTest {
     for (int i = 0; i < 4; i++) {
       stressTestBuilder.addOperation(
           StressTestRunner.Operation.create(
-              2_000, 1, new OperationUpdaterDirectCall(longUpDownCounter, "K", "V")));
+              200, 1, new OperationUpdaterDirectCall(longUpDownCounter, "K", "V")));
       stressTestBuilder.addOperation(
           StressTestRunner.Operation.create(
-              2_000,
+              200,
               1,
               new OperationUpdaterWithBinding(
                   ((SdkLongUpDownCounter) longUpDownCounter)
@@ -213,7 +213,7 @@ class SdkLongUpDownCounterTest {
                             assertThat(point)
                                 .hasStartEpochNanos(testClock.now())
                                 .hasEpochNanos(testClock.now())
-                                .hasValue(160_000)
+                                .hasValue(16000)
                                 .attributes()
                                 .hasSize(1)
                                 .containsEntry("K", "V")));
@@ -234,11 +234,11 @@ class SdkLongUpDownCounterTest {
     for (int i = 0; i < 4; i++) {
       stressTestBuilder.addOperation(
           StressTestRunner.Operation.create(
-              1_000, 2, new OperationUpdaterDirectCall(longUpDownCounter, keys[i], values[i])));
+              200, 2, new OperationUpdaterDirectCall(longUpDownCounter, keys[i], values[i])));
 
       stressTestBuilder.addOperation(
           StressTestRunner.Operation.create(
-              1_000,
+              200,
               2,
               new OperationUpdaterWithBinding(
                   ((SdkLongUpDownCounter) longUpDownCounter)
@@ -262,7 +262,7 @@ class SdkLongUpDownCounterTest {
                             assertThat(point)
                                 .hasStartEpochNanos(testClock.now())
                                 .hasEpochNanos(testClock.now())
-                                .hasValue(20_000))
+                                .hasValue(4000))
                     .extracting(PointData::getAttributes)
                     .containsExactlyInAnyOrder(
                         Attributes.of(stringKey(keys[0]), values[0]),


### PR DESCRIPTION
Currently the stress tests take several seconds, which I think is too much for unit tests that don't do I/O (even I/O tests are usually 300ms for first, and 10-20ms for remaining reusing the same server). It seemed OK to reduce the number of operations a lot, let me know if this seems reasonable and I will apply to the rest of the instruments.