### PR TITLE
Only log grpc unimplemented error once.

### DIFF
--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterUtil.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterUtil.java
@@ -10,6 +10,9 @@ import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import java.net.URI;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 final class GrpcExporterUtil {
 
@@ -41,6 +44,37 @@ final class GrpcExporterUtil {
       return new DefaultGrpcExporterBuilder<>(
           type, stubFactory.get(), defaultTimeoutSecs, defaultEndpoint, grpcServiceName);
     }
+  }
+
+  static void logUnavailable(Logger logger, String type, @Nullable String fullErrorMessage) {
+    String envVar;
+    switch (type) {
+      case "span":
+        envVar = "OTLP_TRACES_EXPORTER";
+        break;
+      case "metric":
+        envVar = "OTLP_METRICS_EXPORTER";
+        break;
+      case "log":
+        envVar = "OTLP_LOGS_EXPORTER";
+        break;
+      default:
+        throw new IllegalStateException(
+            "Unrecognized type, this is a programming bug in the OpenTelemetry SDK");
+    }
+
+    logger.log(
+        Level.SEVERE,
+        "Failed to export "
+            + type
+            + "s. Server is UNAVAILABLE. "
+            + "Make sure your collector is running and reachable from this network. "
+            + "If export is not desired and you are using OpenTelemetry autoconfiguration or the javaagent, "
+            + "disable export by setting "
+            + envVar
+            + "=none."
+            + "Full error message:"
+            + fullErrorMessage);
   }
 
   private GrpcExporterUtil() {}


### PR DESCRIPTION
Unavailable indicates a configuration error, which may be just not disabling the signal exporter when it's not needed. There's no need to continue to spam logs for such a scenario.
