### PR TITLE
Run tests with Java 18

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -21,6 +21,8 @@ jobs:
           - 8
           - 11
           - 17
+          - 18
+        # Collect coverage on latest LTS
         include:
           - os: ubuntu-20.04
             test-java-version: 17
@@ -30,23 +32,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - id: setup-java-8
-        name: Set up Java 8 for tests
+      - id: setup-java-test
+        name: Set up Java ${{ matrix.test-java-version }} for tests
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 8
-          java-package: jre
+          java-version: ${{ matrix.test-java-version }}
 
-      - id: setup-java-11
-        name: Set up Java 11 for tests
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 11
-
-      - id: setup-java-17
-        name: Set up Java 17
+      - id: setup-java
+        name: Set up Java for build
         uses: actions/setup-java@v3
         with:
           distribution: temurin
@@ -58,7 +52,7 @@ jobs:
             build 
             ${{ matrix.coverage && 'jacocoTestReport' || '' }}
             -PtestJavaVersion=${{ matrix.test-java-version }}
-            -Porg.gradle.java.installations.paths=${{ steps.setup-java-8.outputs.path }},${{ steps.setup-java-11.outputs.path }},${{ steps.setup-java-16.outputs.path }},${{ steps.setup-java-17.outputs.path }}
+            -Porg.gradle.java.installations.paths=${{ steps.setup-java-test.outputs.path }},${{ steps.setup-java.outputs.path }}
       - uses: codecov/codecov-action@v3
         if: ${{ matrix.coverage }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
           - 8
           - 11
           - 17
+          - 18
+        # Collect coverage on latest LTS
         include:
           - os: ubuntu-20.04
             test-java-version: 17
@@ -30,23 +32,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - id: setup-java-8
-        name: Set up Java 8 for tests
+      - id: setup-java-test
+        name: Set up Java ${{ matrix.test-java-version }} for tests
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 8
-          java-package: jre
+          java-version: ${{ matrix.test-java-version }}
 
-      - id: setup-java-11
-        name: Set up Java 11 for tests
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 11
-
-      - id: setup-java-17
-        name: Set up Java 17
+      - id: setup-java
+        name: Set up Java for build
         uses: actions/setup-java@v3
         with:
           distribution: temurin
@@ -58,7 +52,7 @@ jobs:
             build
             ${{ matrix.coverage && 'jacocoTestReport' || '' }}
             -PtestJavaVersion=${{ matrix.test-java-version }}
-            -Porg.gradle.java.installations.paths=${{ steps.setup-java-8.outputs.path }},${{ steps.setup-java-11.outputs.path }},${{ steps.setup-java-17.outputs.path }}
+            -Porg.gradle.java.installations.paths=${{ steps.setup-java-test.outputs.path }},${{ steps.setup-java.outputs.path }}
 
       - uses: codecov/codecov-action@v3
         if: ${{ matrix.coverage }}
@@ -91,8 +85,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - id: setup-java-11
-        name: Set up Java 11
+      - id: setup-java
+        name: Set up Java
         uses: actions/setup-java@v3
         with:
           distribution: temurin

--- a/buildSrc/src/main/kotlin/otel.jacoco-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.jacoco-conventions.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 jacoco {
-  toolVersion = "0.8.7"
+  toolVersion = "0.8.8"
 }
 
 // https://docs.gradle.org/current/samples/sample_jvm_multi_project_with_code_coverage.html


### PR DESCRIPTION
Also doesn't set up multiple test Javas in a workflow which is a legacy when we tested all versions in the same job.