### PR TITLE
Retry markdown link check on failure

### DIFF
--- a/.github/scripts/markdown-link-check-with-retry.sh
+++ b/.github/scripts/markdown-link-check-with-retry.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+retry_count=3
+
+for file in "$@"; do
+  for i in $(seq 1 $retry_count); do
+    if markdown-link-check --config "$(dirname "$0")/markdown-link-check-config.json" \
+                           "$file"; then
+      break
+    elif [[ $i -eq $retry_count ]]; then
+      exit 1
+    fi
+    sleep 5
+  done
+done

--- a/.github/workflows/reusable-markdown-link-check.yml
+++ b/.github/workflows/reusable-markdown-link-check.yml
@@ -17,5 +17,4 @@ jobs:
           find . -type f \
                  -name '*.md' \
                  -not -path './CHANGELOG.md' \
-               | xargs markdown-link-check \
-                       --config .github/scripts/markdown-link-check-config.json
+               | xargs .github/scripts/markdown-link-check-with-retry.sh


### PR DESCRIPTION
It looks like we need this after all: https://github.com/open-telemetry/opentelemetry-java/runs/6033601095?check_suite_focus=true