### PR TITLE
Retry on connection timeouts

### DIFF
--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/retry/RetryInterceptor.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/retry/RetryInterceptor.java
@@ -98,7 +98,11 @@ public final class RetryInterceptor implements Interceptor {
 
   // Visible for testing
   static boolean isRetryableException(IOException e) {
-    return e instanceof SocketTimeoutException;
+    if (!(e instanceof SocketTimeoutException)) {
+      return false;
+    }
+    String message = e.getMessage();
+    return message != null && message.toLowerCase().contains("connect timed out");
   }
 
   // Visible for testing

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/retry/RetryInterceptor.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/retry/RetryInterceptor.java
@@ -5,14 +5,11 @@
 
 package io.opentelemetry.exporter.internal.retry;
 
-import io.opentelemetry.sdk.internal.ThrottlingLogger;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import okhttp3.Interceptor;
 import okhttp3.Response;
 
@@ -24,9 +21,6 @@ import okhttp3.Response;
  */
 public final class RetryInterceptor implements Interceptor {
 
-  private static final Logger logger = Logger.getLogger(RetryInterceptor.class.getName());
-
-  private final ThrottlingLogger throttlingLogger = new ThrottlingLogger(logger);
   private final RetryPolicy retryPolicy;
   private final Function<Response, Boolean> isRetryable;
   private final Function<IOException, Boolean> isRetryableException;
@@ -86,14 +80,6 @@ public final class RetryInterceptor implements Interceptor {
       try {
         response = chain.proceed(chain.request());
       } catch (IOException e) {
-        throttlingLogger.log(
-            Level.FINE,
-            "Error executing "
-                + chain.request().method()
-                + " "
-                + chain.request().url()
-                + ": "
-                + e.getMessage());
         exception = e;
       }
       if (response != null && !Boolean.TRUE.equals(isRetryable.apply(response))) {

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/retry/RetryInterceptorTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/retry/RetryInterceptorTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -36,7 +37,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,20 +46,21 @@ class RetryInterceptorTest {
 
   @Mock private RetryInterceptor.Sleeper sleeper;
   @Mock private RetryInterceptor.BoundedLongGenerator random;
-  // Note: cannot replace this with lambda or method reference because we need to spy on it
-  @Spy
-  private Function<IOException, Boolean> isRetryableException =
-      new Function<IOException, Boolean>() {
-        @Override
-        public Boolean apply(IOException exception) {
-          return RetryInterceptor.isRetryableException(exception);
-        }
-      };
+  private Function<IOException, Boolean> isRetryableException;
 
   private OkHttpClient client;
 
   @BeforeEach
   void setUp() {
+    // Note: cannot replace this with lambda or method reference because we need to spy on it
+    isRetryableException =
+        spy(
+            new Function<IOException, Boolean>() {
+              @Override
+              public Boolean apply(IOException exception) {
+                return RetryInterceptor.isRetryableException(exception);
+              }
+            });
     RetryInterceptor retrier =
         new RetryInterceptor(
             RetryPolicy.builder()

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/retry/RetryInterceptorTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/retry/RetryInterceptorTest.java
@@ -182,7 +182,17 @@ class RetryInterceptorTest {
 
   @Test
   void isRetryableException() {
-    assertThat(RetryInterceptor.isRetryableException(new SocketTimeoutException("error"))).isTrue();
+    assertThat(
+            RetryInterceptor.isRetryableException(new SocketTimeoutException("Connect timed out")))
+        .isTrue();
+    assertThat(
+            RetryInterceptor.isRetryableException(new SocketTimeoutException("connect timed out")))
+        .isTrue();
+    assertThat(RetryInterceptor.isRetryableException(new SocketTimeoutException("Read timed out")))
+        .isFalse();
+    assertThat(RetryInterceptor.isRetryableException(new SocketTimeoutException("timeout")))
+        .isFalse();
+    assertThat(RetryInterceptor.isRetryableException(new SocketTimeoutException())).isFalse();
     assertThat(RetryInterceptor.isRetryableException(new IOException("error"))).isFalse();
   }
 

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/retry/RetryInterceptorTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/retry/RetryInterceptorTest.java
@@ -168,8 +168,8 @@ class RetryInterceptorTest {
 
     // Connecting to a non-routable IP address to trigger connection timeout
     assertThatThrownBy(
-        () ->
-            client.newCall(new Request.Builder().url("http://10.255.255.1").build()).execute())
+            () ->
+                client.newCall(new Request.Builder().url("http://10.255.255.1").build()).execute())
         .isInstanceOf(SocketTimeoutException.class)
         .matches(
             (Predicate<Throwable>)


### PR DESCRIPTION
Some New Relic folks using the retry feature let me know that `RetryInterceptor` doesn't retry on transient network errors like connection timeout. I took a look and confirmed that this is the case. 

Anytime we call `chain.proceed(chain.request())` without wrapping in a try / catch, connection errors can occur which bubble up without retry. This PR wraps treats all `IOExceptions` that occur during calls to `chain.proceed(chain.request())` as retryable. 

Note that there a variety of settings on `OkHttpClient.Builder` that can impact the conditions that cause `IOException` to be throw:
- [callTimeout](https://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.Builder.html#callTimeout-java.time.Duration-) - we set this today to 10s, and allow users to configure it. The total amount of time allotted to the entire call, including resolving DNS, connecting, writing, reading, and any redirects and retries.
- [connectTimeout](https://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.Builder.html#connectTimeout-java.time.Duration-) - this defaults to 10 seconds. This controls the time allotted to connect to a TCP socket to the host. With this PR, a violation of this would trigger a retry.
- [readTimeout](https://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.Builder.html#readTimeout-java.time.Duration-) - this defaults to 10 seconds. This controls the time allocated to the TCP socket connection and individual read IO operations. With this PR, a violation of this would trigger a retry.
- [writeTimeout](https://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.Builder.html#writeTimeout-java.time.Duration-) - this defaults to 10 seconds. This controls the time allocated to individual write IO operations. With this PR, a violation of this would trigger a retry.

**Update** - I've adjusted this PR to limit the scope to retrying when `IOException` is instance of `SocketTimeoutException`. Its hard to know the conditions which produce `IOException`, so I think better to narrow retrying to only the things we know should definitely be retried. 