### PR TITLE
Make metric / log exporter closeable and improve behavior of some tests

### DIFF
--- a/extensions/kotlin/src/test/kotlin/io/opentelemetry/extension/kotlin/KotlinCoroutinesTest.kt
+++ b/extensions/kotlin/src/test/kotlin/io/opentelemetry/extension/kotlin/KotlinCoroutinesTest.kt
@@ -79,8 +79,10 @@ class KotlinCoroutinesTest {
     val context1 = Context.root().with(ANIMAL, "cat")
     runBlocking(context1.asContextElement()) {
       assertThat(Context.current().get(ANIMAL)).isEqualTo("cat")
+      delay(10)
+      assertThat(Context.current().get(ANIMAL)).isEqualTo("cat")
       for (i in 0 until 100) {
-        GlobalScope.launch {
+        launch {
           assertThat(Context.current().get(ANIMAL)).isEqualTo("cat")
           withContext(context1.with(ANIMAL, "dog").asContextElement()) {
             assertThat(Context.current().get(ANIMAL)).isEqualTo("dog")
@@ -88,7 +90,7 @@ class KotlinCoroutinesTest {
             assertThat(Context.current().get(ANIMAL)).isEqualTo("dog")
           }
         }
-        GlobalScope.launch {
+        launch {
           assertThat(Context.current().get(ANIMAL)).isEqualTo("cat")
           withContext(context1.with(ANIMAL, "koala").asContextElement()) {
             assertThat(Context.current().get(ANIMAL)).isEqualTo("koala")

--- a/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/InteroperabilityTest.java
+++ b/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/InteroperabilityTest.java
@@ -66,7 +66,6 @@ class InteroperabilityTest {
 
   static {
     spanExporter = spy(SpanExporter.class);
-    when(spanExporter.export(anyList())).thenReturn(CompletableResultCode.ofSuccess());
 
     SpanProcessor spanProcessor = SimpleSpanProcessor.create(spanExporter);
     openTelemetry =
@@ -80,6 +79,7 @@ class InteroperabilityTest {
   @BeforeEach
   void resetMocks() {
     reset(spanExporter);
+    when(spanExporter.export(anyList())).thenReturn(CompletableResultCode.ofSuccess());
   }
 
   @Test

--- a/sdk-extensions/autoconfigure/src/testOtlpGrpc/java/io/opentelemetry/sdk/autoconfigure/OtlpGrpcRetryTest.java
+++ b/sdk-extensions/autoconfigure/src/testOtlpGrpc/java/io/opentelemetry/sdk/autoconfigure/OtlpGrpcRetryTest.java
@@ -57,15 +57,16 @@ class OtlpGrpcRetryTest {
     props.put(
         "otel.exporter.otlp.traces.certificate", certificate.certificateFile().getAbsolutePath());
     props.put("otel.experimental.exporter.otlp.retry.enabled", "true");
-    SpanExporter spanExporter =
+    try (SpanExporter spanExporter =
         SpanExporterConfiguration.configureExporter(
             "otlp",
             DefaultConfigProperties.createForTest(props),
             Collections.emptyMap(),
-            MeterProvider.noop());
+            MeterProvider.noop())) {
 
-    testRetryableStatusCodes(() -> SPAN_DATA, spanExporter::export, server.traceRequests::size);
-    testDefaultRetryPolicy(() -> SPAN_DATA, spanExporter::export, server.traceRequests::size);
+      testRetryableStatusCodes(() -> SPAN_DATA, spanExporter::export, server.traceRequests::size);
+      testDefaultRetryPolicy(() -> SPAN_DATA, spanExporter::export, server.traceRequests::size);
+    }
   }
 
   @Test
@@ -91,12 +92,13 @@ class OtlpGrpcRetryTest {
     props.put(
         "otel.exporter.otlp.logs.certificate", certificate.certificateFile().getAbsolutePath());
     props.put("otel.experimental.exporter.otlp.retry.enabled", "true");
-    LogExporter logExporter =
+    try (LogExporter logExporter =
         LogExporterConfiguration.configureOtlpLogs(
-            DefaultConfigProperties.createForTest(props), MeterProvider.noop());
+            DefaultConfigProperties.createForTest(props), MeterProvider.noop())) {
 
-    testRetryableStatusCodes(() -> LOG_DATA, logExporter::export, server.logRequests::size);
-    testDefaultRetryPolicy(() -> LOG_DATA, logExporter::export, server.logRequests::size);
+      testRetryableStatusCodes(() -> LOG_DATA, logExporter::export, server.logRequests::size);
+      testDefaultRetryPolicy(() -> LOG_DATA, logExporter::export, server.logRequests::size);
+    }
   }
 
   private static <T> void testRetryableStatusCodes(

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/LogExporter.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/LogExporter.java
@@ -9,16 +9,18 @@ import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.logs.LogProcessor;
 import io.opentelemetry.sdk.logs.SdkLogEmitterProvider;
 import io.opentelemetry.sdk.logs.data.LogData;
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * An exporter is responsible for taking a collection of {@link LogData}s and transmitting them to
  * their ultimate destination.
  */
-public interface LogExporter {
+public interface LogExporter extends Closeable {
 
   /**
    * Returns a {@link LogExporter} which delegates all exports to the {@code exporters} in order.
@@ -73,4 +75,10 @@ public interface LogExporter {
    * @return a {@link CompletableResultCode} which is completed when shutdown completes
    */
   CompletableResultCode shutdown();
+
+  /** Closes this {@link LogExporter}, releasing any resources. */
+  @Override
+  default void close() {
+    shutdown().join(10, TimeUnit.SECONDS);
+  }
 }

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/export/SimpleLogProcessorTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/export/SimpleLogProcessorTest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.sdk.logs.data.Severity.DEBUG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -38,6 +39,7 @@ class SimpleLogProcessorTest {
   @BeforeEach
   void setUp() {
     logProcessor = SimpleLogProcessor.create(logExporter);
+    when(logExporter.export(anyCollection())).thenReturn(CompletableResultCode.ofSuccess());
     when(logExporter.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/MetricExporter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/MetricExporter.java
@@ -8,7 +8,9 @@ package io.opentelemetry.sdk.metrics.export;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import java.io.Closeable;
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
@@ -17,7 +19,7 @@ import javax.annotation.Nullable;
  *
  * <p>All OpenTelemetry exporters should allow access to a {@code MetricExporter} instance.
  */
-public interface MetricExporter {
+public interface MetricExporter extends Closeable {
 
   /** Returns the preferred temporality for metrics. */
   @Nullable
@@ -50,4 +52,10 @@ public interface MetricExporter {
    * @return a {@link CompletableResultCode} which is completed when shutdown completes.
    */
   CompletableResultCode shutdown();
+
+  /** Closes this {@link MetricExporter}, releasing any resources. */
+  @Override
+  default void close() {
+    shutdown().join(10, TimeUnit.SECONDS);
+  }
 }


### PR DESCRIPTION
Enabling output streams on tests shows some places that are not closing gRPC channels, returning `null` from FooExporter (which fails when putting into the SimpleSpanProcessor's pending task map), and incorrect kotlin coroutines usage.