### PR TITLE
Add Prometheus text format serializers.

### DIFF
--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/MetricAdapter.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/MetricAdapter.java
@@ -98,7 +98,7 @@ final class MetricAdapter {
     return Collector.Type.UNKNOWN;
   }
 
-  private static final Function<String, String> sanitizer = new LabelNameSanitizer();
+  static final Function<String, String> sanitizer = new LabelNameSanitizer();
 
   // Converts a list of points from MetricData to a list of Prometheus Samples.
   static List<Sample> toSamples(
@@ -277,7 +277,7 @@ final class MetricAdapter {
     return numPoints;
   }
 
-  private static Collection<? extends PointData> getPoints(MetricData metricData) {
+  static Collection<? extends PointData> getPoints(MetricData metricData) {
     switch (metricData.getType()) {
       case DOUBLE_GAUGE:
         return metricData.getDoubleGaugeData().getPoints();

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusType.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusType.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.prometheus;
+
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.DoubleSumData;
+import io.opentelemetry.sdk.metrics.data.LongSumData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+
+// Four types we use are same in prometheus and openmetrics format
+enum PrometheusType {
+  GAUGE("gauge"),
+  COUNTER("counter"),
+  SUMMARY("summary"),
+  HISTOGRAM("histogram");
+
+  private final String typeString;
+
+  PrometheusType(String typeString) {
+    this.typeString = typeString;
+  }
+
+  static PrometheusType forMetric(MetricData metric) {
+    switch (metric.getType()) {
+      case LONG_GAUGE:
+      case DOUBLE_GAUGE:
+        return GAUGE;
+      case LONG_SUM:
+        LongSumData longSumData = metric.getLongSumData();
+        if (longSumData.isMonotonic()
+            && longSumData.getAggregationTemporality() == AggregationTemporality.CUMULATIVE) {
+          return COUNTER;
+        }
+        return GAUGE;
+      case DOUBLE_SUM:
+        DoubleSumData doubleSumData = metric.getDoubleSumData();
+        if (doubleSumData.isMonotonic()
+            && doubleSumData.getAggregationTemporality() == AggregationTemporality.CUMULATIVE) {
+          return COUNTER;
+        }
+        return GAUGE;
+      case SUMMARY:
+        return SUMMARY;
+      case HISTOGRAM:
+      case EXPONENTIAL_HISTOGRAM:
+        return HISTOGRAM;
+    }
+    throw new IllegalArgumentException(
+        "Unsupported metric type, this generally indicates version misalignment "
+            + "among opentelemetry dependencies. Please make sure to use opentelemetry-bom.");
+  }
+
+  String getTypeString() {
+    return typeString;
+  }
+}

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Serializer.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Serializer.java
@@ -77,7 +77,7 @@ abstract class Serializer {
   }
 
   private void write(MetricData metric, Writer writer) throws IOException {
-    // TODO: Implement
+    // Not supported in specification yet.
     if (metric.getType() == MetricDataType.EXPONENTIAL_HISTOGRAM) {
       return;
     }

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Serializer.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Serializer.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Includes work from:
+
+/*
+ * Prometheus instrumentation library for JVM applications
+ * Copyright 2012-2015 The Prometheus Authors
+ *
+ * This product includes software developed at
+ * Boxever Ltd. (http://www.boxever.com/).
+ *
+ * This product includes software developed at
+ * SoundCloud Ltd. (http://soundcloud.com/).
+ *
+ * This product includes software developed as part of the
+ * Ocelli project by Netflix Inc. (https://github.com/Netflix/ocelli/).
+ */
+
+package io.opentelemetry.exporter.prometheus;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.data.DoubleHistogramPointData;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.DoubleSummaryPointData;
+import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.MetricDataType;
+import io.opentelemetry.sdk.metrics.data.PointData;
+import io.opentelemetry.sdk.metrics.data.ValueAtPercentile;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.regex.Pattern;
+
+/** Serializes metrics into Prometheus exposition formats. */
+// Adapted from
+// https://github.com/prometheus/client_java/blob/master/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
+abstract class Serializer {
+
+  private static final Pattern SANITIZE_PREFIX_PATTERN = Pattern.compile("^[^a-zA-Z_:]");
+  private static final Pattern SANITIZE_BODY_PATTERN = Pattern.compile("[^a-zA-Z0-9_:]");
+
+  abstract String headerName(String name, PrometheusType type);
+
+  abstract void writeHelp(Writer writer, String description) throws IOException;
+
+  abstract void writeTimestamp(Writer writer, long timestampNanos) throws IOException;
+
+  abstract void writeExemplar(
+      Writer writer, Collection<ExemplarData> exemplars, double minExemplar, double maxExemplar)
+      throws IOException;
+
+  abstract void writeEof(Writer writer) throws IOException;
+
+  final void write(Collection<MetricData> metrics, OutputStream output) throws IOException {
+    try (Writer writer =
+        new BufferedWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8))) {
+      for (MetricData metric : metrics) {
+        write(metric, writer);
+      }
+      writeEof(writer);
+    }
+  }
+
+  private void write(MetricData metric, Writer writer) throws IOException {
+    // TODO: Implement
+    if (metric.getType() == MetricDataType.EXPONENTIAL_HISTOGRAM) {
+      return;
+    }
+
+    PrometheusType type = PrometheusType.forMetric(metric);
+    String name = sanitizeMetricName(metric.getName());
+    String headerName = headerName(name, type);
+    if (type == PrometheusType.COUNTER) {
+      name = name + "_total";
+    }
+
+    writer.write("# TYPE ");
+    writer.write(headerName);
+    writer.write(' ');
+    writer.write(type.getTypeString());
+    writer.write('\n');
+
+    writer.write("# HELP ");
+    writer.write(headerName);
+    writer.write(' ');
+    writeHelp(writer, metric.getDescription());
+    writer.write('\n');
+
+    for (PointData point : MetricAdapter.getPoints(metric)) {
+      switch (metric.getType()) {
+        case DOUBLE_SUM:
+        case DOUBLE_GAUGE:
+          writePoint(
+              writer,
+              name,
+              ((DoublePointData) point).getValue(),
+              point.getAttributes(),
+              point.getEpochNanos());
+          break;
+        case LONG_SUM:
+        case LONG_GAUGE:
+          writePoint(
+              writer,
+              name,
+              ((LongPointData) point).getValue(),
+              point.getAttributes(),
+              point.getEpochNanos());
+          break;
+        case HISTOGRAM:
+          writeHistogram(writer, name, (DoubleHistogramPointData) point);
+          break;
+        case SUMMARY:
+          writeSummary(writer, name, (DoubleSummaryPointData) point);
+          break;
+        case EXPONENTIAL_HISTOGRAM:
+          throw new IllegalArgumentException("Can't happen");
+      }
+    }
+  }
+
+  private void writeHistogram(Writer writer, String name, DoubleHistogramPointData point)
+      throws IOException {
+    writePoint(
+        writer, name + "_count", point.getCount(), point.getAttributes(), point.getEpochNanos());
+    writePoint(writer, name + "_sum", point.getSum(), point.getAttributes(), point.getEpochNanos());
+
+    long cumulativeCount = 0;
+    List<Long> counts = point.getCounts();
+    for (int i = 0; i < counts.size(); i++) {
+      // This is the upper boundary (inclusive). I.e. all values should be < this value (LE -
+      // Less-then-or-Equal).
+      double boundary = point.getBucketUpperBound(i);
+
+      cumulativeCount += counts.get(i);
+      writePoint(
+          writer,
+          name + "_bucket",
+          cumulativeCount,
+          point.getAttributes(),
+          point.getEpochNanos(),
+          "le",
+          boundary,
+          point.getExemplars(),
+          point.getBucketLowerBound(i),
+          boundary);
+    }
+  }
+
+  private void writeSummary(Writer writer, String name, DoubleSummaryPointData point)
+      throws IOException {
+    writePoint(
+        writer, name + "_count", point.getCount(), point.getAttributes(), point.getEpochNanos());
+    writePoint(writer, name + "_sum", point.getSum(), point.getAttributes(), point.getEpochNanos());
+
+    List<ValueAtPercentile> valueAtPercentiles = point.getPercentileValues();
+    for (ValueAtPercentile valueAtPercentile : valueAtPercentiles) {
+      writePoint(
+          writer,
+          name,
+          valueAtPercentile.getValue(),
+          point.getAttributes(),
+          point.getEpochNanos(),
+          "quantile",
+          valueAtPercentile.getPercentile(),
+          Collections.emptyList(),
+          0,
+          0);
+    }
+  }
+
+  private void writePoint(
+      Writer writer, String name, double value, Attributes attributes, long epochNanos)
+      throws IOException {
+    writer.write(name);
+    writeAttributes(writer, attributes);
+    writer.write(' ');
+    writeDouble(writer, value);
+    writer.write(' ');
+    writeTimestamp(writer, epochNanos);
+    writer.write('\n');
+  }
+
+  private void writePoint(
+      Writer writer,
+      String name,
+      double value,
+      Attributes attributes,
+      long epochNanos,
+      String additionalAttrKey,
+      double additionalAttrValue,
+      Collection<ExemplarData> exemplars,
+      double minExemplar,
+      double maxExemplar)
+      throws IOException {
+    writer.write(name);
+    writeAttributes(writer, attributes, additionalAttrKey, additionalAttrValue);
+    writer.write(' ');
+    writeDouble(writer, value);
+    writer.write(' ');
+    writeTimestamp(writer, epochNanos);
+    writeExemplar(writer, exemplars, minExemplar, maxExemplar);
+    writer.write('\n');
+  }
+
+  private static void writeAttributes(Writer writer, Attributes attributes) throws IOException {
+    if (attributes.isEmpty()) {
+      return;
+    }
+    writer.write('{');
+    writeAttributePairs(writer, attributes);
+    writer.write('}');
+  }
+
+  private static void writeAttributes(
+      Writer writer, Attributes attributes, String additionalAttrKey, double additionalAttrValue)
+      throws IOException {
+    writer.write('{');
+    writeAttributePairs(writer, attributes);
+    writer.write(',');
+    writer.write(additionalAttrKey);
+    writer.write("=\"");
+    writeDouble(writer, additionalAttrValue);
+    writer.write('"');
+    writer.write('}');
+  }
+
+  private static void writeAttributePairs(Writer writer, Attributes attributes) throws IOException {
+    try {
+      attributes.forEach(
+          new BiConsumer<AttributeKey<?>, Object>() {
+            private boolean wroteOne;
+
+            @Override
+            public void accept(AttributeKey<?> key, Object value) {
+              try {
+                if (wroteOne) {
+                  writer.write(',');
+                } else {
+                  wroteOne = true;
+                }
+                writer.write(MetricAdapter.sanitizer.apply(key.getKey()));
+                writer.write("=\"");
+                writeEscapedLabelValue(writer, value.toString());
+                writer.write('"');
+              } catch (IOException e) {
+                throw new UncheckedIOException(e);
+              }
+            }
+          });
+    } catch (UncheckedIOException e) {
+      throw e.getCause();
+    }
+  }
+
+  private static void writeDouble(Writer writer, double d) throws IOException {
+    if (d == Double.POSITIVE_INFINITY) {
+      writer.write("+Inf");
+    } else if (d == Double.NEGATIVE_INFINITY) {
+      writer.write("-Inf");
+    } else {
+      writer.write(Double.toString(d));
+    }
+  }
+
+  static void writeEscapedLabelValue(Writer writer, String s) throws IOException {
+    for (int i = 0; i < s.length(); i++) {
+      char c = s.charAt(i);
+      switch (c) {
+        case '\\':
+          writer.write("\\\\");
+          break;
+        case '\"':
+          writer.write("\\\"");
+          break;
+        case '\n':
+          writer.write("\\n");
+          break;
+        default:
+          writer.write(c);
+      }
+    }
+  }
+
+  // TODO(anuraaga): Can likely be optimized especially for the already-sanitized case.
+  private static String sanitizeMetricName(String metricName) {
+    return SANITIZE_BODY_PATTERN
+        .matcher(SANITIZE_PREFIX_PATTERN.matcher(metricName).replaceFirst("_"))
+        .replaceAll("_");
+  }
+
+  static class Prometheus004Serializer extends Serializer {
+
+    static final Serializer INSTANCE = new Prometheus004Serializer();
+
+    @Override
+    String headerName(String name, PrometheusType type) {
+      if (type == PrometheusType.COUNTER) {
+        return name + "_total";
+      }
+      return name;
+    }
+
+    @Override
+    void writeHelp(Writer writer, String help) throws IOException {
+      for (int i = 0; i < help.length(); i++) {
+        char c = help.charAt(i);
+        switch (c) {
+          case '\\':
+            writer.write("\\\\");
+            break;
+          case '\n':
+            writer.write("\\n");
+            break;
+          default:
+            writer.write(c);
+        }
+      }
+    }
+
+    @Override
+    void writeTimestamp(Writer writer, long timestampNanos) throws IOException {
+      writer.write(Long.toString(TimeUnit.NANOSECONDS.toMillis(timestampNanos)));
+    }
+
+    @Override
+    void writeExemplar(
+        Writer writer, Collection<ExemplarData> exemplars, double minExemplar, double maxExemplar) {
+      // Don't write exemplars
+    }
+
+    @Override
+    void writeEof(Writer writer) {
+      // Don't write EOF
+    }
+  }
+
+  static class OpenMetrics100Serializer extends Serializer {
+
+    static final Serializer INSTANCE = new OpenMetrics100Serializer();
+
+    @Override
+    String headerName(String name, PrometheusType type) {
+      return name;
+    }
+
+    @Override
+    void writeHelp(Writer writer, String description) throws IOException {
+      writeEscapedLabelValue(writer, description);
+    }
+
+    @Override
+    void writeTimestamp(Writer writer, long timestampNanos) throws IOException {
+      long timestampMillis = TimeUnit.NANOSECONDS.toMillis(timestampNanos);
+      writer.write(Long.toString(timestampMillis / 1000));
+      writer.write(".");
+      long millis = timestampMillis % 1000;
+      if (millis < 100) {
+        writer.write('0');
+      }
+      if (millis < 10) {
+        writer.write('0');
+      }
+      writer.write(Long.toString(millis));
+    }
+
+    @Override
+    void writeExemplar(
+        Writer writer, Collection<ExemplarData> exemplars, double minExemplar, double maxExemplar)
+        throws IOException {
+      for (ExemplarData exemplar : exemplars) {
+        double value = exemplar.getValueAsDouble();
+        if (value > minExemplar && value <= maxExemplar) {
+          writer.write(" # {");
+          String traceId = exemplar.getTraceId();
+          String spanId = exemplar.getSpanId();
+          if (traceId != null && spanId != null) {
+            // NB: Output sorted to match prometheus client library even though it shouldn't matter.
+            // OTel generally outputs in trace_id span_id order though so we can consider breaking
+            // from reference implementation if it makes sense.
+            writer.write("span_id=\"");
+            writer.write(spanId);
+            writer.write("\",trace_id=\"");
+            writer.write(traceId);
+            writer.write('"');
+          }
+          writer.write("} ");
+          writeDouble(writer, value);
+          writer.write(' ');
+          writeTimestamp(writer, exemplar.getEpochNanos());
+          // Only write one exemplar.
+          return;
+        }
+      }
+    }
+
+    @Override
+    void writeEof(Writer writer) throws IOException {
+      writer.write("# EOF\n");
+    }
+  }
+}

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/SerializerTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/SerializerTest.java
@@ -206,6 +206,31 @@ class SerializerTest {
                               /* spanId= */ "span_id",
                               /* traceId= */ "trace_id",
                               /* value= */ 4))))));
+  private static final MetricData DOUBLE_GAUGE_NO_ATTRIBUTES =
+      MetricData.createDoubleGauge(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          DoubleGaugeData.create(
+              Collections.singletonList(
+                  DoublePointData.create(
+                      1633947011000000000L, 1633950672000000000L, Attributes.empty(), 7))));
+  private static final MetricData DOUBLE_GAUGE_MULTIPLE_ATTRIBUTES =
+      MetricData.createDoubleGauge(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          DoubleGaugeData.create(
+              Collections.singletonList(
+                  DoublePointData.create(
+                      1633947011000000000L,
+                      1633950672000000000L,
+                      KP_VP_ATTR.toBuilder().put("animal", "bear").build(),
+                      8))));
 
   @Test
   void prometheus004() {
@@ -226,7 +251,9 @@ class SerializerTest {
                 DOUBLE_GAUGE,
                 LONG_GAUGE,
                 SUMMARY,
-                HISTOGRAM))
+                HISTOGRAM,
+                DOUBLE_GAUGE_NO_ATTRIBUTES,
+                DOUBLE_GAUGE_MULTIPLE_ATTRIBUTES))
         .isEqualTo(
             "# TYPE instrument_name_total counter\n"
                 + "# HELP instrument_name_total description\n"
@@ -268,7 +295,13 @@ class SerializerTest {
                 + "# HELP instrument_name description\n"
                 + "instrument_name_count{kp=\"vp\"} 2.0 1633950672000\n"
                 + "instrument_name_sum{kp=\"vp\"} 1.0 1633950672000\n"
-                + "instrument_name_bucket{kp=\"vp\",le=\"+Inf\"} 2.0 1633950672000\n");
+                + "instrument_name_bucket{kp=\"vp\",le=\"+Inf\"} 2.0 1633950672000\n"
+                + "# TYPE instrument_name gauge\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name 7.0 1633950672000\n"
+                + "# TYPE instrument_name gauge\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name{animal=\"bear\",kp=\"vp\"} 8.0 1633950672000\n");
   }
 
   @Test
@@ -286,7 +319,9 @@ class SerializerTest {
                 DOUBLE_GAUGE,
                 LONG_GAUGE,
                 SUMMARY,
-                HISTOGRAM))
+                HISTOGRAM,
+                DOUBLE_GAUGE_NO_ATTRIBUTES,
+                DOUBLE_GAUGE_MULTIPLE_ATTRIBUTES))
         .isEqualTo(
             "# TYPE instrument_name counter\n"
                 + "# HELP instrument_name description\n"
@@ -329,6 +364,12 @@ class SerializerTest {
                 + "instrument_name_count{kp=\"vp\"} 2.0 1633950672.000\n"
                 + "instrument_name_sum{kp=\"vp\"} 1.0 1633950672.000\n"
                 + "instrument_name_bucket{kp=\"vp\",le=\"+Inf\"} 2.0 1633950672.000 # {span_id=\"span_id\",trace_id=\"trace_id\"} 4.0 0.001\n"
+                + "# TYPE instrument_name gauge\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name 7.0 1633950672.000\n"
+                + "# TYPE instrument_name gauge\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name{animal=\"bear\",kp=\"vp\"} 8.0 1633950672.000\n"
                 + "# EOF\n");
   }
 

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/SerializerTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/SerializerTest.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.prometheus;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.DoubleGaugeData;
+import io.opentelemetry.sdk.metrics.data.DoubleHistogramData;
+import io.opentelemetry.sdk.metrics.data.DoubleHistogramPointData;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.DoubleSumData;
+import io.opentelemetry.sdk.metrics.data.DoubleSummaryData;
+import io.opentelemetry.sdk.metrics.data.DoubleSummaryPointData;
+import io.opentelemetry.sdk.metrics.data.LongExemplarData;
+import io.opentelemetry.sdk.metrics.data.LongGaugeData;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.LongSumData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.ValueAtPercentile;
+import io.opentelemetry.sdk.resources.Resource;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class SerializerTest {
+
+  private static final Attributes KP_VP_ATTR = Attributes.of(stringKey("kp"), "vp");
+
+  private static final MetricData MONOTONIC_CUMULATIVE_DOUBLE_SUM =
+      MetricData.createDoubleSum(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          DoubleSumData.create(
+              /* isMonotonic= */ true,
+              AggregationTemporality.CUMULATIVE,
+              Collections.singletonList(
+                  DoublePointData.create(
+                      1633947011000000000L, 1633950672000000000L, KP_VP_ATTR, 5))));
+  private static final MetricData NON_MONOTONIC_CUMULATIVE_DOUBLE_SUM =
+      MetricData.createDoubleSum(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          DoubleSumData.create(
+              /* isMonotonic= */ false,
+              AggregationTemporality.CUMULATIVE,
+              Collections.singletonList(
+                  DoublePointData.create(
+                      1633947011000000000L, 1633950672000000000L, KP_VP_ATTR, 5))));
+  private static final MetricData MONOTONIC_DELTA_DOUBLE_SUM =
+      MetricData.createDoubleSum(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          DoubleSumData.create(
+              /* isMonotonic= */ true,
+              AggregationTemporality.DELTA,
+              Collections.singletonList(
+                  DoublePointData.create(
+                      1633947011000000000L, 1633950672000000000L, KP_VP_ATTR, 5))));
+  private static final MetricData NON_MONOTONIC_DELTA_DOUBLE_SUM =
+      MetricData.createDoubleSum(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          DoubleSumData.create(
+              /* isMonotonic= */ false,
+              AggregationTemporality.DELTA,
+              Collections.singletonList(
+                  DoublePointData.create(
+                      1633947011000000000L, 1633950672000000000L, KP_VP_ATTR, 5))));
+  private static final MetricData MONOTONIC_CUMULATIVE_LONG_SUM =
+      MetricData.createLongSum(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          LongSumData.create(
+              /* isMonotonic= */ true,
+              AggregationTemporality.CUMULATIVE,
+              Collections.singletonList(
+                  LongPointData.create(
+                      1633947011000000000L, 1633950672000000000L, KP_VP_ATTR, 5))));
+  private static final MetricData NON_MONOTONIC_CUMULATIVE_LONG_SUM =
+      MetricData.createLongSum(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          LongSumData.create(
+              /* isMonotonic= */ false,
+              AggregationTemporality.CUMULATIVE,
+              Collections.singletonList(
+                  LongPointData.create(
+                      1633947011000000000L, 1633950672000000000L, KP_VP_ATTR, 5))));
+  private static final MetricData MONOTONIC_DELTA_LONG_SUM =
+      MetricData.createLongSum(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          LongSumData.create(
+              /* isMonotonic= */ true,
+              AggregationTemporality.DELTA,
+              Collections.singletonList(
+                  LongPointData.create(
+                      1633947011000000000L, 1633950672000000000L, KP_VP_ATTR, 5))));
+  private static final MetricData NON_MONOTONIC_DELTA_LONG_SUM =
+      MetricData.createLongSum(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          LongSumData.create(
+              /* isMonotonic= */ false,
+              AggregationTemporality.DELTA,
+              Collections.singletonList(
+                  LongPointData.create(
+                      1633947011000000000L, 1633950672000000000L, KP_VP_ATTR, 5))));
+
+  private static final MetricData DOUBLE_GAUGE =
+      MetricData.createDoubleGauge(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          DoubleGaugeData.create(
+              Collections.singletonList(
+                  DoublePointData.create(
+                      1633947011000000000L, 1633950672000000000L, KP_VP_ATTR, 5))));
+  private static final MetricData LONG_GAUGE =
+      MetricData.createLongGauge(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          LongGaugeData.create(
+              Collections.singletonList(
+                  LongPointData.create(
+                      1633947011000000000L, 1633950672000000000L, KP_VP_ATTR, 5))));
+  private static final MetricData SUMMARY =
+      MetricData.createDoubleSummary(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          DoubleSummaryData.create(
+              Collections.singletonList(
+                  DoubleSummaryPointData.create(
+                      1633947011000000000L,
+                      1633950672000000000L,
+                      KP_VP_ATTR,
+                      5,
+                      7,
+                      Arrays.asList(
+                          ValueAtPercentile.create(0.9, 0.1),
+                          ValueAtPercentile.create(0.99, 0.3))))));
+  private static final MetricData HISTOGRAM =
+      MetricData.createDoubleHistogram(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationLibraryInfo.create("full", "version"),
+          "instrument.name",
+          "description",
+          "1",
+          DoubleHistogramData.create(
+              AggregationTemporality.DELTA,
+              Collections.singletonList(
+                  DoubleHistogramPointData.create(
+                      1633947011000000000L,
+                      1633950672000000000L,
+                      KP_VP_ATTR,
+                      1.0,
+                      Collections.emptyList(),
+                      Collections.singletonList(2L),
+                      Collections.singletonList(
+                          LongExemplarData.create(
+                              Attributes.empty(),
+                              TimeUnit.MILLISECONDS.toNanos(1L),
+                              /* spanId= */ "span_id",
+                              /* traceId= */ "trace_id",
+                              /* value= */ 4))))));
+
+  @Test
+  void prometheus004() {
+    // Same output as prometheus client library except for these changes which are compatible with
+    // Prometheus
+    // TYPE / HELP line order reversed
+    // Attributes do not end in trailing comma
+    assertThat(
+            serialize004(
+                MONOTONIC_CUMULATIVE_DOUBLE_SUM,
+                NON_MONOTONIC_CUMULATIVE_DOUBLE_SUM,
+                MONOTONIC_DELTA_DOUBLE_SUM,
+                NON_MONOTONIC_DELTA_DOUBLE_SUM,
+                MONOTONIC_CUMULATIVE_LONG_SUM,
+                NON_MONOTONIC_CUMULATIVE_LONG_SUM,
+                MONOTONIC_DELTA_LONG_SUM,
+                NON_MONOTONIC_DELTA_LONG_SUM,
+                DOUBLE_GAUGE,
+                LONG_GAUGE,
+                SUMMARY,
+                HISTOGRAM))
+        .isEqualTo(
+            "# TYPE instrument_name_total counter\n"
+                + "# HELP instrument_name_total description\n"
+                + "instrument_name_total{kp=\"vp\"} 5.0 1633950672000\n"
+                + "# TYPE instrument_name gauge\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name{kp=\"vp\"} 5.0 1633950672000\n"
+                + "# TYPE instrument_name gauge\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name{kp=\"vp\"} 5.0 1633950672000\n"
+                + "# TYPE instrument_name gauge\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name{kp=\"vp\"} 5.0 1633950672000\n"
+                + "# TYPE instrument_name_total counter\n"
+                + "# HELP instrument_name_total description\n"
+                + "instrument_name_total{kp=\"vp\"} 5.0 1633950672000\n"
+                + "# TYPE instrument_name gauge\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name{kp=\"vp\"} 5.0 1633950672000\n"
+                + "# TYPE instrument_name gauge\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name{kp=\"vp\"} 5.0 1633950672000\n"
+                + "# TYPE instrument_name gauge\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name{kp=\"vp\"} 5.0 1633950672000\n"
+                + "# TYPE instrument_name gauge\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name{kp=\"vp\"} 5.0 1633950672000\n"
+                + "# TYPE instrument_name gauge\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name{kp=\"vp\"} 5.0 1633950672000\n"
+                + "# TYPE instrument_name summary\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name_count{kp=\"vp\"} 5.0 1633950672000\n"
+                + "instrument_name_sum{kp=\"vp\"} 7.0 1633950672000\n"
+                + "instrument_name{kp=\"vp\",quantile=\"0.9\"} 0.1 1633950672000\n"
+                + "instrument_name{kp=\"vp\",quantile=\"0.99\"} 0.3 1633950672000\n"
+                + "# TYPE instrument_name histogram\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name_count{kp=\"vp\"} 2.0 1633950672000\n"
+                + "instrument_name_sum{kp=\"vp\"} 1.0 1633950672000\n"
+                + "instrument_name_bucket{kp=\"vp\",le=\"+Inf\"} 2.0 1633950672000\n");
+  }
+
+  @Test
+  void openMetrics() {
+    assertThat(
+            serializeOpenMetrics(
+                MONOTONIC_CUMULATIVE_DOUBLE_SUM,
+                NON_MONOTONIC_CUMULATIVE_DOUBLE_SUM,
+                MONOTONIC_DELTA_DOUBLE_SUM,
+                NON_MONOTONIC_DELTA_DOUBLE_SUM,
+                MONOTONIC_CUMULATIVE_LONG_SUM,
+                NON_MONOTONIC_CUMULATIVE_LONG_SUM,
+                MONOTONIC_DELTA_LONG_SUM,
+                NON_MONOTONIC_DELTA_LONG_SUM,
+                DOUBLE_GAUGE,
+                LONG_GAUGE,
+                SUMMARY,
+                HISTOGRAM))
+        .isEqualTo(
+            "# TYPE instrument_name counter\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name_total{kp=\"vp\"} 5.0 1633950672.000\n"
+                + "# TYPE instrument_name gauge\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name{kp=\"vp\"} 5.0 1633950672.000\n"
+                + "# TYPE instrument_name gauge\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name{kp=\"vp\"} 5.0 1633950672.000\n"
+                + "# TYPE instrument_name gauge\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name{kp=\"vp\"} 5.0 1633950672.000\n"
+                + "# TYPE instrument_name counter\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name_total{kp=\"vp\"} 5.0 1633950672.000\n"
+                + "# TYPE instrument_name gauge\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name{kp=\"vp\"} 5.0 1633950672.000\n"
+                + "# TYPE instrument_name gauge\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name{kp=\"vp\"} 5.0 1633950672.000\n"
+                + "# TYPE instrument_name gauge\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name{kp=\"vp\"} 5.0 1633950672.000\n"
+                + "# TYPE instrument_name gauge\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name{kp=\"vp\"} 5.0 1633950672.000\n"
+                + "# TYPE instrument_name gauge\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name{kp=\"vp\"} 5.0 1633950672.000\n"
+                + "# TYPE instrument_name summary\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name_count{kp=\"vp\"} 5.0 1633950672.000\n"
+                + "instrument_name_sum{kp=\"vp\"} 7.0 1633950672.000\n"
+                + "instrument_name{kp=\"vp\",quantile=\"0.9\"} 0.1 1633950672.000\n"
+                + "instrument_name{kp=\"vp\",quantile=\"0.99\"} 0.3 1633950672.000\n"
+                + "# TYPE instrument_name histogram\n"
+                + "# HELP instrument_name description\n"
+                + "instrument_name_count{kp=\"vp\"} 2.0 1633950672.000\n"
+                + "instrument_name_sum{kp=\"vp\"} 1.0 1633950672.000\n"
+                + "instrument_name_bucket{kp=\"vp\",le=\"+Inf\"} 2.0 1633950672.000 # {span_id=\"span_id\",trace_id=\"trace_id\"} 4.0 0.001\n"
+                + "# EOF\n");
+  }
+
+  private static String serialize004(MetricData... metrics) {
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try {
+      Serializer.Prometheus004Serializer.INSTANCE.write(Arrays.asList(metrics), bos);
+      return bos.toString("UTF-8");
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private static String serializeOpenMetrics(MetricData... metrics) {
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try {
+      Serializer.OpenMetrics100Serializer.INSTANCE.write(Arrays.asList(metrics), bos);
+      return bos.toString("UTF-8");
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}


### PR DESCRIPTION
With metrics nearing stability, I think coupling the exporter to the prometheus client library has some risk as it may not make it in time. It's nice to also get some performance by directly serializing given how huge they can be (in particular, lots of arrays allocated for histograms in the adapter code that are eliminated). Many Java apps have a strong correlation between full GC and Prometheus scrapes :) I will move the `Collector` integration into an alpha extension instead so it can be decoupled from a stable release.

This only adds serialization logic, it doesn't use it yet or remove a few smaller usages of the client library that are left which will come in followups. 

Maintenance-wise, given the above benefits, I think 414 LoC of the serializer vs 340 LoC for the MetricAdapter is not that much more. Code is not quite as simple but prometheus format is relatively straight forward so doesn't seem too bad.

The output makes sure to match the client library 100% for openmetrics. It has some small deviations for legacy prometheus format which are compatible with prometheus, presumably the client library didn't mess with that format to avoid breaking unit tests relying on the strings. 

