### PR TITLE
Throw exception if view instrument selector selects nothing

### DIFF
--- a/sdk-extensions/metric-incubator/src/test/java/io/opentelemetry/sdk/viewconfig/ViewConfigTest.java
+++ b/sdk-extensions/metric-incubator/src/test/java/io/opentelemetry/sdk/viewconfig/ViewConfigTest.java
@@ -144,13 +144,6 @@ class ViewConfigTest {
   }
 
   @Test
-  void toInstrumentSelector_Empty() {
-    InstrumentSelector selector =
-        ViewConfig.toInstrumentSelector(SelectorSpecification.builder().build());
-    assertThat(selector).isEqualTo(InstrumentSelector.builder().build());
-  }
-
-  @Test
   void toInstrumentSelector() {
     InstrumentSelector selector =
         ViewConfig.toInstrumentSelector(

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/InstrumentSelectorBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/InstrumentSelectorBuilder.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import static io.opentelemetry.api.internal.Utils.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import io.opentelemetry.sdk.metrics.internal.view.StringPredicates;
@@ -120,6 +121,13 @@ public final class InstrumentSelectorBuilder {
 
   /** Returns an InstrumentSelector instance with the content of this builder. */
   public InstrumentSelector build() {
+    checkArgument(
+        instrumentType != null
+            || instrumentNameFilter != StringPredicates.ALL
+            || meterNameFilter != StringPredicates.ALL
+            || meterVersionFilter != StringPredicates.ALL
+            || meterSchemaUrlFilter != StringPredicates.ALL,
+        "Instrument selector must contain selection criteria");
     return InstrumentSelector.create(
         instrumentType,
         instrumentNameFilter,

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/ViewRegistry.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/ViewRegistry.java
@@ -28,7 +28,9 @@ public final class ViewRegistry {
   static final View DEFAULT_VIEW = View.builder().build();
   static final RegisteredView DEFAULT_REGISTERED_VIEW =
       RegisteredView.create(
-          InstrumentSelector.builder().build(),
+          // InstrumentSelector requires some selection criteria but the default view is a special
+          // case, so we trick it by setting a select all criteria manually.
+          InstrumentSelector.builder().setName((unused) -> true).build(),
           DEFAULT_VIEW,
           AttributesProcessor.NOOP,
           SourceInfo.noSourceInfo());

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/InstrumentSelectorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/InstrumentSelectorTest.java
@@ -43,6 +43,9 @@ class InstrumentSelectorTest {
             () -> InstrumentSelector.builder().setMeterSchemaUrl((Predicate<String>) null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("meterSchemaUrlFilter");
+    assertThatThrownBy(() -> InstrumentSelector.builder().build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Instrument selector must contain selection criteria");
   }
 
   @Test


### PR DESCRIPTION
Per the [view](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view) spec:

> If none the optional criteria is provided, the SDK SHOULD treat it as an error. It is recommended that the SDK implementations fail fast. Please refer to [Error handling in OpenTelemetry](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/error-handling.md) for the general guidance.