### PR TITLE
Make createAggregator non-public

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/AggregatorFactory.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/AggregatorFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.internal.aggregator;
+
+import io.opentelemetry.sdk.metrics.exemplar.ExemplarFilter;
+import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
+
+/**
+ * An internal interface for returning an Aggregator from an Aggregation.
+ *
+ * <p>This interface should be removed when adding support for custom aggregations to the metrics
+ * SDK.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public interface AggregatorFactory {
+  /**
+   * Returns a new {@link Aggregator}.
+   *
+   * @param instrumentDescriptor the descriptor of the {@code Instrument} that will record
+   *     measurements.
+   * @param exemplarFilter the filter on which measurements should turn into exemplars
+   * @return a new {@link Aggregator}. {@link Aggregator#drop()} indicates no measurements should be
+   *     recorded.
+   */
+  <T> Aggregator<T> createAggregator(
+      InstrumentDescriptor instrumentDescriptor, ExemplarFilter exemplarFilter);
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorage.java
@@ -17,6 +17,7 @@ import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
+import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.internal.aggregator.EmptyMetricData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
@@ -59,7 +60,8 @@ public final class AsynchronousMetricStorage<T> implements MetricStorage {
       Consumer<ObservableDoubleMeasurement> metricUpdater) {
     MetricDescriptor metricDescriptor = MetricDescriptor.create(view, instrument);
     Aggregator<T> aggregator =
-        view.getAggregation().createAggregator(instrument, ExemplarFilter.neverSample());
+        ((AggregatorFactory) view.getAggregation())
+            .createAggregator(instrument, ExemplarFilter.neverSample());
 
     AsyncAccumulator<T> measurementAccumulator = new AsyncAccumulator<>(instrument);
     if (Aggregator.drop() == aggregator) {
@@ -95,7 +97,8 @@ public final class AsynchronousMetricStorage<T> implements MetricStorage {
       Consumer<ObservableLongMeasurement> metricUpdater) {
     MetricDescriptor metricDescriptor = MetricDescriptor.create(view, instrument);
     Aggregator<T> aggregator =
-        view.getAggregation().createAggregator(instrument, ExemplarFilter.neverSample());
+        ((AggregatorFactory) view.getAggregation())
+            .createAggregator(instrument, ExemplarFilter.neverSample());
     AsyncAccumulator<T> measurementAccumulator = new AsyncAccumulator<>(instrument);
     if (Aggregator.drop() == aggregator) {
       return empty();

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorage.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.metrics.internal.state;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
+import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.metrics.view.View;
@@ -35,7 +36,8 @@ public interface SynchronousMetricStorage extends MetricStorage, WriteableMetric
       View view, InstrumentDescriptor instrumentDescriptor, ExemplarFilter exemplarFilter) {
     MetricDescriptor metricDescriptor = MetricDescriptor.create(view, instrumentDescriptor);
     Aggregator<T> aggregator =
-        view.getAggregation().createAggregator(instrumentDescriptor, exemplarFilter);
+        ((AggregatorFactory) view.getAggregation())
+            .createAggregator(instrumentDescriptor, exemplarFilter);
     // We won't be storing this metric.
     if (Aggregator.drop() == aggregator) {
       return empty();

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/Aggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/Aggregation.java
@@ -5,9 +5,6 @@
 
 package io.opentelemetry.sdk.metrics.view;
 
-import io.opentelemetry.sdk.metrics.exemplar.ExemplarFilter;
-import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
-import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import java.util.List;
 
 /**
@@ -17,18 +14,6 @@ import java.util.List;
  */
 public abstract class Aggregation {
   Aggregation() {}
-
-  /**
-   * Returns a new {@link Aggregator}.
-   *
-   * @param instrumentDescriptor the descriptor of the {@code Instrument} that will record
-   *     measurements.
-   * @param exemplarFilter the filter on which measurements should turn into exemplars
-   * @return a new {@link Aggregator}. {@link Aggregator#drop()} indicates no measurements should be
-   *     recorded.
-   */
-  public abstract <T> Aggregator<T> createAggregator(
-      InstrumentDescriptor instrumentDescriptor, ExemplarFilter exemplarFilter);
 
   /** The drop Aggregation will ignore/drop all Instrument Measurements. */
   public static Aggregation drop() {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/DefaultAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/DefaultAggregation.java
@@ -8,12 +8,13 @@ package io.opentelemetry.sdk.metrics.view;
 import io.opentelemetry.sdk.internal.ThrottlingLogger;
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
+import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /** Aggregation that selects the specified default based on instrument. */
-class DefaultAggregation extends Aggregation {
+final class DefaultAggregation extends Aggregation implements AggregatorFactory {
 
   static final Aggregation INSTANCE = new DefaultAggregation();
 
@@ -41,7 +42,8 @@ class DefaultAggregation extends Aggregation {
   @Override
   public <T> Aggregator<T> createAggregator(
       InstrumentDescriptor instrumentDescriptor, ExemplarFilter exemplarFilter) {
-    return resolve(instrumentDescriptor).createAggregator(instrumentDescriptor, exemplarFilter);
+    return ((AggregatorFactory) resolve(instrumentDescriptor))
+        .createAggregator(instrumentDescriptor, exemplarFilter);
   }
 
   @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/DropAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/DropAggregation.java
@@ -7,10 +7,11 @@ package io.opentelemetry.sdk.metrics.view;
 
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
+import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 
 /** Configuration representing no aggregation. */
-class DropAggregation extends Aggregation {
+final class DropAggregation extends Aggregation implements AggregatorFactory {
 
   static final Aggregation INSTANCE = new DropAggregation();
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/ExplicitBucketHistogramAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/ExplicitBucketHistogramAggregation.java
@@ -9,13 +9,14 @@ import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarReservoir;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
+import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.internal.aggregator.DoubleHistogramAggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.ExplicitBucketHistogramUtils;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import java.util.List;
 
 /** Explicit bucket histogram aggregation configuration. */
-class ExplicitBucketHistogramAggregation extends Aggregation {
+final class ExplicitBucketHistogramAggregation extends Aggregation implements AggregatorFactory {
 
   static final Aggregation DEFAULT =
       new ExplicitBucketHistogramAggregation(

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/LastValueAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/LastValueAggregation.java
@@ -8,12 +8,13 @@ package io.opentelemetry.sdk.metrics.view;
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarReservoir;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
+import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.internal.aggregator.DoubleLastValueAggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.LongLastValueAggregator;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 
 /** Last-value aggregation configuration. */
-class LastValueAggregation extends Aggregation {
+final class LastValueAggregation extends Aggregation implements AggregatorFactory {
 
   static final Aggregation INSTANCE = new LastValueAggregation();
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/SumAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/SumAggregation.java
@@ -10,13 +10,14 @@ import io.opentelemetry.sdk.internal.RandomSupplier;
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarReservoir;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
+import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.internal.aggregator.DoubleSumAggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.LongSumAggregator;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import java.util.function.Supplier;
 
 /** A sum aggregation configuration. */
-class SumAggregation extends Aggregation {
+final class SumAggregation extends Aggregation implements AggregatorFactory {
   static final SumAggregation DEFAULT = new SumAggregation();
 
   private SumAggregation() {}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/DeltaMetricStorageTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/DeltaMetricStorageTest.java
@@ -12,6 +12,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarFilter;
+import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.internal.aggregator.DoubleAccumulation;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.internal.export.CollectionHandle;
@@ -41,7 +42,8 @@ class DeltaMetricStorageTest {
     allCollectors.add(collector2);
     storage =
         new DeltaMetricStorage<>(
-            Aggregation.sum().createAggregator(DESCRIPTOR, ExemplarFilter.neverSample()),
+            ((AggregatorFactory) Aggregation.sum())
+                .createAggregator(DESCRIPTOR, ExemplarFilter.neverSample()),
             DESCRIPTOR);
   }
 

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorageTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorageTest.java
@@ -16,6 +16,7 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.export.MetricReader;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
+import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.internal.aggregator.EmptyMetricData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
@@ -45,7 +46,8 @@ public class SynchronousMetricStorageTest {
       MetricDescriptor.create("name", "description", "unit");
   private final TestClock testClock = TestClock.create();
   private final Aggregator<Long> aggregator =
-      Aggregation.lastValue().createAggregator(DESCRIPTOR, ExemplarFilter.neverSample());
+      ((AggregatorFactory) Aggregation.lastValue())
+          .createAggregator(DESCRIPTOR, ExemplarFilter.neverSample());
   private final AttributesProcessor attributesProcessor = AttributesProcessor.noop();
   private CollectionHandle collector;
   private Set<CollectionHandle> allCollectors;

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorageTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorageTest.java
@@ -16,6 +16,7 @@ import io.opentelemetry.sdk.metrics.data.DoublePointData;
 import io.opentelemetry.sdk.metrics.data.PointData;
 import io.opentelemetry.sdk.metrics.exemplar.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
+import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.internal.aggregator.DoubleAccumulation;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
@@ -43,10 +44,12 @@ class TemporalMetricStorageTest {
   private static final MetricDescriptor METRIC_DESCRIPTOR =
       MetricDescriptor.create("name", "description", "unit");
   private static final Aggregator<DoubleAccumulation> SUM =
-      Aggregation.sum().createAggregator(DESCRIPTOR, ExemplarFilter.neverSample());
+      ((AggregatorFactory) Aggregation.sum())
+          .createAggregator(DESCRIPTOR, ExemplarFilter.neverSample());
 
   private static final Aggregator<DoubleAccumulation> ASYNC_SUM =
-      Aggregation.sum().createAggregator(ASYNC_DESCRIPTOR, ExemplarFilter.neverSample());
+      ((AggregatorFactory) Aggregation.sum())
+          .createAggregator(ASYNC_DESCRIPTOR, ExemplarFilter.neverSample());
 
   private CollectionHandle collector1;
   private CollectionHandle collector2;


### PR DESCRIPTION
`Aggregator` is an internal type since we don't support custom aggregations yet, so we can't have a public API method returning it. This internal interface hack is probably the only solution but it should work well.