### PR TITLE
Cleanup retry configuration

### DIFF
--- a/exporters/otlp-http/logs/src/test/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogExporterTest.java
+++ b/exporters/otlp-http/logs/src/test/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogExporterTest.java
@@ -23,9 +23,9 @@ import com.linecorp.armeria.testing.junit5.server.mock.RecordedRequest;
 import io.github.netmikey.logunit.api.LogCapturer;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.exporter.internal.okhttp.OkHttpExporter;
-import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
 import io.opentelemetry.exporter.internal.otlp.logs.ResourceLogsMarshaler;
 import io.opentelemetry.exporter.internal.retry.RetryPolicy;
+import io.opentelemetry.exporter.internal.retry.RetryUtil;
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceResponse;
 import io.opentelemetry.proto.logs.v1.ResourceLogs;
@@ -186,12 +186,11 @@ class OtlpHttpLogExporterTest {
   }
 
   @Test
-  void testBuilderDelegate() {
+  void testSetRetryPolicyOnDelegate() {
     assertThatCode(
             () ->
-                OkHttpExporterBuilder.getDelegateBuilder(
-                        OtlpHttpLogExporterBuilder.class, OtlpHttpLogExporter.builder())
-                    .setRetryPolicy(RetryPolicy.getDefault()))
+                RetryUtil.setRetryPolicyOnDelegate(
+                    OtlpHttpLogExporter.builder(), RetryPolicy.getDefault()))
         .doesNotThrowAnyException();
   }
 

--- a/exporters/otlp-http/metrics/src/test/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterTest.java
+++ b/exporters/otlp-http/metrics/src/test/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterTest.java
@@ -23,9 +23,9 @@ import com.linecorp.armeria.testing.junit5.server.mock.MockWebServerExtension;
 import io.github.netmikey.logunit.api.LogCapturer;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.exporter.internal.okhttp.OkHttpExporter;
-import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
 import io.opentelemetry.exporter.internal.otlp.metrics.ResourceMetricsMarshaler;
 import io.opentelemetry.exporter.internal.retry.RetryPolicy;
+import io.opentelemetry.exporter.internal.retry.RetryUtil;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
 import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
@@ -191,12 +191,11 @@ class OtlpHttpMetricExporterTest {
   }
 
   @Test
-  void testBuilderDelegate() {
+  void testSetRetryPolicyOnDelegate() {
     assertThatCode(
             () ->
-                OkHttpExporterBuilder.getDelegateBuilder(
-                        OtlpHttpMetricExporterBuilder.class, OtlpHttpMetricExporter.builder())
-                    .setRetryPolicy(RetryPolicy.getDefault()))
+                RetryUtil.setRetryPolicyOnDelegate(
+                    OtlpHttpMetricExporter.builder(), RetryPolicy.getDefault()))
         .doesNotThrowAnyException();
   }
 

--- a/exporters/otlp-http/trace/src/test/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterTest.java
+++ b/exporters/otlp-http/trace/src/test/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterTest.java
@@ -26,9 +26,9 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.exporter.internal.okhttp.OkHttpExporter;
-import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
 import io.opentelemetry.exporter.internal.otlp.traces.ResourceSpansMarshaler;
 import io.opentelemetry.exporter.internal.retry.RetryPolicy;
+import io.opentelemetry.exporter.internal.retry.RetryUtil;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
@@ -174,12 +174,11 @@ class OtlpHttpSpanExporterTest {
   }
 
   @Test
-  void testBuilderDelegate() {
+  void testSetRetryPolicyOnDelegate() {
     assertThatCode(
             () ->
-                OkHttpExporterBuilder.getDelegateBuilder(
-                        OtlpHttpSpanExporterBuilder.class, OtlpHttpSpanExporter.builder())
-                    .setRetryPolicy(RetryPolicy.getDefault()))
+                RetryUtil.setRetryPolicyOnDelegate(
+                    OtlpHttpSpanExporter.builder(), RetryPolicy.getDefault()))
         .doesNotThrowAnyException();
   }
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/OkHttpExporterBuilder.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/OkHttpExporterBuilder.java
@@ -11,7 +11,6 @@ import io.opentelemetry.exporter.internal.TlsUtil;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.exporter.internal.retry.RetryInterceptor;
 import io.opentelemetry.exporter.internal.retry.RetryPolicy;
-import java.lang.reflect.Field;
 import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -118,26 +117,5 @@ public final class OkHttpExporterBuilder<T extends Marshaler> {
 
     return new OkHttpExporter<>(
         type, clientBuilder.build(), meterProvider, endpoint, headers, compressionEnabled);
-  }
-
-  /**
-   * Reflectively access a {@link OkHttpExporterBuilder} instance in field called "delegate" of the
-   * instance.
-   *
-   * @throws IllegalArgumentException if the instance does not contain a field called "delegate" of
-   *     type {@link OkHttpExporterBuilder}
-   */
-  public static <T> OkHttpExporterBuilder<?> getDelegateBuilder(Class<T> type, T instance) {
-    try {
-      Field field = type.getDeclaredField("delegate");
-      field.setAccessible(true);
-      Object value = field.get(instance);
-      if (!(value instanceof OkHttpExporterBuilder)) {
-        throw new IllegalArgumentException("delegate field is not type OkHttpExporterBuilder");
-      }
-      return (OkHttpExporterBuilder<?>) value;
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      throw new IllegalArgumentException("Unable to access delegate reflectively.", e);
-    }
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/retry/RetryUtil.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/retry/RetryUtil.java
@@ -8,6 +8,7 @@ package io.opentelemetry.exporter.internal.retry;
 import io.opentelemetry.exporter.internal.grpc.DefaultGrpcExporterBuilder;
 import io.opentelemetry.exporter.internal.grpc.GrpcStatusUtil;
 import io.opentelemetry.exporter.internal.grpc.OkHttpGrpcExporterBuilder;
+import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
@@ -49,8 +50,9 @@ public class RetryUtil {
   }
 
   /**
-   * Reflectively access a {@link DefaultGrpcExporterBuilder} or {@link OkHttpGrpcExporterBuilder}
-   * instance in field called "delegate" of the instance, and set the {@link RetryPolicy}.
+   * Reflectively access a {@link DefaultGrpcExporterBuilder}, {@link OkHttpGrpcExporterBuilder}, or
+   * {@link OkHttpExporterBuilder} instance in field called "delegate" of the instance, and set the
+   * {@link RetryPolicy}.
    *
    * @throws IllegalArgumentException if the instance does not contain a field called "delegate" of
    *     type {@link DefaultGrpcExporterBuilder}
@@ -64,6 +66,8 @@ public class RetryUtil {
         ((DefaultGrpcExporterBuilder<?>) value).setRetryPolicy(retryPolicy);
       } else if (value instanceof OkHttpGrpcExporterBuilder) {
         ((OkHttpGrpcExporterBuilder<?>) value).setRetryPolicy(retryPolicy);
+      } else if (value instanceof OkHttpExporterBuilder) {
+        ((OkHttpExporterBuilder<?>) value).setRetryPolicy(retryPolicy);
       } else {
         throw new IllegalArgumentException(
             "delegate field is not type DefaultGrpcExporterBuilder or OkHttpGrpcExporterBuilder");

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/retry/RetryUtilTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/retry/RetryUtilTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.exporter.internal.grpc.DefaultGrpcExporterBuilder;
 import io.opentelemetry.exporter.internal.grpc.OkHttpGrpcExporterBuilder;
+import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
 import java.net.URI;
 import java.net.URISyntaxException;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -38,6 +39,18 @@ class RetryUtilTest {
     OkHttpGrpcExporterBuilder<?> builder =
         new OkHttpGrpcExporterBuilder<>("test", "/test", 0, new URI("http://localhost"));
 
+    RetryUtil.setRetryPolicyOnDelegate(new WithDelegate(builder), retryPolicy);
+
+    assertThat(builder)
+        .extracting("retryPolicy", as(InstanceOfAssertFactories.type(RetryPolicy.class)))
+        .isEqualTo(retryPolicy);
+  }
+
+  @Test
+  void setRetryPolicyOnDelegate_OkHttpExporterBuilder() {
+    RetryPolicy retryPolicy = RetryPolicy.getDefault();
+    OkHttpExporterBuilder<?> builder =
+        new OkHttpExporterBuilder<>("test", "http://localhost:4318/test");
     RetryUtil.setRetryPolicyOnDelegate(new WithDelegate(builder), retryPolicy);
 
     assertThat(builder)

--- a/exporters/otlp/logs/src/test/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogExporterTest.java
+++ b/exporters/otlp/logs/src/test/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogExporterTest.java
@@ -36,7 +36,7 @@ class OtlpGrpcLogExporterTest extends AbstractGrpcTelemetryExporterTest<LogData,
   }
 
   @Test
-  void testBuilderDelegate() {
+  void testSetRetryPolicyOnDelegate() {
     assertThatCode(
             () ->
                 RetryUtil.setRetryPolicyOnDelegate(

--- a/exporters/otlp/logs/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcNettyLogExporterTest.java
+++ b/exporters/otlp/logs/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcNettyLogExporterTest.java
@@ -37,7 +37,7 @@ class OtlpGrpcNettyLogExporterTest
   }
 
   @Test
-  void testBuilderDelegate() {
+  void testSetRetryPolicyOnDelegate() {
     assertThatCode(
             () ->
                 RetryUtil.setRetryPolicyOnDelegate(

--- a/exporters/otlp/metrics/src/test/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterTest.java
+++ b/exporters/otlp/metrics/src/test/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterTest.java
@@ -39,7 +39,7 @@ class OtlpGrpcMetricExporterTest
   }
 
   @Test
-  void testBuilderDelegate() {
+  void testSetRetryPolicyOnDelegate() {
     assertThatCode(
             () ->
                 RetryUtil.setRetryPolicyOnDelegate(

--- a/exporters/otlp/metrics/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcNettyMetricExporterTest.java
+++ b/exporters/otlp/metrics/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcNettyMetricExporterTest.java
@@ -39,7 +39,7 @@ class OtlpGrpcNettyMetricExporterTest
   }
 
   @Test
-  void testBuilderDelegate() {
+  void testSetRetryPolicyOnDelegate() {
     assertThatCode(
             () ->
                 RetryUtil.setRetryPolicyOnDelegate(

--- a/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/trace/src/test/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterTest.java
@@ -41,7 +41,7 @@ class OtlpGrpcSpanExporterTest extends AbstractGrpcTelemetryExporterTest<SpanDat
   }
 
   @Test
-  void testBuilderDelegate() {
+  void testSetRetryPolicyOnDelegate() {
     assertThatCode(
             () ->
                 RetryUtil.setRetryPolicyOnDelegate(

--- a/exporters/otlp/trace/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcNettySpanExporterTest.java
+++ b/exporters/otlp/trace/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcNettySpanExporterTest.java
@@ -42,7 +42,7 @@ class OtlpGrpcNettySpanExporterTest
   }
 
   @Test
-  void builderDelegate() {
+  void testSetRetryPolicyOnDelegate() {
     assertThatCode(
             () ->
                 RetryUtil.setRetryPolicyOnDelegate(

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/LogExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/LogExporterConfiguration.java
@@ -10,7 +10,6 @@ import static io.opentelemetry.sdk.autoconfigure.OtlpConfigUtil.PROTOCOL_GRPC;
 import static io.opentelemetry.sdk.autoconfigure.OtlpConfigUtil.PROTOCOL_HTTP_PROTOBUF;
 
 import io.opentelemetry.api.metrics.MeterProvider;
-import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
 import io.opentelemetry.exporter.internal.retry.RetryUtil;
 import io.opentelemetry.exporter.logging.SystemOutLogExporter;
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogExporter;
@@ -102,9 +101,7 @@ class LogExporterConfiguration {
           builder::setCompression,
           builder::setTimeout,
           builder::setTrustedCertificates,
-          retryPolicy ->
-              OkHttpExporterBuilder.getDelegateBuilder(OtlpHttpLogExporterBuilder.class, builder)
-                  .setRetryPolicy(retryPolicy));
+          retryPolicy -> RetryUtil.setRetryPolicyOnDelegate(builder, retryPolicy));
 
       builder.setMeterProvider(meterProvider);
 

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
@@ -9,7 +9,6 @@ import static io.opentelemetry.sdk.autoconfigure.OtlpConfigUtil.DATA_TYPE_METRIC
 import static io.opentelemetry.sdk.autoconfigure.OtlpConfigUtil.PROTOCOL_GRPC;
 import static io.opentelemetry.sdk.autoconfigure.OtlpConfigUtil.PROTOCOL_HTTP_PROTOBUF;
 
-import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
 import io.opentelemetry.exporter.internal.retry.RetryUtil;
 import io.opentelemetry.exporter.logging.LoggingMetricExporter;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
@@ -106,9 +105,7 @@ final class MetricExporterConfiguration {
           builder::setCompression,
           builder::setTimeout,
           builder::setTrustedCertificates,
-          retryPolicy ->
-              OkHttpExporterBuilder.getDelegateBuilder(OtlpHttpMetricExporterBuilder.class, builder)
-                  .setRetryPolicy(retryPolicy));
+          retryPolicy -> RetryUtil.setRetryPolicyOnDelegate(builder, retryPolicy));
       OtlpConfigUtil.configureOtlpAggregationTemporality(config, builder::setPreferredTemporality);
 
       exporter = builder.build();

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfiguration.java
@@ -11,7 +11,6 @@ import static io.opentelemetry.sdk.autoconfigure.OtlpConfigUtil.PROTOCOL_HTTP_PR
 import static java.util.stream.Collectors.toMap;
 
 import io.opentelemetry.api.metrics.MeterProvider;
-import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
 import io.opentelemetry.exporter.internal.retry.RetryUtil;
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter;
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporterBuilder;
@@ -128,9 +127,7 @@ final class SpanExporterConfiguration {
           builder::setCompression,
           builder::setTimeout,
           builder::setTrustedCertificates,
-          retryPolicy ->
-              OkHttpExporterBuilder.getDelegateBuilder(OtlpHttpSpanExporterBuilder.class, builder)
-                  .setRetryPolicy(retryPolicy));
+          retryPolicy -> RetryUtil.setRetryPolicyOnDelegate(builder, retryPolicy));
 
       builder.setMeterProvider(meterProvider);
 


### PR DESCRIPTION
There's some remnant inconsistency between how retry is configured for the otlp grpc and otlp http/protobuf exporters. This resolves the differences.