### PR TITLE
Add missing internal disclaimers

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/internal/Contract.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/Contract.java
@@ -87,6 +87,9 @@ import java.lang.annotation.Target;
  *
  * <p>This annotation is the same provided with Jetbrains annotations and used by Nullaway for
  * verifying nullness. We copy the annotation to avoid an external dependency.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
  */
 @Documented
 @Retention(RetentionPolicy.CLASS)

--- a/api/all/src/main/java/io/opentelemetry/api/internal/GuardedBy.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/GuardedBy.java
@@ -37,6 +37,9 @@ import java.lang.annotation.Target;
  * members, so there is no reason to publish them and we avoid requiring end users to have to depend
  * on the annotations in their own build. See the original <a
  * href="https://github.com/open-telemetry/opentelemetry-java/issues/2897">issue</a> for more info.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
  */
 @Target({ElementType.FIELD, ElementType.METHOD})
 @Retention(RetentionPolicy.SOURCE)

--- a/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
@@ -24,6 +24,9 @@ import javax.annotation.concurrent.Immutable;
  * of being "empty", you'll need to remove them before calling the constructor, assuming you don't
  * want the "empty" keys to be kept in your collection.
  *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ *
  * @param <V> The type of the values contained in this.
  */
 @Immutable

--- a/api/all/src/main/java/io/opentelemetry/api/internal/OtelEncodingUtils.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/OtelEncodingUtils.java
@@ -8,6 +8,10 @@ package io.opentelemetry.api.internal;
 import java.util.Arrays;
 import javax.annotation.concurrent.Immutable;
 
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
 @Immutable
 public final class OtelEncodingUtils {
   static final int LONG_BYTES = Long.SIZE / Byte.SIZE;

--- a/api/all/src/main/java/io/opentelemetry/api/internal/ReadOnlyArrayMap.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/ReadOnlyArrayMap.java
@@ -31,7 +31,12 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import javax.annotation.Nullable;
 
-/** A read-only view of an array of key-value pairs. */
+/**
+ * A read-only view of an array of key-value pairs.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 @SuppressWarnings("unchecked")
 public final class ReadOnlyArrayMap<K, V> extends AbstractMap<K, V> {
 

--- a/api/all/src/main/java/io/opentelemetry/api/internal/Utils.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/Utils.java
@@ -7,7 +7,12 @@ package io.opentelemetry.api.internal;
 
 import javax.annotation.concurrent.Immutable;
 
-/** General internal utility methods. */
+/**
+ * General internal utility methods.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 @Immutable
 public final class Utils {
 

--- a/api/all/src/main/java/io/opentelemetry/api/internal/ValidationUtil.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/ValidationUtil.java
@@ -9,7 +9,12 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.concurrent.Immutable;
 
-/** General internal validation utility methods. */
+/**
+ * General internal validation utility methods.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 @Immutable
 public final class ValidationUtil {
 

--- a/context/src/main/java/io/opentelemetry/context/internal/shaded/AbstractWeakConcurrentMap.java
+++ b/context/src/main/java/io/opentelemetry/context/internal/shaded/AbstractWeakConcurrentMap.java
@@ -43,6 +43,9 @@ import java.util.concurrent.ConcurrentMap;
  *
  * <p>This class has been copied as is from
  * https://github.com/raphw/weak-lock-free/blob/ad0e5e0c04d4a31f9485bf12b89afbc9d75473b3/src/main/java/com/blogspot/mydailyjava/weaklockfree/WeakConcurrentMap.java
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
  */
 // Suppress warnings since this is vendored as-is.
 @SuppressWarnings({"MissingSummary", "EqualsBrokenForNull", "FieldMissingNullable"})

--- a/context/src/main/java/io/opentelemetry/context/internal/shaded/WeakConcurrentMap.java
+++ b/context/src/main/java/io/opentelemetry/context/internal/shaded/WeakConcurrentMap.java
@@ -39,6 +39,9 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * <p>This class has been copied as is from
  * https://github.com/raphw/weak-lock-free/blob/ad0e5e0c04d4a31f9485bf12b89afbc9d75473b3/src/main/java/com/blogspot/mydailyjava/weaklockfree/WeakConcurrentMap.java
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
  */
 // Suppress warnings since this is copied as-is.
 @SuppressWarnings({

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Serializer.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/Serializer.java
@@ -17,6 +17,9 @@ import javax.annotation.Nullable;
  *   <li>Handles proto3 semantics of not outputting the value when it matches the default of a field
  *   <li>Can be implemented to serialize into protobuf JSON format (not binary)
  * </ul>
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
  */
 public abstract class Serializer implements AutoCloseable {
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/grpc/GrpcExporterBuilder.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/grpc/GrpcExporterBuilder.java
@@ -12,7 +12,12 @@ import io.opentelemetry.exporter.otlp.internal.retry.RetryPolicy;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
-/** A builder for {@link GrpcExporter}. */
+/**
+ * A builder for {@link GrpcExporter}.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 public interface GrpcExporterBuilder<T extends Marshaler> {
   GrpcExporterBuilder<T> setChannel(ManagedChannel channel);
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/metrics/ExponentialHistogramBucketsMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/metrics/ExponentialHistogramBucketsMarshaler.java
@@ -14,6 +14,10 @@ import io.opentelemetry.sdk.metrics.data.ExponentialHistogramBuckets;
 import java.io.IOException;
 import java.util.List;
 
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
 public class ExponentialHistogramBucketsMarshaler extends MarshalerWithSize {
   private final int offset;
   private final List<Long> counts;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/metrics/ExponentialHistogramDataPointMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/metrics/ExponentialHistogramDataPointMarshaler.java
@@ -14,6 +14,10 @@ import io.opentelemetry.sdk.metrics.data.ExponentialHistogramPointData;
 import java.io.IOException;
 import java.util.Collection;
 
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
 public class ExponentialHistogramDataPointMarshaler extends MarshalerWithSize {
 
   private final long startTimeUnixNano;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/metrics/ExponentialHistogramMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/metrics/ExponentialHistogramMarshaler.java
@@ -13,6 +13,10 @@ import io.opentelemetry.proto.metrics.v1.internal.ExponentialHistogram;
 import io.opentelemetry.sdk.metrics.data.ExponentialHistogramData;
 import java.io.IOException;
 
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
 public class ExponentialHistogramMarshaler extends MarshalerWithSize {
   private final ExponentialHistogramDataPointMarshaler[] dataPoints;
   private final ProtoEnumInfo aggregationTemporality;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/okhttp/OkHttpExporter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/okhttp/OkHttpExporter.java
@@ -29,7 +29,12 @@ import okio.BufferedSink;
 import okio.GzipSink;
 import okio.Okio;
 
-/** An exporter for http/protobuf using a signal-specific Marshaler. */
+/**
+ * An exporter for http/protobuf using a signal-specific Marshaler.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 @SuppressWarnings("checkstyle:JavadocMethod")
 public final class OkHttpExporter<T extends Marshaler> {
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/okhttp/OkHttpExporterBuilder.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/okhttp/OkHttpExporterBuilder.java
@@ -21,7 +21,12 @@ import javax.net.ssl.X509TrustManager;
 import okhttp3.Headers;
 import okhttp3.OkHttpClient;
 
-/** A builder for {@link OkHttpExporter}. */
+/**
+ * A builder for {@link OkHttpExporter}.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 @SuppressWarnings("checkstyle:JavadocMethod")
 public final class OkHttpExporterBuilder<T extends Marshaler> {
   public static final long DEFAULT_TIMEOUT_SECS = 10;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/okhttp/OkHttpUtil.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/okhttp/OkHttpUtil.java
@@ -11,7 +11,12 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import okhttp3.Dispatcher;
 
-/** Utilities for OkHttp. */
+/**
+ * Utilities for OkHttp.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 public final class OkHttpUtil {
 
   /** Returns a {@link Dispatcher} using daemon threads, otherwise matching the OkHttp default. */

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/retry/RetryInterceptor.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/retry/RetryInterceptor.java
@@ -12,7 +12,12 @@ import java.util.function.Function;
 import okhttp3.Interceptor;
 import okhttp3.Response;
 
-/** Retrier of OkHttp requests. */
+/**
+ * Retrier of OkHttp requests.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 public final class RetryInterceptor implements Interceptor {
 
   private final RetryPolicy retryPolicy;

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/ComponentRegistry.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/ComponentRegistry.java
@@ -17,6 +17,9 @@ import javax.annotation.Nullable;
 /**
  * Base class for all the provider classes (TracerProvider, MeterProvider, etc.).
  *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can hange at
+ * any time.
+ *
  * @param <V> the type of the registered value.
  */
 public final class ComponentRegistry<V> {
@@ -36,7 +39,7 @@ public final class ComponentRegistry<V> {
    * @param instrumentationName the name of the instrumentation library.
    * @return the registered value associated with this name and {@code null} version.
    */
-  public final V get(String instrumentationName) {
+  public V get(String instrumentationName) {
     return get(instrumentationName, null);
   }
 
@@ -49,7 +52,7 @@ public final class ComponentRegistry<V> {
    * @param instrumentationVersion the version of the instrumentation library.
    * @return the registered value associated with this name and version.
    */
-  public final V get(String instrumentationName, @Nullable String instrumentationVersion) {
+  public V get(String instrumentationName, @Nullable String instrumentationVersion) {
     return get(instrumentationName, instrumentationVersion, null);
   }
 
@@ -63,7 +66,7 @@ public final class ComponentRegistry<V> {
    * @return the registered value associated with this name and version.
    * @since 1.4.0
    */
-  public final V get(
+  public V get(
       String instrumentationName,
       @Nullable String instrumentationVersion,
       @Nullable String schemaUrl) {
@@ -86,7 +89,7 @@ public final class ComponentRegistry<V> {
    *
    * @return a {@code Collection} view of the registered components.
    */
-  public final Collection<V> getComponents() {
+  public Collection<V> getComponents() {
     return Collections.unmodifiableCollection(new ArrayList<>(registry.values()));
   }
 }

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/DaemonThreadFactory.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/DaemonThreadFactory.java
@@ -12,6 +12,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * A {@link ThreadFactory} that delegates to {@code Executors.defaultThreadFactory()} and marks all
  * threads as daemon.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
  */
 public final class DaemonThreadFactory implements ThreadFactory {
   private final String namePrefix;

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/JavaVersionSpecific.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/JavaVersionSpecific.java
@@ -32,6 +32,9 @@ import java.util.logging.Logger;
  * implementations in this class must be forwards-compatible on all Java versions because this class
  * may be used outside the multi-release JAR, e.g., in testing or when a user shades without
  * creating their own multi-release JAR.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
  */
 public class JavaVersionSpecific {
 

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/ThrottlingLogger.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/ThrottlingLogger.java
@@ -14,7 +14,12 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
-/** Will limit the number of log messages emitted, so as not to spam when problems are happening. */
+/**
+ * Will limit the number of log messages emitted, so as not to spam when problems are happening.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 public class ThrottlingLogger {
   private static final double RATE_LIMIT = 5;
   private static final double THROTTLED_RATE_LIMIT = 1;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/AttributesProcessor.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/AttributesProcessor.java
@@ -24,6 +24,9 @@ import javax.annotation.concurrent.Immutable;
  *
  * <p>An AttributesProcessor is used to define the actual set of attributes that will be used in a
  * Metric vs. the inbound set of attributes from a measurement.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
  */
 @Immutable
 public abstract class AttributesProcessor {

--- a/sdk/trace-shaded-deps/src/main/java/io/opentelemetry/sdk/trace/internal/JcTools.java
+++ b/sdk/trace-shaded-deps/src/main/java/io/opentelemetry/sdk/trace/internal/JcTools.java
@@ -10,7 +10,12 @@ import java.util.concurrent.ArrayBlockingQueue;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.MpscArrayQueue;
 
-/** Internal accessor of JCTools package for fast queues. */
+/**
+ * Internal accessor of JCTools package for fast queues.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 public final class JcTools {
 
   /**


### PR DESCRIPTION
Noticed that several public classes in internal packages were missing the `This class is internal and is hence not for public use. Its APIs are unstable and can change at any time.` disclaimer. 

Did a survey of all internal packages and added it to all public classes and interfaces. 