### PR TITLE
Fix slow ExponentialHistogram tests 

### DIFF
--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramAggregatorTest.java
@@ -151,6 +151,7 @@ class DoubleExponentialHistogramAggregatorTest {
     assertThat(bucketCounts.get(bucketCounts.size() - 1)).isEqualTo(1);
     assertThat(bucketCounts.stream().filter(i -> i == 0).count())
         .isEqualTo(bucketCounts.size() - 2);
+    assertThat(acc.getPositiveBuckets().getTotalCount()).isEqualTo(2);
 
     // With 320 buckets allowed, minimum scale is -3
     assertThat(acc.getScale()).isEqualTo(-3);
@@ -234,8 +235,8 @@ class DoubleExponentialHistogramAggregatorTest {
     // Note: This test relies on implementation details of ExponentialCounter, specifically it
     // assumes that an Array of all zeros is the same as an empty counter array for negative
     // buckets.
-    assertThat(aggregator.diff(previousAccumulation, nextAccumulation))
-        .isEqualTo(getTestAccumulation(exemplars, 0, 1));
+    ExponentialHistogramAccumulation diff = aggregator.diff(previousAccumulation, nextAccumulation);
+    assertThat(diff).isEqualTo(getTestAccumulation(exemplars, 0, 1));
   }
 
   @Test
@@ -340,6 +341,7 @@ class DoubleExponentialHistogramAggregatorTest {
     ExponentialHistogramAccumulation acc = handle.accumulateThenReset(Attributes.empty());
     assertThat(Objects.requireNonNull(acc).getScale()).isEqualTo(4);
     assertThat(acc.getPositiveBuckets().getBucketCounts().size()).isEqualTo(320);
+    assertThat(acc.getPositiveBuckets().getTotalCount()).isEqualTo(n);
   }
 
   @Test
@@ -361,6 +363,7 @@ class DoubleExponentialHistogramAggregatorTest {
     assertThat(acc.getSum()).isEqualTo(23.5);
     assertThat(buckets.getOffset()).isEqualTo(-1);
     assertThat(buckets.getBucketCounts()).isEqualTo(Arrays.asList(1L, 1L, 1L, 1L, 0L, 1L));
+    assertThat(buckets.getTotalCount()).isEqualTo(5);
   }
 
   @Test


### PR DESCRIPTION
Issue: https://github.com/open-telemetry/opentelemetry-java/issues/4201

The slow test is `diffAccumulation()` which was taking around 10 seconds on my machine. The problem is when the tests are comparing bucket counts between one empty and one non-empty bucket counts. The bucket set that is empty has `indexStart = Integer.MIN_VALUE` so comparing the buckets takes several seconds because it's iterating from such a low value. 

~~I've added the `isEmpty()` check to the beginning of the `sameBucketCounts()` method to fix this.~~

~~However, this brings a problem with `AdaptingCircularBufferArray`. In the case where an `AdaptingCircularBufferArray` has been `diff()`ed back down so it's empty, `isEmpty()` returns false because the index is no longer the null index. As a result I have added the O(maxSize) iteration into `isEmpty()` but I acknowledge it's less than ideal. I tried a few ways but I could never avoid adding an O(maxSize) check somewhere in `AdaptingCircularBufferArray`. I am kind of reluctant to slow down main code so test can be faster.~~

~~The loop I've added to `isEmpty()` returns within the first iteration in the vast majority of cases, because the lowest bucket will have non zero count almost always. So in reality it's probably negligible performance difference anyway.~~ 

@jsuereth I would appreciate your thoughts on this one :) 
