### PR TITLE
fix: fix BatchSpanProcessor with non-runtime exception

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -122,6 +122,11 @@ public final class BatchSpanProcessor implements SpanProcessor {
     return worker.batch;
   }
 
+  // Visible for testing
+  Queue<ReadableSpan> getQueue() {
+    return worker.queue;
+  }
+
   @Override
   public String toString() {
     return "BatchSpanProcessor{"

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -324,7 +324,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
         } else {
           logger.log(Level.FINE, "Exporter failed");
         }
-      } catch (RuntimeException e) {
+      } catch (Throwable e) {
         logger.log(Level.WARNING, "Exporter threw an Exception", e);
       } finally {
         batch.clear();

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -13,6 +13,7 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.internal.DaemonThreadFactory;
+import io.opentelemetry.sdk.internal.ThrowableUtil;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
@@ -324,8 +325,9 @@ public final class BatchSpanProcessor implements SpanProcessor {
         } else {
           logger.log(Level.FINE, "Exporter failed");
         }
-      } catch (Throwable e) {
-        logger.log(Level.WARNING, "Exporter threw an Exception", e);
+      } catch (Throwable t) {
+        ThrowableUtil.propagateIfFatal(t);
+        logger.log(Level.WARNING, "Exporter threw an Exception", t);
       } finally {
         batch.clear();
       }


### PR DESCRIPTION
Fix `BatchSpanProcessor` worker thread is killed by non-runtime exception.

close #4348 