### PR TITLE
Enable OTLP metric export by default in autoconfigure

### DIFF
--- a/sdk-extensions/autoconfigure/build.gradle.kts
+++ b/sdk-extensions/autoconfigure/build.gradle.kts
@@ -77,7 +77,6 @@ testing {
       targets {
         all {
           testTask {
-            environment("OTEL_METRICS_EXPORTER", "otlp")
             environment("OTEL_LOGS_EXPORTER", "otlp")
             environment("OTEL_RESOURCE_ATTRIBUTES", "service.name=test,cat=meow")
             environment("OTEL_PROPAGATORS", "tracecontext,baggage,b3,b3multi,jaeger,ottrace,xray,test")
@@ -97,6 +96,7 @@ testing {
         all {
           testTask {
             environment("OTEL_TRACES_EXPORTER", "none")
+            environment("OTEL_METRICS_EXPORTER", "none")
           }
         }
       }
@@ -114,6 +114,7 @@ testing {
       targets {
         all {
           testTask {
+            environment("OTEL_METRICS_EXPORTER", "none")
             environment("OTEL_TRACES_EXPORTER", "jaeger")
             environment("OTEL_BSP_SCHEDULE_DELAY", "10")
           }
@@ -133,14 +134,6 @@ testing {
         implementation("com.linecorp.armeria:armeria-grpc")
         runtimeOnly("io.grpc:grpc-netty-shaded")
       }
-
-      targets {
-        all {
-          testTask {
-            environment("OTEL_METRICS_EXPORTER", "otlp")
-          }
-        }
-      }
     }
     val testOtlpHttp by registering(JvmTestSuite::class) {
       dependencies {
@@ -155,14 +148,6 @@ testing {
         implementation("com.squareup.okhttp3:okhttp")
         implementation("com.squareup.okhttp3:okhttp-tls")
         implementation("io.opentelemetry.proto:opentelemetry-proto")
-      }
-
-      targets {
-        all {
-          testTask {
-            environment("OTEL_METRICS_EXPORTER", "otlp")
-          }
-        }
       }
     }
     val testPrometheus by registering(JvmTestSuite::class) {
@@ -224,6 +209,7 @@ testing {
       targets {
         all {
           testTask {
+            environment("OTEL_METRICS_EXPORTER", "none")
             environment("OTEL_TRACES_EXPORTER", "zipkin")
             environment("OTEL_BSP_SCHEDULE_DELAY", "10")
           }

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MeterProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MeterProviderConfiguration.java
@@ -41,7 +41,10 @@ final class MeterProviderConfiguration {
     }
 
     String exporterName = config.getString("otel.metrics.exporter");
-    if (exporterName != null && !exporterName.equals("none")) {
+    if (exporterName == null) {
+      exporterName = "otlp";
+    }
+    if (!exporterName.equals("none")) {
       MetricExporterConfiguration.configureExporter(
           exporterName, config, serviceClassLoader, meterProviderBuilder, metricExporterCustomizer);
     }

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/NotOnClasspathTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/NotOnClasspathTest.java
@@ -119,7 +119,10 @@ class NotOnClasspathTest {
                     MetricExporterConfiguration.class.getClassLoader(),
                     SdkMeterProvider.builder(),
                     (a, unused) -> a))
-        .doesNotThrowAnyException();
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining(
+            "OTLP gRPC Metrics Exporter enabled but opentelemetry-exporter-otlp not found on "
+                + "classpath");
   }
 
   @Test
@@ -135,7 +138,8 @@ class NotOnClasspathTest {
                     MetricExporterConfiguration.class.getClassLoader(),
                     SdkMeterProvider.builder(),
                     (a, unused) -> a))
-        .doesNotThrowAnyException();
+        .hasMessageContaining(
+            "OTLP HTTP Metrics Exporter enabled but opentelemetry-exporter-otlp-http-metrics not found on classpath");
   }
 
   @Test

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableMetricExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableMetricExporterTest.java
@@ -5,27 +5,17 @@
 
 package io.opentelemetry.sdk.autoconfigure;
 
-import static io.opentelemetry.sdk.autoconfigure.OtlpConfigUtil.PROTOCOL_HTTP_PROTOBUF;
-import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
-import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
-import io.opentelemetry.sdk.metrics.export.MetricReader;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Collections;
-import java.util.function.BiFunction;
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
 public class ConfigurableMetricExporterTest {
@@ -70,37 +60,5 @@ public class ConfigurableMetricExporterTest {
                     (a, unused) -> a))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("catExporter");
-  }
-
-  @Test
-  void configureExporter_OtlpHttpExporterNotOnClasspath() {
-    // Use the OTLP http/protobuf exporter which is not on the classpath
-    ConfigProperties configProperties =
-        DefaultConfigProperties.createForTest(
-            ImmutableMap.of("otel.exporter.otlp.protocol", PROTOCOL_HTTP_PROTOBUF));
-    SdkMeterProviderBuilder meterProviderBuilder = SdkMeterProvider.builder();
-    BiFunction<? super MetricExporter, ConfigProperties, ? extends MetricExporter>
-        metricCustomizer =
-            spy(
-                new BiFunction<MetricExporter, ConfigProperties, MetricExporter>() {
-                  @Override
-                  public MetricExporter apply(
-                      MetricExporter metricExporter, ConfigProperties configProperties) {
-                    return metricExporter;
-                  }
-                });
-
-    MetricExporterConfiguration.configureExporter(
-        "otlp",
-        configProperties,
-        MetricExporterConfiguration.class.getClassLoader(),
-        meterProviderBuilder,
-        metricCustomizer);
-
-    // Should not call customizer or register a metric reader
-    verify(metricCustomizer, never()).apply(any(), any());
-    assertThat(meterProviderBuilder)
-        .extracting("metricReaders", as(InstanceOfAssertFactories.list(MetricReader.class)))
-        .hasSize(0);
   }
 }

--- a/sdk-extensions/metric-incubator/src/test/java/io/opentelemetry/sdk/viewconfig/ViewConfigCustomizerTest.java
+++ b/sdk-extensions/metric-incubator/src/test/java/io/opentelemetry/sdk/viewconfig/ViewConfigCustomizerTest.java
@@ -33,6 +33,8 @@ class ViewConfigCustomizerTest {
               return ImmutableMap.of(
                   "otel.traces.exporter",
                   "none",
+                  "otel.metrics.exporter",
+                  "none",
                   "otel.experimental.metrics.view.config",
                   "classpath:/view-config-customizer-test.yaml");
             })


### PR DESCRIPTION
We discussed in the 3/31 SIG that the next release would be a metrics SDK RC. This alternative to #4302 enables OTLP metric export by default in the autoconfigure module, but keeps the metrics artifacts as `alpha`. 