### PR TITLE
feat: Add enabled resource providers configuration

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ResourceConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ResourceConfiguration.java
@@ -31,6 +31,8 @@ final class ResourceConfiguration {
       BiFunction<? super Resource, ConfigProperties, ? extends Resource> resourceCustomizer) {
     Resource result = Resource.getDefault();
 
+    Set<String> enabledProviders = new HashSet<>(
+        config.getList("otel.java.enabled.resource.providers"));
     // TODO(anuraaga): We use a hyphen only once in this artifact, for
     // otel.java.disabled.resource-providers. But fetching by the dot version is the simplest way
     // to implement it for now.
@@ -38,6 +40,10 @@ final class ResourceConfiguration {
         new HashSet<>(config.getList("otel.java.disabled.resource.providers"));
     for (ResourceProvider resourceProvider :
         ServiceLoader.load(ResourceProvider.class, serviceClassLoader)) {
+      if (!enabledProviders.isEmpty() && !enabledProviders.contains(
+          resourceProvider.getClass().getName())) {
+        continue;
+      }
       if (disabledProviders.contains(resourceProvider.getClass().getName())) {
         continue;
       }

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ResourceConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ResourceConfiguration.java
@@ -31,8 +31,8 @@ final class ResourceConfiguration {
       BiFunction<? super Resource, ConfigProperties, ? extends Resource> resourceCustomizer) {
     Resource result = Resource.getDefault();
 
-    Set<String> enabledProviders = new HashSet<>(
-        config.getList("otel.java.enabled.resource.providers"));
+    Set<String> enabledProviders =
+        new HashSet<>(config.getList("otel.java.enabled.resource.providers"));
     // TODO(anuraaga): We use a hyphen only once in this artifact, for
     // otel.java.disabled.resource-providers. But fetching by the dot version is the simplest way
     // to implement it for now.
@@ -40,8 +40,8 @@ final class ResourceConfiguration {
         new HashSet<>(config.getList("otel.java.disabled.resource.providers"));
     for (ResourceProvider resourceProvider :
         ServiceLoader.load(ResourceProvider.class, serviceClassLoader)) {
-      if (!enabledProviders.isEmpty() && !enabledProviders.contains(
-          resourceProvider.getClass().getName())) {
+      if (!enabledProviders.isEmpty()
+          && !enabledProviders.contains(resourceProvider.getClass().getName())) {
         continue;
       }
       if (disabledProviders.contains(resourceProvider.getClass().getName())) {

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
@@ -55,7 +55,8 @@ class ResourceConfigurationTest {
   @Test
   void onlyEnabledCustomResourceProvider() {
     Map<String, String> customConfigs = new HashMap<>(1);
-    customConfigs.put("otel.java.enabled.resource.providers",
+    customConfigs.put(
+        "otel.java.enabled.resource.providers",
         "io.opentelemetry.sdk.autoconfigure.ResourceProviderCustomizer");
     Attributes attributes =
         ResourceConfiguration.configureResource(

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
@@ -71,7 +71,7 @@ class ResourceConfigurationTest {
 
   @Test
   void settingEnabledAndDisabledConfiguration() {
-    Map<String, String> customConfigs = new HashMap<>(1);
+    Map<String, String> customConfigs = new HashMap<>(2);
     customConfigs.put(
         "otel.java.enabled.resource.providers",
         "io.opentelemetry.sdk.autoconfigure.ResourceProviderCustomizer,io.opentelemetry.sdk.extension.resources.OsResourceProvider,io.opentelemetry.sdk.extension.resources.ProcessResourceProvider");
@@ -92,6 +92,23 @@ class ResourceConfigurationTest {
     assertThat(attributes.get(ResourceAttributes.PROCESS_EXECUTABLE_PATH)).isNotNull();
     assertThat(attributes.get(ResourceAttributes.PROCESS_COMMAND_LINE)).isNotNull();
 
+    assertThat(attributes.get(AttributeKey.stringKey("animal"))).isEqualTo("cat");
+  }
+
+  @Test
+  void onlySettingEnabledConfiguration() {
+    Map<String, String> customConfigs = new HashMap<>(1);
+    customConfigs.put(
+        "otel.java.enabled.resource.providers",
+        "io.opentelemetry.sdk.autoconfigure.ResourceProviderCustomizer");
+    Attributes attributes =
+        ResourceConfiguration.configureResource(
+                DefaultConfigProperties.get(customConfigs),
+                ResourceConfigurationTest.class.getClassLoader(),
+                (r, c) -> r)
+            .getAttributes();
+
+    assertProcessAttributeIsNull(attributes);
     assertThat(attributes.get(AttributeKey.stringKey("animal"))).isEqualTo("cat");
   }
 

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
@@ -7,11 +7,14 @@ package io.opentelemetry.sdk.autoconfigure;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class ResourceConfigurationTest {
@@ -46,6 +49,26 @@ class ResourceConfigurationTest {
                 (r, c) -> r)
             .getAttributes();
 
+    assertProcessAttributeIsNull(attributes);
+  }
+
+  @Test
+  void onlyEnabledCustomResourceProvider() {
+    Map<String, String> customConfigs = new HashMap<>(1);
+    customConfigs.put("otel.java.enabled.resource.providers",
+        "io.opentelemetry.sdk.autoconfigure.ResourceProviderCustomizer");
+    Attributes attributes =
+        ResourceConfiguration.configureResource(
+                DefaultConfigProperties.get(customConfigs),
+                ResourceConfigurationTest.class.getClassLoader(),
+                (r, c) -> r)
+            .getAttributes();
+
+    assertProcessAttributeIsNull(attributes);
+    assertThat(attributes.get(AttributeKey.stringKey("animal"))).isEqualTo("cat");
+  }
+
+  void assertProcessAttributeIsNull(Attributes attributes) {
     assertThat(attributes.get(ResourceAttributes.OS_TYPE)).isNull();
     assertThat(attributes.get(ResourceAttributes.OS_DESCRIPTION)).isNull();
 

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
@@ -69,6 +69,32 @@ class ResourceConfigurationTest {
     assertThat(attributes.get(AttributeKey.stringKey("animal"))).isEqualTo("cat");
   }
 
+  @Test
+  void settingEnabledAndDisabledConfiguration() {
+    Map<String, String> customConfigs = new HashMap<>(1);
+    customConfigs.put(
+        "otel.java.enabled.resource.providers",
+        "io.opentelemetry.sdk.autoconfigure.ResourceProviderCustomizer,io.opentelemetry.sdk.extension.resources.OsResourceProvider,io.opentelemetry.sdk.extension.resources.ProcessResourceProvider");
+    customConfigs.put(
+        "otel.java.disabled.resource.providers",
+        "io.opentelemetry.sdk.extension.resources.OsResourceProvider");
+    Attributes attributes =
+        ResourceConfiguration.configureResource(
+                DefaultConfigProperties.get(customConfigs),
+                ResourceConfigurationTest.class.getClassLoader(),
+                (r, c) -> r)
+            .getAttributes();
+
+    assertThat(attributes.get(ResourceAttributes.OS_TYPE)).isNull();
+    assertThat(attributes.get(ResourceAttributes.OS_DESCRIPTION)).isNull();
+
+    assertThat(attributes.get(ResourceAttributes.PROCESS_PID)).isNotNull();
+    assertThat(attributes.get(ResourceAttributes.PROCESS_EXECUTABLE_PATH)).isNotNull();
+    assertThat(attributes.get(ResourceAttributes.PROCESS_COMMAND_LINE)).isNotNull();
+
+    assertThat(attributes.get(AttributeKey.stringKey("animal"))).isEqualTo("cat");
+  }
+
   void assertProcessAttributeIsNull(Attributes attributes) {
     assertThat(attributes.get(ResourceAttributes.OS_TYPE)).isNull();
     assertThat(attributes.get(ResourceAttributes.OS_DESCRIPTION)).isNull();

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ResourceProviderCustomizer.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ResourceProviderCustomizer.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.sdk.resources.Resource;
+
+public class ResourceProviderCustomizer implements ResourceProvider {
+  @Override
+  public Resource createResource(ConfigProperties config) {
+    return Resource.create(Attributes.of(AttributeKey.stringKey("animal"), "cat"));
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.sdk.autoconfigure.ResourceProviderCustomizer


### PR DESCRIPTION
Add a new configuration: `otel.java.enabled.resource.providers`. 

All resource providers will be enabled if this configuration key is not configured, otherwise only the specific resource providers will be enabled.

If a resource provider is configured in both `otel.java.enabled.resource.providers` and `otel.java.disabled.resource.providers`, then it will be disabled.

close #4220 