### PR TITLE
Deprecate automatic histogram method for removal.

### DIFF
--- a/sdk-extensions/metric-incubator/src/test/java/io/opentelemetry/sdk/viewconfig/ViewConfigTest.java
+++ b/sdk-extensions/metric-incubator/src/test/java/io/opentelemetry/sdk/viewconfig/ViewConfigTest.java
@@ -133,7 +133,8 @@ class ViewConfigTest {
   void toAggregation() {
     assertThat(ViewConfig.toAggregation("sum")).isEqualTo(Aggregation.sum());
     assertThat(ViewConfig.toAggregation("last_value")).isEqualTo(Aggregation.lastValue());
-    assertThat(ViewConfig.toAggregation("histogram")).isEqualTo(Aggregation.histogram());
+    assertThat(ViewConfig.toAggregation("histogram"))
+        .isEqualTo(Aggregation.explicitBucketHistogram());
     assertThat(ViewConfig.toAggregation("drop")).isEqualTo(Aggregation.drop());
     assertThatThrownBy(() -> ViewConfig.toAggregation("foo"))
         .isInstanceOf(ConfigurationException.class)

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/Aggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/Aggregation.java
@@ -52,7 +52,12 @@ public abstract class Aggregation {
     return new ExplicitBucketHistogramAggregation(bucketBoundaries);
   }
 
-  /** Aggregates measurements using the best available Histogram. */
+  /**
+   * Aggregates measurements using the best available Histogram.
+   *
+   * @deprecated Use {@link #explicitBucketHistogram()}.
+   */
+  @Deprecated
   public static Aggregation histogram() {
     return explicitBucketHistogram();
   }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/view/ViewRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/view/ViewRegistryTest.java
@@ -80,7 +80,7 @@ class ViewRegistryTest {
   @Test
   void selection_FirstAddedViewWins() {
     View view1 = View.builder().setAggregation(Aggregation.lastValue()).build();
-    View view2 = View.builder().setAggregation(Aggregation.histogram()).build();
+    View view2 = View.builder().setAggregation(Aggregation.explicitBucketHistogram()).build();
 
     ViewRegistry viewRegistry =
         ViewRegistry.builder()

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/view/AggregationTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/view/AggregationTest.java
@@ -30,6 +30,8 @@ class AggregationTest {
   @Test
   void histogramUsesExplicitBucket() {
     // Note: This will change when exponential histograms are launched.
-    assertThat(Aggregation.histogram()).asString().contains("ExplicitBucketHistogram");
+    assertThat(Aggregation.explicitBucketHistogram())
+        .asString()
+        .contains("ExplicitBucketHistogram");
   }
 }


### PR DESCRIPTION
As discussed at the SIG, we don't see a way to actually change the histogram that is returned by this method in the future, in which case it currently overlaps with `explicitBucketsHistogram`, and constrains us if we do end up wanting to encourage a different one, such as exponential, as the de-facto.

https://github.com/open-telemetry/opentelemetry-specification/issues/2382