### PR TITLE
Add min and max to HistogramPointData

### DIFF
--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/metrics/MetricsRequestMarshalerTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/metrics/MetricsRequestMarshalerTest.java
@@ -345,12 +345,21 @@ class MetricsRequestMarshalerTest {
             toHistogramDataPoints(
                 ImmutableList.of(
                     ImmutableHistogramPointData.create(
-                        123, 456, KV_ATTR, 14.2, ImmutableList.of(1.0), ImmutableList.of(1L, 5L)),
+                        123,
+                        456,
+                        KV_ATTR,
+                        14.2,
+                        4.1,
+                        10.1,
+                        ImmutableList.of(1.0),
+                        ImmutableList.of(1L, 5L)),
                     ImmutableHistogramPointData.create(
                         123,
                         456,
                         Attributes.empty(),
                         15.3,
+                        3.3,
+                        12.0,
                         ImmutableList.of(),
                         ImmutableList.of(7L),
                         ImmutableList.of(
@@ -746,6 +755,8 @@ class MetricsRequestMarshalerTest {
                                 456,
                                 KV_ATTR,
                                 4.0,
+                                1.0,
+                                3.0,
                                 ImmutableList.of(),
                                 ImmutableList.of(33L)))))))
         .isEqualTo(

--- a/exporters/prometheus/src/integrationTest/java/io/opentelemetry/exporter/prometheus/MetricAdapterTest.java
+++ b/exporters/prometheus/src/integrationTest/java/io/opentelemetry/exporter/prometheus/MetricAdapterTest.java
@@ -209,6 +209,8 @@ class MetricAdapterTest {
                       1633950672000000000L,
                       KP_VP_ATTR,
                       1.0,
+                      null,
+                      null,
                       Collections.emptyList(),
                       Collections.singletonList(2L),
                       Collections.singletonList(
@@ -543,6 +545,8 @@ class MetricAdapterTest {
                     1633943350000000000L,
                     KP_VP_ATTR,
                     18.3,
+                    0.0,
+                    0.0,
                     ImmutableList.of(1.0),
                     ImmutableList.of(4L, 9L),
                     ImmutableList.of(

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/SerializerTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/SerializerTest.java
@@ -199,6 +199,8 @@ class SerializerTest {
                       1633950672000000000L,
                       KP_VP_ATTR,
                       1.0,
+                      null,
+                      null,
                       Collections.emptyList(),
                       Collections.singletonList(2L),
                       Collections.singletonList(

--- a/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/internal/metrics/MetricAdapter.java
+++ b/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/internal/metrics/MetricAdapter.java
@@ -236,6 +236,8 @@ public final class MetricAdapter {
                             endTimestamp,
                             attributes,
                             distribution.getSum(),
+                            null,
+                            null,
                             mapBoundaries(distribution.getBucketOptions()),
                             mapCounts(distribution.getBuckets()),
                             mapExemplars(distribution.getBuckets())),

--- a/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/HistogramPointDataAssert.java
+++ b/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/HistogramPointDataAssert.java
@@ -34,6 +34,7 @@ public class HistogramPointDataAssert
   /** Ensures the {@code min} field matches the expected value. */
   public HistogramPointDataAssert hasMin(double expected) {
     isNotNull();
+    Assertions.assertThat(actual.hasMin()).isTrue();
     Assertions.assertThat(actual.getMin()).as("min").isEqualTo(expected);
     return this;
   }
@@ -41,6 +42,7 @@ public class HistogramPointDataAssert
   /** Ensures the {@code max} field matches the expected value. */
   public HistogramPointDataAssert hasMax(double expected) {
     isNotNull();
+    Assertions.assertThat(actual.hasMax()).isTrue();
     Assertions.assertThat(actual.getMax()).as("max").isEqualTo(expected);
     return this;
   }

--- a/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/HistogramPointDataAssert.java
+++ b/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/HistogramPointDataAssert.java
@@ -31,6 +31,20 @@ public class HistogramPointDataAssert
     return this;
   }
 
+  /** Ensures the {@code min} field matches the expected value. */
+  public HistogramPointDataAssert hasMin(double expected) {
+    isNotNull();
+    Assertions.assertThat(actual.getMin()).as("min").isEqualTo(expected);
+    return this;
+  }
+
+  /** Ensures the {@code max} field matches the expected value. */
+  public HistogramPointDataAssert hasMax(double expected) {
+    isNotNull();
+    Assertions.assertThat(actual.getMax()).as("max").isEqualTo(expected);
+    return this;
+  }
+
   /** Ensures the {@code count} field matches the expected value. */
   public HistogramPointDataAssert hasCount(long expected) {
     isNotNull();

--- a/sdk/metrics-testing/src/test/java/io/opentelemetry/sdk/testing/assertj/MetricAssertionsTest.java
+++ b/sdk/metrics-testing/src/test/java/io/opentelemetry/sdk/testing/assertj/MetricAssertionsTest.java
@@ -223,7 +223,14 @@ public class MetricAssertionsTest {
 
   private static final HistogramPointData DOUBLE_HISTOGRAM_POINT_DATA =
       ImmutableHistogramPointData.create(
-          1, 2, Attributes.empty(), 15, Collections.singletonList(10.0), Arrays.asList(1L, 2L));
+          1,
+          2,
+          Attributes.empty(),
+          15,
+          4.0,
+          7.0,
+          Collections.singletonList(10.0),
+          Arrays.asList(1L, 2L));
 
   @Test
   void metric_passing() {
@@ -492,6 +499,8 @@ public class MetricAssertionsTest {
     assertThat(DOUBLE_HISTOGRAM_POINT_DATA)
         .hasCount(3)
         .hasSum(15)
+        .hasMin(4.0)
+        .hasMax(7.0)
         .hasSumGreaterThan(10)
         .hasEpochNanos(2)
         .hasStartEpochNanos(1)

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/HistogramPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/HistogramPointData.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.sdk.metrics.data;
 
 import java.util.List;
-import javax.annotation.Nullable;
 
 /**
  * A histogram metric point.
@@ -29,21 +28,17 @@ public interface HistogramPointData extends PointData {
    */
   long getCount();
 
-  /**
-   * The min of all measurements recorded.
-   *
-   * @return the min of recorded measurements, or {@code null} if not available.
-   */
-  @Nullable
-  Double getMin();
+  /** Return {@code true} if {@link #getMin()} is set. */
+  boolean hasMin();
 
-  /**
-   * The max of all measurements recorded.
-   *
-   * @return the max of recorded measurements, or {@code null} if not available.
-   */
-  @Nullable
-  Double getMax();
+  /** The min of all measurements recorded, if {@link #hasMin()} is {@code true}. */
+  double getMin();
+
+  /** Return {@code true} if {@link #getMax()} is set. */
+  boolean hasMax();
+
+  /** The max of all measurements recorded, if {@link #hasMax()} is {@code true}. */
+  double getMax();
 
   /**
    * The bucket boundaries. For a Histogram with N defined boundaries, e.g, [x, y, z]. There are N+1

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/HistogramPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/HistogramPointData.java
@@ -31,13 +31,19 @@ public interface HistogramPointData extends PointData {
   /** Return {@code true} if {@link #getMin()} is set. */
   boolean hasMin();
 
-  /** The min of all measurements recorded, if {@link #hasMin()} is {@code true}. */
+  /**
+   * The min of all measurements recorded, if {@link #hasMin()} is {@code true}. If {@link
+   * #hasMin()} is {@code false}, the response should be ignored.
+   */
   double getMin();
 
   /** Return {@code true} if {@link #getMax()} is set. */
   boolean hasMax();
 
-  /** The max of all measurements recorded, if {@link #hasMax()} is {@code true}. */
+  /**
+   * The max of all measurements recorded, if {@link #hasMax()} is {@code true}. If {@link
+   * #hasMax()} is {@code false}, the response should be ignored.
+   */
   double getMax();
 
   /**

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/HistogramPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/HistogramPointData.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.metrics.data;
 
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * A histogram metric point.
@@ -27,6 +28,22 @@ public interface HistogramPointData extends PointData {
    * @return the count of recorded measurements.
    */
   long getCount();
+
+  /**
+   * The min of all measurements recorded.
+   *
+   * @return the min of recorded measurements, or {@code null} if not available.
+   */
+  @Nullable
+  Double getMin();
+
+  /**
+   * The max of all measurements recorded.
+   *
+   * @return the max of recorded measurements, or {@code null} if not available.
+   */
+  @Nullable
+  Double getMax();
 
   /**
    * The bucket boundaries. For a Histogram with N defined boundaries, e.g, [x, y, z]. There are N+1

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleHistogramAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleHistogramAggregator.java
@@ -91,19 +91,18 @@ public final class DoubleHistogramAggregator implements Aggregator<HistogramAccu
    * return it.
    */
   @Nullable
-  private static <T> T applyToNullable(
-      BiFunction<T, T, T> function, @Nullable T val1, @Nullable T val2) {
+  private static Double applyToNullable(
+      BiFunction<Double, Double, Double> function, @Nullable Double val1, @Nullable Double val2) {
     if (val1 != null && val2 != null) {
       return function.apply(val1, val2);
-    }
-    if (val1 == null && val2 == null) {
-      return null;
     }
     if (val1 != null) {
       return val1;
     }
-    // val2 != null
-    return val2;
+    if (val2 != null) {
+      return val2;
+    }
+    return null;
   }
 
   @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/HistogramAccumulation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/HistogramAccumulation.java
@@ -9,6 +9,7 @@ import com.google.auto.value.AutoValue;
 import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
@@ -20,12 +21,18 @@ abstract class HistogramAccumulation {
    *
    * @return a new {@link HistogramAccumulation} with the given values.
    */
-  static HistogramAccumulation create(double sum, long[] counts) {
-    return create(sum, counts, Collections.emptyList());
+  static HistogramAccumulation create(
+      double sum, @Nullable Double min, @Nullable Double max, long[] counts) {
+    return create(sum, min, max, counts, Collections.emptyList());
   }
 
-  static HistogramAccumulation create(double sum, long[] counts, List<ExemplarData> exemplars) {
-    return new AutoValue_HistogramAccumulation(sum, counts, exemplars);
+  static HistogramAccumulation create(
+      double sum,
+      @Nullable Double min,
+      @Nullable Double max,
+      long[] counts,
+      List<ExemplarData> exemplars) {
+    return new AutoValue_HistogramAccumulation(sum, min, max, counts, exemplars);
   }
 
   HistogramAccumulation() {}
@@ -36,6 +43,22 @@ abstract class HistogramAccumulation {
    * @return the sum of recorded measurements.
    */
   abstract double getSum();
+
+  /**
+   * The min of all measurements recorded.
+   *
+   * @return the min of recorded measurements, or {@code null} if not available.
+   */
+  @Nullable
+  abstract Double getMin();
+
+  /**
+   * The max of all measurements recorded.
+   *
+   * @return the max of recorded measurements, or {@code null} if not available.
+   */
+  @Nullable
+  abstract Double getMax();
 
   /**
    * The counts in each bucket. The returned type is a mutable object, but it should be fine because

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/HistogramAccumulation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/HistogramAccumulation.java
@@ -9,7 +9,6 @@ import com.google.auto.value.AutoValue;
 import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import java.util.Collections;
 import java.util.List;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
@@ -22,17 +21,18 @@ abstract class HistogramAccumulation {
    * @return a new {@link HistogramAccumulation} with the given values.
    */
   static HistogramAccumulation create(
-      double sum, @Nullable Double min, @Nullable Double max, long[] counts) {
-    return create(sum, min, max, counts, Collections.emptyList());
+      double sum, boolean hasMinMax, double min, double max, long[] counts) {
+    return create(sum, hasMinMax, min, max, counts, Collections.emptyList());
   }
 
   static HistogramAccumulation create(
       double sum,
-      @Nullable Double min,
-      @Nullable Double max,
+      boolean hasMinMax,
+      double min,
+      double max,
       long[] counts,
       List<ExemplarData> exemplars) {
-    return new AutoValue_HistogramAccumulation(sum, min, max, counts, exemplars);
+    return new AutoValue_HistogramAccumulation(sum, hasMinMax, min, max, counts, exemplars);
   }
 
   HistogramAccumulation() {}
@@ -44,21 +44,20 @@ abstract class HistogramAccumulation {
    */
   abstract double getSum();
 
-  /**
-   * The min of all measurements recorded.
-   *
-   * @return the min of recorded measurements, or {@code null} if not available.
-   */
-  @Nullable
-  abstract Double getMin();
+  /** Return {@code true} if {@link #getMin()} and {@link #getMax()} is set. */
+  abstract boolean hasMinMax();
 
   /**
-   * The max of all measurements recorded.
-   *
-   * @return the max of recorded measurements, or {@code null} if not available.
+   * The min of all measurements recorded, if {@link #hasMinMax()} is {@code true}. If {@link
+   * #hasMinMax()} is {@code false}, the response should be ignored.
    */
-  @Nullable
-  abstract Double getMax();
+  abstract double getMin();
+
+  /**
+   * The max of all measurements recorded, if {@link #hasMinMax()} is {@code true}. If {@link
+   * #hasMinMax()} is {@code false}, the response should be ignored.
+   */
+  abstract double getMax();
 
   /**
    * The counts in each bucket. The returned type is a mutable object, but it should be fine because

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/MetricDataUtils.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/MetricDataUtils.java
@@ -24,7 +24,6 @@ final class MetricDataUtils {
   private MetricDataUtils() {}
 
   /** Returns true if the instrument does not allow negative measurements. */
-  @SuppressWarnings("deprecation") // Support OBSERVABLE_SUM until removed
   static boolean isMonotonicInstrument(InstrumentDescriptor descriptor) {
     InstrumentType type = descriptor.getType();
     return type == InstrumentType.HISTOGRAM
@@ -77,6 +76,8 @@ final class MetricDataUtils {
                   epochNanos,
                   labels,
                   aggregator.getSum(),
+                  aggregator.getMin(),
+                  aggregator.getMax(),
                   boundaries,
                   counts,
                   aggregator.getExemplars()));

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/ImmutableHistogramPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/ImmutableHistogramPointData.java
@@ -13,6 +13,7 @@ import io.opentelemetry.sdk.metrics.data.HistogramPointData;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -37,10 +38,20 @@ public abstract class ImmutableHistogramPointData implements HistogramPointData 
       long epochNanos,
       Attributes attributes,
       double sum,
+      @Nullable Double min,
+      @Nullable Double max,
       List<Double> boundaries,
       List<Long> counts) {
     return create(
-        startEpochNanos, epochNanos, attributes, sum, boundaries, counts, Collections.emptyList());
+        startEpochNanos,
+        epochNanos,
+        attributes,
+        sum,
+        min,
+        max,
+        boundaries,
+        counts,
+        Collections.emptyList());
   }
 
   /**
@@ -55,6 +66,8 @@ public abstract class ImmutableHistogramPointData implements HistogramPointData 
       long epochNanos,
       Attributes attributes,
       double sum,
+      @Nullable Double min,
+      @Nullable Double max,
       List<Double> boundaries,
       List<Long> counts,
       List<ExemplarData> exemplars) {
@@ -84,6 +97,8 @@ public abstract class ImmutableHistogramPointData implements HistogramPointData 
         exemplars,
         sum,
         totalCount,
+        min,
+        max,
         Collections.unmodifiableList(new ArrayList<>(boundaries)),
         Collections.unmodifiableList(new ArrayList<>(counts)));
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/ImmutableHistogramPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/ImmutableHistogramPointData.java
@@ -97,8 +97,10 @@ public abstract class ImmutableHistogramPointData implements HistogramPointData 
         exemplars,
         sum,
         totalCount,
-        min,
-        max,
+        min != null,
+        min != null ? min : -1,
+        max != null,
+        max != null ? max : -1,
         Collections.unmodifiableList(new ArrayList<>(boundaries)),
         Collections.unmodifiableList(new ArrayList<>(counts)));
   }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/ImmutableMetricDataTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/ImmutableMetricDataTest.java
@@ -34,6 +34,8 @@ class ImmutableMetricDataTest {
   private static final long EPOCH_NANOS = TimeUnit.MILLISECONDS.toNanos(2000);
   private static final long LONG_VALUE = 10;
   private static final double DOUBLE_VALUE = 1.234;
+  private static final double DOUBLE_VALUE_MIN = 1.02;
+  private static final double DOUBLE_VALUE_MAX = 0.214;
   private static final AttributeKey<String> KEY = AttributeKey.stringKey("key");
   private static final ValueAtQuantile MINIMUM_VALUE =
       ImmutableValueAtQuantile.create(0.0, DOUBLE_VALUE);
@@ -61,6 +63,8 @@ class ImmutableMetricDataTest {
           EPOCH_NANOS,
           Attributes.of(KEY, "value"),
           DOUBLE_VALUE,
+          DOUBLE_VALUE_MIN,
+          DOUBLE_VALUE_MAX,
           ImmutableList.of(1.0),
           ImmutableList.of(1L, 1L));
 
@@ -176,6 +180,8 @@ class ImmutableMetricDataTest {
     assertThat(HISTOGRAM_POINT.getAttributes().get(KEY)).isEqualTo("value");
     assertThat(HISTOGRAM_POINT.getCount()).isEqualTo(2L);
     assertThat(HISTOGRAM_POINT.getSum()).isEqualTo(DOUBLE_VALUE);
+    assertThat(HISTOGRAM_POINT.getMin()).isEqualTo(DOUBLE_VALUE_MIN);
+    assertThat(HISTOGRAM_POINT.getMax()).isEqualTo(DOUBLE_VALUE_MAX);
     assertThat(HISTOGRAM_POINT.getBoundaries()).isEqualTo(ImmutableList.of(1.0));
     assertThat(HISTOGRAM_POINT.getCounts()).isEqualTo(ImmutableList.of(1L, 1L));
 
@@ -193,7 +199,14 @@ class ImmutableMetricDataTest {
     assertThatThrownBy(
             () ->
                 ImmutableHistogramPointData.create(
-                    0, 0, Attributes.empty(), 0.0, ImmutableList.of(), ImmutableList.of()))
+                    0,
+                    0,
+                    Attributes.empty(),
+                    0.0,
+                    0.0,
+                    0.0,
+                    ImmutableList.of(),
+                    ImmutableList.of()))
         .isInstanceOf(IllegalArgumentException.class);
     assertThatThrownBy(
             () ->
@@ -201,6 +214,8 @@ class ImmutableMetricDataTest {
                     0,
                     0,
                     Attributes.empty(),
+                    0.0,
+                    0.0,
                     0.0,
                     ImmutableList.of(1.0, 1.0),
                     ImmutableList.of(0L, 0L, 0L)))
@@ -211,6 +226,8 @@ class ImmutableMetricDataTest {
                     0,
                     0,
                     Attributes.empty(),
+                    0.0,
+                    0.0,
                     0.0,
                     ImmutableList.of(Double.NEGATIVE_INFINITY),
                     ImmutableList.of(0L, 0L)))

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleHistogramAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleHistogramAggregatorTest.java
@@ -62,7 +62,9 @@ class DoubleHistogramAggregatorTest {
     aggregatorHandle.recordLong(150);
     aggregatorHandle.recordLong(2000);
     assertThat(aggregatorHandle.accumulateThenReset(Attributes.empty()))
-        .isEqualTo(HistogramAccumulation.create(2175, 5d, 2000d, new long[] {1, 1, 1, 1}));
+        .isEqualTo(
+            HistogramAccumulation.create(
+                2175, /* hasMinMax= */ true, 5d, 2000d, new long[] {1, 1, 1, 1}));
   }
 
   @Test
@@ -85,7 +87,9 @@ class DoubleHistogramAggregatorTest {
     AggregatorHandle<HistogramAccumulation> aggregatorHandle = aggregator.createHandle();
     aggregatorHandle.recordDouble(0, attributes, Context.root());
     assertThat(aggregatorHandle.accumulateThenReset(Attributes.empty()))
-        .isEqualTo(HistogramAccumulation.create(0, 0d, 0d, new long[] {1, 0, 0, 0}, exemplars));
+        .isEqualTo(
+            HistogramAccumulation.create(
+                0, /* hasMinMax= */ true, 0, 0, new long[] {1, 0, 0, 0}, exemplars));
   }
 
   @Test
@@ -95,21 +99,29 @@ class DoubleHistogramAggregatorTest {
 
     aggregatorHandle.recordLong(100);
     assertThat(aggregatorHandle.accumulateThenReset(Attributes.empty()))
-        .isEqualTo(HistogramAccumulation.create(100, 100d, 100d, new long[] {0, 1, 0, 0}));
+        .isEqualTo(
+            HistogramAccumulation.create(
+                100, /* hasMinMax= */ true, 100d, 100d, new long[] {0, 1, 0, 0}));
     assertThat(aggregatorHandle.accumulateThenReset(Attributes.empty())).isNull();
 
     aggregatorHandle.recordLong(0);
     assertThat(aggregatorHandle.accumulateThenReset(Attributes.empty()))
-        .isEqualTo(HistogramAccumulation.create(0, 0d, 0d, new long[] {1, 0, 0, 0}));
+        .isEqualTo(
+            HistogramAccumulation.create(
+                0, /* hasMinMax= */ true, 0d, 0d, new long[] {1, 0, 0, 0}));
     assertThat(aggregatorHandle.accumulateThenReset(Attributes.empty())).isNull();
   }
 
   @Test
   void accumulateData() {
     assertThat(aggregator.accumulateDoubleMeasurement(11.1, Attributes.empty(), Context.current()))
-        .isEqualTo(HistogramAccumulation.create(11.1, 11.1, 11.1, new long[] {0, 1, 0, 0}));
+        .isEqualTo(
+            HistogramAccumulation.create(
+                11.1, /* hasMinMax= */ true, 11.1, 11.1, new long[] {0, 1, 0, 0}));
     assertThat(aggregator.accumulateLongMeasurement(10, Attributes.empty(), Context.current()))
-        .isEqualTo(HistogramAccumulation.create(10.0, 10.0, 10.0, new long[] {1, 0, 0, 0}));
+        .isEqualTo(
+            HistogramAccumulation.create(
+                10.0, /* hasMinMax= */ true, 10.0, 10.0, new long[] {1, 0, 0, 0}));
   }
 
   @Test
@@ -138,12 +150,16 @@ class DoubleHistogramAggregatorTest {
                     TraceState.getDefault()),
                 2));
     HistogramAccumulation previousAccumulation =
-        HistogramAccumulation.create(2, 1d, 2d, new long[] {1, 1, 0}, previousExemplars);
+        HistogramAccumulation.create(
+            2, /* hasMinMax= */ true, 1d, 2d, new long[] {1, 1, 0}, previousExemplars);
     HistogramAccumulation nextAccumulation =
-        HistogramAccumulation.create(2, 2d, 3d, new long[] {0, 0, 2}, exemplars);
+        HistogramAccumulation.create(
+            2, /* hasMinMax= */ true, 2d, 3d, new long[] {0, 0, 2}, exemplars);
     // Assure most recent exemplars are kept.
     assertThat(aggregator.merge(previousAccumulation, nextAccumulation))
-        .isEqualTo(HistogramAccumulation.create(4, 1d, 3d, new long[] {1, 1, 2}, exemplars));
+        .isEqualTo(
+            HistogramAccumulation.create(
+                4, /* hasMinMax= */ true, 1d, 3d, new long[] {1, 1, 2}, exemplars));
   }
 
   @Test
@@ -151,28 +167,42 @@ class DoubleHistogramAggregatorTest {
     // If min / max is null for both accumulations set min / max to null
     assertThat(
             aggregator.merge(
-                HistogramAccumulation.create(0, 1d, 2d, new long[] {}, Collections.emptyList()),
                 HistogramAccumulation.create(
-                    0, null, null, new long[] {}, Collections.emptyList())))
-        .isEqualTo(HistogramAccumulation.create(0, 1d, 2d, new long[] {}, Collections.emptyList()));
+                    0, /* hasMinMax= */ true, 1d, 2d, new long[] {}, Collections.emptyList()),
+                HistogramAccumulation.create(
+                    0, /* hasMinMax= */ false, 0, 0, new long[] {}, Collections.emptyList())))
+        .isEqualTo(
+            HistogramAccumulation.create(
+                0, /* hasMinMax= */ true, 1d, 2d, new long[] {}, Collections.emptyList()));
     // If min / max is non-null for only one accumulation set min / max to it
     assertThat(
             aggregator.merge(
-                HistogramAccumulation.create(0, 1d, 2d, new long[] {}, Collections.emptyList()),
                 HistogramAccumulation.create(
-                    0, null, null, new long[] {}, Collections.emptyList())))
-        .isEqualTo(HistogramAccumulation.create(0, 1d, 2d, new long[] {}, Collections.emptyList()));
+                    0, /* hasMinMax= */ true, 1d, 2d, new long[] {}, Collections.emptyList()),
+                HistogramAccumulation.create(
+                    0, /* hasMinMax= */ false, 0, 0, new long[] {}, Collections.emptyList())))
+        .isEqualTo(
+            HistogramAccumulation.create(
+                0, /* hasMinMax= */ true, 1d, 2d, new long[] {}, Collections.emptyList()));
     assertThat(
             aggregator.merge(
-                HistogramAccumulation.create(0, null, null, new long[] {}, Collections.emptyList()),
-                HistogramAccumulation.create(0, 1d, 2d, new long[] {}, Collections.emptyList())))
-        .isEqualTo(HistogramAccumulation.create(0, 1d, 2d, new long[] {}, Collections.emptyList()));
+                HistogramAccumulation.create(
+                    0, /* hasMinMax= */ false, 0, 0, new long[] {}, Collections.emptyList()),
+                HistogramAccumulation.create(
+                    0, /* hasMinMax= */ true, 1d, 2d, new long[] {}, Collections.emptyList())))
+        .isEqualTo(
+            HistogramAccumulation.create(
+                0, /* hasMinMax= */ true, 1d, 2d, new long[] {}, Collections.emptyList()));
     // If both accumulations have min / max compute the min / max
     assertThat(
             aggregator.merge(
-                HistogramAccumulation.create(0, 1d, 1d, new long[] {}, Collections.emptyList()),
-                HistogramAccumulation.create(0, 2d, 2d, new long[] {}, Collections.emptyList())))
-        .isEqualTo(HistogramAccumulation.create(0, 1d, 2d, new long[] {}, Collections.emptyList()));
+                HistogramAccumulation.create(
+                    0, /* hasMinMax= */ true, 1d, 1d, new long[] {}, Collections.emptyList()),
+                HistogramAccumulation.create(
+                    0, /* hasMinMax= */ true, 2d, 2d, new long[] {}, Collections.emptyList())))
+        .isEqualTo(
+            HistogramAccumulation.create(
+                0, /* hasMinMax= */ true, 1d, 2d, new long[] {}, Collections.emptyList()));
   }
 
   @Test
@@ -201,12 +231,16 @@ class DoubleHistogramAggregatorTest {
                     TraceState.getDefault()),
                 2));
     HistogramAccumulation previousAccumulation =
-        HistogramAccumulation.create(2, 1d, 2d, new long[] {1, 1, 2}, previousExemplars);
+        HistogramAccumulation.create(
+            2, /* hasMinMax= */ true, 1d, 2d, new long[] {1, 1, 2}, previousExemplars);
     HistogramAccumulation nextAccumulation =
-        HistogramAccumulation.create(5, 2d, 3d, new long[] {2, 2, 2}, exemplars);
+        HistogramAccumulation.create(
+            5, /* hasMinMax= */ true, 2d, 3d, new long[] {2, 2, 2}, exemplars);
     // Assure most recent exemplars are kept.
     assertThat(aggregator.diff(previousAccumulation, nextAccumulation))
-        .isEqualTo(HistogramAccumulation.create(3, null, null, new long[] {1, 1, 0}, exemplars));
+        .isEqualTo(
+            HistogramAccumulation.create(
+                3, /* hasMinMax= */ false, -1, -1, new long[] {1, 1, 0}, exemplars));
   }
 
   @Test
@@ -246,7 +280,12 @@ class DoubleHistogramAggregatorTest {
             1);
     HistogramAccumulation accumulation =
         HistogramAccumulation.create(
-            2, 2d, 2d, new long[] {1, 0, 0, 0}, Collections.singletonList(exemplar));
+            2,
+            /* hasMinMax= */ true,
+            2d,
+            2d,
+            new long[] {1, 0, 0, 0},
+            Collections.singletonList(exemplar));
     assertThat(
             aggregator.toMetricData(
                 RESOURCE,
@@ -323,7 +362,9 @@ class DoubleHistogramAggregatorTest {
     summarizer.process(aggregatorHandle.accumulateThenReset(Attributes.empty()));
 
     assertThat(summarizer.accumulation)
-        .isEqualTo(HistogramAccumulation.create(1010000, 1d, 23d, new long[] {50000, 50000, 0, 0}));
+        .isEqualTo(
+            HistogramAccumulation.create(
+                1010000, /* hasMinMax= */ true, 1d, 23d, new long[] {50000, 50000, 0, 0}));
   }
 
   private static final class Histogram {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleHistogramAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleHistogramAggregatorTest.java
@@ -147,6 +147,35 @@ class DoubleHistogramAggregatorTest {
   }
 
   @Test
+  void mergeAccumulation_MinAndMax() {
+    // If min / max is null for both accumulations set min / max to null
+    assertThat(
+            aggregator.merge(
+                HistogramAccumulation.create(0, 1d, 2d, new long[] {}, Collections.emptyList()),
+                HistogramAccumulation.create(
+                    0, null, null, new long[] {}, Collections.emptyList())))
+        .isEqualTo(HistogramAccumulation.create(0, 1d, 2d, new long[] {}, Collections.emptyList()));
+    // If min / max is non-null for only one accumulation set min / max to it
+    assertThat(
+            aggregator.merge(
+                HistogramAccumulation.create(0, 1d, 2d, new long[] {}, Collections.emptyList()),
+                HistogramAccumulation.create(
+                    0, null, null, new long[] {}, Collections.emptyList())))
+        .isEqualTo(HistogramAccumulation.create(0, 1d, 2d, new long[] {}, Collections.emptyList()));
+    assertThat(
+            aggregator.merge(
+                HistogramAccumulation.create(0, null, null, new long[] {}, Collections.emptyList()),
+                HistogramAccumulation.create(0, 1d, 2d, new long[] {}, Collections.emptyList())))
+        .isEqualTo(HistogramAccumulation.create(0, 1d, 2d, new long[] {}, Collections.emptyList()));
+    // If both accumulations have min / max compute the min / max
+    assertThat(
+            aggregator.merge(
+                HistogramAccumulation.create(0, 1d, 1d, new long[] {}, Collections.emptyList()),
+                HistogramAccumulation.create(0, 2d, 2d, new long[] {}, Collections.emptyList())))
+        .isEqualTo(HistogramAccumulation.create(0, 1d, 2d, new long[] {}, Collections.emptyList()));
+  }
+
+  @Test
   void diffAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
     ExemplarData exemplar =


### PR DESCRIPTION
Related to #4267.

Figure it would be good to make these part of the metric data model before stabilization. Not strictly necessary to do now because they're optional and could be later added with a default of `null`. 