### PR TITLE
Deprecate gRPC setChannel

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-jaeger.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-jaeger.txt
@@ -1,2 +1,5 @@
 Comparing source compatibility of  against 
-No changes.
+===  UNCHANGED CLASS: PUBLIC FINAL io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	===  UNCHANGED METHOD: PUBLIC io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporterBuilder setChannel(io.grpc.ManagedChannel)
+		+++  NEW ANNOTATION: java.lang.Deprecated

--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp-trace.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp-trace.txt
@@ -1,2 +1,5 @@
 Comparing source compatibility of  against 
-No changes.
+===  UNCHANGED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	===  UNCHANGED METHOD: PUBLIC io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder setChannel(io.grpc.ManagedChannel)
+		+++  NEW ANNOTATION: java.lang.Deprecated

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-jaeger-remote-sampler.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-jaeger-remote-sampler.txt
@@ -1,4 +1,6 @@
 Comparing source compatibility of  against 
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.extension.trace.jaeger.sampler.JaegerRemoteSamplerBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	===  UNCHANGED METHOD: PUBLIC io.opentelemetry.sdk.extension.trace.jaeger.sampler.JaegerRemoteSamplerBuilder setChannel(io.grpc.ManagedChannel)
+		+++  NEW ANNOTATION: java.lang.Deprecated
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.extension.trace.jaeger.sampler.JaegerRemoteSamplerBuilder setTrustedCertificates(byte[])

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterBuilder.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterBuilder.java
@@ -46,7 +46,10 @@ public final class JaegerGrpcSpanExporterBuilder {
    *
    * @param channel the channel to use.
    * @return this.
+   * @deprecated Use {@link #setEndpoint(String)}. If you have a use case not satisfied by the
+   *     methods on this builder, please file an issue to let us know what it is.
    */
+  @Deprecated
   public JaegerGrpcSpanExporterBuilder setChannel(ManagedChannel channel) {
     delegate.setChannel(channel);
     return this;

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogExporterBuilder.java
@@ -49,7 +49,10 @@ public final class OtlpGrpcLogExporterBuilder {
    *
    * @param channel the channel to use
    * @return this builder's instance
+   * @deprecated Use {@link #setEndpoint(String)}. If you have a use case not satisfied by the
+   *     methods on this builder, please file an issue to let us know what it is.
    */
+  @Deprecated
   public OtlpGrpcLogExporterBuilder setChannel(ManagedChannel channel) {
     delegate.setChannel(channel);
     return this;

--- a/exporters/otlp/metrics/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
+++ b/exporters/otlp/metrics/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
@@ -53,7 +53,10 @@ public final class OtlpGrpcMetricExporterBuilder {
    *
    * @param channel the channel to use
    * @return this builder's instance
+   * @deprecated Use {@link #setEndpoint(String)}. If you have a use case not satisfied by the
+   *     methods on this builder, please file an issue to let us know what it is.
    */
+  @Deprecated
   public OtlpGrpcMetricExporterBuilder setChannel(ManagedChannel channel) {
     delegate.setChannel(channel);
     return this;

--- a/exporters/otlp/trace/build.gradle.kts
+++ b/exporters/otlp/trace/build.gradle.kts
@@ -54,9 +54,9 @@ testing {
     }
     val testSpanPipeline by registering(JvmTestSuite::class) {
       dependencies {
-        implementation("io.grpc:grpc-protobuf")
-        implementation("io.grpc:grpc-testing")
         implementation("io.opentelemetry.proto:opentelemetry-proto")
+        implementation("com.linecorp.armeria:armeria-grpc-protocol")
+        implementation("com.linecorp.armeria:armeria-junit5")
       }
     }
   }

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
@@ -49,7 +49,10 @@ public final class OtlpGrpcSpanExporterBuilder {
    *
    * @param channel the channel to use
    * @return this builder's instance
+   * @deprecated Use {@link #setEndpoint(String)}. If you have a use case not satisfied by the
+   *     methods on this builder, please file an issue to let us know what it is.
    */
+  @Deprecated
   public OtlpGrpcSpanExporterBuilder setChannel(ManagedChannel channel) {
     delegate.setChannel(channel);
     return this;

--- a/exporters/otlp/trace/src/testSpanPipeline/java/io/opentelemetry/exporter/otlp/trace/SpanPipelineOtlpBenchmark.java
+++ b/exporters/otlp/trace/src/testSpanPipeline/java/io/opentelemetry/exporter/otlp/trace/SpanPipelineOtlpBenchmark.java
@@ -5,30 +5,30 @@
 
 package io.opentelemetry.exporter.otlp.trace;
 
-import io.grpc.ManagedChannel;
-import io.grpc.Server;
-import io.grpc.inprocess.InProcessChannelBuilder;
-import io.grpc.inprocess.InProcessServerBuilder;
-import io.grpc.stub.StreamObserver;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.grpc.protocol.AbstractUnaryGrpcService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
-import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class SpanPipelineOtlpBenchmark {
+class SpanPipelineOtlpBenchmark {
   private static final Resource RESOURCE =
       Resource.create(
           Attributes.builder()
@@ -52,41 +52,46 @@ public class SpanPipelineOtlpBenchmark {
           .put(AttributeKey.doubleKey("key_double"), 100.3)
           .build();
 
-  private static final NoopCollector collector = new NoopCollector();
-  private static final String serverName = InProcessServerBuilder.generateName();
-  private static final ManagedChannel inProcessChannel =
-      InProcessChannelBuilder.forName(serverName).directExecutor().build();
-  private static final Server server;
+  @RegisterExtension
+  public static final ServerExtension server =
+      new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+          sb.service(
+              "/opentelemetry.proto.collector.trace.v1.TraceService/Export",
+              new AbstractUnaryGrpcService() {
+                @Override
+                protected CompletionStage<byte[]> handleMessage(
+                    ServiceRequestContext ctx, byte[] message) {
+                  return CompletableFuture.completedFuture(
+                      ExportTraceServiceResponse.getDefaultInstance().toByteArray());
+                }
+              });
+        }
+      };
 
-  static {
-    try {
-      server =
-          InProcessServerBuilder.forName(serverName)
-              .directExecutor()
-              .addService(collector)
-              .build()
-              .start();
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
+  private static SdkTracerProvider tracerProvider;
+  private static Tracer tracer;
+
+  @BeforeAll
+  public static void setUp() {
+    tracerProvider =
+        SdkTracerProvider.builder()
+            .setResource(RESOURCE)
+            .addSpanProcessor(
+                BatchSpanProcessor.builder(
+                        OtlpGrpcSpanExporter.builder()
+                            .setEndpoint(server.httpUri().toString())
+                            .build())
+                    .setScheduleDelay(Duration.ofMillis(500))
+                    .build())
+            .build();
+    tracer = tracerProvider.get("benchmark");
   }
 
-  private static final SdkTracerProvider tracerProvider =
-      SdkTracerProvider.builder()
-          .setResource(RESOURCE)
-          .addSpanProcessor(
-              BatchSpanProcessor.builder(
-                      OtlpGrpcSpanExporter.builder().setChannel(inProcessChannel).build())
-                  .setScheduleDelay(Duration.ofMillis(500))
-                  .build())
-          .build();
-
-  private static final Tracer tracer = tracerProvider.get("benchmark");
-
-  private static void tearDown() {
+  @AfterAll
+  public static void tearDown() {
     tracerProvider.close();
-    server.shutdownNow();
-    inProcessChannel.shutdownNow();
   }
 
   private static void createSpan() {
@@ -108,16 +113,6 @@ public class SpanPipelineOtlpBenchmark {
       }
     } finally {
       SpanPipelineOtlpBenchmark.tearDown();
-    }
-  }
-
-  private static class NoopCollector extends TraceServiceGrpc.TraceServiceImplBase {
-    @Override
-    public void export(
-        ExportTraceServiceRequest request,
-        StreamObserver<ExportTraceServiceResponse> responseObserver) {
-      responseObserver.onNext(ExportTraceServiceResponse.getDefaultInstance());
-      responseObserver.onCompleted();
     }
   }
 }

--- a/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerBuilder.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerBuilder.java
@@ -98,7 +98,11 @@ public final class JaegerRemoteSamplerBuilder {
   /**
    * Sets the managed channel to use when communicating with the backend. Takes precedence over
    * {@link #setEndpoint(String)} if both are called.
+   *
+   * @deprecated Use {@link #setEndpoint(String)}. If you have a use case not satisfied by the
+   *     methods on this builder, please file an issue to let us know what it is.
    */
+  @Deprecated
   public JaegerRemoteSamplerBuilder setChannel(ManagedChannel channel) {
     requireNonNull(channel, "channel");
     delegate.setChannel(channel);


### PR DESCRIPTION
We'd generally like users to be using the okhttp transport and wouldn't even have this method in the API ideally to allow switching transports when we need. For now let's deprecate, and maybe hear back on some use cases which would probably be forwarded to the spec.