### PR TITLE
Drop java convention for old proto module

### DIFF
--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -65,11 +65,6 @@ tasks {
         )
       }
 
-      // disable deprecation warnings for the protobuf module
-      if (project.name == "proto") {
-        compilerArgs.add("-Xlint:-deprecation")
-      }
-
       encoding = "UTF-8"
 
       if (name.contains("Test")) {


### PR DESCRIPTION
Found an old rule for the proto module, which was dropped.  