### PR TITLE
Deprecate SdkTracerProviderConfigurer

### DIFF
--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/traces/SdkTracerProviderConfigurer.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/traces/SdkTracerProviderConfigurer.java
@@ -5,15 +5,20 @@
 
 package io.opentelemetry.sdk.autoconfigure.spi.traces;
 
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import java.util.function.BiFunction;
 
 /**
  * A service provider interface (SPI) for performing additional programmatic configuration of a
  * {@link SdkTracerProviderBuilder} during initialization. When using auto-configuration, you should
  * prefer to use system properties or environment variables for configuration, but this may be
  * useful to register components that are not part of the SDK such as custom exporters.
+ *
+ * @deprecated Use {@link AutoConfigurationCustomizer#addTracerProviderCustomizer(BiFunction)}.
  */
+@Deprecated
 public interface SdkTracerProviderConfigurer {
   /** Configures the {@link SdkTracerProviderBuilder}. */
   void configure(SdkTracerProviderBuilder tracerProviderBuilder, ConfigProperties config);

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -15,7 +15,6 @@ import io.opentelemetry.sdk.OpenTelemetrySdkBuilder;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.logs.SdkLogEmitterProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
@@ -282,9 +281,12 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
     return AutoConfiguredOpenTelemetrySdk.create(openTelemetrySdk, resource, config);
   }
 
+  @SuppressWarnings("deprecation") // Support deprecated SdkTracerProviderConfigurer
   private void mergeSdkTracerProviderConfigurer() {
-    for (SdkTracerProviderConfigurer configurer :
-        ServiceLoader.load(SdkTracerProviderConfigurer.class, serviceClassLoader)) {
+    for (io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer configurer :
+        ServiceLoader.load(
+            io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer.class,
+            serviceClassLoader)) {
       addTracerProviderCustomizer(
           (builder, config) -> {
             configurer.configure(builder, config);

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/TestTracerProviderConfigurer.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/TestTracerProviderConfigurer.java
@@ -12,7 +12,7 @@ import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 
-@SuppressWarnings("deprecation") // Support testings of SdkTracerProviderConfigurer
+@SuppressWarnings("deprecation") // Support testing of SdkTracerProviderConfigurer
 public class TestTracerProviderConfigurer
     implements io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer {
   @Override

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/TestTracerProviderConfigurer.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/TestTracerProviderConfigurer.java
@@ -7,13 +7,14 @@ package io.opentelemetry.sdk.autoconfigure;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 
-public class TestTracerProviderConfigurer implements SdkTracerProviderConfigurer {
+@SuppressWarnings("deprecation") // Support testings of SdkTracerProviderConfigurer
+public class TestTracerProviderConfigurer
+    implements io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer {
   @Override
   public void configure(SdkTracerProviderBuilder tracerProvider, ConfigProperties config) {
     tracerProvider.addSpanProcessor(


### PR DESCRIPTION
`SdkTracerProviderConfigurer` has been superseded by `AutoConfigurationCustomizer#addTracerProviderCustomizer(BiFunction)`.