### PR TITLE
Use ExporterMetrics for OkHttpGrpcExporter

### DIFF
--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ExporterMetrics.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/ExporterMetrics.java
@@ -60,6 +60,12 @@ public class ExporterMetrics {
     return new ExporterMetrics(meterProvider.get("io.opentelemetry.exporters.otlp-grpc"), type);
   }
 
+  /** Create an instance for recording OTLP gRPC OkHttp exporter metrics. */
+  public static ExporterMetrics createGrpcOkHttp(String type, MeterProvider meterProvider) {
+    return new ExporterMetrics(
+        meterProvider.get("io.opentelemetry.exporters.otlp-grpc-okhttp"), type);
+  }
+
   /** Create an instance for recording OTLP http/protobuf exporter metrics. */
   public static ExporterMetrics createHttpProtobuf(String type, MeterProvider meterProvider) {
     return new ExporterMetrics(meterProvider.get("io.opentelemetry.exporters.otlp-http"), type);


### PR DESCRIPTION
There was a typo in the name of the counter for OkHttpGrpcExporter. Was `otlp.exported.exported`, should have been `otlp.exporter.exported`.

Refactored to use `ExporterMetrics` like the other OTLP exporters so that metric names and attributes are standardized. 