### PR TITLE
Reduce lock scope in CompletableResultCode.whenComplete()

### DIFF
--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/CompletableResultCode.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/CompletableResultCode.java
@@ -121,12 +121,16 @@ public final class CompletableResultCode {
    * @return this completable result so that it may be further composed
    */
   public CompletableResultCode whenComplete(Runnable action) {
+    boolean runNow = false;
     synchronized (lock) {
       if (succeeded != null) {
-        action.run();
+        runNow = true;
       } else {
         this.completionActions.add(action);
       }
+    }
+    if (runNow) {
+      action.run();
     }
     return this;
   }


### PR DESCRIPTION
In particular I think this is important for the `CompletableResultCode.SUCCESS` singleton, since you can easily have multiple threads calling `whenComplete()` on it.

See #4282 for an alternative option to this PR.