### PR TITLE
Deprecate log name field

### DIFF
--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingLogExporterTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingLogExporterTest.java
@@ -36,6 +36,7 @@ class OtlpJsonLoggingLogExporterTest {
   private static final Resource RESOURCE =
       Resource.create(Attributes.builder().put("key", "value").build());
 
+  @SuppressWarnings("deprecation") // test deprecated setName method
   private static final LogData LOG1 =
       LogDataBuilder.create(RESOURCE, InstrumentationLibraryInfo.create("instrumentation", "1"))
           .setName("testLog1")
@@ -52,6 +53,7 @@ class OtlpJsonLoggingLogExporterTest {
                   TraceState.getDefault()))
           .build();
 
+  @SuppressWarnings("deprecation") // test deprecated setName method
   private static final LogData LOG2 =
       LogDataBuilder.create(RESOURCE, InstrumentationLibraryInfo.create("instrumentation2", "2"))
           .setName("testLog2")

--- a/exporters/otlp-http/logs/src/test/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogExporterTest.java
+++ b/exporters/otlp-http/logs/src/test/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogExporterTest.java
@@ -330,6 +330,7 @@ class OtlpHttpLogExporterTest {
     return HttpResponse.of(httpStatus, APPLICATION_PROTOBUF, message.toByteArray());
   }
 
+  @SuppressWarnings("deprecation") // test deprecated setName method
   private static LogData generateFakeLog() {
     return LogDataBuilder.create(
             Resource.getDefault(),

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/logs/LogMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/logs/LogMarshaler.java
@@ -36,6 +36,7 @@ final class LogMarshaler extends MarshalerWithSize {
   @Nullable private final String traceId;
   @Nullable private final String spanId;
 
+  @SuppressWarnings("deprecation") // name field to be removed
   static LogMarshaler create(io.opentelemetry.sdk.logs.data.LogData logData) {
     KeyValueMarshaler[] attributeMarshalers =
         KeyValueMarshaler.createRepeated(logData.getAttributes());

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/logs/LogsRequestMarshalerTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/logs/LogsRequestMarshalerTest.java
@@ -50,6 +50,7 @@ class LogsRequestMarshalerTest {
   private static final String BODY = "Hello world from this log...";
 
   @Test
+  @SuppressWarnings("deprecation") // test deprecated setName method
   void toProtoResourceLogs() {
     ResourceLogsMarshaler[] resourceLogsMarshalers =
         ResourceLogsMarshaler.create(
@@ -83,6 +84,7 @@ class LogsRequestMarshalerTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation") // test deprecated setName method
   void toProtoLogRecord() {
     LogRecord logRecord =
         parse(

--- a/exporters/otlp/logs/src/test/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogExporterTest.java
+++ b/exporters/otlp/logs/src/test/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogExporterTest.java
@@ -104,6 +104,7 @@ class OtlpGrpcLogExporterTest extends AbstractGrpcTelemetryExporterTest<LogData,
   }
 
   @Override
+  @SuppressWarnings("deprecation") // test deprecated setName method
   protected LogData generateFakeTelemetry() {
     return LogDataBuilder.create(
             Resource.create(Attributes.builder().put("testKey", "testValue").build()),

--- a/exporters/otlp/logs/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcNettyLogExporterTest.java
+++ b/exporters/otlp/logs/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcNettyLogExporterTest.java
@@ -105,6 +105,7 @@ class OtlpGrpcNettyLogExporterTest
   }
 
   @Override
+  @SuppressWarnings("deprecation") // test deprecated setName method
   protected LogData generateFakeTelemetry() {
     return LogDataBuilder.create(
             Resource.create(Attributes.builder().put("testKey", "testValue").build()),

--- a/exporters/otlp/logs/src/testGrpcNettyShaded/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcNettyShadedLogExporterTest.java
+++ b/exporters/otlp/logs/src/testGrpcNettyShaded/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcNettyShadedLogExporterTest.java
@@ -94,6 +94,7 @@ class OtlpGrpcNettyShadedLogExporterTest
   }
 
   @Override
+  @SuppressWarnings("deprecation") // test deprecated setName method
   protected LogData generateFakeTelemetry() {
     return LogDataBuilder.create(
             Resource.create(Attributes.builder().put("testKey", "testValue").build()),

--- a/exporters/otlp/logs/src/testGrpcOkhttp/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcNettyOkHttpLogExporterTest.java
+++ b/exporters/otlp/logs/src/testGrpcOkhttp/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcNettyOkHttpLogExporterTest.java
@@ -94,6 +94,7 @@ class OtlpGrpcNettyOkHttpLogExporterTest
   }
 
   @Override
+  @SuppressWarnings("deprecation") // test deprecated setName method
   protected LogData generateFakeTelemetry() {
     return LogDataBuilder.create(
             Resource.create(Attributes.builder().put("testKey", "testValue").build()),

--- a/integration-tests/otlp/src/main/java/io/opentelemetry/integrationtest/OtlpExporterIntegrationTest.java
+++ b/integration-tests/otlp/src/main/java/io/opentelemetry/integrationtest/OtlpExporterIntegrationTest.java
@@ -373,6 +373,7 @@ abstract class OtlpExporterIntegrationTest {
     testLogExporter(otlpHttpLogExporter);
   }
 
+  @SuppressWarnings("deprecation") // test deprecated setName method
   private static void testLogExporter(LogExporter logExporter) {
     LogData logData =
         LogDataBuilder.create(

--- a/sdk/logs-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LogDataAssert.java
+++ b/sdk/logs-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LogDataAssert.java
@@ -114,6 +114,7 @@ public class LogDataAssert extends AbstractAssert<LogDataAssert, LogData> {
   }
 
   /** Asserts the log has the given name. */
+  @Deprecated
   public LogDataAssert hasName(String name) {
     isNotNull();
     if (!name.equals(actual.getName())) {
@@ -149,7 +150,6 @@ public class LogDataAssert extends AbstractAssert<LogDataAssert, LogData> {
           actual.getAttributes(),
           attributes,
           "Expected log to have attributes <%s> but was <%s>",
-          actual.getName(),
           attributes,
           actual.getAttributes());
     }

--- a/sdk/logs-testing/src/test/java/io/opentelemetry/sdk/testing/assertj/LogAssertionsTest.java
+++ b/sdk/logs-testing/src/test/java/io/opentelemetry/sdk/testing/assertj/LogAssertionsTest.java
@@ -43,6 +43,7 @@ public class LogAssertionsTest {
           .put("coins", 0.01, 0.05, 0.1)
           .build();
 
+  @SuppressWarnings("deprecation") // test deprecated setName method
   private static final LogData LOG_DATA =
       LogDataBuilder.create(RESOURCE, INSTRUMENTATION_LIBRARY_INFO)
           .setEpoch(100, TimeUnit.NANOSECONDS)
@@ -57,6 +58,7 @@ public class LogAssertionsTest {
           .build();
 
   @Test
+  @SuppressWarnings("deprecation") // test deprecated hasName method
   void passing() {
     assertThat(LOG_DATA)
         .hasResource(RESOURCE)
@@ -113,6 +115,7 @@ public class LogAssertionsTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation") // test deprecated hasName method
   void failure() {
     assertThatThrownBy(() -> assertThat(LOG_DATA).hasResource(Resource.empty()));
     assertThatThrownBy(

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogBuilder.java
@@ -57,6 +57,7 @@ final class SdkLogBuilder implements LogBuilder {
   }
 
   @Override
+  @Deprecated
   public LogBuilder setName(String name) {
     logDataBuilder.setName(name);
     return this;

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/data/LogData.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/data/LogData.java
@@ -40,6 +40,7 @@ public interface LogData {
   String getSeverityText();
 
   /** Returns the name for this log, or null if unset. */
+  @Deprecated
   @Nullable
   String getName();
 

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/data/LogData.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/data/LogData.java
@@ -39,7 +39,11 @@ public interface LogData {
   @Nullable
   String getSeverityText();
 
-  /** Returns the name for this log, or null if unset. */
+  /**
+   * Returns the name for this log, or null if unset.
+   *
+   * @deprecated will be removed without replacement.
+   */
   @Deprecated
   @Nullable
   String getName();

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/data/LogDataBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/data/LogDataBuilder.java
@@ -86,6 +86,7 @@ public final class LogDataBuilder {
   }
 
   /** Set the name. */
+  @Deprecated
   public LogDataBuilder setName(String name) {
     this.name = name;
     return this;

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/data/LogDataBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/data/LogDataBuilder.java
@@ -85,7 +85,11 @@ public final class LogDataBuilder {
     return this;
   }
 
-  /** Set the name. */
+  /**
+   * Set the name.
+   *
+   * @deprecated will be removed without replacement.
+   */
   @Deprecated
   public LogDataBuilder setName(String name) {
     this.name = name;

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/data/LogDataImpl.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/data/LogDataImpl.java
@@ -14,7 +14,9 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @AutoValue
+@AutoValue.CopyAnnotations
 @Immutable
+@SuppressWarnings("deprecation") // name field to be removed
 abstract class LogDataImpl implements LogData {
 
   LogDataImpl() {}

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLogBuilderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLogBuilderTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 class SdkLogBuilderTest {
 
   @Test
+  @SuppressWarnings("deprecation") // test deprecated setName method
   void buildAndEmit() {
     Instant now = Instant.now();
     String name = "skippy";

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/util/TestUtil.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/util/TestUtil.java
@@ -22,7 +22,6 @@ public final class TestUtil {
         .setEpoch(System.currentTimeMillis(), TimeUnit.MILLISECONDS)
         .setSeverity(severity)
         .setSeverityText("really severe")
-        .setName("log1")
         .setBody(message)
         .setAttributes(Attributes.builder().put("animal", "cat").build())
         .build();


### PR DESCRIPTION
The log name has been removed from the [spec](https://github.com/open-telemetry/opentelemetry-specification/pull/2271) and is [being deprecated](https://github.com/open-telemetry/opentelemetry-proto/pull/357) from the proto. 