### PR TITLE
Use crane to copy test docker images

### DIFF
--- a/.github/workflows/docker-test-containers.yml
+++ b/.github/workflows/docker-test-containers.yml
@@ -26,8 +26,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Pull and push
+      - name: Copy image
+        # Non-debug image doesn't seem to support reading the .docker creds.
         run: |
-          docker pull ${{ matrix.source }}
-          docker tag ${{ matrix.source }} ghcr.io/open-telemetry/opentelemetry-java/${{ matrix.target_image }}
-          docker push ghcr.io/open-telemetry/opentelemetry-java/${{ matrix.target_image }}
+          docker run --rm -v $HOME/.docker:/root/.docker gcr.io/go-containerregistry/crane:debug \
+          cp ${{ matrix.source }} ghcr.io/open-telemetry/opentelemetry-java/${{ matrix.target_image }}


### PR DESCRIPTION
`docker pull` then `push` causes only the current platform's image to be copied, missing multiarch, e.g. arm64. This isn't a huge deal but it's probably better to make sure the reimaging is multiplatform given it's relatively easy.

https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md