### PR TITLE
Experimental support for disabling resource keys

### DIFF
--- a/sdk-extensions/autoconfigure/README.md
+++ b/sdk-extensions/autoconfigure/README.md
@@ -161,10 +161,11 @@ Supported values are
 The [OpenTelemetry Resource](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/sdk.md)
 is a representation of the entity producing telemetry.
 
-| System property          | Environment variable     | Description                                                                                                |
-|--------------------------|--------------------------|------------------------------------------------------------------------------------------------------------|
-| otel.resource.attributes | OTEL_RESOURCE_ATTRIBUTES | Specify resource attributes in the following format: key1=val1,key2=val2,key3=val3                         |
-| otel.service.name        | OTEL_SERVICE_NAME        | Specify logical service name. Takes precedence over `service.name` defined with `otel.resource.attributes` |
+| System property                          | Environment variable                     | Description                                                                                                |
+|------------------------------------------|------------------------------------------|------------------------------------------------------------------------------------------------------------|
+| otel.resource.attributes                 | OTEL_RESOURCE_ATTRIBUTES                 | Specify resource attributes in the following format: key1=val1,key2=val2,key3=val3                         |
+| otel.service.name                        | OTEL_SERVICE_NAME                        | Specify logical service name. Takes precedence over `service.name` defined with `otel.resource.attributes` |
+| otel.experimental.disabled.resource.keys | OTEL_EXPERIMENTAL_DISABLED_RESOURCE_KEYS | Specify resource attribute keys that are filtered.                                                         |
 
 You almost always want to specify the [`service.name`](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/resource/semantic_conventions#service) for your application.
 It corresponds to how you describe the application, for example `authservice` could be an application that authenticates requests, and `cats` could be an application that returns information about [cats](https://en.wikipedia.org/wiki/Cat).

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
@@ -5,12 +5,15 @@
 
 package io.opentelemetry.sdk.autoconfigure;
 
+import static io.opentelemetry.sdk.autoconfigure.ResourceConfiguration.DISABLED_ATTRIBUTE_KEYS;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 
 import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.util.HashMap;
@@ -26,7 +29,8 @@ class ResourceConfigurationTest {
   void customConfigResource() {
     Map<String, String> props = new HashMap<>();
     props.put("otel.service.name", "test-service");
-    props.put("otel.resource.attributes", "food=cheesecake");
+    props.put("otel.resource.attributes", "food=cheesecake,drink=juice");
+    props.put("otel.experimental.disabled.resource.keys", "drink");
 
     assertThat(
             ResourceConfiguration.configureResource(
@@ -99,5 +103,34 @@ class ResourceConfigurationTest {
                 singletonMap(ResourceConfiguration.ATTRIBUTE_PROPERTY, "")));
 
     assertThat(attributes).isEmpty();
+  }
+
+  @Test
+  void filterAttributes() {
+    ConfigProperties configProperties =
+        DefaultConfigProperties.createForTest(ImmutableMap.of(DISABLED_ATTRIBUTE_KEYS, "foo,bar"));
+
+    Resource resourceNoSchema =
+        Resource.builder().put("foo", "val").put("bar", "val").put("baz", "val").build();
+    Resource resourceWithSchema =
+        resourceNoSchema.toBuilder().setSchemaUrl("http://example.com").build();
+
+    assertThat(ResourceConfiguration.filterAttributes(resourceNoSchema, configProperties))
+        .satisfies(
+            resource -> {
+              assertThat(resource.getSchemaUrl()).isNull();
+              assertThat(resource.getAttributes()).containsEntry("baz", "val");
+              assertThat(resource.getAttributes().get(AttributeKey.stringKey("foo"))).isNull();
+              assertThat(resource.getAttributes().get(AttributeKey.stringKey("bar"))).isNull();
+            });
+
+    assertThat(ResourceConfiguration.filterAttributes(resourceWithSchema, configProperties))
+        .satisfies(
+            resource -> {
+              assertThat(resource.getSchemaUrl()).isEqualTo("http://example.com");
+              assertThat(resource.getAttributes()).containsEntry("baz", "val");
+              assertThat(resource.getAttributes().get(AttributeKey.stringKey("foo"))).isNull();
+              assertThat(resource.getAttributes().get(AttributeKey.stringKey("bar"))).isNull();
+            });
   }
 }


### PR DESCRIPTION
Allow you to exclude resource attribute keys with `export OTEL_EXPERIMENTAL_DISABLED_RESOURCE_KEYS=foo,bar`.

This stems from conversations about filtering out `process.command_line` resource attributes, which are lengthy, and may contain sensitive information.

Its also possible to do accomplish something similar by using `otel.java.disabled.resource-providers` to disable the entire `ProcessResourceProvider`, but that results in other useful process resource attributes being filtered out.

Its also possible to split out a separate `ProcessCommandLineResourceProvider`, so the command line can be disabled on its own.

Its also possible to disable `process.command_line` in `ProcessResourceProvider` by default, and make it opt in through some env var / system property.

However, I think having a general mechanism for this is a nice tool because it allows users to be able to make fine-grained decisions about each resource attribute, weighing the cost from the additional bytes on the wire against the value it provides. 

I didn't find any conversation about this in the spec, but may have missed something. Its possible that this issue doesn't affect other language SDKs if they lack features to automatically detect resources (i.e. if the resource attributes are already opt in), but my hunch is that this would be a valuable feature to have general support.