### PR TITLE
Use noop meter provider if no readers registered

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MeterProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MeterProviderConfiguration.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.sdk.autoconfigure;
 
-import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.metrics.SdkMeterProviderConfigurer;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
@@ -16,7 +15,7 @@ import java.util.ServiceLoader;
 
 final class MeterProviderConfiguration {
 
-  static MeterProvider configureMeterProvider(
+  static SdkMeterProvider configureMeterProvider(
       Resource resource, ConfigProperties config, ClassLoader serviceClassLoader) {
     SdkMeterProviderBuilder meterProviderBuilder = SdkMeterProvider.builder().setResource(resource);
 
@@ -44,12 +43,10 @@ final class MeterProviderConfiguration {
     }
 
     String exporterName = config.getString("otel.metrics.exporter");
-    if (exporterName == null || exporterName.equals("none")) {
-      // In the event no exporters are configured set a noop exporter
-      return MeterProvider.noop();
+    if (exporterName != null && !exporterName.equals("none")) {
+      MetricExporterConfiguration.configureExporter(
+          exporterName, config, serviceClassLoader, meterProviderBuilder);
     }
-    MetricExporterConfiguration.configureExporter(
-        exporterName, config, serviceClassLoader, meterProviderBuilder);
 
     return meterProviderBuilder.build();
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProvider.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProvider.java
@@ -89,6 +89,9 @@ public final class SdkMeterProvider implements MeterProvider, Closeable {
 
   @Override
   public MeterBuilder meterBuilder(String instrumentationName) {
+    if (collectionInfoMap.isEmpty()) {
+      return MeterProvider.noop().meterBuilder(instrumentationName);
+    }
     if (instrumentationName == null || instrumentationName.isEmpty()) {
       LOGGER.fine("Meter requested without instrumentation name.");
       instrumentationName = DEFAULT_METER_NAME;
@@ -101,6 +104,9 @@ public final class SdkMeterProvider implements MeterProvider, Closeable {
    * resulting {@link CompletableResultCode} completes when all complete.
    */
   public CompletableResultCode forceFlush() {
+    if (collectionInfoMap.isEmpty()) {
+      return CompletableResultCode.ofSuccess();
+    }
     List<CompletableResultCode> results = new ArrayList<>();
     for (CollectionInfo collectionInfo : collectionInfoMap.values()) {
       results.add(collectionInfo.getReader().flush());
@@ -115,6 +121,9 @@ public final class SdkMeterProvider implements MeterProvider, Closeable {
   public CompletableResultCode shutdown() {
     if (!isClosed.compareAndSet(false, true)) {
       LOGGER.info("Multiple close calls");
+      return CompletableResultCode.ofSuccess();
+    }
+    if (collectionInfoMap.isEmpty()) {
       return CompletableResultCode.ofSuccess();
     }
     List<CompletableResultCode> results = new ArrayList<>();


### PR DESCRIPTION
I was working on adding support for metrics customizers in `AutoConfigurationCustomizer` and ran into an issue: We currently don't register the `SdkMeterProvider` with `OpenTelemetrySdkBuilder` unless an exporter is explicitly set. This presents issues when adding a meter provider customizer method because we no we won't be able to know whether or not an `SdkMeterProviderBuilder` was extended with a reader based on whether `otel.metrics.exporter` has been set. And actually, the current metrics SPI `ConfigurableMetricExporterProvider` suffers from this same issue: if I configure a reader via `ConfigurableMetricExporterProvider`, but don't change `otel.metrics.exporter`, then my SPI customization will be ignored. 

I don't actually thing the existing protective measure is doing anything at all. As it stands today, if `otel.metrics.exporter` is unset, `GlobalOpenTelemetry` will be set with a `MeterProvider` equal to `SdkMeterProvider.builder().build()`. 

I decided to fix the issue with autoconfigure and also optimize `SdkMeterProvider` to use the noop implementation if no readers are registers. 