### PR TITLE
Drop HistogramPointData utility methods

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-common.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-common.txt
@@ -2,3 +2,6 @@ Comparing source compatibility of  against
 ===  UNCHANGED CLASS: PUBLIC ABSTRACT io.opentelemetry.sdk.common.InstrumentationLibraryInfo  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW ANNOTATION: java.lang.Deprecated
+***  MODIFIED CLASS: PUBLIC io.opentelemetry.sdk.resources.ResourceBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.resources.ResourceBuilder removeIf(java.util.function.Predicate)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
@@ -4,6 +4,8 @@ Comparing source compatibility of  against
 	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.AttributeAssertion equalTo(io.opentelemetry.api.common.AttributeKey, int)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.SpanDataAssert  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.SpanDataAssert hasAttribute(io.opentelemetry.api.common.AttributeKey, java.lang.Object)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.SpanDataAssert hasAttribute(io.opentelemetry.sdk.testing.assertj.AttributeAssertion)
 	===  UNCHANGED METHOD: PUBLIC io.opentelemetry.sdk.testing.assertj.SpanDataAssert hasInstrumentationLibraryInfo(io.opentelemetry.sdk.common.InstrumentationLibraryInfo)
 		+++  NEW ANNOTATION: java.lang.Deprecated
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.SpanDataAssert hasInstrumentationScopeInfo(io.opentelemetry.sdk.common.InstrumentationScopeInfo)

--- a/exporters/prometheus/src/integrationTest/java/io/opentelemetry/exporter/prometheus/MetricAdapter.java
+++ b/exporters/prometheus/src/integrationTest/java/io/opentelemetry/exporter/prometheus/MetricAdapter.java
@@ -237,7 +237,7 @@ final class MetricAdapter {
       List<String> labelValuesWithLe = new ArrayList<>(labelValues.size() + 1);
       // This is the upper boundary (inclusive). I.e. all values should be < this value (LE -
       // Less-then-or-Equal).
-      double boundary = histogramPointData.getBucketUpperBound(i);
+      double boundary = Serializer.getBucketUpperBound(histogramPointData, i);
       labelValuesWithLe.addAll(labelValues);
       labelValuesWithLe.add(doubleToGoString(boundary));
 
@@ -250,7 +250,7 @@ final class MetricAdapter {
               cumulativeCount,
               filterExemplars(
                   histogramPointData.getExemplars(),
-                  histogramPointData.getBucketLowerBound(i),
+                  Serializer.getBucketLowerBound(histogramPointData, i),
                   boundary),
               histogramPointData.getEpochNanos()));
     }

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Serializer.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Serializer.java
@@ -172,7 +172,7 @@ abstract class Serializer {
     for (int i = 0; i < counts.size(); i++) {
       // This is the upper boundary (inclusive). I.e. all values should be < this value (LE -
       // Less-then-or-Equal).
-      double boundary = point.getBucketUpperBound(i);
+      double boundary = getBucketUpperBound(point, i);
 
       cumulativeCount += counts.get(i);
       writePoint(
@@ -184,9 +184,30 @@ abstract class Serializer {
           "le",
           boundary,
           point.getExemplars(),
-          point.getBucketLowerBound(i),
+          getBucketLowerBound(point, i),
           boundary);
     }
+  }
+
+  /**
+   * Returns the lower bound of a bucket (all values would have been greater than).
+   *
+   * @param bucketIndex The bucket index, should match {@link HistogramPointData#getCounts()} index.
+   */
+  static double getBucketLowerBound(HistogramPointData point, int bucketIndex) {
+    return bucketIndex > 0 ? point.getBoundaries().get(bucketIndex - 1) : Double.NEGATIVE_INFINITY;
+  }
+
+  /**
+   * Returns the upper inclusive bound of a bucket (all values would have been less then or equal).
+   *
+   * @param bucketIndex The bucket index, should match {@link HistogramPointData#getCounts()} index.
+   */
+  static double getBucketUpperBound(HistogramPointData point, int bucketIndex) {
+    List<Double> boundaries = point.getBoundaries();
+    return (bucketIndex < boundaries.size())
+        ? boundaries.get(bucketIndex)
+        : Double.POSITIVE_INFINITY;
   }
 
   private void writeSummary(Writer writer, String name, SummaryPointData point) throws IOException {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/HistogramPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/HistogramPointData.java
@@ -43,18 +43,4 @@ public interface HistogramPointData extends PointData {
    * @return the read-only counts in each bucket. <b>do not mutate</b> the returned object.
    */
   List<Long> getCounts();
-
-  /**
-   * Returns the lower bound of a bucket (all values would have been greater than).
-   *
-   * @param bucketIndex The bucket index, should match {@link #getCounts()} index.
-   */
-  double getBucketLowerBound(int bucketIndex);
-
-  /**
-   * Returns the upper inclusive bound of a bucket (all values would have been less then or equal).
-   *
-   * @param bucketIndex The bucket index, should match {@link #getCounts()} index.
-   */
-  double getBucketUpperBound(int bucketIndex);
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/ImmutableHistogramPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/ImmutableHistogramPointData.java
@@ -90,18 +90,6 @@ public abstract class ImmutableHistogramPointData implements HistogramPointData 
 
   ImmutableHistogramPointData() {}
 
-  @Override
-  public double getBucketLowerBound(int bucketIndex) {
-    return bucketIndex > 0 ? getBoundaries().get(bucketIndex - 1) : Double.NEGATIVE_INFINITY;
-  }
-
-  @Override
-  public double getBucketUpperBound(int bucketIndex) {
-    return (bucketIndex < getBoundaries().size())
-        ? getBoundaries().get(bucketIndex)
-        : Double.POSITIVE_INFINITY;
-  }
-
   private static boolean isStrictlyIncreasing(List<Double> xs) {
     for (int i = 0; i < xs.size() - 1; i++) {
       if (xs.get(i).compareTo(xs.get(i + 1)) >= 0) {


### PR DESCRIPTION
These methods were only used in one place and not essential to the histogram data model. 