### PR TITLE
Improved workflow PR creation

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,16 +23,17 @@ jobs:
       - name: Create pull request
         env:
           NUMBER: ${{ github.event.inputs.number }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           commit=$(gh pr view $NUMBER --json mergeCommit --jq .mergeCommit.oid)
           title=$(gh pr view $NUMBER --json title --jq .title)
           url=$(gh pr view $NUMBER --json url --jq .url)
 
-          git cherry-pick $commit
-          git push origin HEAD:backport-$NUMBER-to-$GITHUB_REF_NAME
+          branch=backport-$NUMBER-to-${GITHUB_REF_NAME//\//-}
 
+          git cherry-pick $commit
+          git push origin HEAD:$branch
           gh pr create --title "[$GITHUB_REF_NAME] $title" \
-                       --body "Clean cherry-pick of #$NUMBER to the $GITHUB_REF_NAME branch." \
-                       --head backport-$NUMBER-to-$GITHUB_REF_NAME \
+                       --body "Clean cherry-pick of #$NUMBER to the \`$GITHUB_REF_NAME\` branch." \
+                       --head $branch \
                        --base $GITHUB_REF_NAME

--- a/.github/workflows/merge-change-log-to-main.yml
+++ b/.github/workflows/merge-change-log-to-main.yml
@@ -22,13 +22,16 @@ jobs:
         # this will fail if there have been conflicting change log updates introduced in main
       - name: Create pull request against main
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
+          message="Merge change log updates from $GITHUB_REF_NAME"
+          body="Merge change log updates from \`$GITHUB_REF_NAME\`."
+          branch=merge-change-log-updates-from-${GITHUB_REF_NAME//\//-}
+
           git format-patch --stdout HEAD..origin/$GITHUB_REF_NAME CHANGELOG.md | git apply
-          msg="Merge change log updates from $GITHUB_REF_NAME to main"
-          git commit -a -m "$msg"
-          git push origin HEAD:merge-change-log-updates-to-main
-          gh pr create --title "$msg" \
-                       --body "$msg" \
-                       --head merge-change-log-updates-to-main \
+          git commit -a -m "$message"
+          git push origin HEAD:$branch
+          gh pr create --title "$message" \
+                       --body "$body" \
+                       --head $branch \
                        --base main

--- a/.github/workflows/prepare-patch-release.yml
+++ b/.github/workflows/prepare-patch-release.yml
@@ -31,12 +31,14 @@ jobs:
 
       - name: Create pull request
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
-          msg="Prepare release $VERSION"
-          git commit -a -m "$msg"
-          git push origin HEAD:prepare-release-$VERSION
-          gh pr create --title "[$GITHUB_REF_NAME] $msg" \
-                       --body "$msg" \
-                       --head prepare-release-$VERSION \
+          message="Prepare release $VERSION"
+          branch=prepare-release-$VERSION
+
+          git commit -a -m "$message"
+          git push origin HEAD:$branch
+          gh pr create --title "[$GITHUB_REF_NAME] $message" \
+                       --body "$message." \
+                       --head $branch \
                        --base $GITHUB_REF_NAME

--- a/.github/workflows/prepare-release-branch.yml
+++ b/.github/workflows/prepare-release-branch.yml
@@ -30,14 +30,16 @@ jobs:
 
       - name: Create pull request against the release branch
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
-          msg="Prepare release $VERSION"
-          git commit -a -m "$msg"
-          git push origin HEAD:prepare-release-$VERSION
-          gh pr create --title "[$RELEASE_BRANCH_NAME] $msg" \
-                       --body "$msg" \
-                       --head prepare-release-$VERSION \
+          message="Prepare release $VERSION"
+          branch=prepare-release-$VERSION
+
+          git commit -a -m "$message"
+          git push origin HEAD:$branch
+          gh pr create --title "[$RELEASE_BRANCH_NAME] $message" \
+                       --body "$message." \
+                       --head $branch \
                        --base $RELEASE_BRANCH_NAME
 
   create-pull-request-against-main:
@@ -65,12 +67,15 @@ jobs:
 
       - name: Create pull request against main
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
-          msg="Update version"
-          git commit -a -m "$msg"
-          git push origin HEAD:update-version-on-main
-          gh pr create --title "$msg" \
-                       --body "$msg" \
-                       --head update-version-on-main \
+          message="Update version to $NEXT_VERSION"
+          body="Update version to \`$NEXT_VERSION\`."
+          branch=update-version-to-$NEXT_VERSION
+
+          git commit -a -m "$message"
+          git push origin HEAD:$branch
+          gh pr create --title "$message" \
+                       --body "$body" \
+                       --head $branch \
                        --base main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Generate release notes
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           # conditional blocks not indented because of the heredoc
           if [[ $VERSION == *.0 ]]; then
@@ -89,7 +89,7 @@ jobs:
 
       - name: Create GitHub release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           gh release create --target $GITHUB_REF_NAME \
                             --title "Version $VERSION" \
@@ -99,7 +99,7 @@ jobs:
 
       - name: Update the change log with the release date
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           date=$(gh release view v$VERSION --json publishedAt --jq .publishedAt | sed 's/T.*//')
           sed -ri "s/## Version $VERSION .*/## Version $VERSION ($date)/" CHANGELOG.md
@@ -111,12 +111,14 @@ jobs:
 
       - name: Create pull request against the release branch
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
-          msg="Add $VERSION release date to the change log"
-          git commit -a -m "$msg"
-          git push origin HEAD:add-$VERSION-release-date
-          gh pr create --title "[$GITHUB_REF_NAME] $msg" \
-                       --body "$msg" \
-                       --head add-$VERSION-release-date \
+          message="Add the release date for $VERSION to the change log"
+          branch=add-release-date-for-$VERSION
+
+          git commit -a -m "$message"
+          git push origin HEAD:$branch
+          gh pr create --title "[$GITHUB_REF_NAME] $message" \
+                       --body "$message." \
+                       --head $branch \
                        --base $GITHUB_REF_NAME

--- a/.github/workflows/reusable-create-issue-for-failure.yml
+++ b/.github/workflows/reusable-create-issue-for-failure.yml
@@ -11,7 +11,7 @@ jobs:
 
       - name: Create issue
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           cat > body.txt << EOF
           [$GITHUB_WORKFLOW #$GITHUB_RUN_NUMBER](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) failed.


### PR DESCRIPTION
This should allow PRs generated by workflows to run workflows. I added `BOT_TOKEN` to secrets for this repo. We'll need to keep the old (longer) name `OPENTELEMETRY_JAVA_BOT_TOKEN` until the 1.13.x release branch is no longer needed.

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs.

https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow

Also improved consistency in this PR across the various `gh pr create` uses.

I added "opentelemetry-java-bot PAT" to the 1password account, will need to create a github action secret named `BOT_TOKEN`.