### PR TITLE
Instrumentation scope

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
@@ -106,44 +106,45 @@ public final class GlobalOpenTelemetry {
   /**
    * Gets or creates a named tracer instance from the globally registered {@link TracerProvider}.
    *
-   * <p>This is a shortcut method for {@code getTracerProvider().get(instrumentationName)}
+   * <p>This is a shortcut method for {@code getTracerProvider().get(instrumentationScopeName)}
    *
-   * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.
+   * @param instrumentationScopeName A name uniquely identifying the instrumentation scope, such as
+   *     the instrumentation library, package, or fully qualified class name. Must not be null.
    * @return a tracer instance.
    */
-  public static Tracer getTracer(String instrumentationName) {
-    return get().getTracer(instrumentationName);
+  public static Tracer getTracer(String instrumentationScopeName) {
+    return get().getTracer(instrumentationScopeName);
   }
 
   /**
    * Gets or creates a named and versioned tracer instance from the globally registered {@link
    * TracerProvider}.
    *
-   * <p>This is a shortcut method for {@code getTracerProvider().get(instrumentationName,
-   * instrumentationVersion)}
+   * <p>This is a shortcut method for {@code getTracerProvider().get(instrumentationScopeName,
+   * instrumentationScopeVersion)}
    *
-   * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.
-   * @param instrumentationVersion The version of the instrumentation library (e.g., "1.0.0").
+   * @param instrumentationScopeName A name uniquely identifying the instrumentation scope, such as
+   *     the instrumentation library, package, or fully qualified class name. Must not be null.
+   * @param instrumentationScopeVersion The version of the instrumentation scope (e.g., "1.0.0").
    * @return a tracer instance.
    */
-  public static Tracer getTracer(String instrumentationName, String instrumentationVersion) {
-    return get().getTracer(instrumentationName, instrumentationVersion);
+  public static Tracer getTracer(
+      String instrumentationScopeName, String instrumentationScopeVersion) {
+    return get().getTracer(instrumentationScopeName, instrumentationScopeVersion);
   }
 
   /**
    * Creates a TracerBuilder for a named {@link Tracer} instance.
    *
-   * <p>This is a shortcut method for {@code get().tracerBuilder(instrumentationName)}
+   * <p>This is a shortcut method for {@code get().tracerBuilder(instrumentationScopeName)}
    *
-   * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library.
+   * @param instrumentationScopeName A name uniquely identifying the instrumentation scope, such as
+   *     the instrumentation library, package, or fully qualified class name. Must not be null.
    * @return a TracerBuilder instance.
    * @since 1.4.0
    */
-  public static TracerBuilder tracerBuilder(String instrumentationName) {
-    return get().tracerBuilder(instrumentationName);
+  public static TracerBuilder tracerBuilder(String instrumentationScopeName) {
+    return get().tracerBuilder(instrumentationScopeName);
   }
 
   /**
@@ -158,29 +159,29 @@ public final class GlobalOpenTelemetry {
   /**
    * Gets or creates a named meter instance from the globally registered {@link MeterProvider}.
    *
-   * <p>This is a shortcut method for {@code getMeterProvider().get(instrumentationName)}
+   * <p>This is a shortcut method for {@code getMeterProvider().get(instrumentationScopeName)}
    *
-   * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.
+   * @param instrumentationScopeName A name uniquely identifying the instrumentation scope, such as
+   *     the instrumentation library, package, or fully qualified class name. Must not be null.
    * @return a Meter instance.
    * @since 1.10.0
    */
-  public static Meter getMeter(String instrumentationName) {
-    return get().getMeter(instrumentationName);
+  public static Meter getMeter(String instrumentationScopeName) {
+    return get().getMeter(instrumentationScopeName);
   }
 
   /**
    * Creates a MeterBuilder for a named {@link Meter} instance.
    *
-   * <p>This is a shortcut method for {@code get().meterBuilder(instrumentationName)}
+   * <p>This is a shortcut method for {@code get().meterBuilder(instrumentationScopeName)}
    *
-   * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library.
+   * @param instrumentationScopeName A name uniquely identifying the instrumentation scope, such as
+   *     the instrumentation library, package, or fully qualified class name. Must not be null.
    * @return a MeterBuilder instance.
    * @since 1.10.0
    */
-  public static MeterBuilder meterBuilder(String instrumentationName) {
-    return get().meterBuilder(instrumentationName);
+  public static MeterBuilder meterBuilder(String instrumentationScopeName) {
+    return get().meterBuilder(instrumentationScopeName);
   }
 
   /**
@@ -258,8 +259,8 @@ public final class GlobalOpenTelemetry {
     }
 
     @Override
-    public TracerBuilder tracerBuilder(String instrumentationName) {
-      return delegate.tracerBuilder(instrumentationName);
+    public TracerBuilder tracerBuilder(String instrumentationScopeName) {
+      return delegate.tracerBuilder(instrumentationScopeName);
     }
   }
 }

--- a/api/all/src/main/java/io/opentelemetry/api/OpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/OpenTelemetry.java
@@ -46,37 +46,37 @@ public interface OpenTelemetry {
    * Gets or creates a named tracer instance from the {@link TracerProvider} for this {@link
    * OpenTelemetry}.
    *
-   * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.
+   * @param instrumentationScopeName A name uniquely identifying the instrumentation scope, such as
+   *     the instrumentation library, package, or fully qualified class name. Must not be null.
    * @return a tracer instance.
    */
-  default Tracer getTracer(String instrumentationName) {
-    return getTracerProvider().get(instrumentationName);
+  default Tracer getTracer(String instrumentationScopeName) {
+    return getTracerProvider().get(instrumentationScopeName);
   }
 
   /**
    * Gets or creates a named and versioned tracer instance from the {@link TracerProvider} in this
    * {@link OpenTelemetry}.
    *
-   * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.
-   * @param instrumentationVersion The version of the instrumentation library (e.g., "1.0.0").
+   * @param instrumentationScopeName A name uniquely identifying the instrumentation scope, such as
+   *     the instrumentation library, package, or fully qualified class name. Must not be null.
+   * @param instrumentationScopeVersion The version of the instrumentation scope (e.g., "1.0.0").
    * @return a tracer instance.
    */
-  default Tracer getTracer(String instrumentationName, String instrumentationVersion) {
-    return getTracerProvider().get(instrumentationName, instrumentationVersion);
+  default Tracer getTracer(String instrumentationScopeName, String instrumentationScopeVersion) {
+    return getTracerProvider().get(instrumentationScopeName, instrumentationScopeVersion);
   }
 
   /**
    * Creates a {@link TracerBuilder} for a named {@link Tracer} instance.
    *
-   * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library.
+   * @param instrumentationScopeName A name uniquely identifying the instrumentation scope, such as
+   *     the instrumentation library, package, or fully qualified class name. Must not be null.
    * @return a TracerBuilder instance.
    * @since 1.4.0
    */
-  default TracerBuilder tracerBuilder(String instrumentationName) {
-    return getTracerProvider().tracerBuilder(instrumentationName);
+  default TracerBuilder tracerBuilder(String instrumentationScopeName) {
+    return getTracerProvider().tracerBuilder(instrumentationScopeName);
   }
 
   /**
@@ -92,25 +92,25 @@ public interface OpenTelemetry {
    * Gets or creates a named meter instance from the {@link MeterProvider} for this {@link
    * OpenTelemetry}.
    *
-   * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null.
+   * @param instrumentationScopeName A name uniquely identifying the instrumentation scope, such as
+   *     the instrumentation library, package, or fully qualified class name. Must not be null.
    * @return a Meter instance.
    * @since 1.10.0
    */
-  default Meter getMeter(String instrumentationName) {
-    return getMeterProvider().get(instrumentationName);
+  default Meter getMeter(String instrumentationScopeName) {
+    return getMeterProvider().get(instrumentationScopeName);
   }
 
   /**
    * Creates a {@link MeterBuilder} for a named {@link Tracer} instance.
    *
-   * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library.
+   * @param instrumentationScopeName A name uniquely identifying the instrumentation scope, such as
+   *     the instrumentation library, package, or fully qualified class name. Must not be null.
    * @return a MeterBuilder instance.
    * @since 1.10.0
    */
-  default MeterBuilder meterBuilder(String instrumentationName) {
-    return getMeterProvider().meterBuilder(instrumentationName);
+  default MeterBuilder meterBuilder(String instrumentationScopeName) {
+    return getMeterProvider().meterBuilder(instrumentationScopeName);
   }
 
   /** Returns the {@link ContextPropagators} for this {@link OpenTelemetry}. */

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DefaultMeterProvider.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DefaultMeterProvider.java
@@ -8,7 +8,7 @@ package io.opentelemetry.api.metrics;
 /** A {@link MeterProvider} that does nothing. */
 class DefaultMeterProvider implements MeterProvider {
   @Override
-  public MeterBuilder meterBuilder(String instrumentationName) {
+  public MeterBuilder meterBuilder(String instrumentationScopeName) {
     return BUILDER_INSTANCE;
   }
 
@@ -29,7 +29,7 @@ class DefaultMeterProvider implements MeterProvider {
     }
 
     @Override
-    public MeterBuilder setInstrumentationVersion(String instrumentationVersion) {
+    public MeterBuilder setInstrumentationVersion(String instrumentationScopeVersion) {
       return this;
     }
 

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/Meter.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/Meter.java
@@ -13,7 +13,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * <p>Instruments are obtained through builders provided by this interface. Each builder has a
  * default "type" associated with recordings that may be changed.
  *
- * <p>A Meter is generally associated with an instrumentation library, e.g. "I monitor apache
+ * <p>A Meter is generally associated with an instrumentation scope, e.g. "I monitor apache
  * httpclient".
  *
  * <p>Choosing an instrument can be hard, but here's a rule of thumb for selecting the right

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/MeterBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/MeterBuilder.java
@@ -18,19 +18,18 @@ public interface MeterBuilder {
    * <p>Schemas are used to identify expected metrics (semantic conventions) and allow backends to
    * "automatically migrate" to supported versions.
    *
-   * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation
-   *     library.
+   * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation scope.
    * @return this
    */
   MeterBuilder setSchemaUrl(String schemaUrl);
 
   /**
-   * Assigns a version to the instrumentation library that is using the resulting Meter.
+   * Assigns a version to the instrumentation scope that is using the resulting Meter.
    *
-   * @param instrumentationVersion The version of the instrumentation library.
+   * @param instrumentationScopeVersion The version of the instrumentation scope.
    * @return this
    */
-  MeterBuilder setInstrumentationVersion(String instrumentationVersion);
+  MeterBuilder setInstrumentationVersion(String instrumentationScopeVersion);
 
   /**
    * Gets or creates a {@link Meter} instance.

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/MeterProvider.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/MeterProvider.java
@@ -23,23 +23,23 @@ public interface MeterProvider {
   /**
    * Gets or creates a named and versioned meter instance.
    *
-   * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library.
+   * @param instrumentationScopeName A name uniquely identifying the instrumentation scope, such as
+   *     the instrumentation library, package, or fully qualified class name. Must not be null.
    * @return a meter instance.
    */
-  default Meter get(String instrumentationName) {
-    return meterBuilder(instrumentationName).build();
+  default Meter get(String instrumentationScopeName) {
+    return meterBuilder(instrumentationScopeName).build();
   }
 
   /**
    * Creates a MeterBuilder for a named meter instance.
    *
-   * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library.
+   * @param instrumentationScopeName A name uniquely identifying the instrumentation scope, such as
+   *     the instrumentation library, package, or fully qualified class name. Must not be null.
    * @return a MeterBuilder instance.
    * @since 1.4.0
    */
-  MeterBuilder meterBuilder(String instrumentationName);
+  MeterBuilder meterBuilder(String instrumentationScopeName);
 
   /** Returns a no-op {@link MeterProvider} which provides meters which do not record or emit. */
   static MeterProvider noop() {

--- a/api/all/src/main/java/io/opentelemetry/api/trace/DefaultTracerBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/DefaultTracerBuilder.java
@@ -18,7 +18,7 @@ class DefaultTracerBuilder implements TracerBuilder {
   }
 
   @Override
-  public TracerBuilder setInstrumentationVersion(String instrumentationVersion) {
+  public TracerBuilder setInstrumentationVersion(String instrumentationScopeVersion) {
     return this;
   }
 

--- a/api/all/src/main/java/io/opentelemetry/api/trace/DefaultTracerProvider.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/DefaultTracerProvider.java
@@ -17,12 +17,12 @@ class DefaultTracerProvider implements TracerProvider {
   }
 
   @Override
-  public Tracer get(String instrumentationName) {
+  public Tracer get(String instrumentationScopeName) {
     return DefaultTracer.getInstance();
   }
 
   @Override
-  public Tracer get(String instrumentationName, String instrumentationVersion) {
+  public Tracer get(String instrumentationScopeName, String instrumentationScopeVersion) {
     return DefaultTracer.getInstance();
   }
 

--- a/api/all/src/main/java/io/opentelemetry/api/trace/TracerBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/TracerBuilder.java
@@ -15,16 +15,15 @@ public interface TracerBuilder {
   /**
    * Assign an OpenTelemetry schema URL to the resulting Tracer.
    *
-   * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation
-   *     library.
+   * @param schemaUrl The URL of the OpenTelemetry schema being used by this instrumentation scope.
    * @return this
    */
   TracerBuilder setSchemaUrl(String schemaUrl);
 
   /**
-   * Assign a version to the instrumentation library that is using the resulting Tracer.
+   * Assign a version to the instrumentation scope that is using the resulting Tracer.
    *
-   * @param instrumentationVersion The version of the instrumentation library.
+   * @param instrumentationVersion The version of the instrumentation scope.
    * @return this
    */
   TracerBuilder setInstrumentationVersion(String instrumentationVersion);

--- a/api/all/src/main/java/io/opentelemetry/api/trace/TracerBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/TracerBuilder.java
@@ -23,10 +23,10 @@ public interface TracerBuilder {
   /**
    * Assign a version to the instrumentation scope that is using the resulting Tracer.
    *
-   * @param instrumentationVersion The version of the instrumentation scope.
+   * @param instrumentationScopeVersion The version of the instrumentation scope.
    * @return this
    */
-  TracerBuilder setInstrumentationVersion(String instrumentationVersion);
+  TracerBuilder setInstrumentationVersion(String instrumentationScopeVersion);
 
   /**
    * Gets or creates a {@link Tracer} instance.

--- a/api/all/src/main/java/io/opentelemetry/api/trace/TracerProvider.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/TracerProvider.java
@@ -27,35 +27,31 @@ public interface TracerProvider {
   /**
    * Gets or creates a named tracer instance.
    *
-   * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null. If the
-   *     instrumented library is providing its own instrumentation, this should match the library
-   *     name.
+   * @param instrumentationScopeName A name uniquely identifying the instrumentation scope, such as
+   *     the instrumentation library, package, or fully qualified class name. Must not be null.
    * @return a tracer instance.
    */
-  Tracer get(String instrumentationName);
+  Tracer get(String instrumentationScopeName);
 
   /**
    * Gets or creates a named and versioned tracer instance.
    *
-   * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library (e.g., "io.opentelemetry.contrib.mongodb"). Must not be null. If the
-   *     instrumented library is providing its own instrumentation, this should match the library
-   *     name.
-   * @param instrumentationVersion The version of the instrumentation library (e.g., "1.0.0").
+   * @param instrumentationScopeName A name uniquely identifying the instrumentation scope, such as
+   *     the instrumentation library, package, or fully qualified class name. Must not be null.
+   * @param instrumentationScopeVersion The version of the instrumentation scope (e.g., "1.0.0").
    * @return a tracer instance.
    */
-  Tracer get(String instrumentationName, String instrumentationVersion);
+  Tracer get(String instrumentationScopeName, String instrumentationScopeVersion);
 
   /**
    * Creates a TracerBuilder for a named {@link Tracer} instance.
    *
-   * @param instrumentationName The name of the instrumentation library, not the name of the
-   *     instrument*ed* library.
+   * @param instrumentationScopeName A name uniquely identifying the instrumentation scope, such as
+   *     the instrumentation library, package, or fully qualified class name. Must not be null.
    * @return a TracerBuilder instance.
    * @since 1.4.0
    */
-  default TracerBuilder tracerBuilder(String instrumentationName) {
+  default TracerBuilder tracerBuilder(String instrumentationScopeName) {
     return DefaultTracerBuilder.getInstance();
   }
 }

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-common.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-common.txt
@@ -1,2 +1,12 @@
 Comparing source compatibility of  against 
-No changes.
++++  NEW CLASS: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.common.InstrumentationScopeInfo  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.common.InstrumentationScopeInfo create(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.common.InstrumentationScopeInfo create(java.lang.String, java.lang.String, java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.common.InstrumentationScopeInfo empty()
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) java.lang.String getName()
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) java.lang.String getSchemaUrl()
+		+++  NEW ANNOTATION: javax.annotation.Nullable
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) java.lang.String getVersion()
+		+++  NEW ANNOTATION: javax.annotation.Nullable

--- a/extensions/noop-api/src/main/java/io/opentelemetry/extension/noopapi/NoopTracerProvider.java
+++ b/extensions/noop-api/src/main/java/io/opentelemetry/extension/noopapi/NoopTracerProvider.java
@@ -20,12 +20,12 @@ enum NoopTracerProvider implements TracerProvider {
   INSTANCE;
 
   @Override
-  public Tracer get(String instrumentationName) {
+  public Tracer get(String instrumentationScopeName) {
     return NoopTracer.INSTANCE;
   }
 
   @Override
-  public Tracer get(String instrumentationName, String instrumentationVersion) {
+  public Tracer get(String instrumentationScopeName, String instrumentationScopeVersion) {
     return NoopTracer.INSTANCE;
   }
 

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -98,13 +98,13 @@ public final class OpenTelemetrySdk implements OpenTelemetry {
     }
 
     @Override
-    public Tracer get(String instrumentationName) {
-      return delegate.get(instrumentationName);
+    public Tracer get(String instrumentationScopeName) {
+      return delegate.get(instrumentationScopeName);
     }
 
     @Override
-    public Tracer get(String instrumentationName, String instrumentationVersion) {
-      return delegate.get(instrumentationName, instrumentationVersion);
+    public Tracer get(String instrumentationScopeName, String instrumentationScopeVersion) {
+      return delegate.get(instrumentationScopeName, instrumentationScopeVersion);
     }
 
     @Override

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -108,8 +108,8 @@ public final class OpenTelemetrySdk implements OpenTelemetry {
     }
 
     @Override
-    public TracerBuilder tracerBuilder(String instrumentationName) {
-      return delegate.tracerBuilder(instrumentationName);
+    public TracerBuilder tracerBuilder(String instrumentationScopeName) {
+      return delegate.tracerBuilder(instrumentationScopeName);
     }
 
     public SdkTracerProvider unobfuscate() {
@@ -135,8 +135,8 @@ public final class OpenTelemetrySdk implements OpenTelemetry {
     }
 
     @Override
-    public MeterBuilder meterBuilder(String instrumentationName) {
-      return delegate.meterBuilder(instrumentationName);
+    public MeterBuilder meterBuilder(String instrumentationScopeName) {
+      return delegate.meterBuilder(instrumentationScopeName);
     }
 
     public SdkMeterProvider unobfuscate() {

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/InstrumentationScopeInfo.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/InstrumentationScopeInfo.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.common;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * Holds information about instrumentation scope.
+ *
+ * <p>Instrumentation scope is a logical unit of the application code with which emitted telemetry
+ * is associated. The most common approach is to use the instrumentation library as the scope,
+ * however other scopes are also common, e.g. a module, a package, or a class can be chosen as the
+ * instrumentation scope.
+ */
+@AutoValue
+@Immutable
+public abstract class InstrumentationScopeInfo {
+  private static final InstrumentationScopeInfo EMPTY = create("");
+
+  /** Creates a new instance of {@link InstrumentationScopeInfo}. */
+  public static InstrumentationScopeInfo create(String name) {
+    requireNonNull(name, "name");
+    return new AutoValue_InstrumentationScopeInfo(name, null, null);
+  }
+
+  /** Creates a new instance of {@link InstrumentationScopeInfo}. */
+  public static InstrumentationScopeInfo create(
+      String name, @Nullable String version, @Nullable String schemaUrl) {
+    requireNonNull(name, "name");
+    return new AutoValue_InstrumentationScopeInfo(name, version, schemaUrl);
+  }
+
+  /** Returns an "empty" {@link InstrumentationScopeInfo}. */
+  public static InstrumentationScopeInfo empty() {
+    return EMPTY;
+  }
+
+  /** Returns the name of the instrumentation scope. */
+  public abstract String getName();
+
+  /** Returns the version of the instrumentation scope, or {@code null} if not available. */
+  @Nullable
+  public abstract String getVersion();
+
+  /**
+   * Returns the URL of the schema used by this instrumentation scope, or {@code null} if not
+   * available.
+   */
+  @Nullable
+  public abstract String getSchemaUrl();
+
+  InstrumentationScopeInfo() {}
+}

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/InstrumentationScopeInfo.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/InstrumentationScopeInfo.java
@@ -16,7 +16,7 @@ import javax.annotation.concurrent.Immutable;
  *
  * <p>Instrumentation scope is a logical unit of the application code with which emitted telemetry
  * is associated. The most common approach is to use the instrumentation library as the scope,
- * however other scopes are also common, e.g. a module, a package, or a class can be chosen as the
+ * however other scopes are also common, e.g. a module, a package, or a class may be chosen as the
  * instrumentation scope.
  */
 @AutoValue

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/InstrumentationScopeUtil.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/InstrumentationScopeUtil.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.internal;
+
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public class InstrumentationScopeUtil {
+
+  /** Convert to {@link InstrumentationLibraryInfo}. */
+  public static InstrumentationLibraryInfo toInstrumentationLibraryInfo(
+      InstrumentationScopeInfo instrumentationScopeInfo) {
+    return InstrumentationLibraryInfo.create(
+        instrumentationScopeInfo.getName(),
+        instrumentationScopeInfo.getVersion(),
+        instrumentationScopeInfo.getSchemaUrl());
+  }
+
+  private InstrumentationScopeUtil() {}
+}

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/InstrumentationScopeUtil.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/InstrumentationScopeUtil.java
@@ -12,7 +12,7 @@ import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
-public class InstrumentationScopeUtil {
+public final class InstrumentationScopeUtil {
 
   /** Convert to {@link InstrumentationLibraryInfo}. */
   public static InstrumentationLibraryInfo toInstrumentationLibraryInfo(

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/InstrumentationScopeInfoTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/InstrumentationScopeInfoTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class InstrumentationScopeInfoTest {
+
+  @Test
+  void emptyScopeInfo() {
+    assertThat(InstrumentationScopeInfo.empty().getName()).isEmpty();
+    assertThat(InstrumentationScopeInfo.empty().getVersion()).isNull();
+  }
+
+  @Test
+  void nullName() {
+    assertThatThrownBy(() -> InstrumentationScopeInfo.create(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("name");
+  }
+}

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/internal/ComponentRegistryTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/internal/ComponentRegistryTest.java
@@ -8,10 +8,9 @@ package io.opentelemetry.sdk.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import org.junit.jupiter.api.Test;
 
-/** Tests for {@link InstrumentationLibraryInfo}. */
 class ComponentRegistryTest {
 
   private static final String INSTRUMENTATION_NAME = "test_name";
@@ -20,18 +19,18 @@ class ComponentRegistryTest {
       new ComponentRegistry<>(TestComponent::new);
 
   @Test
-  void libraryName_MustNotBeNull() {
+  void scopeName_MustNotBeNull() {
     assertThatThrownBy(() -> registry.get(null, "version"))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("name");
   }
 
   @Test
-  void libraryVersion_AllowsNull() {
+  void scopeVersion_AllowsNull() {
     TestComponent testComponent = registry.get(INSTRUMENTATION_NAME, null);
     assertThat(testComponent).isNotNull();
-    assertThat(testComponent.instrumentationLibraryInfo.getName()).isEqualTo(INSTRUMENTATION_NAME);
-    assertThat(testComponent.instrumentationLibraryInfo.getVersion()).isNull();
+    assertThat(testComponent.instrumentationScopeInfo.getName()).isEqualTo(INSTRUMENTATION_NAME);
+    assertThat(testComponent.instrumentationScopeInfo.getVersion()).isNull();
   }
 
   @Test
@@ -60,10 +59,10 @@ class ComponentRegistryTest {
   }
 
   private static final class TestComponent {
-    private final InstrumentationLibraryInfo instrumentationLibraryInfo;
+    private final InstrumentationScopeInfo instrumentationScopeInfo;
 
-    private TestComponent(InstrumentationLibraryInfo instrumentationLibraryInfo) {
-      this.instrumentationLibraryInfo = instrumentationLibraryInfo;
+    private TestComponent(InstrumentationScopeInfo instrumentationScopeInfo) {
+      this.instrumentationScopeInfo = instrumentationScopeInfo;
     }
   }
 }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/LogEmitterBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/LogEmitterBuilder.java
@@ -11,18 +11,18 @@ public interface LogEmitterBuilder {
   /**
    * Assign an OpenTelemetry schema URL to the resulting {@link LogEmitter}.
    *
-   * @param schemaUrl the URL of the OpenTelemetry schema being used by this instrumentation library
+   * @param schemaUrl the URL of the OpenTelemetry schema being used by this instrumentation scope
    * @return this
    */
   LogEmitterBuilder setSchemaUrl(String schemaUrl);
 
   /**
-   * Assign a version to the instrumentation library that is using the resulting {@link LogEmitter}.
+   * Assign a version to the instrumentation scope that is using the resulting {@link LogEmitter}.
    *
-   * @param instrumentationVersion the version of the instrumentation library
+   * @param instrumentationScopeVersion the version of the instrumentation scope
    * @return this
    */
-  LogEmitterBuilder setInstrumentationVersion(String instrumentationVersion);
+  LogEmitterBuilder setInstrumentationVersion(String instrumentationScopeVersion);
 
   /**
    * Gets or creates a {@link LogEmitter} instance.

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogEmitter.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogEmitter.java
@@ -6,19 +6,24 @@
 package io.opentelemetry.sdk.logs;
 
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.internal.InstrumentationScopeUtil;
 import io.opentelemetry.sdk.logs.data.LogDataBuilder;
 
 /** SDK implementation of {@link LogEmitter}. */
 final class SdkLogEmitter implements LogEmitter {
 
   private final LogEmitterSharedState logEmitterSharedState;
+  private final InstrumentationScopeInfo instrumentationScopeInfo;
   private final InstrumentationLibraryInfo instrumentationLibraryInfo;
 
   SdkLogEmitter(
       LogEmitterSharedState logEmitterSharedState,
-      InstrumentationLibraryInfo instrumentationLibraryInfo) {
+      InstrumentationScopeInfo instrumentationScopeInfo) {
     this.logEmitterSharedState = logEmitterSharedState;
-    this.instrumentationLibraryInfo = instrumentationLibraryInfo;
+    this.instrumentationScopeInfo = instrumentationScopeInfo;
+    this.instrumentationLibraryInfo =
+        InstrumentationScopeUtil.toInstrumentationLibraryInfo(instrumentationScopeInfo);
   }
 
   @Override
@@ -32,7 +37,7 @@ final class SdkLogEmitter implements LogEmitter {
   }
 
   // VisibleForTesting
-  InstrumentationLibraryInfo getInstrumentationLibraryInfo() {
-    return instrumentationLibraryInfo;
+  InstrumentationScopeInfo getInstrumentationScopeInfo() {
+    return instrumentationScopeInfo;
   }
 }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogEmitterBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogEmitterBuilder.java
@@ -11,13 +11,13 @@ import javax.annotation.Nullable;
 final class SdkLogEmitterBuilder implements LogEmitterBuilder {
 
   private final ComponentRegistry<SdkLogEmitter> registry;
-  private final String instrumentationName;
-  @Nullable private String getInstrumentationVersion;
+  private final String instrumentationScopeName;
+  @Nullable private String instrumentationScopeVersion;
   @Nullable private String schemaUrl;
 
-  SdkLogEmitterBuilder(ComponentRegistry<SdkLogEmitter> registry, String instrumentationName) {
+  SdkLogEmitterBuilder(ComponentRegistry<SdkLogEmitter> registry, String instrumentationScopeName) {
     this.registry = registry;
-    this.instrumentationName = instrumentationName;
+    this.instrumentationScopeName = instrumentationScopeName;
   }
 
   @Override
@@ -27,13 +27,13 @@ final class SdkLogEmitterBuilder implements LogEmitterBuilder {
   }
 
   @Override
-  public SdkLogEmitterBuilder setInstrumentationVersion(String instrumentationVersion) {
-    this.getInstrumentationVersion = instrumentationVersion;
+  public SdkLogEmitterBuilder setInstrumentationVersion(String instrumentationScopeVersion) {
+    this.instrumentationScopeVersion = instrumentationScopeVersion;
     return this;
   }
 
   @Override
   public SdkLogEmitter build() {
-    return registry.get(instrumentationName, getInstrumentationVersion, schemaUrl);
+    return registry.get(instrumentationScopeName, instrumentationScopeVersion, schemaUrl);
   }
 }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogEmitterProvider.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogEmitterProvider.java
@@ -48,25 +48,26 @@ public final class SdkLogEmitterProvider implements Closeable {
   /**
    * Gets or creates a named log emitter instance.
    *
-   * @param instrumentationName the name of the instrumentation library
+   * @param instrumentationScopeName A name uniquely identifying the instrumentation scope, such as
+   *     the instrumentation library, package, or fully qualified class name. Must not be null.
    * @return a log emitter instance
    */
-  public LogEmitter get(String instrumentationName) {
-    return logEmitterBuilder(instrumentationName).build();
+  public LogEmitter get(String instrumentationScopeName) {
+    return logEmitterBuilder(instrumentationScopeName).build();
   }
 
   /**
    * Creates a {@link LogEmitterBuilder} instance.
    *
-   * @param instrumentationName the name of the instrumentation library
+   * @param instrumentationScopeName the name of the instrumentation scope
    * @return a log emitter builder instance
    */
-  public LogEmitterBuilder logEmitterBuilder(String instrumentationName) {
-    if (instrumentationName == null || instrumentationName.isEmpty()) {
-      LOGGER.fine("LogEmitter requested without instrumentation name.");
-      instrumentationName = DEFAULT_EMITTER_NAME;
+  public LogEmitterBuilder logEmitterBuilder(String instrumentationScopeName) {
+    if (instrumentationScopeName == null || instrumentationScopeName.isEmpty()) {
+      LOGGER.fine("LogEmitter requested without instrumentation scope name.");
+      instrumentationScopeName = DEFAULT_EMITTER_NAME;
     }
-    return new SdkLogEmitterBuilder(logEmitterComponentRegistry, instrumentationName);
+    return new SdkLogEmitterBuilder(logEmitterComponentRegistry, instrumentationScopeName);
   }
 
   /**

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogEmitterProvider.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogEmitterProvider.java
@@ -42,8 +42,7 @@ public final class SdkLogEmitterProvider implements Closeable {
     this.sharedState = new LogEmitterSharedState(resource, logLimitsSupplier, processors, clock);
     this.logEmitterComponentRegistry =
         new ComponentRegistry<>(
-            instrumentationLibraryInfo ->
-                new SdkLogEmitter(sharedState, instrumentationLibraryInfo));
+            instrumentationScopeInfo -> new SdkLogEmitter(sharedState, instrumentationScopeInfo));
   }
 
   /**

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLogEmitterProviderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLogEmitterProviderTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.when;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.logs.data.LogData;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.ArrayList;
@@ -175,8 +175,8 @@ class SdkLogEmitterProviderTest {
 
   @Test
   void logEmitterBuilder_PropagatesToEmitter() {
-    InstrumentationLibraryInfo expected =
-        InstrumentationLibraryInfo.create("test", "version", "http://url");
+    InstrumentationScopeInfo expected =
+        InstrumentationScopeInfo.create("test", "version", "http://url");
     assertThat(
             ((SdkLogEmitter)
                     sdkLogEmitterProvider
@@ -184,7 +184,7 @@ class SdkLogEmitterProviderTest {
                         .setInstrumentationVersion("version")
                         .setSchemaUrl("http://url")
                         .build())
-                .getInstrumentationLibraryInfo())
+                .getInstrumentationScopeInfo())
         .isEqualTo(expected);
   }
 
@@ -192,13 +192,13 @@ class SdkLogEmitterProviderTest {
   void logEmitterBuilder_DefaultEmitterName() {
     assertThat(
             ((SdkLogEmitter) sdkLogEmitterProvider.logEmitterBuilder(null).build())
-                .getInstrumentationLibraryInfo()
+                .getInstrumentationScopeInfo()
                 .getName())
         .isEqualTo(SdkLogEmitterProvider.DEFAULT_EMITTER_NAME);
 
     assertThat(
             ((SdkLogEmitter) sdkLogEmitterProvider.logEmitterBuilder("").build())
-                .getInstrumentationLibraryInfo()
+                .getInstrumentationScopeInfo()
                 .getName())
         .isEqualTo(SdkLogEmitterProvider.DEFAULT_EMITTER_NAME);
   }

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLogEmitterTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLogEmitterTest.java
@@ -18,7 +18,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.internal.StringUtils;
 import io.opentelemetry.sdk.common.Clock;
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.logs.data.LogData;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Arrays;
@@ -30,7 +30,7 @@ class SdkLogEmitterTest {
   @Test
   void logBuilder() {
     LogEmitterSharedState state = mock(LogEmitterSharedState.class);
-    InstrumentationLibraryInfo info = InstrumentationLibraryInfo.create("foo", "bar");
+    InstrumentationScopeInfo info = InstrumentationScopeInfo.create("foo");
     AtomicReference<LogData> seenLog = new AtomicReference<>();
     LogProcessor logProcessor = seenLog::set;
     Clock clock = mock(Clock.class);

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java
@@ -10,7 +10,8 @@ import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.LongCounterBuilder;
 import io.opentelemetry.api.metrics.LongUpDownCounterBuilder;
 import io.opentelemetry.api.metrics.Meter;
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.internal.InstrumentationScopeUtil;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.export.CollectionInfo;
 import io.opentelemetry.sdk.metrics.internal.state.MeterProviderSharedState;
@@ -19,19 +20,23 @@ import java.util.Collection;
 
 /** {@link SdkMeter} is SDK implementation of {@link Meter}. */
 final class SdkMeter implements Meter {
+  private final InstrumentationScopeInfo instrumentationScopeInfo;
   private final MeterProviderSharedState meterProviderSharedState;
   private final MeterSharedState meterSharedState;
 
   SdkMeter(
       MeterProviderSharedState meterProviderSharedState,
-      InstrumentationLibraryInfo instrumentationLibraryInfo) {
+      InstrumentationScopeInfo instrumentationScopeInfo) {
+    this.instrumentationScopeInfo = instrumentationScopeInfo;
     this.meterProviderSharedState = meterProviderSharedState;
-    this.meterSharedState = MeterSharedState.create(instrumentationLibraryInfo);
+    this.meterSharedState =
+        MeterSharedState.create(
+            InstrumentationScopeUtil.toInstrumentationLibraryInfo(instrumentationScopeInfo));
   }
 
-  // Only used in testing....
-  InstrumentationLibraryInfo getInstrumentationLibraryInfo() {
-    return meterSharedState.getInstrumentationLibraryInfo();
+  // Visible for testing
+  InstrumentationScopeInfo getInstrumentationScopeInfo() {
+    return instrumentationScopeInfo;
   }
 
   /** Collects all the metric recordings that changed since the previous call. */

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterBuilder.java
@@ -13,13 +13,13 @@ import javax.annotation.Nullable;
 class SdkMeterBuilder implements MeterBuilder {
 
   private final ComponentRegistry<SdkMeter> registry;
-  private final String instrumentationName;
-  @Nullable private String instrumentationVersion;
+  private final String instrumentationScopeName;
+  @Nullable private String instrumentationScopeVersion;
   @Nullable private String schemaUrl;
 
-  SdkMeterBuilder(ComponentRegistry<SdkMeter> registry, String instrumentationName) {
+  SdkMeterBuilder(ComponentRegistry<SdkMeter> registry, String instrumentationScopeName) {
     this.registry = registry;
-    this.instrumentationName = instrumentationName;
+    this.instrumentationScopeName = instrumentationScopeName;
   }
 
   @Override
@@ -29,13 +29,13 @@ class SdkMeterBuilder implements MeterBuilder {
   }
 
   @Override
-  public MeterBuilder setInstrumentationVersion(String instrumentationVersion) {
-    this.instrumentationVersion = instrumentationVersion;
+  public MeterBuilder setInstrumentationVersion(String instrumentationScopeVersion) {
+    this.instrumentationScopeVersion = instrumentationScopeVersion;
     return this;
   }
 
   @Override
   public Meter build() {
-    return registry.get(instrumentationName, instrumentationVersion, schemaUrl);
+    return registry.get(instrumentationScopeName, instrumentationScopeVersion, schemaUrl);
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProvider.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProvider.java
@@ -88,15 +88,15 @@ public final class SdkMeterProvider implements MeterProvider, Closeable {
   }
 
   @Override
-  public MeterBuilder meterBuilder(String instrumentationName) {
+  public MeterBuilder meterBuilder(String instrumentationScopeName) {
     if (collectionInfoMap.isEmpty()) {
-      return MeterProvider.noop().meterBuilder(instrumentationName);
+      return MeterProvider.noop().meterBuilder(instrumentationScopeName);
     }
-    if (instrumentationName == null || instrumentationName.isEmpty()) {
-      LOGGER.fine("Meter requested without instrumentation name.");
-      instrumentationName = DEFAULT_METER_NAME;
+    if (instrumentationScopeName == null || instrumentationScopeName.isEmpty()) {
+      LOGGER.fine("Meter requested without instrumentation scope name.");
+      instrumentationScopeName = DEFAULT_METER_NAME;
     }
-    return new SdkMeterBuilder(registry, instrumentationName);
+    return new SdkMeterBuilder(registry, instrumentationScopeName);
   }
 
   /**

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterRegistryTest.java
@@ -5,8 +5,8 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import static io.opentelemetry.sdk.internal.InstrumentationScopeUtil.toInstrumentationLibraryInfo;
 import static io.opentelemetry.sdk.testing.assertj.MetricAssertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
@@ -14,7 +14,8 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.common.Clock;
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.opentelemetry.sdk.testing.time.TestClock;
@@ -89,9 +90,9 @@ class SdkMeterRegistryTest {
   }
 
   @Test
-  void propagatesInstrumentationLibraryInfoToMeter() {
-    InstrumentationLibraryInfo expected =
-        InstrumentationLibraryInfo.create("theName", "theVersion", "http://theschema");
+  void propagatesInstrumentationScopeInfoToMeter() {
+    InstrumentationScopeInfo expected =
+        InstrumentationScopeInfo.create("theName", "theVersion", "http://theschema");
     SdkMeter meter =
         (SdkMeter)
             meterProvider
@@ -99,11 +100,10 @@ class SdkMeterRegistryTest {
                 .setInstrumentationVersion(expected.getVersion())
                 .setSchemaUrl(expected.getSchemaUrl())
                 .build();
-    assertThat(meter.getInstrumentationLibraryInfo()).isEqualTo(expected);
+    assertThat(meter.getInstrumentationScopeInfo()).isEqualTo(expected);
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   void metricProducer_GetAllMetrics() {
     Meter sdkMeter1 = meterProvider.get("io.opentelemetry.sdk.metrics.MeterSdkRegistryTest_1");
     LongCounter longCounter1 = sdkMeter1.counterBuilder("testLongCounter").build();
@@ -127,31 +127,31 @@ class SdkMeterRegistryTest {
                                 .hasValue(10)
                                 .hasStartEpochNanos(testClock.now())
                                 .hasEpochNanos(testClock.now())))
-        .extracting(metric -> metric.getInstrumentationLibraryInfo())
+        .extracting(MetricData::getInstrumentationLibraryInfo)
         .containsExactlyInAnyOrder(
-            ((SdkMeter) sdkMeter1).getInstrumentationLibraryInfo(),
-            ((SdkMeter) sdkMeter2).getInstrumentationLibraryInfo());
+            toInstrumentationLibraryInfo(((SdkMeter) sdkMeter1).getInstrumentationScopeInfo()),
+            toInstrumentationLibraryInfo(((SdkMeter) sdkMeter2).getInstrumentationScopeInfo()));
   }
 
   @Test
   void suppliesDefaultMeterForNullName() {
     SdkMeter meter = (SdkMeter) meterProvider.get(null);
-    assertThat(meter.getInstrumentationLibraryInfo().getName())
+    assertThat(meter.getInstrumentationScopeInfo().getName())
         .isEqualTo(SdkMeterProvider.DEFAULT_METER_NAME);
 
     meter = (SdkMeter) meterProvider.meterBuilder(null).build();
-    assertThat(meter.getInstrumentationLibraryInfo().getName())
+    assertThat(meter.getInstrumentationScopeInfo().getName())
         .isEqualTo(SdkMeterProvider.DEFAULT_METER_NAME);
   }
 
   @Test
   void suppliesDefaultMeterForEmptyName() {
     SdkMeter meter = (SdkMeter) meterProvider.get("");
-    assertThat(meter.getInstrumentationLibraryInfo().getName())
+    assertThat(meter.getInstrumentationScopeInfo().getName())
         .isEqualTo(SdkMeterProvider.DEFAULT_METER_NAME);
 
     meter = (SdkMeter) meterProvider.meterBuilder("").build();
-    assertThat(meter.getInstrumentationLibraryInfo().getName())
+    assertThat(meter.getInstrumentationScopeInfo().getName())
         .isEqualTo(SdkMeterProvider.DEFAULT_METER_NAME);
   }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerBuilder.java
@@ -13,13 +13,13 @@ import javax.annotation.Nullable;
 class SdkTracerBuilder implements TracerBuilder {
 
   private final ComponentRegistry<SdkTracer> registry;
-  private final String instrumentationName;
-  @Nullable private String instrumentationVersion;
+  private final String instrumentationScopeName;
+  @Nullable private String instrumentationScopeVersion;
   @Nullable private String schemaUrl;
 
-  SdkTracerBuilder(ComponentRegistry<SdkTracer> registry, String instrumentationName) {
+  SdkTracerBuilder(ComponentRegistry<SdkTracer> registry, String instrumentationScopeName) {
     this.registry = registry;
-    this.instrumentationName = instrumentationName;
+    this.instrumentationScopeName = instrumentationScopeName;
   }
 
   @Override
@@ -29,13 +29,13 @@ class SdkTracerBuilder implements TracerBuilder {
   }
 
   @Override
-  public TracerBuilder setInstrumentationVersion(String instrumentationVersion) {
-    this.instrumentationVersion = instrumentationVersion;
+  public TracerBuilder setInstrumentationVersion(String instrumentationScopeVersion) {
+    this.instrumentationScopeVersion = instrumentationScopeVersion;
     return this;
   }
 
   @Override
   public Tracer build() {
-    return registry.get(instrumentationName, instrumentationVersion, schemaUrl);
+    return registry.get(instrumentationScopeName, instrumentationScopeVersion, schemaUrl);
   }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
@@ -49,7 +49,7 @@ public final class SdkTracerProvider implements TracerProvider, Closeable {
             clock, idsGenerator, resource, spanLimitsSupplier, sampler, spanProcessors);
     this.tracerSdkComponentRegistry =
         new ComponentRegistry<>(
-            instrumentationLibraryInfo -> new SdkTracer(sharedState, instrumentationLibraryInfo));
+            instrumentationScopeInfo -> new SdkTracer(sharedState, instrumentationScopeInfo));
   }
 
   @Override

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
@@ -65,13 +65,13 @@ public final class SdkTracerProvider implements TracerProvider, Closeable {
   }
 
   @Override
-  public TracerBuilder tracerBuilder(@Nullable String instrumentationName) {
+  public TracerBuilder tracerBuilder(@Nullable String instrumentationScopeName) {
     // Per the spec, both null and empty are "invalid" and a default value should be used.
-    if (instrumentationName == null || instrumentationName.isEmpty()) {
-      logger.fine("Tracer requested without instrumentation name.");
-      instrumentationName = DEFAULT_TRACER_NAME;
+    if (instrumentationScopeName == null || instrumentationScopeName.isEmpty()) {
+      logger.fine("Tracer requested without instrumentation scope name.");
+      instrumentationScopeName = DEFAULT_TRACER_NAME;
     }
-    return new SdkTracerBuilder(tracerSdkComponentRegistry, instrumentationName);
+    return new SdkTracerBuilder(tracerSdkComponentRegistry, instrumentationScopeName);
   }
 
   /** Returns the {@link SpanLimits} that are currently applied to created spans. */

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
@@ -53,14 +53,14 @@ public final class SdkTracerProvider implements TracerProvider, Closeable {
   }
 
   @Override
-  public Tracer get(String instrumentationName) {
-    return tracerBuilder(instrumentationName).build();
+  public Tracer get(String instrumentationScopeName) {
+    return tracerBuilder(instrumentationScopeName).build();
   }
 
   @Override
-  public Tracer get(String instrumentationName, String instrumentationVersion) {
-    return tracerBuilder(instrumentationName)
-        .setInstrumentationVersion(instrumentationVersion)
+  public Tracer get(String instrumentationScopeName, String instrumentationScopeVersion) {
+    return tracerBuilder(instrumentationScopeName)
+        .setInstrumentationVersion(instrumentationScopeVersion)
         .build();
   }
 

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderTest.java
@@ -16,7 +16,7 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
@@ -169,16 +169,16 @@ class SdkTracerProviderTest {
   }
 
   @Test
-  void propagatesInstrumentationLibraryInfoToTracer() {
-    InstrumentationLibraryInfo expected =
-        InstrumentationLibraryInfo.create("theName", "theVersion", "http://url");
+  void propagatesInstrumentationScopeInfoToTracer() {
+    InstrumentationScopeInfo expected =
+        InstrumentationScopeInfo.create("theName", "theVersion", "http://url");
     Tracer tracer =
         tracerFactory
             .tracerBuilder(expected.getName())
             .setInstrumentationVersion(expected.getVersion())
             .setSchemaUrl(expected.getSchemaUrl())
             .build();
-    assertThat(((SdkTracer) tracer).getInstrumentationLibraryInfo()).isEqualTo(expected);
+    assertThat(((SdkTracer) tracer).getInstrumentationScopeInfo()).isEqualTo(expected);
   }
 
   @Test
@@ -228,22 +228,22 @@ class SdkTracerProviderTest {
   @Test
   void suppliesDefaultTracerForNullName() {
     SdkTracer tracer = (SdkTracer) tracerFactory.get(null);
-    assertThat(tracer.getInstrumentationLibraryInfo().getName())
+    assertThat(tracer.getInstrumentationScopeInfo().getName())
         .isEqualTo(SdkTracerProvider.DEFAULT_TRACER_NAME);
 
     tracer = (SdkTracer) tracerFactory.get(null, null);
-    assertThat(tracer.getInstrumentationLibraryInfo().getName())
+    assertThat(tracer.getInstrumentationScopeInfo().getName())
         .isEqualTo(SdkTracerProvider.DEFAULT_TRACER_NAME);
   }
 
   @Test
   void suppliesDefaultTracerForEmptyName() {
     SdkTracer tracer = (SdkTracer) tracerFactory.get("");
-    assertThat(tracer.getInstrumentationLibraryInfo().getName())
+    assertThat(tracer.getInstrumentationScopeInfo().getName())
         .isEqualTo(SdkTracerProvider.DEFAULT_TRACER_NAME);
 
     tracer = (SdkTracer) tracerFactory.get("", "");
-    assertThat(tracer.getInstrumentationLibraryInfo().getName())
+    assertThat(tracer.getInstrumentationScopeInfo().getName())
         .isEqualTo(SdkTracerProvider.DEFAULT_TRACER_NAME);
   }
 }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerTest.java
@@ -12,6 +12,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.trace.StressTestRunner.OperationUpdater;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
@@ -23,18 +24,18 @@ import org.junit.jupiter.api.Test;
 class SdkTracerTest {
 
   private static final String SPAN_NAME = "span_name";
-  private static final String INSTRUMENTATION_LIBRARY_NAME =
+  private static final String INSTRUMENTATION_SCOPE_NAME =
       "io.opentelemetry.sdk.trace.TracerSdkTest";
-  private static final String INSTRUMENTATION_LIBRARY_VERSION = "0.2.0";
-  private static final InstrumentationLibraryInfo instrumentationLibraryInfo =
-      InstrumentationLibraryInfo.create(
-          INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION, "http://schemaurl");
+  private static final String INSTRUMENTATION_SCOPE_VERSION = "0.2.0";
+  private static final InstrumentationScopeInfo instrumentationScopeInfo =
+      InstrumentationScopeInfo.create(
+          INSTRUMENTATION_SCOPE_NAME, INSTRUMENTATION_SCOPE_VERSION, "http://schemaurl");
   private final SdkTracer tracer =
       (SdkTracer)
           SdkTracerProvider.builder()
               .build()
-              .tracerBuilder(INSTRUMENTATION_LIBRARY_NAME)
-              .setInstrumentationVersion(INSTRUMENTATION_LIBRARY_VERSION)
+              .tracerBuilder(INSTRUMENTATION_SCOPE_NAME)
+              .setInstrumentationVersion(INSTRUMENTATION_SCOPE_VERSION)
               .setSchemaUrl("http://schemaurl")
               .build();
 
@@ -44,14 +45,19 @@ class SdkTracerTest {
   }
 
   @Test
-  void getInstrumentationLibraryInfo() {
-    assertThat(tracer.getInstrumentationLibraryInfo()).isEqualTo(instrumentationLibraryInfo);
+  void getInstrumentationScopeInfo() {
+    assertThat(tracer.getInstrumentationScopeInfo()).isEqualTo(instrumentationScopeInfo);
   }
 
   @Test
-  void propagatesInstrumentationLibraryInfoToSpan() {
+  void propagatesInstrumentationScopeInfoToSpan() {
     ReadableSpan readableSpan = (ReadableSpan) tracer.spanBuilder("spanName").startSpan();
-    assertThat(readableSpan.getInstrumentationLibraryInfo()).isEqualTo(instrumentationLibraryInfo);
+    assertThat(readableSpan.getInstrumentationLibraryInfo())
+        .isEqualTo(
+            InstrumentationLibraryInfo.create(
+                instrumentationScopeInfo.getName(),
+                instrumentationScopeInfo.getVersion(),
+                instrumentationScopeInfo.getSchemaUrl()));
   }
 
   @Test
@@ -70,7 +76,7 @@ class SdkTracerTest {
         SdkTracerProvider.builder().addSpanProcessor(spanProcessor).build();
     SdkTracer tracer =
         (SdkTracer)
-            sdkTracerProvider.get(INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION);
+            sdkTracerProvider.get(INSTRUMENTATION_SCOPE_NAME, INSTRUMENTATION_SCOPE_VERSION);
 
     StressTestRunner.Builder stressTestBuilder =
         StressTestRunner.builder().setTracer(tracer).setSpanProcessor(spanProcessor);
@@ -93,7 +99,7 @@ class SdkTracerTest {
         SdkTracerProvider.builder().addSpanProcessor(spanProcessor).build();
     SdkTracer tracer =
         (SdkTracer)
-            sdkTracerProvider.get(INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_LIBRARY_VERSION);
+            sdkTracerProvider.get(INSTRUMENTATION_SCOPE_NAME, INSTRUMENTATION_SCOPE_VERSION);
 
     StressTestRunner.Builder stressTestBuilder =
         StressTestRunner.builder().setTracer(tracer).setSpanProcessor(spanProcessor);


### PR DESCRIPTION
Related to #4190.

Solves the following items:
- Add InstrumentationScopeInfo
- Adjust TracerProvider docs to reflect that name is instrumentation scope name
- Adjust MeterProvider docs to reflect that name is instrumentation scope name
- Adjust LogEmitterProvider to reflect that name is instrumentation scope name

Updates `ComponentRegistry` to use new `InstrumentationScopeInfo` class internally, but `SpanData`, `MetricData`, and `LogData` still return `InstrumentationLibraryInfo`. Saving that for a subsequent PR.