### PR TITLE
BatchSpanProcessor metrics

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
@@ -90,6 +90,7 @@ final class TracerProviderConfiguration {
   static BatchSpanProcessor configureBatchSpanProcessor(
       ConfigProperties config, SpanExporter exporter, MeterProvider meterProvider) {
     BatchSpanProcessorBuilder builder = BatchSpanProcessor.builder(exporter);
+    builder.setMeterProvider(meterProvider);
 
     Duration scheduleDelay = config.getDuration("otel.bsp.schedule.delay");
     if (scheduleDelay != null) {

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
@@ -89,7 +89,8 @@ final class TracerProviderConfiguration {
   // VisibleForTesting
   static BatchSpanProcessor configureBatchSpanProcessor(
       ConfigProperties config, SpanExporter exporter, MeterProvider meterProvider) {
-    BatchSpanProcessorBuilder builder = BatchSpanProcessor.builder(exporter).setMeterProvider(meterProvider);
+    BatchSpanProcessorBuilder builder =
+        BatchSpanProcessor.builder(exporter).setMeterProvider(meterProvider);
 
     Duration scheduleDelay = config.getDuration("otel.bsp.schedule.delay");
     if (scheduleDelay != null) {

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
@@ -89,8 +89,7 @@ final class TracerProviderConfiguration {
   // VisibleForTesting
   static BatchSpanProcessor configureBatchSpanProcessor(
       ConfigProperties config, SpanExporter exporter, MeterProvider meterProvider) {
-    BatchSpanProcessorBuilder builder = BatchSpanProcessor.builder(exporter);
-    builder.setMeterProvider(meterProvider);
+    BatchSpanProcessorBuilder builder = BatchSpanProcessor.builder(exporter).setMeterProvider(meterProvider);
 
     Duration scheduleDelay = config.getDuration("otel.bsp.schedule.delay");
     if (scheduleDelay != null) {

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
@@ -60,14 +60,16 @@ final class TracerProviderConfiguration {
         SpanExporterConfiguration.configureSpanExporters(
             config, serviceClassLoader, meterProvider, spanExporterCustomizer);
 
-    configureSpanProcessors(config, exportersByName)
+    configureSpanProcessors(config, exportersByName, meterProvider)
         .forEach(tracerProviderBuilder::addSpanProcessor);
 
     return tracerProviderBuilder.build();
   }
 
   static List<SpanProcessor> configureSpanProcessors(
-      ConfigProperties config, Map<String, SpanExporter> exportersByName) {
+      ConfigProperties config,
+      Map<String, SpanExporter> exportersByName,
+      MeterProvider meterProvider) {
     Map<String, SpanExporter> exportersByNameCopy = new HashMap<>(exportersByName);
     List<SpanProcessor> spanProcessors = new ArrayList<>();
 
@@ -78,7 +80,7 @@ final class TracerProviderConfiguration {
 
     if (!exportersByNameCopy.isEmpty()) {
       SpanExporter compositeSpanExporter = SpanExporter.composite(exportersByNameCopy.values());
-      spanProcessors.add(configureBatchSpanProcessor(config, compositeSpanExporter));
+      spanProcessors.add(configureBatchSpanProcessor(config, compositeSpanExporter, meterProvider));
     }
 
     return spanProcessors;
@@ -86,7 +88,7 @@ final class TracerProviderConfiguration {
 
   // VisibleForTesting
   static BatchSpanProcessor configureBatchSpanProcessor(
-      ConfigProperties config, SpanExporter exporter) {
+      ConfigProperties config, SpanExporter exporter, MeterProvider meterProvider) {
     BatchSpanProcessorBuilder builder = BatchSpanProcessor.builder(exporter);
 
     Duration scheduleDelay = config.getDuration("otel.bsp.schedule.delay");

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
@@ -89,7 +89,8 @@ class TracerProviderConfigurationTest {
   @Test
   void configureBatchSpanProcessor_empty() {
     BatchSpanProcessor processor =
-        TracerProviderConfiguration.configureBatchSpanProcessor(EMPTY, mockSpanExporter);
+        TracerProviderConfiguration.configureBatchSpanProcessor(
+            EMPTY, mockSpanExporter, MeterProvider.noop());
 
     try {
       assertThat(processor)
@@ -124,7 +125,9 @@ class TracerProviderConfigurationTest {
 
     BatchSpanProcessor processor =
         TracerProviderConfiguration.configureBatchSpanProcessor(
-            DefaultConfigProperties.createForTest(properties), mockSpanExporter);
+            DefaultConfigProperties.createForTest(properties),
+            mockSpanExporter,
+            MeterProvider.noop());
 
     try {
       assertThat(processor)

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
@@ -119,7 +119,7 @@ public class ConfigurableSpanExporterTest {
 
     assertThat(
             TracerProviderConfiguration.configureSpanProcessors(
-                properties, ImmutableMap.of(exporterName, exporter)))
+                properties, ImmutableMap.of(exporterName, exporter), MeterProvider.noop()))
         .hasSize(1)
         .first()
         .isInstanceOf(SimpleSpanProcessor.class);
@@ -134,7 +134,7 @@ public class ConfigurableSpanExporterTest {
 
     assertThat(
             TracerProviderConfiguration.configureSpanProcessors(
-                properties, ImmutableMap.of(exporterName, exporter)))
+                properties, ImmutableMap.of(exporterName, exporter), MeterProvider.noop()))
         .hasSize(1)
         .first()
         .isInstanceOf(BatchSpanProcessor.class);
@@ -150,7 +150,9 @@ public class ConfigurableSpanExporterTest {
 
     assertThat(
             TracerProviderConfiguration.configureSpanProcessors(
-                properties, ImmutableMap.of("otlp", otlpExporter, "zipkin", zipkinExporter)))
+                properties,
+                ImmutableMap.of("otlp", otlpExporter, "zipkin", zipkinExporter),
+                MeterProvider.noop()))
         .hasSize(1)
         .hasAtLeastOneElementOfType(BatchSpanProcessor.class)
         .first()
@@ -185,7 +187,9 @@ public class ConfigurableSpanExporterTest {
 
     assertThat(
             TracerProviderConfiguration.configureSpanProcessors(
-                properties, ImmutableMap.of("logging", loggingExporter, "zipkin", zipkinExporter)))
+                properties,
+                ImmutableMap.of("logging", loggingExporter, "zipkin", zipkinExporter),
+                MeterProvider.noop()))
         .hasSize(2)
         .hasAtLeastOneElementOfType(SimpleSpanProcessor.class)
         .hasAtLeastOneElementOfType(BatchSpanProcessor.class);


### PR DESCRIPTION
closes #4109 

Configures the `BatchSpanProcessor` with the `MeterProvider` provided to the `TracerProviderConfiguration` in the autoconfigure extension.

I'm open to ideas for any additional test cases as well to help protect against this again in future refactors 