### PR TITLE
Release workflow fixes

### DIFF
--- a/.github/scripts/generate-release-contributors.sh
+++ b/.github/scripts/generate-release-contributors.sh
@@ -79,4 +79,5 @@ echo $contributors1 $contributors2 \
   | grep -v linux-foundation-easycla \
   | grep -v github-actions \
   | grep -v dependabot \
+  | grep -v codecov \
   | sed 's/^/@/'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [[ $version == *.0 ]]; then
+          if [[ $VERSION == *.0 ]]; then
             cat > release-notes.txt << EOF
             This release targets the OpenTelemetry SDK $VERSION.
 
@@ -74,7 +74,7 @@ jobs:
             | perl -0pe 's/\n +/ /g' \
             >> release-notes.txt
 
-          if [[ $version == *.0 ]]; then
+          if [[ $VERSION == *.0 ]]; then
             cat >> release-notes.txt << EOF
 
             ### 🙇 Thank you

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,16 +53,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # conditional blocks not indented because of the heredoc
           if [[ $VERSION == *.0 ]]; then
-            cat > release-notes.txt << EOF
-            This release targets the OpenTelemetry SDK $VERSION.
+          cat > release-notes.txt << EOF
+          This release targets the OpenTelemetry SDK $VERSION.
 
-            EOF
+          EOF
           else
-            cat > release-notes.txt << EOF
-            This is a patch release on the previous $PRIOR_VERSION release, fixing the issue(s) below.
+          cat > release-notes.txt << EOF
+          This is a patch release on the previous $PRIOR_VERSION release, fixing the issue(s) below.
 
-            EOF
+          EOF
           fi
 
           sed -n "/^## Version $VERSION/,/^## Version /p" CHANGELOG.md \
@@ -74,15 +75,16 @@ jobs:
             | perl -0pe 's/\n +/ /g' \
             >> release-notes.txt
 
+          # conditional block not indented because of the heredoc
           if [[ $VERSION == *.0 ]]; then
-            cat >> release-notes.txt << EOF
+          cat >> release-notes.txt << EOF
 
-            ### 🙇 Thank you
-            This release was possible thanks to the following contributors who shared their brilliant ideas and awesome pull requests:
+          ### 🙇 Thank you
+          This release was possible thanks to the following contributors who shared their brilliant ideas and awesome pull requests:
 
-            EOF
+          EOF
 
-            .github/scripts/generate-release-contributors.sh v$PRIOR_VERSION v$VERSION >> release-notes.txt
+          .github/scripts/generate-release-contributors.sh v$PRIOR_VERSION $GITHUB_REF_NAME >> release-notes.txt
           fi
 
       - name: Create GitHub release

--- a/docs/common-github-actions-practices.md
+++ b/docs/common-github-actions-practices.md
@@ -631,11 +631,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # conditional block not indented because of the heredoc
           if [[ $VERSION != *.0 ]]; then
-            cat > release-notes.txt << EOF
-            This is a patch release on the previous $PRIOR_VERSION release, fixing the issue(s) below.
+          cat > release-notes.txt << EOF
+          This is a patch release on the previous $PRIOR_VERSION release, fixing the issue(s) below.
 
-            EOF
+          EOF
           fi
 
           # TODO this is dependent on the conventions you follow in your CHANGELOG.md

--- a/docs/common-github-actions-practices.md
+++ b/docs/common-github-actions-practices.md
@@ -631,7 +631,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [[ $version != *.0 ]]; then
+          if [[ $VERSION != *.0 ]]; then
             cat > release-notes.txt << EOF
             This is a patch release on the previous $PRIOR_VERSION release, fixing the issue(s) below.
 


### PR DESCRIPTION
* heredoc problems in the scripts
* trying to use the release tag before it was made (when calling generate-release-contributors.sh)
* chmod +x for generate-release-contributors.sh
* usage of `$version` instead of `$VERSION` in a couple of places