### PR TITLE
Deprecate PrometheusCollector

### DIFF
--- a/exporters/prometheus/src/integrationTest/java/io/opentelemetry/exporter/prometheus/AbstractPrometheusIntegrationTest.java
+++ b/exporters/prometheus/src/integrationTest/java/io/opentelemetry/exporter/prometheus/AbstractPrometheusIntegrationTest.java
@@ -146,6 +146,8 @@ abstract class AbstractPrometheusIntegrationTest {
   static class PrometheusCollectorIntegrationTest extends AbstractPrometheusIntegrationTest {
     private final HTTPServer server;
 
+    // Tests deprecated class
+    @SuppressWarnings("deprecation")
     PrometheusCollectorIntegrationTest() throws IOException {
       server = new HTTPServer(0);
       port = server.getPort();

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusCollector.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusCollector.java
@@ -22,7 +22,16 @@ import java.util.List;
  * A reader of OpenTelemetry metrics that exports into Prometheus as a Collector.
  *
  * <p>Usage: <code>sdkMeterProvider.registerMetricReader(PrometheusCollector.create());</code>
+ *
+ * @deprecated This class was intended to fill OpenTelemetry metrics into a Prometheus registry.
+ *     Instead, use {@link PrometheusHttpServer} to expose OpenTelemetry metrics as a Prometheus
+ *     HTTP endpoint. If you generate metrics with Micrometer in addition to OpenTelemetry, also use
+ *     <a
+ *     href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/micrometer/micrometer-1.5/library">
+ *     Micrometer OpenTelemetry Integration</a> to export Micrometer metrics together. If your use
+ *     case is not handled by these, please file an issue to let us know.
  */
+@Deprecated
 public final class PrometheusCollector extends Collector implements MetricReader {
   private final MetricProducer metricProducer;
   private volatile boolean registered = false;

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/PrometheusCollectorTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/PrometheusCollectorTest.java
@@ -35,6 +35,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
+// Tests deprecated class
+@SuppressWarnings("deprecation")
 class PrometheusCollectorTest {
   @Mock MetricProducer metricProducer;
   PrometheusCollector prometheusCollector;


### PR DESCRIPTION
I don't mind extracting this into an extension right away but wonder what people think of just deprecating for this release and see if we get feedback. Yes it's weird to deprecate prometheus with a reference to micrometer integration :) But I think in practice it's much more common to be using micrometer than the prometheus library directly so want to see if it's enough. For reference, unlike `setChannel` with the similar strategy, this module is still alpha.