### PR TITLE
Remove old option for specifying temporality

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtil.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtil.java
@@ -136,10 +136,6 @@ final class OtlpConfigUtil {
       Consumer<Function<InstrumentType, AggregationTemporality>> setAggregationTemporality) {
     String temporalityStr = config.getString("otel.exporter.otlp.metrics.temporality.preference");
     if (temporalityStr == null) {
-      // TODO(jack-berg): remove support after 1.13.0
-      temporalityStr = config.getString("otel.exporter.otlp.metrics.temporality");
-    }
-    if (temporalityStr == null) {
       return;
     }
     AggregationTemporality temporality;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtilTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtilTest.java
@@ -352,18 +352,6 @@ class OtlpConfigUtilTest {
             configureAggregationTemporality(
                 ImmutableMap.of("otel.exporter.otlp.metrics.temporality.preference", "delta")))
         .isEqualTo(AggregationTemporality.DELTA);
-    assertThat(
-            configureAggregationTemporality(
-                ImmutableMap.of("otel.exporter.otlp.metrics.temporality", "DELTA")))
-        .isEqualTo(AggregationTemporality.DELTA);
-    assertThat(
-            configureAggregationTemporality(
-                ImmutableMap.of(
-                    "otel.exporter.otlp.metrics.temporality",
-                    "DELTA",
-                    "otel.exporter.otlp.metrics.temporality.preference",
-                    "CUMULATIVE")))
-        .isEqualTo(AggregationTemporality.CUMULATIVE);
   }
 
   /** Configure and return the aggregation temporality using the given properties. */

--- a/sdk-extensions/autoconfigure/src/testOtlpGrpc/java/io/opentelemetry/sdk/autoconfigure/OtlpGrpcConfigTest.java
+++ b/sdk-extensions/autoconfigure/src/testOtlpGrpc/java/io/opentelemetry/sdk/autoconfigure/OtlpGrpcConfigTest.java
@@ -174,7 +174,7 @@ class OtlpGrpcConfigTest {
     props.put("otel.exporter.otlp.metrics.headers", "header-key=header-value");
     props.put("otel.exporter.otlp.metrics.compression", "gzip");
     props.put("otel.exporter.otlp.metrics.timeout", "15s");
-    props.put("otel.exporter.otlp.metrics.temporality", "DELTA");
+    props.put("otel.exporter.otlp.metrics.temporality.preference", "DELTA");
     try (MetricExporter metricExporter =
         MetricExporterConfiguration.configureOtlpMetrics(
             DefaultConfigProperties.createForTest(props))) {

--- a/sdk-extensions/autoconfigure/src/testOtlpHttp/java/io/opentelemetry/sdk/autoconfigure/OtlpHttpConfigTest.java
+++ b/sdk-extensions/autoconfigure/src/testOtlpHttp/java/io/opentelemetry/sdk/autoconfigure/OtlpHttpConfigTest.java
@@ -191,7 +191,7 @@ class OtlpHttpConfigTest {
     props.put("otel.exporter.otlp.metrics.headers", "header-key=header-value");
     props.put("otel.exporter.otlp.metrics.compression", "gzip");
     props.put("otel.exporter.otlp.metrics.timeout", "15s");
-    props.put("otel.exporter.otlp.metrics.temporality", "DELTA");
+    props.put("otel.exporter.otlp.metrics.temporality.preference", "DELTA");
     MetricExporter metricExporter =
         MetricExporterConfiguration.configureOtlpMetrics(
             DefaultConfigProperties.createForTest(props));


### PR DESCRIPTION
Remove `otel.exporter.otlp.metrics.temporality`, which is superseded by `otel.exporter.otlp.metrics.temporality.preference`. 