### PR TITLE
Add DelegatingMetricData

### DIFF
--- a/sdk/metrics/build.gradle.kts
+++ b/sdk/metrics/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
   testImplementation(project(":sdk:metrics-testing"))
   testImplementation(project(":sdk:testing"))
   testImplementation("com.google.guava:guava")
+  testImplementation("com.google.guava:guava-testlib")
 
   jmh(project(":sdk:trace"))
   jmh(project(":sdk:metrics-testing"))

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricData.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.data;
+
+import static java.util.Objects.requireNonNull;
+
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import javax.annotation.Nullable;
+
+/**
+ * A {@link MetricData} which delegates all methods to another {@link MetricData}. Extend this class
+ * to modify {@link MetricData} that will be exported, for example by creating a delegating {@link
+ * io.opentelemetry.sdk.metrics.export.MetricExporter} which wraps {@link MetricData} with a custom
+ * implementation.
+ */
+public abstract class DelegatingMetricData implements MetricData {
+
+  private final MetricData delegate;
+
+  protected DelegatingMetricData(MetricData delegate) {
+    this.delegate = requireNonNull(delegate, "delegate");
+  }
+
+  @Override
+  public Resource getResource() {
+    return delegate.getResource();
+  }
+
+  @Override
+  public InstrumentationLibraryInfo getInstrumentationLibraryInfo() {
+    return delegate.getInstrumentationLibraryInfo();
+  }
+
+  @Override
+  public String getName() {
+    return delegate.getName();
+  }
+
+  @Override
+  public String getDescription() {
+    return delegate.getDescription();
+  }
+
+  @Override
+  public String getUnit() {
+    return delegate.getUnit();
+  }
+
+  @Override
+  public MetricDataType getType() {
+    return delegate.getType();
+  }
+
+  @Override
+  public Data<?> getData() {
+    return delegate.getData();
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof MetricDataImpl) {
+      MetricDataImpl that = (MetricDataImpl) o;
+      return getResource().equals(that.getResource())
+          && getInstrumentationLibraryInfo().equals(that.getInstrumentationLibraryInfo())
+          && getName().equals(that.getName())
+          && getDescription().equals(that.getDescription())
+          && getUnit().equals(that.getUnit())
+          && getType().equals(that.getType())
+          && getData().equals(that.getData());
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int code = 1;
+    code *= 1000003;
+    code ^= getResource().hashCode();
+    code *= 1000003;
+    code ^= getInstrumentationLibraryInfo().hashCode();
+    code *= 1000003;
+    code ^= getName().hashCode();
+    code *= 1000003;
+    code ^= getDescription().hashCode();
+    code *= 1000003;
+    code ^= getUnit().hashCode();
+    code *= 1000003;
+    code ^= getType().hashCode();
+    code *= 1000003;
+    code ^= getData().hashCode();
+    return code;
+  }
+
+  @Override
+  public String toString() {
+    return "DelegatingMetricData{"
+        + "resource="
+        + getResource()
+        + ", "
+        + "instrumentationLibraryInfo="
+        + getInstrumentationLibraryInfo()
+        + ", "
+        + "name="
+        + getName()
+        + ", "
+        + "description="
+        + getDescription()
+        + ", "
+        + "unit="
+        + getUnit()
+        + ", "
+        + "type="
+        + getType()
+        + ", "
+        + "data="
+        + getData()
+        + "}";
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricDataTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricDataTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.data;
+
+import static io.opentelemetry.sdk.testing.assertj.MetricAssertions.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
+import org.junit.jupiter.api.Test;
+
+class DelegatingMetricDataTest {
+
+  @Test
+  void delegates() {
+    MetricData metricData = createMetricData();
+    MetricData noopWrapper = new NoOpDelegatingMetricData(metricData);
+    // Test should always verify delegation is working even when methods are added since it calls
+    // each method individually.
+    Assertions.assertThat(noopWrapper)
+        .usingRecursiveComparison(
+            RecursiveComparisonConfiguration.builder().withIgnoredFields("delegate").build())
+        .isEqualTo(metricData);
+  }
+
+  @Test
+  void overrideDelegate() {
+    MetricData metricData = createMetricData();
+    MetricData enrichedMetricData =
+        new MetricDataWithAttributes(
+            metricData, Attributes.builder().put("key2", "value2").build());
+    assertThat(enrichedMetricData)
+        .hasLongSum()
+        .points()
+        .satisfiesExactly(
+            point ->
+                assertThat(point)
+                    .hasAttributes(
+                        Attributes.builder().put("key1", "value1").put("key2", "value2").build()));
+  }
+
+  @Test
+  void equals() {
+    MetricData metricData = createMetricData();
+    MetricData noopWrapper = new NoOpDelegatingMetricData(metricData);
+    MetricData enrichedMetricData =
+        new MetricDataWithAttributes(
+            metricData, Attributes.builder().put("key2", "value2").build());
+
+    assertThat(noopWrapper).isEqualTo(metricData);
+    // TODO(jack-berg): Bug - metricData.equals(noopWrapper) should be equal but AutoValue does not
+    // implement equals for interfaces properly. We can't add it as a separate group either since
+    // noopWrapper.equals(metricData) does work properly.
+    assertThat(metricData).isNotEqualTo(noopWrapper);
+
+    new EqualsTester()
+        .addEqualityGroup(noopWrapper)
+        .addEqualityGroup(enrichedMetricData)
+        .testEquals();
+  }
+
+  static MetricData createMetricData() {
+    return MetricData.createLongSum(
+        Resource.getDefault(),
+        InstrumentationLibraryInfo.create("test", null),
+        "name",
+        "description",
+        "unit",
+        LongSumData.create(
+            /* isMonotonic= */ true,
+            AggregationTemporality.CUMULATIVE,
+            Collections.singleton(
+                LongPointData.create(
+                    TimeUnit.MILLISECONDS.toNanos(Instant.now().toEpochMilli()),
+                    TimeUnit.MILLISECONDS.toNanos(Instant.now().plusSeconds(60).toEpochMilli()),
+                    Attributes.builder().put("key1", "value1").build(),
+                    10))));
+  }
+
+  private static final class NoOpDelegatingMetricData extends DelegatingMetricData {
+    private NoOpDelegatingMetricData(MetricData delegate) {
+      super(delegate);
+    }
+  }
+
+  private static class MetricDataWithAttributes extends DelegatingMetricData {
+
+    private final Attributes attributes;
+
+    private MetricDataWithAttributes(MetricData delegate, Attributes attributes) {
+      super(delegate);
+      this.attributes = attributes;
+    }
+
+    @Override
+    public Data<?> getData() {
+      if (!super.getType().equals(MetricDataType.LONG_SUM)) {
+        return super.getData();
+      }
+      LongSumData longSumData = (LongSumData) super.getData();
+      List<LongPointData> points =
+          longSumData.getPoints().stream()
+              .map(
+                  pointData ->
+                      LongPointData.create(
+                          pointData.getStartEpochNanos(),
+                          pointData.getEpochNanos(),
+                          pointData.getAttributes().toBuilder().putAll(attributes).build(),
+                          pointData.getValue(),
+                          pointData.getExemplars()))
+              .collect(Collectors.toList());
+      return LongSumData.create(
+          longSumData.isMonotonic(), longSumData.getAggregationTemporality(), points);
+    }
+  }
+}


### PR DESCRIPTION
The metrics corollary to `DelegatingSpanData`. 

Opening as a draft because unlike `SpanData`, `MetricData` has publicly accessible static methods for creating instances, meaning that having a delegating metric data isn't as vital. Let me know if you think this is useful enough to add? 