### PR TITLE
Marshal trace state in OTLP exporter

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/trace/propagation/internal/W3CTraceContextEncoding.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/propagation/internal/W3CTraceContextEncoding.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.trace.propagation.internal;
+
+import static io.opentelemetry.api.internal.Utils.checkArgument;
+
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.api.trace.TraceStateBuilder;
+import java.util.regex.Pattern;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * Implementation of the {@code tracestate} header encoding and decoding as defined by the <a
+ * href="https://www.w3.org/TR/trace-context-1/#tracestate-header">W3C Trace Context</a>
+ * recommendation.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+@Immutable
+public final class W3CTraceContextEncoding {
+
+  private W3CTraceContextEncoding() {}
+
+  private static final int TRACESTATE_MAX_SIZE = 512;
+  private static final int TRACESTATE_MAX_MEMBERS = 32;
+  private static final char TRACESTATE_KEY_VALUE_DELIMITER = '=';
+  private static final char TRACESTATE_ENTRY_DELIMITER = ',';
+  private static final Pattern TRACESTATE_ENTRY_DELIMITER_SPLIT_PATTERN =
+      Pattern.compile("[ \t]*" + TRACESTATE_ENTRY_DELIMITER + "[ \t]*");
+
+  /**
+   * Decodes a trace state header into a {@link TraceState} object.
+   *
+   * @throws IllegalArgumentException if {@code traceStateHeader} does not comply with the
+   *     specification
+   */
+  public static TraceState decodeTraceState(String traceStateHeader) {
+    TraceStateBuilder traceStateBuilder = TraceState.builder();
+    String[] listMembers = TRACESTATE_ENTRY_DELIMITER_SPLIT_PATTERN.split(traceStateHeader);
+    checkArgument(
+        listMembers.length <= TRACESTATE_MAX_MEMBERS, "TraceState has too many elements.");
+    // Iterate in reverse order because when call builder set the elements is added in the
+    // front of the list.
+    for (int i = listMembers.length - 1; i >= 0; i--) {
+      String listMember = listMembers[i];
+      int index = listMember.indexOf(TRACESTATE_KEY_VALUE_DELIMITER);
+      checkArgument(index != -1, "Invalid TraceState list-member format.");
+      traceStateBuilder.put(listMember.substring(0, index), listMember.substring(index + 1));
+    }
+    TraceState traceState = traceStateBuilder.build();
+    if (traceState.size() != listMembers.length) {
+      // Validation failure, drop the tracestate
+      return TraceState.getDefault();
+    }
+    return traceState;
+  }
+
+  /** Return the trace state encoded as a string according to the W3C specification. */
+  public static String encodeTraceState(TraceState traceState) {
+    if (traceState.isEmpty()) {
+      return "";
+    }
+    StringBuilder builder = new StringBuilder(TRACESTATE_MAX_SIZE);
+    traceState.forEach(
+        (key, value) -> {
+          if (builder.length() != 0) {
+            builder.append(TRACESTATE_ENTRY_DELIMITER);
+          }
+          builder.append(key).append(TRACESTATE_KEY_VALUE_DELIMITER).append(value);
+        });
+    return builder.toString();
+  }
+}

--- a/api/all/src/main/java/io/opentelemetry/api/trace/propagation/internal/package-info.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/propagation/internal/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Interfaces and implementations that are internal to OpenTelemetry.
+ *
+ * <p>All the content under this package and its subpackages are considered not part of the public
+ * API, and must not be used by users of the OpenTelemetry library.
+ */
+@ParametersAreNonnullByDefault
+package io.opentelemetry.api.trace.propagation.internal;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanLinkMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanLinkMarshaler.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.exporter.internal.otlp.traces;
 
+import static io.opentelemetry.api.trace.propagation.internal.W3CTraceContextEncoding.encodeTraceState;
+
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
 import io.opentelemetry.exporter.internal.marshal.MarshalerWithSize;
 import io.opentelemetry.exporter.internal.marshal.Serializer;
@@ -12,12 +15,15 @@ import io.opentelemetry.exporter.internal.otlp.KeyValueMarshaler;
 import io.opentelemetry.proto.trace.v1.internal.Span;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 final class SpanLinkMarshaler extends MarshalerWithSize {
   private static final SpanLinkMarshaler[] EMPTY = new SpanLinkMarshaler[0];
+  private static final byte[] EMPTY_BYTES = new byte[0];
   private final String traceId;
   private final String spanId;
+  private final byte[] traceStateUtf8;
   private final KeyValueMarshaler[] attributeMarshalers;
   private final int droppedAttributesCount;
 
@@ -37,9 +43,15 @@ final class SpanLinkMarshaler extends MarshalerWithSize {
 
   // Visible for testing
   static SpanLinkMarshaler create(LinkData link) {
+    TraceState traceState = link.getSpanContext().getTraceState();
+    byte[] traceStateUtf8 =
+        traceState.isEmpty()
+            ? EMPTY_BYTES
+            : encodeTraceState(traceState).getBytes(StandardCharsets.UTF_8);
     return new SpanLinkMarshaler(
         link.getSpanContext().getTraceId(),
         link.getSpanContext().getSpanId(),
+        traceStateUtf8,
         KeyValueMarshaler.createRepeated(link.getAttributes()),
         link.getTotalAttributeCount() - link.getAttributes().size());
   }
@@ -47,11 +59,15 @@ final class SpanLinkMarshaler extends MarshalerWithSize {
   private SpanLinkMarshaler(
       String traceId,
       String spanId,
+      byte[] traceStateUtf8,
       KeyValueMarshaler[] attributeMarshalers,
       int droppedAttributesCount) {
-    super(calculateSize(traceId, spanId, attributeMarshalers, droppedAttributesCount));
+    super(
+        calculateSize(
+            traceId, spanId, traceStateUtf8, attributeMarshalers, droppedAttributesCount));
     this.traceId = traceId;
     this.spanId = spanId;
+    this.traceStateUtf8 = traceStateUtf8;
     this.attributeMarshalers = attributeMarshalers;
     this.droppedAttributesCount = droppedAttributesCount;
   }
@@ -60,7 +76,7 @@ final class SpanLinkMarshaler extends MarshalerWithSize {
   public void writeTo(Serializer output) throws IOException {
     output.serializeTraceId(Span.Link.TRACE_ID, traceId);
     output.serializeSpanId(Span.Link.SPAN_ID, spanId);
-    // TODO: Set TraceState;
+    output.serializeString(Span.Link.TRACE_STATE, traceStateUtf8);
     output.serializeRepeatedMessage(Span.Link.ATTRIBUTES, attributeMarshalers);
     output.serializeUInt32(Span.Link.DROPPED_ATTRIBUTES_COUNT, droppedAttributesCount);
   }
@@ -68,12 +84,13 @@ final class SpanLinkMarshaler extends MarshalerWithSize {
   private static int calculateSize(
       String traceId,
       String spanId,
+      byte[] traceStateUtf8,
       KeyValueMarshaler[] attributeMarshalers,
       int droppedAttributesCount) {
     int size = 0;
     size += MarshalerUtil.sizeTraceId(Span.Link.TRACE_ID, traceId);
     size += MarshalerUtil.sizeSpanId(Span.Link.SPAN_ID, spanId);
-    // TODO: Set TraceState;
+    size += MarshalerUtil.sizeBytes(Span.Link.TRACE_STATE, traceStateUtf8);
     size += MarshalerUtil.sizeRepeatedMessage(Span.Link.ATTRIBUTES, attributeMarshalers);
     size += MarshalerUtil.sizeUInt32(Span.Link.DROPPED_ATTRIBUTES_COUNT, droppedAttributesCount);
     return size;


### PR DESCRIPTION
Includes the trace state in the marshaled spans and span links, resolving the corresponding TODOs in the code.

Adds a static utility method to W3CTraceContextPropagator to serialize a `TraceState` to string (according to the W3C trace context recommendation.

Fixes: #4189