### PR TITLE
Use debian openjdk17 test image

### DIFF
--- a/.github/workflows/docker-test-containers.yml
+++ b/.github/workflows/docker-test-containers.yml
@@ -18,7 +18,7 @@ jobs:
             target_image: toxiproxy
           - source: eclipse-temurin:8-jdk
             target_image: openjdk8
-          - source: eclipse-temurin:17-jre-alpine
+          - source: eclipse-temurin:17-jre-focal
             target_image: openjdk17
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
While the alpine image is a little smaller, not that much, but it loses out on multiarch (i.e., performance on Apple silicon).﻿
