### PR TITLE
Fix retry interceptor test flake

### DIFF
--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/retry/RetryInterceptorTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/retry/RetryInterceptorTest.java
@@ -74,10 +74,7 @@ class RetryInterceptorTest {
             isRetryableException,
             sleeper,
             random);
-    client =
-        new OkHttpClient.Builder()
-            .addInterceptor(retrier)
-            .build();
+    client = new OkHttpClient.Builder().addInterceptor(retrier).build();
   }
 
   @Test


### PR DESCRIPTION
There's been a number of test flakes in the `RetryInterceptorTest` since I introduced the change to retry on connect timeout. I believe the flakes are due to a very low connect timeout setting, which causes normal requests to occasionally timeout. 

I considered extending the connect timeout setting to something like 100ms, which would reduce the likelihood of the flake but may not eliminate it altogether since normal requests might take longer than 100ms to connect if the test environment is resource constrained. Instead, I opted to use a `OkHttpClient` with a short connect timeout configuration only for the connect timeout tests. The other tests get the default 10s connect timeout. 