### PR TITLE
Remove explicit okio dependency

### DIFF
--- a/exporters/otlp-http/logs/build.gradle.kts
+++ b/exporters/otlp-http/logs/build.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
   implementation(project(":exporters:otlp:common"))
 
   implementation("com.squareup.okhttp3:okhttp")
-  implementation("com.squareup.okio:okio")
 
   testImplementation(project(":sdk:testing"))
 

--- a/exporters/otlp-http/metrics/build.gradle.kts
+++ b/exporters/otlp-http/metrics/build.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
   implementation(project(":exporters:otlp:common"))
 
   implementation("com.squareup.okhttp3:okhttp")
-  implementation("com.squareup.okio:okio")
 
   testImplementation(project(":sdk:testing"))
 

--- a/exporters/otlp-http/trace/build.gradle.kts
+++ b/exporters/otlp-http/trace/build.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
   implementation(project(":exporters:otlp:common"))
 
   implementation("com.squareup.okhttp3:okhttp")
-  implementation("com.squareup.okio:okio")
 
   testImplementation(project(":sdk:testing"))
 


### PR DESCRIPTION
We are only interested in okio as it pertains to using okhttp, and since okhttp exposes okio as api dependency, it's perfectly reasonable for us to use the transitive dep to avoid pulling it up in the POM.

https://github.com/square/okhttp/blob/master/okhttp/build.gradle.kts#L66

Fixes #4186 (I guess)