### PR TITLE
Return noop instrument if name is invalid

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/internal/ValidationUtil.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/ValidationUtil.java
@@ -7,6 +7,7 @@ package io.opentelemetry.api.internal;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -18,12 +19,50 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public final class ValidationUtil {
 
-  private ValidationUtil() {}
+  public static final String API_USAGE_LOGGER_NAME = "io.opentelemetry.ApiUsageLogging";
 
-  private static final Logger API_USAGE_LOGGER =
-      Logger.getLogger("io.opentelemetry.ApiUsageLogging");
+  private static final Logger API_USAGE_LOGGER = Logger.getLogger(API_USAGE_LOGGER_NAME);
 
-  public static void log(String msg) {
-    API_USAGE_LOGGER.log(Level.FINEST, msg, new AssertionError());
+  /**
+   * Instrument names MUST conform to the following syntax.
+   *
+   * <ul>
+   *   <li>They are not null or empty strings.
+   *   <li>They are case-insensitive, ASCII strings.
+   *   <li>The first character must be an alphabetic character.
+   *   <li>Subsequent characters must belong to the alphanumeric characters, '_', '.', and '-'.
+   *   <li>They can have a maximum length of 63 characters.
+   * </ul>
+   */
+  private static final Pattern VALID_INSTRUMENT_NAME_PATTERN =
+      Pattern.compile("([A-Za-z]){1}([A-Za-z0-9\\_\\-\\.]){0,62}");
+
+  /** Log the API usage {@code message}. */
+  public static void log(String message) {
+    API_USAGE_LOGGER.log(Level.FINEST, message, new AssertionError());
   }
+
+  /** Determine if the instrument name is valid. If invalid, log a warning. */
+  public static boolean isValidInstrumentName(String name) {
+    return isValidInstrumentName(name, "");
+  }
+
+  /**
+   * Determine if the instrument name is valid. If invalid, log a warning with the {@code logSuffix}
+   * appended.
+   */
+  public static boolean isValidInstrumentName(String name, String logSuffix) {
+    if (name == null || !VALID_INSTRUMENT_NAME_PATTERN.matcher(name).matches()) {
+      API_USAGE_LOGGER.log(
+          Level.WARNING,
+          "Instrument name \""
+              + name
+              + "\" is invalid, returning noop instrument. Instrument names must consist of 63 or less characters including alphanumeric, _, ., -, and start with a letter."
+              + logSuffix);
+      return false;
+    }
+    return true;
+  }
+
+  private ValidationUtil() {}
 }

--- a/api/all/src/main/java/io/opentelemetry/api/internal/ValidationUtil.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/ValidationUtil.java
@@ -54,16 +54,16 @@ public final class ValidationUtil {
     API_USAGE_LOGGER.log(level, message, new AssertionError());
   }
 
-  /** Determine if the instrument name is valid. If invalid, log a warning. */
-  public static boolean isValidInstrumentName(String name) {
-    return isValidInstrumentName(name, "");
+  /** Check if the instrument name is valid. If invalid, log a warning. */
+  public static boolean checkValidInstrumentName(String name) {
+    return checkValidInstrumentName(name, "");
   }
 
   /**
-   * Determine if the instrument name is valid. If invalid, log a warning with the {@code logSuffix}
+   * Check if the instrument name is valid. If invalid, log a warning with the {@code logSuffix}
    * appended.
    */
-  public static boolean isValidInstrumentName(String name, String logSuffix) {
+  public static boolean checkValidInstrumentName(String name, String logSuffix) {
     if (name != null && VALID_INSTRUMENT_NAME_PATTERN.matcher(name).matches()) {
       return true;
     }
@@ -76,16 +76,16 @@ public final class ValidationUtil {
     return false;
   }
 
-  /** Determine if the instrument unit is valid. If invalid, log a warning. */
-  public static boolean isValidInstrumentUnit(String unit) {
-    return isValidInstrumentUnit(unit, "");
+  /** Check if the instrument unit is valid. If invalid, log a warning. */
+  public static boolean checkValidInstrumentUnit(String unit) {
+    return checkValidInstrumentUnit(unit, "");
   }
 
   /**
-   * Determine if the instrument unit is valid. If invalid, log a warning with the {@code logSuffix}
+   * Check if the instrument unit is valid. If invalid, log a warning with the {@code logSuffix}
    * appended.
    */
-  public static boolean isValidInstrumentUnit(String unit, String logSuffix) {
+  public static boolean checkValidInstrumentUnit(String unit, String logSuffix) {
     if (unit != null
         && !unit.equals("")
         && unit.length() < 64

--- a/api/all/src/main/java/io/opentelemetry/api/internal/ValidationUtil.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/ValidationUtil.java
@@ -64,16 +64,16 @@ public final class ValidationUtil {
    * appended.
    */
   public static boolean isValidInstrumentName(String name, String logSuffix) {
-    if (name == null || !VALID_INSTRUMENT_NAME_PATTERN.matcher(name).matches()) {
-      API_USAGE_LOGGER.log(
-          Level.WARNING,
-          "Instrument name \""
-              + name
-              + "\" is invalid, returning noop instrument. Instrument names must consist of 63 or less characters including alphanumeric, _, ., -, and start with a letter."
-              + logSuffix);
-      return false;
+    if (name != null && VALID_INSTRUMENT_NAME_PATTERN.matcher(name).matches()) {
+      return true;
     }
-    return true;
+    log(
+        "Instrument name \""
+            + name
+            + "\" is invalid, returning noop instrument. Instrument names must consist of 63 or less characters including alphanumeric, _, ., -, and start with a letter."
+            + logSuffix,
+        Level.WARNING);
+    return false;
   }
 
   /** Determine if the instrument unit is valid. If invalid, log a warning. */

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DefaultMeter.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DefaultMeter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.api.metrics;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.internal.ValidationUtil;
 import io.opentelemetry.context.Context;
 import java.util.function.Consumer;
 import javax.annotation.concurrent.ThreadSafe;
@@ -50,21 +51,25 @@ class DefaultMeter implements Meter {
 
   @Override
   public LongCounterBuilder counterBuilder(String name) {
+    ValidationUtil.isValidInstrumentName(name);
     return NOOP_LONG_COUNTER_BUILDER;
   }
 
   @Override
   public LongUpDownCounterBuilder upDownCounterBuilder(String name) {
+    ValidationUtil.isValidInstrumentName(name);
     return NOOP_LONG_UP_DOWN_COUNTER_BUILDER;
   }
 
   @Override
   public DoubleHistogramBuilder histogramBuilder(String name) {
+    ValidationUtil.isValidInstrumentName(name);
     return NOOP_DOUBLE_HISTOGRAM_BUILDER;
   }
 
   @Override
   public DoubleGaugeBuilder gaugeBuilder(String name) {
+    ValidationUtil.isValidInstrumentName(name);
     return NOOP_DOUBLE_GAUGE_BUILDER;
   }
 

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DefaultMeter.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DefaultMeter.java
@@ -51,25 +51,25 @@ class DefaultMeter implements Meter {
 
   @Override
   public LongCounterBuilder counterBuilder(String name) {
-    ValidationUtil.isValidInstrumentName(name);
+    ValidationUtil.checkValidInstrumentName(name);
     return NOOP_LONG_COUNTER_BUILDER;
   }
 
   @Override
   public LongUpDownCounterBuilder upDownCounterBuilder(String name) {
-    ValidationUtil.isValidInstrumentName(name);
+    ValidationUtil.checkValidInstrumentName(name);
     return NOOP_LONG_UP_DOWN_COUNTER_BUILDER;
   }
 
   @Override
   public DoubleHistogramBuilder histogramBuilder(String name) {
-    ValidationUtil.isValidInstrumentName(name);
+    ValidationUtil.checkValidInstrumentName(name);
     return NOOP_DOUBLE_HISTOGRAM_BUILDER;
   }
 
   @Override
   public DoubleGaugeBuilder gaugeBuilder(String name) {
-    ValidationUtil.isValidInstrumentName(name);
+    ValidationUtil.checkValidInstrumentName(name);
     return NOOP_DOUBLE_GAUGE_BUILDER;
   }
 
@@ -111,7 +111,7 @@ class DefaultMeter implements Meter {
 
     @Override
     public LongCounterBuilder setUnit(String unit) {
-      ValidationUtil.isValidInstrumentUnit(unit);
+      ValidationUtil.checkValidInstrumentUnit(unit);
       return this;
     }
 
@@ -143,7 +143,7 @@ class DefaultMeter implements Meter {
 
     @Override
     public DoubleCounterBuilder setUnit(String unit) {
-      ValidationUtil.isValidInstrumentUnit(unit);
+      ValidationUtil.checkValidInstrumentUnit(unit);
       return this;
     }
 
@@ -195,7 +195,7 @@ class DefaultMeter implements Meter {
 
     @Override
     public LongUpDownCounterBuilder setUnit(String unit) {
-      ValidationUtil.isValidInstrumentUnit(unit);
+      ValidationUtil.checkValidInstrumentUnit(unit);
       return this;
     }
 
@@ -229,7 +229,7 @@ class DefaultMeter implements Meter {
 
     @Override
     public DoubleUpDownCounterBuilder setUnit(String unit) {
-      ValidationUtil.isValidInstrumentUnit(unit);
+      ValidationUtil.checkValidInstrumentUnit(unit);
       return this;
     }
 
@@ -279,7 +279,7 @@ class DefaultMeter implements Meter {
 
     @Override
     public DoubleHistogramBuilder setUnit(String unit) {
-      ValidationUtil.isValidInstrumentUnit(unit);
+      ValidationUtil.checkValidInstrumentUnit(unit);
       return this;
     }
 
@@ -304,7 +304,7 @@ class DefaultMeter implements Meter {
 
     @Override
     public LongHistogramBuilder setUnit(String unit) {
-      ValidationUtil.isValidInstrumentUnit(unit);
+      ValidationUtil.checkValidInstrumentUnit(unit);
       return this;
     }
 
@@ -325,7 +325,7 @@ class DefaultMeter implements Meter {
 
     @Override
     public DoubleGaugeBuilder setUnit(String unit) {
-      ValidationUtil.isValidInstrumentUnit(unit);
+      ValidationUtil.checkValidInstrumentUnit(unit);
       return this;
     }
 
@@ -350,7 +350,7 @@ class DefaultMeter implements Meter {
 
     @Override
     public LongGaugeBuilder setUnit(String unit) {
-      ValidationUtil.isValidInstrumentUnit(unit);
+      ValidationUtil.checkValidInstrumentUnit(unit);
       return this;
     }
 

--- a/api/all/src/test/java/io/opentelemetry/api/internal/ValidationUtilTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/internal/ValidationUtilTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.netmikey.logunit.api.LogCapturer;
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@SuppressLogger(loggerName = ValidationUtil.API_USAGE_LOGGER_NAME)
+public class ValidationUtilTest {
+
+  @RegisterExtension
+  LogCapturer apiUsageLogs =
+      LogCapturer.create().captureForLogger(ValidationUtil.API_USAGE_LOGGER_NAME);
+
+  @Test
+  void isValidInstrumentName_InvalidNameLogs() {
+    assertThat(ValidationUtil.isValidInstrumentName("1", " suffix")).isFalse();
+    apiUsageLogs.assertContains(
+        "Instrument name \"1\" is invalid, returning noop instrument. Instrument names must consist of 63 or less characters including alphanumeric, _, ., -, and start with a letter. suffix");
+  }
+
+  @Test
+  void isValidInstrumentName() {
+    // Valid names
+    assertThat(ValidationUtil.isValidInstrumentName("f")).isTrue();
+    assertThat(ValidationUtil.isValidInstrumentName("F")).isTrue();
+    assertThat(ValidationUtil.isValidInstrumentName("foo")).isTrue();
+    assertThat(ValidationUtil.isValidInstrumentName("a1")).isTrue();
+    assertThat(ValidationUtil.isValidInstrumentName("a.")).isTrue();
+    assertThat(ValidationUtil.isValidInstrumentName("abcdefghijklmnopqrstuvwxyz")).isTrue();
+    assertThat(ValidationUtil.isValidInstrumentName("ABCDEFGHIJKLMNOPQRSTUVWXYZ")).isTrue();
+    assertThat(ValidationUtil.isValidInstrumentName("a1234567890")).isTrue();
+    assertThat(ValidationUtil.isValidInstrumentName("a_-.")).isTrue();
+    assertThat(ValidationUtil.isValidInstrumentName(new String(new char[63]).replace('\0', 'a')))
+        .isTrue();
+
+    // Empty and null not allowed
+    assertThat(ValidationUtil.isValidInstrumentName(null)).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("")).isFalse();
+    // Must start with a letter
+    assertThat(ValidationUtil.isValidInstrumentName("1")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName(".")).isFalse();
+    // Illegal characters
+    assertThat(ValidationUtil.isValidInstrumentName("a~")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a!")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a@")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a#")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a$")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a%")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a^")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a&")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a*")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a(")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a)")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a=")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a+")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a{")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a}")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a[")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a]")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a\\")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a|")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a<")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a>")).isFalse();
+    assertThat(ValidationUtil.isValidInstrumentName("a?")).isFalse();
+    // Must be 63 characters or less
+    assertThat(ValidationUtil.isValidInstrumentName(new String(new char[64]).replace('\0', 'a')))
+        .isFalse();
+  }
+}

--- a/api/all/src/test/java/io/opentelemetry/api/internal/ValidationUtilTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/internal/ValidationUtilTest.java
@@ -20,84 +20,84 @@ public class ValidationUtilTest {
       LogCapturer.create().captureForLogger(ValidationUtil.API_USAGE_LOGGER_NAME);
 
   @Test
-  void isValidInstrumentName_InvalidNameLogs() {
-    assertThat(ValidationUtil.isValidInstrumentName("1", " suffix")).isFalse();
+  void checkValidInstrumentName_InvalidNameLogs() {
+    assertThat(ValidationUtil.checkValidInstrumentName("1", " suffix")).isFalse();
     apiUsageLogs.assertContains(
         "Instrument name \"1\" is invalid, returning noop instrument. Instrument names must consist of 63 or less characters including alphanumeric, _, ., -, and start with a letter. suffix");
   }
 
   @Test
-  void isValidInstrumentName() {
+  void checkValidInstrumentName() {
     // Valid names
-    assertThat(ValidationUtil.isValidInstrumentName("f")).isTrue();
-    assertThat(ValidationUtil.isValidInstrumentName("F")).isTrue();
-    assertThat(ValidationUtil.isValidInstrumentName("foo")).isTrue();
-    assertThat(ValidationUtil.isValidInstrumentName("a1")).isTrue();
-    assertThat(ValidationUtil.isValidInstrumentName("a.")).isTrue();
-    assertThat(ValidationUtil.isValidInstrumentName("abcdefghijklmnopqrstuvwxyz")).isTrue();
-    assertThat(ValidationUtil.isValidInstrumentName("ABCDEFGHIJKLMNOPQRSTUVWXYZ")).isTrue();
-    assertThat(ValidationUtil.isValidInstrumentName("a1234567890")).isTrue();
-    assertThat(ValidationUtil.isValidInstrumentName("a_-.")).isTrue();
-    assertThat(ValidationUtil.isValidInstrumentName(new String(new char[63]).replace('\0', 'a')))
+    assertThat(ValidationUtil.checkValidInstrumentName("f")).isTrue();
+    assertThat(ValidationUtil.checkValidInstrumentName("F")).isTrue();
+    assertThat(ValidationUtil.checkValidInstrumentName("foo")).isTrue();
+    assertThat(ValidationUtil.checkValidInstrumentName("a1")).isTrue();
+    assertThat(ValidationUtil.checkValidInstrumentName("a.")).isTrue();
+    assertThat(ValidationUtil.checkValidInstrumentName("abcdefghijklmnopqrstuvwxyz")).isTrue();
+    assertThat(ValidationUtil.checkValidInstrumentName("ABCDEFGHIJKLMNOPQRSTUVWXYZ")).isTrue();
+    assertThat(ValidationUtil.checkValidInstrumentName("a1234567890")).isTrue();
+    assertThat(ValidationUtil.checkValidInstrumentName("a_-.")).isTrue();
+    assertThat(ValidationUtil.checkValidInstrumentName(new String(new char[63]).replace('\0', 'a')))
         .isTrue();
 
     // Empty and null not allowed
-    assertThat(ValidationUtil.isValidInstrumentName(null)).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName(null)).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("")).isFalse();
     // Must start with a letter
-    assertThat(ValidationUtil.isValidInstrumentName("1")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName(".")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("1")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName(".")).isFalse();
     // Illegal characters
-    assertThat(ValidationUtil.isValidInstrumentName("a~")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a!")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a@")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a#")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a$")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a%")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a^")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a&")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a*")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a(")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a)")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a=")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a+")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a{")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a}")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a[")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a]")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a\\")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a|")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a<")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a>")).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentName("a?")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a~")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a!")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a@")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a#")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a$")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a%")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a^")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a&")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a*")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a(")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a)")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a=")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a+")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a{")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a}")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a[")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a]")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a\\")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a|")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a<")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a>")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentName("a?")).isFalse();
     // Must be 63 characters or less
-    assertThat(ValidationUtil.isValidInstrumentName(new String(new char[64]).replace('\0', 'a')))
+    assertThat(ValidationUtil.checkValidInstrumentName(new String(new char[64]).replace('\0', 'a')))
         .isFalse();
   }
 
   @Test
-  void isValidInstrumentUnit_InvalidUnitLogs() {
-    assertThat(ValidationUtil.isValidInstrumentUnit("日", " suffix")).isFalse();
+  void checkValidInstrumentUnit_InvalidUnitLogs() {
+    assertThat(ValidationUtil.checkValidInstrumentUnit("日", " suffix")).isFalse();
     apiUsageLogs.assertContains(
         "Unit \"日\" is invalid. Instrument unit must be 63 or less ASCII characters." + " suffix");
   }
 
   @Test
-  void isValidInstrumentUnit() {
-    assertThat(ValidationUtil.isValidInstrumentUnit("a")).isTrue();
-    assertThat(ValidationUtil.isValidInstrumentUnit("A")).isTrue();
-    assertThat(ValidationUtil.isValidInstrumentUnit("foo129")).isTrue();
-    assertThat(ValidationUtil.isValidInstrumentUnit("!@#$%^&*()")).isTrue();
-    assertThat(ValidationUtil.isValidInstrumentUnit(new String(new char[63]).replace('\0', 'a')))
+  void checkValidInstrumentUnit() {
+    assertThat(ValidationUtil.checkValidInstrumentUnit("a")).isTrue();
+    assertThat(ValidationUtil.checkValidInstrumentUnit("A")).isTrue();
+    assertThat(ValidationUtil.checkValidInstrumentUnit("foo129")).isTrue();
+    assertThat(ValidationUtil.checkValidInstrumentUnit("!@#$%^&*()")).isTrue();
+    assertThat(ValidationUtil.checkValidInstrumentUnit(new String(new char[63]).replace('\0', 'a')))
         .isTrue();
 
     // Empty and null not allowed
-    assertThat(ValidationUtil.isValidInstrumentUnit(null)).isFalse();
-    assertThat(ValidationUtil.isValidInstrumentUnit("")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentUnit(null)).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentUnit("")).isFalse();
     // Non-ascii characters
-    assertThat(ValidationUtil.isValidInstrumentUnit("日")).isFalse();
+    assertThat(ValidationUtil.checkValidInstrumentUnit("日")).isFalse();
     // Must be 63 characters or less
-    assertThat(ValidationUtil.isValidInstrumentUnit(new String(new char[64]).replace('\0', 'a')))
+    assertThat(ValidationUtil.checkValidInstrumentUnit(new String(new char[64]).replace('\0', 'a')))
         .isFalse();
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilder.java
@@ -44,7 +44,7 @@ abstract class AbstractInstrumentBuilder<BuilderT extends AbstractInstrumentBuil
   protected abstract BuilderT getThis();
 
   public BuilderT setUnit(String unit) {
-    if (!ValidationUtil.isValidInstrumentUnit(
+    if (!ValidationUtil.checkValidInstrumentUnit(
         unit, " Using " + DEFAULT_UNIT + " for instrument " + this.instrumentName + " instead.")) {
       this.unit = DEFAULT_UNIT;
     } else {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import io.opentelemetry.api.internal.ValidationUtil;
 import io.opentelemetry.api.metrics.DoubleGaugeBuilder;
 import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.LongCounterBuilder;
@@ -17,30 +18,18 @@ import io.opentelemetry.sdk.metrics.internal.export.CollectionInfo;
 import io.opentelemetry.sdk.metrics.internal.state.MeterProviderSharedState;
 import io.opentelemetry.sdk.metrics.internal.state.MeterSharedState;
 import java.util.Collection;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.regex.Pattern;
 
 /** {@link SdkMeter} is SDK implementation of {@link Meter}. */
 final class SdkMeter implements Meter {
 
   /**
-   * Instrument names MUST conform to the following syntax.
-   *
-   * <ul>
-   *   <li>They are not null or empty strings.
-   *   <li>They are case-insensitive, ASCII strings.
-   *   <li>The first character must be an alphabetic character.
-   *   <li>Subsequent characters must belong to the alphanumeric characters, '_', '.', and '-'.
-   *   <li>They can have a maximum length of 63 characters.
-   * </ul>
+   * Message appended to warnings when {@link ValidationUtil#isValidInstrumentName(String, String)}
+   * is {@code false}.
    */
-  private static final String VALID_INSTRUMENT_PATTERN =
-      "([A-Za-z]){1}([A-Za-z0-9\\_\\-\\.]){0,62}";
+  private static final String NOOP_INSTRUMENT_WARNING = " Returning noop instrument.";
 
-  private static final Pattern VALID_INSTRUMENT_NAME = Pattern.compile(VALID_INSTRUMENT_PATTERN);
-
-  private static final Logger logger = Logger.getLogger(SdkMeter.class.getName());
+  private static final Meter NOOP_METER = MeterProvider.noop().get("noop");
+  private static final String NOOP_INSTRUMENT_NAME = "noop";
 
   private final InstrumentationScopeInfo instrumentationScopeInfo;
   private final MeterProviderSharedState meterProviderSharedState;
@@ -68,44 +57,29 @@ final class SdkMeter implements Meter {
 
   @Override
   public LongCounterBuilder counterBuilder(String name) {
-    return !isValidName(name)
-        ? MeterProvider.noop().meterBuilder(name).build().counterBuilder(name)
+    return !ValidationUtil.isValidInstrumentName(name, NOOP_INSTRUMENT_WARNING)
+        ? NOOP_METER.counterBuilder(NOOP_INSTRUMENT_NAME)
         : new SdkLongCounter.Builder(meterProviderSharedState, meterSharedState, name);
   }
 
   @Override
   public LongUpDownCounterBuilder upDownCounterBuilder(String name) {
-    return !isValidName(name)
-        ? MeterProvider.noop().meterBuilder(name).build().upDownCounterBuilder(name)
+    return !ValidationUtil.isValidInstrumentName(name, NOOP_INSTRUMENT_WARNING)
+        ? NOOP_METER.upDownCounterBuilder(NOOP_INSTRUMENT_NAME)
         : new SdkLongUpDownCounter.Builder(meterProviderSharedState, meterSharedState, name);
   }
 
   @Override
   public DoubleHistogramBuilder histogramBuilder(String name) {
-    return !isValidName(name)
-        ? MeterProvider.noop().meterBuilder(name).build().histogramBuilder(name)
+    return !ValidationUtil.isValidInstrumentName(name, NOOP_INSTRUMENT_WARNING)
+        ? NOOP_METER.histogramBuilder(NOOP_INSTRUMENT_NAME)
         : new SdkDoubleHistogram.Builder(meterProviderSharedState, meterSharedState, name);
   }
 
   @Override
   public DoubleGaugeBuilder gaugeBuilder(String name) {
-    return !isValidName(name)
-        ? MeterProvider.noop().meterBuilder(name).build().gaugeBuilder(name)
+    return !ValidationUtil.isValidInstrumentName(name, NOOP_INSTRUMENT_WARNING)
+        ? NOOP_METER.gaugeBuilder(NOOP_INSTRUMENT_NAME)
         : new SdkDoubleGaugeBuilder(meterProviderSharedState, meterSharedState, name);
-  }
-
-  // Visible for testing
-  static boolean isValidName(String name) {
-    if (name == null || !VALID_INSTRUMENT_NAME.matcher(name).matches()) {
-      logger.log(
-          Level.WARNING,
-          "Instrument names \""
-              + name
-              + "\" is invalid, returning noop instrument. Valid instrument names must match "
-              + VALID_INSTRUMENT_PATTERN
-              + ".");
-      return false;
-    }
-    return true;
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java
@@ -23,8 +23,8 @@ import java.util.Collection;
 final class SdkMeter implements Meter {
 
   /**
-   * Message appended to warnings when {@link ValidationUtil#isValidInstrumentName(String, String)}
-   * is {@code false}.
+   * Message appended to warnings when {@link ValidationUtil#checkValidInstrumentName(String,
+   * String)} is {@code false}.
    */
   private static final String NOOP_INSTRUMENT_WARNING = " Returning noop instrument.";
 
@@ -57,28 +57,28 @@ final class SdkMeter implements Meter {
 
   @Override
   public LongCounterBuilder counterBuilder(String name) {
-    return !ValidationUtil.isValidInstrumentName(name, NOOP_INSTRUMENT_WARNING)
+    return !ValidationUtil.checkValidInstrumentName(name, NOOP_INSTRUMENT_WARNING)
         ? NOOP_METER.counterBuilder(NOOP_INSTRUMENT_NAME)
         : new SdkLongCounter.Builder(meterProviderSharedState, meterSharedState, name);
   }
 
   @Override
   public LongUpDownCounterBuilder upDownCounterBuilder(String name) {
-    return !ValidationUtil.isValidInstrumentName(name, NOOP_INSTRUMENT_WARNING)
+    return !ValidationUtil.checkValidInstrumentName(name, NOOP_INSTRUMENT_WARNING)
         ? NOOP_METER.upDownCounterBuilder(NOOP_INSTRUMENT_NAME)
         : new SdkLongUpDownCounter.Builder(meterProviderSharedState, meterSharedState, name);
   }
 
   @Override
   public DoubleHistogramBuilder histogramBuilder(String name) {
-    return !ValidationUtil.isValidInstrumentName(name, NOOP_INSTRUMENT_WARNING)
+    return !ValidationUtil.checkValidInstrumentName(name, NOOP_INSTRUMENT_WARNING)
         ? NOOP_METER.histogramBuilder(NOOP_INSTRUMENT_NAME)
         : new SdkDoubleHistogram.Builder(meterProviderSharedState, meterSharedState, name);
   }
 
   @Override
   public DoubleGaugeBuilder gaugeBuilder(String name) {
-    return !ValidationUtil.isValidInstrumentName(name, NOOP_INSTRUMENT_WARNING)
+    return !ValidationUtil.checkValidInstrumentName(name, NOOP_INSTRUMENT_WARNING)
         ? NOOP_METER.gaugeBuilder(NOOP_INSTRUMENT_NAME)
         : new SdkDoubleGaugeBuilder(meterProviderSharedState, meterSharedState, name);
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java
@@ -10,15 +10,38 @@ import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.LongCounterBuilder;
 import io.opentelemetry.api.metrics.LongUpDownCounterBuilder;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.export.CollectionInfo;
 import io.opentelemetry.sdk.metrics.internal.state.MeterProviderSharedState;
 import io.opentelemetry.sdk.metrics.internal.state.MeterSharedState;
 import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 /** {@link SdkMeter} is SDK implementation of {@link Meter}. */
 final class SdkMeter implements Meter {
+
+  /**
+   * Instrument names MUST conform to the following syntax.
+   *
+   * <ul>
+   *   <li>They are not null or empty strings.
+   *   <li>They are case-insensitive, ASCII strings.
+   *   <li>The first character must be an alphabetic character.
+   *   <li>Subsequent characters must belong to the alphanumeric characters, '_', '.', and '-'.
+   *   <li>They can have a maximum length of 63 characters.
+   * </ul>
+   */
+  private static final String VALID_INSTRUMENT_PATTERN =
+      "([A-Za-z]){1}([A-Za-z0-9\\_\\-\\.]){0,62}";
+
+  private static final Pattern VALID_INSTRUMENT_NAME = Pattern.compile(VALID_INSTRUMENT_PATTERN);
+
+  private static final Logger logger = Logger.getLogger(SdkMeter.class.getName());
+
   private final InstrumentationScopeInfo instrumentationScopeInfo;
   private final MeterProviderSharedState meterProviderSharedState;
   private final MeterSharedState meterSharedState;
@@ -45,21 +68,44 @@ final class SdkMeter implements Meter {
 
   @Override
   public LongCounterBuilder counterBuilder(String name) {
-    return new SdkLongCounter.Builder(meterProviderSharedState, meterSharedState, name);
+    return !isValidName(name)
+        ? MeterProvider.noop().meterBuilder(name).build().counterBuilder(name)
+        : new SdkLongCounter.Builder(meterProviderSharedState, meterSharedState, name);
   }
 
   @Override
   public LongUpDownCounterBuilder upDownCounterBuilder(String name) {
-    return new SdkLongUpDownCounter.Builder(meterProviderSharedState, meterSharedState, name);
+    return !isValidName(name)
+        ? MeterProvider.noop().meterBuilder(name).build().upDownCounterBuilder(name)
+        : new SdkLongUpDownCounter.Builder(meterProviderSharedState, meterSharedState, name);
   }
 
   @Override
   public DoubleHistogramBuilder histogramBuilder(String name) {
-    return new SdkDoubleHistogram.Builder(meterProviderSharedState, meterSharedState, name);
+    return !isValidName(name)
+        ? MeterProvider.noop().meterBuilder(name).build().histogramBuilder(name)
+        : new SdkDoubleHistogram.Builder(meterProviderSharedState, meterSharedState, name);
   }
 
   @Override
   public DoubleGaugeBuilder gaugeBuilder(String name) {
-    return new SdkDoubleGaugeBuilder(meterProviderSharedState, meterSharedState, name);
+    return !isValidName(name)
+        ? MeterProvider.noop().meterBuilder(name).build().gaugeBuilder(name)
+        : new SdkDoubleGaugeBuilder(meterProviderSharedState, meterSharedState, name);
+  }
+
+  // Visible for testing
+  static boolean isValidName(String name) {
+    if (name == null || !VALID_INSTRUMENT_NAME.matcher(name).matches()) {
+      logger.log(
+          Level.WARNING,
+          "Instrument names \""
+              + name
+              + "\" is invalid, returning noop instrument. Valid instrument names must match "
+              + VALID_INSTRUMENT_PATTERN
+              + ".");
+      return false;
+    }
+    return true;
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/IdentityTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/IdentityTest.java
@@ -964,6 +964,7 @@ class IdentityTest {
   }
 
   @Test
+  @SuppressLogger(ViewRegistry.class)
   void sameMeterDifferentInstrumentIncompatibleViewAggregation() {
     SdkMeterProvider meterProvider =
         builder

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterTest.java
@@ -15,21 +15,38 @@ import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.LongUpDownCounter;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.metrics.internal.state.MetricStorageRegistry;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+@SuppressLogger(SdkMeter.class)
 @SuppressLogger(MetricStorageRegistry.class)
 class SdkMeterTest {
   // Meter must have an exporter configured to actual run.
   private final SdkMeterProvider testMeterProvider =
       SdkMeterProvider.builder().registerMetricReader(InMemoryMetricReader.create()).build();
   private final Meter sdkMeter = testMeterProvider.get(getClass().getName());
+  private final Meter noopMeter = MeterProvider.noop().get("");
+
+  @RegisterExtension LogCapturer sdkMeterLogs = LogCapturer.create().captureForType(SdkMeter.class);
 
   @RegisterExtension
-  LogCapturer logs = LogCapturer.create().captureForType(MetricStorageRegistry.class);
+  LogCapturer metricStorageLogs = LogCapturer.create().captureForType(MetricStorageRegistry.class);
+
+  @Test
+  void counterBuilder_InvalidName() {
+    assertThat(sdkMeter.counterBuilder("1").build())
+        .isSameAs(noopMeter.counterBuilder("1").build());
+    assertThat(sdkMeter.counterBuilder("1").ofDoubles().build())
+        .isSameAs(noopMeter.counterBuilder("1").ofDoubles().build());
+    assertThat(sdkMeter.counterBuilder("1").buildWithCallback(unused -> {}))
+        .isSameAs(noopMeter.counterBuilder("1").buildWithCallback(unused -> {}));
+    assertThat(sdkMeter.counterBuilder("1").ofDoubles().buildWithCallback(unused -> {}))
+        .isSameAs(noopMeter.counterBuilder("1").ofDoubles().buildWithCallback(unused -> {}));
+  }
 
   @Test
   void testLongCounter() {
@@ -48,10 +65,10 @@ class SdkMeterTest {
         .setDescription("My very own counter")
         .setUnit("metric tonnes")
         .build();
-    assertThat(logs.getEvents()).isEmpty();
+    assertThat(metricStorageLogs.getEvents()).isEmpty();
 
     sdkMeter.counterBuilder("testLongCounter").build();
-    logs.assertContains("Found duplicate metric definition");
+    metricStorageLogs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -64,7 +81,19 @@ class SdkMeterTest {
             .build();
     assertThat(longCounter).isNotNull();
     sdkMeter.counterBuilder("testLongCounter".toUpperCase()).build();
-    logs.assertContains("Found duplicate metric definition");
+    metricStorageLogs.assertContains("Found duplicate metric definition");
+  }
+
+  @Test
+  void upDownCounterBuilder_InvalidName() {
+    assertThat(sdkMeter.upDownCounterBuilder("1").build())
+        .isSameAs(noopMeter.upDownCounterBuilder("1").build());
+    assertThat(sdkMeter.upDownCounterBuilder("1").ofDoubles().build())
+        .isSameAs(noopMeter.upDownCounterBuilder("1").ofDoubles().build());
+    assertThat(sdkMeter.upDownCounterBuilder("1").buildWithCallback(unused -> {}))
+        .isSameAs(noopMeter.upDownCounterBuilder("1").buildWithCallback(unused -> {}));
+    assertThat(sdkMeter.upDownCounterBuilder("1").ofDoubles().buildWithCallback(unused -> {}))
+        .isSameAs(noopMeter.upDownCounterBuilder("1").ofDoubles().buildWithCallback(unused -> {}));
   }
 
   @Test
@@ -85,10 +114,10 @@ class SdkMeterTest {
         .setDescription("My very own counter")
         .setUnit("metric tonnes")
         .build();
-    assertThat(logs.getEvents()).isEmpty();
+    assertThat(metricStorageLogs.getEvents()).isEmpty();
 
     sdkMeter.upDownCounterBuilder("testLongUpDownCounter").build();
-    logs.assertContains("Found duplicate metric definition");
+    metricStorageLogs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -100,9 +129,17 @@ class SdkMeterTest {
             .setUnit("metric tonnes")
             .build();
     assertThat(longUpDownCounter).isNotNull();
-    assertThat(logs.getEvents()).isEmpty();
+    assertThat(metricStorageLogs.getEvents()).isEmpty();
     sdkMeter.upDownCounterBuilder("testLongUpDownCounter".toUpperCase()).build();
-    logs.assertContains("Found duplicate metric definition");
+    metricStorageLogs.assertContains("Found duplicate metric definition");
+  }
+
+  @Test
+  void histogramBuilder_InvalidName() {
+    assertThat(sdkMeter.histogramBuilder("1").build())
+        .isSameAs(noopMeter.histogramBuilder("1").build());
+    assertThat(sdkMeter.histogramBuilder("1").ofLongs().build())
+        .isSameAs(noopMeter.histogramBuilder("1").ofLongs().build());
   }
 
   @Test
@@ -115,7 +152,7 @@ class SdkMeterTest {
             .setUnit("metric tonnes")
             .build();
     assertThat(longHistogram).isNotNull();
-    assertThat(logs.getEvents()).isEmpty();
+    assertThat(metricStorageLogs.getEvents()).isEmpty();
 
     // Note: We no longer get the same instrument instance as these instances are lightweight
     // objects backed by storage now.  Here we just make sure it doesn't log an error.
@@ -125,10 +162,10 @@ class SdkMeterTest {
         .setDescription("My very own counter")
         .setUnit("metric tonnes")
         .build();
-    assertThat(logs.getEvents()).isEmpty();
+    assertThat(metricStorageLogs.getEvents()).isEmpty();
 
     sdkMeter.histogramBuilder("testLongValueRecorder").ofLongs().build();
-    logs.assertContains("Found duplicate metric definition");
+    metricStorageLogs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -141,10 +178,18 @@ class SdkMeterTest {
             .setUnit("metric tonnes")
             .build();
     assertThat(longHistogram).isNotNull();
-    assertThat(logs.getEvents()).isEmpty();
+    assertThat(metricStorageLogs.getEvents()).isEmpty();
 
     sdkMeter.histogramBuilder("testLongValueRecorder".toUpperCase()).ofLongs().build();
-    logs.assertContains("Found duplicate metric definition");
+    metricStorageLogs.assertContains("Found duplicate metric definition");
+  }
+
+  @Test
+  void gaugeBuilder_InvalidName() {
+    assertThat(sdkMeter.gaugeBuilder("1").buildWithCallback(unused -> {}))
+        .isSameAs(noopMeter.gaugeBuilder("1").buildWithCallback(unused -> {}));
+    assertThat(sdkMeter.gaugeBuilder("1").ofLongs().buildWithCallback(unused -> {}))
+        .isSameAs(noopMeter.gaugeBuilder("1").ofLongs().buildWithCallback(unused -> {}));
   }
 
   @Test
@@ -155,10 +200,10 @@ class SdkMeterTest {
         .setDescription("My very own counter")
         .setUnit("metric tonnes")
         .buildWithCallback(obs -> {});
-    assertThat(logs.getEvents()).isEmpty();
+    assertThat(metricStorageLogs.getEvents()).isEmpty();
 
     sdkMeter.gaugeBuilder("longValueObserver").ofLongs().buildWithCallback(x -> {});
-    logs.assertContains("Found duplicate metric definition");
+    metricStorageLogs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -169,10 +214,10 @@ class SdkMeterTest {
         .setDescription("My very own counter")
         .setUnit("metric tonnes")
         .buildWithCallback(obs -> {});
-    assertThat(logs.getEvents()).isEmpty();
+    assertThat(metricStorageLogs.getEvents()).isEmpty();
 
     sdkMeter.gaugeBuilder("longValueObserver".toUpperCase()).ofLongs().buildWithCallback(x -> {});
-    logs.assertContains("Found duplicate metric definition");
+    metricStorageLogs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -182,10 +227,10 @@ class SdkMeterTest {
         .setDescription("My very own counter")
         .setUnit("metric tonnes")
         .buildWithCallback(x -> {});
-    assertThat(logs.getEvents()).isEmpty();
+    assertThat(metricStorageLogs.getEvents()).isEmpty();
 
     sdkMeter.counterBuilder("testLongSumObserver").buildWithCallback(x -> {});
-    logs.assertContains("Found duplicate metric definition");
+    metricStorageLogs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -195,10 +240,10 @@ class SdkMeterTest {
         .setDescription("My very own counter")
         .setUnit("metric tonnes")
         .buildWithCallback(x -> {});
-    assertThat(logs.getEvents()).isEmpty();
+    assertThat(metricStorageLogs.getEvents()).isEmpty();
 
     sdkMeter.counterBuilder("testLongSumObserver".toUpperCase()).buildWithCallback(x -> {});
-    logs.assertContains("Found duplicate metric definition");
+    metricStorageLogs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -208,10 +253,10 @@ class SdkMeterTest {
         .setDescription("My very own counter")
         .setUnit("metric tonnes")
         .buildWithCallback(x -> {});
-    assertThat(logs.getEvents()).isEmpty();
+    assertThat(metricStorageLogs.getEvents()).isEmpty();
 
     sdkMeter.upDownCounterBuilder("testLongUpDownSumObserver").buildWithCallback(x -> {});
-    logs.assertContains("Found duplicate metric definition");
+    metricStorageLogs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -221,12 +266,12 @@ class SdkMeterTest {
         .setDescription("My very own counter")
         .setUnit("metric tonnes")
         .buildWithCallback(x -> {});
-    assertThat(logs.getEvents()).isEmpty();
+    assertThat(metricStorageLogs.getEvents()).isEmpty();
 
     sdkMeter
         .upDownCounterBuilder("testLongUpDownSumObserver".toUpperCase())
         .buildWithCallback(x -> {});
-    logs.assertContains("Found duplicate metric definition");
+    metricStorageLogs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -248,10 +293,10 @@ class SdkMeterTest {
         .setDescription("My very own counter")
         .setUnit("metric tonnes")
         .build();
-    assertThat(logs.getEvents()).isEmpty();
+    assertThat(metricStorageLogs.getEvents()).isEmpty();
 
     sdkMeter.counterBuilder("testDoubleCounter").ofDoubles().build();
-    logs.assertContains("Found duplicate metric definition");
+    metricStorageLogs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -273,10 +318,10 @@ class SdkMeterTest {
         .setDescription("My very own counter")
         .setUnit("metric tonnes")
         .build();
-    assertThat(logs.getEvents()).isEmpty();
+    assertThat(metricStorageLogs.getEvents()).isEmpty();
 
     sdkMeter.upDownCounterBuilder("testDoubleUpDownCounter").ofDoubles().build();
-    logs.assertContains("Found duplicate metric definition");
+    metricStorageLogs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -296,10 +341,10 @@ class SdkMeterTest {
         .setDescription("My very own ValueRecorder")
         .setUnit("metric tonnes")
         .build();
-    assertThat(logs.getEvents()).isEmpty();
+    assertThat(metricStorageLogs.getEvents()).isEmpty();
 
     sdkMeter.histogramBuilder("testDoubleValueRecorder").build();
-    logs.assertContains("Found duplicate metric definition");
+    metricStorageLogs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -310,10 +355,10 @@ class SdkMeterTest {
         .setDescription("My very own counter")
         .setUnit("metric tonnes")
         .buildWithCallback(x -> {});
-    assertThat(logs.getEvents()).isEmpty();
+    assertThat(metricStorageLogs.getEvents()).isEmpty();
     sdkMeter.counterBuilder("testDoubleSumObserver").ofDoubles().buildWithCallback(x -> {});
     sdkMeter.histogramBuilder("testDoubleValueRecorder").build();
-    logs.assertContains("Found duplicate metric definition");
+    metricStorageLogs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -324,14 +369,14 @@ class SdkMeterTest {
         .setDescription("My very own counter")
         .setUnit("metric tonnes")
         .buildWithCallback(x -> {});
-    assertThat(logs.getEvents()).isEmpty();
+    assertThat(metricStorageLogs.getEvents()).isEmpty();
 
     sdkMeter
         .upDownCounterBuilder("testDoubleUpDownSumObserver")
         .ofDoubles()
         .buildWithCallback(x -> {});
     sdkMeter.histogramBuilder("testDoubleValueRecorder").build();
-    logs.assertContains("Found duplicate metric definition");
+    metricStorageLogs.assertContains("Found duplicate metric definition");
   }
 
   @Test
@@ -341,9 +386,63 @@ class SdkMeterTest {
         .setDescription("My very own counter")
         .setUnit("metric tonnes")
         .buildWithCallback(x -> {});
-    assertThat(logs.getEvents()).isEmpty();
+    assertThat(metricStorageLogs.getEvents()).isEmpty();
 
     sdkMeter.gaugeBuilder("doubleValueObserver").buildWithCallback(x -> {});
-    logs.assertContains("Found duplicate metric definition");
+    metricStorageLogs.assertContains("Found duplicate metric definition");
+  }
+
+  @Test
+  void isValidName_InvalidNameLogs() {
+    assertThat(SdkMeter.isValidName("1")).isFalse();
+    sdkMeterLogs.assertContains(
+        "Instrument names \"1\" is invalid, returning noop instrument. Valid instrument names must match ([A-Za-z]){1}([A-Za-z0-9\\_\\-\\.]){0,62}.");
+  }
+
+  @Test
+  void isValidName() {
+    // Valid names
+    assertThat(SdkMeter.isValidName("f")).isTrue();
+    assertThat(SdkMeter.isValidName("F")).isTrue();
+    assertThat(SdkMeter.isValidName("foo")).isTrue();
+    assertThat(SdkMeter.isValidName("a1")).isTrue();
+    assertThat(SdkMeter.isValidName("a.")).isTrue();
+    assertThat(SdkMeter.isValidName("abcdefghijklmnopqrstuvwxyz")).isTrue();
+    assertThat(SdkMeter.isValidName("ABCDEFGHIJKLMNOPQRSTUVWXYZ")).isTrue();
+    assertThat(SdkMeter.isValidName("a1234567890")).isTrue();
+    assertThat(SdkMeter.isValidName("a_-.")).isTrue();
+    assertThat(SdkMeter.isValidName(new String(new char[63]).replace('\0', 'a'))).isTrue();
+
+    // Empty and null not allowed
+    assertThat(SdkMeter.isValidName(null)).isFalse();
+    assertThat(SdkMeter.isValidName("")).isFalse();
+    // Must start with a letter
+    assertThat(SdkMeter.isValidName("1")).isFalse();
+    assertThat(SdkMeter.isValidName(".")).isFalse();
+    // Illegal characters
+    assertThat(SdkMeter.isValidName("a~")).isFalse();
+    assertThat(SdkMeter.isValidName("a!")).isFalse();
+    assertThat(SdkMeter.isValidName("a@")).isFalse();
+    assertThat(SdkMeter.isValidName("a#")).isFalse();
+    assertThat(SdkMeter.isValidName("a$")).isFalse();
+    assertThat(SdkMeter.isValidName("a%")).isFalse();
+    assertThat(SdkMeter.isValidName("a^")).isFalse();
+    assertThat(SdkMeter.isValidName("a&")).isFalse();
+    assertThat(SdkMeter.isValidName("a*")).isFalse();
+    assertThat(SdkMeter.isValidName("a(")).isFalse();
+    assertThat(SdkMeter.isValidName("a)")).isFalse();
+    assertThat(SdkMeter.isValidName("a=")).isFalse();
+    assertThat(SdkMeter.isValidName("a+")).isFalse();
+    assertThat(SdkMeter.isValidName("a{")).isFalse();
+    assertThat(SdkMeter.isValidName("a}")).isFalse();
+    assertThat(SdkMeter.isValidName("a[")).isFalse();
+    assertThat(SdkMeter.isValidName("a]")).isFalse();
+    assertThat(SdkMeter.isValidName("a\\")).isFalse();
+    assertThat(SdkMeter.isValidName("a|")).isFalse();
+    assertThat(SdkMeter.isValidName("a<")).isFalse();
+    assertThat(SdkMeter.isValidName("a>")).isFalse();
+    assertThat(SdkMeter.isValidName("a?")).isFalse();
+    // Must be 63 characters or less
+    assertThat(SdkMeter.isValidName(new String(new char[64]).replace('\0', 'a'))).isFalse();
   }
 }


### PR DESCRIPTION
Resolves #4378.

I think returning a noop instrument is the least wrong solution:
- Throwing an exception is not in line with API patterns
- If we log a warning but allowed the invalid name to be used, we'd put the burden on exporters to figure out how to handle metrics that break the rules.
- If we log a warning an transform the name to be valid, we'd be making up unspecified rules, and could cause unexpected conflicts with other metrics.