### PR TITLE
Enable reflective setting of retry policy for OkHttpGrpcExporter

### DIFF
--- a/exporters/otlp/common/build.gradle.kts
+++ b/exporters/otlp/common/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
   testImplementation("com.linecorp.armeria:armeria-junit5")
   testImplementation("io.opentelemetry.proto:opentelemetry-proto")
   testImplementation("org.skyscreamer:jsonassert")
+  testImplementation("org.assertj:assertj-core")
 
   testImplementation("com.google.api.grpc:proto-google-common-protos")
   testImplementation("io.grpc:grpc-testing")

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/grpc/DefaultGrpcExporterBuilder.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/grpc/DefaultGrpcExporterBuilder.java
@@ -43,7 +43,7 @@ public final class DefaultGrpcExporterBuilder<T extends Marshaler>
   private boolean compressionEnabled = false;
   @Nullable private Metadata metadata;
   @Nullable private byte[] trustedCertificatesPem;
-  @Nullable private RetryPolicy retryPolicy;
+  @Nullable RetryPolicy retryPolicy;
   private MeterProvider meterProvider = MeterProvider.noop();
 
   /** Creates a new {@link DefaultGrpcExporterBuilder}. */

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/grpc/DefaultGrpcExporterBuilder.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/grpc/DefaultGrpcExporterBuilder.java
@@ -17,7 +17,6 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.otlp.internal.ExporterBuilderUtil;
 import io.opentelemetry.exporter.otlp.internal.Marshaler;
 import io.opentelemetry.exporter.otlp.internal.retry.RetryPolicy;
-import java.lang.reflect.Field;
 import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -158,30 +157,5 @@ public final class DefaultGrpcExporterBuilder<T extends Marshaler>
     MarshalerServiceStub<T, ?, ?> stub =
         stubFactory.apply(channel).withCompression(codec.getMessageEncoding());
     return new DefaultGrpcExporter<>(type, channel, stub, meterProvider, timeoutNanos);
-  }
-
-  /**
-   * Reflectively access a {@link DefaultGrpcExporterBuilder} instance in field called "delegate" of
-   * the instance.
-   *
-   * @throws IllegalArgumentException if the instance does not contain a field called "delegate" of
-   *     type {@link DefaultGrpcExporterBuilder}
-   * @deprecated Use {@link
-   *     io.opentelemetry.exporter.otlp.internal.retry.RetryUtil#setRetryPolicyOnDelegate(Object,
-   *     RetryPolicy)}
-   */
-  @Deprecated
-  public static <T> DefaultGrpcExporterBuilder<?> getDelegateBuilder(Class<T> type, T instance) {
-    try {
-      Field field = type.getDeclaredField("delegate");
-      field.setAccessible(true);
-      Object value = field.get(instance);
-      if (!(value instanceof DefaultGrpcExporterBuilder)) {
-        throw new IllegalArgumentException("delegate field is not type DefaultGrpcExporterBuilder");
-      }
-      return (DefaultGrpcExporterBuilder<?>) value;
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      throw new IllegalArgumentException("Unable to access delegate reflectively.", e);
-    }
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/grpc/DefaultGrpcExporterBuilder.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/grpc/DefaultGrpcExporterBuilder.java
@@ -166,7 +166,11 @@ public final class DefaultGrpcExporterBuilder<T extends Marshaler>
    *
    * @throws IllegalArgumentException if the instance does not contain a field called "delegate" of
    *     type {@link DefaultGrpcExporterBuilder}
+   * @deprecated Use {@link
+   *     io.opentelemetry.exporter.otlp.internal.retry.RetryUtil#setRetryPolicyOnDelegate(Object,
+   *     RetryPolicy)}
    */
+  @Deprecated
   public static <T> DefaultGrpcExporterBuilder<?> getDelegateBuilder(Class<T> type, T instance) {
     try {
       Field field = type.getDeclaredField("delegate");

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/retry/RetryUtilTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/otlp/internal/retry/RetryUtilTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal.retry;
+
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.opentelemetry.exporter.otlp.internal.grpc.DefaultGrpcExporterBuilder;
+import io.opentelemetry.exporter.otlp.internal.grpc.OkHttpGrpcExporterBuilder;
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+
+class RetryUtilTest {
+
+  @Test
+  void setRetryPolicyOnDelegate_DefaultGrpcExporterBuilder() throws URISyntaxException {
+    RetryPolicy retryPolicy = RetryPolicy.getDefault();
+    DefaultGrpcExporterBuilder<?> builder =
+        new DefaultGrpcExporterBuilder<>(
+            "test", unused -> null, 0, new URI("http://localhost"), "test");
+
+    RetryUtil.setRetryPolicyOnDelegate(new WithDelegate(builder), retryPolicy);
+
+    assertThat(builder)
+        .extracting("retryPolicy", as(InstanceOfAssertFactories.type(RetryPolicy.class)))
+        .isEqualTo(retryPolicy);
+  }
+
+  @Test
+  void setRetryPolicyOnDelegate_OkHttpGrpcExporterBuilder() throws URISyntaxException {
+    RetryPolicy retryPolicy = RetryPolicy.getDefault();
+    OkHttpGrpcExporterBuilder<?> builder =
+        new OkHttpGrpcExporterBuilder<>("test", "/test", 0, new URI("http://localhost"));
+
+    RetryUtil.setRetryPolicyOnDelegate(new WithDelegate(builder), retryPolicy);
+
+    assertThat(builder)
+        .extracting("retryPolicy", as(InstanceOfAssertFactories.type(RetryPolicy.class)))
+        .isEqualTo(retryPolicy);
+  }
+
+  @Test
+  void setRetryPolicyOnDelegate_InvalidUsage() {
+    assertThatThrownBy(
+            () -> RetryUtil.setRetryPolicyOnDelegate(new Object(), RetryPolicy.getDefault()))
+        .hasMessageContaining("Unable to access delegate reflectively");
+    assertThatThrownBy(
+            () ->
+                RetryUtil.setRetryPolicyOnDelegate(
+                    new WithDelegate(new Object()), RetryPolicy.getDefault()))
+        .hasMessageContaining(
+            "delegate field is not type DefaultGrpcExporterBuilder or OkHttpGrpcExporterBuilder");
+  }
+
+  @SuppressWarnings({"UnusedVariable", "FieldCanBeLocal"})
+  private static class WithDelegate {
+    private final Object delegate;
+
+    private WithDelegate(Object delegate) {
+      this.delegate = delegate;
+    }
+  }
+}

--- a/exporters/otlp/logs/src/test/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogExporterTest.java
+++ b/exporters/otlp/logs/src/test/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogExporterTest.java
@@ -6,12 +6,14 @@
 package io.opentelemetry.exporter.otlp.logs;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.exporter.otlp.internal.Marshaler;
 import io.opentelemetry.exporter.otlp.internal.grpc.OkHttpGrpcExporterBuilder;
 import io.opentelemetry.exporter.otlp.internal.logs.ResourceLogsMarshaler;
 import io.opentelemetry.exporter.otlp.internal.retry.RetryPolicy;
+import io.opentelemetry.exporter.otlp.internal.retry.RetryUtil;
 import io.opentelemetry.exporter.otlp.testing.internal.AbstractGrpcTelemetryExporterTest;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporter;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporterBuilder;
@@ -31,6 +33,15 @@ class OtlpGrpcLogExporterTest extends AbstractGrpcTelemetryExporterTest<LogData,
 
   OtlpGrpcLogExporterTest() {
     super("log", ResourceLogs.getDefaultInstance());
+  }
+
+  @Test
+  void testBuilderDelegate() {
+    assertThatCode(
+            () ->
+                RetryUtil.setRetryPolicyOnDelegate(
+                    OtlpGrpcLogExporter.builder(), RetryPolicy.getDefault()))
+        .doesNotThrowAnyException();
   }
 
   @Test

--- a/exporters/otlp/logs/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcNettyLogExporterTest.java
+++ b/exporters/otlp/logs/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcNettyLogExporterTest.java
@@ -13,6 +13,7 @@ import io.opentelemetry.exporter.otlp.internal.Marshaler;
 import io.opentelemetry.exporter.otlp.internal.grpc.DefaultGrpcExporterBuilder;
 import io.opentelemetry.exporter.otlp.internal.logs.ResourceLogsMarshaler;
 import io.opentelemetry.exporter.otlp.internal.retry.RetryPolicy;
+import io.opentelemetry.exporter.otlp.internal.retry.RetryUtil;
 import io.opentelemetry.exporter.otlp.testing.internal.AbstractGrpcTelemetryExporterTest;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporter;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporterBuilder;
@@ -39,9 +40,8 @@ class OtlpGrpcNettyLogExporterTest
   void testBuilderDelegate() {
     assertThatCode(
             () ->
-                DefaultGrpcExporterBuilder.getDelegateBuilder(
-                        OtlpGrpcLogExporterBuilder.class, OtlpGrpcLogExporter.builder())
-                    .setRetryPolicy(RetryPolicy.getDefault()))
+                RetryUtil.setRetryPolicyOnDelegate(
+                    OtlpGrpcLogExporter.builder(), RetryPolicy.getDefault()))
         .doesNotThrowAnyException();
   }
 

--- a/exporters/otlp/metrics/src/test/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterTest.java
+++ b/exporters/otlp/metrics/src/test/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterTest.java
@@ -7,12 +7,14 @@ package io.opentelemetry.exporter.otlp.metrics;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.exporter.otlp.internal.Marshaler;
 import io.opentelemetry.exporter.otlp.internal.grpc.OkHttpGrpcExporterBuilder;
 import io.opentelemetry.exporter.otlp.internal.metrics.ResourceMetricsMarshaler;
 import io.opentelemetry.exporter.otlp.internal.retry.RetryPolicy;
+import io.opentelemetry.exporter.otlp.internal.retry.RetryUtil;
 import io.opentelemetry.exporter.otlp.testing.internal.AbstractGrpcTelemetryExporterTest;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporter;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporterBuilder;
@@ -34,6 +36,15 @@ class OtlpGrpcMetricExporterTest
 
   OtlpGrpcMetricExporterTest() {
     super("metric", ResourceMetrics.getDefaultInstance());
+  }
+
+  @Test
+  void testBuilderDelegate() {
+    assertThatCode(
+            () ->
+                RetryUtil.setRetryPolicyOnDelegate(
+                    OtlpGrpcMetricExporter.builder(), RetryPolicy.getDefault()))
+        .doesNotThrowAnyException();
   }
 
   @Test

--- a/exporters/otlp/metrics/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcNettyMetricExporterTest.java
+++ b/exporters/otlp/metrics/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcNettyMetricExporterTest.java
@@ -14,6 +14,7 @@ import io.opentelemetry.exporter.otlp.internal.Marshaler;
 import io.opentelemetry.exporter.otlp.internal.grpc.DefaultGrpcExporterBuilder;
 import io.opentelemetry.exporter.otlp.internal.metrics.ResourceMetricsMarshaler;
 import io.opentelemetry.exporter.otlp.internal.retry.RetryPolicy;
+import io.opentelemetry.exporter.otlp.internal.retry.RetryUtil;
 import io.opentelemetry.exporter.otlp.testing.internal.AbstractGrpcTelemetryExporterTest;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporter;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporterBuilder;
@@ -41,9 +42,8 @@ class OtlpGrpcNettyMetricExporterTest
   void testBuilderDelegate() {
     assertThatCode(
             () ->
-                DefaultGrpcExporterBuilder.getDelegateBuilder(
-                        OtlpGrpcMetricExporterBuilder.class, OtlpGrpcMetricExporter.builder())
-                    .setRetryPolicy(RetryPolicy.getDefault()))
+                RetryUtil.setRetryPolicyOnDelegate(
+                    OtlpGrpcMetricExporter.builder(), RetryPolicy.getDefault()))
         .doesNotThrowAnyException();
   }
 

--- a/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.exporter.otlp.trace;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
@@ -14,6 +15,7 @@ import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.exporter.otlp.internal.Marshaler;
 import io.opentelemetry.exporter.otlp.internal.grpc.OkHttpGrpcExporterBuilder;
 import io.opentelemetry.exporter.otlp.internal.retry.RetryPolicy;
+import io.opentelemetry.exporter.otlp.internal.retry.RetryUtil;
 import io.opentelemetry.exporter.otlp.internal.traces.ResourceSpansMarshaler;
 import io.opentelemetry.exporter.otlp.testing.internal.AbstractGrpcTelemetryExporterTest;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporter;
@@ -36,6 +38,15 @@ class OtlpGrpcSpanExporterTest extends AbstractGrpcTelemetryExporterTest<SpanDat
 
   OtlpGrpcSpanExporterTest() {
     super("span", ResourceSpans.getDefaultInstance());
+  }
+
+  @Test
+  void testBuilderDelegate() {
+    assertThatCode(
+            () ->
+                RetryUtil.setRetryPolicyOnDelegate(
+                    OtlpGrpcSpanExporter.builder(), RetryPolicy.getDefault()))
+        .doesNotThrowAnyException();
   }
 
   @Test

--- a/exporters/otlp/trace/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcNettySpanExporterTest.java
+++ b/exporters/otlp/trace/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcNettySpanExporterTest.java
@@ -15,6 +15,7 @@ import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.exporter.otlp.internal.Marshaler;
 import io.opentelemetry.exporter.otlp.internal.grpc.DefaultGrpcExporterBuilder;
 import io.opentelemetry.exporter.otlp.internal.retry.RetryPolicy;
+import io.opentelemetry.exporter.otlp.internal.retry.RetryUtil;
 import io.opentelemetry.exporter.otlp.internal.traces.ResourceSpansMarshaler;
 import io.opentelemetry.exporter.otlp.testing.internal.AbstractGrpcTelemetryExporterTest;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporter;
@@ -44,9 +45,8 @@ class OtlpGrpcNettySpanExporterTest
   void builderDelegate() {
     assertThatCode(
             () ->
-                DefaultGrpcExporterBuilder.getDelegateBuilder(
-                        OtlpGrpcSpanExporterBuilder.class, OtlpGrpcSpanExporter.builder())
-                    .setRetryPolicy(RetryPolicy.getDefault()))
+                RetryUtil.setRetryPolicyOnDelegate(
+                    OtlpGrpcSpanExporter.builder(), RetryPolicy.getDefault()))
         .doesNotThrowAnyException();
   }
 

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/LogExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/LogExporterConfiguration.java
@@ -13,8 +13,8 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.logging.SystemOutLogExporter;
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogExporter;
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogExporterBuilder;
-import io.opentelemetry.exporter.otlp.internal.grpc.DefaultGrpcExporterBuilder;
 import io.opentelemetry.exporter.otlp.internal.okhttp.OkHttpExporterBuilder;
+import io.opentelemetry.exporter.otlp.internal.retry.RetryUtil;
 import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogExporter;
 import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogExporterBuilder;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
@@ -129,10 +129,7 @@ class LogExporterConfiguration {
           builder::setCompression,
           builder::setTimeout,
           builder::setTrustedCertificates,
-          retryPolicy ->
-              DefaultGrpcExporterBuilder.getDelegateBuilder(
-                      OtlpGrpcLogExporterBuilder.class, builder)
-                  .setRetryPolicy(retryPolicy));
+          retryPolicy -> RetryUtil.setRetryPolicyOnDelegate(builder, retryPolicy));
       builder.setMeterProvider(meterProvider);
 
       return builder.build();

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
@@ -12,8 +12,8 @@ import static io.opentelemetry.sdk.autoconfigure.OtlpConfigUtil.PROTOCOL_HTTP_PR
 import io.opentelemetry.exporter.logging.LoggingMetricExporter;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder;
-import io.opentelemetry.exporter.otlp.internal.grpc.DefaultGrpcExporterBuilder;
 import io.opentelemetry.exporter.otlp.internal.okhttp.OkHttpExporterBuilder;
+import io.opentelemetry.exporter.otlp.internal.retry.RetryUtil;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder;
 import io.opentelemetry.exporter.prometheus.PrometheusHttpServer;
@@ -134,10 +134,7 @@ final class MetricExporterConfiguration {
           builder::setCompression,
           builder::setTimeout,
           builder::setTrustedCertificates,
-          retryPolicy ->
-              DefaultGrpcExporterBuilder.getDelegateBuilder(
-                      OtlpGrpcMetricExporterBuilder.class, builder)
-                  .setRetryPolicy(retryPolicy));
+          retryPolicy -> RetryUtil.setRetryPolicyOnDelegate(builder, retryPolicy));
       OtlpConfigUtil.configureOtlpAggregationTemporality(config, builder::setPreferredTemporality);
 
       exporter = builder.build();

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfiguration.java
@@ -16,8 +16,8 @@ import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporterBuilder;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder;
-import io.opentelemetry.exporter.otlp.internal.grpc.DefaultGrpcExporterBuilder;
 import io.opentelemetry.exporter.otlp.internal.okhttp.OkHttpExporterBuilder;
+import io.opentelemetry.exporter.otlp.internal.retry.RetryUtil;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
 import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
@@ -150,10 +150,7 @@ final class SpanExporterConfiguration {
           builder::setCompression,
           builder::setTimeout,
           builder::setTrustedCertificates,
-          retryPolicy ->
-              DefaultGrpcExporterBuilder.getDelegateBuilder(
-                      OtlpGrpcSpanExporterBuilder.class, builder)
-                  .setRetryPolicy(retryPolicy));
+          retryPolicy -> RetryUtil.setRetryPolicyOnDelegate(builder, retryPolicy));
       builder.setMeterProvider(meterProvider);
 
       return builder.build();


### PR DESCRIPTION
Was updating some code to use the latest version of the agent, and to use the `OkHttpGrpcExporter` instead of the `DefaultGrpcExporter`, and realized that while `OkHttpGrpcExporter` supports setting a retry policy, its not actually possible to enable it programmatically or via environment variables. 😞 

This fixes that by adjusting the reflective access method to work with both `DefaultGrpcExporterBuilder` and `OkHttpGrpcExporterBuilder`. 