### PR TITLE
Cleanup ExemplarData

### DIFF
--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/metrics/MetricsRequestMarshalerTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/metrics/MetricsRequestMarshalerTest.java
@@ -18,6 +18,9 @@ import com.google.protobuf.Message;
 import com.google.protobuf.util.JsonFormat;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.internal.OtelEncodingUtils;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.proto.common.v1.AnyValue;
@@ -92,8 +95,11 @@ class MetricsRequestMarshalerTest {
                             LongExemplarData.create(
                                 Attributes.of(stringKey("test"), "value"),
                                 2,
-                                /*spanId=*/ "0000000000000002",
-                                /*traceId=*/ "00000000000000000000000000000001",
+                                SpanContext.create(
+                                    "00000000000000000000000000000001",
+                                    "0000000000000002",
+                                    TraceFlags.getDefault(),
+                                    TraceState.getDefault()),
                                 0))))))
         .containsExactly(
             NumberDataPoint.newBuilder()
@@ -131,8 +137,11 @@ class MetricsRequestMarshalerTest {
                             DoubleExemplarData.create(
                                 Attributes.of(stringKey("test"), "value"),
                                 2,
-                                /*spanId=*/ "0000000000000002",
-                                /*traceId=*/ "00000000000000000000000000000001",
+                                SpanContext.create(
+                                    "00000000000000000000000000000001",
+                                    "0000000000000002",
+                                    TraceFlags.getDefault(),
+                                    TraceState.getDefault()),
                                 0))))))
         .containsExactly(
             NumberDataPoint.newBuilder()
@@ -174,8 +183,11 @@ class MetricsRequestMarshalerTest {
                             LongExemplarData.create(
                                 Attributes.of(stringKey("test"), "value"),
                                 2,
-                                /*spanId=*/ "0000000000000002",
-                                /*traceId=*/ "00000000000000000000000000000001",
+                                SpanContext.create(
+                                    "00000000000000000000000000000001",
+                                    "0000000000000002",
+                                    TraceFlags.getDefault(),
+                                    TraceState.getDefault()),
                                 1))))))
         .containsExactly(
             NumberDataPoint.newBuilder()
@@ -342,8 +354,11 @@ class MetricsRequestMarshalerTest {
                             DoubleExemplarData.create(
                                 Attributes.of(stringKey("test"), "value"),
                                 2,
-                                /*spanId=*/ "0000000000000002",
-                                /*traceId=*/ "00000000000000000000000000000001",
+                                SpanContext.create(
+                                    "00000000000000000000000000000001",
+                                    "0000000000000002",
+                                    TraceFlags.getDefault(),
+                                    TraceState.getDefault()),
                                 1.5))))))
         .containsExactly(
             HistogramDataPoint.newBuilder()
@@ -399,8 +414,11 @@ class MetricsRequestMarshalerTest {
                             DoubleExemplarData.create(
                                 Attributes.of(stringKey("test"), "value"),
                                 2,
-                                /*spanId=*/ "0000000000000002",
-                                /*traceId=*/ "00000000000000000000000000000001",
+                                SpanContext.create(
+                                    "00000000000000000000000000000001",
+                                    "0000000000000002",
+                                    TraceFlags.getDefault(),
+                                    TraceState.getDefault()),
                                 1.5))))))
         .containsExactly(
             ExponentialHistogramDataPoint.newBuilder()

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/MetricAdapterTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/MetricAdapterTest.java
@@ -10,6 +10,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.DoubleGaugeData;
@@ -213,8 +216,11 @@ class MetricAdapterTest {
                           LongExemplarData.create(
                               Attributes.empty(),
                               TimeUnit.MILLISECONDS.toNanos(1L),
-                              /* spanId= */ "span_id",
-                              /* traceId= */ "trace_id",
+                              SpanContext.create(
+                                  "00000000000000000000000000000001",
+                                  "0000000000000002",
+                                  TraceFlags.getDefault(),
+                                  TraceState.getDefault()),
                               /* value= */ 4))))));
 
   @Test
@@ -544,14 +550,20 @@ class MetricAdapterTest {
                         LongExemplarData.create(
                             Attributes.empty(),
                             /*recordTime=*/ 0,
-                            "other_span_id",
-                            "other_trace_id",
+                            SpanContext.create(
+                                "00000000000000000000000000000004",
+                                "0000000000000003",
+                                TraceFlags.getDefault(),
+                                TraceState.getDefault()),
                             /*value=*/ 0),
                         LongExemplarData.create(
                             Attributes.empty(),
                             /*recordTime=*/ TimeUnit.MILLISECONDS.toNanos(2),
-                            "my_span_id",
-                            "my_trace_id",
+                            SpanContext.create(
+                                "00000000000000000000000000000001",
+                                "0000000000000002",
+                                TraceFlags.getDefault(),
+                                TraceState.getDefault()),
                             /*value=*/ 2)))));
     assertThat(result)
         .withRepresentation(new ExemplarFriendlyRepresentation())
@@ -575,14 +587,26 @@ class MetricAdapterTest {
                 ImmutableList.of("kp", "le"),
                 ImmutableList.of("vp", "1.0"),
                 4,
-                new Exemplar(0d, 0L, "trace_id", "other_trace_id", "span_id", "other_span_id"),
+                new Exemplar(
+                    0d,
+                    0L,
+                    "trace_id",
+                    "00000000000000000000000000000004",
+                    "span_id",
+                    "0000000000000003"),
                 1633943350000L),
             new Sample(
                 "full_name_bucket",
                 ImmutableList.of("kp", "le"),
                 ImmutableList.of("vp", "+Inf"),
                 13,
-                new Exemplar(2d, 2L, "trace_id", "my_trace_id", "span_id", "my_span_id"),
+                new Exemplar(
+                    2d,
+                    2L,
+                    "trace_id",
+                    "00000000000000000000000000000001",
+                    "span_id",
+                    "0000000000000002"),
                 1633943350000L));
   }
 
@@ -719,7 +743,7 @@ class MetricAdapterTest {
                 + "# HELP instrument_name description\n"
                 + "instrument_name_count{kp=\"vp\"} 2.0 1633950672.000\n"
                 + "instrument_name_sum{kp=\"vp\"} 1.0 1633950672.000\n"
-                + "instrument_name_bucket{kp=\"vp\",le=\"+Inf\"} 2.0 1633950672.000 # {span_id=\"span_id\",trace_id=\"trace_id\"} 4.0 0.001\n"
+                + "instrument_name_bucket{kp=\"vp\",le=\"+Inf\"} 2.0 1633950672.000 # {span_id=\"0000000000000002\",trace_id=\"00000000000000000000000000000001\"} 4.0 0.001\n"
                 + "# EOF\n");
   }
 

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/SerializerTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/SerializerTest.java
@@ -9,6 +9,9 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.DoubleGaugeData;
@@ -203,8 +206,11 @@ class SerializerTest {
                           LongExemplarData.create(
                               Attributes.empty(),
                               TimeUnit.MILLISECONDS.toNanos(1L),
-                              /* spanId= */ "span_id",
-                              /* traceId= */ "trace_id",
+                              SpanContext.create(
+                                  "00000000000000000000000000000001",
+                                  "0000000000000002",
+                                  TraceFlags.getDefault(),
+                                  TraceState.getDefault()),
                               /* value= */ 4))))));
   private static final MetricData DOUBLE_GAUGE_NO_ATTRIBUTES =
       MetricData.createDoubleGauge(
@@ -363,7 +369,7 @@ class SerializerTest {
                 + "# HELP instrument_name description\n"
                 + "instrument_name_count{kp=\"vp\"} 2.0 1633950672.000\n"
                 + "instrument_name_sum{kp=\"vp\"} 1.0 1633950672.000\n"
-                + "instrument_name_bucket{kp=\"vp\",le=\"+Inf\"} 2.0 1633950672.000 # {span_id=\"span_id\",trace_id=\"trace_id\"} 4.0 0.001\n"
+                + "instrument_name_bucket{kp=\"vp\",le=\"+Inf\"} 2.0 1633950672.000 # {span_id=\"0000000000000002\",trace_id=\"00000000000000000000000000000001\"} 4.0 0.001\n"
                 + "# TYPE instrument_name gauge\n"
                 + "# HELP instrument_name description\n"
                 + "instrument_name 7.0 1633950672.000\n"

--- a/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/internal/metrics/MetricAdapterTest.java
+++ b/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/internal/metrics/MetricAdapterTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.opencensusshim.internal.metrics;
 
 import static io.opentelemetry.sdk.testing.assertj.MetricAssertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opencensus.common.Timestamp;
 import io.opencensus.metrics.LabelKey;
@@ -22,6 +21,9 @@ import io.opencensus.metrics.export.TimeSeries;
 import io.opencensus.metrics.export.Value;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.ValueAtPercentile;
 import io.opentelemetry.sdk.resources.Resource;
@@ -193,7 +195,7 @@ class MetricAdapterTest {
     exemplarAttachements.put(
         "SpanContext",
         AttachmentValue.AttachmentValueString.create(
-            "SpanContext{traceId=TraceId{traceId=1234}, spanId=SpanId{spanId=5678}, others=stuff}"));
+            "SpanContext{traceId=TraceId{traceId=00000000000000000000000000000001}, spanId=SpanId{spanId=0000000000000002}, others=stuff}"));
     Metric censusMetric =
         Metric.createWithOneTimeSeries(
             MetricDescriptor.create(
@@ -245,13 +247,16 @@ class MetricAdapterTest {
                     .hasBucketCounts(2, 6, 2)
                     .hasExemplars(
                         DoubleExemplarData.create(
-                            Attributes.empty(),
-                            2000000,
-                            /* spanId= */ null,
-                            /* traceId= */ null,
-                            1.0),
+                            Attributes.empty(), 2000000, SpanContext.getInvalid(), 1.0),
                         DoubleExemplarData.create(
-                            Attributes.empty(), 1000000, "5678", "1234", 4.0)));
+                            Attributes.empty(),
+                            1000000,
+                            SpanContext.create(
+                                "00000000000000000000000000000001",
+                                "0000000000000002",
+                                TraceFlags.getDefault(),
+                                TraceState.getDefault()),
+                            4.0)));
   }
 
   @Test
@@ -306,7 +311,7 @@ class MetricAdapterTest {
     exemplarAttachements.put(
         "SpanContext",
         AttachmentValue.AttachmentValueString.create(
-            "SpanContext{traceId=TraceId{traceId=1234}, spanId=SpanId{spanId=5678}, others=stuff}"));
+            "SpanContext{traceId=TraceId{traceId=00000000000000000000000000000001}, spanId=SpanId{spanId=0000000000000002}, others=stuff}"));
     Metric censusMetric =
         Metric.createWithOneTimeSeries(
             MetricDescriptor.create(
@@ -357,12 +362,15 @@ class MetricAdapterTest {
                     .hasBucketCounts(2, 6, 2)
                     .hasExemplars(
                         DoubleExemplarData.create(
-                            Attributes.empty(),
-                            2000000,
-                            /* spanId= */ null,
-                            /* traceId= */ null,
-                            1.0),
+                            Attributes.empty(), 2000000, SpanContext.getInvalid(), 1.0),
                         DoubleExemplarData.create(
-                            Attributes.empty(), 1000000, "5678", "1234", 4.0)));
+                            Attributes.empty(),
+                            1000000,
+                            SpanContext.create(
+                                "00000000000000000000000000000001",
+                                "0000000000000002",
+                                TraceFlags.getDefault(),
+                                TraceState.getDefault()),
+                            4.0)));
   }
 }

--- a/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/ExemplarDataAssert.java
+++ b/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/ExemplarDataAssert.java
@@ -6,7 +6,9 @@
 package io.opentelemetry.sdk.testing.assertj;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.LongExemplarData;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
 
@@ -26,21 +28,25 @@ public class ExemplarDataAssert extends AbstractAssert<ExemplarDataAssert, Exemp
   /** Ensures the {@code spanId} field matches the expected value. */
   public ExemplarDataAssert hasSpanId(String expected) {
     isNotNull();
-    Assertions.assertThat(actual.getSpanId()).as("spanId").isEqualTo(expected);
+    Assertions.assertThat(actual.getSpanContext().getSpanId()).as("spanId").isEqualTo(expected);
     return this;
   }
 
   /** Ensures the {@code traceId} field matches the expected value. */
   public ExemplarDataAssert hasTraceId(String expected) {
     isNotNull();
-    Assertions.assertThat(actual.getTraceId()).as("traceId").isEqualTo(expected);
+    Assertions.assertThat(actual.getSpanContext().getTraceId()).as("traceId").isEqualTo(expected);
     return this;
   }
 
   /** Ensures the {@code value} field matches the expected value. */
   public ExemplarDataAssert hasValue(double expected) {
     isNotNull();
-    Assertions.assertThat(actual.getValueAsDouble()).as("value").isEqualTo(expected);
+    double value =
+        actual instanceof DoubleExemplarData
+            ? ((DoubleExemplarData) actual).getValue()
+            : ((LongExemplarData) actual).getValue();
+    Assertions.assertThat(value).as("value").isEqualTo(expected);
     return this;
   }
 

--- a/sdk/metrics-testing/src/test/java/io/opentelemetry/sdk/testing/assertj/MetricAssertionsTest.java
+++ b/sdk/metrics-testing/src/test/java/io/opentelemetry/sdk/testing/assertj/MetricAssertionsTest.java
@@ -10,6 +10,9 @@ import static io.opentelemetry.sdk.testing.assertj.MetricAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
@@ -134,7 +137,15 @@ public class MetricAssertionsTest {
               Collections.emptyList()));
 
   private static final DoubleExemplarData DOUBLE_EXEMPLAR =
-      DoubleExemplarData.create(Attributes.empty(), 0, "span", "trace", 1.0);
+      DoubleExemplarData.create(
+          Attributes.empty(),
+          0,
+          SpanContext.create(
+              "00000000000000000000000000000001",
+              "0000000000000002",
+              TraceFlags.getDefault(),
+              TraceState.getDefault()),
+          1.0);
 
   private static final DoublePointData DOUBLE_POINT_DATA =
       DoublePointData.create(1, 2, Attributes.empty(), 3.0, Collections.emptyList());
@@ -181,7 +192,15 @@ public class MetricAssertionsTest {
               Collections.emptyList()));
 
   private static final LongExemplarData LONG_EXEMPLAR =
-      LongExemplarData.create(Attributes.empty(), 0, "span", "trace", 1);
+      LongExemplarData.create(
+          Attributes.empty(),
+          0,
+          SpanContext.create(
+              "00000000000000000000000000000001",
+              "0000000000000002",
+              TraceFlags.getDefault(),
+              TraceState.getDefault()),
+          1);
 
   private static final LongPointData LONG_POINT_DATA =
       LongPointData.create(1, 2, Attributes.empty(), 3, Collections.emptyList());
@@ -346,7 +365,15 @@ public class MetricAssertionsTest {
             () ->
                 assertThat(DOUBLE_POINT_DATA)
                     .hasExemplars(
-                        DoubleExemplarData.create(Attributes.empty(), 0, "span", "trace", 1.0)))
+                        DoubleExemplarData.create(
+                            Attributes.empty(),
+                            0,
+                            SpanContext.create(
+                                "00000000000000000000000000000001",
+                                "0000000000000002",
+                                TraceFlags.getDefault(),
+                                TraceState.getDefault()),
+                            1.0)))
         .isInstanceOf(AssertionError.class);
   }
 
@@ -381,7 +408,15 @@ public class MetricAssertionsTest {
             () ->
                 assertThat(LONG_POINT_DATA)
                     .hasExemplars(
-                        LongExemplarData.create(Attributes.empty(), 0, "span", "trace", 1)))
+                        LongExemplarData.create(
+                            Attributes.empty(),
+                            0,
+                            SpanContext.create(
+                                "00000000000000000000000000000001",
+                                "0000000000000002",
+                                TraceFlags.getDefault(),
+                                TraceState.getDefault()),
+                            1)))
         .isInstanceOf(AssertionError.class);
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DoubleExemplarData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DoubleExemplarData.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.metrics.data;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.common.Attributes;
-import javax.annotation.Nullable;
+import io.opentelemetry.api.trace.SpanContext;
 import javax.annotation.concurrent.Immutable;
 
 /** An {@link ExemplarData} with {@code double} measurements. */
@@ -21,18 +21,13 @@ public abstract class DoubleExemplarData implements ExemplarData {
    * @param filteredAttributes The set of {@link Attributes} not already associated with the {@link
    *     PointData}.
    * @param recordTimeNanos The time when the sample qas recorded in nanoseconds.
-   * @param spanId (optional) The associated SpanId.
-   * @param traceId (optional) The associated TraceId.
+   * @param spanContext The associated span context.
    * @param value The value recorded.
    */
   public static DoubleExemplarData create(
-      Attributes filteredAttributes,
-      long recordTimeNanos,
-      @Nullable String spanId,
-      @Nullable String traceId,
-      double value) {
+      Attributes filteredAttributes, long recordTimeNanos, SpanContext spanContext, double value) {
     return new AutoValue_DoubleExemplarData(
-        filteredAttributes, recordTimeNanos, spanId, traceId, value);
+        filteredAttributes, recordTimeNanos, spanContext, value);
   }
 
   DoubleExemplarData() {}
@@ -41,6 +36,7 @@ public abstract class DoubleExemplarData implements ExemplarData {
   public abstract double getValue();
 
   @Override
+  @Deprecated
   public final double getValueAsDouble() {
     return getValue();
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/ExemplarData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/ExemplarData.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.metrics.data;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -28,26 +29,49 @@ public interface ExemplarData {
   long getEpochNanos();
 
   /**
+   * Returns the {@link SpanContext} associated with this exemplar. If the exemplar was not recorded
+   * inside a sampled trace, the {@link SpanContext} will be {@linkplain SpanContext#getInvalid()
+   * invalid}.
+   */
+  SpanContext getSpanContext();
+
+  /**
    * (Optional) Span ID of the exemplar trace.
    *
    * <p>Span ID may be {@code null} if the measurement is not recorded inside a trace or the trace
    * was not sampled.
+   *
+   * @deprecated Use {@link ExemplarData#getSpanContext()}.
    */
   @Nullable
-  String getSpanId();
+  @Deprecated
+  default String getSpanId() {
+    SpanContext spanContext = getSpanContext();
+    return spanContext != null ? spanContext.getSpanId() : null;
+  }
   /**
    * (Optional) Trace ID of the exemplar trace.
    *
    * <p>Trace ID may be {@code null} if the measurement is not recorded inside a trace or if the
    * trace is not sampled.
+   *
+   * @deprecated Use {@link ExemplarData#getSpanContext()}.
    */
   @Nullable
-  String getTraceId();
+  @Deprecated
+  default String getTraceId() {
+    SpanContext spanContext = getSpanContext();
+    return spanContext != null ? spanContext.getTraceId() : null;
+  }
 
   /**
    * Coerces this exemplar to a double value.
    *
    * <p>Note: This could create a loss of precision from {@code long} measurements.
+   *
+   * @deprecated Cast to {@link LongExemplarData} or {@link DoubleExemplarData} and call {@code
+   *     getValue()}.
    */
+  @Deprecated
   double getValueAsDouble();
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/LongExemplarData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/LongExemplarData.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.metrics.data;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
 import javax.annotation.concurrent.Immutable;
 
 /** An {@link ExemplarData} with {@code long} measurements. */
@@ -20,18 +21,12 @@ public abstract class LongExemplarData implements ExemplarData {
    * @param filteredAttributes The set of {@link Attributes} not already associated with the {@link
    *     PointData}.
    * @param recordTimeNanos The time when the sample qas recorded in nanoseconds.
-   * @param spanId (optional) The associated SpanId.
-   * @param traceId (optional) The associated TraceId.
+   * @param spanContext The associated span context.
    * @param value The value recorded.
    */
   public static LongExemplarData create(
-      Attributes filteredAttributes,
-      long recordTimeNanos,
-      String spanId,
-      String traceId,
-      long value) {
-    return new AutoValue_LongExemplarData(
-        filteredAttributes, recordTimeNanos, spanId, traceId, value);
+      Attributes filteredAttributes, long recordTimeNanos, SpanContext spanContext, long value) {
+    return new AutoValue_LongExemplarData(filteredAttributes, recordTimeNanos, spanContext, value);
   }
 
   LongExemplarData() {}
@@ -40,6 +35,7 @@ public abstract class LongExemplarData implements ExemplarData {
   public abstract long getValue();
 
   @Override
+  @Deprecated
   public final double getValueAsDouble() {
     return (double) getValue();
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/AbstractFixedSizeExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/exemplar/AbstractFixedSizeExemplarReservoir.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.metrics.exemplar;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
@@ -94,8 +95,7 @@ abstract class AbstractFixedSizeExemplarReservoir implements ExemplarReservoir {
   private class ReservoirCell {
     private double value;
     @Nullable private Attributes attributes;
-    @Nullable private String spanId;
-    @Nullable private String traceId;
+    private SpanContext spanContext = SpanContext.getInvalid();
     private long recordTime;
 
     synchronized void offerMeasurement(double value, Attributes attributes, Context context) {
@@ -109,8 +109,7 @@ abstract class AbstractFixedSizeExemplarReservoir implements ExemplarReservoir {
     private void updateFromContext(Context context) {
       Span current = Span.fromContext(context);
       if (current.getSpanContext().isValid()) {
-        this.spanId = current.getSpanContext().getSpanId();
-        this.traceId = current.getSpanContext().getTraceId();
+        this.spanContext = current.getSpanContext();
       }
     }
 
@@ -120,11 +119,10 @@ abstract class AbstractFixedSizeExemplarReservoir implements ExemplarReservoir {
       if (attributes != null) {
         ExemplarData result =
             DoubleExemplarData.create(
-                filtered(attributes, pointAttributes), recordTime, spanId, traceId, value);
+                filtered(attributes, pointAttributes), recordTime, spanContext, value);
         this.attributes = null;
         this.value = 0;
-        this.spanId = null;
-        this.traceId = null;
+        this.spanContext = SpanContext.getInvalid();
         this.recordTime = 0;
         return result;
       }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/AggregatorHandleTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/AggregatorHandleTest.java
@@ -9,6 +9,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.util.concurrent.AtomicDouble;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.ExemplarData;
@@ -127,7 +130,16 @@ class AggregatorHandleTest {
   void testGenerateExemplarsOnCollect() {
     TestAggregatorHandle testAggregator = new TestAggregatorHandle(reservoir);
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData result = DoubleExemplarData.create(attributes, 2L, "spanid", "traceid", 1);
+    ExemplarData result =
+        DoubleExemplarData.create(
+            attributes,
+            2L,
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()),
+            1);
     // We need to first record a value so that collect and reset does something.
     testAggregator.recordDouble(1.0, Attributes.empty(), Context.root());
     Mockito.when(reservoir.collectAndReset(attributes))

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramAggregatorTest.java
@@ -9,6 +9,9 @@ import static io.opentelemetry.sdk.testing.assertj.MetricAssertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
@@ -181,7 +184,16 @@ class DoubleExponentialHistogramAggregatorTest {
         new DoubleExponentialHistogramAggregator(() -> reservoir);
 
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar = DoubleExemplarData.create(attributes, 2L, "spanid", "traceid", 1);
+    ExemplarData exemplar =
+        DoubleExemplarData.create(
+            attributes,
+            2L,
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()),
+            1);
     List<ExemplarData> exemplars = Collections.singletonList(exemplar);
     Mockito.when(reservoir.collectAndReset(Attributes.empty())).thenReturn(exemplars);
 
@@ -219,11 +231,28 @@ class DoubleExponentialHistogramAggregatorTest {
   @Test
   void diffAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar = DoubleExemplarData.create(attributes, 2L, "spanid", "traceid", 1);
+    ExemplarData exemplar =
+        DoubleExemplarData.create(
+            attributes,
+            2L,
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()),
+            1);
     List<ExemplarData> exemplars = Collections.singletonList(exemplar);
     List<ExemplarData> previousExemplars =
         Collections.singletonList(
-            DoubleExemplarData.create(attributes, 1L, "spanId", "traceId", 2));
+            DoubleExemplarData.create(
+                attributes,
+                1L,
+                SpanContext.create(
+                    "00000000000000000000000000000001",
+                    "0000000000000002",
+                    TraceFlags.getDefault(),
+                    TraceState.getDefault()),
+                2));
 
     ExponentialHistogramAccumulation nextAccumulation =
         getTestAccumulation(exemplars, 0, 0, 1, 1, -1);
@@ -241,11 +270,28 @@ class DoubleExponentialHistogramAggregatorTest {
   @Test
   void diffDownScaledAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar = DoubleExemplarData.create(attributes, 2L, "spanid", "traceid", 1);
+    ExemplarData exemplar =
+        DoubleExemplarData.create(
+            attributes,
+            2L,
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()),
+            1);
     List<ExemplarData> exemplars = Collections.singletonList(exemplar);
     List<ExemplarData> previousExemplars =
         Collections.singletonList(
-            DoubleExemplarData.create(attributes, 1L, "spanId", "traceId", 2));
+            DoubleExemplarData.create(
+                attributes,
+                1L,
+                SpanContext.create(
+                    "00000000000000000000000000000001",
+                    "0000000000000002",
+                    TraceFlags.getDefault(),
+                    TraceState.getDefault()),
+                2));
 
     ExponentialHistogramAccumulation nextAccumulation =
         getTestAccumulation(exemplars, 1, 1, 100, -1, -100);
@@ -260,11 +306,28 @@ class DoubleExponentialHistogramAggregatorTest {
   @Test
   void testMergeAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar = DoubleExemplarData.create(attributes, 2L, "spanid", "traceid", 1);
+    ExemplarData exemplar =
+        DoubleExemplarData.create(
+            attributes,
+            2L,
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()),
+            1);
     List<ExemplarData> exemplars = Collections.singletonList(exemplar);
     List<ExemplarData> previousExemplars =
         Collections.singletonList(
-            DoubleExemplarData.create(attributes, 1L, "spanId", "traceId", 2));
+            DoubleExemplarData.create(
+                attributes,
+                1L,
+                SpanContext.create(
+                    "00000000000000000000000000000001",
+                    "0000000000000002",
+                    TraceFlags.getDefault(),
+                    TraceState.getDefault()),
+                2));
     ExponentialHistogramAccumulation previousAccumulation =
         getTestAccumulation(previousExemplars, 0, 4.1, 100, 100, 10000, 1000000);
     ExponentialHistogramAccumulation nextAccumulation =
@@ -366,7 +429,16 @@ class DoubleExponentialHistogramAggregatorTest {
   @Test
   void testToMetricData() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar = DoubleExemplarData.create(attributes, 2L, "spanid", "traceid", 1);
+    ExemplarData exemplar =
+        DoubleExemplarData.create(
+            attributes,
+            2L,
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()),
+            1);
     @SuppressWarnings("unchecked")
     Supplier<ExemplarReservoir> reservoirSupplier = Mockito.mock(Supplier.class);
     Mockito.when(reservoir.collectAndReset(Attributes.empty()))

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleHistogramAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleHistogramAggregatorTest.java
@@ -9,6 +9,9 @@ import static io.opentelemetry.sdk.testing.assertj.MetricAssertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
@@ -65,7 +68,16 @@ class DoubleHistogramAggregatorTest {
   @Test
   void testExemplarsInAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar = DoubleExemplarData.create(attributes, 2L, "spanid", "traceid", 1);
+    ExemplarData exemplar =
+        DoubleExemplarData.create(
+            attributes,
+            2L,
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()),
+            1);
     List<ExemplarData> exemplars = Collections.singletonList(exemplar);
     Mockito.when(reservoir.collectAndReset(Attributes.empty())).thenReturn(exemplars);
     DoubleHistogramAggregator aggregator =
@@ -103,11 +115,28 @@ class DoubleHistogramAggregatorTest {
   @Test
   void mergeAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar = DoubleExemplarData.create(attributes, 2L, "spanid", "traceid", 1);
+    ExemplarData exemplar =
+        DoubleExemplarData.create(
+            attributes,
+            2L,
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()),
+            1);
     List<ExemplarData> exemplars = Collections.singletonList(exemplar);
     List<ExemplarData> previousExemplars =
         Collections.singletonList(
-            DoubleExemplarData.create(attributes, 1L, "spanId", "traceId", 2));
+            DoubleExemplarData.create(
+                attributes,
+                1L,
+                SpanContext.create(
+                    "00000000000000000000000000000001",
+                    "0000000000000002",
+                    TraceFlags.getDefault(),
+                    TraceState.getDefault()),
+                2));
     HistogramAccumulation previousAccumulation =
         HistogramAccumulation.create(2, new long[] {1, 1, 0}, previousExemplars);
     HistogramAccumulation nextAccumulation =
@@ -120,11 +149,28 @@ class DoubleHistogramAggregatorTest {
   @Test
   void diffAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar = DoubleExemplarData.create(attributes, 2L, "spanid", "traceid", 1);
+    ExemplarData exemplar =
+        DoubleExemplarData.create(
+            attributes,
+            2L,
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()),
+            1);
     List<ExemplarData> exemplars = Collections.singletonList(exemplar);
     List<ExemplarData> previousExemplars =
         Collections.singletonList(
-            DoubleExemplarData.create(attributes, 1L, "spanId", "traceId", 2));
+            DoubleExemplarData.create(
+                attributes,
+                1L,
+                SpanContext.create(
+                    "00000000000000000000000000000001",
+                    "0000000000000002",
+                    TraceFlags.getDefault(),
+                    TraceState.getDefault()),
+                2));
     HistogramAccumulation previousAccumulation =
         HistogramAccumulation.create(2, new long[] {1, 1, 2}, previousExemplars);
     HistogramAccumulation nextAccumulation =
@@ -159,7 +205,16 @@ class DoubleHistogramAggregatorTest {
   @Test
   void toMetricDataWithExemplars() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar = DoubleExemplarData.create(attributes, 2L, "spanid", "traceid", 1);
+    ExemplarData exemplar =
+        DoubleExemplarData.create(
+            attributes,
+            2L,
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()),
+            1);
     HistogramAccumulation accumulation =
         HistogramAccumulation.create(
             2, new long[] {1, 0, 0, 0}, Collections.singletonList(exemplar));

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleLastValueAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleLastValueAggregatorTest.java
@@ -6,9 +6,11 @@
 package io.opentelemetry.sdk.metrics.internal.aggregator;
 
 import static io.opentelemetry.sdk.testing.assertj.MetricAssertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
@@ -63,11 +65,28 @@ class DoubleLastValueAggregatorTest {
   @Test
   void mergeAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar = DoubleExemplarData.create(attributes, 2L, "spanid", "traceid", 1);
+    ExemplarData exemplar =
+        DoubleExemplarData.create(
+            attributes,
+            2L,
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()),
+            1);
     List<ExemplarData> exemplars = Collections.singletonList(exemplar);
     List<ExemplarData> previousExemplars =
         Collections.singletonList(
-            DoubleExemplarData.create(attributes, 1L, "spanId", "traceId", 2));
+            DoubleExemplarData.create(
+                attributes,
+                1L,
+                SpanContext.create(
+                    "00000000000000000000000000000001",
+                    "0000000000000002",
+                    TraceFlags.getDefault(),
+                    TraceState.getDefault()),
+                2));
     DoubleAccumulation result =
         aggregator.merge(
             DoubleAccumulation.create(1, previousExemplars),
@@ -79,11 +98,28 @@ class DoubleLastValueAggregatorTest {
   @Test
   void diffAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar = DoubleExemplarData.create(attributes, 2L, "spanid", "traceid", 1);
+    ExemplarData exemplar =
+        DoubleExemplarData.create(
+            attributes,
+            2L,
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()),
+            1);
     List<ExemplarData> exemplars = Collections.singletonList(exemplar);
     List<ExemplarData> previousExemplars =
         Collections.singletonList(
-            DoubleExemplarData.create(attributes, 1L, "spanId", "traceId", 2));
+            DoubleExemplarData.create(
+                attributes,
+                1L,
+                SpanContext.create(
+                    "00000000000000000000000000000001",
+                    "0000000000000002",
+                    TraceFlags.getDefault(),
+                    TraceState.getDefault()),
+                2));
     DoubleAccumulation result =
         aggregator.diff(
             DoubleAccumulation.create(1, previousExemplars),

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleSumAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleSumAggregatorTest.java
@@ -8,6 +8,9 @@ package io.opentelemetry.sdk.metrics.internal.aggregator;
 import static io.opentelemetry.sdk.testing.assertj.MetricAssertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
@@ -97,7 +100,16 @@ class DoubleSumAggregatorTest {
   @Test
   void testExemplarsInAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar = DoubleExemplarData.create(attributes, 2L, "spanid", "traceid", 1);
+    ExemplarData exemplar =
+        DoubleExemplarData.create(
+            attributes,
+            2L,
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()),
+            1);
     List<ExemplarData> exemplars = Collections.singletonList(exemplar);
     Mockito.when(reservoir.collectAndReset(Attributes.empty())).thenReturn(exemplars);
     DoubleSumAggregator aggregator =
@@ -118,11 +130,28 @@ class DoubleSumAggregatorTest {
   @Test
   void mergeAndDiff() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar = DoubleExemplarData.create(attributes, 2L, "spanid", "traceid", 1);
+    ExemplarData exemplar =
+        DoubleExemplarData.create(
+            attributes,
+            2L,
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()),
+            1);
     List<ExemplarData> exemplars = Collections.singletonList(exemplar);
     List<ExemplarData> previousExemplars =
         Collections.singletonList(
-            DoubleExemplarData.create(attributes, 1L, "spanId", "traceId", 2));
+            DoubleExemplarData.create(
+                attributes,
+                1L,
+                SpanContext.create(
+                    "00000000000000000000000000000001",
+                    "0000000000000002",
+                    TraceFlags.getDefault(),
+                    TraceState.getDefault()),
+                2));
     for (InstrumentType instrumentType : InstrumentType.values()) {
       for (AggregationTemporality temporality : AggregationTemporality.values()) {
         DoubleSumAggregator aggregator =
@@ -191,7 +220,16 @@ class DoubleSumAggregatorTest {
   @Test
   void toMetricDataWithExemplars() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar = DoubleExemplarData.create(attributes, 2L, "spanid", "traceid", 1);
+    ExemplarData exemplar =
+        DoubleExemplarData.create(
+            attributes,
+            2L,
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()),
+            1);
     DoubleAccumulation accumulation =
         DoubleAccumulation.create(1, Collections.singletonList(exemplar));
     assertThat(

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongLastValueAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongLastValueAggregatorTest.java
@@ -8,6 +8,9 @@ package io.opentelemetry.sdk.metrics.internal.aggregator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.ExemplarData;
@@ -64,10 +67,28 @@ class LongLastValueAggregatorTest {
   @Test
   void mergeAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar = LongExemplarData.create(attributes, 2L, "spanid", "traceid", 1);
+    ExemplarData exemplar =
+        LongExemplarData.create(
+            attributes,
+            2L,
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()),
+            1);
     List<ExemplarData> exemplars = Collections.singletonList(exemplar);
     List<ExemplarData> previousExemplars =
-        Collections.singletonList(LongExemplarData.create(attributes, 1L, "spanId", "traceId", 2));
+        Collections.singletonList(
+            LongExemplarData.create(
+                attributes,
+                1L,
+                SpanContext.create(
+                    "00000000000000000000000000000001",
+                    "0000000000000002",
+                    TraceFlags.getDefault(),
+                    TraceState.getDefault()),
+                2));
     LongAccumulation result =
         aggregator.merge(
             LongAccumulation.create(1, previousExemplars), LongAccumulation.create(2, exemplars));

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongSumAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongSumAggregatorTest.java
@@ -6,9 +6,11 @@
 package io.opentelemetry.sdk.metrics.internal.aggregator;
 
 import static io.opentelemetry.sdk.testing.assertj.MetricAssertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
@@ -99,7 +101,16 @@ class LongSumAggregatorTest {
   @Test
   void testExemplarsInAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar = DoubleExemplarData.create(attributes, 2L, "spanid", "traceid", 1);
+    ExemplarData exemplar =
+        DoubleExemplarData.create(
+            attributes,
+            2L,
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()),
+            1);
     List<ExemplarData> exemplars = Collections.singletonList(exemplar);
     Mockito.when(reservoir.collectAndReset(Attributes.empty())).thenReturn(exemplars);
     LongSumAggregator aggregator =
@@ -120,7 +131,15 @@ class LongSumAggregatorTest {
   @Test
   void mergeAndDiff() {
     ExemplarData exemplar =
-        DoubleExemplarData.create(Attributes.empty(), 2L, "spanid", "traceid", 1);
+        DoubleExemplarData.create(
+            Attributes.empty(),
+            2L,
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()),
+            1);
     List<ExemplarData> exemplars = Collections.singletonList(exemplar);
     for (InstrumentType instrumentType : InstrumentType.values()) {
       for (AggregationTemporality temporality : AggregationTemporality.values()) {
@@ -187,7 +206,16 @@ class LongSumAggregatorTest {
   @Test
   void toMetricDataWithExemplars() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar = DoubleExemplarData.create(attributes, 2L, "spanid", "traceid", 1);
+    ExemplarData exemplar =
+        DoubleExemplarData.create(
+            attributes,
+            2L,
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()),
+            1);
     LongAccumulation accumulation = LongAccumulation.create(1, Collections.singletonList(exemplar));
     assertThat(
             aggregator.toMetricData(


### PR DESCRIPTION
I deprecated in this PR but maybe we'll just delete anyways as there will probably be some harder changes coming up. 

- Record SpanContext instead of span / trace ID. Throughout the SDK we conventionally use invalid SpanContext to indicate not traced, and valid one to indicate traced. It seems to work well here, eliminating Nullable, and notably the cross-nullable relationship where either both are null or both are filled.

- Remove getValueAsDouble. We don't have it on e.g. SumData so this doesn't feel symmetric. getValueAsDouble seems to be primarily useful in prometheus conversion but such a utility can just live there. (Another location was the assertion but that should possibly be double / long specific like our other assertions). An alternative is to remove LongExemplarData, we don't wire it up to anything currently and I wonder if there is any plan for wiring it. If not, then it'd be much simpler to have only one for double.