### PR TITLE
Expand GlobaOpenTelemetry and OpenTelemetry to include metric accessors

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.api;
 
 import io.opentelemetry.api.internal.GuardedBy;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterBuilder;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerBuilder;
@@ -142,6 +144,43 @@ public final class GlobalOpenTelemetry {
    */
   public static TracerBuilder tracerBuilder(String instrumentationName) {
     return get().tracerBuilder(instrumentationName);
+  }
+
+  /**
+   * Returns the globally registered {@link MeterProvider}.
+   *
+   * @since 1.10.0
+   */
+  public static MeterProvider getMeterProvider() {
+    return get().getMeterProvider();
+  }
+
+  /**
+   * Gets or creates a named meter instance from the globally registered {@link MeterProvider}.
+   *
+   * <p>This is a shortcut method for {@code getMeterProvider().get(instrumentationName)}
+   *
+   * @param instrumentationName The name of the instrumentation library, not the name of the
+   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.
+   * @return a Meter instance.
+   * @since 1.10.0
+   */
+  public static Meter getMeter(String instrumentationName) {
+    return get().getMeter(instrumentationName);
+  }
+
+  /**
+   * Creates a MeterBuilder for a named {@link Meter} instance.
+   *
+   * <p>This is a shortcut method for {@code get().meterBuilder(instrumentationName)}
+   *
+   * @param instrumentationName The name of the instrumentation library, not the name of the
+   *     instrument*ed* library.
+   * @return a MeterBuilder instance.
+   * @since 1.10.0
+   */
+  public static MeterBuilder meterBuilder(String instrumentationName) {
+    return get().meterBuilder(instrumentationName);
   }
 
   /**

--- a/api/all/src/main/java/io/opentelemetry/api/OpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/OpenTelemetry.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.api;
 
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterBuilder;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerBuilder;
@@ -39,11 +41,6 @@ public interface OpenTelemetry {
 
   /** Returns the {@link TracerProvider} for this {@link OpenTelemetry}. */
   TracerProvider getTracerProvider();
-
-  /** Returns the {@link MeterProvider} for this {@link OpenTelemetry}. */
-  default MeterProvider getMeterProvider() {
-    return MeterProvider.noop();
-  }
 
   /**
    * Gets or creates a named tracer instance from the {@link TracerProvider} for this {@link
@@ -80,6 +77,40 @@ public interface OpenTelemetry {
    */
   default TracerBuilder tracerBuilder(String instrumentationName) {
     return getTracerProvider().tracerBuilder(instrumentationName);
+  }
+
+  /**
+   * Returns the {@link MeterProvider} for this {@link OpenTelemetry}.
+   *
+   * @since 1.10.0
+   */
+  default MeterProvider getMeterProvider() {
+    return MeterProvider.noop();
+  }
+
+  /**
+   * Gets or creates a named meter instance from the {@link MeterProvider} for this {@link
+   * OpenTelemetry}.
+   *
+   * @param instrumentationName The name of the instrumentation library, not the name of the
+   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.
+   * @return a Meter instance.
+   * @since 1.10.0
+   */
+  default Meter getMeter(String instrumentationName) {
+    return getMeterProvider().get(instrumentationName);
+  }
+
+  /**
+   * Creates a {@link MeterBuilder} for a named {@link Tracer} instance.
+   *
+   * @param instrumentationName The name of the instrumentation library, not the name of the
+   *     instrument*ed* library.
+   * @return a MeterBuilder instance.
+   * @since 1.10.0
+   */
+  default MeterBuilder meterBuilder(String instrumentationName) {
+    return getMeterProvider().meterBuilder(instrumentationName);
   }
 
   /** Returns the {@link ContextPropagators} for this {@link OpenTelemetry}. */

--- a/docs/apidiffs/current_vs_latest/opentelemetry-api.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-api.txt
@@ -1,4 +1,9 @@
 Comparing source compatibility of  against 
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.api.GlobalOpenTelemetry  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.api.metrics.Meter getMeter(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.api.metrics.MeterProvider getMeterProvider()
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.api.metrics.MeterBuilder meterBuilder(java.lang.String)
 +++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.metrics.DoubleCounter  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW SUPERCLASS: java.lang.Object
@@ -140,4 +145,6 @@ Comparing source compatibility of  against
 	+++  NEW SUPERCLASS: java.lang.Object
 ***! MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.api.OpenTelemetry  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++! NEW METHOD: PUBLIC(+) io.opentelemetry.api.metrics.Meter getMeter(java.lang.String)
 	+++! NEW METHOD: PUBLIC(+) io.opentelemetry.api.metrics.MeterProvider getMeterProvider()
+	+++! NEW METHOD: PUBLIC(+) io.opentelemetry.api.metrics.MeterBuilder meterBuilder(java.lang.String)

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -55,7 +55,8 @@ class OpenTelemetrySdkTest {
         .isSameAs(GlobalOpenTelemetry.getTracerProvider().get(""))
         .isSameAs(GlobalOpenTelemetry.get().getTracer(""));
     assertThat(sdk.getMeterProvider().get(""))
-        .isSameAs(GlobalOpenTelemetry.get().getMeterProvider().get(""));
+        .isSameAs(GlobalOpenTelemetry.get().getMeterProvider().get(""))
+        .isSameAs(GlobalOpenTelemetry.get().getMeter(""));
 
     assertThat(GlobalOpenTelemetry.getPropagators())
         .isSameAs(GlobalOpenTelemetry.get().getPropagators())
@@ -89,6 +90,20 @@ class OpenTelemetrySdkTest {
         .isSameAs(
             GlobalOpenTelemetry.getTracerProvider()
                 .tracerBuilder("testTracer2")
+                .setInstrumentationVersion("testVersion")
+                .setSchemaUrl("https://example.invalid")
+                .build());
+
+    assertThat(GlobalOpenTelemetry.getMeter("testMeter1"))
+        .isSameAs(GlobalOpenTelemetry.getMeterProvider().get("testMeter1"));
+    assertThat(
+            GlobalOpenTelemetry.meterBuilder("testMeter2")
+                .setInstrumentationVersion("testVersion")
+                .setSchemaUrl("https://example.invalid")
+                .build())
+        .isSameAs(
+            GlobalOpenTelemetry.getMeterProvider()
+                .meterBuilder("testMeter2")
                 .setInstrumentationVersion("testVersion")
                 .setSchemaUrl("https://example.invalid")
                 .build());


### PR DESCRIPTION
Add to `GlobalOpenTelemetry`:
- `MeterProvider getMeterProvider()`
- `Meter getMeter(String instrumentationName)`
- `MeterBuilder meterBuilder(String instrumentationName)`

Add to `OpenTelemetry`:
- `MeterProvider getMeterProvider()`
- `Meter getMeter(String instrumentationName)`
- `MeterBuilder meterBuilder(String instrumentationName)`

I've omitted the `Meter getMeter(String instrumentationName, String instrumentationVersion)` versions of accessors as they don't exist for metrics. 