### PR TITLE
Remove legacy approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,10 +211,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 Approvers ([@open-telemetry/java-approvers](https://github.com/orgs/open-telemetry/teams/java-approvers)):
 
-- [Armin Ruech](https://github.com/arminru), Dynatrace
-- [Pavol Loffay](https://github.com/pavolloffay), Traceable.ai
-- [Tyler Benson](https://github.com/tylerbenson), DataDog
-- [Giovanni Liva](https://github.com/thisthat), Dynatrace
 - [Christian Neumüller](https://github.com/Oberon00), Dynatrace
 - [Carlos Alberto](https://github.com/carlosalberto), LightStep
 - [Jakub Wach](https://github.com/kubawach), Splunk


### PR DESCRIPTION
We discussed removing some folks from the approver list a while ago, but apparently, I never followed through and did it. Not sure where that PR went, but here it is again.

Anyway, thanks @pavolloffay @thisthat @arminru and @tylerbenson for your service. Please let us know if you are interested in getting back into the approval game.