### PR TITLE
Export otel.scope.name, otel.scope.version

### DIFF
--- a/exporters/jaeger-thrift/src/main/java/io/opentelemetry/exporter/jaeger/thrift/Adapter.java
+++ b/exporters/jaeger-thrift/src/main/java/io/opentelemetry/exporter/jaeger/thrift/Adapter.java
@@ -44,6 +44,8 @@ final class Adapter {
   static final String KEY_SPAN_KIND = "span.kind";
   static final String KEY_SPAN_STATUS_MESSAGE = "otel.status_message";
   static final String KEY_SPAN_STATUS_CODE = "otel.status_code";
+  static final String KEY_INSTRUMENTATION_SCOPE_NAME = "otel.scope.name";
+  static final String KEY_INSTRUMENTATION_SCOPE_VERSION = "otel.scope.version";
   static final String KEY_INSTRUMENTATION_LIBRARY_NAME = "otel.library.name";
   static final String KEY_INSTRUMENTATION_LIBRARY_VERSION = "otel.library.version";
 
@@ -121,10 +123,18 @@ final class Adapter {
     }
 
     tags.add(
+        new Tag(KEY_INSTRUMENTATION_SCOPE_NAME, TagType.STRING)
+            .setVStr(span.getInstrumentationScopeInfo().getName()));
+    // Include instrumentation library name for backwards compatibility
+    tags.add(
         new Tag(KEY_INSTRUMENTATION_LIBRARY_NAME, TagType.STRING)
             .setVStr(span.getInstrumentationScopeInfo().getName()));
 
     if (span.getInstrumentationScopeInfo().getVersion() != null) {
+      tags.add(
+          new Tag(KEY_INSTRUMENTATION_SCOPE_VERSION, TagType.STRING)
+              .setVStr(span.getInstrumentationScopeInfo().getVersion()));
+      // Include instrumentation library name for backwards compatibility
       tags.add(
           new Tag(KEY_INSTRUMENTATION_LIBRARY_VERSION, TagType.STRING)
               .setVStr(span.getInstrumentationScopeInfo().getVersion()));

--- a/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/AdapterTest.java
+++ b/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/AdapterTest.java
@@ -85,7 +85,7 @@ class AdapterTest {
     assertThat(jaegerSpan.getStartTime()).isEqualTo(MILLISECONDS.toMicros(startMs));
     assertThat(jaegerSpan.getDuration()).isEqualTo(MILLISECONDS.toMicros(duration));
 
-    assertThat(jaegerSpan.getTagsSize()).isEqualTo(7);
+    assertThat(jaegerSpan.getTagsSize()).isEqualTo(8);
     assertThat(getValue(jaegerSpan.getTags(), Adapter.KEY_SPAN_KIND).getVStr()).isEqualTo("server");
     assertThat(getValue(jaegerSpan.getTags(), Adapter.KEY_SPAN_STATUS_CODE).getVLong())
         .isEqualTo(0);
@@ -119,7 +119,7 @@ class AdapterTest {
     // test
     io.jaegertracing.thriftjava.Span jaegerSpan = Adapter.toJaeger(span);
 
-    assertThat(jaegerSpan.getTagsSize()).isEqualTo(4);
+    assertThat(jaegerSpan.getTagsSize()).isEqualTo(5);
     assertThat(getValue(jaegerSpan.getTags(), Adapter.KEY_SPAN_KIND)).isNull();
   }
 

--- a/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftSpanExporterTest.java
+++ b/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftSpanExporterTest.java
@@ -130,7 +130,10 @@ class JaegerThriftSpanExporterTest {
     expectedSpan.addToTags(new Tag("span.kind", TagType.STRING).setVStr("consumer"));
     expectedSpan.addToTags(new Tag("otel.status_code", TagType.STRING).setVStr("OK"));
     expectedSpan.addToTags(
+        new Tag("otel.scope.name", TagType.STRING).setVStr("io.opentelemetry.auto"));
+    expectedSpan.addToTags(
         new Tag("otel.library.name", TagType.STRING).setVStr("io.opentelemetry.auto"));
+    expectedSpan.addToTags(new Tag("otel.scope.version", TagType.STRING).setVStr("1.0.0"));
     expectedSpan.addToTags(new Tag("otel.library.version", TagType.STRING).setVStr("1.0.0"));
 
     List<Span> expectedSpans = Collections.singletonList(expectedSpan);
@@ -229,7 +232,10 @@ class JaegerThriftSpanExporterTest {
     expectedSpan1.addToTags(new Tag("span.kind", TagType.STRING).setVStr("consumer"));
     expectedSpan1.addToTags(new Tag("otel.status_code", TagType.STRING).setVStr("OK"));
     expectedSpan1.addToTags(
+        new Tag("otel.scope.name", TagType.STRING).setVStr("io.opentelemetry.auto"));
+    expectedSpan1.addToTags(
         new Tag("otel.library.name", TagType.STRING).setVStr("io.opentelemetry.auto"));
+    expectedSpan1.addToTags(new Tag("otel.scope.version", TagType.STRING).setVStr("1.0.0"));
     expectedSpan1.addToTags(new Tag("otel.library.version", TagType.STRING).setVStr("1.0.0"));
 
     Span expectedSpan2 =
@@ -245,7 +251,10 @@ class JaegerThriftSpanExporterTest {
     expectedSpan2.addToTags(new Tag("span.kind", TagType.STRING).setVStr("consumer"));
     expectedSpan2.addToTags(new Tag("otel.status_code", TagType.STRING).setVStr("OK"));
     expectedSpan2.addToTags(
+        new Tag("otel.scope.name", TagType.STRING).setVStr("io.opentelemetry.auto"));
+    expectedSpan2.addToTags(
         new Tag("otel.library.name", TagType.STRING).setVStr("io.opentelemetry.auto"));
+    expectedSpan2.addToTags(new Tag("otel.scope.version", TagType.STRING).setVStr("1.0.0"));
     expectedSpan2.addToTags(new Tag("otel.library.version", TagType.STRING).setVStr("1.0.0"));
 
     verify(thriftSender).send(expectedProcess2, Collections.singletonList(expectedSpan2));

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/SpanMarshaler.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/SpanMarshaler.java
@@ -32,6 +32,10 @@ final class SpanMarshaler extends MarshalerWithSize {
       AttributeKey.stringKey("otel.status_description");
   private static final AttributeKey<String> KEY_SPAN_STATUS_CODE =
       AttributeKey.stringKey("otel.status_code");
+  private static final AttributeKey<String> KEY_INSTRUMENTATION_SCOPE_NAME =
+      AttributeKey.stringKey("otel.scope.name");
+  private static final AttributeKey<String> KEY_INSTRUMENTATION_SCOPE_VERSION =
+      AttributeKey.stringKey("otel.scope.version");
   private static final AttributeKey<String> KEY_INSTRUMENTATION_LIBRARY_NAME =
       AttributeKey.stringKey("otel.library.name");
   private static final AttributeKey<String> KEY_INSTRUMENTATION_LIBRARY_VERSION =
@@ -100,9 +104,17 @@ final class SpanMarshaler extends MarshalerWithSize {
 
     tags.add(
         KeyValueMarshaler.create(
+            KEY_INSTRUMENTATION_SCOPE_NAME, span.getInstrumentationScopeInfo().getName()));
+    // Include instrumentation library name for backwards compatibility
+    tags.add(
+        KeyValueMarshaler.create(
             KEY_INSTRUMENTATION_LIBRARY_NAME, span.getInstrumentationScopeInfo().getName()));
 
     if (span.getInstrumentationScopeInfo().getVersion() != null) {
+      tags.add(
+          KeyValueMarshaler.create(
+              KEY_INSTRUMENTATION_SCOPE_VERSION, span.getInstrumentationScopeInfo().getVersion()));
+      // Include instrumentation library name for backwards compatibility
       tags.add(
           KeyValueMarshaler.create(
               KEY_INSTRUMENTATION_LIBRARY_VERSION,

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterTest.java
@@ -250,6 +250,12 @@ class JaegerGrpcSpanExporterTest {
     assertThat(batch.getProcess().getTagsCount()).isEqualTo(5);
 
     assertThat(
+            getSpanTagValue(batch.getSpans(0), "otel.scope.name")
+                .orElseThrow(() -> new AssertionError("otel.scope.name not found"))
+                .getVStr())
+        .isEqualTo("io.opentelemetry.auto");
+
+    assertThat(
             getSpanTagValue(batch.getSpans(0), "otel.library.name")
                 .orElseThrow(() -> new AssertionError("otel.library.name not found"))
                 .getVStr())
@@ -258,6 +264,12 @@ class JaegerGrpcSpanExporterTest {
     assertThat(
             getSpanTagValue(batch.getSpans(0), "otel.library.version")
                 .orElseThrow(() -> new AssertionError("otel.library.version not found"))
+                .getVStr())
+        .isEqualTo("1.0.0");
+
+    assertThat(
+            getSpanTagValue(batch.getSpans(0), "otel.scope.version")
+                .orElseThrow(() -> new AssertionError("otel.scope.version not found"))
                 .getVStr())
         .isEqualTo("1.0.0");
 

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/PostSpansRequestMarshalerTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/PostSpansRequestMarshalerTest.java
@@ -92,7 +92,7 @@ class PostSpansRequestMarshalerTest {
     assertThat(jaegerSpan.getStartTime()).isEqualTo(Timestamps.fromMillis(startMs));
     assertThat(jaegerSpan.getDuration()).isEqualTo(Durations.fromMillis(duration));
 
-    assertThat(jaegerSpan.getTagsCount()).isEqualTo(6);
+    assertThat(jaegerSpan.getTagsCount()).isEqualTo(7);
     Model.KeyValue keyValue = getValue(jaegerSpan.getTagsList(), KEY_SPAN_KIND);
     assertThat(keyValue).isNotNull();
     assertThat(keyValue.getVStr()).isEqualTo("server");

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
@@ -52,6 +52,8 @@ public final class ZipkinSpanExporter implements SpanExporter {
   static final String OTEL_STATUS_CODE = "otel.status_code";
   static final AttributeKey<String> STATUS_ERROR = stringKey("error");
 
+  static final String KEY_INSTRUMENTATION_SCOPE_NAME = "otel.scope.name";
+  static final String KEY_INSTRUMENTATION_SCOPE_VERSION = "otel.scope.version";
   static final String KEY_INSTRUMENTATION_LIBRARY_NAME = "otel.library.name";
   static final String KEY_INSTRUMENTATION_LIBRARY_VERSION = "otel.library.version";
 
@@ -130,9 +132,13 @@ public final class ZipkinSpanExporter implements SpanExporter {
     InstrumentationScopeInfo instrumentationScopeInfo = spanData.getInstrumentationScopeInfo();
 
     if (!instrumentationScopeInfo.getName().isEmpty()) {
+      spanBuilder.putTag(KEY_INSTRUMENTATION_SCOPE_NAME, instrumentationScopeInfo.getName());
+      // Include instrumentation library name for backwards compatibility
       spanBuilder.putTag(KEY_INSTRUMENTATION_LIBRARY_NAME, instrumentationScopeInfo.getName());
     }
     if (instrumentationScopeInfo.getVersion() != null) {
+      spanBuilder.putTag(KEY_INSTRUMENTATION_SCOPE_VERSION, instrumentationScopeInfo.getVersion());
+      // Include instrumentation library name for backwards compatibility
       spanBuilder.putTag(
           KEY_INSTRUMENTATION_LIBRARY_VERSION, instrumentationScopeInfo.getVersion());
     }

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterTest.java
@@ -239,6 +239,8 @@ class ZipkinSpanExporterTest {
     assertThat(exporter.generateSpan(data))
         .isEqualTo(
             buildZipkinSpan(Span.Kind.CLIENT).toBuilder()
+                .putTag("otel.scope.name", "io.opentelemetry.auto")
+                .putTag("otel.scope.version", "1.0.0")
                 .putTag("otel.library.name", "io.opentelemetry.auto")
                 .putTag("otel.library.version", "1.0.0")
                 .putTag(ZipkinSpanExporter.OTEL_STATUS_CODE, "OK")


### PR DESCRIPTION
Resolves #4190.

- Adjust zipkin exporter to export otel.scope.name, otel.scope.version
- Adjust jaeger exporter to export otel.scope.name, otel.scope.version