### PR TITLE
Add toString to SDK trace components and print autoconfigured SDK

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
@@ -1,4 +1,13 @@
 Comparing source compatibility of  against 
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.export.BatchSpanProcessor  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) java.lang.String toString()
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.export.BatchSpanProcessorBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.BatchSpanProcessorBuilder setMeterProvider(io.opentelemetry.api.metrics.MeterProvider)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.export.SimpleSpanProcessor  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) java.lang.String toString()
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.SdkTracerProvider  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) java.lang.String toString()

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk.txt
@@ -4,6 +4,7 @@ Comparing source compatibility of  against
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.metrics.MeterProvider getMeterProvider()
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.logs.SdkLogEmitterProvider getSdkLogEmitterProvider()
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.metrics.SdkMeterProvider getSdkMeterProvider()
+	+++  NEW METHOD: PUBLIC(+) java.lang.String toString()
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.OpenTelemetrySdkBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.OpenTelemetrySdkBuilder setLogEmitterProvider(io.opentelemetry.sdk.logs.SdkLogEmitterProvider)

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -210,7 +210,8 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
 
     if (setResultAsGlobal) {
       GlobalOpenTelemetry.set(openTelemetrySdk);
-      logger.log(Level.FINE, "Global OpenTelemetrySdk set to {0}", openTelemetrySdk);
+      logger.log(
+          Level.FINE, "Global OpenTelemetrySdk set to {0} by autoconfiguration", openTelemetrySdk);
     }
 
     return AutoConfiguredOpenTelemetrySdk.create(openTelemetrySdk, resource, config);

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
@@ -35,6 +37,9 @@ import javax.annotation.Nullable;
  * behavior such as filtering out telemetry attributes.
  */
 public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigurationCustomizer {
+
+  private static final Logger logger =
+      Logger.getLogger(AutoConfiguredOpenTelemetrySdkBuilder.class.getName());
 
   @Nullable private ConfigProperties config;
 
@@ -205,6 +210,7 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
 
     if (setResultAsGlobal) {
       GlobalOpenTelemetry.set(openTelemetrySdk);
+      logger.log(Level.FINE, "Global OpenTelemetrySdk set to {0}", openTelemetrySdk);
     }
 
     return AutoConfiguredOpenTelemetrySdk.create(openTelemetrySdk, resource, config);

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -74,6 +74,12 @@ public final class OpenTelemetrySdk implements OpenTelemetry {
     return propagators;
   }
 
+  @Override
+  public String toString() {
+    // TODO(anuraaga): Add metrics / logs / propagators
+    return "OpenTelemetrySdk{" + "tracerProvider=" + tracerProvider.unobfuscate() + '}';
+  }
+
   /**
    * This class allows the SDK to unobfuscate an obfuscated static global provider.
    *

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -297,12 +297,11 @@ class OpenTelemetrySdkTest {
         .isEqualTo(
             "OpenTelemetrySdk{"
                 + "tracerProvider=SdkTracerProvider{"
-                + "sharedState=TracerSharedState{"
                 + "clock=SystemClock{}, "
                 + "idGenerator=RandomIdGenerator{}, "
                 + "resource=Resource{schemaUrl=null, attributes={service.name=\"unknown_service:java\", telemetry.sdk.language=\"java\", telemetry.sdk.name=\"opentelemetry\", telemetry.sdk.version=\"1.10.0-SNAPSHOT\"}}, "
                 + "spanLimitsSupplier=SpanLimitsValue{maxNumberOfAttributes=128, maxNumberOfEvents=128, maxNumberOfLinks=128, maxNumberOfAttributesPerEvent=128, maxNumberOfAttributesPerLink=128, maxAttributeValueLength=2147483647}, "
                 + "sampler=ParentBased{root:AlwaysOnSampler,remoteParentSampled:AlwaysOnSampler,remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,localParentNotSampled:AlwaysOffSampler}, "
-                + "activeSpanProcessor=SimpleSpanProcessor{spanExporter=MultiSpanExporter{spanExporters=[MockSpanExporter{}, MockSpanExporter{}]}}}}}");
+                + "spanProcessor=SimpleSpanProcessor{spanExporter=MultiSpanExporter{spanExporters=[MockSpanExporter{}, MockSpanExporter{}]}}}}");
   }
 }

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
@@ -277,5 +278,31 @@ class OpenTelemetrySdkTest {
                 .build())
         .setPropagators(ContextPropagators.create(mock(TextMapPropagator.class)))
         .build();
+  }
+
+  @Test
+  void stringRepresentation() {
+    SpanExporter exporter = mock(SpanExporter.class);
+    when(exporter.toString()).thenReturn("MockSpanExporter{}");
+    OpenTelemetrySdk sdk =
+        OpenTelemetrySdk.builder()
+            .setTracerProvider(
+                SdkTracerProvider.builder()
+                    .addSpanProcessor(
+                        SimpleSpanProcessor.create(SpanExporter.composite(exporter, exporter)))
+                    .build())
+            .build();
+
+    assertThat(sdk.toString())
+        .isEqualTo(
+            "OpenTelemetrySdk{"
+                + "tracerProvider=SdkTracerProvider{"
+                + "sharedState=TracerSharedState{"
+                + "clock=SystemClock{}, "
+                + "idGenerator=RandomIdGenerator{}, "
+                + "resource=Resource{schemaUrl=null, attributes={service.name=\"unknown_service:java\", telemetry.sdk.language=\"java\", telemetry.sdk.name=\"opentelemetry\", telemetry.sdk.version=\"1.10.0-SNAPSHOT\"}}, "
+                + "spanLimitsSupplier=SpanLimitsValue{maxNumberOfAttributes=128, maxNumberOfEvents=128, maxNumberOfLinks=128, maxNumberOfAttributesPerEvent=128, maxNumberOfAttributesPerLink=128, maxAttributeValueLength=2147483647}, "
+                + "sampler=ParentBased{root:AlwaysOnSampler,remoteParentSampled:AlwaysOnSampler,remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,localParentNotSampled:AlwaysOffSampler}, "
+                + "activeSpanProcessor=SimpleSpanProcessor{spanExporter=MultiSpanExporter{spanExporters=[MockSpanExporter{}, MockSpanExporter{}]}}}}}");
   }
 }

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/SystemClock.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/SystemClock.java
@@ -34,4 +34,9 @@ final class SystemClock implements Clock {
   public long nanoTime() {
     return System.nanoTime();
   }
+
+  @Override
+  public String toString() {
+    return "SystemClock{}";
+  }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/MultiSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/MultiSpanProcessor.java
@@ -92,4 +92,16 @@ final class MultiSpanProcessor implements SpanProcessor {
       }
     }
   }
+
+  @Override
+  public String toString() {
+    return "MultiSpanProcessor{"
+        + "spanProcessorsStart="
+        + spanProcessorsStart
+        + ", spanProcessorsEnd="
+        + spanProcessorsEnd
+        + ", spanProcessorsAll="
+        + spanProcessorsAll
+        + '}';
+  }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/NoopSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/NoopSpanProcessor.java
@@ -31,4 +31,9 @@ final class NoopSpanProcessor implements SpanProcessor {
   }
 
   private NoopSpanProcessor() {}
+
+  @Override
+  public String toString() {
+    return "NoopSpanProcessor{}";
+  }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RandomIdGenerator.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RandomIdGenerator.java
@@ -37,4 +37,9 @@ enum RandomIdGenerator implements IdGenerator {
     } while (idLo == INVALID_ID);
     return TraceId.fromLongs(idHi, idLo);
   }
+
+  @Override
+  public String toString() {
+    return "RandomIdGenerator{}";
+  }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
@@ -133,4 +133,9 @@ public final class SdkTracerProvider implements TracerProvider, Closeable {
   public void close() {
     shutdown().join(10, TimeUnit.SECONDS);
   }
+
+  @Override
+  public String toString() {
+    return "SdkTracerProvider{" + "sharedState=" + sharedState + '}';
+  }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
@@ -136,6 +136,19 @@ public final class SdkTracerProvider implements TracerProvider, Closeable {
 
   @Override
   public String toString() {
-    return "SdkTracerProvider{" + "sharedState=" + sharedState + '}';
+    return "SdkTracerProvider{"
+        + "clock="
+        + sharedState.getClock()
+        + ", idGenerator="
+        + sharedState.getIdGenerator()
+        + ", resource="
+        + sharedState.getResource()
+        + ", spanLimitsSupplier="
+        + sharedState.getSpanLimits()
+        + ", sampler="
+        + sharedState.getSampler()
+        + ", spanProcessor="
+        + sharedState.getActiveSpanProcessor()
+        + '}';
   }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/TracerSharedState.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/TracerSharedState.java
@@ -104,22 +104,4 @@ final class TracerSharedState {
       return shutdownResult;
     }
   }
-
-  @Override
-  public String toString() {
-    return "TracerSharedState{"
-        + "clock="
-        + clock
-        + ", idGenerator="
-        + idGenerator
-        + ", resource="
-        + resource
-        + ", spanLimitsSupplier="
-        + spanLimitsSupplier.get()
-        + ", sampler="
-        + sampler
-        + ", activeSpanProcessor="
-        + activeSpanProcessor
-        + '}';
-  }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/TracerSharedState.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/TracerSharedState.java
@@ -104,4 +104,22 @@ final class TracerSharedState {
       return shutdownResult;
     }
   }
+
+  @Override
+  public String toString() {
+    return "TracerSharedState{"
+        + "clock="
+        + clock
+        + ", idGenerator="
+        + idGenerator
+        + ", resource="
+        + resource
+        + ", spanLimitsSupplier="
+        + spanLimitsSupplier.get()
+        + ", sampler="
+        + sampler
+        + ", activeSpanProcessor="
+        + activeSpanProcessor
+        + '}';
+  }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -121,6 +121,11 @@ public final class BatchSpanProcessor implements SpanProcessor {
     return worker.batch;
   }
 
+  @Override
+  public String toString() {
+    return "BatchSpanProcessor{" + "worker=" + worker + '}';
+  }
+
   // Worker is a thread that batches multiple spans and calls the registered SpanExporter to export
   // the data.
   private static final class Worker implements Runnable {
@@ -316,6 +321,20 @@ public final class BatchSpanProcessor implements SpanProcessor {
       } finally {
         batch.clear();
       }
+    }
+
+    @Override
+    public String toString() {
+      return "Worker{"
+          + "spanExporter="
+          + spanExporter
+          + ", scheduleDelayNanos="
+          + scheduleDelayNanos
+          + ", maxExportBatchSize="
+          + maxExportBatchSize
+          + ", exporterTimeoutNanos="
+          + exporterTimeoutNanos
+          + '}';
     }
   }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -123,7 +123,16 @@ public final class BatchSpanProcessor implements SpanProcessor {
 
   @Override
   public String toString() {
-    return "BatchSpanProcessor{" + "worker=" + worker + '}';
+    return "BatchSpanProcessor{"
+        + "spanExporter="
+        + worker.spanExporter
+        + ", scheduleDelayNanos="
+        + worker.scheduleDelayNanos
+        + ", maxExportBatchSize="
+        + worker.maxExportBatchSize
+        + ", exporterTimeoutNanos="
+        + worker.exporterTimeoutNanos
+        + '}';
   }
 
   // Worker is a thread that batches multiple spans and calls the registered SpanExporter to export
@@ -321,20 +330,6 @@ public final class BatchSpanProcessor implements SpanProcessor {
       } finally {
         batch.clear();
       }
-    }
-
-    @Override
-    public String toString() {
-      return "Worker{"
-          + "spanExporter="
-          + spanExporter
-          + ", scheduleDelayNanos="
-          + scheduleDelayNanos
-          + ", maxExportBatchSize="
-          + maxExportBatchSize
-          + ", exporterTimeoutNanos="
-          + exporterTimeoutNanos
-          + '}';
     }
   }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/MultiSpanExporter.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/MultiSpanExporter.java
@@ -9,6 +9,7 @@ import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
@@ -96,5 +97,10 @@ final class MultiSpanExporter implements SpanExporter {
 
   private MultiSpanExporter(SpanExporter[] spanExporters) {
     this.spanExporters = spanExporters;
+  }
+
+  @Override
+  public String toString() {
+    return "MultiSpanExporter{" + "spanExporters=" + Arrays.toString(spanExporters) + '}';
   }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/NoopSpanExporter.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/NoopSpanExporter.java
@@ -31,4 +31,9 @@ final class NoopSpanExporter implements SpanExporter {
   public CompletableResultCode shutdown() {
     return CompletableResultCode.ofSuccess();
   }
+
+  @Override
+  public String toString() {
+    return "NoopSpanExporter{}";
+  }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
@@ -125,4 +125,9 @@ public final class SimpleSpanProcessor implements SpanProcessor {
   public CompletableResultCode forceFlush() {
     return CompletableResultCode.ofAll(pendingExports);
   }
+
+  @Override
+  public String toString() {
+    return "SimpleSpanProcessor{" + "spanExporter=" + spanExporter + '}';
+  }
 }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/MultiSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/MultiSpanProcessorTest.java
@@ -106,4 +106,18 @@ class MultiSpanProcessorTest {
     verify(spanProcessor1).shutdown();
     verify(spanProcessor2).shutdown();
   }
+
+  @Test
+  void stringRepresentation() {
+    when(spanProcessor1.toString()).thenReturn("spanProcessor1");
+    when(spanProcessor2.toString()).thenReturn("spanProcessor1");
+    SpanProcessor multiSpanProcessor =
+        SpanProcessor.composite(Arrays.asList(spanProcessor1, spanProcessor2));
+    assertThat(multiSpanProcessor)
+        .hasToString(
+            "MultiSpanProcessor{"
+                + "spanProcessorsStart=[spanProcessor1, spanProcessor1], "
+                + "spanProcessorsEnd=[spanProcessor1, spanProcessor1], "
+                + "spanProcessorsAll=[spanProcessor1, spanProcessor1]}");
+  }
 }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/NoopSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/NoopSpanProcessorTest.java
@@ -28,4 +28,9 @@ class NoopSpanProcessorTest {
     noopSpanProcessor.forceFlush();
     noopSpanProcessor.shutdown();
   }
+
+  @Test
+  void stringRepresentation() {
+    assertThat(NoopSpanProcessor.getInstance()).hasToString("NoopSpanProcessor{}");
+  }
 }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -488,6 +488,20 @@ class BatchSpanProcessorTest {
     assertThat(result.isSuccess()).isFalse();
   }
 
+  @Test
+  void stringRepresentation() {
+    BatchSpanProcessor processor = BatchSpanProcessor.builder(mockSpanExporter).build();
+    String processorStr = processor.toString();
+    processor.close();
+    assertThat(processorStr)
+        .hasToString(
+            "BatchSpanProcessor{"
+                + "spanExporter=mockSpanExporter, "
+                + "scheduleDelayNanos=5000000000, "
+                + "maxExportBatchSize=512, "
+                + "exporterTimeoutNanos=30000000000}");
+  }
+
   private static final class BlockingSpanExporter implements SpanExporter {
 
     final Object monitor = new Object();

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/NoopSpanExporterTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/NoopSpanExporterTest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.trace.export;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class NoopSpanExporterTest {
+
+  @Test
+  void stringRepresentation() {
+    assertThat(NoopSpanExporter.getInstance()).hasToString("NoopSpanExporter{}");
+  }
+}


### PR DESCRIPTION
When debugging issues, it can be invaluable to know the resolved SDK configuration, for example a typo like `OTEL_TRACE_SAMPLER=traceidratio(0.1)` could result in all spans being traced despite seeming to have set the sampler. I think it's worth it for us to add toString to SDK components with their configuration, especially because we have autoconfigure, not programming-only configuration.

Note this was triggered by debugging a production issue related to sampling and wanting to know what the actual sampler being used is in a reliable way.

The toString isn't beautiful at all without newlines, I just stuck with what IntelliJ generates. But it doesn't necessarily need to be beautiful, just give the information which is currently not easy to get to (mostly in javaagent, where SDK is hidden into another classloader)