### PR TITLE
Fix tracestate builder reuse, max entry check, and optimize it.

### DIFF
--- a/api/all/src/jmh/java/io/opentelemetry/api/trace/TraceStateBenchmark.java
+++ b/api/all/src/jmh/java/io/opentelemetry/api/trace/TraceStateBenchmark.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.trace;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@Fork(1)
+@Measurement(iterations = 15, time = 1)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+public class TraceStateBenchmark {
+
+  @Benchmark
+  public TraceState oneItem() {
+    TraceStateBuilder builder = TraceState.builder();
+    builder.put("key1", "val");
+    return builder.build();
+  }
+
+  @Benchmark
+  public TraceState fiveItems() {
+    TraceStateBuilder builder = TraceState.builder();
+    builder.put("key1", "val");
+    builder.put("key2", "val");
+    builder.put("key3", "val");
+    builder.put("key4", "val");
+    builder.put("key5", "val");
+    return builder.build();
+  }
+
+  @Benchmark
+  public TraceState fiveItemsWithRemoval() {
+    TraceStateBuilder builder = TraceState.builder();
+    builder.put("key1", "val");
+    builder.put("key2", "val");
+    builder.put("key3", "val");
+    builder.remove("key2");
+    builder.remove("key3");
+    builder.put("key2", "val");
+    builder.put("key3", "val");
+    builder.put("key4", "val");
+    builder.put("key5", "val");
+    return builder.build();
+  }
+}

--- a/api/all/src/main/java/io/opentelemetry/api/trace/ArrayBasedTraceState.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/ArrayBasedTraceState.java
@@ -7,7 +7,6 @@ package io.opentelemetry.api.trace;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.internal.ReadOnlyArrayMap;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -68,7 +67,7 @@ abstract class ArrayBasedTraceState implements TraceState {
   }
 
   static ArrayBasedTraceState create(List<String> entries) {
-    return new AutoValue_ArrayBasedTraceState(Collections.unmodifiableList(entries));
+    return new AutoValue_ArrayBasedTraceState(entries);
   }
 
   ArrayBasedTraceState() {}


### PR DESCRIPTION
I had started by just optimizing, but noticed the builder reuse bug while at it - I probably wouldn't have noticed if there wasn't a significant loss in performance for single item after the optimizations which I was investigating.

I have also gone ahead and fixed max entry check here.

After
```
Benchmark                                                                  Mode  Cnt     Score     Error   Units
TraceStateBenchmark.fiveItems                                              avgt   15   228.005 ±  11.950   ns/op
TraceStateBenchmark.fiveItems:·gc.alloc.rate                               avgt   15   536.211 ±  24.653  MB/sec
TraceStateBenchmark.fiveItems:·gc.alloc.rate.norm                          avgt   15   192.009 ±   0.003    B/op
TraceStateBenchmark.fiveItems:·gc.churn.G1_Eden_Space                      avgt   15   537.299 ± 208.097  MB/sec
TraceStateBenchmark.fiveItems:·gc.churn.G1_Eden_Space.norm                 avgt   15   191.932 ±  71.954    B/op
TraceStateBenchmark.fiveItems:·gc.churn.G1_Survivor_Space                  avgt   15     0.093 ±   0.308  MB/sec
TraceStateBenchmark.fiveItems:·gc.churn.G1_Survivor_Space.norm             avgt   15     0.033 ±   0.109    B/op
TraceStateBenchmark.fiveItems:·gc.count                                    avgt   15    21.000            counts
TraceStateBenchmark.fiveItems:·gc.time                                     avgt   15    36.000                ms
TraceStateBenchmark.fiveItemsWithRemoval                                   avgt   15   312.882 ±   2.273   ns/op
TraceStateBenchmark.fiveItemsWithRemoval:·gc.alloc.rate                    avgt   15   390.004 ±   2.836  MB/sec
TraceStateBenchmark.fiveItemsWithRemoval:·gc.alloc.rate.norm               avgt   15   192.009 ±   0.001    B/op
TraceStateBenchmark.fiveItemsWithRemoval:·gc.churn.G1_Eden_Space           avgt   15   383.783 ±   0.029  MB/sec
TraceStateBenchmark.fiveItemsWithRemoval:·gc.churn.G1_Eden_Space.norm      avgt   15   188.954 ±   1.373    B/op
TraceStateBenchmark.fiveItemsWithRemoval:·gc.churn.G1_Survivor_Space       avgt   15     0.092 ±   0.306  MB/sec
TraceStateBenchmark.fiveItemsWithRemoval:·gc.churn.G1_Survivor_Space.norm  avgt   15     0.045 ±   0.151    B/op
TraceStateBenchmark.fiveItemsWithRemoval:·gc.count                         avgt   15    15.000            counts
TraceStateBenchmark.fiveItemsWithRemoval:·gc.time                          avgt   15    18.000                ms
TraceStateBenchmark.oneItem                                                avgt   15    45.759 ±   0.337   ns/op
TraceStateBenchmark.oneItem:·gc.alloc.rate                                 avgt   15  2222.362 ±  16.534  MB/sec
TraceStateBenchmark.oneItem:·gc.alloc.rate.norm                            avgt   15   160.007 ±   0.001    B/op
TraceStateBenchmark.oneItem:·gc.churn.G1_Eden_Space                        avgt   15  2226.055 ± 169.868  MB/sec
TraceStateBenchmark.oneItem:·gc.churn.G1_Eden_Space.norm                   avgt   15   160.252 ±  11.890    B/op
TraceStateBenchmark.oneItem:·gc.churn.G1_Survivor_Space                    avgt   15     0.005 ±   0.004  MB/sec
TraceStateBenchmark.oneItem:·gc.churn.G1_Survivor_Space.norm               avgt   15    ≈ 10⁻³              B/op
TraceStateBenchmark.oneItem:·gc.count                                      avgt   15    87.000            counts
TraceStateBenchmark.oneItem:·gc.time                                       avgt   15    53.000                ms
```

Before (with additional `new ArrayList<>` call to copy entries to fix builder reuse bug)
```
Benchmark                                                                  Mode  Cnt     Score     Error   Units
TraceStateBenchmark.fiveItems                                              avgt   15   322.542 ±   2.862   ns/op
TraceStateBenchmark.fiveItems:·gc.alloc.rate                               avgt   15   425.627 ±   3.763  MB/sec
TraceStateBenchmark.fiveItems:·gc.alloc.rate.norm                          avgt   15   216.008 ±   0.003    B/op
TraceStateBenchmark.fiveItems:·gc.churn.G1_Eden_Space                      avgt   15   409.376 ± 105.933  MB/sec
TraceStateBenchmark.fiveItems:·gc.churn.G1_Eden_Space.norm                 avgt   15   207.693 ±  53.100    B/op
TraceStateBenchmark.fiveItems:·gc.churn.G1_Survivor_Space                  avgt   15     0.090 ±   0.300  MB/sec
TraceStateBenchmark.fiveItems:·gc.churn.G1_Survivor_Space.norm             avgt   15     0.045 ±   0.151    B/op
TraceStateBenchmark.fiveItems:·gc.count                                    avgt   15    16.000            counts
TraceStateBenchmark.fiveItems:·gc.time                                     avgt   15    17.000                ms
TraceStateBenchmark.fiveItemsWithRemoval                                   avgt   15   513.889 ±  12.330   ns/op
TraceStateBenchmark.fiveItemsWithRemoval:·gc.alloc.rate                    avgt   15   267.256 ±   6.321  MB/sec
TraceStateBenchmark.fiveItemsWithRemoval:·gc.alloc.rate.norm               avgt   15   216.010 ±   0.008    B/op
TraceStateBenchmark.fiveItemsWithRemoval:·gc.churn.G1_Eden_Space           avgt   15   255.862 ± 200.205  MB/sec
TraceStateBenchmark.fiveItemsWithRemoval:·gc.churn.G1_Eden_Space.norm      avgt   15   205.191 ± 160.620    B/op
TraceStateBenchmark.fiveItemsWithRemoval:·gc.churn.G1_Survivor_Space       avgt   15     0.007 ±   0.012  MB/sec
TraceStateBenchmark.fiveItemsWithRemoval:·gc.churn.G1_Survivor_Space.norm  avgt   15     0.006 ±   0.010    B/op
TraceStateBenchmark.fiveItemsWithRemoval:·gc.count                         avgt   15    10.000            counts
TraceStateBenchmark.fiveItemsWithRemoval:·gc.time                          avgt   15    14.000                ms
TraceStateBenchmark.oneItem                                                avgt   15    42.237 ±  10.163   ns/op
TraceStateBenchmark.oneItem:·gc.alloc.rate                                 avgt   15  2849.131 ± 736.101  MB/sec
TraceStateBenchmark.oneItem:·gc.alloc.rate.norm                            avgt   15   179.740 ±   7.828    B/op
TraceStateBenchmark.oneItem:·gc.churn.G1_Eden_Space                        avgt   15  2846.483 ± 762.214  MB/sec
TraceStateBenchmark.oneItem:·gc.churn.G1_Eden_Space.norm                   avgt   15   179.489 ±  13.215    B/op
TraceStateBenchmark.oneItem:·gc.churn.G1_Survivor_Space                    avgt   15     0.004 ±   0.003  MB/sec
TraceStateBenchmark.oneItem:·gc.churn.G1_Survivor_Space.norm               avgt   15    ≈ 10⁻⁴              B/op
TraceStateBenchmark.oneItem:·gc.count                                      avgt   15    89.000            counts
TraceStateBenchmark.oneItem:·gc.time                                       avgt   15    53.000                ms
```