### PR TITLE
Cleanups to View configuration

### DIFF
--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/MetricCustomizer.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/MetricCustomizer.java
@@ -5,15 +5,11 @@
 
 package io.opentelemetry.sdk.autoconfigure;
 
-import static io.opentelemetry.api.common.AttributeKey.booleanKey;
-
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
-import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.metrics.view.InstrumentSelector;
@@ -30,11 +26,9 @@ public class MetricCustomizer implements AutoConfigurationCustomizerProvider {
 
   private static SdkMeterProviderBuilder sdkMeterProviderCustomizer(
       SdkMeterProviderBuilder meterProviderBuilder, ConfigProperties configProperties) {
-    for (InstrumentType instrumentType : InstrumentType.values()) {
-      meterProviderBuilder.registerView(
-          InstrumentSelector.builder().setInstrumentType(instrumentType).build(),
-          View.builder().appendAttributes(Attributes.of(booleanKey("configured"), true)).build());
-    }
+    meterProviderBuilder.registerView(
+        InstrumentSelector.builder().setName("my-metric").build(),
+        View.builder().setAttributeFilter(name -> name.equals("allowed")).build());
     return meterProviderBuilder;
   }
 

--- a/sdk-extensions/metric-incubator/src/main/java/io/opentelemetry/sdk/viewconfig/ViewConfig.java
+++ b/sdk-extensions/metric-incubator/src/main/java/io/opentelemetry/sdk/viewconfig/ViewConfig.java
@@ -177,7 +177,7 @@ public final class ViewConfig {
     List<String> attributeKeys = viewSpec.getAttributeKeys();
     if (attributeKeys != null) {
       Set<String> keySet = new HashSet<>(attributeKeys);
-      builder.filterAttributes(keySet::contains);
+      builder.setAttributeFilter(keySet::contains);
     }
     return builder.build();
   }
@@ -203,11 +203,11 @@ public final class ViewConfig {
     InstrumentSelectorBuilder builder = InstrumentSelector.builder();
     String instrumentName = selectorSpec.getInstrumentName();
     if (instrumentName != null) {
-      builder.setInstrumentName(instrumentName);
+      builder.setName(instrumentName);
     }
     InstrumentType instrumentType = selectorSpec.getInstrumentType();
     if (instrumentType != null) {
-      builder.setInstrumentType(instrumentType);
+      builder.setType(instrumentType);
     }
 
     MeterSelectorBuilder meterBuilder = MeterSelector.builder();

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/InstrumentSelectorBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/InstrumentSelectorBuilder.java
@@ -10,7 +10,6 @@ import static java.util.Objects.requireNonNull;
 import io.opentelemetry.sdk.metrics.common.InstrumentType;
 import io.opentelemetry.sdk.metrics.internal.view.StringPredicates;
 import java.util.function.Predicate;
-import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 /** Builder for {@link InstrumentSelector}. */
@@ -21,59 +20,26 @@ public final class InstrumentSelectorBuilder {
   private MeterSelector meterSelector = MeterSelector.builder().build();
 
   /** Sets a specifier for {@link InstrumentType}. */
-  public InstrumentSelectorBuilder setInstrumentType(InstrumentType instrumentType) {
+  public InstrumentSelectorBuilder setType(InstrumentType instrumentType) {
     requireNonNull(instrumentType, "instrumentType");
     this.instrumentType = instrumentType;
     return this;
   }
 
+  /** Sets the exact instrument name that will be selected. */
+  public InstrumentSelectorBuilder setName(String name) {
+    requireNonNull(name, "name");
+    return setName(StringPredicates.exact(name));
+  }
+
   /**
-   * Sets the {@link Pattern} for instrument names that will be selected.
-   *
-   * <p>Note: The last provided of {@link #setInstrumentNameFilter}, {@link
-   * #setInstrumentNamePattern} {@link #setInstrumentNameRegex} and {@link #setInstrumentName} is
-   * used.
+   * Sets a {@link Predicate} where instrument names matching the {@link Predicate} will be
+   * selected.
    */
-  public InstrumentSelectorBuilder setInstrumentNameFilter(Predicate<String> instrumentNameFilter) {
-    requireNonNull(instrumentNameFilter, "instrumentNameFilter");
-    this.instrumentNameFilter = instrumentNameFilter;
+  public InstrumentSelectorBuilder setName(Predicate<String> nameFilter) {
+    requireNonNull(nameFilter, "nameFilter");
+    this.instrumentNameFilter = nameFilter;
     return this;
-  }
-
-  /**
-   * Sets the {@link Pattern} for instrument names that will be selected.
-   *
-   * <p>Note: The last provided of {@link #setInstrumentNameFilter}, {@link
-   * #setInstrumentNamePattern} {@link #setInstrumentNameRegex} and {@link #setInstrumentName} is
-   * used.
-   */
-  public InstrumentSelectorBuilder setInstrumentNamePattern(Pattern instrumentNamePattern) {
-    requireNonNull(instrumentNamePattern, "instrumentNamePattern");
-    return setInstrumentNameFilter(StringPredicates.regex(instrumentNamePattern));
-  }
-
-  /**
-   * Sets the exact instrument name that will be selected.
-   *
-   * <p>Note: The last provided of {@link #setInstrumentNameFilter}, {@link
-   * #setInstrumentNamePattern} {@link #setInstrumentNameRegex} and {@link #setInstrumentName} is
-   * used.
-   */
-  public InstrumentSelectorBuilder setInstrumentName(String instrumentName) {
-    requireNonNull(instrumentName, "instrumentName");
-    return setInstrumentNameFilter(StringPredicates.exact(instrumentName));
-  }
-
-  /**
-   * Sets a specifier for selecting Instruments by name.
-   *
-   * <p>Note: The last provided of {@link #setInstrumentNameFilter}, {@link
-   * #setInstrumentNamePattern} {@link #setInstrumentNameRegex} and {@link #setInstrumentName} is
-   * used.
-   */
-  public InstrumentSelectorBuilder setInstrumentNameRegex(String instrumentNameRegex) {
-    requireNonNull(instrumentNameRegex, "instrumentNameRegex");
-    return setInstrumentNamePattern(Pattern.compile(instrumentNameRegex));
   }
 
   /**

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/MeterSelectorBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/MeterSelectorBuilder.java
@@ -9,7 +9,6 @@ import static java.util.Objects.requireNonNull;
 
 import io.opentelemetry.sdk.metrics.internal.view.StringPredicates;
 import java.util.function.Predicate;
-import java.util.regex.Pattern;
 
 /** Builder for {@link MeterSelector}. */
 public final class MeterSelectorBuilder {
@@ -18,106 +17,43 @@ public final class MeterSelectorBuilder {
   private Predicate<String> versionFilter = StringPredicates.ALL;
   private Predicate<String> schemaUrlFilter = StringPredicates.ALL;
 
-  /**
-   * Sets the {@link Predicate} for matching name.
-   *
-   * <p>Note: The last provided of {@link #setNameFilter}, {@link #setNamePattern} and {@link
-   * #setName} is used.
-   */
-  public MeterSelectorBuilder setNameFilter(Predicate<String> nameFilter) {
+  /** Sets a specifier for selecting Instruments by name. */
+  public MeterSelectorBuilder setName(String name) {
+    requireNonNull(name, "name");
+    return setName(StringPredicates.exact(name));
+  }
+
+  /** Sets the {@link Predicate} for matching name. */
+  public MeterSelectorBuilder setName(Predicate<String> nameFilter) {
     requireNonNull(nameFilter, "nameFilter");
     this.nameFilter = nameFilter;
     return this;
   }
 
-  /**
-   * Sets the {@link Pattern} for matching name.
-   *
-   * <p>Note: The last provided of {@link #setNameFilter}, {@link #setNamePattern} and {@link
-   * #setName} is used.
-   */
-  public MeterSelectorBuilder setNamePattern(Pattern pattern) {
-    requireNonNull(pattern, "pattern");
-    return setNameFilter(StringPredicates.regex(pattern));
-  }
-
-  /**
-   * Sets a specifier for selecting Instruments by name.
-   *
-   * <p>Note: The last provided of {@link #setNameFilter}, {@link #setNamePattern} and {@link
-   * #setName} is used.
-   */
-  public MeterSelectorBuilder setName(String name) {
-    requireNonNull(name, "name");
-    return setNameFilter(StringPredicates.exact(name));
-  }
-
-  /**
-   * Sets the {@link Predicate} for matching versions.
-   *
-   * <p>Note: The last provided of {@link #setVersionFilter}, {@link #setVersionPattern} and {@link
-   * #setVersion} is used.
-   */
-  public MeterSelectorBuilder setVersionFilter(Predicate<String> versionFilter) {
+  /** Sets the {@link Predicate} for matching versions. */
+  public MeterSelectorBuilder setVersion(Predicate<String> versionFilter) {
     requireNonNull(versionFilter, "versionFilter");
     this.versionFilter = versionFilter;
     return this;
   }
 
-  /**
-   * Sets the {@link Pattern} for matching versions.
-   *
-   * <p>Note: The last provided of {@link #setVersionFilter}, {@link #setVersionPattern} and {@link
-   * #setVersion} is used.
-   */
-  public MeterSelectorBuilder setVersionPattern(Pattern pattern) {
-    requireNonNull(pattern, "pattern");
-    return setVersionFilter(StringPredicates.regex(pattern));
-  }
-
-  /**
-   * Sets a specifier for selecting Meters by version.
-   *
-   * <p>Note: The last provided of {@link #setVersionFilter}, {@link #setVersionPattern} and {@link
-   * #setVersion} is used.
-   */
+  /** Sets a specifier for selecting Meters by version. */
   public MeterSelectorBuilder setVersion(String version) {
     requireNonNull(version, "version");
-    return setVersionFilter(StringPredicates.exact(version));
+    return setVersion(StringPredicates.exact(version));
   }
 
-  /**
-   * Sets the {@link Predicate} for matching schema urls.
-   *
-   * <p>Note: The last provided of {@link #setSchemaUrlFilter}, {@link #setSchemaUrlPattern} and
-   * {@link #setSchemaUrl} is used.
-   */
-  public MeterSelectorBuilder setSchemaUrlFilter(Predicate<String> schemaUrlFilter) {
+  /** Sets the schema url to match. */
+  public MeterSelectorBuilder setSchemaUrl(String schemaUrl) {
+    requireNonNull(schemaUrl, "schemaUrl");
+    return setSchemaUrl(StringPredicates.exact(schemaUrl));
+  }
+
+  /** Sets the {@link Predicate} for matching schema urls. */
+  public MeterSelectorBuilder setSchemaUrl(Predicate<String> schemaUrlFilter) {
     requireNonNull(schemaUrlFilter, "schemaUrlFilter");
     this.schemaUrlFilter = schemaUrlFilter;
     return this;
-  }
-
-  /**
-   * Sets the {@link Pattern} for matching schema urls.
-   *
-   * <p>Note: The last provided of {@link #setSchemaUrlFilter}, {@link #setSchemaUrlPattern} and
-   * {@link #setSchemaUrl} is used.
-   */
-  public MeterSelectorBuilder setSchemaUrlPattern(Pattern pattern) {
-    requireNonNull(pattern, "pattern");
-    return setSchemaUrlFilter(StringPredicates.regex(pattern));
-  }
-
-  /**
-   * Sets the schema url to match.
-   *
-   * <p>Note: The last provided of {@link #setSchemaUrlFilter}, {@link #setSchemaUrlPattern} and
-   * {@link #setSchemaUrl} is used.
-   */
-  public MeterSelectorBuilder setSchemaUrl(String schemaUrl) {
-    requireNonNull(schemaUrl, "schemaUrl");
-    return setSchemaUrlFilter(StringPredicates.exact(schemaUrl));
   }
 
   /** Returns an InstrumentSelector instance with the content of this builder. */

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/ViewBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/view/ViewBuilder.java
@@ -5,11 +5,9 @@
 
 package io.opentelemetry.sdk.metrics.view;
 
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.internal.view.AttributesProcessor;
 import io.opentelemetry.sdk.metrics.internal.view.StringPredicates;
 import java.util.function.Predicate;
-import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 /** Builder of metric {@link View}s. */
@@ -56,58 +54,16 @@ public final class ViewBuilder {
   }
 
   /**
-   * Specify the attributes processor for this view.
-   *
-   * <p>Note: This resets all attribute filters, baggage appending and other processing.
-   *
-   * <p>Visible for testing.
-   *
-   * @param processor The pre-processor for measurement attributes.
-   * @return this Builder.
-   */
-  public ViewBuilder setAttributesProcessor(AttributesProcessor processor) {
-    this.processor = processor;
-    return this;
-  }
-
-  /**
-   * Filters measurement attributes using a given filter.
+   * Sets a filter for attributes, where only attribute names that pass the supplied {@link
+   * Predicate} will be included in the output.
    *
    * <p>Note: This runs after all other attribute processing added so far.
    *
    * @param keyFilter filter for key names to include.
    * @return this Builder.
    */
-  public ViewBuilder filterAttributes(Predicate<String> keyFilter) {
+  public ViewBuilder setAttributeFilter(Predicate<String> keyFilter) {
     this.processor = this.processor.then(AttributesProcessor.filterByKeyName(keyFilter));
-    return this;
-  }
-
-  /**
-   * Filters measurement attributes using a given regex.
-   *
-   * <p>Note: This runs after all other attribute processing added so far.
-   *
-   * @param keyPattern the regular expression for selecting attributes by key name.
-   * @return this Builder.
-   */
-  public ViewBuilder filterAttributes(Pattern keyPattern) {
-    this.processor =
-        this.processor.then(
-            AttributesProcessor.filterByKeyName(StringPredicates.regex(keyPattern)));
-    return this;
-  }
-
-  /**
-   * Appends a static set of attributes to all measurements.
-   *
-   * <p>Note: This runs after all other attribute processing added so far.
-   *
-   * @param extraAttributes The static attributes to append to measurements.
-   * @return this Builder.
-   */
-  public ViewBuilder appendAttributes(Attributes extraAttributes) {
-    this.processor = this.processor.then(AttributesProcessor.append(extraAttributes));
     return this;
   }
 
@@ -122,22 +78,6 @@ public final class ViewBuilder {
    */
   public ViewBuilder appendFilteredBaggageAttributes(Predicate<String> keyFilter) {
     this.processor = this.processor.then(AttributesProcessor.appendBaggageByKeyName(keyFilter));
-    return this;
-  }
-
-  /**
-   * Appends key-values from baggage to all measurements.
-   *
-   * <p>Note: This runs after all other attribute processing added so far.
-   *
-   * @param keyPattern Only baggage key values pairs where the key matches this regex will be
-   *     appended.
-   * @return this Builder.
-   */
-  public ViewBuilder appendFilteredBaggageAttributesByPattern(Pattern keyPattern) {
-    this.processor =
-        this.processor.then(
-            AttributesProcessor.appendBaggageByKeyName(StringPredicates.regex(keyPattern)));
     return this;
   }
 

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkObservableDoubleCounterTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkObservableDoubleCounterTest.java
@@ -134,9 +134,7 @@ class SdkObservableDoubleCounterTest {
         sdkMeterProviderBuilder
             .registerMetricReader(sdkMeterReader)
             .registerView(
-                InstrumentSelector.builder()
-                    .setInstrumentType(InstrumentType.OBSERVABLE_COUNTER)
-                    .build(),
+                InstrumentSelector.builder().setType(InstrumentType.OBSERVABLE_COUNTER).build(),
                 View.builder().setAggregation(Aggregation.sum()).build())
             .build();
     sdkMeterProvider

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkObservableDoubleUpDownCounterTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkObservableDoubleUpDownCounterTest.java
@@ -132,7 +132,7 @@ class SdkObservableDoubleUpDownCounterTest {
             .registerMetricReader(sdkMeterReader)
             .registerView(
                 InstrumentSelector.builder()
-                    .setInstrumentType(InstrumentType.OBSERVABLE_UP_DOWN_COUNTER)
+                    .setType(InstrumentType.OBSERVABLE_UP_DOWN_COUNTER)
                     .build(),
                 View.builder().setAggregation(Aggregation.sum()).build())
             .build();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkObservableLongCounterTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkObservableLongCounterTest.java
@@ -126,9 +126,7 @@ class SdkObservableLongCounterTest {
         sdkMeterProviderBuilder
             .registerMetricReader(sdkMeterReader)
             .registerView(
-                InstrumentSelector.builder()
-                    .setInstrumentType(InstrumentType.OBSERVABLE_COUNTER)
-                    .build(),
+                InstrumentSelector.builder().setType(InstrumentType.OBSERVABLE_COUNTER).build(),
                 View.builder().setAggregation(Aggregation.sum()).build())
             .build();
     sdkMeterProvider

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkObservableLongUpDownCounterTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkObservableLongUpDownCounterTest.java
@@ -127,7 +127,7 @@ class SdkObservableLongUpDownCounterTest {
             .registerMetricReader(sdkMeterReader)
             .registerView(
                 InstrumentSelector.builder()
-                    .setInstrumentType(InstrumentType.OBSERVABLE_UP_DOWN_COUNTER)
+                    .setType(InstrumentType.OBSERVABLE_UP_DOWN_COUNTER)
                     .build(),
                 View.builder().setAggregation(Aggregation.sum()).build())
             .build();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/view/ViewRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/view/ViewRegistryTest.java
@@ -27,9 +27,7 @@ class ViewRegistryTest {
 
     ViewRegistry viewRegistry =
         ViewRegistry.builder()
-            .addView(
-                InstrumentSelector.builder().setInstrumentType(InstrumentType.COUNTER).build(),
-                view)
+            .addView(InstrumentSelector.builder().setType(InstrumentType.COUNTER).build(), view)
             .build();
     assertThat(
             viewRegistry.findViews(
@@ -56,7 +54,7 @@ class ViewRegistryTest {
 
     ViewRegistry viewRegistry =
         ViewRegistry.builder()
-            .addView(InstrumentSelector.builder().setInstrumentName("overridden").build(), view)
+            .addView(InstrumentSelector.builder().setName("overridden").build(), view)
             .build();
     assertThat(
             viewRegistry.findViews(
@@ -85,8 +83,9 @@ class ViewRegistryTest {
     ViewRegistry viewRegistry =
         ViewRegistry.builder()
             .addView(
-                InstrumentSelector.builder().setInstrumentNameRegex("overridden").build(), view2)
-            .addView(InstrumentSelector.builder().setInstrumentNameRegex(".*").build(), view1)
+                InstrumentSelector.builder().setName(name -> name.equals("overridden")).build(),
+                view2)
+            .addView(InstrumentSelector.builder().setName(name -> true).build(), view1)
             .build();
 
     assertThat(
@@ -108,44 +107,6 @@ class ViewRegistryTest {
   }
 
   @Test
-  void selection_regex() {
-    View view = View.builder().setAggregation(Aggregation.lastValue()).build();
-
-    ViewRegistry viewRegistry =
-        ViewRegistry.builder()
-            .addView(
-                InstrumentSelector.builder().setInstrumentNameRegex("overrid(es|den)").build(),
-                view)
-            .build();
-
-    assertThat(
-            viewRegistry.findViews(
-                InstrumentDescriptor.create(
-                    "overridden", "", "", InstrumentType.COUNTER, InstrumentValueType.LONG),
-                INSTRUMENTATION_LIBRARY_INFO))
-        .hasSize(1)
-        .element(0)
-        .isEqualTo(view);
-    assertThat(
-            viewRegistry.findViews(
-                InstrumentDescriptor.create(
-                    "overrides", "", "", InstrumentType.UP_DOWN_COUNTER, InstrumentValueType.LONG),
-                INSTRUMENTATION_LIBRARY_INFO))
-        .hasSize(1)
-        .element(0)
-        .isEqualTo(view);
-    // this one hasn't been configured, so it gets the default still..
-    assertThat(
-            viewRegistry.findViews(
-                InstrumentDescriptor.create(
-                    "default", "", "", InstrumentType.UP_DOWN_COUNTER, InstrumentValueType.LONG),
-                INSTRUMENTATION_LIBRARY_INFO))
-        .hasSize(1)
-        .element(0)
-        .isSameAs(ViewRegistry.DEFAULT_VIEW);
-  }
-
-  @Test
   void selection_typeAndName() {
     View view = View.builder().setAggregation(Aggregation.lastValue()).build();
 
@@ -153,8 +114,8 @@ class ViewRegistryTest {
         ViewRegistry.builder()
             .addView(
                 InstrumentSelector.builder()
-                    .setInstrumentType(InstrumentType.COUNTER)
-                    .setInstrumentName("overrides")
+                    .setType(InstrumentType.COUNTER)
+                    .setName("overrides")
                     .build(),
                 view)
             .build();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/view/InstrumentSelectorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/view/InstrumentSelectorTest.java
@@ -7,27 +7,22 @@ package io.opentelemetry.sdk.metrics.view;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 
 class InstrumentSelectorTest {
 
   @Test
   void invalidArgs() {
-    assertThatThrownBy(() -> InstrumentSelector.builder().setInstrumentType(null))
+    assertThatThrownBy(() -> InstrumentSelector.builder().setType(null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("instrumentType");
-    assertThatThrownBy(() -> InstrumentSelector.builder().setInstrumentNameFilter(null))
+    assertThatThrownBy(() -> InstrumentSelector.builder().setName((Predicate<String>) null))
         .isInstanceOf(NullPointerException.class)
-        .hasMessage("instrumentNameFilter");
-    assertThatThrownBy(() -> InstrumentSelector.builder().setInstrumentNamePattern(null))
+        .hasMessage("nameFilter");
+    assertThatThrownBy(() -> InstrumentSelector.builder().setName((String) null))
         .isInstanceOf(NullPointerException.class)
-        .hasMessage("instrumentNamePattern");
-    assertThatThrownBy(() -> InstrumentSelector.builder().setInstrumentName(null))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage("instrumentName");
-    assertThatThrownBy(() -> InstrumentSelector.builder().setInstrumentNameRegex(null))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage("instrumentNameRegex");
+        .hasMessage("name");
     assertThatThrownBy(() -> InstrumentSelector.builder().setMeterSelector(null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("meterSelector");

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/view/MeterSelectorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/view/MeterSelectorTest.java
@@ -8,7 +8,7 @@ package io.opentelemetry.sdk.metrics.view;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.regex.Pattern;
+import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 
 public class MeterSelectorTest {
@@ -19,14 +19,8 @@ public class MeterSelectorTest {
     assertThat(exactName.getNameFilter().test("example")).isTrue();
     assertThat(exactName.getNameFilter().test("example2")).isFalse();
 
-    MeterSelector patternName =
-        MeterSelector.builder().setNamePattern(Pattern.compile("ex.*")).build();
-    assertThat(patternName.getNameFilter().test("example")).isTrue();
-    assertThat(patternName.getNameFilter().test("example2")).isTrue();
-    assertThat(patternName.getNameFilter().test("axample")).isFalse();
-
     MeterSelector filterName =
-        MeterSelector.builder().setNameFilter(name -> name.startsWith("ex")).build();
+        MeterSelector.builder().setName(name -> name.startsWith("ex")).build();
     assertThat(filterName.getNameFilter().test("example")).isTrue();
     assertThat(filterName.getNameFilter().test("example2")).isTrue();
     assertThat(filterName.getNameFilter().test("axample")).isFalse();
@@ -37,8 +31,8 @@ public class MeterSelectorTest {
     MeterSelector filterName =
         MeterSelector.builder()
             .setName("example")
-            .setNamePattern(Pattern.compile("ex.*"))
-            .setNameFilter(name -> false)
+            .setName(name -> name.startsWith("ex"))
+            .setName(name -> false)
             .build();
 
     assertThat(filterName.getNameFilter().test("example")).isFalse();
@@ -50,14 +44,8 @@ public class MeterSelectorTest {
     assertThat(exactVersion.getVersionFilter().test("1.2.3")).isTrue();
     assertThat(exactVersion.getVersionFilter().test("1.2.4")).isFalse();
 
-    MeterSelector patternVersion =
-        MeterSelector.builder().setVersionPattern(Pattern.compile("1\\.2\\..*")).build();
-    assertThat(patternVersion.getVersionFilter().test("1.2.3")).isTrue();
-    assertThat(patternVersion.getVersionFilter().test("1.2.4")).isTrue();
-    assertThat(patternVersion.getVersionFilter().test("2.0.0")).isFalse();
-
     MeterSelector filterVersion =
-        MeterSelector.builder().setVersionFilter(v -> v.startsWith("1")).build();
+        MeterSelector.builder().setVersion(v -> v.startsWith("1")).build();
     assertThat(filterVersion.getVersionFilter().test("1.2.3")).isTrue();
     assertThat(filterVersion.getVersionFilter().test("1.1.1")).isTrue();
     assertThat(filterVersion.getVersionFilter().test("2.0.0")).isFalse();
@@ -68,8 +56,8 @@ public class MeterSelectorTest {
     MeterSelector filterVersion =
         MeterSelector.builder()
             .setVersion("1.0")
-            .setVersionPattern(Pattern.compile("1.*"))
-            .setVersionFilter(name -> false)
+            .setVersion(name -> name.startsWith("1"))
+            .setVersion(name -> false)
             .build();
 
     assertThat(filterVersion.getVersionFilter().test("1.0")).isFalse();
@@ -82,14 +70,7 @@ public class MeterSelectorTest {
     assertThat(exact.getSchemaUrlFilter().test("1.2.3")).isTrue();
     assertThat(exact.getSchemaUrlFilter().test("1.2.4")).isFalse();
 
-    MeterSelector pattern =
-        MeterSelector.builder().setSchemaUrlPattern(Pattern.compile("1\\.2\\..*")).build();
-    assertThat(pattern.getSchemaUrlFilter().test("1.2.3")).isTrue();
-    assertThat(pattern.getSchemaUrlFilter().test("1.2.4")).isTrue();
-    assertThat(pattern.getSchemaUrlFilter().test("2.0.0")).isFalse();
-
-    MeterSelector filter =
-        MeterSelector.builder().setSchemaUrlFilter(s -> s.startsWith("1")).build();
+    MeterSelector filter = MeterSelector.builder().setSchemaUrl(s -> s.startsWith("1")).build();
     assertThat(filter.getSchemaUrlFilter().test("1.2.3")).isTrue();
     assertThat(filter.getSchemaUrlFilter().test("1.1.1")).isTrue();
     assertThat(filter.getSchemaUrlFilter().test("2.0.0")).isFalse();
@@ -100,8 +81,8 @@ public class MeterSelectorTest {
     MeterSelector schemaUrl =
         MeterSelector.builder()
             .setSchemaUrl("1.0")
-            .setSchemaUrlPattern(Pattern.compile("1.*"))
-            .setSchemaUrlFilter(s -> false)
+            .setSchemaUrl(name -> name.startsWith("1"))
+            .setSchemaUrl(s -> false)
             .build();
 
     assertThat(schemaUrl.getSchemaUrlFilter().test("1.0")).isFalse();
@@ -110,31 +91,22 @@ public class MeterSelectorTest {
 
   @Test
   void invalidArgs() {
-    assertThatThrownBy(() -> MeterSelector.builder().setNameFilter(null))
+    assertThatThrownBy(() -> MeterSelector.builder().setName((Predicate<String>) null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("nameFilter");
-    assertThatThrownBy(() -> MeterSelector.builder().setNamePattern(null))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage("pattern");
-    assertThatThrownBy(() -> MeterSelector.builder().setName(null))
+    assertThatThrownBy(() -> MeterSelector.builder().setName((String) null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("name");
-    assertThatThrownBy(() -> MeterSelector.builder().setVersionFilter(null))
+    assertThatThrownBy(() -> MeterSelector.builder().setVersion((Predicate<String>) null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("versionFilter");
-    assertThatThrownBy(() -> MeterSelector.builder().setVersionPattern(null))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage("pattern");
-    assertThatThrownBy(() -> MeterSelector.builder().setVersion(null))
+    assertThatThrownBy(() -> MeterSelector.builder().setVersion((String) null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("version");
-    assertThatThrownBy(() -> MeterSelector.builder().setSchemaUrlFilter(null))
+    assertThatThrownBy(() -> MeterSelector.builder().setSchemaUrl((Predicate<String>) null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("schemaUrlFilter");
-    assertThatThrownBy(() -> MeterSelector.builder().setSchemaUrlPattern(null))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage("pattern");
-    assertThatThrownBy(() -> MeterSelector.builder().setSchemaUrl(null))
+    assertThatThrownBy(() -> MeterSelector.builder().setSchemaUrl((String) null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("schemaUrl");
   }


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view

- Removes `AttributesProcessor` (internal class) from public API
- Removes regex matching. Spec only specifies wildcard matching, which we can add support for later, I think in the same `setName` method because wildcards are not valid characters in instrument names. Programmatic matching with `Predicate` is left in as it seems generally useful and can be used to implement regex matching if needed anyways
- Uses same method name for string and predicate filters. I think this removes the need of "only one of" type of methods because it's the pattern of overloading a behavior for different input types. If it looks weird to have `.setName(Predicate<String>)`, happy to revert
- Don't repeat `instrument` in method names of `InstrumentSelector` type
- Removes support for adding static attributes, I can't find it in the spec. Let's restore it after discussion if it's needed

Remaining for followup

- Remove (try to internalize) baggage, which is delayed to spec out in a cross-signal way
- Inline `MeterSelector`? It seems like it'd be simpler to just have e.g. `setMeterName` on `InstrumentSelectorBuilder` itself. Let me know in a comment here if you think this isn't a good change to make.