### PR TITLE
Option for increasing BatchSpanProcessor throughput under slow network / ingestion

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -332,13 +332,14 @@ public final class BatchSpanProcessor implements SpanProcessor {
 
       try {
         CompletableResultCode result = spanExporter.export(Collections.unmodifiableList(batch));
-        result.whenComplete(() -> {
-          if (result.isSuccess()) {
-            processedSpansCounter.add(batch.size(), exportedAttrs);
-          } else {
-            logger.log(Level.FINE, "Exporter failed");
-          }
-        });
+        result.whenComplete(
+            () -> {
+              if (result.isSuccess()) {
+                processedSpansCounter.add(batch.size(), exportedAttrs);
+              } else {
+                logger.log(Level.FINE, "Exporter failed");
+              }
+            });
         return result;
       } catch (RuntimeException e) {
         logger.log(Level.WARNING, "Exporter threw an Exception", e);

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBuilder.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.sdk.trace.export;
 
+import static io.opentelemetry.api.internal.Utils.checkArgument;
+import static java.util.Objects.requireNonNull;
+
 import io.opentelemetry.api.metrics.MeterProvider;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-
-import static io.opentelemetry.api.internal.Utils.checkArgument;
-import static java.util.Objects.requireNonNull;
 
 /** Builder class for {@link BatchSpanProcessor}. */
 public final class BatchSpanProcessorBuilder {


### PR DESCRIPTION
I'm guessing you would want this option to go through spec(?), but wanted to get some initial feedback here ~, including the alternate option (see #4246).~

The problem: under high telemetry load and slower network / ingestion, the BatchSpanProcessor single worker thread can spend a lot of time waiting for responses.

This PR: this option tries to send as many complete batches as possible (up to a new config option `maxConcurrentExports`), and then waits `exporterTimeoutNanos` for all of those batches to complete.