### PR TITLE
Remove redundant compression configuration

### DIFF
--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/grpc/DefaultGrpcExporter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/grpc/DefaultGrpcExporter.java
@@ -8,7 +8,6 @@ package io.opentelemetry.exporter.otlp.internal.grpc;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
-import io.grpc.Codec;
 import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import io.opentelemetry.api.metrics.MeterProvider;
@@ -46,14 +45,12 @@ public final class DefaultGrpcExporter<T extends Marshaler> implements GrpcExpor
       ManagedChannel channel,
       MarshalerServiceStub<T, ?, ?> stub,
       MeterProvider meterProvider,
-      long timeoutNanos,
-      boolean compressionEnabled) {
+      long timeoutNanos) {
     this.type = type;
     this.exporterMetrics = ExporterMetrics.createGrpc(type, meterProvider);
     this.managedChannel = channel;
     this.timeoutNanos = timeoutNanos;
-    Codec codec = compressionEnabled ? new Codec.Gzip() : Codec.Identity.NONE;
-    this.stub = stub.withCompression(codec.getMessageEncoding());
+    this.stub = stub;
   }
 
   @Override

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/grpc/DefaultGrpcExporterBuilder.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/grpc/DefaultGrpcExporterBuilder.java
@@ -170,8 +170,7 @@ public final class DefaultGrpcExporterBuilder<T extends Marshaler>
     Codec codec = compressionEnabled ? new Codec.Gzip() : Codec.Identity.NONE;
     MarshalerServiceStub<T, ?, ?> stub =
         stubFactory.apply(channel).withCompression(codec.getMessageEncoding());
-    return new DefaultGrpcExporter<>(
-        type, channel, stub, meterProvider, timeoutNanos, compressionEnabled);
+    return new DefaultGrpcExporter<>(type, channel, stub, meterProvider, timeoutNanos);
   }
 
   /**


### PR DESCRIPTION
`DefaultGrpcExporter` calls `.withCompression(..)` twice. This removes the redundant call.