### PR TITLE
Don't lookup IP address again in jaeger exporter assertion.

### DIFF
--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporter.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporter.java
@@ -28,8 +28,9 @@ public final class JaegerGrpcSpanExporter implements SpanExporter {
       AttributeKey.stringKey("jaeger.version");
   private static final String CLIENT_VERSION_VALUE = "opentelemetry-java";
   private static final AttributeKey<String> HOSTNAME_KEY = AttributeKey.stringKey("hostname");
-  private static final AttributeKey<String> IP_KEY = AttributeKey.stringKey("ip");
   private static final String IP_DEFAULT = "0.0.0.0";
+  // Visible for testing
+  static final AttributeKey<String> IP_KEY = AttributeKey.stringKey("ip");
 
   private final GrpcExporter<PostSpansRequestMarshaler> delegate;
 
@@ -107,5 +108,10 @@ public final class JaegerGrpcSpanExporter implements SpanExporter {
   @Override
   public CompletableResultCode shutdown() {
     return delegate.shutdown();
+  }
+
+  // Visible for testing
+  Resource getJaegerResource() {
+    return jaegerResource;
   }
 }

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterTest.java
@@ -265,7 +265,7 @@ class JaegerGrpcSpanExporterTest {
             getTagValue(batch.getProcess().getTagsList(), "ip")
                 .orElseThrow(() -> new AssertionError("ip not found"))
                 .getVStr())
-        .isEqualTo(InetAddress.getLocalHost().getHostAddress());
+        .isEqualTo(exporter.getJaegerResource().getAttribute(JaegerGrpcSpanExporter.IP_KEY));
 
     assertThat(
             getTagValue(batch.getProcess().getTagsList(), "hostname")


### PR DESCRIPTION
While rare, an IP address can change between test and assertion causing a flaky test. It seems enough to make sure the value was marshaled correctly.

Fixes #4066 