### PR TITLE
Another round of log suppression

### DIFF
--- a/exporters/otlp-http/metrics/src/test/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterTest.java
+++ b/exporters/otlp-http/metrics/src/test/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterTest.java
@@ -26,6 +26,7 @@ import io.opentelemetry.exporter.internal.okhttp.OkHttpExporter;
 import io.opentelemetry.exporter.internal.otlp.metrics.ResourceMetricsMarshaler;
 import io.opentelemetry.exporter.internal.retry.RetryPolicy;
 import io.opentelemetry.exporter.internal.retry.RetryUtil;
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
 import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
@@ -274,6 +275,7 @@ class OtlpHttpMetricExporterTest {
   }
 
   @Test
+  @SuppressLogger(OkHttpExporter.class)
   void testServerError() {
     server.enqueue(
         buildResponse(
@@ -289,6 +291,7 @@ class OtlpHttpMetricExporterTest {
   }
 
   @Test
+  @SuppressLogger(OkHttpExporter.class)
   void testServerErrorParseError() {
     server.enqueue(
         HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, APPLICATION_PROTOBUF, "Server error!"));

--- a/exporters/otlp-http/trace/src/test/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterTest.java
+++ b/exporters/otlp-http/trace/src/test/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterTest.java
@@ -29,6 +29,7 @@ import io.opentelemetry.exporter.internal.okhttp.OkHttpExporter;
 import io.opentelemetry.exporter.internal.otlp.traces.ResourceSpansMarshaler;
 import io.opentelemetry.exporter.internal.retry.RetryPolicy;
 import io.opentelemetry.exporter.internal.retry.RetryUtil;
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
@@ -264,6 +265,7 @@ class OtlpHttpSpanExporterTest {
   }
 
   @Test
+  @SuppressLogger(OkHttpExporter.class)
   void testServerError() {
     server.enqueue(
         buildResponse(
@@ -279,6 +281,7 @@ class OtlpHttpSpanExporterTest {
   }
 
   @Test
+  @SuppressLogger(OkHttpExporter.class)
   void testServerErrorParseError() {
     server.enqueue(
         HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, APPLICATION_PROTOBUF, "Server error!"));

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
@@ -292,6 +292,8 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
   }
 
   @Test
+  @SuppressLogger(OkHttpGrpcExporter.class)
+  @SuppressLogger(DefaultGrpcExporter.class)
   void exportAfterShutdown() {
     TelemetryExporter<T> exporter =
         exporterBuilder().setEndpoint(server.httpUri().toString()).build();
@@ -431,6 +433,8 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
 
   @ParameterizedTest
   @ValueSource(ints = {1, 4, 8, 10, 11, 14, 15})
+  @SuppressLogger(OkHttpGrpcExporter.class)
+  @SuppressLogger(DefaultGrpcExporter.class)
   void retryableError(int code) {
     addGrpcError(code, null);
 
@@ -451,6 +455,8 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
   }
 
   @Test
+  @SuppressLogger(OkHttpGrpcExporter.class)
+  @SuppressLogger(DefaultGrpcExporter.class)
   void retryableError_tooManyAttempts() {
     addGrpcError(1, null);
     addGrpcError(1, null);

--- a/sdk-extensions/autoconfigure/src/testOtlpGrpc/java/io/opentelemetry/sdk/autoconfigure/OtlpGrpcRetryTest.java
+++ b/sdk-extensions/autoconfigure/src/testOtlpGrpc/java/io/opentelemetry/sdk/autoconfigure/OtlpGrpcRetryTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+@SuppressLogger(DefaultGrpcExporter.class)
 class OtlpGrpcRetryTest {
 
   private static final List<SpanData> SPAN_DATA = Lists.newArrayList(generateFakeSpan());

--- a/sdk-extensions/autoconfigure/src/testOtlpHttp/java/io/opentelemetry/sdk/autoconfigure/OtlpHttpRetryTest.java
+++ b/sdk-extensions/autoconfigure/src/testOtlpHttp/java/io/opentelemetry/sdk/autoconfigure/OtlpHttpRetryTest.java
@@ -15,6 +15,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.internal.grpc.OkHttpGrpcExporter;
+import io.opentelemetry.exporter.internal.okhttp.OkHttpExporter;
 import io.opentelemetry.exporter.internal.retry.RetryPolicy;
 import io.opentelemetry.exporter.internal.retry.RetryUtil;
 import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
@@ -35,6 +36,7 @@ import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+@SuppressLogger(OkHttpExporter.class)
 class OtlpHttpRetryTest {
 
   private static final List<SpanData> SPAN_DATA = Lists.newArrayList(generateFakeSpan());

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.event.Level;
 import org.slf4j.event.LoggingEvent;
 
+@SuppressLogger(OkHttpGrpcService.class)
 class JaegerRemoteSamplerTest {
 
   private static final String SERVICE_NAME = "my-service";

--- a/sdk-extensions/jaeger-remote-sampler/src/testGrpcNetty/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerGrpcNettyTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/testGrpcNetty/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerGrpcNettyTest.java
@@ -16,6 +16,7 @@ import com.linecorp.armeria.server.grpc.protocol.AbstractUnaryGrpcService;
 import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 import io.github.netmikey.logunit.api.LogCapturer;
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.extension.trace.jaeger.proto.api_v2.Sampling;
 import io.opentelemetry.sdk.extension.trace.jaeger.proto.api_v2.Sampling.RateLimitingSamplingStrategy;
 import io.opentelemetry.sdk.extension.trace.jaeger.proto.api_v2.Sampling.SamplingStrategyType;
@@ -37,6 +38,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.event.Level;
 import org.slf4j.event.LoggingEvent;
 
+@SuppressLogger(DefaultGrpcService.class)
 class JaegerRemoteSamplerGrpcNettyTest {
 
   private static final String SERVICE_NAME = "my-service";

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLogEmitterProviderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLogEmitterProviderTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
@@ -210,6 +211,7 @@ class SdkLogEmitterProviderTest {
   }
 
   @Test
+  @SuppressLogger(SdkLogEmitterProvider.class)
   void shutdown() {
     sdkLogEmitterProvider.shutdown();
     sdkLogEmitterProvider.shutdown();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/CardinalityTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/CardinalityTest.java
@@ -11,6 +11,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
@@ -18,6 +19,9 @@ import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+@SuppressLogger(
+    loggerName = "io.opentelemetry.sdk.metrics.internal.state.AsynchronousMetricStorage")
+@SuppressLogger(loggerName = "io.opentelemetry.sdk.metrics.internal.state.DeltaMetricStorage")
 class CardinalityTest {
 
   /** Traces {@code MetricStorageUtils#MAX_ACCUMULATIONS}. */

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleCounterTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleCounterTest.java
@@ -13,6 +13,7 @@ import io.github.netmikey.logunit.api.LogCapturer;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleCounter;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.StressTestRunner.OperationUpdater;
 import io.opentelemetry.sdk.metrics.data.PointData;
@@ -179,6 +180,7 @@ class SdkDoubleCounterTest {
   }
 
   @Test
+  @SuppressLogger(SdkDoubleCounter.class)
   void doubleCounterAdd_Monotonicity() {
     DoubleCounter doubleCounter = sdkMeter.counterBuilder("testCounter").ofDoubles().build();
     doubleCounter.add(-45.77d);
@@ -188,6 +190,7 @@ class SdkDoubleCounterTest {
   }
 
   @Test
+  @SuppressLogger(SdkDoubleCounter.class)
   void boundDoubleCounterAdd_Monotonicity() {
     DoubleCounter doubleCounter = sdkMeter.counterBuilder("testCounter").ofDoubles().build();
     BoundDoubleCounter bound = ((SdkDoubleCounter) doubleCounter).bind(Attributes.empty());

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkObservableInstrumentTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkObservableInstrumentTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import io.github.netmikey.logunit.api.LogCapturer;
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.internal.state.CallbackRegistration;
@@ -25,6 +26,7 @@ class SdkObservableInstrumentTest {
   LogCapturer logs = LogCapturer.create().captureForType(SdkObservableInstrument.class);
 
   @Test
+  @SuppressLogger(SdkObservableInstrument.class)
   void close() {
     MeterSharedState meterSharedState =
         spy(MeterSharedState.create(InstrumentationScopeInfo.empty()));

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -450,6 +450,7 @@ class BatchSpanProcessorTest {
 
   @Test
   @Timeout(10)
+  @SuppressLogger(SdkTracerProvider.class)
   void shutdownFlushes() {
     WaitingSpanExporter waitingSpanExporter =
         new WaitingSpanExporter(1, CompletableResultCode.ofSuccess());

--- a/testing-internal/src/main/java/io/opentelemetry/internal/testing/slf4j/SuppressLogger.java
+++ b/testing-internal/src/main/java/io/opentelemetry/internal/testing/slf4j/SuppressLogger.java
@@ -17,7 +17,10 @@ import java.lang.annotation.RetentionPolicy;
 @Repeatable(SuppressLogger.SuppressLoggers.class)
 public @interface SuppressLogger {
   /** The class whose {@link java.util.logging.Logger} will be suppressed. */
-  Class<?> value();
+  Class<?> value() default Void.class;
+
+  /** The names of {@link java.util.logging.Logger}s to be suppressed. */
+  String loggerName() default "";
 
   @Retention(RetentionPolicy.RUNTIME)
   @interface SuppressLoggers {

--- a/testing-internal/src/main/resources/simplelogger.properties
+++ b/testing-internal/src/main/resources/simplelogger.properties
@@ -1,4 +1,5 @@
 org.slf4j.simpleLogger.defaultLogLevel = warn
 
-org.slf4j.simpleLogger.log.org.junit.platform.launcher.core.LauncherConfigurationParameters.level = warn
-org.slf4j.simpleLogger.log.org.junit.jupiter.engine.config.EnumConfigurationParameterConverter.level = warn
+org.slf4j.simpleLogger.log.org.junit.platform.launcher.core.LauncherConfigurationParameters = warn
+org.slf4j.simpleLogger.log.org.junit.jupiter.engine.config.EnumConfigurationParameterConverter = warn
+org.slf4j.simpleLogger.log.com.linecorp.armeria.server.HttpServerPipelineConfigurator = error


### PR DESCRIPTION
Another round of log suppression. I believe that the only remaining logs to standard error are coming from libraries that log to SLF4J, which our `@SuppressLogger` annotation isn't able to suppress. Would be great to get those suppressed as well as they're all the same SSL exceptions that look like:
```
[armeria-common-worker-nio-2-21] WARN com.linecorp.armeria.server.HttpServerPipelineConfigurator - [id: 0xad7721fe, L:/127.0.0.1:55103 ! R:/127.0.0.1:55150] Unexpected exception:
    io.netty.handler.codec.DecoderException: javax.net.ssl.SSLHandshakeException: error:10000438:SSL routines:OPENSSL_internal:TLSV1_ALERT_INTERNAL_ERROR
```