### PR TITLE
Use newer contributors image link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,11 @@ Maintainer Emeritus:
 
 ### Thanks to all the people who have contributed
 
-[![contributors](https://contributors-img.web.app/image?repo=open-telemetry/opentelemetry-java)](https://github.com/open-telemetry/opentelemetry-java/graphs/contributors)
+<a href="https://github.com/open-telemetry/opentelemetry-java/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=open-telemetry/opentelemetry-java" />
+</a>
+
+Made with [contrib.rocks](https://contrib.rocks).
 
 [ci-image]: https://github.com/open-telemetry/opentelemetry-java/workflows/Continuous%20Build/badge.svg
 [ci-url]: https://github.com/open-telemetry/opentelemetry-java/actions?query=workflow%3Aci+branch%3Amain


### PR DESCRIPTION
I randomly noticed the link in our contributors image (had always assumed it's a GitHub native feature) and tried opening it. Found it redirects to a newer site so figured it's good to use the newer one. The snippet copied from it includes the attribution, while I don't think there's any license requiring it, I think it's nice to do so.