### PR TITLE
Add ability to do loose attribute matching while checking all keys.

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
@@ -1,2 +1,51 @@
 Comparing source compatibility of  against 
-No changes.
++++  NEW CLASS: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.testing.assertj.AttributeAssertion  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.AttributeAssertion attribute(io.opentelemetry.api.common.AttributeKey, java.lang.Object)
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.AttributeAssertion satisfies(io.opentelemetry.api.common.AttributeKey, io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions$StringAssertConsumer)
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.AttributeAssertion satisfies(io.opentelemetry.api.common.AttributeKey, io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions$BooleanAssertConsumer)
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.AttributeAssertion satisfies(io.opentelemetry.api.common.AttributeKey, io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions$LongAssertConsumer)
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.AttributeAssertion satisfies(io.opentelemetry.api.common.AttributeKey, io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions$DoubleAssertConsumer)
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.AttributeAssertion satisfies(io.opentelemetry.api.common.AttributeKey, io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions$StringListAssertConsumer)
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.AttributeAssertion satisfies(io.opentelemetry.api.common.AttributeKey, io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions$BooleanListAssertConsumer)
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.AttributeAssertion satisfies(io.opentelemetry.api.common.AttributeKey, io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions$LongListAssertConsumer)
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.AttributeAssertion satisfies(io.opentelemetry.api.common.AttributeKey, io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions$DoubleListAssertConsumer)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions$BooleanAssertConsumer  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: java.util.function.Consumer
+	+++  NEW SUPERCLASS: java.lang.Object
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions$BooleanListAssertConsumer  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: java.util.function.Consumer
+	+++  NEW SUPERCLASS: java.lang.Object
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions$DoubleAssertConsumer  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: java.util.function.Consumer
+	+++  NEW SUPERCLASS: java.lang.Object
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions$DoubleListAssertConsumer  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: java.util.function.Consumer
+	+++  NEW SUPERCLASS: java.lang.Object
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions$LongAssertConsumer  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: java.util.function.Consumer
+	+++  NEW SUPERCLASS: java.lang.Object
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions$LongListAssertConsumer  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: java.util.function.Consumer
+	+++  NEW SUPERCLASS: java.lang.Object
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions$StringAssertConsumer  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: java.util.function.Consumer
+	+++  NEW SUPERCLASS: java.lang.Object
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions$StringListAssertConsumer  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: java.util.function.Consumer
+	+++  NEW SUPERCLASS: java.lang.Object
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.SpanDataAssert  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.SpanDataAssert hasAttributesSatisfyingExactly(io.opentelemetry.sdk.testing.assertj.AttributeAssertion[])
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.SpanDataAssert hasAttributesSatisfyingExactly(java.lang.Iterable)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
@@ -4,7 +4,7 @@ Comparing source compatibility of  against
 	+++  NEW SUPERCLASS: java.lang.Object
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.AttributeAssertion attribute(io.opentelemetry.api.common.AttributeKey, java.lang.Object)
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.AttributeAssertion equalTo(io.opentelemetry.api.common.AttributeKey, java.lang.Object)
 	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.AttributeAssertion satisfies(io.opentelemetry.api.common.AttributeKey, io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions$StringAssertConsumer)
 	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.AttributeAssertion satisfies(io.opentelemetry.api.common.AttributeKey, io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions$BooleanAssertConsumer)
 	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.AttributeAssertion satisfies(io.opentelemetry.api.common.AttributeKey, io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions$LongAssertConsumer)

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/AttributeAssertion.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/AttributeAssertion.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.testing.assertj;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.api.common.AttributeKey;
+import java.util.function.Consumer;
+import org.assertj.core.api.AbstractAssert;
+
+/** An assertion on an attribute key. */
+@AutoValue
+public abstract class AttributeAssertion {
+
+  // This method is not type-safe! But because the constructor is private, we know it will only be
+  // created through
+  // our factories, which are type-safe.
+  @SuppressWarnings("unchecked")
+  static AttributeAssertion create(
+      AttributeKey<?> key, Consumer<? extends AbstractAssert<?, ?>> assertion) {
+    return new AutoValue_AttributeAssertion(key, (Consumer<AbstractAssert<?, ?>>) assertion);
+  }
+
+  abstract AttributeKey<?> getKey();
+
+  abstract Consumer<AbstractAssert<?, ?>> getAssertion();
+
+  AttributeAssertion() {}
+}

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/AttributesAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/AttributesAssert.java
@@ -16,13 +16,14 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
+import javax.annotation.Nullable;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.error.ShouldContainKeys;
 
 /** Assertions for {@link Attributes}. */
 public final class AttributesAssert extends AbstractAssert<AttributesAssert, Attributes> {
 
-  AttributesAssert(Attributes actual) {
+  AttributesAssert(@Nullable Attributes actual) {
     super(actual, AttributesAssert.class);
   }
 

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/EventDataAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/EventDataAssert.java
@@ -12,11 +12,12 @@ import io.opentelemetry.sdk.trace.data.EventData;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import javax.annotation.Nullable;
 import org.assertj.core.api.AbstractAssert;
 
 /** Assertions for {@link EventData}. */
 public final class EventDataAssert extends AbstractAssert<EventDataAssert, EventData> {
-  EventDataAssert(EventData actual) {
+  EventDataAssert(@Nullable EventData actual) {
     super(actual, EventDataAssert.class);
   }
 

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertions.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertions.java
@@ -195,7 +195,7 @@ public final class OpenTelemetryAssertions extends Assertions {
    * Returns an {@link AttributeAssertion} that asserts the given {@code key} is present with the
    * given {@code value}.
    */
-  public static <T> AttributeAssertion attribute(AttributeKey<T> key, T value) {
+  public static <T> AttributeAssertion equalTo(AttributeKey<T> key, T value) {
     return AttributeAssertion.create(key, val -> val.isEqualTo(value));
   }
 

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertions.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertions.java
@@ -13,8 +13,14 @@ import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import org.assertj.core.api.AbstractBooleanAssert;
+import org.assertj.core.api.AbstractDoubleAssert;
+import org.assertj.core.api.AbstractLongAssert;
+import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ListAssert;
 
 /**
  * Entry point for assertion methods for OpenTelemetry types. To use type-specific assertions,
@@ -110,6 +116,107 @@ public final class OpenTelemetryAssertions extends Assertions {
         AttributeKey.doubleArrayKey(key),
         Arrays.stream(value).boxed().collect(Collectors.toList()));
   }
+
+  /**
+   * Returns an {@link AttributeAssertion} that asserts the given {@code key} is present with a
+   * value satisfying {@code assertion}.
+   */
+  public static AttributeAssertion satisfies(
+      AttributeKey<String> key, StringAssertConsumer assertion) {
+    return AttributeAssertion.create(key, assertion);
+  }
+
+  /**
+   * Returns an {@link AttributeAssertion} that asserts the given {@code key} is present with a
+   * value satisfying {@code assertion}.
+   */
+  public static AttributeAssertion satisfies(
+      AttributeKey<Boolean> key, BooleanAssertConsumer assertion) {
+    return AttributeAssertion.create(key, assertion);
+  }
+
+  /**
+   * Returns an {@link AttributeAssertion} that asserts the given {@code key} is present with a
+   * value satisfying {@code assertion}.
+   */
+  public static AttributeAssertion satisfies(AttributeKey<Long> key, LongAssertConsumer assertion) {
+    return AttributeAssertion.create(key, assertion);
+  }
+
+  /**
+   * Returns an {@link AttributeAssertion} that asserts the given {@code key} is present with a
+   * value satisfying {@code assertion}.
+   */
+  public static AttributeAssertion satisfies(
+      AttributeKey<Double> key, DoubleAssertConsumer assertion) {
+    return AttributeAssertion.create(key, assertion);
+  }
+
+  /**
+   * Returns an {@link AttributeAssertion} that asserts the given {@code key} is present with a
+   * value satisfying {@code assertion}.
+   */
+  // Will require a cast only if using a custom implementation of AttributeKey which is highly
+  // unusual usage.
+  @SuppressWarnings("FunctionalInterfaceClash")
+  public static AttributeAssertion satisfies(
+      AttributeKey<List<String>> key, StringListAssertConsumer assertion) {
+    return AttributeAssertion.create(key, assertion);
+  }
+
+  /**
+   * Returns an {@link AttributeAssertion} that asserts the given {@code key} is present with a
+   * value satisfying {@code assertion}.
+   */
+  public static AttributeAssertion satisfies(
+      AttributeKey<List<Boolean>> key, BooleanListAssertConsumer assertion) {
+    return AttributeAssertion.create(key, assertion);
+  }
+
+  /**
+   * Returns an {@link AttributeAssertion} that asserts the given {@code key} is present with a
+   * value satisfying {@code assertion}.
+   */
+  public static AttributeAssertion satisfies(
+      AttributeKey<List<Long>> key, LongListAssertConsumer assertion) {
+    return AttributeAssertion.create(key, assertion);
+  }
+
+  /**
+   * Returns an {@link AttributeAssertion} that asserts the given {@code key} is present with a
+   * value satisfying {@code assertion}.
+   */
+  public static AttributeAssertion satisfies(
+      AttributeKey<List<Double>> key, DoubleListAssertConsumer assertion) {
+    return AttributeAssertion.create(key, assertion);
+  }
+
+  /**
+   * Returns an {@link AttributeAssertion} that asserts the given {@code key} is present with the
+   * given {@code value}.
+   */
+  public static <T> AttributeAssertion attribute(AttributeKey<T> key, T value) {
+    return AttributeAssertion.create(key, val -> val.isEqualTo(value));
+  }
+
+  // Unique interfaces to prevent generic functional interface clash. These are not interesting at
+  // all but are required to be able to use the same method name in methods like satisfies above.
+
+  public interface StringAssertConsumer extends Consumer<AbstractStringAssert<?>> {}
+
+  public interface BooleanAssertConsumer extends Consumer<AbstractBooleanAssert<?>> {}
+
+  public interface LongAssertConsumer extends Consumer<AbstractLongAssert<?>> {}
+
+  public interface DoubleAssertConsumer extends Consumer<AbstractDoubleAssert<?>> {}
+
+  public interface StringListAssertConsumer extends Consumer<ListAssert<String>> {}
+
+  public interface BooleanListAssertConsumer extends Consumer<ListAssert<Boolean>> {}
+
+  public interface LongListAssertConsumer extends Consumer<ListAssert<Long>> {}
+
+  public interface DoubleListAssertConsumer extends Consumer<ListAssert<Double>> {}
 
   private static List<Boolean> toList(boolean... values) {
     Boolean[] boxed = new Boolean[values.length];

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertions.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertions.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.AbstractDoubleAssert;
 import org.assertj.core.api.AbstractLongAssert;
@@ -30,17 +31,17 @@ import org.assertj.core.api.ListAssert;
 public final class OpenTelemetryAssertions extends Assertions {
 
   /** Returns an assertion for {@link Attributes}. */
-  public static AttributesAssert assertThat(Attributes attributes) {
+  public static AttributesAssert assertThat(@Nullable Attributes attributes) {
     return new AttributesAssert(attributes);
   }
 
   /** Returns an assertion for {@link SpanDataAssert}. */
-  public static SpanDataAssert assertThat(SpanData spanData) {
+  public static SpanDataAssert assertThat(@Nullable SpanData spanData) {
     return new SpanDataAssert(spanData);
   }
 
   /** Returns an assertion for {@link EventDataAssert}. */
-  public static EventDataAssert assertThat(EventData eventData) {
+  public static EventDataAssert assertThat(@Nullable EventData eventData) {
     return new EventDataAssert(eventData);
   }
 

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertionsTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertionsTest.java
@@ -6,8 +6,8 @@
 package io.opentelemetry.sdk.testing.assertj;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.attribute;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.attributeEntry;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
@@ -152,14 +152,14 @@ class OpenTelemetryAssertionsTest {
             attributeEntry("scores", 0L, 1L),
             attributeEntry("coins", 0.01, 0.05, 0.1))
         .hasAttributesSatisfyingExactly(
-            attribute(BEAR, "mya"),
-            attribute(WARM, true),
-            attribute(TEMPERATURE, 30L),
-            attribute(LENGTH, 1.2),
-            attribute(COLORS, Arrays.asList("red", "blue")),
-            attribute(CONDITIONS, Arrays.asList(false, true)),
-            attribute(SCORES, Arrays.asList(0L, 1L)),
-            attribute(COINS, Arrays.asList(0.01, 0.05, 0.1)))
+            equalTo(BEAR, "mya"),
+            equalTo(WARM, true),
+            equalTo(TEMPERATURE, 30L),
+            equalTo(LENGTH, 1.2),
+            equalTo(COLORS, Arrays.asList("red", "blue")),
+            equalTo(CONDITIONS, Arrays.asList(false, true)),
+            equalTo(SCORES, Arrays.asList(0L, 1L)),
+            equalTo(COINS, Arrays.asList(0.01, 0.05, 0.1)))
         .hasAttributesSatisfyingExactly(
             satisfies(BEAR, val -> val.startsWith("mya")),
             satisfies(WARM, val -> val.isTrue()),
@@ -171,13 +171,13 @@ class OpenTelemetryAssertionsTest {
             satisfies(COINS, val -> val.containsExactly(0.01, 0.05, 0.1)))
         // Demonstrates common usage of many exact matches and one needing a loose one.
         .hasAttributesSatisfyingExactly(
-            attribute(BEAR, "mya"),
-            attribute(WARM, true),
-            attribute(TEMPERATURE, 30L),
-            attribute(COLORS, Arrays.asList("red", "blue")),
-            attribute(CONDITIONS, Arrays.asList(false, true)),
-            attribute(SCORES, Arrays.asList(0L, 1L)),
-            attribute(COINS, Arrays.asList(0.01, 0.05, 0.1)),
+            equalTo(BEAR, "mya"),
+            equalTo(WARM, true),
+            equalTo(TEMPERATURE, 30L),
+            equalTo(COLORS, Arrays.asList("red", "blue")),
+            equalTo(CONDITIONS, Arrays.asList(false, true)),
+            equalTo(SCORES, Arrays.asList(0L, 1L)),
+            equalTo(COINS, Arrays.asList(0.01, 0.05, 0.1)),
             satisfies(LENGTH, val -> val.isCloseTo(1, offset(0.3))))
         .hasAttributesSatisfying(
             attributes ->


### PR DESCRIPTION
Fixes #3993 

Played around a bit and came up with this which seems to have good UX. The goals are

1) Can define all assertions with lambdas
2) Can use same method name for all types
3) All entrypoints in one location (OpenTelemetryAssertions)
4) Can mix exact and loose assertions (lower priority)

Took a lot of API to achieve these, especially 2) but I guess we want to prioritize ease of writing assertions and this seems OK but open to any feedback to make it better.