### PR TITLE
Implement metric identity specification

### DIFF
--- a/sdk/metrics/src/debugEnabledTest/java/io/opentelemetry/sdk/metrics/internal/descriptor/InstrumentDescriptorTest.java
+++ b/sdk/metrics/src/debugEnabledTest/java/io/opentelemetry/sdk/metrics/internal/descriptor/InstrumentDescriptorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.internal.descriptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.sdk.metrics.common.InstrumentType;
+import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link InstrumentDescriptor#equals(Object)} must ignore {@link
+ * InstrumentDescriptor#getSourceInfo()}, which only returns a meaningful value when {@code
+ * otel.experimental.sdk.metrics.debug=true}.
+ */
+class InstrumentDescriptorTest {
+
+  @Test
+  void equals() {
+    InstrumentDescriptor descriptor =
+        InstrumentDescriptor.create(
+            "name", "description", "unit", InstrumentType.COUNTER, InstrumentValueType.LONG);
+
+    assertThat(descriptor)
+        .isEqualTo(
+            InstrumentDescriptor.create(
+                "name", "description", "unit", InstrumentType.COUNTER, InstrumentValueType.LONG));
+
+    // Validate getSourceInfo() is not equal for otherwise equal descriptors
+    assertThat(descriptor.getSourceInfo())
+        .isNotEqualTo(
+            InstrumentDescriptor.create(
+                    "name", "description", "unit", InstrumentType.COUNTER, InstrumentValueType.LONG)
+                .getSourceInfo());
+
+    // Validate that name, description, unit, type, and value type are considered in equals
+    assertThat(descriptor)
+        .isNotEqualTo(
+            InstrumentDescriptor.create(
+                "foo", "description", "unit", InstrumentType.COUNTER, InstrumentValueType.LONG));
+    assertThat(descriptor)
+        .isNotEqualTo(
+            InstrumentDescriptor.create(
+                "name", "foo", "unit", InstrumentType.COUNTER, InstrumentValueType.LONG));
+    assertThat(descriptor)
+        .isNotEqualTo(
+            InstrumentDescriptor.create(
+                "name", "description", "foo", InstrumentType.COUNTER, InstrumentValueType.LONG));
+    assertThat(descriptor)
+        .isNotEqualTo(
+            InstrumentDescriptor.create(
+                "name",
+                "description",
+                "unit",
+                InstrumentType.UP_DOWN_COUNTER,
+                InstrumentValueType.LONG));
+    assertThat(descriptor)
+        .isNotEqualTo(
+            InstrumentDescriptor.create(
+                "name", "description", "unit", InstrumentType.COUNTER, InstrumentValueType.DOUBLE));
+  }
+}

--- a/sdk/metrics/src/debugEnabledTest/java/io/opentelemetry/testing/TestSourceInfo.java
+++ b/sdk/metrics/src/debugEnabledTest/java/io/opentelemetry/testing/TestSourceInfo.java
@@ -44,11 +44,16 @@ class TestSourceInfo {
         MetricDescriptor.create(
             View.builder().build(),
             InstrumentDescriptor.create(
-                "name", "description2", "unit2", InstrumentType.COUNTER, InstrumentValueType.LONG));
+                "name2",
+                "description2",
+                "unit2",
+                InstrumentType.COUNTER,
+                InstrumentValueType.LONG));
     assertThat(DebugUtils.duplicateMetricErrorMessage(simple, simpleWithNewDescription))
         .contains("Found duplicate metric definition: name")
-        .contains("- Unit [unit2] does not match [unit]")
-        .contains("- Description [description2] does not match [description]")
+        .contains("- InstrumentDescription [description2] does not match [description]")
+        .contains("- InstrumentName [name2] does not match [name]")
+        .contains("- InstrumentUnit [unit2] does not match [unit]")
         .contains("- InstrumentType [COUNTER] does not match [OBSERVABLE_COUNTER]")
         .contains("- InstrumentValueType [LONG] does not match [DOUBLE]")
         .contains(simple.getSourceInstrument().getSourceInfo().multiLineDebugString())
@@ -59,10 +64,9 @@ class TestSourceInfo {
 
   @Test
   void testDuplicateExceptionMessage_viewBasedConflict() {
-    View problemView = View.builder().setName("name2").build();
     MetricDescriptor simple =
         MetricDescriptor.create(
-            problemView,
+            View.builder().setName("name2").build(),
             InstrumentDescriptor.create(
                 "name",
                 "description",
@@ -81,9 +85,9 @@ class TestSourceInfo {
     assertThat(DebugUtils.duplicateMetricErrorMessage(simple, simpleWithNewDescription))
         .contains("Found duplicate metric definition: name2")
         .contains(simple.getSourceInstrument().getSourceInfo().multiLineDebugString())
-        .contains("- Description [description2] does not match [description]")
+        .contains("- InstrumentDescription [description2] does not match [description]")
         .contains("Conflicting view registered")
-        .contains(problemView.getSourceInfo().multiLineDebugString())
+        .contains(simple.getSourceView().getSourceInfo().multiLineDebugString())
         .contains("FROM instrument name")
         .contains(
             simpleWithNewDescription.getSourceInstrument().getSourceInfo().multiLineDebugString());
@@ -116,7 +120,7 @@ class TestSourceInfo {
         .contains(problemView.getSourceInfo().multiLineDebugString())
         .contains("FROM instrument name2")
         .contains(simple.getSourceInstrument().getSourceInfo().multiLineDebugString())
-        .contains("- Unit [unit] does not match [unit2]")
+        .contains("- InstrumentUnit [unit] does not match [unit2]")
         .contains("Original instrument registered with same name but is incompatible.")
         .contains(
             simpleWithNewDescription.getSourceInstrument().getSourceInfo().multiLineDebugString());

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramAggregator.java
@@ -131,7 +131,7 @@ final class DoubleExponentialHistogramAggregator
         instrumentationLibrary,
         metricDescriptor.getName(),
         metricDescriptor.getDescription(),
-        metricDescriptor.getUnit(),
+        metricDescriptor.getSourceInstrument().getUnit(),
         ExponentialHistogramData.create(
             temporality,
             MetricDataUtils.toExponentialHistogramPointList(

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleHistogramAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleHistogramAggregator.java
@@ -103,7 +103,7 @@ public final class DoubleHistogramAggregator implements Aggregator<HistogramAccu
         instrumentationLibraryInfo,
         metricDescriptor.getName(),
         metricDescriptor.getDescription(),
-        metricDescriptor.getUnit(),
+        metricDescriptor.getSourceInstrument().getUnit(),
         DoubleHistogramData.create(
             temporality,
             MetricDataUtils.toDoubleHistogramPointList(

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleLastValueAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleLastValueAggregator.java
@@ -72,7 +72,7 @@ public final class DoubleLastValueAggregator implements Aggregator<DoubleAccumul
         instrumentationLibraryInfo,
         descriptor.getName(),
         descriptor.getDescription(),
-        descriptor.getUnit(),
+        descriptor.getSourceInstrument().getUnit(),
         ImmutableGaugeData.create(
             MetricDataUtils.toDoublePointList(
                 accumulationByLabels,

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleSumAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleSumAggregator.java
@@ -84,7 +84,7 @@ public final class DoubleSumAggregator extends AbstractSumAggregator<DoubleAccum
         instrumentationLibraryInfo,
         descriptor.getName(),
         descriptor.getDescription(),
-        descriptor.getUnit(),
+        descriptor.getSourceInstrument().getUnit(),
         DoubleSumData.create(
             isMonotonic(),
             temporality,

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongLastValueAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongLastValueAggregator.java
@@ -69,7 +69,7 @@ public final class LongLastValueAggregator implements Aggregator<LongAccumulatio
         instrumentationLibraryInfo,
         descriptor.getName(),
         descriptor.getDescription(),
-        descriptor.getUnit(),
+        descriptor.getSourceInstrument().getUnit(),
         ImmutableGaugeData.create(
             MetricDataUtils.toLongPointList(
                 accumulationByLabels,

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongSumAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongSumAggregator.java
@@ -71,7 +71,7 @@ public final class LongSumAggregator extends AbstractSumAggregator<LongAccumulat
         instrumentationLibraryInfo,
         descriptor.getName(),
         descriptor.getDescription(),
-        descriptor.getUnit(),
+        descriptor.getSourceInstrument().getUnit(),
         LongSumData.create(
             isMonotonic(),
             temporality,

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/descriptor/InstrumentDescriptor.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/descriptor/InstrumentDescriptor.java
@@ -21,14 +21,16 @@ import javax.annotation.concurrent.Immutable;
 @AutoValue
 @Immutable
 public abstract class InstrumentDescriptor {
+
+  private final SourceInfo sourceInfo = SourceInfo.fromCurrentStack();
+
   public static InstrumentDescriptor create(
       String name,
       String description,
       String unit,
       InstrumentType type,
       InstrumentValueType valueType) {
-    return new AutoValue_InstrumentDescriptor(
-        name, description, unit, type, valueType, SourceInfo.fromCurrentStack());
+    return new AutoValue_InstrumentDescriptor(name, description, unit, type, valueType);
   }
 
   public abstract String getName();
@@ -41,8 +43,13 @@ public abstract class InstrumentDescriptor {
 
   public abstract InstrumentValueType getValueType();
 
-  /** Debugging information for this instrument. */
-  public abstract SourceInfo getSourceInfo();
+  /**
+   * Debugging information for this instrument. Ignored from {@link #equals(Object)} and {@link
+   * #toString()}
+   */
+  public final SourceInfo getSourceInfo() {
+    return sourceInfo;
+  }
 
   @Memoized
   @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/descriptor/MetricDescriptor.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/descriptor/MetricDescriptor.java
@@ -11,7 +11,6 @@ import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.view.View;
 import java.util.Objects;
-import java.util.Optional;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -27,7 +26,7 @@ import javax.annotation.concurrent.Immutable;
 public abstract class MetricDescriptor {
 
   /**
-   * Constructs a metric descriptor with no source instrument/view.
+   * Constructs a metric descriptor with no instrument and default view.
    *
    * <p>Used for testing + empty-storage only.
    */
@@ -35,8 +34,7 @@ public abstract class MetricDescriptor {
     return new AutoValue_MetricDescriptor(
         name,
         description,
-        unit,
-        Optional.empty(),
+        View.builder().build(),
         InstrumentDescriptor.create(
             name, description, unit, InstrumentType.OBSERVABLE_GAUGE, InstrumentValueType.DOUBLE));
   }
@@ -46,20 +44,31 @@ public abstract class MetricDescriptor {
     String name = (view.getName() == null) ? instrument.getName() : view.getName();
     String description =
         (view.getDescription() == null) ? instrument.getDescription() : view.getDescription();
-    return new AutoValue_MetricDescriptor(
-        name, description, instrument.getUnit(), Optional.of(view), instrument);
+    return new AutoValue_MetricDescriptor(name, description, view, instrument);
   }
 
+  /**
+   * The name of the descriptor, equal to {@link View#getName()} if not null, else {@link
+   * InstrumentDescriptor#getName()}.
+   */
   public abstract String getName();
 
+  /**
+   * The description of the descriptor, equal to {@link View#getDescription()} if not null, else
+   * {@link InstrumentDescriptor#getDescription()}.
+   */
   public abstract String getDescription();
 
-  public abstract String getUnit();
+  /** The view that lead to the creation of this metric. */
+  public abstract View getSourceView();
 
-  /** The view that lead to the creation of this metric, if applicable. */
-  public abstract Optional<View> getSourceView();
   /** The instrument which lead to the creation of this metric. */
   public abstract InstrumentDescriptor getSourceInstrument();
+
+  /** The FQCN of the view aggregation. */
+  public String getAggregationName() {
+    return getSourceView().getAggregation().getClass().getName();
+  }
 
   @Memoized
   @Override
@@ -73,7 +82,10 @@ public abstract class MetricDescriptor {
    * <ul>
    *   <li>{@link #getName()} is equal
    *   <li>{@link #getDescription()} is equal
-   *   <li>{@link #getUnit()} is equal
+   *   <li>{@link #getAggregationName()} is equal
+   *   <li>{@link InstrumentDescriptor#getName()} is equal
+   *   <li>{@link InstrumentDescriptor#getDescription()} is equal
+   *   <li>{@link InstrumentDescriptor#getUnit()} is equal
    *   <li>{@link InstrumentDescriptor#getType()} is equal
    *   <li>{@link InstrumentDescriptor#getValueType()} is equal
    * </ul>
@@ -81,7 +93,11 @@ public abstract class MetricDescriptor {
   public boolean isCompatibleWith(MetricDescriptor other) {
     return Objects.equals(getName(), other.getName())
         && Objects.equals(getDescription(), other.getDescription())
-        && Objects.equals(getUnit(), other.getUnit())
+        && Objects.equals(getAggregationName(), other.getAggregationName())
+        && Objects.equals(getSourceInstrument().getName(), other.getSourceInstrument().getName())
+        && Objects.equals(
+            getSourceInstrument().getDescription(), other.getSourceInstrument().getDescription())
+        && Objects.equals(getSourceInstrument().getUnit(), other.getSourceInstrument().getUnit())
         && Objects.equals(getSourceInstrument().getType(), other.getSourceInstrument().getType())
         && Objects.equals(
             getSourceInstrument().getValueType(), other.getSourceInstrument().getValueType());

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MeterSharedState.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MeterSharedState.java
@@ -17,11 +17,7 @@ import io.opentelemetry.sdk.metrics.internal.export.CollectionInfo;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Consumer;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -33,8 +29,6 @@ import javax.annotation.concurrent.Immutable;
 @AutoValue
 @Immutable
 public abstract class MeterSharedState {
-
-  private static final Logger logger = Logger.getLogger(MeterSharedState.class.getName());
 
   public static MeterSharedState create(InstrumentationLibraryInfo instrumentationLibraryInfo) {
     return new AutoValue_MeterSharedState(instrumentationLibraryInfo, new MetricStorageRegistry());
@@ -77,7 +71,7 @@ public abstract class MeterSharedState {
   public final WriteableMetricStorage registerSynchronousMetricStorage(
       InstrumentDescriptor instrument, MeterProviderSharedState meterProviderSharedState) {
 
-    List<WriteableMetricStorage> storage =
+    List<SynchronousMetricStorage> storages =
         meterProviderSharedState
             .getViewRegistry()
             .findViews(instrument, getInstrumentationLibraryInfo())
@@ -87,15 +81,17 @@ public abstract class MeterSharedState {
                     SynchronousMetricStorage.create(
                         view, instrument, meterProviderSharedState.getExemplarFilter()))
             .filter(m -> !m.isEmpty())
-            .map(this::register)
-            .filter(Objects::nonNull)
             .collect(toList());
 
-    if (storage.size() == 1) {
-      return storage.get(0);
+    List<SynchronousMetricStorage> registeredStorages = new ArrayList<>(storages.size());
+    for (SynchronousMetricStorage storage : storages) {
+      registeredStorages.add(getMetricStorageRegistry().register(storage));
     }
-    // If the size is 0, we return an, effectively, no-op writer.
-    return new MultiWritableMetricStorage(storage);
+
+    if (registeredStorages.size() == 1) {
+      return registeredStorages.get(0);
+    }
+    return new MultiWritableMetricStorage(registeredStorages);
   }
 
   /** Registers new asynchronous storage associated with a given {@code long} instrument. */
@@ -117,11 +113,10 @@ public abstract class MeterSharedState {
     List<AsynchronousMetricStorage<?, ObservableLongMeasurement>> registeredStorages =
         new ArrayList<>();
     for (AsynchronousMetricStorage<?, ObservableLongMeasurement> storage : storages) {
-      AsynchronousMetricStorage<?, ObservableLongMeasurement> registeredStorage = register(storage);
-      if (registeredStorage != null) {
-        registeredStorage.addCallback(callback);
-        registeredStorages.add(registeredStorage);
-      }
+      AsynchronousMetricStorage<?, ObservableLongMeasurement> registeredStorage =
+          getMetricStorageRegistry().register(storage);
+      registeredStorage.addCallback(callback);
+      registeredStorages.add(registeredStorage);
     }
     return registeredStorages;
   }
@@ -146,24 +141,10 @@ public abstract class MeterSharedState {
         new ArrayList<>();
     for (AsynchronousMetricStorage<?, ObservableDoubleMeasurement> storage : storages) {
       AsynchronousMetricStorage<?, ObservableDoubleMeasurement> registeredStorage =
-          register(storage);
-      if (registeredStorage != null) {
-        registeredStorage.addCallback(callback);
-        registeredStorages.add(registeredStorage);
-      }
+          getMetricStorageRegistry().register(storage);
+      registeredStorage.addCallback(callback);
+      registeredStorages.add(registeredStorage);
     }
     return registeredStorages;
-  }
-
-  @Nullable
-  private <S extends MetricStorage> S register(S storage) {
-    try {
-      return getMetricStorageRegistry().register(storage);
-    } catch (DuplicateMetricStorageException e) {
-      if (logger.isLoggable(Level.WARNING)) {
-        logger.log(Level.WARNING, DebugUtils.duplicateMetricErrorMessage(e), e);
-      }
-    }
-    return null;
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MultiWritableMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MultiWritableMetricStorage.java
@@ -10,9 +10,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 class MultiWritableMetricStorage implements WriteableMetricStorage {
-  private final List<WriteableMetricStorage> underlyingMetrics;
+  private final List<? extends WriteableMetricStorage> underlyingMetrics;
 
-  MultiWritableMetricStorage(List<WriteableMetricStorage> metrics) {
+  MultiWritableMetricStorage(List<? extends WriteableMetricStorage> metrics) {
     this.underlyingMetrics = metrics;
   }
 

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/IdentityTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/IdentityTest.java
@@ -1,0 +1,935 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics;
+
+import static io.opentelemetry.sdk.testing.assertj.MetricAssertions.assertThat;
+
+import io.github.netmikey.logunit.api.LogCapturer;
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.metrics.common.InstrumentType;
+import io.opentelemetry.sdk.metrics.internal.state.MetricStorageRegistry;
+import io.opentelemetry.sdk.metrics.view.Aggregation;
+import io.opentelemetry.sdk.metrics.view.InstrumentSelector;
+import io.opentelemetry.sdk.metrics.view.MeterSelector;
+import io.opentelemetry.sdk.metrics.view.View;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class IdentityTest {
+
+  @RegisterExtension
+  LogCapturer logs = LogCapturer.create().captureForType(MetricStorageRegistry.class);
+
+  private InMemoryMetricReader reader;
+  private SdkMeterProviderBuilder builder;
+
+  @BeforeEach
+  void setup() {
+    reader = InMemoryMetricReader.createDelta();
+    builder =
+        SdkMeterProvider.builder()
+            .registerMetricReader(reader)
+            .setMinimumCollectionInterval(Duration.ZERO);
+  }
+
+  @Test
+  void sameMeterSameInstrumentNoViews() {
+    // Instruments are the same if their name, type, value type, description, and unit are all
+    // equal.
+    SdkMeterProvider meterProvider = builder.build();
+
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(20)));
+
+    meterProvider.get("meter2").counterBuilder("counter2").ofDoubles().build().add(10);
+    meterProvider.get("meter2").counterBuilder("counter2").ofDoubles().build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter2"))
+                    .hasName("counter2")
+                    .hasDoubleSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(20)));
+
+    meterProvider
+        .get("meter3")
+        .counterBuilder("counter3")
+        .setDescription("description3")
+        .build()
+        .add(10);
+    meterProvider
+        .get("meter3")
+        .counterBuilder("counter3")
+        .setDescription("description3")
+        .build()
+        .add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter3"))
+                    .hasName("counter3")
+                    .hasDescription("description3")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(20)));
+
+    meterProvider.get("meter4").counterBuilder("counter4").setUnit("unit4").build().add(10);
+    meterProvider.get("meter4").counterBuilder("counter4").setUnit("unit4").build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter4"))
+                    .hasName("counter4")
+                    .hasUnit("unit4")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(20)));
+
+    assertThat(logs.getEvents()).hasSize(0);
+  }
+
+  @Test
+  void sameMeterDifferentInstrumentNoViews() {
+    SdkMeterProvider meterProvider = builder.build();
+
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+    meterProvider.get("meter1").counterBuilder("counter2").build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)),
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter2")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)));
+
+    assertThat(logs.getEvents()).hasSize(0);
+  }
+
+  @Test
+  void differentMeterSameInstrumentNoViews() {
+    // Meters are the same if their name, version, and scope are all equals
+    SdkMeterProvider meterProvider = builder.build();
+
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+    meterProvider.get("meter2").counterBuilder("counter1").build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)),
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter2"))
+                    .hasName("counter1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)));
+
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+    meterProvider
+        .meterBuilder("meter1")
+        .setInstrumentationVersion("version1")
+        .build()
+        .counterBuilder("counter1")
+        .build()
+        .add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)),
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(
+                        InstrumentationLibraryInfo.create("meter1", "version1"))
+                    .hasName("counter1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)));
+
+    meterProvider
+        .meterBuilder("meter1")
+        .setInstrumentationVersion("version1")
+        .build()
+        .counterBuilder("counter1")
+        .build()
+        .add(10);
+    meterProvider
+        .meterBuilder("meter1")
+        .setInstrumentationVersion("version1")
+        .setSchemaUrl("schema1")
+        .build()
+        .counterBuilder("counter1")
+        .build()
+        .add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(
+                        InstrumentationLibraryInfo.create("meter1", "version1"))
+                    .hasName("counter1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)),
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(
+                        InstrumentationLibraryInfo.create("meter1", "version1", "schema1"))
+                    .hasName("counter1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)));
+
+    assertThat(logs.getEvents()).hasSize(0);
+  }
+
+  @Test
+  @SuppressLogger(MetricStorageRegistry.class)
+  void sameMeterConflictingInstrumentDescriptionNoViews() {
+    // Instruments with the same name but different descriptions are in conflict.
+    SdkMeterProvider meterProvider = builder.build();
+
+    meterProvider
+        .get("meter1")
+        .counterBuilder("counter1")
+        .setDescription("description1")
+        .build()
+        .add(10);
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasDescription("description1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)),
+            metricData -> {
+              assertThat(metricData)
+                  .hasInstrumentationLibrary(forMeter("meter1"))
+                  .hasName("counter1")
+                  .hasLongSum()
+                  .points()
+                  .satisfiesExactly(point -> assertThat(point).hasValue(10));
+              assertThat(metricData.getDescription()).isBlank();
+            });
+
+    assertThat(logs.getEvents())
+        .allSatisfy(
+            logEvent ->
+                assertThat(logEvent.getMessage()).contains("Found duplicate metric definition"))
+        .hasSize(1);
+  }
+
+  @Test
+  @SuppressLogger(MetricStorageRegistry.class)
+  void sameMeterConflictingInstrumentUnitNoViews() {
+    // Instruments with the same name but different units are in conflict.
+    SdkMeterProvider meterProvider = builder.build();
+
+    meterProvider.get("meter1").counterBuilder("counter1").setUnit("unit1").build().add(10);
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasUnit("unit1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)),
+            metricData -> {
+              assertThat(metricData)
+                  .hasInstrumentationLibrary(forMeter("meter1"))
+                  .hasName("counter1")
+                  .hasLongSum()
+                  .points()
+                  .satisfiesExactly(point -> assertThat(point).hasValue(10));
+              assertThat(metricData.getUnit()).isEqualTo("1");
+            });
+
+    assertThat(logs.getEvents())
+        .allSatisfy(
+            logEvent ->
+                assertThat(logEvent.getMessage()).contains("Found duplicate metric definition"))
+        .hasSize(1);
+  }
+
+  @Test
+  @SuppressLogger(MetricStorageRegistry.class)
+  void sameMeterConflictingInstrumentTypeNoViews() {
+    // Instruments with the same name but different types are in conflict.
+    SdkMeterProvider meterProvider = builder.build();
+
+    meterProvider.get("meter1").upDownCounterBuilder("counter1").build().add(10);
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasLongSum()
+                    .isNotMonotonic()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)),
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasLongSum()
+                    .isMonotonic()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)));
+
+    assertThat(logs.getEvents())
+        .allSatisfy(
+            logEvent ->
+                assertThat(logEvent.getMessage()).contains("Found duplicate metric definition"))
+        .hasSize(1);
+  }
+
+  @Test
+  @SuppressLogger(MetricStorageRegistry.class)
+  void sameMeterConflictingInstrumentValueTypeNoViews() {
+    // Instruments with the same name but different instrument value types are in conflict.
+    SdkMeterProvider meterProvider = builder.build();
+
+    meterProvider.get("meter1").counterBuilder("counter1").ofDoubles().build().add(10);
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasDoubleSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)),
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)));
+
+    assertThat(logs.getEvents())
+        .allSatisfy(
+            logEvent ->
+                assertThat(logEvent.getMessage()).contains("Found duplicate metric definition"))
+        .hasSize(1);
+  }
+
+  @Test
+  void sameMeterSameInstrumentSingleView() {
+    SdkMeterProvider meterProvider =
+        builder
+            .registerView(
+                InstrumentSelector.builder().setInstrumentType(InstrumentType.COUNTER).build(),
+                View.builder().setDescription("description1").build())
+            .build();
+
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasDescription("description1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(20)));
+
+    assertThat(logs.getEvents()).hasSize(0);
+  }
+
+  @Test
+  void differentMeterSameInstrumentSingleView() {
+    SdkMeterProvider meterProvider =
+        builder
+            .registerView(
+                InstrumentSelector.builder().setInstrumentType(InstrumentType.COUNTER).build(),
+                View.builder().setDescription("description1").build())
+            .build();
+
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+    meterProvider.get("meter2").counterBuilder("counter1").build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasDescription("description1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)),
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter2"))
+                    .hasName("counter1")
+                    .hasDescription("description1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)));
+
+    assertThat(logs.getEvents()).hasSize(0);
+  }
+
+  @Test
+  void sameMeterDifferentInstrumentSingleView() {
+    SdkMeterProvider meterProvider =
+        builder
+            .registerView(
+                InstrumentSelector.builder().setInstrumentType(InstrumentType.COUNTER).build(),
+                View.builder().setDescription("description1").build())
+            .build();
+
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+    meterProvider.get("meter1").counterBuilder("counter2").build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasDescription("description1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)),
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter2")
+                    .hasDescription("description1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)));
+
+    assertThat(logs.getEvents()).hasSize(0);
+  }
+
+  @Test
+  void sameMeterDifferentInstrumentViewSelectingInstrumentName() {
+    SdkMeterProvider meterProvider =
+        builder
+            .registerView(
+                InstrumentSelector.builder().setInstrumentName("counter1").build(),
+                View.builder().setDescription("description1").build())
+            .build();
+
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+    meterProvider.get("meter1").counterBuilder("counter2").build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasDescription("description1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)),
+            metricData -> {
+              assertThat(metricData)
+                  .hasInstrumentationLibrary(forMeter("meter1"))
+                  .hasName("counter2")
+                  .hasLongSum()
+                  .points()
+                  .satisfiesExactly(point -> assertThat(point).hasValue(10));
+              assertThat(metricData.getDescription()).isBlank();
+            });
+
+    assertThat(logs.getEvents()).hasSize(0);
+  }
+
+  @Test
+  void sameMeterDifferentInstrumentViewSelectingInstrumentType() {
+    SdkMeterProvider meterProvider =
+        builder
+            .registerView(
+                InstrumentSelector.builder().setInstrumentType(InstrumentType.COUNTER).build(),
+                View.builder().setDescription("description1").build())
+            .build();
+
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+    meterProvider.get("meter1").upDownCounterBuilder("counter2").build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasDescription("description1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)),
+            metricData -> {
+              assertThat(metricData)
+                  .hasInstrumentationLibrary(forMeter("meter1"))
+                  .hasName("counter2")
+                  .hasLongSum()
+                  .points()
+                  .satisfiesExactly(point -> assertThat(point).hasValue(10));
+              assertThat(metricData.getDescription()).isBlank();
+            });
+
+    assertThat(logs.getEvents()).hasSize(0);
+  }
+
+  @Test
+  void differentMeterSameInstrumentViewSelectingMeterName() {
+    SdkMeterProvider meterProvider =
+        builder
+            .registerView(
+                InstrumentSelector.builder()
+                    .setMeterSelector(MeterSelector.builder().setName("meter1").build())
+                    .build(),
+                View.builder().setDescription("description1").build())
+            .build();
+
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+    meterProvider.get("meter2").counterBuilder("counter1").build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasDescription("description1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)),
+            metricData -> {
+              assertThat(metricData)
+                  .hasInstrumentationLibrary(forMeter("meter2"))
+                  .hasName("counter1")
+                  .hasLongSum()
+                  .points()
+                  .satisfiesExactly(point -> assertThat(point).hasValue(10));
+              assertThat(metricData.getDescription()).isBlank();
+            });
+
+    assertThat(logs.getEvents()).hasSize(0);
+  }
+
+  @Test
+  void differentMeterSameInstrumentViewSelectingMeterVersion() {
+    SdkMeterProvider meterProvider =
+        builder
+            .registerView(
+                InstrumentSelector.builder()
+                    .setMeterSelector(MeterSelector.builder().setVersion("version1").build())
+                    .build(),
+                View.builder().setDescription("description1").build())
+            .build();
+
+    meterProvider
+        .meterBuilder("meter1")
+        .setInstrumentationVersion("version1")
+        .build()
+        .counterBuilder("counter1")
+        .build()
+        .add(10);
+    meterProvider
+        .meterBuilder("meter1")
+        .setInstrumentationVersion("version2")
+        .build()
+        .counterBuilder("counter1")
+        .build()
+        .add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(
+                        InstrumentationLibraryInfo.create("meter1", "version1"))
+                    .hasName("counter1")
+                    .hasDescription("description1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)),
+            metricData -> {
+              assertThat(metricData)
+                  .hasInstrumentationLibrary(
+                      InstrumentationLibraryInfo.create("meter1", "version2"))
+                  .hasName("counter1")
+                  .hasLongSum()
+                  .points()
+                  .satisfiesExactly(point -> assertThat(point).hasValue(10));
+              assertThat(metricData.getDescription()).isBlank();
+            });
+
+    assertThat(logs.getEvents()).hasSize(0);
+  }
+
+  @Test
+  void differentMeterSameInstrumentViewSelectingMeterSchema() {
+    SdkMeterProvider meterProvider =
+        builder
+            .registerView(
+                InstrumentSelector.builder()
+                    .setMeterSelector(MeterSelector.builder().setSchemaUrl("schema1").build())
+                    .build(),
+                View.builder().setDescription("description1").build())
+            .build();
+
+    meterProvider
+        .meterBuilder("meter1")
+        .setSchemaUrl("schema1")
+        .build()
+        .counterBuilder("counter1")
+        .build()
+        .add(10);
+    meterProvider
+        .meterBuilder("meter1")
+        .setSchemaUrl("schema2")
+        .build()
+        .counterBuilder("counter1")
+        .build()
+        .add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(
+                        InstrumentationLibraryInfo.create("meter1", null, "schema1"))
+                    .hasName("counter1")
+                    .hasDescription("description1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)),
+            metricData -> {
+              assertThat(metricData)
+                  .hasInstrumentationLibrary(
+                      InstrumentationLibraryInfo.create("meter1", null, "schema2"))
+                  .hasName("counter1")
+                  .hasLongSum()
+                  .points()
+                  .satisfiesExactly(point -> assertThat(point).hasValue(10));
+              assertThat(metricData.getDescription()).isBlank();
+            });
+
+    assertThat(logs.getEvents()).hasSize(0);
+  }
+
+  @Test
+  void differentMeterDifferentInstrumentViewSelectingInstrumentNameAndMeterName() {
+    // A view selecting based on meter name and instrument name should not affect different
+    // instruments in the selected meter, or the same instrument in a different meter.
+    SdkMeterProvider meterProvider =
+        builder
+            .registerView(
+                InstrumentSelector.builder()
+                    .setMeterSelector(MeterSelector.builder().setName("meter1").build())
+                    .setInstrumentName("counter1")
+                    .build(),
+                View.builder().setDescription("description1").build())
+            .build();
+
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+    meterProvider.get("meter1").counterBuilder("counter2").build().add(10);
+    meterProvider.get("meter2").upDownCounterBuilder("counter1").build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasDescription("description1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)),
+            metricData -> {
+              assertThat(metricData)
+                  .hasInstrumentationLibrary(forMeter("meter1"))
+                  .hasName("counter2")
+                  .hasLongSum()
+                  .points()
+                  .satisfiesExactly(point -> assertThat(point).hasValue(10));
+              assertThat(metricData.getDescription()).isBlank();
+            },
+            metricData -> {
+              assertThat(metricData)
+                  .hasInstrumentationLibrary(forMeter("meter2"))
+                  .hasName("counter1")
+                  .hasLongSum()
+                  .points()
+                  .satisfiesExactly(point -> assertThat(point).hasValue(10));
+              assertThat(metricData.getDescription()).isBlank();
+            });
+
+    assertThat(logs.getEvents()).hasSize(0);
+  }
+
+  @Test
+  @SuppressLogger(MetricStorageRegistry.class)
+  void sameMeterSameInstrumentConflictingViewDescriptions() {
+    // Registering multiple views that select the same instrument(s) and change the description
+    // produces an identity conflict as description is part of instrument identity.
+    SdkMeterProvider meterProvider =
+        builder
+            .registerView(
+                InstrumentSelector.builder().setInstrumentType(InstrumentType.COUNTER).build(),
+                View.builder().setDescription("description1").build())
+            .registerView(
+                InstrumentSelector.builder().setInstrumentType(InstrumentType.COUNTER).build(),
+                View.builder().setDescription("description2").build())
+            .build();
+
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasDescription("description1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(20)),
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasDescription("description2")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(20)));
+
+    assertThat(logs.getEvents())
+        .allSatisfy(
+            logEvent ->
+                assertThat(logEvent.getMessage()).contains("Found duplicate metric definition"))
+        .hasSize(1);
+  }
+
+  @Test
+  @SuppressLogger(MetricStorageRegistry.class)
+  void sameMeterSameInstrumentConflictingViewAggregations() {
+    // Registering multiple views that select the same instrument(s) and change the aggregation
+    // produces an identity conflict as aggregation is part of instrument identity.
+    SdkMeterProvider meterProvider =
+        builder
+            .registerView(
+                InstrumentSelector.builder().setInstrumentType(InstrumentType.COUNTER).build(),
+                View.builder().setAggregation(Aggregation.defaultAggregation()).build())
+            .registerView(
+                InstrumentSelector.builder().setInstrumentType(InstrumentType.COUNTER).build(),
+                View.builder().setAggregation(Aggregation.lastValue()).build())
+            .build();
+
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(20)),
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasLongGauge()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)));
+
+    assertThat(logs.getEvents())
+        .allSatisfy(
+            logEvent ->
+                assertThat(logEvent.getMessage()).contains("Found duplicate metric definition"))
+        .hasSize(1);
+  }
+
+  @Test
+  @SuppressLogger(MetricStorageRegistry.class)
+  void sameMeterDifferentInstrumentConflictingViewName() {
+    // A view that selects multiple instruments and sets the name produces an identity conflict. If
+    // it could, views could be used to merge compatible instruments, which is out of scope.
+    SdkMeterProvider meterProvider =
+        builder
+            .registerView(
+                InstrumentSelector.builder().setInstrumentType(InstrumentType.COUNTER).build(),
+                View.builder().setName("counter-new").build())
+            .build();
+
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+    meterProvider.get("meter1").counterBuilder("counter2").build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter-new")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)),
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter-new")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)));
+
+    assertThat(logs.getEvents())
+        .allSatisfy(
+            logEvent ->
+                assertThat(logEvent.getMessage()).contains("Found duplicate metric definition"))
+        .hasSize(1);
+  }
+
+  @Test
+  void differentMeterDifferentInstrumentViewSetsName() {
+    // A view can select multiple instruments and set the name without producing a conflict if the
+    // instruments belong to different meters.
+    SdkMeterProvider meterProvider =
+        builder
+            .registerView(
+                InstrumentSelector.builder().setInstrumentType(InstrumentType.COUNTER).build(),
+                View.builder().setName("counter-new").build())
+            .build();
+
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+    meterProvider.get("meter2").counterBuilder("counter2").build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter-new")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)),
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter2"))
+                    .hasName("counter-new")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)));
+
+    assertThat(logs.getEvents()).hasSize(0);
+  }
+
+  @Test
+  void sameMeterDifferentInstrumentCompatibleViews() {
+    // Multiple views can select the same instrument(s) without conflict if they produce instruments
+    // with unique identities. For example, one view might change part of the instrument identity
+    // (description, aggregation) and another might change the aggregation and name to avoid
+    // identity conflicts.
+    SdkMeterProvider meterProvider =
+        builder
+            .registerView(
+                InstrumentSelector.builder().setInstrumentType(InstrumentType.COUNTER).build(),
+                View.builder().setDescription("description1").build())
+            .registerView(
+                InstrumentSelector.builder().setInstrumentName("counter1").build(),
+                View.builder()
+                    .setName("counter1-gauge")
+                    .setAggregation(Aggregation.lastValue())
+                    .build())
+            .build();
+
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+    meterProvider.get("meter1").counterBuilder("counter1").build().add(10);
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1")
+                    .hasDescription("description1")
+                    .hasLongSum()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(20)),
+            metricData ->
+                assertThat(metricData)
+                    .hasInstrumentationLibrary(forMeter("meter1"))
+                    .hasName("counter1-gauge")
+                    .hasLongGauge()
+                    .points()
+                    .satisfiesExactly(point -> assertThat(point).hasValue(10)));
+
+    assertThat(logs.getEvents()).hasSize(0);
+  }
+
+  private static InstrumentationLibraryInfo forMeter(String meterName) {
+    return InstrumentationLibraryInfo.create(meterName, null);
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.sdk.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.slf4j.event.Level.WARN;
 
 import io.github.netmikey.logunit.api.LogCapturer;
 import io.opentelemetry.api.metrics.DoubleCounter;
@@ -17,19 +16,20 @@ import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.LongUpDownCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
-import io.opentelemetry.sdk.metrics.internal.state.MeterSharedState;
+import io.opentelemetry.sdk.metrics.internal.state.MetricStorageRegistry;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-@SuppressLogger(MeterSharedState.class)
+@SuppressLogger(MetricStorageRegistry.class)
 class SdkMeterTest {
   // Meter must have an exporter configured to actual run.
   private final SdkMeterProvider testMeterProvider =
       SdkMeterProvider.builder().registerMetricReader(InMemoryMetricReader.create()).build();
   private final Meter sdkMeter = testMeterProvider.get(getClass().getName());
 
-  @RegisterExtension LogCapturer logs = LogCapturer.create().captureForType(MeterSharedState.class);
+  @RegisterExtension
+  LogCapturer logs = LogCapturer.create().captureForType(MetricStorageRegistry.class);
 
   @Test
   void testLongCounter() {
@@ -51,12 +51,7 @@ class SdkMeterTest {
     assertThat(logs.getEvents()).isEmpty();
 
     sdkMeter.counterBuilder("testLongCounter").build();
-    assertThat(
-            logs.assertContains(
-                    loggingEvent -> loggingEvent.getLevel().equals(WARN),
-                    "Failed to register metric.")
-                .getThrowable())
-        .hasMessageContaining("Metric with same name and different descriptor already created.");
+    logs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -69,12 +64,7 @@ class SdkMeterTest {
             .build();
     assertThat(longCounter).isNotNull();
     sdkMeter.counterBuilder("testLongCounter".toUpperCase()).build();
-    assertThat(
-            logs.assertContains(
-                    loggingEvent -> loggingEvent.getLevel().equals(WARN),
-                    "Failed to register metric.")
-                .getThrowable())
-        .hasMessageContaining("Metric with same name and different descriptor already created.");
+    logs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -98,12 +88,7 @@ class SdkMeterTest {
     assertThat(logs.getEvents()).isEmpty();
 
     sdkMeter.upDownCounterBuilder("testLongUpDownCounter").build();
-    assertThat(
-            logs.assertContains(
-                    loggingEvent -> loggingEvent.getLevel().equals(WARN),
-                    "Failed to register metric.")
-                .getThrowable())
-        .hasMessageContaining("Metric with same name and different descriptor already created.");
+    logs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -117,12 +102,7 @@ class SdkMeterTest {
     assertThat(longUpDownCounter).isNotNull();
     assertThat(logs.getEvents()).isEmpty();
     sdkMeter.upDownCounterBuilder("testLongUpDownCounter".toUpperCase()).build();
-    assertThat(
-            logs.assertContains(
-                    loggingEvent -> loggingEvent.getLevel().equals(WARN),
-                    "Failed to register metric.")
-                .getThrowable())
-        .hasMessageContaining("Metric with same name and different descriptor already created.");
+    logs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -148,12 +128,7 @@ class SdkMeterTest {
     assertThat(logs.getEvents()).isEmpty();
 
     sdkMeter.histogramBuilder("testLongValueRecorder").ofLongs().build();
-    assertThat(
-            logs.assertContains(
-                    loggingEvent -> loggingEvent.getLevel().equals(WARN),
-                    "Failed to register metric.")
-                .getThrowable())
-        .hasMessageContaining("Metric with same name and different descriptor already created.");
+    logs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -169,12 +144,7 @@ class SdkMeterTest {
     assertThat(logs.getEvents()).isEmpty();
 
     sdkMeter.histogramBuilder("testLongValueRecorder".toUpperCase()).ofLongs().build();
-    assertThat(
-            logs.assertContains(
-                    loggingEvent -> loggingEvent.getLevel().equals(WARN),
-                    "Failed to register metric.")
-                .getThrowable())
-        .hasMessageContaining("Metric with same name and different descriptor already created.");
+    logs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -188,12 +158,7 @@ class SdkMeterTest {
     assertThat(logs.getEvents()).isEmpty();
 
     sdkMeter.gaugeBuilder("longValueObserver").ofLongs().buildWithCallback(x -> {});
-    assertThat(
-            logs.assertContains(
-                    loggingEvent -> loggingEvent.getLevel().equals(WARN),
-                    "Failed to register metric.")
-                .getThrowable())
-        .hasMessageContaining("Metric with same name and different descriptor already created.");
+    logs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -207,12 +172,7 @@ class SdkMeterTest {
     assertThat(logs.getEvents()).isEmpty();
 
     sdkMeter.gaugeBuilder("longValueObserver".toUpperCase()).ofLongs().buildWithCallback(x -> {});
-    assertThat(
-            logs.assertContains(
-                    loggingEvent -> loggingEvent.getLevel().equals(WARN),
-                    "Failed to register metric.")
-                .getThrowable())
-        .hasMessageContaining("Metric with same name and different descriptor already created.");
+    logs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -225,12 +185,7 @@ class SdkMeterTest {
     assertThat(logs.getEvents()).isEmpty();
 
     sdkMeter.counterBuilder("testLongSumObserver").buildWithCallback(x -> {});
-    assertThat(
-            logs.assertContains(
-                    loggingEvent -> loggingEvent.getLevel().equals(WARN),
-                    "Failed to register metric.")
-                .getThrowable())
-        .hasMessageContaining("Metric with same name and different descriptor already created.");
+    logs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -243,12 +198,7 @@ class SdkMeterTest {
     assertThat(logs.getEvents()).isEmpty();
 
     sdkMeter.counterBuilder("testLongSumObserver".toUpperCase()).buildWithCallback(x -> {});
-    assertThat(
-            logs.assertContains(
-                    loggingEvent -> loggingEvent.getLevel().equals(WARN),
-                    "Failed to register metric.")
-                .getThrowable())
-        .hasMessageContaining("Metric with same name and different descriptor already created.");
+    logs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -261,12 +211,7 @@ class SdkMeterTest {
     assertThat(logs.getEvents()).isEmpty();
 
     sdkMeter.upDownCounterBuilder("testLongUpDownSumObserver").buildWithCallback(x -> {});
-    assertThat(
-            logs.assertContains(
-                    loggingEvent -> loggingEvent.getLevel().equals(WARN),
-                    "Failed to register metric.")
-                .getThrowable())
-        .hasMessageContaining("Metric with same name and different descriptor already created.");
+    logs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -281,12 +226,7 @@ class SdkMeterTest {
     sdkMeter
         .upDownCounterBuilder("testLongUpDownSumObserver".toUpperCase())
         .buildWithCallback(x -> {});
-    assertThat(
-            logs.assertContains(
-                    loggingEvent -> loggingEvent.getLevel().equals(WARN),
-                    "Failed to register metric.")
-                .getThrowable())
-        .hasMessageContaining("Metric with same name and different descriptor already created.");
+    logs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -311,12 +251,7 @@ class SdkMeterTest {
     assertThat(logs.getEvents()).isEmpty();
 
     sdkMeter.counterBuilder("testDoubleCounter").ofDoubles().build();
-    assertThat(
-            logs.assertContains(
-                    loggingEvent -> loggingEvent.getLevel().equals(WARN),
-                    "Failed to register metric.")
-                .getThrowable())
-        .hasMessageContaining("Metric with same name and different descriptor already created.");
+    logs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -341,12 +276,7 @@ class SdkMeterTest {
     assertThat(logs.getEvents()).isEmpty();
 
     sdkMeter.upDownCounterBuilder("testDoubleUpDownCounter").ofDoubles().build();
-    assertThat(
-            logs.assertContains(
-                    loggingEvent -> loggingEvent.getLevel().equals(WARN),
-                    "Failed to register metric.")
-                .getThrowable())
-        .hasMessageContaining("Metric with same name and different descriptor already created.");
+    logs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -369,12 +299,7 @@ class SdkMeterTest {
     assertThat(logs.getEvents()).isEmpty();
 
     sdkMeter.histogramBuilder("testDoubleValueRecorder").build();
-    assertThat(
-            logs.assertContains(
-                    loggingEvent -> loggingEvent.getLevel().equals(WARN),
-                    "Failed to register metric.")
-                .getThrowable())
-        .hasMessageContaining("Metric with same name and different descriptor already created.");
+    logs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -388,12 +313,7 @@ class SdkMeterTest {
     assertThat(logs.getEvents()).isEmpty();
     sdkMeter.counterBuilder("testDoubleSumObserver").ofDoubles().buildWithCallback(x -> {});
     sdkMeter.histogramBuilder("testDoubleValueRecorder").build();
-    assertThat(
-            logs.assertContains(
-                    loggingEvent -> loggingEvent.getLevel().equals(WARN),
-                    "Failed to register metric.")
-                .getThrowable())
-        .hasMessageContaining("Metric with same name and different descriptor already created.");
+    logs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -411,12 +331,7 @@ class SdkMeterTest {
         .ofDoubles()
         .buildWithCallback(x -> {});
     sdkMeter.histogramBuilder("testDoubleValueRecorder").build();
-    assertThat(
-            logs.assertContains(
-                    loggingEvent -> loggingEvent.getLevel().equals(WARN),
-                    "Failed to register metric.")
-                .getThrowable())
-        .hasMessageContaining("Metric with same name and different descriptor already created.");
+    logs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -429,11 +344,6 @@ class SdkMeterTest {
     assertThat(logs.getEvents()).isEmpty();
 
     sdkMeter.gaugeBuilder("doubleValueObserver").buildWithCallback(x -> {});
-    assertThat(
-            logs.assertContains(
-                    loggingEvent -> loggingEvent.getLevel().equals(WARN),
-                    "Failed to register metric.")
-                .getThrowable())
-        .hasMessageContaining("Metric with same name and different descriptor already created.");
+    logs.assertContains("Found duplicate metric definition");
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageRegistryTest.java
@@ -6,9 +6,10 @@
 package io.opentelemetry.sdk.metrics.internal.state;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.github.netmikey.logunit.api.LogCapturer;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.common.InstrumentValueType;
@@ -19,8 +20,10 @@ import io.opentelemetry.sdk.metrics.internal.export.CollectionInfo;
 import io.opentelemetry.sdk.metrics.view.View;
 import io.opentelemetry.sdk.resources.Resource;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link MetricStorageRegistry}. */
+@SuppressLogger(MetricStorageRegistry.class)
 class MetricStorageRegistryTest {
   private static final MetricDescriptor SYNC_DESCRIPTOR =
       descriptor("sync", "description", InstrumentType.COUNTER);
@@ -30,6 +33,9 @@ class MetricStorageRegistryTest {
       descriptor("async", "description", InstrumentType.OBSERVABLE_GAUGE);
   private static final MetricDescriptor OTHER_ASYNC_DESCRIPTOR =
       descriptor("async", "other_description", InstrumentType.OBSERVABLE_GAUGE);
+
+  @RegisterExtension
+  LogCapturer logs = LogCapturer.create().captureForType(MetricStorageRegistry.class);
 
   private final MetricStorageRegistry metricStorageRegistry = new MetricStorageRegistry();
 
@@ -46,11 +52,10 @@ class MetricStorageRegistryTest {
   void register_SyncIncompatibleDescriptor() {
     TestMetricStorage storage = new TestMetricStorage(SYNC_DESCRIPTOR);
     assertThat(metricStorageRegistry.register(storage)).isSameAs(storage);
-
-    assertThatThrownBy(
-            () -> metricStorageRegistry.register(new TestMetricStorage(OTHER_SYNC_DESCRIPTOR)))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Metric with same name and different descriptor already created.");
+    assertThat(logs.getEvents()).isEmpty();
+    assertThat(metricStorageRegistry.register(new TestMetricStorage(OTHER_SYNC_DESCRIPTOR)))
+        .isNotSameAs(storage);
+    logs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -66,11 +71,10 @@ class MetricStorageRegistryTest {
   void register_AsyncIncompatibleDescriptor() {
     TestMetricStorage storage = new TestMetricStorage(ASYNC_DESCRIPTOR);
     assertThat(metricStorageRegistry.register(storage)).isSameAs(storage);
-
-    assertThatThrownBy(
-            () -> metricStorageRegistry.register(new TestMetricStorage(OTHER_ASYNC_DESCRIPTOR)))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Metric with same name and different descriptor already created.");
+    assertThat(logs.getEvents()).isEmpty();
+    assertThat(metricStorageRegistry.register(new TestMetricStorage(OTHER_ASYNC_DESCRIPTOR)))
+        .isNotSameAs(storage);
+    logs.assertContains("Found duplicate metric definition");
   }
 
   private static MetricDescriptor descriptor(


### PR DESCRIPTION
Implements changes merged in spec PR [#2317](https://github.com/open-telemetry/opentelemetry-specification/pull/2317).

In summary:
- Each instrument is identified by its name, description, unit, type, and value type. 
- If you ask a meter for an instrument with the same identity as one previously registered, you'll record to the same instrument.
- If you ask a meter for an instrument the same name as one previously registered but some difference in description, unit, type, or value type, you've created an identity conflict. Multiple metrics with the same name will be exported, and we'll log a diagnostic error message.
- Views also play a role in identity. Since you can use views to change the name, description, and aggregation, its fairly easy to create an identity conflict when you register multiple views that select the same instrument(s).