### PR TITLE
Do not register periodic metric reader when exporter is null

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
@@ -57,6 +57,11 @@ final class MetricExporterConfiguration {
         metricExporter = spiExporter;
     }
 
+    // exporter may be null in otlp case
+    if (metricExporter == null) {
+      return;
+    }
+
     metricExporter = metricExporterCustomizer.apply(metricExporter, config);
     sdkMeterProviderBuilder.registerMetricReader(
         configurePeriodicMetricReader(config, metricExporter));

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableMetricExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableMetricExporterTest.java
@@ -5,17 +5,27 @@
 
 package io.opentelemetry.sdk.autoconfigure;
 
+import static io.opentelemetry.sdk.autoconfigure.OtlpConfigUtil.PROTOCOL_HTTP_PROTOBUF;
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.opentelemetry.sdk.metrics.export.MetricReaderFactory;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Collections;
+import java.util.function.BiFunction;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
 public class ConfigurableMetricExporterTest {
@@ -60,5 +70,37 @@ public class ConfigurableMetricExporterTest {
                     (a, unused) -> a))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("catExporter");
+  }
+
+  @Test
+  void configureExporter_OtlpHttpExporterNotOnClasspath() {
+    // Use the OTLP http/protobuf exporter which is not on the classpath
+    ConfigProperties configProperties =
+        DefaultConfigProperties.createForTest(
+            ImmutableMap.of("otel.exporter.otlp.protocol", PROTOCOL_HTTP_PROTOBUF));
+    SdkMeterProviderBuilder meterProviderBuilder = SdkMeterProvider.builder();
+    BiFunction<? super MetricExporter, ConfigProperties, ? extends MetricExporter>
+        metricCustomizer =
+            spy(
+                new BiFunction<MetricExporter, ConfigProperties, MetricExporter>() {
+                  @Override
+                  public MetricExporter apply(
+                      MetricExporter metricExporter, ConfigProperties configProperties) {
+                    return metricExporter;
+                  }
+                });
+
+    MetricExporterConfiguration.configureExporter(
+        "otlp",
+        configProperties,
+        MetricExporterConfiguration.class.getClassLoader(),
+        meterProviderBuilder,
+        metricCustomizer);
+
+    // Should not call customizer or register a metric reader
+    verify(metricCustomizer, never()).apply(any(), any());
+    assertThat(meterProviderBuilder)
+        .extracting("metricReaders", as(InstanceOfAssertFactories.list(MetricReaderFactory.class)))
+        .hasSize(0);
   }
 }


### PR DESCRIPTION
Likely fixes #4164.

If a user configured OTLP metrics, but doesn't have the OTLP exporter on the classpath for the configured exporter, then a periodic metric reader will be registered with a `null` exporter, which causes errors. 