### PR TITLE
Add module-info to prometheus exporter

### DIFF
--- a/exporters/prometheus/src/module/java/io/opentelemetry/exporter/prometheus/HackForJpms.java
+++ b/exporters/prometheus/src/module/java/io/opentelemetry/exporter/prometheus/HackForJpms.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.prometheus;
+
+// Empty class to allow module-info to compile, not included in published JAR.
+class HackForJpms {}

--- a/exporters/prometheus/src/module/java/module-info.java
+++ b/exporters/prometheus/src/module/java/module-info.java
@@ -1,0 +1,7 @@
+@SuppressWarnings({"requires-automatic", "requires-transitive-automatic"})
+module io.opentelemetry.exporter.prometheus {
+  exports io.opentelemetry.exporter.prometheus;
+
+  requires transitive io.opentelemetry.sdk.metrics;
+  requires jdk.httpserver;
+}

--- a/exporters/prometheus/src/testJpms/java/io/opentelemetry/exporters/prometheus/test/JpmsTest.java
+++ b/exporters/prometheus/src/testJpms/java/io/opentelemetry/exporters/prometheus/test/JpmsTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporters.prometheus.test;
+
+import io.opentelemetry.exporter.prometheus.PrometheusHttpServer;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import org.junit.jupiter.api.Test;
+
+class JpmsTest {
+
+  @Test
+  void noLinkageErrors() {
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder()
+            .registerMetricReader(PrometheusHttpServer.builder().newMetricReaderFactory())
+            .build();
+    meterProvider.close();
+  }
+}

--- a/exporters/prometheus/src/testJpms/java/module-info.java
+++ b/exporters/prometheus/src/testJpms/java/module-info.java
@@ -1,0 +1,4 @@
+@SuppressWarnings({"requires-automatic", "requires-transitive-automatic"})
+open module io.opentelemetry.exporters.prometheus.test {
+  requires transitive io.opentelemetry.exporter.prometheus;
+}


### PR DESCRIPTION
Fixes #4192

With this adding module-info somewhere, it's probably best to go ahead and add it everywhere, will followup with that afterward. Currently it's only particularly important for prometheus and zpages which are using httpserver.

Tried using javamodularity plugin but don't think it works in toolchains mostly because of an old [TODO](https://github.com/java9-modularity/gradle-modules-plugin/blob/master/src/main/java/org/javamodularity/moduleplugin/extensions/DefaultModularityExtension.java#L74). It's approach of having two java compilation tasks output to the same directory also will probably break build caching. The alternative is a `HackForJpms.java` unfortunately.

When applying to all the projects, I will try out a DSL to define the module in the java file to let it autogenerate the hack to avoid exposing it.