### PR TITLE
(Alternate) Option for increasing BatchSpanProcessor throughput under slow network / ingestion

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBuilder.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.sdk.trace.export;
 
+import static io.opentelemetry.api.internal.Utils.checkArgument;
+import static java.util.Objects.requireNonNull;
+
 import io.opentelemetry.api.metrics.MeterProvider;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-
-import static io.opentelemetry.api.internal.Utils.checkArgument;
-import static java.util.Objects.requireNonNull;
 
 /** Builder class for {@link BatchSpanProcessor}. */
 public final class BatchSpanProcessorBuilder {

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -350,6 +350,7 @@ class BatchSpanProcessorTest {
             .setExporterTimeout(exporterTimeoutMillis, TimeUnit.MILLISECONDS)
             .setScheduleDelay(1, TimeUnit.MILLISECONDS)
             .setMaxQueueSize(1)
+            .setMaxConcurrentExports(2)
             .build();
     sdkTracerProvider = SdkTracerProvider.builder().addSpanProcessor(bsp).build();
 


### PR DESCRIPTION
I'm guessing you would want this option to go through spec(?), but wanted to get some initial feedback here, including the alternate option (see #4245).

I prefer this option, I call this option "use the single worker thread as much as possible".

This option conflicts with `exporterTimeoutNanos`, though I think that it makes more sense for downstream exporters to be responsible for their own timeout behavior anyways (e.g. `OTEL_EXPORTER_OTLP_TIMEOUT`).

With more complexity, it could probably support `exporterTimeoutNanos` as well, but I would probably prefer the other PR in that case from a simplicity perspective.