### PR TITLE
Output logging messages in tests.

### DIFF
--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -95,6 +95,8 @@ tasks {
       showExceptions = true
       showCauses = true
       showStackTraces = true
+
+      showStandardStreams = true
     }
     maxHeapSize = "1500m"
   }


### PR DESCRIPTION
While this does contribute to some confusing output in tests (e.g., ERROR being displayed even though it's correct for the test) I think overall it's still worth it to more easily find unexpected logs happening instead (such as jaeger spam in https://github.com/anuraaga/opentelemetry-java/runs/4932526232?check_suite_focus=true)