### PR TITLE
Remove grpc dependency from examples

### DIFF
--- a/examples/jaeger/README.md
+++ b/examples/jaeger/README.md
@@ -27,7 +27,7 @@ docker run --rm -it --name jaeger\
 
 ## 3 - Start the Application
 ```shell script
-java -cp build/libs/opentelemetry-examples-jaeger-0.1.0-SNAPSHOT-all.jar io.opentelemetry.example.jaeger.JaegerExample localhost 14250
+java -cp build/libs/opentelemetry-examples-jaeger-0.1.0-SNAPSHOT-all.jar io.opentelemetry.example.jaeger.JaegerExample http://localhost:14250
 ```
 ## 4 - Open the Jaeger UI
 

--- a/examples/jaeger/build.gradle
+++ b/examples/jaeger/build.gradle
@@ -12,7 +12,4 @@ dependencies {
 
     //alpha module
     implementation "io.opentelemetry:opentelemetry-semconv"
-
-    implementation("io.grpc:grpc-stub")
-    implementation("io.grpc:grpc-netty-shaded")
 }

--- a/examples/jaeger/build.gradle
+++ b/examples/jaeger/build.gradle
@@ -13,6 +13,6 @@ dependencies {
     //alpha module
     implementation "io.opentelemetry:opentelemetry-semconv"
 
-    implementation("io.grpc:grpc-protobuf")
+    implementation("io.grpc:grpc-stub")
     implementation("io.grpc:grpc-netty-shaded")
 }

--- a/examples/jaeger/src/main/java/io/opentelemetry/example/jaeger/ExampleConfiguration.java
+++ b/examples/jaeger/src/main/java/io/opentelemetry/example/jaeger/ExampleConfiguration.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.example.jaeger;
 
-import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter;
@@ -26,18 +24,14 @@ class ExampleConfiguration {
   /**
    * Initialize an OpenTelemetry SDK with a Jaeger exporter and a SimpleSpanProcessor.
    *
-   * @param jaegerHost The host of your Jaeger instance.
-   * @param jaegerPort the port of your Jaeger instance.
+   * @param jaegerEndpoint The endpoint of your Jaeger instance.
    * @return A ready-to-use {@link OpenTelemetry} instance.
    */
-  static OpenTelemetry initOpenTelemetry(String jaegerHost, int jaegerPort) {
-    // Create a channel towards Jaeger end point
-    ManagedChannel jaegerChannel =
-        ManagedChannelBuilder.forAddress(jaegerHost, jaegerPort).usePlaintext().build();
+  static OpenTelemetry initOpenTelemetry(String jaegerEndpoint) {
     // Export traces to Jaeger
     JaegerGrpcSpanExporter jaegerExporter =
         JaegerGrpcSpanExporter.builder()
-            .setChannel(jaegerChannel)
+            .setEndpoint(jaegerEndpoint)
             .setTimeout(30, TimeUnit.SECONDS)
             .build();
 

--- a/examples/jaeger/src/main/java/io/opentelemetry/example/jaeger/JaegerExample.java
+++ b/examples/jaeger/src/main/java/io/opentelemetry/example/jaeger/JaegerExample.java
@@ -32,16 +32,14 @@ public final class JaegerExample {
 
   public static void main(String[] args) {
     // Parsing the input
-    if (args.length < 2) {
-      System.out.println("Missing [hostname] [port]");
+    if (args.length < 1) {
+      System.out.println("Missing [endpoint]");
       System.exit(1);
     }
-    String jaegerHostName = args[0];
-    int jaegerPort = Integer.parseInt(args[1]);
+    String jaegerEndpoint = args[0];
 
     // it is important to initialize your SDK as early as possible in your application's lifecycle
-    OpenTelemetry openTelemetry =
-        ExampleConfiguration.initOpenTelemetry(jaegerHostName, jaegerPort);
+    OpenTelemetry openTelemetry = ExampleConfiguration.initOpenTelemetry(jaegerEndpoint);
 
     // Start the example
     JaegerExample example = new JaegerExample(openTelemetry);

--- a/examples/otlp/build.gradle
+++ b/examples/otlp/build.gradle
@@ -15,7 +15,4 @@ dependencies {
     implementation("io.opentelemetry:opentelemetry-api-metrics")
     implementation("io.opentelemetry:opentelemetry-sdk-metrics")
     implementation("io.opentelemetry:opentelemetry-exporter-otlp-metrics")
-
-    //external dependency for the grpc transport implementation
-    implementation "io.grpc:grpc-netty-shaded"
 }

--- a/examples/otlp/docker/docker-compose.yaml
+++ b/examples/otlp/docker/docker-compose.yaml
@@ -26,8 +26,7 @@ services:
       - "8888:8888"   # Prometheus metrics exposed by the collector
       - "8889:8889"   # Prometheus exporter metrics
       - "13133:13133" # health_check extension
-      - "55678"       # OpenCensus receiver
-      - "55681:55679" # zpages extension
+      - "55679:55679" # zpages extension
       - "4317:4317"   # otlp receiver
     depends_on:
       - jaeger-all-in-one

--- a/examples/otlp/src/main/java/io/opentelemetry/example/otlp/ExampleConfiguration.java
+++ b/examples/otlp/src/main/java/io/opentelemetry/example/otlp/ExampleConfiguration.java
@@ -41,7 +41,11 @@ public final class ExampleConfiguration {
     SdkTracerProvider tracerProvider =
         SdkTracerProvider.builder()
             .addSpanProcessor(spanProcessor)
-            .setResource(AutoConfiguredOpenTelemetrySdk.initialize().getResource())
+            .setResource(
+                AutoConfiguredOpenTelemetrySdk.builder()
+                    .setResultAsGlobal(false)
+                    .build()
+                    .getResource())
             .build();
     OpenTelemetrySdk openTelemetrySdk =
         OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).buildAndRegisterGlobal();
@@ -66,9 +70,7 @@ public final class ExampleConfiguration {
             .newMetricReaderFactory();
 
     SdkMeterProvider sdkMeterProvider =
-        SdkMeterProvider.builder()
-            .registerMetricReader(periodicReaderFactory)
-            .buildAndRegisterGlobal();
+        SdkMeterProvider.builder().registerMetricReader(periodicReaderFactory).build();
 
     Runtime.getRuntime().addShutdownHook(new Thread(sdkMeterProvider::shutdown));
     return sdkMeterProvider;

--- a/examples/otlp/src/main/java/io/opentelemetry/example/otlp/OtlpExporterExample.java
+++ b/examples/otlp/src/main/java/io/opentelemetry/example/otlp/OtlpExporterExample.java
@@ -56,5 +56,7 @@ public final class OtlpExporterExample {
 
     // sleep for a bit to let everything settle
     Thread.sleep(2000);
+
+    System.out.println("Bye");
   }
 }

--- a/exporters/jaeger/build.gradle.kts
+++ b/exporters/jaeger/build.gradle.kts
@@ -42,8 +42,8 @@ wire {
   }
 }
 
-tasks {
-  compileJava {
-    source("$buildDir/generated/source/wire")
+sourceSets {
+  main {
+    java.srcDir("$buildDir/generated/source/wire")
   }
 }

--- a/exporters/otlp/common/build.gradle.kts
+++ b/exporters/otlp/common/build.gradle.kts
@@ -68,8 +68,8 @@ wire {
   }
 }
 
-tasks {
-  compileJava {
-    source("$buildDir/generated/source/wire")
+sourceSets {
+  main {
+    java.srcDir("$buildDir/generated/source/wire")
   }
 }


### PR DESCRIPTION
Resolves #4040.

Another option would be to use `setEndpoint(String)` instead of `setChannel(ManagedChannel)` for [configuration](https://github.com/open-telemetry/opentelemetry-java/blob/main/examples/jaeger/src/main/java/io/opentelemetry/example/jaeger/ExampleConfiguration.java#L40).

