### PR TITLE
Add context wrapping methods for arguments found in CompletableFuture…

### DIFF
--- a/context/src/main/java/io/opentelemetry/context/Context.java
+++ b/context/src/main/java/io/opentelemetry/context/Context.java
@@ -27,6 +27,11 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 /**
@@ -244,5 +249,65 @@ public interface Context {
    */
   default ScheduledExecutorService wrap(ScheduledExecutorService executor) {
     return new ContextScheduledExecutorService(this, executor);
+  }
+
+  /**
+   * Returns a {@link Function} that makes this the {@linkplain Context#current() current context}
+   * and then invokes the input {@link Function}.
+   */
+  default <T, U> Function<T, U> wrapFunction(Function<T, U> function) {
+    return t -> {
+      try (Scope ignored = makeCurrent()) {
+        return function.apply(t);
+      }
+    };
+  }
+
+  /**
+   * Returns a {@link BiFunction} that makes this the {@linkplain Context#current() current context}
+   * and then invokes the input {@link BiFunction}.
+   */
+  default <T, U, V> BiFunction<T, U, V> wrapFunction(BiFunction<T, U, V> function) {
+    return (t, u) -> {
+      try (Scope ignored = makeCurrent()) {
+        return function.apply(t, u);
+      }
+    };
+  }
+
+  /**
+   * Returns a {@link Consumer} that makes this the {@linkplain Context#current() current context}
+   * and then invokes the input {@link Consumer}.
+   */
+  default <T> Consumer<T> wrapConsumer(Consumer<T> consumer) {
+    return t -> {
+      try (Scope ignored = makeCurrent()) {
+        consumer.accept(t);
+      }
+    };
+  }
+
+  /**
+   * Returns a {@link BiConsumer} that makes this the {@linkplain Context#current() current context}
+   * and then invokes the input {@link BiConsumer}.
+   */
+  default <T, U> BiConsumer<T, U> wrapConsumer(BiConsumer<T, U> consumer) {
+    return (t, u) -> {
+      try (Scope ignored = makeCurrent()) {
+        consumer.accept(t, u);
+      }
+    };
+  }
+
+  /**
+   * Returns a {@link Supplier} that makes this the {@linkplain Context#current() current context}
+   * and then invokes the input {@link Supplier}.
+   */
+  default <T> Supplier<T> wrapSupplier(Supplier<T> supplier) {
+    return () -> {
+      try (Scope ignored = makeCurrent()) {
+        return supplier.get();
+      }
+    };
   }
 }

--- a/context/src/strictContextEnabledTest/java/io/opentelemetry/context/StrictContextStorageTest.java
+++ b/context/src/strictContextEnabledTest/java/io/opentelemetry/context/StrictContextStorageTest.java
@@ -29,6 +29,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -38,6 +39,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.event.Level;
 import org.slf4j.event.LoggingEvent;
 
+@SuppressLogger(StrictContextStorage.class)
 @SuppressWarnings("MustBeClosedChecker")
 class StrictContextStorageTest {
 

--- a/docs/apidiffs/current_vs_latest/opentelemetry-context.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-context.txt
@@ -1,2 +1,8 @@
 Comparing source compatibility of  against 
-No changes.
+***! MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.context.Context  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++! NEW METHOD: PUBLIC(+) java.util.function.Consumer wrapConsumer(java.util.function.Consumer)
+	+++! NEW METHOD: PUBLIC(+) java.util.function.BiConsumer wrapConsumer(java.util.function.BiConsumer)
+	+++! NEW METHOD: PUBLIC(+) java.util.function.Function wrapFunction(java.util.function.Function)
+	+++! NEW METHOD: PUBLIC(+) java.util.function.BiFunction wrapFunction(java.util.function.BiFunction)
+	+++! NEW METHOD: PUBLIC(+) java.util.function.Supplier wrapSupplier(java.util.function.Supplier)


### PR DESCRIPTION
… APIs.

Lately I get questions about propagating context when using `CompletableFuture` and have to give the unsatisfying answer that we don't currently have helpers for most of its methods. Given it's a common Java 8 API, we probably should.

Too bad we can't use `wrap` for all of them since it causes lambdas to resolve ambiguously.