### PR TITLE
Remove --stacktrace from gradle builds

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -55,7 +55,6 @@ jobs:
         with:
           arguments: |
             build
-            --stacktrace
             ${{ matrix.coverage && 'jacocoTestReport' || '' }}
             -PtestJavaVersion=${{ matrix.test-java-version }}
             -Porg.gradle.java.installations.paths=${{ steps.setup-java-8.outputs.path }},${{ steps.setup-java-11.outputs.path }},${{ steps.setup-java-17.outputs.path }}
@@ -101,7 +100,7 @@ jobs:
 
       - uses: gradle/gradle-build-action@v2
         with:
-          arguments: snapshot --stacktrace
+          arguments: snapshot
         env:
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -77,7 +77,6 @@ jobs:
         with:
           arguments: |
             build
-            --stacktrace
             -Prelease.version=${{ github.event.inputs.version }}
 
       - uses: gradle/gradle-build-action@v2
@@ -86,7 +85,6 @@ jobs:
           arguments: |
             final
             closeAndReleaseSonatypeStagingRepository
-            --stacktrace
             -Prelease.version=${{ github.event.inputs.version }}
         env:
           GRGIT_USER: ${{ github.actor }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -55,7 +55,6 @@ jobs:
         with:
           arguments: |
             build 
-            --stacktrace 
             ${{ matrix.coverage && 'jacocoTestReport' || '' }}
             -PtestJavaVersion=${{ matrix.test-java-version }}
             -Porg.gradle.java.installations.paths=${{ steps.setup-java-8.outputs.path }},${{ steps.setup-java-11.outputs.path }},${{ steps.setup-java-16.outputs.path }},${{ steps.setup-java-17.outputs.path }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -23,7 +23,6 @@ jobs:
         with:
           arguments: |
             build
-            --stacktrace
             -Prelease.version=${{ github.event.inputs.version }}
 
       - uses: gradle/gradle-build-action@v2
@@ -32,7 +31,6 @@ jobs:
           arguments: |
             final
             closeAndReleaseSonatypeStagingRepository
-            --stacktrace
             -Prelease.version=${{ github.event.inputs.version }}
         env:
           GRGIT_USER: ${{ github.actor }}


### PR DESCRIPTION
Similar to @iNikem's https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/4470:

> Every time I look at the failed build, I have to scroll several screens up to find out the root case. Gradle failure stacktrace is useful when we have a problem within gradle tool itself, which happens very seldom.

Also sent similar PR to contrib: https://github.com/open-telemetry/opentelemetry-java-contrib/pull/277