### PR TITLE
Add github action concurrency control

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -3,6 +3,10 @@ name: Build pull request
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Missed this one: https://github.com/open-telemetry/opentelemetry-java/blob/main/docs/common-github-actions-practices.md#configure-cancel-in-progress-on-pull-request-workflows