### PR TITLE
Rename RecordEventsReadableSpan to SdkSpan

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
@@ -35,9 +35,9 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /** Implementation for the {@link Span} class that records trace events. */
 @ThreadSafe
-final class RecordEventsReadableSpan implements ReadWriteSpan {
+final class SdkSpan implements ReadWriteSpan {
 
-  private static final Logger logger = Logger.getLogger(RecordEventsReadableSpan.class.getName());
+  private static final Logger logger = Logger.getLogger(SdkSpan.class.getName());
 
   // The config used when constructing this Span.
   private final SpanLimits spanLimits;
@@ -87,7 +87,7 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
   @GuardedBy("lock")
   private boolean hasEnded;
 
-  private RecordEventsReadableSpan(
+  private SdkSpan(
       SpanContext context,
       String name,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
@@ -133,7 +133,7 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
    * @param links the links set during span creation, may be truncated. The list MUST be immutable.
    * @return a new and started span.
    */
-  static RecordEventsReadableSpan startSpan(
+  static SdkSpan startSpan(
       SpanContext context,
       String name,
       InstrumentationLibraryInfo instrumentationLibraryInfo,
@@ -150,8 +150,8 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
       long userStartEpochNanos) {
     boolean createdAnchoredClock;
     AnchoredClock clock;
-    if (parentSpan instanceof RecordEventsReadableSpan) {
-      RecordEventsReadableSpan parentRecordEventsSpan = (RecordEventsReadableSpan) parentSpan;
+    if (parentSpan instanceof SdkSpan) {
+      SdkSpan parentRecordEventsSpan = (SdkSpan) parentSpan;
       clock = parentRecordEventsSpan.clock;
       createdAnchoredClock = false;
     } else {
@@ -171,8 +171,8 @@ final class RecordEventsReadableSpan implements ReadWriteSpan {
       startEpochNanos = clock.now();
     }
 
-    RecordEventsReadableSpan span =
-        new RecordEventsReadableSpan(
+    SdkSpan span =
+        new SdkSpan(
             context,
             name,
             instrumentationLibraryInfo,

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
@@ -527,7 +527,7 @@ final class SdkSpan implements ReadWriteSpan {
       totalRecordedEvents = this.totalRecordedEvents;
       endEpochNanos = this.endEpochNanos;
     }
-    return "RecordEventsReadableSpan{traceId="
+    return "SdkSpan{traceId="
         + context.getTraceId()
         + ", spanId="
         + context.getSpanId()

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java
@@ -214,7 +214,7 @@ final class SdkSpanBuilder implements SpanBuilder {
     AttributesMap recordedAttributes = attributes;
     attributes = null;
 
-    return RecordEventsReadableSpan.startSpan(
+    return SdkSpan.startSpan(
         spanContext,
         spanName,
         instrumentationLibraryInfo,

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SpanWrapper.java
@@ -19,19 +19,18 @@ import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * Immutable class that stores {@link SpanData} based on a {@link RecordEventsReadableSpan}.
+ * Immutable class that stores {@link SpanData} based on a {@link SdkSpan}.
  *
- * <p>This class stores a reference to a mutable {@link RecordEventsReadableSpan} ({@code delegate})
- * which it uses only the immutable parts from, and a copy of all the mutable parts.
+ * <p>This class stores a reference to a mutable {@link SdkSpan} ({@code delegate}) which it uses
+ * only the immutable parts from, and a copy of all the mutable parts.
  *
- * <p>When adding a new field to {@link RecordEventsReadableSpan}, store a copy if and only if the
- * field is mutable in the {@link RecordEventsReadableSpan}. Otherwise retrieve it from the
- * referenced {@link RecordEventsReadableSpan}.
+ * <p>When adding a new field to {@link SdkSpan}, store a copy if and only if the field is mutable
+ * in the {@link SdkSpan}. Otherwise retrieve it from the referenced {@link SdkSpan}.
  */
 @Immutable
 @AutoValue
 abstract class SpanWrapper implements SpanData {
-  abstract RecordEventsReadableSpan delegate();
+  abstract SdkSpan delegate();
 
   abstract List<LinkData> resolvedLinks();
 
@@ -56,7 +55,7 @@ abstract class SpanWrapper implements SpanData {
    * preserve the overall immutability of the class.
    */
   static SpanWrapper create(
-      RecordEventsReadableSpan delegate,
+      SdkSpan delegate,
       List<LinkData> links,
       List<EventData> events,
       Attributes attributes,

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
@@ -85,7 +85,7 @@ class SdkSpanBuilderTest {
     spanBuilder.addLink(sampledSpanContext);
     spanBuilder.addLink(sampledSpanContext, Attributes.empty());
 
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
     try {
       assertThat(span.toSpanData().getLinks()).hasSize(2);
     } finally {
@@ -100,7 +100,7 @@ class SdkSpanBuilderTest {
     spanBuilder.addLink(Span.getInvalid().getSpanContext());
     spanBuilder.addLink(Span.getInvalid().getSpanContext(), Attributes.empty());
 
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
     try {
       assertThat(span.toSpanData().getLinks()).isEmpty();
     } finally {
@@ -118,7 +118,7 @@ class SdkSpanBuilderTest {
     for (int i = 0; i < 2 * maxNumberOfLinks; i++) {
       spanBuilder.addLink(sampledSpanContext);
     }
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
     try {
       SpanData spanData = span.toSpanData();
       List<LinkData> links = spanData.getLinks();
@@ -144,7 +144,7 @@ class SdkSpanBuilderTest {
             stringKey("key1"), "str",
             stringKey("key2"), "str");
     spanBuilder.addLink(sampledSpanContext, attributes);
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
     try {
       assertThat(span.toSpanData().getLinks())
           .containsExactly(
@@ -178,7 +178,7 @@ class SdkSpanBuilderTest {
             .build();
     spanBuilder.addLink(sampledSpanContext, attributes);
 
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
     try {
       attributes = span.toSpanData().getLinks().get(0).getAttributes();
 
@@ -201,7 +201,7 @@ class SdkSpanBuilderTest {
   void addLink_NoEffectAfterStartSpan() {
     SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME);
     spanBuilder.addLink(sampledSpanContext);
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
     try {
       assertThat(span.toSpanData().getLinks())
           .containsExactly(LinkData.create(sampledSpanContext, Attributes.empty()));
@@ -248,7 +248,7 @@ class SdkSpanBuilderTest {
             .setAttribute("boolean", true)
             .setAttribute(stringKey("stringAttribute"), "attrvalue");
 
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
     try {
       SpanData spanData = span.toSpanData();
       Attributes attrs = spanData.getAttributes();
@@ -273,7 +273,7 @@ class SdkSpanBuilderTest {
     spanBuilder.setAttribute("boolean", true);
     spanBuilder.setAttribute(stringKey("stringAttribute"), "attrvalue");
 
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
     try {
       Attributes attrs = span.toSpanData().getAttributes();
       assertThat(attrs.size()).isEqualTo(5);
@@ -308,7 +308,7 @@ class SdkSpanBuilderTest {
     spanBuilder.setAttribute(booleanArrayKey("boolArrayAttribute"), emptyList());
     spanBuilder.setAttribute(longArrayKey("longArrayAttribute"), emptyList());
     spanBuilder.setAttribute(doubleArrayKey("doubleArrayAttribute"), emptyList());
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(4);
   }
 
@@ -319,7 +319,7 @@ class SdkSpanBuilderTest {
     spanBuilder.setAttribute("nullString", null);
     spanBuilder.setAttribute(stringKey("nullStringAttributeValue"), null);
     spanBuilder.setAttribute(stringKey("emptyStringAttributeValue"), "");
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(2);
   }
 
@@ -327,7 +327,7 @@ class SdkSpanBuilderTest {
   void setAttribute_onlyNullStringValue() {
     SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME);
     spanBuilder.setAttribute(stringKey("nullStringAttributeValue"), null);
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
     assertThat(span.toSpanData().getAttributes().isEmpty()).isTrue();
   }
 
@@ -336,7 +336,7 @@ class SdkSpanBuilderTest {
     SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME);
     spanBuilder.setAttribute("key1", "value1");
     spanBuilder.setAttribute("key2", "value2");
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
 
     Attributes beforeAttributes = span.toSpanData().getAttributes();
     assertThat(beforeAttributes.size()).isEqualTo(2);
@@ -365,7 +365,7 @@ class SdkSpanBuilderTest {
     spanBuilder.setAttribute(booleanArrayKey("boolArrayAttribute"), Arrays.asList(true, null));
     spanBuilder.setAttribute(longArrayKey("longArrayAttribute"), Arrays.asList(12345L, null));
     spanBuilder.setAttribute(doubleArrayKey("doubleArrayAttribute"), Arrays.asList(1.2345, null));
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(9);
   }
 
@@ -381,7 +381,7 @@ class SdkSpanBuilderTest {
     spanBuilder.setAttribute(booleanArrayKey("boolArrayAttribute"), Arrays.asList(true, null));
     spanBuilder.setAttribute(longArrayKey("longArrayAttribute"), Arrays.asList(12345L, null));
     spanBuilder.setAttribute(doubleArrayKey("doubleArrayAttribute"), Arrays.asList(1.2345, null));
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(9);
     span.end();
     span.setAttribute("emptyString", null);
@@ -406,7 +406,7 @@ class SdkSpanBuilderTest {
     for (int i = 0; i < 2 * maxNumberOfAttrs; i++) {
       spanBuilder.setAttribute("key" + i, i);
     }
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
     try {
       Attributes attrs = span.toSpanData().getAttributes();
       assertThat(attrs.size()).isEqualTo(maxNumberOfAttrs);
@@ -444,7 +444,7 @@ class SdkSpanBuilderTest {
     TracerProvider tracerProvider = SdkTracerProvider.builder().setSampler(sampler).build();
     // Verify methods do not crash.
     SpanBuilder spanBuilder = tracerProvider.get("test").spanBuilder(SPAN_NAME);
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
     span.end();
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(1);
     assertThat(span.toSpanData().getAttributes().get(stringKey("cat"))).isEqualTo("meow");
@@ -463,7 +463,7 @@ class SdkSpanBuilderTest {
 
     SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME).setAllAttributes(attributes);
 
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
     try {
       SpanData spanData = span.toSpanData();
       Attributes attrs = spanData.getAttributes();
@@ -498,7 +498,7 @@ class SdkSpanBuilderTest {
             .setAttribute("existingString", "existingValue")
             .setAllAttributes(attributes);
 
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
     try {
       SpanData spanData = span.toSpanData();
       Attributes attrs = spanData.getAttributes();
@@ -519,7 +519,7 @@ class SdkSpanBuilderTest {
   void setAllAttributes_nullAttributes() {
     SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME).setAllAttributes(null);
 
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
     try {
       SpanData spanData = span.toSpanData();
       Attributes attrs = spanData.getAttributes();
@@ -534,7 +534,7 @@ class SdkSpanBuilderTest {
   void setAllAttributes_emptyAttributes() {
     SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME).setAllAttributes(Attributes.empty());
 
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
     try {
       SpanData spanData = span.toSpanData();
       Attributes attrs = spanData.getAttributes();
@@ -557,8 +557,7 @@ class SdkSpanBuilderTest {
 
   @Test
   void kind_default() {
-    RecordEventsReadableSpan span =
-        (RecordEventsReadableSpan) sdkTracer.spanBuilder(SPAN_NAME).startSpan();
+    SdkSpan span = (SdkSpan) sdkTracer.spanBuilder(SPAN_NAME).startSpan();
     try {
       assertThat(span.toSpanData().getKind()).isEqualTo(SpanKind.INTERNAL);
     } finally {
@@ -568,9 +567,8 @@ class SdkSpanBuilderTest {
 
   @Test
   void kind() {
-    RecordEventsReadableSpan span =
-        (RecordEventsReadableSpan)
-            sdkTracer.spanBuilder(SPAN_NAME).setSpanKind(SpanKind.CONSUMER).startSpan();
+    SdkSpan span =
+        (SdkSpan) sdkTracer.spanBuilder(SPAN_NAME).setSpanKind(SpanKind.CONSUMER).startSpan();
     try {
       assertThat(span.toSpanData().getKind()).isEqualTo(SpanKind.CONSUMER);
     } finally {
@@ -598,8 +596,8 @@ class SdkSpanBuilderTest {
   void sampler_decisionAttributes() {
     String samplerAttributeName = "sampler-attribute";
     AttributeKey<String> samplerAttributeKey = stringKey(samplerAttributeName);
-    RecordEventsReadableSpan span =
-        (RecordEventsReadableSpan)
+    SdkSpan span =
+        (SdkSpan)
             SdkTracerProvider.builder()
                 .setSampler(
                     new Sampler() {
@@ -649,8 +647,8 @@ class SdkSpanBuilderTest {
   void sampler_updatedTraceState() {
     String samplerAttributeName = "sampler-attribute";
     AttributeKey<String> samplerAttributeKey = stringKey(samplerAttributeName);
-    RecordEventsReadableSpan span =
-        (RecordEventsReadableSpan)
+    SdkSpan span =
+        (SdkSpan)
             SdkTracerProvider.builder()
                 .setSampler(
                     new Sampler() {
@@ -757,8 +755,8 @@ class SdkSpanBuilderTest {
     Span parent = sdkTracer.spanBuilder(SPAN_NAME).startSpan();
     try {
       Context parentContext = Context.current().with(parent);
-      RecordEventsReadableSpan span =
-          (RecordEventsReadableSpan)
+      SdkSpan span =
+          (SdkSpan)
               sdkTracer.spanBuilder(SPAN_NAME).setNoParent().setParent(parentContext).startSpan();
       try {
         Mockito.verify(mockedSpanProcessor)
@@ -769,8 +767,8 @@ class SdkSpanBuilderTest {
             .isEqualTo(parent.getSpanContext().getSpanId());
 
         Context parentContext2 = Context.current().with(parent);
-        RecordEventsReadableSpan span2 =
-            (RecordEventsReadableSpan)
+        SdkSpan span2 =
+            (SdkSpan)
                 sdkTracer
                     .spanBuilder(SPAN_NAME)
                     .setNoParent()
@@ -798,8 +796,8 @@ class SdkSpanBuilderTest {
     try {
 
       Context parentContext = Context.current().with(parent);
-      RecordEventsReadableSpan span =
-          (RecordEventsReadableSpan)
+      SdkSpan span =
+          (SdkSpan)
               sdkTracer.spanBuilder(SPAN_NAME).setNoParent().setParent(parentContext).startSpan();
       try {
         Mockito.verify(mockedSpanProcessor)
@@ -821,9 +819,8 @@ class SdkSpanBuilderTest {
     Span parent = sdkTracer.spanBuilder(SPAN_NAME).startSpan();
     Context context = Context.current().with(parent);
     try {
-      RecordEventsReadableSpan span =
-          (RecordEventsReadableSpan)
-              sdkTracer.spanBuilder(SPAN_NAME).setNoParent().setParent(context).startSpan();
+      SdkSpan span =
+          (SdkSpan) sdkTracer.spanBuilder(SPAN_NAME).setNoParent().setParent(context).startSpan();
       try {
         Mockito.verify(mockedSpanProcessor)
             .onStart(Mockito.same(context), Mockito.same((ReadWriteSpan) span));
@@ -844,11 +841,9 @@ class SdkSpanBuilderTest {
     Context emptyContext = Context.current();
     Span parent = sdkTracer.spanBuilder(SPAN_NAME).startSpan();
     try {
-      RecordEventsReadableSpan span;
+      SdkSpan span;
       try (Scope scope = parent.makeCurrent()) {
-        span =
-            (RecordEventsReadableSpan)
-                sdkTracer.spanBuilder(SPAN_NAME).setParent(emptyContext).startSpan();
+        span = (SdkSpan) sdkTracer.spanBuilder(SPAN_NAME).setParent(emptyContext).startSpan();
       }
 
       try {
@@ -871,8 +866,7 @@ class SdkSpanBuilderTest {
     Span parent = sdkTracer.spanBuilder(SPAN_NAME).startSpan();
     try (Scope ignored = parent.makeCurrent()) {
       Context implicitParent = Context.current();
-      RecordEventsReadableSpan span =
-          (RecordEventsReadableSpan) sdkTracer.spanBuilder(SPAN_NAME).startSpan();
+      SdkSpan span = (SdkSpan) sdkTracer.spanBuilder(SPAN_NAME).startSpan();
       try {
         Mockito.verify(mockedSpanProcessor)
             .onStart(Mockito.same(implicitParent), Mockito.same((ReadWriteSpan) span));
@@ -893,9 +887,7 @@ class SdkSpanBuilderTest {
     Span parent = Span.getInvalid();
 
     Context parentContext = Context.current().with(parent);
-    RecordEventsReadableSpan span =
-        (RecordEventsReadableSpan)
-            sdkTracer.spanBuilder(SPAN_NAME).setParent(parentContext).startSpan();
+    SdkSpan span = (SdkSpan) sdkTracer.spanBuilder(SPAN_NAME).setParent(parentContext).startSpan();
     try {
       Mockito.verify(mockedSpanProcessor)
           .onStart(
@@ -910,8 +902,8 @@ class SdkSpanBuilderTest {
 
   @Test
   void startTimestamp_numeric() {
-    RecordEventsReadableSpan span =
-        (RecordEventsReadableSpan)
+    SdkSpan span =
+        (SdkSpan)
             sdkTracer
                 .spanBuilder(SPAN_NAME)
                 .setStartTimestamp(10, TimeUnit.NANOSECONDS)
@@ -922,8 +914,8 @@ class SdkSpanBuilderTest {
 
   @Test
   void startTimestamp_instant() {
-    RecordEventsReadableSpan span =
-        (RecordEventsReadableSpan)
+    SdkSpan span =
+        (SdkSpan)
             sdkTracer
                 .spanBuilder(SPAN_NAME)
                 .setStartTimestamp(Instant.ofEpochMilli(100))
@@ -937,10 +929,9 @@ class SdkSpanBuilderTest {
   void parent_clockIsSame() {
     Span parent = sdkTracer.spanBuilder(SPAN_NAME).startSpan();
     try (Scope scope = parent.makeCurrent()) {
-      RecordEventsReadableSpan span =
-          (RecordEventsReadableSpan) sdkTracer.spanBuilder(SPAN_NAME).startSpan();
+      SdkSpan span = (SdkSpan) sdkTracer.spanBuilder(SPAN_NAME).startSpan();
 
-      assertThat(span.getClock()).isSameAs(((RecordEventsReadableSpan) parent).getClock());
+      assertThat(span.getClock()).isSameAs(((SdkSpan) parent).getClock());
     } finally {
       parent.end();
     }
@@ -950,10 +941,9 @@ class SdkSpanBuilderTest {
   void parentCurrentSpan_clockIsSame() {
     Span parent = sdkTracer.spanBuilder(SPAN_NAME).startSpan();
     try (Scope ignored = parent.makeCurrent()) {
-      RecordEventsReadableSpan span =
-          (RecordEventsReadableSpan) sdkTracer.spanBuilder(SPAN_NAME).startSpan();
+      SdkSpan span = (SdkSpan) sdkTracer.spanBuilder(SPAN_NAME).startSpan();
 
-      assertThat(span.getClock()).isSameAs(((RecordEventsReadableSpan) parent).getClock());
+      assertThat(span.getClock()).isSameAs(((SdkSpan) parent).getClock());
     } finally {
       parent.end();
     }
@@ -980,7 +970,7 @@ class SdkSpanBuilderTest {
   @Test
   void spanDataToString() {
     SpanBuilder spanBuilder = sdkTracer.spanBuilder(SPAN_NAME);
-    RecordEventsReadableSpan span = (RecordEventsReadableSpan) spanBuilder.startSpan();
+    SdkSpan span = (SdkSpan) spanBuilder.startSpan();
     span.setAttribute("http.status_code", 500);
     span.setAttribute("http.url", "https://opentelemetry.io");
     span.setStatus(StatusCode.ERROR, "error");

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanTest.java
@@ -922,7 +922,7 @@ class SdkSpanTest {
     assertThat(events).hasSize(1);
     EventData event = events.get(0);
     assertThat(event.getAttributes().get(SemanticAttributes.EXCEPTION_TYPE))
-        .isEqualTo("io.opentelemetry.sdk.trace.RecordEventsReadableSpanTest.InnerClassException");
+        .isEqualTo("io.opentelemetry.sdk.trace.SdkSpanTest.InnerClassException");
   }
 
   @Test

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanTest.java
@@ -61,7 +61,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 @ExtendWith(MockitoExtension.class)
-class RecordEventsReadableSpanTest {
+class SdkSpanTest {
   private static final String SPAN_NAME = "MySpanName";
   private static final String SPAN_NEW_NAME = "NewName";
   private static final long NANOS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);
@@ -99,7 +99,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void nothingChangedAfterEnd() {
-    RecordEventsReadableSpan span = createTestSpan(SpanKind.INTERNAL);
+    SdkSpan span = createTestSpan(SpanKind.INTERNAL);
     span.end();
     // Check that adding trace events or update fields after Span#end() does not throw any thrown
     // and are ignored.
@@ -119,7 +119,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void endSpanTwice_DoNotCrash() {
-    RecordEventsReadableSpan span = createTestSpan(SpanKind.INTERNAL);
+    SdkSpan span = createTestSpan(SpanKind.INTERNAL);
     assertThat(span.hasEnded()).isFalse();
     span.end();
     assertThat(span.hasEnded()).isTrue();
@@ -129,7 +129,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void toSpanData_ActiveSpan() {
-    RecordEventsReadableSpan span = createTestSpan(SpanKind.INTERNAL);
+    SdkSpan span = createTestSpan(SpanKind.INTERNAL);
     try {
       assertThat(span.hasEnded()).isFalse();
       spanDoWork(span, null, null);
@@ -157,7 +157,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void toSpanData_EndedSpan() {
-    RecordEventsReadableSpan span = createTestSpan(SpanKind.INTERNAL);
+    SdkSpan span = createTestSpan(SpanKind.INTERNAL);
     try {
       spanDoWork(span, StatusCode.ERROR, "CANCELLED");
     } finally {
@@ -181,7 +181,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void toSpanData_immutableLinks() {
-    RecordEventsReadableSpan span = createTestSpan(SpanKind.INTERNAL);
+    SdkSpan span = createTestSpan(SpanKind.INTERNAL);
     SpanData spanData = span.toSpanData();
 
     assertThatThrownBy(() -> spanData.getLinks().add(LinkData.create(SpanContext.getInvalid())))
@@ -190,7 +190,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void toSpanData_immutableEvents() {
-    RecordEventsReadableSpan span = createTestSpan(SpanKind.INTERNAL);
+    SdkSpan span = createTestSpan(SpanKind.INTERNAL);
     SpanData spanData = span.toSpanData();
 
     assertThatThrownBy(
@@ -200,7 +200,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void toSpanData_immutableEvents_ended() {
-    RecordEventsReadableSpan span = createTestSpan(SpanKind.INTERNAL);
+    SdkSpan span = createTestSpan(SpanKind.INTERNAL);
     span.end();
     SpanData spanData = span.toSpanData();
 
@@ -211,7 +211,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void toSpanData_RootSpan() {
-    RecordEventsReadableSpan span = createTestRootSpan();
+    SdkSpan span = createTestRootSpan();
     try {
       spanDoWork(span, null, null);
     } finally {
@@ -224,7 +224,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void toSpanData_ChildSpan() {
-    RecordEventsReadableSpan span = createTestSpan(SpanKind.INTERNAL);
+    SdkSpan span = createTestSpan(SpanKind.INTERNAL);
     try {
       spanDoWork(span, null, null);
     } finally {
@@ -239,7 +239,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void toSpanData_WithInitialAttributes() {
-    RecordEventsReadableSpan span = createTestSpanWithAttributes(attributes);
+    SdkSpan span = createTestSpanWithAttributes(attributes);
     span.setAttribute("anotherKey", "anotherValue");
     span.end();
     SpanData spanData = span.toSpanData();
@@ -250,7 +250,7 @@ class RecordEventsReadableSpanTest {
   @Test
   void toSpanData_SpanDataDoesNotChangeWhenModifyingSpan() {
     // Create a span
-    RecordEventsReadableSpan span = createTestSpanWithAttributes(attributes);
+    SdkSpan span = createTestSpanWithAttributes(attributes);
 
     // Convert it to a SpanData object -- this should be an immutable snapshot.
     SpanData spanData = span.toSpanData();
@@ -283,7 +283,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void toSpanData_Status() {
-    RecordEventsReadableSpan span = createTestSpan(SpanKind.CONSUMER);
+    SdkSpan span = createTestSpan(SpanKind.CONSUMER);
     try {
       testClock.advance(Duration.ofSeconds(1));
       assertThat(span.toSpanData().getStatus()).isEqualTo(StatusData.unset());
@@ -299,7 +299,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void toSpanData_Kind() {
-    RecordEventsReadableSpan span = createTestSpan(SpanKind.SERVER);
+    SdkSpan span = createTestSpan(SpanKind.SERVER);
     try {
       assertThat(span.toSpanData().getKind()).isEqualTo(SpanKind.SERVER);
     } finally {
@@ -309,7 +309,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void getKind() {
-    RecordEventsReadableSpan span = createTestSpan(SpanKind.SERVER);
+    SdkSpan span = createTestSpan(SpanKind.SERVER);
     try {
       assertThat(span.getKind()).isEqualTo(SpanKind.SERVER);
     } finally {
@@ -319,7 +319,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void getAttribute() {
-    RecordEventsReadableSpan span = createTestSpanWithAttributes(attributes);
+    SdkSpan span = createTestSpanWithAttributes(attributes);
     try {
       assertThat(span.getAttribute(longKey("MyLongAttributeKey"))).isEqualTo(123L);
     } finally {
@@ -329,7 +329,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void getInstrumentationLibraryInfo() {
-    RecordEventsReadableSpan span = createTestSpan(SpanKind.CLIENT);
+    SdkSpan span = createTestSpan(SpanKind.CLIENT);
     try {
       assertThat(span.getInstrumentationLibraryInfo()).isEqualTo(instrumentationLibraryInfo);
     } finally {
@@ -339,7 +339,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void getAndUpdateSpanName() {
-    RecordEventsReadableSpan span = createTestRootSpan();
+    SdkSpan span = createTestRootSpan();
     try {
       assertThat(span.getName()).isEqualTo(SPAN_NAME);
       span.updateName(SPAN_NEW_NAME);
@@ -351,7 +351,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void getLatencyNs_ActiveSpan() {
-    RecordEventsReadableSpan span = createTestSpan(SpanKind.INTERNAL);
+    SdkSpan span = createTestSpan(SpanKind.INTERNAL);
     try {
       testClock.advance(Duration.ofSeconds(1));
       long elapsedTimeNanos1 = testClock.now() - START_EPOCH_NANOS;
@@ -366,7 +366,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void getLatencyNs_EndedSpan() {
-    RecordEventsReadableSpan span = createTestSpan(SpanKind.INTERNAL);
+    SdkSpan span = createTestSpan(SpanKind.INTERNAL);
     testClock.advance(Duration.ofSeconds(1));
     span.end();
     long elapsedTimeNanos = testClock.now() - START_EPOCH_NANOS;
@@ -377,7 +377,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void setAttribute() {
-    RecordEventsReadableSpan span = createTestRootSpan();
+    SdkSpan span = createTestRootSpan();
     try {
       span.setAttribute("StringKey", "StringVal");
       span.setAttribute("NullStringKey", null);
@@ -439,7 +439,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void setAttribute_emptyKeys() {
-    RecordEventsReadableSpan span = createTestRootSpan();
+    SdkSpan span = createTestRootSpan();
     span.setAttribute("", "");
     span.setAttribute("", 1000L);
     span.setAttribute("", 10.0);
@@ -453,7 +453,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void setAttribute_nullKeys() {
-    RecordEventsReadableSpan span = createTestRootSpan();
+    SdkSpan span = createTestRootSpan();
     span.setAttribute(stringKey(null), "");
     span.setAttribute(null, 1000L);
     span.setAttribute(null, 10.0);
@@ -467,7 +467,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void setAttribute_emptyArrayAttributeValue() {
-    RecordEventsReadableSpan span = createTestRootSpan();
+    SdkSpan span = createTestRootSpan();
     span.setAttribute(stringArrayKey("stringArrayAttribute"), null);
     assertThat(span.toSpanData().getAttributes().size()).isZero();
     span.setAttribute(stringArrayKey("stringArrayAttribute"), Collections.emptyList());
@@ -488,7 +488,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void setAttribute_nullStringValue() {
-    RecordEventsReadableSpan span = createTestRootSpan();
+    SdkSpan span = createTestRootSpan();
     span.setAttribute("nullString", null);
     span.setAttribute("emptyString", "");
     span.setAttribute(stringKey("nullStringAttributeValue"), null);
@@ -498,7 +498,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void setAttribute_nullAttributeValue() {
-    RecordEventsReadableSpan span = createTestRootSpan();
+    SdkSpan span = createTestRootSpan();
     span.setAttribute("emptyString", "");
     span.setAttribute(stringKey("nullString"), null);
     span.setAttribute(stringKey("nullStringAttributeValue"), null);
@@ -515,7 +515,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void setAllAttributes() {
-    RecordEventsReadableSpan span = createTestRootSpan();
+    SdkSpan span = createTestRootSpan();
     Attributes attributes =
         Attributes.builder()
             .put("StringKey", "StringVal")
@@ -580,7 +580,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void setAllAttributes_mergesAttributes() {
-    RecordEventsReadableSpan span = createTestRootSpan();
+    SdkSpan span = createTestRootSpan();
     Attributes attributes =
         Attributes.builder()
             .put("StringKey", "StringVal")
@@ -613,21 +613,21 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void setAllAttributes_nullAttributes() {
-    RecordEventsReadableSpan span = createTestRootSpan();
+    SdkSpan span = createTestRootSpan();
     span.setAllAttributes(null);
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(0);
   }
 
   @Test
   void setAllAttributes_emptyAttributes() {
-    RecordEventsReadableSpan span = createTestRootSpan();
+    SdkSpan span = createTestRootSpan();
     span.setAllAttributes(Attributes.empty());
     assertThat(span.toSpanData().getAttributes().size()).isEqualTo(0);
   }
 
   @Test
   void addEvent() {
-    RecordEventsReadableSpan span = createTestRootSpan();
+    SdkSpan span = createTestRootSpan();
     try {
       span.addEvent("event1");
       span.addEvent("event2", Attributes.of(stringKey("e1key"), "e1Value"));
@@ -692,7 +692,7 @@ class RecordEventsReadableSpanTest {
   @Test
   void attributeLength() {
     int maxLength = 25;
-    RecordEventsReadableSpan span =
+    SdkSpan span =
         createTestSpan(SpanLimits.builder().setMaxAttributeValueLength(maxLength).build());
     try {
       String strVal = IntStream.range(0, maxLength).mapToObj(i -> "a").collect(joining());
@@ -730,7 +730,7 @@ class RecordEventsReadableSpanTest {
   @Test
   void eventAttributeLength() {
     int maxLength = 25;
-    RecordEventsReadableSpan span =
+    SdkSpan span =
         createTestSpan(SpanLimits.builder().setMaxAttributeValueLength(maxLength).build());
     try {
       String strVal = IntStream.range(0, maxLength).mapToObj(i -> "a").collect(joining());
@@ -770,7 +770,7 @@ class RecordEventsReadableSpanTest {
     int maxNumberOfAttributes = 8;
     SpanLimits spanLimits =
         SpanLimits.builder().setMaxNumberOfAttributes(maxNumberOfAttributes).build();
-    RecordEventsReadableSpan span = createTestSpan(spanLimits);
+    SdkSpan span = createTestSpan(spanLimits);
     try {
       for (int i = 0; i < 2 * maxNumberOfAttributes; i++) {
         span.setAttribute(longKey("MyStringAttributeKey" + i), (long) i);
@@ -788,14 +788,14 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void endWithTimestamp_numeric() {
-    RecordEventsReadableSpan span1 = createTestRootSpan();
+    SdkSpan span1 = createTestRootSpan();
     span1.end(10, TimeUnit.NANOSECONDS);
     assertThat(span1.toSpanData().getEndEpochNanos()).isEqualTo(10);
   }
 
   @Test
   void endWithTimestamp_instant() {
-    RecordEventsReadableSpan span1 = createTestRootSpan();
+    SdkSpan span1 = createTestRootSpan();
     span1.end(Instant.ofEpochMilli(10));
     assertThat(span1.toSpanData().getEndEpochNanos()).isEqualTo(TimeUnit.MILLISECONDS.toNanos(10));
   }
@@ -805,7 +805,7 @@ class RecordEventsReadableSpanTest {
     int maxNumberOfAttributes = 8;
     SpanLimits spanLimits =
         SpanLimits.builder().setMaxNumberOfAttributes(maxNumberOfAttributes).build();
-    RecordEventsReadableSpan span = createTestSpan(spanLimits);
+    SdkSpan span = createTestSpan(spanLimits);
     try {
       for (int i = 0; i < 2 * maxNumberOfAttributes; i++) {
         span.setAttribute(longKey("MyStringAttributeKey" + i), (long) i);
@@ -839,7 +839,7 @@ class RecordEventsReadableSpanTest {
   void droppingEvents() {
     int maxNumberOfEvents = 8;
     SpanLimits spanLimits = SpanLimits.builder().setMaxNumberOfEvents(maxNumberOfEvents).build();
-    RecordEventsReadableSpan span = createTestSpan(spanLimits);
+    SdkSpan span = createTestSpan(spanLimits);
     try {
       for (int i = 0; i < 2 * maxNumberOfEvents; i++) {
         span.addEvent("event2", Attributes.empty());
@@ -871,7 +871,7 @@ class RecordEventsReadableSpanTest {
   @Test
   void recordException() {
     IllegalStateException exception = new IllegalStateException("there was an exception");
-    RecordEventsReadableSpan span = createTestRootSpan();
+    SdkSpan span = createTestRootSpan();
 
     StringWriter writer = new StringWriter();
     exception.printStackTrace(new PrintWriter(writer));
@@ -899,7 +899,7 @@ class RecordEventsReadableSpanTest {
   @Test
   void recordException_noMessage() {
     IllegalStateException exception = new IllegalStateException();
-    RecordEventsReadableSpan span = createTestRootSpan();
+    SdkSpan span = createTestRootSpan();
 
     span.recordException(exception);
 
@@ -914,7 +914,7 @@ class RecordEventsReadableSpanTest {
   @Test
   void recordException_innerClassException() {
     InnerClassException exception = new InnerClassException();
-    RecordEventsReadableSpan span = createTestRootSpan();
+    SdkSpan span = createTestRootSpan();
 
     span.recordException(exception);
 
@@ -928,7 +928,7 @@ class RecordEventsReadableSpanTest {
   @Test
   void recordException_additionalAttributes() {
     IllegalStateException exception = new IllegalStateException("there was an exception");
-    RecordEventsReadableSpan span = createTestRootSpan();
+    SdkSpan span = createTestRootSpan();
 
     StringWriter writer = new StringWriter();
     exception.printStackTrace(new PrintWriter(writer));
@@ -962,7 +962,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void badArgsIgnored() {
-    RecordEventsReadableSpan span = createTestRootSpan();
+    SdkSpan span = createTestRootSpan();
 
     // Should be no exceptions
     span.setAttribute(null, 0L);
@@ -991,8 +991,7 @@ class RecordEventsReadableSpanTest {
     assertThat(data.getName()).isEqualTo(SPAN_NAME);
   }
 
-  private RecordEventsReadableSpan createTestSpanWithAttributes(
-      Map<AttributeKey, Object> attributes) {
+  private SdkSpan createTestSpanWithAttributes(Map<AttributeKey, Object> attributes) {
     SpanLimits spanLimits = SpanLimits.getDefault();
     AttributesMap attributesMap =
         new AttributesMap(
@@ -1006,7 +1005,7 @@ class RecordEventsReadableSpanTest {
         Collections.singletonList(link));
   }
 
-  private RecordEventsReadableSpan createTestRootSpan() {
+  private SdkSpan createTestRootSpan() {
     return createTestSpan(
         SpanKind.INTERNAL,
         SpanLimits.getDefault(),
@@ -1015,25 +1014,25 @@ class RecordEventsReadableSpanTest {
         Collections.singletonList(link));
   }
 
-  private RecordEventsReadableSpan createTestSpan(SpanKind kind) {
+  private SdkSpan createTestSpan(SpanKind kind) {
     return createTestSpan(
         kind, SpanLimits.getDefault(), parentSpanId, null, Collections.singletonList(link));
   }
 
-  private RecordEventsReadableSpan createTestSpan(SpanLimits config) {
+  private SdkSpan createTestSpan(SpanLimits config) {
     return createTestSpan(
         SpanKind.INTERNAL, config, parentSpanId, null, Collections.singletonList(link));
   }
 
-  private RecordEventsReadableSpan createTestSpan(
+  private SdkSpan createTestSpan(
       SpanKind kind,
       SpanLimits config,
       @Nullable String parentSpanId,
       @Nullable AttributesMap attributes,
       List<LinkData> links) {
 
-    RecordEventsReadableSpan span =
-        RecordEventsReadableSpan.startSpan(
+    SdkSpan span =
+        SdkSpan.startSpan(
             spanContext,
             SPAN_NAME,
             instrumentationLibraryInfo,
@@ -1057,9 +1056,7 @@ class RecordEventsReadableSpanTest {
   }
 
   private void spanDoWork(
-      RecordEventsReadableSpan span,
-      @Nullable StatusCode canonicalCode,
-      @Nullable String descriptio) {
+      SdkSpan span, @Nullable StatusCode canonicalCode, @Nullable String descriptio) {
     span.setAttribute("MySingleStringAttributeKey", "MySingleStringAttributeValue");
     attributes.forEach(span::setAttribute);
     testClock.advance(Duration.ofSeconds(1));
@@ -1121,8 +1118,8 @@ class RecordEventsReadableSpanTest {
         SpanContext.create(traceId, spanId, TraceFlags.getDefault(), TraceState.getDefault());
     LinkData link1 = LinkData.create(context, TestUtils.generateRandomAttributes());
 
-    RecordEventsReadableSpan readableSpan =
-        RecordEventsReadableSpan.startSpan(
+    SdkSpan readableSpan =
+        SdkSpan.startSpan(
             context,
             name,
             instrumentationLibraryInfo,
@@ -1177,7 +1174,7 @@ class RecordEventsReadableSpanTest {
 
   @Test
   void testConcurrentModification() throws ExecutionException, InterruptedException {
-    RecordEventsReadableSpan span = createTestSpan(SpanKind.INTERNAL);
+    SdkSpan span = createTestSpan(SpanKind.INTERNAL);
     ExecutorService es = Executors.newSingleThreadExecutor();
     Future<?> modifierFuture =
         es.submit(


### PR DESCRIPTION
Before: Highly obtuse name
After: Consistent with every other (*) SDKFoo implementation of an API Foo.

Also note that the builder for this class is `SdkSpanBuilder`

(*) I didn't actually confirm but highly suspect this is true