### PR TITLE
Make AbstractInstrumentBuilder private.

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilder.java
@@ -17,7 +17,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
 /** Helper to make implementing builders easier. */
-public abstract class AbstractInstrumentBuilder<BuilderT extends AbstractInstrumentBuilder<?>> {
+abstract class AbstractInstrumentBuilder<BuilderT extends AbstractInstrumentBuilder<?>> {
 
   private final MeterProviderSharedState meterProviderSharedState;
   private final MeterSharedState meterSharedState;


### PR DESCRIPTION
Looks like accidentally made public, since constructor is private there is almost no way a user could be using this so no need to deprecate. Though anyways this will probably be the release with many non-deprecatable changes to metrics SDK.