### PR TITLE
Have long aggregators export long exemplars

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-metrics.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-metrics.txt
@@ -10,6 +10,7 @@ Comparing source compatibility of  against
 	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.Aggregation sum()
 +++  NEW ENUM: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.metrics.data.AggregationTemporality  (compatible)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: java.lang.constant.Constable
 	+++  NEW INTERFACE: java.lang.Comparable
 	+++  NEW INTERFACE: java.io.Serializable
 	+++  NEW SUPERCLASS: java.lang.Enum
@@ -30,6 +31,7 @@ Comparing source compatibility of  against
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW INTERFACE: io.opentelemetry.sdk.metrics.data.PointData
 	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) java.util.List getExemplars()
 	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) double getValue()
 +++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.metrics.data.ExemplarData  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
@@ -54,6 +56,7 @@ Comparing source compatibility of  against
 	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) java.util.List getBoundaries()
 	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) long getCount()
 	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) java.util.List getCounts()
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) java.util.List getExemplars()
 	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) double getMax()
 	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) double getMin()
 	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) double getSum()
@@ -68,6 +71,7 @@ Comparing source compatibility of  against
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW INTERFACE: io.opentelemetry.sdk.metrics.data.PointData
 	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) java.util.List getExemplars()
 	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) long getValue()
 +++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.metrics.data.MetricData  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
@@ -88,6 +92,7 @@ Comparing source compatibility of  against
 	+++  NEW METHOD: PUBLIC(+) boolean isEmpty()
 +++  NEW ENUM: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.metrics.data.MetricDataType  (compatible)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: java.lang.constant.Constable
 	+++  NEW INTERFACE: java.lang.Comparable
 	+++  NEW INTERFACE: java.io.Serializable
 	+++  NEW SUPERCLASS: java.lang.Enum
@@ -193,6 +198,7 @@ Comparing source compatibility of  against
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.metrics.InstrumentSelectorBuilder setType(io.opentelemetry.sdk.metrics.InstrumentType)
 +++  NEW ENUM: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.metrics.InstrumentType  (compatible)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: java.lang.constant.Constable
 	+++  NEW INTERFACE: java.lang.Comparable
 	+++  NEW INTERFACE: java.io.Serializable
 	+++  NEW SUPERCLASS: java.lang.Enum
@@ -206,6 +212,7 @@ Comparing source compatibility of  against
 	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.InstrumentType[] values()
 +++  NEW ENUM: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.metrics.InstrumentValueType  (compatible)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: java.lang.constant.Constable
 	+++  NEW INTERFACE: java.lang.Comparable
 	+++  NEW INTERFACE: java.io.Serializable
 	+++  NEW SUPERCLASS: java.lang.Enum

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
@@ -9,7 +9,6 @@ Comparing source compatibility of  against
 	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert hasAttributesSatisfying(io.opentelemetry.sdk.testing.assertj.AttributeAssertion[])
 	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert hasAttributesSatisfying(java.lang.Iterable)
 	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert hasEpochNanos(long)
-	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert hasExemplars(io.opentelemetry.sdk.metrics.data.ExemplarData[])
 	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert hasExemplarsSatisfying(java.util.function.Consumer[])
 		+++  NEW ANNOTATION: java.lang.SafeVarargs
 	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert hasExemplarsSatisfying(java.lang.Iterable)
@@ -22,6 +21,7 @@ Comparing source compatibility of  against
 +++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.DoublePointDataAssert  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW SUPERCLASS: io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.DoublePointDataAssert hasExemplars(io.opentelemetry.sdk.metrics.data.DoubleExemplarData[])
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.DoublePointDataAssert hasValue(double)
 +++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.ExemplarDataAssert  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
@@ -44,6 +44,7 @@ Comparing source compatibility of  against
 +++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.LongPointDataAssert  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW SUPERCLASS: io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LongPointDataAssert hasExemplars(io.opentelemetry.sdk.metrics.data.LongExemplarData[])
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LongPointDataAssert hasValue(long)
 +++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExemplarMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExemplarMarshaler.java
@@ -28,7 +28,7 @@ final class ExemplarMarshaler extends MarshalerWithSize {
 
   private final KeyValueMarshaler[] filteredAttributeMarshalers;
 
-  static ExemplarMarshaler[] createRepeated(List<ExemplarData> exemplars) {
+  static ExemplarMarshaler[] createRepeated(List<? extends ExemplarData> exemplars) {
     int numExemplars = exemplars.size();
     ExemplarMarshaler[] marshalers = new ExemplarMarshaler[numExemplars];
     for (int i = 0; i < numExemplars; i++) {

--- a/exporters/prometheus/src/integrationTest/java/io/opentelemetry/exporter/prometheus/MetricAdapter.java
+++ b/exporters/prometheus/src/integrationTest/java/io/opentelemetry/exporter/prometheus/MetricAdapter.java
@@ -258,7 +258,7 @@ final class MetricAdapter {
 
   @Nullable
   private static ExemplarData filterExemplars(
-      Collection<ExemplarData> exemplars, double min, double max) {
+      Collection<? extends ExemplarData> exemplars, double min, double max) {
     ExemplarData result = null;
     for (ExemplarData e : exemplars) {
       double value = getExemplarValue(e);

--- a/exporters/prometheus/src/integrationTest/java/io/opentelemetry/exporter/prometheus/MetricAdapterTest.java
+++ b/exporters/prometheus/src/integrationTest/java/io/opentelemetry/exporter/prometheus/MetricAdapterTest.java
@@ -17,11 +17,11 @@ import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricDataType;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoubleExemplarData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoublePointData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableGaugeData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableHistogramData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableHistogramPointData;
-import io.opentelemetry.sdk.metrics.internal.data.ImmutableLongExemplarData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableLongPointData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableSumData;
@@ -214,7 +214,7 @@ class MetricAdapterTest {
                       Collections.emptyList(),
                       Collections.singletonList(2L),
                       Collections.singletonList(
-                          ImmutableLongExemplarData.create(
+                          ImmutableDoubleExemplarData.create(
                               Attributes.empty(),
                               TimeUnit.MILLISECONDS.toNanos(1L),
                               SpanContext.create(
@@ -550,7 +550,7 @@ class MetricAdapterTest {
                     ImmutableList.of(1.0),
                     ImmutableList.of(4L, 9L),
                     ImmutableList.of(
-                        ImmutableLongExemplarData.create(
+                        ImmutableDoubleExemplarData.create(
                             Attributes.empty(),
                             /*recordTime=*/ 0,
                             SpanContext.create(
@@ -559,7 +559,7 @@ class MetricAdapterTest {
                                 TraceFlags.getDefault(),
                                 TraceState.getDefault()),
                             /*value=*/ 0),
-                        ImmutableLongExemplarData.create(
+                        ImmutableDoubleExemplarData.create(
                             Attributes.empty(),
                             /*recordTime=*/ TimeUnit.MILLISECONDS.toNanos(2),
                             SpanContext.create(

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Serializer.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Serializer.java
@@ -88,7 +88,10 @@ abstract class Serializer {
   abstract void writeTimestamp(Writer writer, long timestampNanos) throws IOException;
 
   abstract void writeExemplar(
-      Writer writer, Collection<ExemplarData> exemplars, double minExemplar, double maxExemplar)
+      Writer writer,
+      Collection<? extends ExemplarData> exemplars,
+      double minExemplar,
+      double maxExemplar)
       throws IOException;
 
   abstract void writeEof(Writer writer) throws IOException;
@@ -278,7 +281,7 @@ abstract class Serializer {
       long epochNanos,
       String additionalAttrKey,
       double additionalAttrValue,
-      Collection<ExemplarData> exemplars,
+      Collection<? extends ExemplarData> exemplars,
       double minExemplar,
       double maxExemplar)
       throws IOException {
@@ -416,7 +419,10 @@ abstract class Serializer {
 
     @Override
     void writeExemplar(
-        Writer writer, Collection<ExemplarData> exemplars, double minExemplar, double maxExemplar) {
+        Writer writer,
+        Collection<? extends ExemplarData> exemplars,
+        double minExemplar,
+        double maxExemplar) {
       // Don't write exemplars
     }
 
@@ -464,7 +470,10 @@ abstract class Serializer {
 
     @Override
     void writeExemplar(
-        Writer writer, Collection<ExemplarData> exemplars, double minExemplar, double maxExemplar)
+        Writer writer,
+        Collection<? extends ExemplarData> exemplars,
+        double minExemplar,
+        double maxExemplar)
         throws IOException {
       for (ExemplarData exemplar : exemplars) {
         double value = getExemplarValue(exemplar);

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/SerializerTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/SerializerTest.java
@@ -16,11 +16,11 @@ import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoubleExemplarData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoublePointData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableGaugeData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableHistogramData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableHistogramPointData;
-import io.opentelemetry.sdk.metrics.internal.data.ImmutableLongExemplarData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableLongPointData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableSumData;
@@ -229,7 +229,7 @@ class SerializerTest {
                       Collections.emptyList(),
                       Collections.singletonList(2L),
                       Collections.singletonList(
-                          ImmutableLongExemplarData.create(
+                          ImmutableDoubleExemplarData.create(
                               Attributes.empty(),
                               TimeUnit.MILLISECONDS.toNanos(1L),
                               SpanContext.create(
@@ -258,7 +258,7 @@ class SerializerTest {
                       Collections.emptyList(),
                       Collections.singletonList(2L),
                       Collections.singletonList(
-                          ImmutableLongExemplarData.create(
+                          ImmutableDoubleExemplarData.create(
                               Attributes.empty(),
                               TimeUnit.MILLISECONDS.toNanos(1L),
                               SpanContext.create(

--- a/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/internal/metrics/MetricAdapter.java
+++ b/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/internal/metrics/MetricAdapter.java
@@ -22,8 +22,8 @@ import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.DoublePointData;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.data.GaugeData;
 import io.opentelemetry.sdk.metrics.data.HistogramData;
 import io.opentelemetry.sdk.metrics.data.HistogramPointData;
@@ -329,8 +329,8 @@ public final class MetricAdapter {
     return result;
   }
 
-  static List<ExemplarData> mapExemplars(List<Distribution.Bucket> buckets) {
-    List<ExemplarData> result = new ArrayList<>();
+  static List<DoubleExemplarData> mapExemplars(List<Distribution.Bucket> buckets) {
+    List<DoubleExemplarData> result = new ArrayList<>();
     for (Distribution.Bucket bucket : buckets) {
       Exemplar exemplar = bucket.getExemplar();
       if (exemplar != null) {
@@ -340,7 +340,7 @@ public final class MetricAdapter {
     return result;
   }
 
-  private static ExemplarData mapExemplar(Exemplar exemplar) {
+  private static DoubleExemplarData mapExemplar(Exemplar exemplar) {
     // Look for trace/span id.
     SpanContext spanContext = SpanContext.getInvalid();
     if (exemplar.getAttachments().containsKey("SpanContext")) {

--- a/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/AbstractPointDataAssert.java
+++ b/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/AbstractPointDataAssert.java
@@ -8,6 +8,8 @@ package io.opentelemetry.sdk.testing.assertj;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.data.PointData;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractIterableAssert;
 import org.assertj.core.api.Assertions;
@@ -62,9 +64,11 @@ public class AbstractPointDataAssert<
    */
   public PointAssertT hasExemplars(ExemplarData... exemplars) {
     isNotNull();
-    Assertions.assertThat(actual.getExemplars())
+    // TODO(anuraaga): This code will be removed so use hacky approach to check ExemplarData.
+    Assertions.assertThat(
+            actual.getExemplars().stream().map(Object.class::cast).collect(Collectors.toList()))
         .as("exemplars")
-        .containsExactlyInAnyOrder(exemplars);
+        .containsExactlyInAnyOrderElementsOf(Arrays.asList(exemplars));
     return myself;
   }
 }

--- a/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/internal/aggregator/HistogramAggregationParam.java
+++ b/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/internal/aggregator/HistogramAggregationParam.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.sdk.metrics.internal.aggregator;
 
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
+import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
 import io.opentelemetry.sdk.metrics.internal.state.ExponentialCounterFactory;
 import java.util.Collections;
 
@@ -16,33 +16,33 @@ public enum HistogramAggregationParam {
       new DoubleHistogramAggregator(
           ExplicitBucketHistogramUtils.createBoundaryArray(
               ExplicitBucketHistogramUtils.DEFAULT_HISTOGRAM_BUCKET_BOUNDARIES),
-          ExemplarReservoir::noSamples)),
+          DoubleExemplarReservoir::noSamples)),
   EXPLICIT_SINGLE_BUCKET(
       new DoubleHistogramAggregator(
           ExplicitBucketHistogramUtils.createBoundaryArray(Collections.emptyList()),
-          ExemplarReservoir::noSamples)),
+          DoubleExemplarReservoir::noSamples)),
   EXPONENTIAL_SMALL_CIRCULAR_BUFFER(
       new DoubleExponentialHistogramAggregator(
-          ExemplarReservoir::noSamples,
+          DoubleExemplarReservoir::noSamples,
           ExponentialBucketStrategy.newStrategy(
               20, 20, ExponentialCounterFactory.circularBufferCounter()))),
   EXPONENTIAL_CIRCULAR_BUFFER(
       new DoubleExponentialHistogramAggregator(
-          ExemplarReservoir::noSamples,
+          DoubleExemplarReservoir::noSamples,
           ExponentialBucketStrategy.newStrategy(
               20, 320, ExponentialCounterFactory.circularBufferCounter()))),
   EXPONENTIAL_MAP_COUNTER(
       new DoubleExponentialHistogramAggregator(
-          ExemplarReservoir::noSamples,
+          DoubleExemplarReservoir::noSamples,
           ExponentialBucketStrategy.newStrategy(20, 320, ExponentialCounterFactory.mapCounter())));
 
-  private final Aggregator<?> aggregator;
+  private final Aggregator<?, ?> aggregator;
 
-  private HistogramAggregationParam(Aggregator<?> aggregator) {
+  private HistogramAggregationParam(Aggregator<?, ?> aggregator) {
     this.aggregator = aggregator;
   }
 
-  public Aggregator<?> getAggregator() {
+  public Aggregator<?, ?> getAggregator() {
     return this.aggregator;
   }
 }

--- a/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/internal/aggregator/HistogramBenchmark.java
+++ b/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/internal/aggregator/HistogramBenchmark.java
@@ -33,7 +33,7 @@ public class HistogramBenchmark {
   public static class ThreadState {
     @Param HistogramValueGenerator valueGen;
     @Param HistogramAggregationParam aggregation;
-    private AggregatorHandle<?> aggregatorHandle;
+    private AggregatorHandle<?, ?> aggregatorHandle;
     private DoubleSupplier valueSupplier;
 
     @Setup(Level.Trial)

--- a/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/internal/aggregator/HistogramScaleBenchmark.java
+++ b/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/internal/aggregator/HistogramScaleBenchmark.java
@@ -38,7 +38,7 @@ public class HistogramScaleBenchmark {
   public static class ThreadState {
     @Param HistogramValueGenerator valueGen;
     @Param HistogramAggregationParam aggregation;
-    private AggregatorHandle<?> aggregatorHandle;
+    private AggregatorHandle<?, ?> aggregatorHandle;
     private DoubleSupplier valueSupplier;
 
     @Setup(Level.Invocation)

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DoublePointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DoublePointData.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.sdk.metrics.data;
 
+import java.util.List;
+
 /** A single data point in a timeseries that describes the time-varying value of a double metric. */
 public interface DoublePointData extends PointData {
   /**
@@ -13,4 +15,8 @@ public interface DoublePointData extends PointData {
    * @return the value of the data point.
    */
   double getValue();
+
+  /** List of exemplars collected from measurements that were used to form the data point. */
+  @Override
+  List<DoubleExemplarData> getExemplars();
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/HistogramPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/HistogramPointData.java
@@ -61,4 +61,8 @@ public interface HistogramPointData extends PointData {
    * @return the read-only counts in each bucket. <b>do not mutate</b> the returned object.
    */
   List<Long> getCounts();
+
+  /** List of exemplars collected from measurements that were used to form the data point. */
+  @Override
+  List<DoubleExemplarData> getExemplars();
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/LongPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/LongPointData.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.sdk.metrics.data;
 
+import java.util.List;
+
 public interface LongPointData extends PointData {
   /**
    * Returns the value of the data point.
@@ -12,4 +14,8 @@ public interface LongPointData extends PointData {
    * @return the value of the data point.
    */
   long getValue();
+
+  /** List of exemplars collected from measurements that were used to form the data point. */
+  @Override
+  List<LongExemplarData> getExemplars();
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/PointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/PointData.java
@@ -39,6 +39,7 @@ public interface PointData {
    * @return the attributes associated with this {@code Point}.
    */
   Attributes getAttributes();
+
   /** List of exemplars collected from measurements that were used to form the data point. */
-  List<ExemplarData> getExemplars();
+  List<? extends ExemplarData> getExemplars();
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/AbstractSumAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/AbstractSumAggregator.java
@@ -5,9 +5,10 @@
 
 package io.opentelemetry.sdk.metrics.internal.aggregator;
 
+import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 
-abstract class AbstractSumAggregator<T> implements Aggregator<T> {
+abstract class AbstractSumAggregator<T, U extends ExemplarData> implements Aggregator<T, U> {
   private final boolean isMonotonic;
 
   AbstractSumAggregator(InstrumentDescriptor instrumentDescriptor) {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/Aggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/Aggregator.java
@@ -9,6 +9,8 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
+import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricDataType;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
@@ -30,9 +32,9 @@ import javax.annotation.concurrent.Immutable;
  * at any time.
  */
 @Immutable
-public interface Aggregator<T> {
+public interface Aggregator<T, U extends ExemplarData> {
   /** Returns the drop aggregator, an aggregator that drops measurements. */
-  static Aggregator<Object> drop() {
+  static Aggregator<Object, DoubleExemplarData> drop() {
     return DropAggregator.INSTANCE;
   }
 
@@ -42,7 +44,7 @@ public interface Aggregator<T> {
    *
    * @return a new {@link AggregatorHandle}.
    */
-  AggregatorHandle<T> createHandle();
+  AggregatorHandle<T, U> createHandle();
 
   /**
    * Returns a new {@code Accumulation} for the given value. This MUST be used by the asynchronous
@@ -54,7 +56,7 @@ public interface Aggregator<T> {
    */
   @Nullable
   default T accumulateLongMeasurement(long value, Attributes attributes, Context context) {
-    AggregatorHandle<T> handle = createHandle();
+    AggregatorHandle<T, U> handle = createHandle();
     handle.recordLong(value, attributes, context);
     return handle.accumulateThenReset(attributes);
   }
@@ -69,7 +71,7 @@ public interface Aggregator<T> {
    */
   @Nullable
   default T accumulateDoubleMeasurement(double value, Attributes attributes, Context context) {
-    AggregatorHandle<T> handle = createHandle();
+    AggregatorHandle<T, U> handle = createHandle();
     handle.recordDouble(value, attributes, context);
     return handle.accumulateThenReset(attributes);
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/AggregatorFactory.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/AggregatorFactory.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.metrics.internal.aggregator;
 
+import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
 
@@ -27,7 +28,7 @@ public interface AggregatorFactory {
    * @return a new {@link Aggregator}. {@link Aggregator#drop()} indicates no measurements should be
    *     recorded.
    */
-  <T> Aggregator<T> createAggregator(
+  <T, U extends ExemplarData> Aggregator<T, U> createAggregator(
       InstrumentDescriptor instrumentDescriptor, ExemplarFilter exemplarFilter);
 
   /**

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/AggregatorHandle.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/AggregatorHandle.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.metrics.internal.aggregator;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
 import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
 import io.opentelemetry.sdk.metrics.internal.state.BoundStorageHandle;
 import java.util.List;
@@ -32,7 +33,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * at any time.
  */
 @ThreadSafe
-public abstract class AggregatorHandle<T> implements BoundStorageHandle {
+public abstract class AggregatorHandle<T, U extends ExemplarData> implements BoundStorageHandle {
   // Atomically counts the number of references (usages) while also keeping a state of
   // mapped/unmapped into a registry map.
   private final AtomicLong refCountMapped;
@@ -43,9 +44,9 @@ public abstract class AggregatorHandle<T> implements BoundStorageHandle {
   private volatile boolean hasRecordings = false;
 
   // A reservoir of sampled exemplars for this time period.
-  private final ExemplarReservoir exemplarReservoir;
+  private final ExemplarReservoir<U> exemplarReservoir;
 
-  protected AggregatorHandle(ExemplarReservoir exemplarReservoir) {
+  protected AggregatorHandle(ExemplarReservoir<U> exemplarReservoir) {
     // Start with this binding already bound.
     this.refCountMapped = new AtomicLong(2);
     this.exemplarReservoir = exemplarReservoir;
@@ -98,7 +99,7 @@ public abstract class AggregatorHandle<T> implements BoundStorageHandle {
   }
 
   /** Implementation of the {@code accumulateThenReset}. */
-  protected abstract T doAccumulateThenReset(List<ExemplarData> exemplars);
+  protected abstract T doAccumulateThenReset(List<U> exemplars);
 
   @Override
   public final void recordLong(long value, Attributes attributes, Context context) {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/AggregatorHandle.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/AggregatorHandle.java
@@ -10,6 +10,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
 import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
+import io.opentelemetry.sdk.metrics.internal.exemplar.LongExemplarReservoir;
 import io.opentelemetry.sdk.metrics.internal.state.BoundStorageHandle;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
@@ -103,7 +104,11 @@ public abstract class AggregatorHandle<T, U extends ExemplarData> implements Bou
 
   @Override
   public final void recordLong(long value, Attributes attributes, Context context) {
-    exemplarReservoir.offerMeasurement(value, attributes, context);
+    // TODO(anuraaga): This should always be true, but removing this cast will require significant
+    // refactoring.
+    if (exemplarReservoir instanceof LongExemplarReservoir) {
+      ((LongExemplarReservoir) exemplarReservoir).offerMeasurement(value, attributes, context);
+    }
     recordLong(value);
   }
 
@@ -130,7 +135,11 @@ public abstract class AggregatorHandle<T, U extends ExemplarData> implements Bou
 
   @Override
   public final void recordDouble(double value, Attributes attributes, Context context) {
-    exemplarReservoir.offerMeasurement(value, attributes, context);
+    // TODO(anuraaga): This should always be true, but removing this cast will require significant
+    // refactoring.
+    if (exemplarReservoir instanceof DoubleExemplarReservoir) {
+      ((DoubleExemplarReservoir) exemplarReservoir).offerMeasurement(value, attributes, context);
+    }
     recordDouble(value);
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleAccumulation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleAccumulation.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.metrics.internal.aggregator;
 
 import com.google.auto.value.AutoValue;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
@@ -23,7 +23,7 @@ import javax.annotation.concurrent.Immutable;
 @AutoValue
 public abstract class DoubleAccumulation {
 
-  static DoubleAccumulation create(double value, List<ExemplarData> exemplars) {
+  static DoubleAccumulation create(double value, List<DoubleExemplarData> exemplars) {
     return new AutoValue_DoubleAccumulation(value, exemplars);
   }
 
@@ -37,5 +37,5 @@ public abstract class DoubleAccumulation {
   public abstract double getValue();
 
   /** Sampled measurements recorded during this accumulation. */
-  abstract List<ExemplarData> getExemplars();
+  abstract List<DoubleExemplarData> getExemplars();
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramAggregator.java
@@ -8,7 +8,7 @@ package io.opentelemetry.sdk.metrics.internal.aggregator;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
 import io.opentelemetry.sdk.metrics.internal.data.exponentialhistogram.ExponentialHistogramData;
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 final class DoubleExponentialHistogramAggregator
-    implements Aggregator<ExponentialHistogramAccumulation> {
+    implements Aggregator<ExponentialHistogramAccumulation, DoubleExemplarData> {
 
   private final Supplier<DoubleExemplarReservoir> reservoirSupplier;
   private final ExponentialBucketStrategy bucketStrategy;
@@ -34,13 +34,14 @@ final class DoubleExponentialHistogramAggregator
   }
 
   DoubleExponentialHistogramAggregator(
-          Supplier<DoubleExemplarReservoir> reservoirSupplier, ExponentialBucketStrategy bucketStrategy) {
+      Supplier<DoubleExemplarReservoir> reservoirSupplier,
+      ExponentialBucketStrategy bucketStrategy) {
     this.reservoirSupplier = reservoirSupplier;
     this.bucketStrategy = bucketStrategy;
   }
 
   @Override
-  public AggregatorHandle<ExponentialHistogramAccumulation> createHandle() {
+  public AggregatorHandle<ExponentialHistogramAccumulation, DoubleExemplarData> createHandle() {
     return new Handle(reservoirSupplier.get(), this.bucketStrategy);
   }
 
@@ -143,7 +144,8 @@ final class DoubleExponentialHistogramAggregator
                 epochNanos)));
   }
 
-  static final class Handle extends AggregatorHandle<ExponentialHistogramAccumulation> {
+  static final class Handle
+      extends AggregatorHandle<ExponentialHistogramAccumulation, DoubleExemplarData> {
     private final ExponentialBucketStrategy bucketStrategy;
     private final DoubleExponentialHistogramBuckets positiveBuckets;
     private final DoubleExponentialHistogramBuckets negativeBuckets;
@@ -161,7 +163,7 @@ final class DoubleExponentialHistogramAggregator
 
     @Override
     protected synchronized ExponentialHistogramAccumulation doAccumulateThenReset(
-        List<ExemplarData> exemplars) {
+        List<DoubleExemplarData> exemplars) {
       ExponentialHistogramAccumulation acc =
           ExponentialHistogramAccumulation.create(
               this.positiveBuckets.getScale(),

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramAggregator.java
@@ -13,7 +13,7 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
 import io.opentelemetry.sdk.metrics.internal.data.exponentialhistogram.ExponentialHistogramData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
+import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
 import io.opentelemetry.sdk.metrics.internal.state.ExponentialCounterFactory;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.List;
@@ -23,10 +23,10 @@ import java.util.function.Supplier;
 final class DoubleExponentialHistogramAggregator
     implements Aggregator<ExponentialHistogramAccumulation> {
 
-  private final Supplier<ExemplarReservoir> reservoirSupplier;
+  private final Supplier<DoubleExemplarReservoir> reservoirSupplier;
   private final ExponentialBucketStrategy bucketStrategy;
 
-  DoubleExponentialHistogramAggregator(Supplier<ExemplarReservoir> reservoirSupplier) {
+  DoubleExponentialHistogramAggregator(Supplier<DoubleExemplarReservoir> reservoirSupplier) {
     this(
         reservoirSupplier,
         ExponentialBucketStrategy.newStrategy(
@@ -34,7 +34,7 @@ final class DoubleExponentialHistogramAggregator
   }
 
   DoubleExponentialHistogramAggregator(
-      Supplier<ExemplarReservoir> reservoirSupplier, ExponentialBucketStrategy bucketStrategy) {
+          Supplier<DoubleExemplarReservoir> reservoirSupplier, ExponentialBucketStrategy bucketStrategy) {
     this.reservoirSupplier = reservoirSupplier;
     this.bucketStrategy = bucketStrategy;
   }
@@ -150,7 +150,7 @@ final class DoubleExponentialHistogramAggregator
     private long zeroCount;
     private double sum;
 
-    Handle(ExemplarReservoir reservoir, ExponentialBucketStrategy bucketStrategy) {
+    Handle(DoubleExemplarReservoir reservoir, ExponentialBucketStrategy bucketStrategy) {
       super(reservoir);
       this.sum = 0;
       this.zeroCount = 0;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleHistogramAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleHistogramAggregator.java
@@ -14,7 +14,7 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableHistogramData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
+import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,7 +36,7 @@ public final class DoubleHistogramAggregator implements Aggregator<HistogramAccu
   // a cache for converting to MetricData
   private final List<Double> boundaryList;
 
-  private final Supplier<ExemplarReservoir> reservoirSupplier;
+  private final Supplier<DoubleExemplarReservoir> reservoirSupplier;
 
   /**
    * Constructs a histogram aggregator.
@@ -45,7 +45,7 @@ public final class DoubleHistogramAggregator implements Aggregator<HistogramAccu
    * @param reservoirSupplier Supplier of exemplar reservoirs per-stream.
    */
   public DoubleHistogramAggregator(
-      double[] boundaries, Supplier<ExemplarReservoir> reservoirSupplier) {
+      double[] boundaries, Supplier<DoubleExemplarReservoir> reservoirSupplier) {
     this.boundaries = boundaries;
 
     List<Double> boundaryList = new ArrayList<>(this.boundaries.length);
@@ -159,7 +159,7 @@ public final class DoubleHistogramAggregator implements Aggregator<HistogramAccu
 
     private final ReentrantLock lock = new ReentrantLock();
 
-    Handle(double[] boundaries, ExemplarReservoir reservoir) {
+    Handle(double[] boundaries, DoubleExemplarReservoir reservoir) {
       super(reservoir);
       this.boundaries = boundaries;
       this.counts = new long[this.boundaries.length + 1];

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleHistogramAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleHistogramAggregator.java
@@ -9,7 +9,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.internal.GuardedBy;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableHistogramData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
@@ -30,7 +30,8 @@ import java.util.function.Supplier;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public final class DoubleHistogramAggregator implements Aggregator<HistogramAccumulation> {
+public final class DoubleHistogramAggregator
+    implements Aggregator<HistogramAccumulation, DoubleExemplarData> {
   private final double[] boundaries;
 
   // a cache for converting to MetricData
@@ -57,7 +58,7 @@ public final class DoubleHistogramAggregator implements Aggregator<HistogramAccu
   }
 
   @Override
-  public AggregatorHandle<HistogramAccumulation> createHandle() {
+  public AggregatorHandle<HistogramAccumulation, DoubleExemplarData> createHandle() {
     return new Handle(this.boundaries, reservoirSupplier.get());
   }
 
@@ -138,7 +139,7 @@ public final class DoubleHistogramAggregator implements Aggregator<HistogramAccu
                 boundaryList)));
   }
 
-  static final class Handle extends AggregatorHandle<HistogramAccumulation> {
+  static final class Handle extends AggregatorHandle<HistogramAccumulation, DoubleExemplarData> {
     // read-only
     private final double[] boundaries;
 
@@ -170,7 +171,7 @@ public final class DoubleHistogramAggregator implements Aggregator<HistogramAccu
     }
 
     @Override
-    protected HistogramAccumulation doAccumulateThenReset(List<ExemplarData> exemplars) {
+    protected HistogramAccumulation doAccumulateThenReset(List<DoubleExemplarData> exemplars) {
       lock.lock();
       try {
         HistogramAccumulation acc =

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleLastValueAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleLastValueAggregator.java
@@ -13,7 +13,7 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableGaugeData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
+import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.List;
 import java.util.Map;
@@ -35,9 +35,9 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class DoubleLastValueAggregator implements Aggregator<DoubleAccumulation> {
-  private final Supplier<ExemplarReservoir> reservoirSupplier;
+  private final Supplier<DoubleExemplarReservoir> reservoirSupplier;
 
-  public DoubleLastValueAggregator(Supplier<ExemplarReservoir> reservoirSupplier) {
+  public DoubleLastValueAggregator(Supplier<DoubleExemplarReservoir> reservoirSupplier) {
     this.reservoirSupplier = reservoirSupplier;
   }
 
@@ -87,7 +87,7 @@ public final class DoubleLastValueAggregator implements Aggregator<DoubleAccumul
     @Nullable private static final Double DEFAULT_VALUE = null;
     private final AtomicReference<Double> current = new AtomicReference<>(DEFAULT_VALUE);
 
-    private Handle(ExemplarReservoir reservoir) {
+    private Handle(DoubleExemplarReservoir reservoir) {
       super(reservoir);
     }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleLastValueAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleLastValueAggregator.java
@@ -8,7 +8,7 @@ package io.opentelemetry.sdk.metrics.internal.aggregator;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableGaugeData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
@@ -34,7 +34,8 @@ import javax.annotation.concurrent.ThreadSafe;
  * at any time.
  */
 @ThreadSafe
-public final class DoubleLastValueAggregator implements Aggregator<DoubleAccumulation> {
+public final class DoubleLastValueAggregator
+    implements Aggregator<DoubleAccumulation, DoubleExemplarData> {
   private final Supplier<DoubleExemplarReservoir> reservoirSupplier;
 
   public DoubleLastValueAggregator(Supplier<DoubleExemplarReservoir> reservoirSupplier) {
@@ -42,7 +43,7 @@ public final class DoubleLastValueAggregator implements Aggregator<DoubleAccumul
   }
 
   @Override
-  public AggregatorHandle<DoubleAccumulation> createHandle() {
+  public AggregatorHandle<DoubleAccumulation, DoubleExemplarData> createHandle() {
     return new Handle(reservoirSupplier.get());
   }
 
@@ -83,7 +84,7 @@ public final class DoubleLastValueAggregator implements Aggregator<DoubleAccumul
                 epochNanos)));
   }
 
-  static final class Handle extends AggregatorHandle<DoubleAccumulation> {
+  static final class Handle extends AggregatorHandle<DoubleAccumulation, DoubleExemplarData> {
     @Nullable private static final Double DEFAULT_VALUE = null;
     private final AtomicReference<Double> current = new AtomicReference<>(DEFAULT_VALUE);
 
@@ -92,7 +93,7 @@ public final class DoubleLastValueAggregator implements Aggregator<DoubleAccumul
     }
 
     @Override
-    protected DoubleAccumulation doAccumulateThenReset(List<ExemplarData> exemplars) {
+    protected DoubleAccumulation doAccumulateThenReset(List<DoubleExemplarData> exemplars) {
       return DoubleAccumulation.create(this.current.getAndSet(DEFAULT_VALUE), exemplars);
     }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleSumAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleSumAggregator.java
@@ -9,7 +9,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.concurrent.AdderUtil;
 import io.opentelemetry.sdk.metrics.internal.concurrent.DoubleAdder;
@@ -29,7 +29,8 @@ import java.util.function.Supplier;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public final class DoubleSumAggregator extends AbstractSumAggregator<DoubleAccumulation> {
+public final class DoubleSumAggregator
+    extends AbstractSumAggregator<DoubleAccumulation, DoubleExemplarData> {
   private final Supplier<DoubleExemplarReservoir> reservoirSupplier;
 
   /**
@@ -39,14 +40,15 @@ public final class DoubleSumAggregator extends AbstractSumAggregator<DoubleAccum
    * @param reservoirSupplier Supplier of exemplar reservoirs per-stream.
    */
   public DoubleSumAggregator(
-      InstrumentDescriptor instrumentDescriptor, Supplier<DoubleExemplarReservoir> reservoirSupplier) {
+      InstrumentDescriptor instrumentDescriptor,
+      Supplier<DoubleExemplarReservoir> reservoirSupplier) {
     super(instrumentDescriptor);
 
     this.reservoirSupplier = reservoirSupplier;
   }
 
   @Override
-  public AggregatorHandle<DoubleAccumulation> createHandle() {
+  public AggregatorHandle<DoubleAccumulation, DoubleExemplarData> createHandle() {
     return new Handle(reservoirSupplier.get());
   }
 
@@ -97,7 +99,7 @@ public final class DoubleSumAggregator extends AbstractSumAggregator<DoubleAccum
                 epochNanos)));
   }
 
-  static final class Handle extends AggregatorHandle<DoubleAccumulation> {
+  static final class Handle extends AggregatorHandle<DoubleAccumulation, DoubleExemplarData> {
     private final DoubleAdder current = AdderUtil.createDoubleAdder();
 
     Handle(DoubleExemplarReservoir exemplarReservoir) {
@@ -105,7 +107,7 @@ public final class DoubleSumAggregator extends AbstractSumAggregator<DoubleAccum
     }
 
     @Override
-    protected DoubleAccumulation doAccumulateThenReset(List<ExemplarData> exemplars) {
+    protected DoubleAccumulation doAccumulateThenReset(List<DoubleExemplarData> exemplars) {
       return DoubleAccumulation.create(this.current.sumThenReset(), exemplars);
     }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleSumAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleSumAggregator.java
@@ -17,7 +17,7 @@ import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableSumData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
+import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +30,7 @@ import java.util.function.Supplier;
  * at any time.
  */
 public final class DoubleSumAggregator extends AbstractSumAggregator<DoubleAccumulation> {
-  private final Supplier<ExemplarReservoir> reservoirSupplier;
+  private final Supplier<DoubleExemplarReservoir> reservoirSupplier;
 
   /**
    * Constructs a sum aggregator.
@@ -39,7 +39,7 @@ public final class DoubleSumAggregator extends AbstractSumAggregator<DoubleAccum
    * @param reservoirSupplier Supplier of exemplar reservoirs per-stream.
    */
   public DoubleSumAggregator(
-      InstrumentDescriptor instrumentDescriptor, Supplier<ExemplarReservoir> reservoirSupplier) {
+      InstrumentDescriptor instrumentDescriptor, Supplier<DoubleExemplarReservoir> reservoirSupplier) {
     super(instrumentDescriptor);
 
     this.reservoirSupplier = reservoirSupplier;
@@ -100,7 +100,7 @@ public final class DoubleSumAggregator extends AbstractSumAggregator<DoubleAccum
   static final class Handle extends AggregatorHandle<DoubleAccumulation> {
     private final DoubleAdder current = AdderUtil.createDoubleAdder();
 
-    Handle(ExemplarReservoir exemplarReservoir) {
+    Handle(DoubleExemplarReservoir exemplarReservoir) {
       super(exemplarReservoir);
     }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DropAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DropAggregator.java
@@ -8,10 +8,10 @@ package io.opentelemetry.sdk.metrics.internal.aggregator;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
+import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.List;
 import java.util.Map;
@@ -22,14 +22,14 @@ import java.util.Map;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public final class DropAggregator implements Aggregator<Object> {
+public final class DropAggregator implements Aggregator<Object, DoubleExemplarData> {
 
   private static final Object ACCUMULATION = new Object();
 
-  public static final Aggregator<Object> INSTANCE = new DropAggregator();
+  public static final Aggregator<Object, DoubleExemplarData> INSTANCE = new DropAggregator();
 
-  private static final AggregatorHandle<Object> HANDLE =
-      new AggregatorHandle<Object>(ExemplarReservoir.noSamples()) {
+  private static final AggregatorHandle<Object, DoubleExemplarData> HANDLE =
+      new AggregatorHandle<Object, DoubleExemplarData>(DoubleExemplarReservoir.noSamples()) {
         @Override
         protected void doRecordLong(long value) {}
 
@@ -37,7 +37,7 @@ public final class DropAggregator implements Aggregator<Object> {
         protected void doRecordDouble(double value) {}
 
         @Override
-        protected Object doAccumulateThenReset(List<ExemplarData> exemplars) {
+        protected Object doAccumulateThenReset(List<DoubleExemplarData> exemplars) {
           return ACCUMULATION;
         }
       };
@@ -45,7 +45,7 @@ public final class DropAggregator implements Aggregator<Object> {
   private DropAggregator() {}
 
   @Override
-  public AggregatorHandle<Object> createHandle() {
+  public AggregatorHandle<Object, DoubleExemplarData> createHandle() {
     return HANDLE;
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/ExponentialHistogramAccumulation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/ExponentialHistogramAccumulation.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.metrics.internal.aggregator;
 
 import com.google.auto.value.AutoValue;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import java.util.List;
 import javax.annotation.Nonnull;
 
@@ -31,7 +31,7 @@ abstract class ExponentialHistogramAccumulation {
       @Nonnull DoubleExponentialHistogramBuckets positiveBuckets,
       @Nonnull DoubleExponentialHistogramBuckets negativeBuckets,
       long zeroCount,
-      List<ExemplarData> exemplars) {
+      List<DoubleExemplarData> exemplars) {
     return new AutoValue_ExponentialHistogramAccumulation(
         scale, sum, positiveBuckets, negativeBuckets, zeroCount, exemplars);
   }
@@ -46,5 +46,5 @@ abstract class ExponentialHistogramAccumulation {
 
   abstract long getZeroCount();
 
-  abstract List<ExemplarData> getExemplars();
+  abstract List<DoubleExemplarData> getExemplars();
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/HistogramAccumulation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/HistogramAccumulation.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.metrics.internal.aggregator;
 
 import com.google.auto.value.AutoValue;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
@@ -31,7 +31,7 @@ abstract class HistogramAccumulation {
       double min,
       double max,
       long[] counts,
-      List<ExemplarData> exemplars) {
+      List<DoubleExemplarData> exemplars) {
     return new AutoValue_HistogramAccumulation(sum, hasMinMax, min, max, counts, exemplars);
   }
 
@@ -69,5 +69,5 @@ abstract class HistogramAccumulation {
   abstract long[] getCounts();
 
   /** Exemplars accumulated during this period. */
-  abstract List<ExemplarData> getExemplars();
+  abstract List<DoubleExemplarData> getExemplars();
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongAccumulation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongAccumulation.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.metrics.internal.aggregator;
 
 import com.google.auto.value.AutoValue;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.LongExemplarData;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
@@ -16,7 +16,7 @@ import javax.annotation.concurrent.Immutable;
 @AutoValue
 abstract class LongAccumulation {
 
-  static LongAccumulation create(long value, List<ExemplarData> exemplars) {
+  static LongAccumulation create(long value, List<LongExemplarData> exemplars) {
     return new AutoValue_LongAccumulation(value, exemplars);
   }
 
@@ -30,5 +30,5 @@ abstract class LongAccumulation {
   abstract long getValue();
 
   /** Sampled measurements recorded during this accumulation. */
-  abstract List<ExemplarData> getExemplars();
+  abstract List<LongExemplarData> getExemplars();
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongLastValueAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongLastValueAggregator.java
@@ -13,7 +13,7 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableGaugeData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
+import io.opentelemetry.sdk.metrics.internal.exemplar.LongExemplarReservoir;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.List;
 import java.util.Map;
@@ -33,9 +33,9 @@ import javax.annotation.Nullable;
  * at any time.
  */
 public final class LongLastValueAggregator implements Aggregator<LongAccumulation> {
-  private final Supplier<ExemplarReservoir> reservoirSupplier;
+  private final Supplier<LongExemplarReservoir> reservoirSupplier;
 
-  public LongLastValueAggregator(Supplier<ExemplarReservoir> reservoirSupplier) {
+  public LongLastValueAggregator(Supplier<LongExemplarReservoir> reservoirSupplier) {
     this.reservoirSupplier = reservoirSupplier;
   }
 
@@ -84,7 +84,7 @@ public final class LongLastValueAggregator implements Aggregator<LongAccumulatio
     @Nullable private static final Long DEFAULT_VALUE = null;
     private final AtomicReference<Long> current = new AtomicReference<>(DEFAULT_VALUE);
 
-    Handle(ExemplarReservoir exemplarReservoir) {
+    Handle(LongExemplarReservoir exemplarReservoir) {
       super(exemplarReservoir);
     }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongLastValueAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongLastValueAggregator.java
@@ -8,7 +8,7 @@ package io.opentelemetry.sdk.metrics.internal.aggregator;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.LongExemplarData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableGaugeData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
@@ -32,7 +32,8 @@ import javax.annotation.Nullable;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public final class LongLastValueAggregator implements Aggregator<LongAccumulation> {
+public final class LongLastValueAggregator
+    implements Aggregator<LongAccumulation, LongExemplarData> {
   private final Supplier<LongExemplarReservoir> reservoirSupplier;
 
   public LongLastValueAggregator(Supplier<LongExemplarReservoir> reservoirSupplier) {
@@ -40,7 +41,7 @@ public final class LongLastValueAggregator implements Aggregator<LongAccumulatio
   }
 
   @Override
-  public AggregatorHandle<LongAccumulation> createHandle() {
+  public AggregatorHandle<LongAccumulation, LongExemplarData> createHandle() {
     return new Handle(reservoirSupplier.get());
   }
 
@@ -80,7 +81,7 @@ public final class LongLastValueAggregator implements Aggregator<LongAccumulatio
                 epochNanos)));
   }
 
-  static final class Handle extends AggregatorHandle<LongAccumulation> {
+  static final class Handle extends AggregatorHandle<LongAccumulation, LongExemplarData> {
     @Nullable private static final Long DEFAULT_VALUE = null;
     private final AtomicReference<Long> current = new AtomicReference<>(DEFAULT_VALUE);
 
@@ -89,7 +90,7 @@ public final class LongLastValueAggregator implements Aggregator<LongAccumulatio
     }
 
     @Override
-    protected LongAccumulation doAccumulateThenReset(List<ExemplarData> exemplars) {
+    protected LongAccumulation doAccumulateThenReset(List<LongExemplarData> exemplars) {
       return LongAccumulation.create(this.current.getAndSet(DEFAULT_VALUE), exemplars);
     }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongSumAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongSumAggregator.java
@@ -8,7 +8,7 @@ package io.opentelemetry.sdk.metrics.internal.aggregator;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.LongExemplarData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.concurrent.AdderUtil;
 import io.opentelemetry.sdk.metrics.internal.concurrent.LongAdder;
@@ -16,7 +16,7 @@ import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableSumData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
-import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
+import io.opentelemetry.sdk.metrics.internal.exemplar.LongExemplarReservoir;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.List;
 import java.util.Map;
@@ -28,18 +28,20 @@ import java.util.function.Supplier;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public final class LongSumAggregator extends AbstractSumAggregator<LongAccumulation> {
+public final class LongSumAggregator
+    extends AbstractSumAggregator<LongAccumulation, LongExemplarData> {
 
-  private final Supplier<DoubleExemplarReservoir> reservoirSupplier;
+  private final Supplier<LongExemplarReservoir> reservoirSupplier;
 
   public LongSumAggregator(
-      InstrumentDescriptor instrumentDescriptor, Supplier<DoubleExemplarReservoir> reservoirSupplier) {
+      InstrumentDescriptor instrumentDescriptor,
+      Supplier<LongExemplarReservoir> reservoirSupplier) {
     super(instrumentDescriptor);
     this.reservoirSupplier = reservoirSupplier;
   }
 
   @Override
-  public AggregatorHandle<LongAccumulation> createHandle() {
+  public AggregatorHandle<LongAccumulation, LongExemplarData> createHandle() {
     return new Handle(reservoirSupplier.get());
   }
 
@@ -84,15 +86,15 @@ public final class LongSumAggregator extends AbstractSumAggregator<LongAccumulat
                 epochNanos)));
   }
 
-  static final class Handle extends AggregatorHandle<LongAccumulation> {
+  static final class Handle extends AggregatorHandle<LongAccumulation, LongExemplarData> {
     private final LongAdder current = AdderUtil.createLongAdder();
 
-    Handle(DoubleExemplarReservoir exemplarReservoir) {
+    Handle(LongExemplarReservoir exemplarReservoir) {
       super(exemplarReservoir);
     }
 
     @Override
-    protected LongAccumulation doAccumulateThenReset(List<ExemplarData> exemplars) {
+    protected LongAccumulation doAccumulateThenReset(List<LongExemplarData> exemplars) {
       return LongAccumulation.create(this.current.sumThenReset(), exemplars);
     }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongSumAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongSumAggregator.java
@@ -16,7 +16,7 @@ import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableSumData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
+import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.List;
 import java.util.Map;
@@ -30,10 +30,10 @@ import java.util.function.Supplier;
  */
 public final class LongSumAggregator extends AbstractSumAggregator<LongAccumulation> {
 
-  private final Supplier<ExemplarReservoir> reservoirSupplier;
+  private final Supplier<DoubleExemplarReservoir> reservoirSupplier;
 
   public LongSumAggregator(
-      InstrumentDescriptor instrumentDescriptor, Supplier<ExemplarReservoir> reservoirSupplier) {
+      InstrumentDescriptor instrumentDescriptor, Supplier<DoubleExemplarReservoir> reservoirSupplier) {
     super(instrumentDescriptor);
     this.reservoirSupplier = reservoirSupplier;
   }
@@ -87,7 +87,7 @@ public final class LongSumAggregator extends AbstractSumAggregator<LongAccumulat
   static final class Handle extends AggregatorHandle<LongAccumulation> {
     private final LongAdder current = AdderUtil.createLongAdder();
 
-    Handle(ExemplarReservoir exemplarReservoir) {
+    Handle(DoubleExemplarReservoir exemplarReservoir) {
       super(exemplarReservoir);
     }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/ImmutableDoublePointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/ImmutableDoublePointData.java
@@ -7,8 +7,8 @@ package io.opentelemetry.sdk.metrics.internal.data;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.DoublePointData;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
@@ -55,9 +55,9 @@ public abstract class ImmutableDoublePointData implements DoublePointData {
       long epochNanos,
       Attributes attributes,
       double value,
-      List<ExemplarData> exemplars) {
+      List<DoubleExemplarData> exemplars) {
     return new AutoValue_ImmutableDoublePointData(
-        startEpochNanos, epochNanos, attributes, exemplars, value);
+        startEpochNanos, epochNanos, attributes, value, exemplars);
   }
 
   ImmutableDoublePointData() {}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/ImmutableHistogramPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/ImmutableHistogramPointData.java
@@ -8,7 +8,7 @@ package io.opentelemetry.sdk.metrics.internal.data;
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.internal.PrimitiveLongList;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.HistogramPointData;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -70,7 +70,7 @@ public abstract class ImmutableHistogramPointData implements HistogramPointData 
       @Nullable Double max,
       List<Double> boundaries,
       List<Long> counts,
-      List<ExemplarData> exemplars) {
+      List<DoubleExemplarData> exemplars) {
     if (counts.size() != boundaries.size() + 1) {
       throw new IllegalArgumentException(
           "invalid counts: size should be "
@@ -94,7 +94,6 @@ public abstract class ImmutableHistogramPointData implements HistogramPointData 
         startEpochNanos,
         epochNanos,
         attributes,
-        exemplars,
         sum,
         totalCount,
         min != null,
@@ -102,7 +101,8 @@ public abstract class ImmutableHistogramPointData implements HistogramPointData 
         max != null,
         max != null ? max : -1,
         Collections.unmodifiableList(new ArrayList<>(boundaries)),
-        Collections.unmodifiableList(new ArrayList<>(counts)));
+        Collections.unmodifiableList(new ArrayList<>(counts)),
+        exemplars);
   }
 
   ImmutableHistogramPointData() {}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/ImmutableLongPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/ImmutableLongPointData.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.metrics.internal.data;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.LongExemplarData;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
 import java.util.Collections;
 import java.util.List;
@@ -59,8 +59,8 @@ public abstract class ImmutableLongPointData implements LongPointData {
       long epochNanos,
       Attributes attributes,
       long value,
-      List<ExemplarData> exemplars) {
+      List<LongExemplarData> exemplars) {
     return new AutoValue_ImmutableLongPointData(
-        startEpochNanos, epochNanos, attributes, exemplars, value);
+        startEpochNanos, epochNanos, attributes, value, exemplars);
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/exponentialhistogram/ExponentialHistogramPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/exponentialhistogram/ExponentialHistogramPointData.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.metrics.internal.data.exponentialhistogram;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.PointData;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
@@ -42,7 +42,7 @@ public interface ExponentialHistogramPointData extends PointData {
       long startEpochNanos,
       long epochNanos,
       Attributes attributes,
-      List<ExemplarData> exemplars) {
+      List<DoubleExemplarData> exemplars) {
 
     return ImmutableExponentialHistogramPointData.create(
         scale,
@@ -103,4 +103,8 @@ public interface ExponentialHistogramPointData extends PointData {
    * @return the negative buckets.
    */
   ExponentialHistogramBuckets getNegativeBuckets();
+
+  /** List of exemplars collected from measurements that were used to form the data point. */
+  @Override
+  List<DoubleExemplarData> getExemplars();
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/exponentialhistogram/ImmutableExponentialHistogramPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/exponentialhistogram/ImmutableExponentialHistogramPointData.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.metrics.internal.data.exponentialhistogram;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
@@ -38,7 +38,7 @@ abstract class ImmutableExponentialHistogramPointData implements ExponentialHist
       long startEpochNanos,
       long epochNanos,
       Attributes attributes,
-      List<ExemplarData> exemplars) {
+      List<DoubleExemplarData> exemplars) {
 
     long count = zeroCount + positiveBuckets.getTotalCount() + negativeBuckets.getTotalCount();
 
@@ -83,5 +83,5 @@ abstract class ImmutableExponentialHistogramPointData implements ExponentialHist
   public abstract Attributes getAttributes();
 
   @Override
-  public abstract List<ExemplarData> getExemplars();
+  public abstract List<DoubleExemplarData> getExemplars();
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/AbstractFixedSizeExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/AbstractFixedSizeExemplarReservoir.java
@@ -11,6 +11,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.Clock;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoubleExemplarData;
 import java.util.ArrayList;
@@ -24,9 +25,9 @@ import javax.annotation.Nullable;
  *
  * <p>Additionally this implementation ONLY exports double valued exemplars.
  */
-abstract class AbstractFixedSizeExemplarReservoir implements ExemplarReservoir {
+abstract class AbstractFixedSizeExemplarReservoir implements DoubleExemplarReservoir {
   private final Clock clock;
-  private final ReservoirCell[] storage;
+  private final DoubleReservoirCell[] storage;
 
   /**
    * Instantiates an exemplar reservoir of fixed size.
@@ -36,9 +37,9 @@ abstract class AbstractFixedSizeExemplarReservoir implements ExemplarReservoir {
    */
   AbstractFixedSizeExemplarReservoir(Clock clock, int size) {
     this.clock = clock;
-    this.storage = new ReservoirCell[size];
+    this.storage = new DoubleReservoirCell[size];
     for (int i = 0; i < size; ++i) {
-      this.storage[i] = new ReservoirCell();
+      this.storage[i] = new DoubleReservoirCell();
     }
   }
 
@@ -70,12 +71,12 @@ abstract class AbstractFixedSizeExemplarReservoir implements ExemplarReservoir {
   }
 
   @Override
-  public final List<ExemplarData> collectAndReset(Attributes pointAttributes) {
+  public final List<DoubleExemplarData> collectAndReset(Attributes pointAttributes) {
     // Note: we are collecting exemplars from buckets piecemeal, but we
     // could still be sampling exemplars during this process.
-    List<ExemplarData> results = new ArrayList<>();
-    for (ReservoirCell reservoirCell : this.storage) {
-      ExemplarData result = reservoirCell.getAndReset(pointAttributes);
+    List<DoubleExemplarData> results = new ArrayList<>();
+    for (DoubleReservoirCell reservoirCell : this.storage) {
+      DoubleExemplarData result = reservoirCell.getAndReset(pointAttributes);
       if (result != null) {
         results.add(result);
       }
@@ -92,7 +93,7 @@ abstract class AbstractFixedSizeExemplarReservoir implements ExemplarReservoir {
    *
    * <p>Allocations are acceptable in the {@link #getAndReset(Attributes)} method.
    */
-  private class ReservoirCell {
+  private class DoubleReservoirCell {
     private double value;
     @Nullable private Attributes attributes;
     private SpanContext spanContext = SpanContext.getInvalid();
@@ -114,7 +115,7 @@ abstract class AbstractFixedSizeExemplarReservoir implements ExemplarReservoir {
     }
 
     @Nullable
-    synchronized ExemplarData getAndReset(Attributes pointAttributes) {
+    synchronized DoubleExemplarData getAndReset(Attributes pointAttributes) {
       Attributes attributes = this.attributes;
       if (attributes != null) {
         ExemplarData result =

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/DoubleExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/DoubleExemplarReservoir.java
@@ -23,6 +23,11 @@ import java.util.function.Supplier;
  */
 public interface DoubleExemplarReservoir extends ExemplarReservoir<DoubleExemplarData> {
 
+  /** An exemplar reservoir that stores no exemplars. */
+  static DoubleExemplarReservoir noSamples() {
+    return NoopDoubleExemplarReservoir.INSTANCE;
+  }
+
   /** Wraps a {@link DoubleExemplarReservoir} with a measurement pre-filter. */
   static DoubleExemplarReservoir filtered(ExemplarFilter filter, DoubleExemplarReservoir original) {
     // Optimisation on memory usage.
@@ -41,7 +46,7 @@ public interface DoubleExemplarReservoir extends ExemplarReservoir<DoubleExempla
    */
   static DoubleExemplarReservoir fixedSizeReservoir(
       Clock clock, int size, Supplier<Random> randomSupplier) {
-    return new FixedSizeExemplarReservoir(clock, size, randomSupplier);
+    return new DoubleFixedSizeExemplarReservoir(clock, size, randomSupplier);
   }
 
   /**

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/DoubleExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/DoubleExemplarReservoir.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.internal.exemplar;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.Clock;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Supplier;
+
+/**
+ * An interface for an exemplar reservoir of samples.
+ *
+ * <p>This represents a reservoir for a specific "point" of metric data.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public interface DoubleExemplarReservoir extends ExemplarReservoir<DoubleExemplarData> {
+
+  /** Wraps a {@link DoubleExemplarReservoir} with a measurement pre-filter. */
+  static DoubleExemplarReservoir filtered(ExemplarFilter filter, DoubleExemplarReservoir original) {
+    // Optimisation on memory usage.
+    if (filter == ExemplarFilter.neverSample()) {
+      return NoopDoubleExemplarReservoir.INSTANCE;
+    }
+    return new FilteredDoubleExemplarReservoir(filter, original);
+  }
+
+  /**
+   * A Reservoir sampler with fixed size that stores the given number of exemplars.
+   *
+   * @param clock The clock to use when annotating measurements with time.
+   * @param size The maximum number of exemplars to preserve.
+   * @param randomSupplier The random number generater to use for sampling.
+   */
+  static DoubleExemplarReservoir fixedSizeReservoir(
+      Clock clock, int size, Supplier<Random> randomSupplier) {
+    return new FixedSizeExemplarReservoir(clock, size, randomSupplier);
+  }
+
+  /**
+   * A Reservoir sampler that preserves the latest seen measurement per-histogram bucket.
+   *
+   * @param clock The clock to use when annotating measurements with time.
+   * @param boundaries A list of (inclusive) upper bounds for the histogram. Should be in order from
+   *     lowest to highest.
+   */
+  static DoubleExemplarReservoir histogramBucketReservoir(Clock clock, List<Double> boundaries) {
+    return HistogramBucketExemplarReservoir.create(clock, boundaries);
+  }
+
+  /** Offers a {@code double} measurement to be sampled. */
+  void offerMeasurement(double value, Attributes attributes, Context context);
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/DoubleFixedSizeExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/DoubleFixedSizeExemplarReservoir.java
@@ -22,7 +22,7 @@ import java.util.function.Supplier;
  *
  * <p>Additionally this implementation ONLY exports double valued exemplars.
  */
-final class FixedSizeExemplarReservoir extends AbstractFixedSizeExemplarReservoir {
+final class DoubleFixedSizeExemplarReservoir extends AbstractDoubleFixedSizeExemplarReservoir {
   private final Supplier<Random> randomSupplier;
   private final LongAdder numMeasurements = AdderUtil.createLongAdder();
 
@@ -33,7 +33,7 @@ final class FixedSizeExemplarReservoir extends AbstractFixedSizeExemplarReservoi
    * @param size The number of exemplars to preserve.
    * @param randomSupplier The random number generator to use for sampling.
    */
-  FixedSizeExemplarReservoir(Clock clock, int size, Supplier<Random> randomSupplier) {
+  DoubleFixedSizeExemplarReservoir(Clock clock, int size, Supplier<Random> randomSupplier) {
     super(clock, size);
     this.randomSupplier = randomSupplier;
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ExemplarReservoir.java
@@ -1,73 +1,20 @@
-/*
- * Copyright The OpenTelemetry Authors
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package io.opentelemetry.sdk.metrics.internal.exemplar;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.context.Context;
-import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import java.util.List;
-import java.util.Random;
-import java.util.function.Supplier;
 
-/**
- * An interface for an exemplar reservoir of samples.
- *
- * <p>This represents a reservoir for a specific "point" of metric data.
- *
- * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
- * at any time.
- */
-public interface ExemplarReservoir {
+public interface ExemplarReservoir<T extends ExemplarData> {
 
   /** An exemplar reservoir that stores no exemplars. */
-  static ExemplarReservoir noSamples() {
-    return NoExemplarReservoir.INSTANCE;
-  }
-
-  /** Wraps a {@link ExemplarReservoir} with a measurement pre-filter. */
-  static ExemplarReservoir filtered(ExemplarFilter filter, ExemplarReservoir original) {
-    // Optimisation on memory usage.
-    if (filter == ExemplarFilter.neverSample()) {
-      return ExemplarReservoir.noSamples();
-    }
-    return new FilteredExemplarReservoir(filter, original);
+  // Empty reservoir so the concrete type does not matter.
+  @SuppressWarnings("unchecked")
+  static <T extends ExemplarData> ExemplarReservoir<T> noSamples() {
+    return (ExemplarReservoir<T>) NoopDoubleExemplarReservoir.INSTANCE;
   }
 
   /**
-   * A Reservoir sampler with fixed size that stores the given number of exemplars.
-   *
-   * @param clock The clock to use when annotating measurements with time.
-   * @param size The maximum number of exemplars to preserve.
-   * @param randomSupplier The random number generater to use for sampling.
-   */
-  static ExemplarReservoir fixedSizeReservoir(
-      Clock clock, int size, Supplier<Random> randomSupplier) {
-    return new FixedSizeExemplarReservoir(clock, size, randomSupplier);
-  }
-
-  /**
-   * A Reservoir sampler that preserves the latest seen measurement per-histogram bucket.
-   *
-   * @param clock The clock to use when annotating measurements with time.
-   * @param boundaries A list of (inclusive) upper bounds for the histogram. Should be in order from
-   *     lowest to highest.
-   */
-  static ExemplarReservoir histogramBucketReservoir(Clock clock, List<Double> boundaries) {
-    return HistogramBucketExemplarReservoir.create(clock, boundaries);
-  }
-
-  /** Offers a {@code long} measurement to be sampled. */
-  void offerMeasurement(long value, Attributes attributes, Context context);
-
-  /** Offers a {@code double} measurement to be sampled. */
-  void offerMeasurement(double value, Attributes attributes, Context context);
-
-  /**
-   * Builds (an immutable) list of Exemplars for exporting from the current reservoir.
+   * Returns an immutable list of Exemplars for exporting from the current reservoir.
    *
    * <p>Additionally, clears the reservoir for the next sampling period.
    *
@@ -76,5 +23,5 @@ public interface ExemplarReservoir {
    * @return An (immutable) list of sampled exemplars for this point. Implementers are expected to
    *     filter out {@code pointAttributes} from the original recorded attributes.
    */
-  List<ExemplarData> collectAndReset(Attributes pointAttributes);
+  List<T> collectAndReset(Attributes pointAttributes);
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ExemplarReservoir.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.sdk.metrics.internal.exemplar;
 
 import io.opentelemetry.api.common.Attributes;
@@ -5,13 +10,6 @@ import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import java.util.List;
 
 public interface ExemplarReservoir<T extends ExemplarData> {
-
-  /** An exemplar reservoir that stores no exemplars. */
-  // Empty reservoir so the concrete type does not matter.
-  @SuppressWarnings("unchecked")
-  static <T extends ExemplarData> ExemplarReservoir<T> noSamples() {
-    return (ExemplarReservoir<T>) NoopDoubleExemplarReservoir.INSTANCE;
-  }
 
   /**
    * Returns an immutable list of Exemplars for exporting from the current reservoir.

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/FilteredDoubleExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/FilteredDoubleExemplarReservoir.java
@@ -7,24 +7,17 @@ package io.opentelemetry.sdk.metrics.internal.exemplar;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import java.util.List;
 
 /** Implementation of a reservoir that has a pre-filter on measurements. */
-class FilteredExemplarReservoir implements ExemplarReservoir {
+class FilteredDoubleExemplarReservoir implements DoubleExemplarReservoir {
   private final ExemplarFilter filter;
-  private final ExemplarReservoir reservoir;
+  private final DoubleExemplarReservoir reservoir;
 
-  FilteredExemplarReservoir(ExemplarFilter filter, ExemplarReservoir reservoir) {
+  FilteredDoubleExemplarReservoir(ExemplarFilter filter, DoubleExemplarReservoir reservoir) {
     this.filter = filter;
     this.reservoir = reservoir;
-  }
-
-  @Override
-  public void offerMeasurement(long value, Attributes attributes, Context context) {
-    if (filter.shouldSampleMeasurement(value, attributes, context)) {
-      reservoir.offerMeasurement(value, attributes, context);
-    }
   }
 
   @Override
@@ -35,7 +28,7 @@ class FilteredExemplarReservoir implements ExemplarReservoir {
   }
 
   @Override
-  public List<ExemplarData> collectAndReset(Attributes pointAttributes) {
+  public List<DoubleExemplarData> collectAndReset(Attributes pointAttributes) {
     return reservoir.collectAndReset(pointAttributes);
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/FilteredLongExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/FilteredLongExemplarReservoir.java
@@ -8,7 +8,6 @@ package io.opentelemetry.sdk.metrics.internal.exemplar;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.metrics.data.LongExemplarData;
-
 import java.util.List;
 
 /** Implementation of a reservoir that has a pre-filter on measurements. */

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/FilteredLongExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/FilteredLongExemplarReservoir.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.internal.exemplar;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.metrics.data.LongExemplarData;
+
+import java.util.List;
+
+/** Implementation of a reservoir that has a pre-filter on measurements. */
+class FilteredLongExemplarReservoir implements LongExemplarReservoir {
+  private final ExemplarFilter filter;
+  private final LongExemplarReservoir reservoir;
+
+  FilteredLongExemplarReservoir(ExemplarFilter filter, LongExemplarReservoir reservoir) {
+    this.filter = filter;
+    this.reservoir = reservoir;
+  }
+
+  @Override
+  public void offerMeasurement(long value, Attributes attributes, Context context) {
+    if (filter.shouldSampleMeasurement(value, attributes, context)) {
+      reservoir.offerMeasurement(value, attributes, context);
+    }
+  }
+
+  @Override
+  public List<LongExemplarData> collectAndReset(Attributes pointAttributes) {
+    return reservoir.collectAndReset(pointAttributes);
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/HistogramBucketExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/HistogramBucketExemplarReservoir.java
@@ -12,7 +12,7 @@ import io.opentelemetry.sdk.metrics.internal.aggregator.ExplicitBucketHistogramU
 import java.util.List;
 
 /** A Reservoir sampler that preserves the latest seen measurement per-histogram bucket. */
-final class HistogramBucketExemplarReservoir extends AbstractFixedSizeExemplarReservoir {
+final class HistogramBucketExemplarReservoir extends AbstractDoubleFixedSizeExemplarReservoir {
   private final double[] boundaries;
 
   /** Constructs a new histogram bucket exemplar reservoir using standard configuration. */

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/LongExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/LongExemplarReservoir.java
@@ -9,7 +9,6 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.metrics.data.LongExemplarData;
-import java.util.List;
 import java.util.Random;
 import java.util.function.Supplier;
 
@@ -22,6 +21,11 @@ import java.util.function.Supplier;
  * at any time.
  */
 public interface LongExemplarReservoir extends ExemplarReservoir<LongExemplarData> {
+
+  /** An exemplar reservoir that stores no exemplars. */
+  static LongExemplarReservoir noSamples() {
+    return NoopLongExemplarReservoir.INSTANCE;
+  }
 
   /** Wraps a {@link LongExemplarReservoir} with a measurement pre-filter. */
   static LongExemplarReservoir filtered(ExemplarFilter filter, LongExemplarReservoir original) {
@@ -41,18 +45,7 @@ public interface LongExemplarReservoir extends ExemplarReservoir<LongExemplarDat
    */
   static LongExemplarReservoir fixedSizeReservoir(
       Clock clock, int size, Supplier<Random> randomSupplier) {
-    return new FixedSizeExemplarReservoir(clock, size, randomSupplier);
-  }
-
-  /**
-   * A Reservoir sampler that preserves the latest seen measurement per-histogram bucket.
-   *
-   * @param clock The clock to use when annotating measurements with time.
-   * @param boundaries A list of (inclusive) upper bounds for the histogram. Should be in order from
-   *     lowest to highest.
-   */
-  static LongExemplarReservoir histogramBucketReservoir(Clock clock, List<Double> boundaries) {
-    return HistogramBucketExemplarReservoir.create(clock, boundaries);
+    return new LongFixedSizeExemplarReservoir(clock, size, randomSupplier);
   }
 
   /** Offers a {@code long} measurement to be sampled. */

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/LongExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/LongExemplarReservoir.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.internal.exemplar;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.Clock;
+import io.opentelemetry.sdk.metrics.data.LongExemplarData;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Supplier;
+
+/**
+ * An interface for an exemplar reservoir of samples.
+ *
+ * <p>This represents a reservoir for a specific "point" of metric data.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public interface LongExemplarReservoir extends ExemplarReservoir<LongExemplarData> {
+
+  /** Wraps a {@link LongExemplarReservoir} with a measurement pre-filter. */
+  static LongExemplarReservoir filtered(ExemplarFilter filter, LongExemplarReservoir original) {
+    // Optimisation on memory usage.
+    if (filter == ExemplarFilter.neverSample()) {
+      return NoopLongExemplarReservoir.INSTANCE;
+    }
+    return new FilteredLongExemplarReservoir(filter, original);
+  }
+
+  /**
+   * A Reservoir sampler with fixed size that stores the given number of exemplars.
+   *
+   * @param clock The clock to use when annotating measurements with time.
+   * @param size The maximum number of exemplars to preserve.
+   * @param randomSupplier The random number generater to use for sampling.
+   */
+  static LongExemplarReservoir fixedSizeReservoir(
+      Clock clock, int size, Supplier<Random> randomSupplier) {
+    return new FixedSizeExemplarReservoir(clock, size, randomSupplier);
+  }
+
+  /**
+   * A Reservoir sampler that preserves the latest seen measurement per-histogram bucket.
+   *
+   * @param clock The clock to use when annotating measurements with time.
+   * @param boundaries A list of (inclusive) upper bounds for the histogram. Should be in order from
+   *     lowest to highest.
+   */
+  static LongExemplarReservoir histogramBucketReservoir(Clock clock, List<Double> boundaries) {
+    return HistogramBucketExemplarReservoir.create(clock, boundaries);
+  }
+
+  /** Offers a {@code long} measurement to be sampled. */
+  void offerMeasurement(long value, Attributes attributes, Context context);
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/LongFixedSizeExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/LongFixedSizeExemplarReservoir.java
@@ -84,6 +84,7 @@ final class LongFixedSizeExemplarReservoir implements LongExemplarReservoir {
         results.add(result);
       }
     }
+    numMeasurements.reset();
     return Collections.unmodifiableList(results);
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/NoopDoubleExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/NoopDoubleExemplarReservoir.java
@@ -7,21 +7,16 @@ package io.opentelemetry.sdk.metrics.internal.exemplar;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import java.util.Collections;
 import java.util.List;
 
 /** Implementation of a reservoir that keeps no exemplars. */
-class NoExemplarReservoir implements ExemplarReservoir {
+class NoopDoubleExemplarReservoir implements DoubleExemplarReservoir {
 
-  static final ExemplarReservoir INSTANCE = new NoExemplarReservoir();
+  static final NoopDoubleExemplarReservoir INSTANCE = new NoopDoubleExemplarReservoir();
 
-  private NoExemplarReservoir() {}
-
-  @Override
-  public void offerMeasurement(long value, Attributes attributes, Context context) {
-    // Stores nothing
-  }
+  private NoopDoubleExemplarReservoir() {}
 
   @Override
   public void offerMeasurement(double value, Attributes attributes, Context context) {
@@ -29,7 +24,7 @@ class NoExemplarReservoir implements ExemplarReservoir {
   }
 
   @Override
-  public List<ExemplarData> collectAndReset(Attributes pointAttributes) {
+  public List<DoubleExemplarData> collectAndReset(Attributes pointAttributes) {
     return Collections.emptyList();
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/NoopLongExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/NoopLongExemplarReservoir.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.internal.exemplar;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.metrics.data.LongExemplarData;
+
+import java.util.Collections;
+import java.util.List;
+
+/** Implementation of a reservoir that keeps no exemplars. */
+class NoopLongExemplarReservoir implements LongExemplarReservoir {
+
+  static final NoopLongExemplarReservoir INSTANCE = new NoopLongExemplarReservoir();
+
+  private NoopLongExemplarReservoir() {}
+
+  @Override
+  public void offerMeasurement(long value, Attributes attributes, Context context) {
+    // Stores nothing.
+  }
+
+  @Override
+  public List<LongExemplarData> collectAndReset(Attributes pointAttributes) {
+    return Collections.emptyList();
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/NoopLongExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/NoopLongExemplarReservoir.java
@@ -8,7 +8,6 @@ package io.opentelemetry.sdk.metrics.internal.exemplar;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.metrics.data.LongExemplarData;
-
 import java.util.Collections;
 import java.util.List;
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorage.java
@@ -13,6 +13,7 @@ import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.internal.ThrottlingLogger;
 import io.opentelemetry.sdk.metrics.View;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
@@ -34,19 +35,19 @@ import java.util.logging.Logger;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-final class AsynchronousMetricStorage<T> implements MetricStorage {
+final class AsynchronousMetricStorage<T, U extends ExemplarData> implements MetricStorage {
   private static final Logger logger = Logger.getLogger(AsynchronousMetricStorage.class.getName());
 
   private final ThrottlingLogger throttlingLogger = new ThrottlingLogger(logger);
   private final MetricDescriptor metricDescriptor;
-  private final TemporalMetricStorage<T> metricStorage;
-  private final Aggregator<T> aggregator;
+  private final TemporalMetricStorage<T, U> metricStorage;
+  private final Aggregator<T, U> aggregator;
   private final AttributesProcessor attributesProcessor;
   private Map<Attributes, T> accumulations = new HashMap<>();
 
   private AsynchronousMetricStorage(
       MetricDescriptor metricDescriptor,
-      Aggregator<T> aggregator,
+      Aggregator<T, U> aggregator,
       AttributesProcessor attributesProcessor) {
     this.metricDescriptor = metricDescriptor;
     this.metricStorage = new TemporalMetricStorage<>(aggregator, /* isSynchronous= */ false);
@@ -57,12 +58,13 @@ final class AsynchronousMetricStorage<T> implements MetricStorage {
   /**
    * Create an asynchronous storage instance for the {@link View} and {@link InstrumentDescriptor}.
    */
-  static <T> AsynchronousMetricStorage<T> create(
+  // TODO(anuraaga): The cast to generic type here looks suspicious.
+  static <T, U extends ExemplarData> AsynchronousMetricStorage<T, U> create(
       RegisteredView registeredView, InstrumentDescriptor instrumentDescriptor) {
     View view = registeredView.getView();
     MetricDescriptor metricDescriptor =
         MetricDescriptor.create(view, registeredView.getViewSourceInfo(), instrumentDescriptor);
-    Aggregator<T> aggregator =
+    Aggregator<T, U> aggregator =
         ((AggregatorFactory) view.getAggregation())
             .createAggregator(instrumentDescriptor, ExemplarFilter.neverSample());
     return new AsynchronousMetricStorage<>(

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/CallbackRegistration.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/CallbackRegistration.java
@@ -36,7 +36,7 @@ public class CallbackRegistration<T> {
       InstrumentDescriptor instrumentDescriptor,
       Consumer<T> callback,
       T measurement,
-      List<AsynchronousMetricStorage<?>> storages) {
+      List<AsynchronousMetricStorage<?, ?>> storages) {
     this.instrumentDescriptor = instrumentDescriptor;
     this.callback = callback;
     this.measurement = measurement;
@@ -47,7 +47,7 @@ public class CallbackRegistration<T> {
   public static CallbackRegistration<ObservableDoubleMeasurement> createDouble(
       InstrumentDescriptor instrumentDescriptor,
       Consumer<ObservableDoubleMeasurement> callback,
-      List<AsynchronousMetricStorage<?>> asyncMetricStorages) {
+      List<AsynchronousMetricStorage<?, ?>> asyncMetricStorages) {
     ObservableDoubleMeasurement measurement =
         new ObservableDoubleMeasurementImpl(asyncMetricStorages);
     return new CallbackRegistration<>(
@@ -58,7 +58,7 @@ public class CallbackRegistration<T> {
   public static CallbackRegistration<ObservableLongMeasurement> createLong(
       InstrumentDescriptor instrumentDescriptor,
       Consumer<ObservableLongMeasurement> callback,
-      List<AsynchronousMetricStorage<?>> asyncMetricStorages) {
+      List<AsynchronousMetricStorage<?, ?>> asyncMetricStorages) {
     ObservableLongMeasurement measurement = new ObservableLongMeasurementImpl(asyncMetricStorages);
     return new CallbackRegistration<>(
         instrumentDescriptor, callback, measurement, asyncMetricStorages);
@@ -88,10 +88,10 @@ public class CallbackRegistration<T> {
 
   private static class ObservableDoubleMeasurementImpl implements ObservableDoubleMeasurement {
 
-    private final List<AsynchronousMetricStorage<?>> asyncMetricStorages;
+    private final List<AsynchronousMetricStorage<?, ?>> asyncMetricStorages;
 
     private ObservableDoubleMeasurementImpl(
-        List<AsynchronousMetricStorage<?>> asyncMetricStorages) {
+        List<AsynchronousMetricStorage<?, ?>> asyncMetricStorages) {
       this.asyncMetricStorages = asyncMetricStorages;
     }
 
@@ -102,7 +102,7 @@ public class CallbackRegistration<T> {
 
     @Override
     public void record(double value, Attributes attributes) {
-      for (AsynchronousMetricStorage<?> asyncMetricStorage : asyncMetricStorages) {
+      for (AsynchronousMetricStorage<?, ?> asyncMetricStorage : asyncMetricStorages) {
         asyncMetricStorage.recordDouble(value, attributes);
       }
     }
@@ -110,9 +110,10 @@ public class CallbackRegistration<T> {
 
   private static class ObservableLongMeasurementImpl implements ObservableLongMeasurement {
 
-    private final List<AsynchronousMetricStorage<?>> asyncMetricStorages;
+    private final List<AsynchronousMetricStorage<?, ?>> asyncMetricStorages;
 
-    private ObservableLongMeasurementImpl(List<AsynchronousMetricStorage<?>> asyncMetricStorages) {
+    private ObservableLongMeasurementImpl(
+        List<AsynchronousMetricStorage<?, ?>> asyncMetricStorages) {
       this.asyncMetricStorages = asyncMetricStorages;
     }
 
@@ -123,7 +124,7 @@ public class CallbackRegistration<T> {
 
     @Override
     public void record(long value, Attributes attributes) {
-      for (AsynchronousMetricStorage<?> asyncMetricStorage : asyncMetricStorages) {
+      for (AsynchronousMetricStorage<?, ?> asyncMetricStorage : asyncMetricStorages) {
         asyncMetricStorage.recordLong(value, attributes);
       }
     }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
@@ -24,15 +25,16 @@ import java.util.Objects;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public final class DefaultSynchronousMetricStorage<T> implements SynchronousMetricStorage {
+public final class DefaultSynchronousMetricStorage<T, U extends ExemplarData>
+    implements SynchronousMetricStorage {
   private final MetricDescriptor metricDescriptor;
-  private final DeltaMetricStorage<T> deltaMetricStorage;
-  private final TemporalMetricStorage<T> temporalMetricStorage;
+  private final DeltaMetricStorage<T, U> deltaMetricStorage;
+  private final TemporalMetricStorage<T, U> temporalMetricStorage;
   private final AttributesProcessor attributesProcessor;
 
   DefaultSynchronousMetricStorage(
       MetricDescriptor metricDescriptor,
-      Aggregator<T> aggregator,
+      Aggregator<T, U> aggregator,
       AttributesProcessor attributesProcessor) {
     this.attributesProcessor = attributesProcessor;
     this.metricDescriptor = metricDescriptor;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MeterSharedState.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MeterSharedState.java
@@ -147,7 +147,7 @@ public class MeterSharedState {
       InstrumentDescriptor instrument,
       MeterProviderSharedState meterProviderSharedState,
       Consumer<ObservableLongMeasurement> callback) {
-    List<AsynchronousMetricStorage<?>> registeredStorages =
+    List<AsynchronousMetricStorage<?, ?>> registeredStorages =
         registerAsynchronousInstrument(instrument, meterProviderSharedState);
 
     CallbackRegistration<ObservableLongMeasurement> registration =
@@ -170,7 +170,7 @@ public class MeterSharedState {
           InstrumentDescriptor instrument,
           MeterProviderSharedState meterProviderSharedState,
           Consumer<ObservableDoubleMeasurement> callback) {
-    List<AsynchronousMetricStorage<?>> registeredStorages =
+    List<AsynchronousMetricStorage<?, ?>> registeredStorages =
         registerAsynchronousInstrument(instrument, meterProviderSharedState);
 
     CallbackRegistration<ObservableDoubleMeasurement> registration =
@@ -181,10 +181,10 @@ public class MeterSharedState {
     return registration;
   }
 
-  private List<AsynchronousMetricStorage<?>> registerAsynchronousInstrument(
+  private List<AsynchronousMetricStorage<?, ?>> registerAsynchronousInstrument(
       InstrumentDescriptor instrumentDescriptor,
       MeterProviderSharedState meterProviderSharedState) {
-    List<AsynchronousMetricStorage<?>> storages =
+    List<AsynchronousMetricStorage<?, ?>> storages =
         meterProviderSharedState
             .getViewRegistry()
             .findViews(instrumentDescriptor, getInstrumentationScopeInfo())
@@ -193,8 +193,8 @@ public class MeterSharedState {
             .filter(storage -> !storage.isEmpty())
             .collect(toList());
 
-    List<AsynchronousMetricStorage<?>> registeredStorages = new ArrayList<>(storages.size());
-    for (AsynchronousMetricStorage<?> storage : storages) {
+    List<AsynchronousMetricStorage<?, ?>> registeredStorages = new ArrayList<>(storages.size());
+    for (AsynchronousMetricStorage<?, ?> storage : storages) {
       registeredStorages.add(getMetricStorageRegistry().register(storage));
     }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageUtils.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageUtils.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.metrics.internal.state;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -23,8 +24,8 @@ final class MetricStorageUtils {
    *
    * <p>Note: This mutates the result map.
    */
-  static <T> void mergeInPlace(
-      Map<Attributes, T> result, Map<Attributes, T> toMerge, Aggregator<T> aggregator) {
+  static <T, U extends ExemplarData> void mergeInPlace(
+      Map<Attributes, T> result, Map<Attributes, T> toMerge, Aggregator<T, U> aggregator) {
     blend(result, toMerge, /* preserve= */ false, aggregator::merge);
   }
 
@@ -34,8 +35,8 @@ final class MetricStorageUtils {
    *
    * <p>Note: This mutates the result map.
    */
-  static <T> void mergeAndPreserveInPlace(
-      Map<Attributes, T> result, Map<Attributes, T> toMerge, Aggregator<T> aggregator) {
+  static <T, U extends ExemplarData> void mergeAndPreserveInPlace(
+      Map<Attributes, T> result, Map<Attributes, T> toMerge, Aggregator<T, U> aggregator) {
     blend(result, toMerge, /* preserve= */ true, aggregator::merge);
   }
 
@@ -47,8 +48,8 @@ final class MetricStorageUtils {
    *
    * <p>Note: This mutates the result map.
    */
-  static <T> void diffInPlace(
-      Map<Attributes, T> result, Map<Attributes, T> toDiff, Aggregator<T> aggregator) {
+  static <T, U extends ExemplarData> void diffInPlace(
+      Map<Attributes, T> result, Map<Attributes, T> toDiff, Aggregator<T, U> aggregator) {
     blend(result, toDiff, /* preserve= */ false, aggregator::diff);
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorage.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.metrics.internal.state;
 
 import io.opentelemetry.sdk.metrics.View;
+import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
@@ -33,14 +34,14 @@ public interface SynchronousMetricStorage extends MetricStorage, WriteableMetric
    * @return The storage, or {@link EmptyMetricStorage#empty()} if the instrument should not be
    *     recorded.
    */
-  static <T> SynchronousMetricStorage create(
+  static <T, U extends ExemplarData> SynchronousMetricStorage create(
       RegisteredView registeredView,
       InstrumentDescriptor instrumentDescriptor,
       ExemplarFilter exemplarFilter) {
     View view = registeredView.getView();
     MetricDescriptor metricDescriptor =
         MetricDescriptor.create(view, registeredView.getViewSourceInfo(), instrumentDescriptor);
-    Aggregator<T> aggregator =
+    Aggregator<T, U> aggregator =
         ((AggregatorFactory) view.getAggregation())
             .createAggregator(instrumentDescriptor, exemplarFilter);
     // We won't be storing this metric.

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorage.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.metrics.internal.state;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.EmptyMetricData;
@@ -20,12 +21,12 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /** Stores last reported time and (optional) accumulation for metrics. */
 @ThreadSafe
-class TemporalMetricStorage<T> {
-  private final Aggregator<T> aggregator;
+class TemporalMetricStorage<T, U extends ExemplarData> {
+  private final Aggregator<T, U> aggregator;
   private final boolean isSynchronous;
   private final Map<CollectionHandle, LastReportedAccumulation<T>> reportHistory = new HashMap<>();
 
-  TemporalMetricStorage(Aggregator<T> aggregator, boolean isSynchronous) {
+  TemporalMetricStorage(Aggregator<T, U> aggregator, boolean isSynchronous) {
     this.aggregator = aggregator;
     this.isSynchronous = isSynchronous;
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/DefaultAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/DefaultAggregation.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.metrics.internal.view;
 
 import io.opentelemetry.sdk.internal.ThrottlingLogger;
 import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
@@ -50,7 +51,7 @@ public final class DefaultAggregation implements Aggregation, AggregatorFactory 
   }
 
   @Override
-  public <T> Aggregator<T> createAggregator(
+  public <T, U extends ExemplarData> Aggregator<T, U> createAggregator(
       InstrumentDescriptor instrumentDescriptor, ExemplarFilter exemplarFilter) {
     return ((AggregatorFactory) resolve(instrumentDescriptor))
         .createAggregator(instrumentDescriptor, exemplarFilter);

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/DropAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/DropAggregation.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.metrics.internal.view;
 
 import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
@@ -29,9 +30,9 @@ public final class DropAggregation implements Aggregation, AggregatorFactory {
 
   @Override
   @SuppressWarnings("unchecked")
-  public <T> Aggregator<T> createAggregator(
+  public <T, U extends ExemplarData> Aggregator<T, U> createAggregator(
       InstrumentDescriptor instrumentDescriptor, ExemplarFilter exemplarFilter) {
-    return (Aggregator<T>) Aggregator.drop();
+    return (Aggregator<T, U>) Aggregator.drop();
   }
 
   @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/ExplicitBucketHistogramAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/ExplicitBucketHistogramAggregation.java
@@ -13,7 +13,7 @@ import io.opentelemetry.sdk.metrics.internal.aggregator.DoubleHistogramAggregato
 import io.opentelemetry.sdk.metrics.internal.aggregator.ExplicitBucketHistogramUtils;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
+import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
 import java.util.List;
 
 /**
@@ -53,9 +53,9 @@ public final class ExplicitBucketHistogramAggregation implements Aggregation, Ag
         new DoubleHistogramAggregator(
             bucketBoundaryArray,
             () ->
-                ExemplarReservoir.filtered(
+                DoubleExemplarReservoir.filtered(
                     exemplarFilter,
-                    ExemplarReservoir.histogramBucketReservoir(
+                    DoubleExemplarReservoir.histogramBucketReservoir(
                         Clock.getDefault(), bucketBoundaries)));
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/ExplicitBucketHistogramAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/ExplicitBucketHistogramAggregation.java
@@ -7,13 +7,14 @@ package io.opentelemetry.sdk.metrics.internal.view;
 
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.internal.aggregator.DoubleHistogramAggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.ExplicitBucketHistogramUtils;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
+import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
 import java.util.List;
 
 /**
@@ -47,9 +48,9 @@ public final class ExplicitBucketHistogramAggregation implements Aggregation, Ag
 
   @Override
   @SuppressWarnings("unchecked")
-  public <T> Aggregator<T> createAggregator(
+  public <T, U extends ExemplarData> Aggregator<T, U> createAggregator(
       InstrumentDescriptor instrumentDescriptor, ExemplarFilter exemplarFilter) {
-    return (Aggregator<T>)
+    return (Aggregator<T, U>)
         new DoubleHistogramAggregator(
             bucketBoundaryArray,
             () ->

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/LastValueAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/LastValueAggregation.java
@@ -7,13 +7,14 @@ package io.opentelemetry.sdk.metrics.internal.view;
 
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.internal.aggregator.DoubleLastValueAggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.LongLastValueAggregator;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
+import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
 import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
 import io.opentelemetry.sdk.metrics.internal.exemplar.LongExemplarReservoir;
 
 /**
@@ -34,15 +35,15 @@ public final class LastValueAggregation implements Aggregation, AggregatorFactor
 
   @Override
   @SuppressWarnings("unchecked")
-  public <T> Aggregator<T> createAggregator(
+  public <T, U extends ExemplarData> Aggregator<T, U> createAggregator(
       InstrumentDescriptor instrumentDescriptor, ExemplarFilter exemplarFilter) {
 
     // For the initial version we do not sample exemplars on gauges.
     switch (instrumentDescriptor.getValueType()) {
       case LONG:
-        return (Aggregator<T>) new LongLastValueAggregator(LongExemplarReservoir::noSamples);
+        return (Aggregator<T, U>) new LongLastValueAggregator(LongExemplarReservoir::noSamples);
       case DOUBLE:
-        return (Aggregator<T>) new DoubleLastValueAggregator(ExemplarReservoir::noSamples);
+        return (Aggregator<T, U>) new DoubleLastValueAggregator(DoubleExemplarReservoir::noSamples);
     }
     throw new IllegalArgumentException("Invalid instrument value type");
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/LastValueAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/LastValueAggregation.java
@@ -14,6 +14,7 @@ import io.opentelemetry.sdk.metrics.internal.aggregator.LongLastValueAggregator;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
+import io.opentelemetry.sdk.metrics.internal.exemplar.LongExemplarReservoir;
 
 /**
  * Last-value aggregation configuration.
@@ -39,7 +40,7 @@ public final class LastValueAggregation implements Aggregation, AggregatorFactor
     // For the initial version we do not sample exemplars on gauges.
     switch (instrumentDescriptor.getValueType()) {
       case LONG:
-        return (Aggregator<T>) new LongLastValueAggregator(ExemplarReservoir::noSamples);
+        return (Aggregator<T>) new LongLastValueAggregator(LongExemplarReservoir::noSamples);
       case DOUBLE:
         return (Aggregator<T>) new DoubleLastValueAggregator(ExemplarReservoir::noSamples);
     }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/SumAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/SumAggregation.java
@@ -14,7 +14,7 @@ import io.opentelemetry.sdk.metrics.internal.aggregator.DoubleSumAggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.LongSumAggregator;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
+import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
 import java.util.function.Supplier;
 
 /**
@@ -36,11 +36,11 @@ public final class SumAggregation implements Aggregation, AggregatorFactory {
   @SuppressWarnings("unchecked")
   public <T> Aggregator<T> createAggregator(
       InstrumentDescriptor instrumentDescriptor, ExemplarFilter exemplarFilter) {
-    Supplier<ExemplarReservoir> reservoirFactory =
+    Supplier<DoubleExemplarReservoir> reservoirFactory =
         () ->
-            ExemplarReservoir.filtered(
+            DoubleExemplarReservoir.filtered(
                 exemplarFilter,
-                ExemplarReservoir.fixedSizeReservoir(
+                DoubleExemplarReservoir.fixedSizeReservoir(
                     Clock.getDefault(),
                     Runtime.getRuntime().availableProcessors(),
                     RandomSupplier.platformDefault()));

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/AggregatorHandleTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/AggregatorHandleTest.java
@@ -15,7 +15,7 @@ import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoubleExemplarData;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
+import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
@@ -30,7 +30,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class AggregatorHandleTest {
 
-  @Mock ExemplarReservoir reservoir;
+  @Mock
+  DoubleExemplarReservoir reservoir;
 
   @Test
   void acquireMapped() {
@@ -153,7 +154,7 @@ class AggregatorHandleTest {
     final AtomicDouble recordedDouble = new AtomicDouble();
     final AtomicReference<List<ExemplarData>> recordedExemplars = new AtomicReference<>();
 
-    TestAggregatorHandle(ExemplarReservoir reservoir) {
+    TestAggregatorHandle(DoubleExemplarReservoir reservoir) {
       super(reservoir);
     }
 

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramAggregatorTest.java
@@ -21,6 +21,7 @@ import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoubleExemplarData;
 import io.opentelemetry.sdk.metrics.internal.data.exponentialhistogram.ExponentialHistogramBuckets;
 import io.opentelemetry.sdk.metrics.internal.data.exponentialhistogram.ExponentialHistogramData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
+import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
 import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
 import io.opentelemetry.sdk.metrics.internal.state.ExponentialCounterFactory;
 import io.opentelemetry.sdk.resources.Resource;
@@ -47,7 +48,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class DoubleExponentialHistogramAggregatorTest {
 
-  @Mock ExemplarReservoir reservoir;
+  @Mock
+  DoubleExemplarReservoir reservoir;
 
   private static final DoubleExponentialHistogramAggregator aggregator =
       new DoubleExponentialHistogramAggregator(ExemplarReservoir::noSamples);
@@ -444,7 +446,7 @@ class DoubleExponentialHistogramAggregatorTest {
                 TraceState.getDefault()),
             1);
     @SuppressWarnings("unchecked")
-    Supplier<ExemplarReservoir> reservoirSupplier = Mockito.mock(Supplier.class);
+    Supplier<DoubleExemplarReservoir> reservoirSupplier = Mockito.mock(Supplier.class);
     Mockito.when(reservoir.collectAndReset(Attributes.empty()))
         .thenReturn(Collections.singletonList(exemplar));
     Mockito.when(reservoirSupplier.get()).thenReturn(reservoir);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramAggregatorTest.java
@@ -15,14 +15,13 @@ import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoubleExemplarData;
 import io.opentelemetry.sdk.metrics.internal.data.exponentialhistogram.ExponentialHistogramBuckets;
 import io.opentelemetry.sdk.metrics.internal.data.exponentialhistogram.ExponentialHistogramData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
 import io.opentelemetry.sdk.metrics.internal.state.ExponentialCounterFactory;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Arrays;
@@ -48,11 +47,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class DoubleExponentialHistogramAggregatorTest {
 
-  @Mock
-  DoubleExemplarReservoir reservoir;
+  @Mock DoubleExemplarReservoir reservoir;
 
   private static final DoubleExponentialHistogramAggregator aggregator =
-      new DoubleExponentialHistogramAggregator(ExemplarReservoir::noSamples);
+      new DoubleExponentialHistogramAggregator(DoubleExemplarReservoir::noSamples);
   private static final Resource RESOURCE = Resource.getDefault();
   private static final InstrumentationScopeInfo INSTRUMENTATION_SCOPE_INFO =
       InstrumentationScopeInfo.empty();
@@ -63,7 +61,7 @@ class DoubleExponentialHistogramAggregatorTest {
     return Stream.of(
         aggregator,
         new DoubleExponentialHistogramAggregator(
-            ExemplarReservoir::noSamples,
+            DoubleExemplarReservoir::noSamples,
             ExponentialBucketStrategy.newStrategy(
                 20, 320, ExponentialCounterFactory.mapCounter())));
   }
@@ -74,8 +72,9 @@ class DoubleExponentialHistogramAggregatorTest {
   }
 
   private static ExponentialHistogramAccumulation getTestAccumulation(
-      List<ExemplarData> exemplars, double... recordings) {
-    AggregatorHandle<ExponentialHistogramAccumulation> aggregatorHandle = aggregator.createHandle();
+      List<DoubleExemplarData> exemplars, double... recordings) {
+    AggregatorHandle<ExponentialHistogramAccumulation, DoubleExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     for (double r : recordings) {
       aggregatorHandle.recordDouble(r);
     }
@@ -90,7 +89,8 @@ class DoubleExponentialHistogramAggregatorTest {
 
   @Test
   void testRecordings() {
-    AggregatorHandle<ExponentialHistogramAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<ExponentialHistogramAccumulation, DoubleExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     aggregatorHandle.recordDouble(0.5);
     aggregatorHandle.recordDouble(1.0);
     aggregatorHandle.recordDouble(12.0);
@@ -128,7 +128,8 @@ class DoubleExponentialHistogramAggregatorTest {
 
   @Test
   void testInvalidRecording() {
-    AggregatorHandle<ExponentialHistogramAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<ExponentialHistogramAccumulation, DoubleExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     // Non finite recordings should be ignored
     aggregatorHandle.recordDouble(Double.POSITIVE_INFINITY);
     aggregatorHandle.recordDouble(Double.NEGATIVE_INFINITY);
@@ -144,7 +145,8 @@ class DoubleExponentialHistogramAggregatorTest {
   @ParameterizedTest
   @MethodSource("provideAggregator")
   void testRecordingsAtLimits(DoubleExponentialHistogramAggregator aggregator) {
-    AggregatorHandle<ExponentialHistogramAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<ExponentialHistogramAccumulation, DoubleExemplarData> aggregatorHandle =
+        aggregator.createHandle();
 
     aggregatorHandle.recordDouble(Double.MIN_VALUE);
     aggregatorHandle.recordDouble(Double.MAX_VALUE);
@@ -188,7 +190,7 @@ class DoubleExponentialHistogramAggregatorTest {
         new DoubleExponentialHistogramAggregator(() -> reservoir);
 
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar =
+    DoubleExemplarData exemplar =
         ImmutableDoubleExemplarData.create(
             attributes,
             2L,
@@ -198,10 +200,11 @@ class DoubleExponentialHistogramAggregatorTest {
                 TraceFlags.getDefault(),
                 TraceState.getDefault()),
             1);
-    List<ExemplarData> exemplars = Collections.singletonList(exemplar);
+    List<DoubleExemplarData> exemplars = Collections.singletonList(exemplar);
     Mockito.when(reservoir.collectAndReset(Attributes.empty())).thenReturn(exemplars);
 
-    AggregatorHandle<ExponentialHistogramAccumulation> aggregatorHandle = agg.createHandle();
+    AggregatorHandle<ExponentialHistogramAccumulation, DoubleExemplarData> aggregatorHandle =
+        agg.createHandle();
     aggregatorHandle.recordDouble(0, attributes, Context.root());
 
     assertThat(
@@ -212,7 +215,8 @@ class DoubleExponentialHistogramAggregatorTest {
 
   @Test
   void testAccumulationAndReset() {
-    AggregatorHandle<ExponentialHistogramAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<ExponentialHistogramAccumulation, DoubleExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     assertThat(aggregatorHandle.accumulateThenReset(Attributes.empty())).isNull();
 
     aggregatorHandle.recordDouble(5.0);
@@ -235,7 +239,7 @@ class DoubleExponentialHistogramAggregatorTest {
   @Test
   void diffAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar =
+    DoubleExemplarData exemplar =
         ImmutableDoubleExemplarData.create(
             attributes,
             2L,
@@ -245,8 +249,8 @@ class DoubleExponentialHistogramAggregatorTest {
                 TraceFlags.getDefault(),
                 TraceState.getDefault()),
             1);
-    List<ExemplarData> exemplars = Collections.singletonList(exemplar);
-    List<ExemplarData> previousExemplars =
+    List<DoubleExemplarData> exemplars = Collections.singletonList(exemplar);
+    List<DoubleExemplarData> previousExemplars =
         Collections.singletonList(
             ImmutableDoubleExemplarData.create(
                 attributes,
@@ -274,7 +278,7 @@ class DoubleExponentialHistogramAggregatorTest {
   @Test
   void diffDownScaledAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar =
+    DoubleExemplarData exemplar =
         ImmutableDoubleExemplarData.create(
             attributes,
             2L,
@@ -284,8 +288,8 @@ class DoubleExponentialHistogramAggregatorTest {
                 TraceFlags.getDefault(),
                 TraceState.getDefault()),
             1);
-    List<ExemplarData> exemplars = Collections.singletonList(exemplar);
-    List<ExemplarData> previousExemplars =
+    List<DoubleExemplarData> exemplars = Collections.singletonList(exemplar);
+    List<DoubleExemplarData> previousExemplars =
         Collections.singletonList(
             ImmutableDoubleExemplarData.create(
                 attributes,
@@ -310,7 +314,7 @@ class DoubleExponentialHistogramAggregatorTest {
   @Test
   void testMergeAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar =
+    DoubleExemplarData exemplar =
         ImmutableDoubleExemplarData.create(
             attributes,
             2L,
@@ -320,8 +324,8 @@ class DoubleExponentialHistogramAggregatorTest {
                 TraceFlags.getDefault(),
                 TraceState.getDefault()),
             1);
-    List<ExemplarData> exemplars = Collections.singletonList(exemplar);
-    List<ExemplarData> previousExemplars =
+    List<DoubleExemplarData> exemplars = Collections.singletonList(exemplar);
+    List<DoubleExemplarData> previousExemplars =
         Collections.singletonList(
             ImmutableDoubleExemplarData.create(
                 attributes,
@@ -394,7 +398,8 @@ class DoubleExponentialHistogramAggregatorTest {
 
   @Test
   void testInsert1M() {
-    AggregatorHandle<ExponentialHistogramAccumulation> handle = aggregator.createHandle();
+    AggregatorHandle<ExponentialHistogramAccumulation, DoubleExemplarData> handle =
+        aggregator.createHandle();
 
     double min = 1.0 / (1 << 16);
     int n = 1024 * 1024 - 1;
@@ -435,7 +440,7 @@ class DoubleExponentialHistogramAggregatorTest {
   @Test
   void testToMetricData() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar =
+    DoubleExemplarData exemplar =
         ImmutableDoubleExemplarData.create(
             attributes,
             2L,
@@ -454,7 +459,7 @@ class DoubleExponentialHistogramAggregatorTest {
     DoubleExponentialHistogramAggregator cumulativeAggregator =
         new DoubleExponentialHistogramAggregator(reservoirSupplier);
 
-    AggregatorHandle<ExponentialHistogramAccumulation> aggregatorHandle =
+    AggregatorHandle<ExponentialHistogramAccumulation, DoubleExemplarData> aggregatorHandle =
         cumulativeAggregator.createHandle();
     aggregatorHandle.recordDouble(0);
     aggregatorHandle.recordDouble(0);
@@ -515,7 +520,8 @@ class DoubleExponentialHistogramAggregatorTest {
 
   @Test
   void testMultithreadedUpdates() throws InterruptedException {
-    AggregatorHandle<ExponentialHistogramAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<ExponentialHistogramAccumulation, DoubleExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     ExponentialHistogram summarizer = new ExponentialHistogram();
     ImmutableList<Double> updates = ImmutableList.of(0D, 0.1D, -0.1D, 1D, -1D, 100D);
     int numberOfThreads = updates.size();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleHistogramAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleHistogramAggregatorTest.java
@@ -15,13 +15,12 @@ import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricDataType;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoubleExemplarData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
 import java.util.List;
@@ -39,8 +38,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class DoubleHistogramAggregatorTest {
 
-  @Mock
-  DoubleExemplarReservoir reservoir;
+  @Mock DoubleExemplarReservoir reservoir;
 
   private static final double[] boundaries = new double[] {10.0, 100.0, 1000.0};
   private static final Resource RESOURCE = Resource.getDefault();
@@ -49,7 +47,7 @@ class DoubleHistogramAggregatorTest {
   private static final MetricDescriptor METRIC_DESCRIPTOR =
       MetricDescriptor.create("name", "description", "unit");
   private static final DoubleHistogramAggregator aggregator =
-      new DoubleHistogramAggregator(boundaries, ExemplarReservoir::noSamples);
+      new DoubleHistogramAggregator(boundaries, DoubleExemplarReservoir::noSamples);
 
   @Test
   void createHandle() {
@@ -58,7 +56,8 @@ class DoubleHistogramAggregatorTest {
 
   @Test
   void testRecordings() {
-    AggregatorHandle<HistogramAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<HistogramAccumulation, DoubleExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     aggregatorHandle.recordLong(20);
     aggregatorHandle.recordLong(5);
     aggregatorHandle.recordLong(150);
@@ -72,7 +71,7 @@ class DoubleHistogramAggregatorTest {
   @Test
   void testExemplarsInAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar =
+    DoubleExemplarData exemplar =
         ImmutableDoubleExemplarData.create(
             attributes,
             2L,
@@ -82,11 +81,12 @@ class DoubleHistogramAggregatorTest {
                 TraceFlags.getDefault(),
                 TraceState.getDefault()),
             1);
-    List<ExemplarData> exemplars = Collections.singletonList(exemplar);
+    List<DoubleExemplarData> exemplars = Collections.singletonList(exemplar);
     Mockito.when(reservoir.collectAndReset(Attributes.empty())).thenReturn(exemplars);
     DoubleHistogramAggregator aggregator =
         new DoubleHistogramAggregator(boundaries, () -> reservoir);
-    AggregatorHandle<HistogramAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<HistogramAccumulation, DoubleExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     aggregatorHandle.recordDouble(0, attributes, Context.root());
     assertThat(aggregatorHandle.accumulateThenReset(Attributes.empty()))
         .isEqualTo(
@@ -96,7 +96,8 @@ class DoubleHistogramAggregatorTest {
 
   @Test
   void toAccumulationAndReset() {
-    AggregatorHandle<HistogramAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<HistogramAccumulation, DoubleExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     assertThat(aggregatorHandle.accumulateThenReset(Attributes.empty())).isNull();
 
     aggregatorHandle.recordLong(100);
@@ -129,7 +130,7 @@ class DoubleHistogramAggregatorTest {
   @Test
   void mergeAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar =
+    DoubleExemplarData exemplar =
         ImmutableDoubleExemplarData.create(
             attributes,
             2L,
@@ -139,8 +140,8 @@ class DoubleHistogramAggregatorTest {
                 TraceFlags.getDefault(),
                 TraceState.getDefault()),
             1);
-    List<ExemplarData> exemplars = Collections.singletonList(exemplar);
-    List<ExemplarData> previousExemplars =
+    List<DoubleExemplarData> exemplars = Collections.singletonList(exemplar);
+    List<DoubleExemplarData> previousExemplars =
         Collections.singletonList(
             ImmutableDoubleExemplarData.create(
                 attributes,
@@ -210,7 +211,7 @@ class DoubleHistogramAggregatorTest {
   @Test
   void diffAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar =
+    DoubleExemplarData exemplar =
         ImmutableDoubleExemplarData.create(
             attributes,
             2L,
@@ -220,8 +221,8 @@ class DoubleHistogramAggregatorTest {
                 TraceFlags.getDefault(),
                 TraceState.getDefault()),
             1);
-    List<ExemplarData> exemplars = Collections.singletonList(exemplar);
-    List<ExemplarData> previousExemplars =
+    List<DoubleExemplarData> exemplars = Collections.singletonList(exemplar);
+    List<DoubleExemplarData> previousExemplars =
         Collections.singletonList(
             ImmutableDoubleExemplarData.create(
                 attributes,
@@ -247,7 +248,8 @@ class DoubleHistogramAggregatorTest {
 
   @Test
   void toMetricData() {
-    AggregatorHandle<HistogramAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<HistogramAccumulation, DoubleExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     aggregatorHandle.recordLong(10);
 
     MetricData metricData =
@@ -270,7 +272,7 @@ class DoubleHistogramAggregatorTest {
   @Test
   void toMetricDataWithExemplars() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar =
+    DoubleExemplarData exemplar =
         ImmutableDoubleExemplarData.create(
             attributes,
             2L,
@@ -326,7 +328,8 @@ class DoubleHistogramAggregatorTest {
                 .length)
         .isEqualTo(boundaries.length + 1);
 
-    AggregatorHandle<HistogramAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<HistogramAccumulation, DoubleExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     aggregatorHandle.recordDouble(1.1);
     HistogramAccumulation histogramAccumulation =
         aggregatorHandle.accumulateThenReset(Attributes.empty());
@@ -336,7 +339,8 @@ class DoubleHistogramAggregatorTest {
 
   @Test
   void testMultithreadedUpdates() throws InterruptedException {
-    AggregatorHandle<HistogramAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<HistogramAccumulation, DoubleExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     Histogram summarizer = new Histogram();
     ImmutableList<Long> updates = ImmutableList.of(1L, 2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L, 23L);
     int numberOfThreads = updates.size();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleHistogramAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleHistogramAggregatorTest.java
@@ -20,6 +20,7 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricDataType;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoubleExemplarData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
+import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
 import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
@@ -38,7 +39,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class DoubleHistogramAggregatorTest {
 
-  @Mock ExemplarReservoir reservoir;
+  @Mock
+  DoubleExemplarReservoir reservoir;
 
   private static final double[] boundaries = new double[] {10.0, 100.0, 1000.0};
   private static final Resource RESOURCE = Resource.getDefault();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleLastValueAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleLastValueAggregatorTest.java
@@ -13,11 +13,11 @@ import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoubleExemplarData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
+import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
 import java.util.List;
@@ -31,7 +31,7 @@ class DoubleLastValueAggregatorTest {
   private static final MetricDescriptor METRIC_DESCRIPTOR =
       MetricDescriptor.create("name", "description", "unit");
   private static final DoubleLastValueAggregator aggregator =
-      new DoubleLastValueAggregator(ExemplarReservoir::noSamples);
+      new DoubleLastValueAggregator(DoubleExemplarReservoir::noSamples);
 
   @Test
   void createHandle() {
@@ -40,7 +40,8 @@ class DoubleLastValueAggregatorTest {
 
   @Test
   void multipleRecords() {
-    AggregatorHandle<DoubleAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<DoubleAccumulation, DoubleExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     aggregatorHandle.recordDouble(12.1);
     assertThat(aggregatorHandle.accumulateThenReset(Attributes.empty()).getValue()).isEqualTo(12.1);
     aggregatorHandle.recordDouble(13.1);
@@ -50,7 +51,8 @@ class DoubleLastValueAggregatorTest {
 
   @Test
   void toAccumulationAndReset() {
-    AggregatorHandle<DoubleAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<DoubleAccumulation, DoubleExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     assertThat(aggregatorHandle.accumulateThenReset(Attributes.empty())).isNull();
 
     aggregatorHandle.recordDouble(13.1);
@@ -65,7 +67,7 @@ class DoubleLastValueAggregatorTest {
   @Test
   void mergeAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar =
+    DoubleExemplarData exemplar =
         ImmutableDoubleExemplarData.create(
             attributes,
             2L,
@@ -75,8 +77,8 @@ class DoubleLastValueAggregatorTest {
                 TraceFlags.getDefault(),
                 TraceState.getDefault()),
             1);
-    List<ExemplarData> exemplars = Collections.singletonList(exemplar);
-    List<ExemplarData> previousExemplars =
+    List<DoubleExemplarData> exemplars = Collections.singletonList(exemplar);
+    List<DoubleExemplarData> previousExemplars =
         Collections.singletonList(
             ImmutableDoubleExemplarData.create(
                 attributes,
@@ -98,7 +100,7 @@ class DoubleLastValueAggregatorTest {
   @Test
   void diffAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar =
+    DoubleExemplarData exemplar =
         ImmutableDoubleExemplarData.create(
             attributes,
             2L,
@@ -108,8 +110,8 @@ class DoubleLastValueAggregatorTest {
                 TraceFlags.getDefault(),
                 TraceState.getDefault()),
             1);
-    List<ExemplarData> exemplars = Collections.singletonList(exemplar);
-    List<ExemplarData> previousExemplars =
+    List<DoubleExemplarData> exemplars = Collections.singletonList(exemplar);
+    List<DoubleExemplarData> previousExemplars =
         Collections.singletonList(
             ImmutableDoubleExemplarData.create(
                 attributes,
@@ -131,7 +133,8 @@ class DoubleLastValueAggregatorTest {
   @Test
   @SuppressWarnings("unchecked")
   void toMetricData() {
-    AggregatorHandle<DoubleAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<DoubleAccumulation, DoubleExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     aggregatorHandle.recordDouble(10);
 
     MetricData metricData =

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleSumAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleSumAggregatorTest.java
@@ -21,6 +21,7 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoubleExemplarData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
+import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
 import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
@@ -35,7 +36,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class DoubleSumAggregatorTest {
 
-  @Mock ExemplarReservoir reservoir;
+  @Mock
+  DoubleExemplarReservoir reservoir;
 
   private static final Resource resource = Resource.getDefault();
   private static final InstrumentationScopeInfo scope = InstrumentationScopeInfo.empty();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongLastValueAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongLastValueAggregatorTest.java
@@ -13,14 +13,14 @@ import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.LongExemplarData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableGaugeData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableLongExemplarData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableLongPointData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
+import io.opentelemetry.sdk.metrics.internal.exemplar.LongExemplarReservoir;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
 import java.util.List;
@@ -34,7 +34,7 @@ class LongLastValueAggregatorTest {
   private static final MetricDescriptor METRIC_DESCRIPTOR =
       MetricDescriptor.create("name", "description", "unit");
   private static final LongLastValueAggregator aggregator =
-      new LongLastValueAggregator(ExemplarReservoir::noSamples);
+      new LongLastValueAggregator(LongExemplarReservoir::noSamples);
 
   @Test
   void createHandle() {
@@ -43,7 +43,8 @@ class LongLastValueAggregatorTest {
 
   @Test
   void multipleRecords() {
-    AggregatorHandle<LongAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<LongAccumulation, LongExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     aggregatorHandle.recordLong(12);
     assertThat(aggregatorHandle.accumulateThenReset(Attributes.empty()).getValue()).isEqualTo(12L);
     aggregatorHandle.recordLong(13);
@@ -53,7 +54,8 @@ class LongLastValueAggregatorTest {
 
   @Test
   void toAccumulationAndReset() {
-    AggregatorHandle<LongAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<LongAccumulation, LongExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     assertThat(aggregatorHandle.accumulateThenReset(Attributes.empty())).isNull();
 
     aggregatorHandle.recordLong(13);
@@ -68,7 +70,7 @@ class LongLastValueAggregatorTest {
   @Test
   void mergeAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar =
+    LongExemplarData exemplar =
         ImmutableLongExemplarData.create(
             attributes,
             2L,
@@ -78,8 +80,8 @@ class LongLastValueAggregatorTest {
                 TraceFlags.getDefault(),
                 TraceState.getDefault()),
             1);
-    List<ExemplarData> exemplars = Collections.singletonList(exemplar);
-    List<ExemplarData> previousExemplars =
+    List<LongExemplarData> exemplars = Collections.singletonList(exemplar);
+    List<LongExemplarData> previousExemplars =
         Collections.singletonList(
             ImmutableLongExemplarData.create(
                 attributes,
@@ -99,7 +101,8 @@ class LongLastValueAggregatorTest {
 
   @Test
   void toMetricData() {
-    AggregatorHandle<LongAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<LongAccumulation, LongExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     aggregatorHandle.recordLong(10);
 
     MetricData metricData =

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongSumAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongSumAggregatorTest.java
@@ -21,6 +21,7 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoubleExemplarData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
+import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
 import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
@@ -35,7 +36,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class LongSumAggregatorTest {
 
-  @Mock ExemplarReservoir reservoir;
+  @Mock
+  DoubleExemplarReservoir reservoir;
 
   private static final Resource resource = Resource.getDefault();
   private static final InstrumentationScopeInfo library = InstrumentationScopeInfo.empty();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongSumAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongSumAggregatorTest.java
@@ -16,13 +16,12 @@ import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.LongExemplarData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
-import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoubleExemplarData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableLongExemplarData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
-import io.opentelemetry.sdk.metrics.internal.exemplar.DoubleExemplarReservoir;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
+import io.opentelemetry.sdk.metrics.internal.exemplar.LongExemplarReservoir;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
 import java.util.List;
@@ -36,8 +35,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class LongSumAggregatorTest {
 
-  @Mock
-  DoubleExemplarReservoir reservoir;
+  @Mock LongExemplarReservoir reservoir;
 
   private static final Resource resource = Resource.getDefault();
   private static final InstrumentationScopeInfo library = InstrumentationScopeInfo.empty();
@@ -51,7 +49,7 @@ class LongSumAggregatorTest {
               "instrument_unit",
               InstrumentType.COUNTER,
               InstrumentValueType.LONG),
-          ExemplarReservoir::noSamples);
+          LongExemplarReservoir::noSamples);
 
   @Test
   void createHandle() {
@@ -60,7 +58,8 @@ class LongSumAggregatorTest {
 
   @Test
   void multipleRecords() {
-    AggregatorHandle<LongAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<LongAccumulation, LongExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     aggregatorHandle.recordLong(12);
     aggregatorHandle.recordLong(12);
     aggregatorHandle.recordLong(12);
@@ -73,7 +72,8 @@ class LongSumAggregatorTest {
 
   @Test
   void multipleRecords_WithNegatives() {
-    AggregatorHandle<LongAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<LongAccumulation, LongExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     aggregatorHandle.recordLong(12);
     aggregatorHandle.recordLong(12);
     aggregatorHandle.recordLong(-23);
@@ -86,7 +86,8 @@ class LongSumAggregatorTest {
 
   @Test
   void toAccumulationAndReset() {
-    AggregatorHandle<LongAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<LongAccumulation, LongExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     assertThat(aggregatorHandle.accumulateThenReset(Attributes.empty())).isNull();
 
     aggregatorHandle.recordLong(13);
@@ -103,8 +104,8 @@ class LongSumAggregatorTest {
   @Test
   void testExemplarsInAccumulation() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar =
-        ImmutableDoubleExemplarData.create(
+    LongExemplarData exemplar =
+        ImmutableLongExemplarData.create(
             attributes,
             2L,
             SpanContext.create(
@@ -113,7 +114,7 @@ class LongSumAggregatorTest {
                 TraceFlags.getDefault(),
                 TraceState.getDefault()),
             1);
-    List<ExemplarData> exemplars = Collections.singletonList(exemplar);
+    List<LongExemplarData> exemplars = Collections.singletonList(exemplar);
     Mockito.when(reservoir.collectAndReset(Attributes.empty())).thenReturn(exemplars);
     LongSumAggregator aggregator =
         new LongSumAggregator(
@@ -124,7 +125,8 @@ class LongSumAggregatorTest {
                 InstrumentType.COUNTER,
                 InstrumentValueType.LONG),
             () -> reservoir);
-    AggregatorHandle<LongAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<LongAccumulation, LongExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     aggregatorHandle.recordLong(0, attributes, Context.root());
     assertThat(aggregatorHandle.accumulateThenReset(Attributes.empty()))
         .isEqualTo(LongAccumulation.create(0, exemplars));
@@ -132,8 +134,8 @@ class LongSumAggregatorTest {
 
   @Test
   void mergeAndDiff() {
-    ExemplarData exemplar =
-        ImmutableDoubleExemplarData.create(
+    LongExemplarData exemplar =
+        ImmutableLongExemplarData.create(
             Attributes.empty(),
             2L,
             SpanContext.create(
@@ -142,14 +144,14 @@ class LongSumAggregatorTest {
                 TraceFlags.getDefault(),
                 TraceState.getDefault()),
             1);
-    List<ExemplarData> exemplars = Collections.singletonList(exemplar);
+    List<LongExemplarData> exemplars = Collections.singletonList(exemplar);
     for (InstrumentType instrumentType : InstrumentType.values()) {
       for (AggregationTemporality temporality : AggregationTemporality.values()) {
         LongSumAggregator aggregator =
             new LongSumAggregator(
                 InstrumentDescriptor.create(
                     "name", "description", "unit", instrumentType, InstrumentValueType.LONG),
-                ExemplarReservoir::noSamples);
+                LongExemplarReservoir::noSamples);
         LongAccumulation merged =
             aggregator.merge(LongAccumulation.create(1L), LongAccumulation.create(2L, exemplars));
         assertThat(merged.getValue())
@@ -174,7 +176,8 @@ class LongSumAggregatorTest {
   @Test
   @SuppressWarnings("unchecked")
   void toMetricData() {
-    AggregatorHandle<LongAccumulation> aggregatorHandle = aggregator.createHandle();
+    AggregatorHandle<LongAccumulation, LongExemplarData> aggregatorHandle =
+        aggregator.createHandle();
     aggregatorHandle.recordLong(10);
 
     MetricData metricData =
@@ -208,8 +211,8 @@ class LongSumAggregatorTest {
   @Test
   void toMetricDataWithExemplars() {
     Attributes attributes = Attributes.builder().put("test", "value").build();
-    ExemplarData exemplar =
-        ImmutableDoubleExemplarData.create(
+    LongExemplarData exemplar =
+        ImmutableLongExemplarData.create(
             attributes,
             2L,
             SpanContext.create(

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/DoubleFixedSizeExemplarReservoirTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/DoubleFixedSizeExemplarReservoirTest.java
@@ -20,7 +20,7 @@ import java.time.Duration;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 
-class FixedSizeExemplarReservoirTest {
+class DoubleFixedSizeExemplarReservoirTest {
   private static final String TRACE_ID = "ff000000000000000000000000000041";
   private static final String SPAN_ID = "ff00000000000041";
 
@@ -28,7 +28,7 @@ class FixedSizeExemplarReservoirTest {
   public void noMeasurement_returnsEmpty() {
     TestClock clock = TestClock.create();
     DoubleExemplarReservoir reservoir =
-        new FixedSizeExemplarReservoir(clock, 1, RandomSupplier.platformDefault());
+        new DoubleFixedSizeExemplarReservoir(clock, 1, RandomSupplier.platformDefault());
     assertThat(reservoir.collectAndReset(Attributes.empty())).isEmpty();
   }
 
@@ -36,8 +36,8 @@ class FixedSizeExemplarReservoirTest {
   public void oneMeasurement_alwaysSamplesFirstMeasurement() {
     TestClock clock = TestClock.create();
     DoubleExemplarReservoir reservoir =
-        new FixedSizeExemplarReservoir(clock, 1, RandomSupplier.platformDefault());
-    reservoir.offerMeasurement(1L, Attributes.empty(), Context.root());
+        new DoubleFixedSizeExemplarReservoir(clock, 1, RandomSupplier.platformDefault());
+    reservoir.offerMeasurement(1.1, Attributes.empty(), Context.root());
     assertThat(reservoir.collectAndReset(Attributes.empty()))
         .hasSize(1)
         .satisfiesExactly(
@@ -45,11 +45,11 @@ class FixedSizeExemplarReservoirTest {
                 assertThat(exemplar)
                     .hasEpochNanos(clock.now())
                     .hasFilteredAttributes(Attributes.empty())
-                    .hasValue(1));
+                    .hasValue(1.1));
 
     // Measurement count is reset, we should sample a new measurement (and only one)
     clock.advance(Duration.ofSeconds(1));
-    reservoir.offerMeasurement(2L, Attributes.empty(), Context.root());
+    reservoir.offerMeasurement(2, Attributes.empty(), Context.root());
     assertThat(reservoir.collectAndReset(Attributes.empty()))
         .hasSize(1)
         .satisfiesExactly(
@@ -68,14 +68,14 @@ class FixedSizeExemplarReservoirTest {
     Attributes remaining = Attributes.builder().put("one", 1).put("two", "two").build();
     TestClock clock = TestClock.create();
     DoubleExemplarReservoir reservoir =
-        new FixedSizeExemplarReservoir(clock, 1, RandomSupplier.platformDefault());
-    reservoir.offerMeasurement(1L, all, Context.root());
+        new DoubleFixedSizeExemplarReservoir(clock, 1, RandomSupplier.platformDefault());
+    reservoir.offerMeasurement(1.1, all, Context.root());
     assertThat(reservoir.collectAndReset(partial))
         .satisfiesExactly(
             exemplar ->
                 assertThat(exemplar)
                     .hasEpochNanos(clock.now())
-                    .hasValue(1)
+                    .hasValue(1.1)
                     .hasFilteredAttributes(remaining));
   }
 
@@ -91,8 +91,8 @@ class FixedSizeExemplarReservoirTest {
                         TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault())));
     TestClock clock = TestClock.create();
     DoubleExemplarReservoir reservoir =
-        new FixedSizeExemplarReservoir(clock, 1, RandomSupplier.platformDefault());
-    reservoir.offerMeasurement(1L, all, context);
+        new DoubleFixedSizeExemplarReservoir(clock, 1, RandomSupplier.platformDefault());
+    reservoir.offerMeasurement(1, all, context);
     assertThat(reservoir.collectAndReset(Attributes.empty()))
         .satisfiesExactly(
             exemplar ->
@@ -122,7 +122,8 @@ class FixedSizeExemplarReservoirTest {
           }
         };
     TestClock clock = TestClock.create();
-    DoubleExemplarReservoir reservoir = new FixedSizeExemplarReservoir(clock, 2, () -> mockRandom);
+    DoubleExemplarReservoir reservoir =
+        new DoubleFixedSizeExemplarReservoir(clock, 2, () -> mockRandom);
     reservoir.offerMeasurement(1, Attributes.of(key, 1L), Context.root());
     reservoir.offerMeasurement(2, Attributes.of(key, 2L), Context.root());
     reservoir.offerMeasurement(3, Attributes.of(key, 3L), Context.root());

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/FilteredDoubleExemplarReservoirTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/FilteredDoubleExemplarReservoirTest.java
@@ -8,7 +8,6 @@ package io.opentelemetry.sdk.metrics.internal.exemplar;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,33 +25,18 @@ class FilteredDoubleExemplarReservoirTest {
   @Mock ExemplarFilter filter;
 
   @Test
-  void testFilter_preventsSamplingDoubles() {
+  void testFilter_preventsSampling() {
     when(filter.shouldSampleMeasurement(anyDouble(), any(), any())).thenReturn(false);
     DoubleExemplarReservoir filtered = new FilteredDoubleExemplarReservoir(filter, reservoir);
     filtered.offerMeasurement(1.0, Attributes.empty(), Context.root());
   }
 
   @Test
-  void testFilter_allowsSamplingDoubles() {
+  void testFilter_allowsSampling() {
     when(filter.shouldSampleMeasurement(anyDouble(), any(), any())).thenReturn(true);
     DoubleExemplarReservoir filtered = new FilteredDoubleExemplarReservoir(filter, reservoir);
     filtered.offerMeasurement(1.0, Attributes.empty(), Context.root());
     verify(reservoir).offerMeasurement(1.0, Attributes.empty(), Context.root());
-  }
-
-  @Test
-  void testFilter_preventsSamplingLongs() {
-    when(filter.shouldSampleMeasurement(anyLong(), any(), any())).thenReturn(false);
-    DoubleExemplarReservoir filtered = new FilteredDoubleExemplarReservoir(filter, reservoir);
-    filtered.offerMeasurement(1L, Attributes.empty(), Context.root());
-  }
-
-  @Test
-  void testFilter_allowsSamplingLongs() {
-    when(filter.shouldSampleMeasurement(anyLong(), any(), any())).thenReturn(true);
-    DoubleExemplarReservoir filtered = new FilteredDoubleExemplarReservoir(filter, reservoir);
-    filtered.offerMeasurement(1L, Attributes.empty(), Context.root());
-    verify(reservoir).offerMeasurement(1L, Attributes.empty(), Context.root());
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/FilteredDoubleExemplarReservoirTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/FilteredDoubleExemplarReservoirTest.java
@@ -21,21 +21,21 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class FilteredExemplarReservoirTest {
-  @Mock ExemplarReservoir reservoir;
+class FilteredDoubleExemplarReservoirTest {
+  @Mock DoubleExemplarReservoir reservoir;
   @Mock ExemplarFilter filter;
 
   @Test
   void testFilter_preventsSamplingDoubles() {
     when(filter.shouldSampleMeasurement(anyDouble(), any(), any())).thenReturn(false);
-    ExemplarReservoir filtered = new FilteredExemplarReservoir(filter, reservoir);
+    DoubleExemplarReservoir filtered = new FilteredDoubleExemplarReservoir(filter, reservoir);
     filtered.offerMeasurement(1.0, Attributes.empty(), Context.root());
   }
 
   @Test
   void testFilter_allowsSamplingDoubles() {
     when(filter.shouldSampleMeasurement(anyDouble(), any(), any())).thenReturn(true);
-    ExemplarReservoir filtered = new FilteredExemplarReservoir(filter, reservoir);
+    DoubleExemplarReservoir filtered = new FilteredDoubleExemplarReservoir(filter, reservoir);
     filtered.offerMeasurement(1.0, Attributes.empty(), Context.root());
     verify(reservoir).offerMeasurement(1.0, Attributes.empty(), Context.root());
   }
@@ -43,14 +43,14 @@ class FilteredExemplarReservoirTest {
   @Test
   void testFilter_preventsSamplingLongs() {
     when(filter.shouldSampleMeasurement(anyLong(), any(), any())).thenReturn(false);
-    ExemplarReservoir filtered = new FilteredExemplarReservoir(filter, reservoir);
+    DoubleExemplarReservoir filtered = new FilteredDoubleExemplarReservoir(filter, reservoir);
     filtered.offerMeasurement(1L, Attributes.empty(), Context.root());
   }
 
   @Test
   void testFilter_allowsSamplingLongs() {
     when(filter.shouldSampleMeasurement(anyLong(), any(), any())).thenReturn(true);
-    ExemplarReservoir filtered = new FilteredExemplarReservoir(filter, reservoir);
+    DoubleExemplarReservoir filtered = new FilteredDoubleExemplarReservoir(filter, reservoir);
     filtered.offerMeasurement(1L, Attributes.empty(), Context.root());
     verify(reservoir).offerMeasurement(1L, Attributes.empty(), Context.root());
   }
@@ -58,7 +58,7 @@ class FilteredExemplarReservoirTest {
   @Test
   void reservoir_collectsUnderlying() {
     when(reservoir.collectAndReset(Attributes.empty())).thenReturn(Collections.emptyList());
-    ExemplarReservoir filtered = new FilteredExemplarReservoir(filter, reservoir);
+    DoubleExemplarReservoir filtered = new FilteredDoubleExemplarReservoir(filter, reservoir);
     assertThat(filtered.collectAndReset(Attributes.empty())).isEmpty();
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/FixedSizeExemplarReservoirTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/FixedSizeExemplarReservoirTest.java
@@ -27,7 +27,7 @@ class FixedSizeExemplarReservoirTest {
   @Test
   public void noMeasurement_returnsEmpty() {
     TestClock clock = TestClock.create();
-    ExemplarReservoir reservoir =
+    DoubleExemplarReservoir reservoir =
         new FixedSizeExemplarReservoir(clock, 1, RandomSupplier.platformDefault());
     assertThat(reservoir.collectAndReset(Attributes.empty())).isEmpty();
   }
@@ -35,7 +35,7 @@ class FixedSizeExemplarReservoirTest {
   @Test
   public void oneMeasurement_alwaysSamplesFirstMeasurement() {
     TestClock clock = TestClock.create();
-    ExemplarReservoir reservoir =
+    DoubleExemplarReservoir reservoir =
         new FixedSizeExemplarReservoir(clock, 1, RandomSupplier.platformDefault());
     reservoir.offerMeasurement(1L, Attributes.empty(), Context.root());
     assertThat(reservoir.collectAndReset(Attributes.empty()))
@@ -67,7 +67,7 @@ class FixedSizeExemplarReservoirTest {
     Attributes partial = Attributes.builder().put("three", true).build();
     Attributes remaining = Attributes.builder().put("one", 1).put("two", "two").build();
     TestClock clock = TestClock.create();
-    ExemplarReservoir reservoir =
+    DoubleExemplarReservoir reservoir =
         new FixedSizeExemplarReservoir(clock, 1, RandomSupplier.platformDefault());
     reservoir.offerMeasurement(1L, all, Context.root());
     assertThat(reservoir.collectAndReset(partial))
@@ -90,7 +90,7 @@ class FixedSizeExemplarReservoirTest {
                     SpanContext.createFromRemoteParent(
                         TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault())));
     TestClock clock = TestClock.create();
-    ExemplarReservoir reservoir =
+    DoubleExemplarReservoir reservoir =
         new FixedSizeExemplarReservoir(clock, 1, RandomSupplier.platformDefault());
     reservoir.offerMeasurement(1L, all, context);
     assertThat(reservoir.collectAndReset(Attributes.empty()))
@@ -122,7 +122,7 @@ class FixedSizeExemplarReservoirTest {
           }
         };
     TestClock clock = TestClock.create();
-    ExemplarReservoir reservoir = new FixedSizeExemplarReservoir(clock, 2, () -> mockRandom);
+    DoubleExemplarReservoir reservoir = new FixedSizeExemplarReservoir(clock, 2, () -> mockRandom);
     reservoir.offerMeasurement(1, Attributes.of(key, 1L), Context.root());
     reservoir.offerMeasurement(2, Attributes.of(key, 2L), Context.root());
     reservoir.offerMeasurement(3, Attributes.of(key, 3L), Context.root());

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/HistogramBucketExemplarReservoirTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/HistogramBucketExemplarReservoirTest.java
@@ -19,14 +19,14 @@ class HistogramBucketExemplarReservoirTest {
   @Test
   public void noMeasurement_returnsEmpty() {
     TestClock clock = TestClock.create();
-    ExemplarReservoir reservoir = new HistogramBucketExemplarReservoir(clock, new double[] {});
+    DoubleExemplarReservoir reservoir = new HistogramBucketExemplarReservoir(clock, new double[] {});
     assertThat(reservoir.collectAndReset(Attributes.empty())).isEmpty();
   }
 
   @Test
   public void oneBucket_samplesEverything() {
     TestClock clock = TestClock.create();
-    ExemplarReservoir reservoir = new HistogramBucketExemplarReservoir(clock, new double[] {});
+    DoubleExemplarReservoir reservoir = new HistogramBucketExemplarReservoir(clock, new double[] {});
     reservoir.offerMeasurement(1L, Attributes.empty(), Context.root());
     assertThat(reservoir.collectAndReset(Attributes.empty()))
         .hasSize(1)
@@ -65,7 +65,7 @@ class HistogramBucketExemplarReservoirTest {
   public void multipleBuckets_samplesIntoCorrectBucket() {
     TestClock clock = TestClock.create();
     AttributeKey<Long> bucketKey = AttributeKey.longKey("bucket");
-    ExemplarReservoir reservoir =
+    DoubleExemplarReservoir reservoir =
         new HistogramBucketExemplarReservoir(clock, new double[] {0, 10, 20});
     reservoir.offerMeasurement(-1, Attributes.of(bucketKey, 0L), Context.root());
     reservoir.offerMeasurement(1, Attributes.of(bucketKey, 1L), Context.root());

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/LongFixedSizeExemplarReservoirTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/LongFixedSizeExemplarReservoirTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.internal.exemplar;
+
+import static io.opentelemetry.sdk.testing.assertj.MetricAssertions.assertThat;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.internal.RandomSupplier;
+import io.opentelemetry.sdk.testing.time.TestClock;
+import java.time.Duration;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+
+class LongFixedSizeExemplarReservoirTest {
+  private static final String TRACE_ID = "ff000000000000000000000000000041";
+  private static final String SPAN_ID = "ff00000000000041";
+
+  @Test
+  public void noMeasurement_returnsEmpty() {
+    TestClock clock = TestClock.create();
+    LongExemplarReservoir reservoir =
+        new LongFixedSizeExemplarReservoir(clock, 1, RandomSupplier.platformDefault());
+    assertThat(reservoir.collectAndReset(Attributes.empty())).isEmpty();
+  }
+
+  @Test
+  public void oneMeasurement_alwaysSamplesFirstMeasurement() {
+    TestClock clock = TestClock.create();
+    LongExemplarReservoir reservoir =
+        new LongFixedSizeExemplarReservoir(clock, 1, RandomSupplier.platformDefault());
+    reservoir.offerMeasurement(1, Attributes.empty(), Context.root());
+    assertThat(reservoir.collectAndReset(Attributes.empty()))
+        .hasSize(1)
+        .satisfiesExactly(
+            exemplar ->
+                assertThat(exemplar)
+                    .hasEpochNanos(clock.now())
+                    .hasFilteredAttributes(Attributes.empty())
+                    .hasValue(1));
+
+    // Measurement count is reset, we should sample a new measurement (and only one)
+    clock.advance(Duration.ofSeconds(1));
+    reservoir.offerMeasurement(2, Attributes.empty(), Context.root());
+    assertThat(reservoir.collectAndReset(Attributes.empty()))
+        .hasSize(1)
+        .satisfiesExactly(
+            exemplar ->
+                assertThat(exemplar)
+                    .hasEpochNanos(clock.now())
+                    .hasFilteredAttributes(Attributes.empty())
+                    .hasValue(2));
+  }
+
+  @Test
+  public void oneMeasurement_filtersAttributes() {
+    Attributes all =
+        Attributes.builder().put("one", 1).put("two", "two").put("three", true).build();
+    Attributes partial = Attributes.builder().put("three", true).build();
+    Attributes remaining = Attributes.builder().put("one", 1).put("two", "two").build();
+    TestClock clock = TestClock.create();
+    LongExemplarReservoir reservoir =
+        new LongFixedSizeExemplarReservoir(clock, 1, RandomSupplier.platformDefault());
+    reservoir.offerMeasurement(1, all, Context.root());
+    assertThat(reservoir.collectAndReset(partial))
+        .satisfiesExactly(
+            exemplar ->
+                assertThat(exemplar)
+                    .hasEpochNanos(clock.now())
+                    .hasValue(1)
+                    .hasFilteredAttributes(remaining));
+  }
+
+  @Test
+  public void oneMeasurement_includesTraceAndSpanIds() {
+    Attributes all =
+        Attributes.builder().put("one", 1).put("two", "two").put("three", true).build();
+    Context context =
+        Context.root()
+            .with(
+                Span.wrap(
+                    SpanContext.createFromRemoteParent(
+                        TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault())));
+    TestClock clock = TestClock.create();
+    LongExemplarReservoir reservoir =
+        new LongFixedSizeExemplarReservoir(clock, 1, RandomSupplier.platformDefault());
+    reservoir.offerMeasurement(1, all, context);
+    assertThat(reservoir.collectAndReset(Attributes.empty()))
+        .satisfiesExactly(
+            exemplar ->
+                assertThat(exemplar)
+                    .hasEpochNanos(clock.now())
+                    .hasValue(1)
+                    .hasFilteredAttributes(all)
+                    .hasTraceId(TRACE_ID)
+                    .hasSpanId(SPAN_ID));
+  }
+
+  @Test
+  public void multiMeasurements_preservesLatestSamples() {
+    AttributeKey<Long> key = AttributeKey.longKey("K");
+    // We cannot mock random in latest jdk, so we create an override.
+    Random mockRandom =
+        new Random() {
+          @Override
+          public int nextInt(int max) {
+            switch (max) {
+                // Force one sample in bucket 1 and two in bucket 0.
+              case 2:
+                return 1;
+              default:
+                return 0;
+            }
+          }
+        };
+    TestClock clock = TestClock.create();
+    LongExemplarReservoir reservoir =
+        new LongFixedSizeExemplarReservoir(clock, 2, () -> mockRandom);
+    reservoir.offerMeasurement(1, Attributes.of(key, 1L), Context.root());
+    reservoir.offerMeasurement(2, Attributes.of(key, 2L), Context.root());
+    reservoir.offerMeasurement(3, Attributes.of(key, 3L), Context.root());
+    assertThat(reservoir.collectAndReset(Attributes.empty()))
+        .satisfiesExactlyInAnyOrder(
+            exemplar -> assertThat(exemplar).hasEpochNanos(clock.now()).hasValue(2),
+            exemplar -> assertThat(exemplar).hasEpochNanos(clock.now()).hasValue(3));
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorageTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorageTest.java
@@ -64,7 +64,7 @@ class AsynchronousMetricStorageTest {
 
   @Test
   void recordLong() {
-    AsynchronousMetricStorage<?> storage =
+    AsynchronousMetricStorage<?, ?> storage =
         AsynchronousMetricStorage.create(
             registeredView,
             InstrumentDescriptor.create(
@@ -103,7 +103,7 @@ class AsynchronousMetricStorageTest {
 
   @Test
   void recordDouble() {
-    AsynchronousMetricStorage<?> storage =
+    AsynchronousMetricStorage<?, ?> storage =
         AsynchronousMetricStorage.create(
             registeredView,
             InstrumentDescriptor.create(
@@ -142,7 +142,7 @@ class AsynchronousMetricStorageTest {
 
   @Test
   void record_ProcessesAttributes() {
-    AsynchronousMetricStorage<?> storage =
+    AsynchronousMetricStorage<?, ?> storage =
         AsynchronousMetricStorage.create(
             RegisteredView.create(
                 selector,
@@ -175,7 +175,7 @@ class AsynchronousMetricStorageTest {
 
   @Test
   void record_MaxAccumulations() {
-    AsynchronousMetricStorage<?> storage =
+    AsynchronousMetricStorage<?, ?> storage =
         AsynchronousMetricStorage.create(
             registeredView,
             InstrumentDescriptor.create(
@@ -202,7 +202,7 @@ class AsynchronousMetricStorageTest {
 
   @Test
   void record_DuplicateAttributes() {
-    AsynchronousMetricStorage<?> storage =
+    AsynchronousMetricStorage<?, ?> storage =
         AsynchronousMetricStorage.create(
             registeredView,
             InstrumentDescriptor.create(

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/CallbackRegistrationTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/CallbackRegistrationTest.java
@@ -51,8 +51,8 @@ class CallbackRegistrationTest {
   @RegisterExtension
   LogCapturer logs = LogCapturer.create().captureForType(CallbackRegistration.class);
 
-  @Mock private AsynchronousMetricStorage<?> storage1;
-  @Mock private AsynchronousMetricStorage<?> storage2;
+  @Mock private AsynchronousMetricStorage<?, ?> storage1;
+  @Mock private AsynchronousMetricStorage<?, ?> storage2;
 
   @Test
   void invokeCallback_Double() {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/DeltaMetricStorageTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/DeltaMetricStorageTest.java
@@ -12,6 +12,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.InstrumentValueType;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.internal.aggregator.DoubleAccumulation;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
@@ -30,7 +31,7 @@ class DeltaMetricStorageTest {
   private CollectionHandle collector1;
   private CollectionHandle collector2;
   private Set<CollectionHandle> allCollectors;
-  private DeltaMetricStorage<DoubleAccumulation> storage;
+  private DeltaMetricStorage<DoubleAccumulation, DoubleExemplarData> storage;
 
   @BeforeEach
   void setup() {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageUtilsTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageUtilsTest.java
@@ -43,7 +43,7 @@ class MetricStorageUtilsTest {
 
   @Test
   void mergeInPlace() {
-    Aggregator<String> agg = buildConcatAggregator();
+    Aggregator<String, ?> agg = buildConcatAggregator();
     MetricStorageUtils.mergeInPlace(result, toMerge, agg);
 
     assertThat(result).containsOnly(entry(b, "merge(B,B')"), entry(c, "C"));
@@ -51,15 +51,15 @@ class MetricStorageUtilsTest {
 
   @Test
   void diffInPlace() {
-    Aggregator<String> agg = buildConcatAggregator();
+    Aggregator<String, ?> agg = buildConcatAggregator();
     MetricStorageUtils.diffInPlace(result, toMerge, agg);
 
     assertThat(result).containsOnly(entry(b, "diff(B,B')"), entry(c, "C"));
   }
 
   @SuppressWarnings("unchecked")
-  private static Aggregator<String> buildConcatAggregator() {
-    Aggregator<String> agg = mock(Aggregator.class);
+  private static Aggregator<String, ?> buildConcatAggregator() {
+    Aggregator<String, ?> agg = mock(Aggregator.class);
     doAnswer(
             invocation -> {
               String previousCumulative = invocation.getArgument(0);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorageTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorageTest.java
@@ -13,6 +13,7 @@ import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.InstrumentValueType;
+import io.opentelemetry.sdk.metrics.data.LongExemplarData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricReader;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
@@ -45,7 +46,7 @@ public class SynchronousMetricStorageTest {
   private static final MetricDescriptor METRIC_DESCRIPTOR =
       MetricDescriptor.create("name", "description", "unit");
   private final TestClock testClock = TestClock.create();
-  private final Aggregator<Long> aggregator =
+  private final Aggregator<Long, LongExemplarData> aggregator =
       ((AggregatorFactory) Aggregation.lastValue())
           .createAggregator(DESCRIPTOR, ExemplarFilter.neverSample());
   private final AttributesProcessor attributesProcessor = AttributesProcessor.noop();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorageTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorageTest.java
@@ -13,6 +13,7 @@ import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.PointData;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
@@ -43,11 +44,11 @@ class TemporalMetricStorageTest {
           InstrumentValueType.DOUBLE);
   private static final MetricDescriptor METRIC_DESCRIPTOR =
       MetricDescriptor.create("name", "description", "unit");
-  private static final Aggregator<DoubleAccumulation> SUM =
+  private static final Aggregator<DoubleAccumulation, DoubleExemplarData> SUM =
       ((AggregatorFactory) Aggregation.sum())
           .createAggregator(DESCRIPTOR, ExemplarFilter.neverSample());
 
-  private static final Aggregator<DoubleAccumulation> ASYNC_SUM =
+  private static final Aggregator<DoubleAccumulation, DoubleExemplarData> ASYNC_SUM =
       ((AggregatorFactory) Aggregation.sum())
           .createAggregator(ASYNC_DESCRIPTOR, ExemplarFilter.neverSample());
 
@@ -74,7 +75,7 @@ class TemporalMetricStorageTest {
   @Test
   void synchronousCumulative_joinsWithLastMeasurementForCumulative() {
     AggregationTemporality temporality = AggregationTemporality.CUMULATIVE;
-    TemporalMetricStorage<DoubleAccumulation> storage =
+    TemporalMetricStorage<DoubleAccumulation, DoubleExemplarData> storage =
         new TemporalMetricStorage<>(SUM, /* isSynchronous= */ true);
     // Send in new measurement at time 10 for collector 1
     assertThat(
@@ -148,7 +149,7 @@ class TemporalMetricStorageTest {
 
   @Test
   void synchronousCumulative_dropsStaleAtLimit() {
-    TemporalMetricStorage<DoubleAccumulation> storage =
+    TemporalMetricStorage<DoubleAccumulation, DoubleExemplarData> storage =
         new TemporalMetricStorage<>(SUM, /* isSynchronous= */ true);
 
     // Send in new measurement at time 10 for collector 1, with attr1
@@ -203,7 +204,7 @@ class TemporalMetricStorageTest {
 
   @Test
   void synchronousDelta_dropsStale() {
-    TemporalMetricStorage<DoubleAccumulation> storage =
+    TemporalMetricStorage<DoubleAccumulation, DoubleExemplarData> storage =
         new TemporalMetricStorage<>(SUM, /* isSynchronous= */ true);
 
     // Send in new measurement at time 10 for collector 1, with attr1
@@ -253,7 +254,7 @@ class TemporalMetricStorageTest {
   @Test
   void synchronousDelta_useLastTimestamp() {
     AggregationTemporality temporality = AggregationTemporality.DELTA;
-    TemporalMetricStorage<DoubleAccumulation> storage =
+    TemporalMetricStorage<DoubleAccumulation, DoubleExemplarData> storage =
         new TemporalMetricStorage<>(SUM, /* isSynchronous= */ true);
     // Send in new measurement at time 10 for collector 1
     assertThat(
@@ -327,7 +328,7 @@ class TemporalMetricStorageTest {
 
   @Test
   void synchronous_deltaAndCumulative() {
-    TemporalMetricStorage<DoubleAccumulation> storage =
+    TemporalMetricStorage<DoubleAccumulation, DoubleExemplarData> storage =
         new TemporalMetricStorage<>(SUM, /* isSynchronous= */ true);
     // Send in new measurement at time 10 for collector 1
     assertThat(
@@ -419,7 +420,7 @@ class TemporalMetricStorageTest {
   @Test
   void asynchronousCumulative_doesNotJoin() {
     AggregationTemporality temporality = AggregationTemporality.CUMULATIVE;
-    TemporalMetricStorage<DoubleAccumulation> storage =
+    TemporalMetricStorage<DoubleAccumulation, DoubleExemplarData> storage =
         new TemporalMetricStorage<>(ASYNC_SUM, /* isSynchronous= */ false);
     // Send in new measurement at time 10 for collector 1
     assertThat(
@@ -493,7 +494,7 @@ class TemporalMetricStorageTest {
 
   @Test
   void asynchronousCumulative_dropsStale() {
-    TemporalMetricStorage<DoubleAccumulation> storage =
+    TemporalMetricStorage<DoubleAccumulation, DoubleExemplarData> storage =
         new TemporalMetricStorage<>(ASYNC_SUM, /* isSynchronous= */ false);
 
     // Send in new measurement at time 10 for collector 1, with attr1
@@ -542,7 +543,7 @@ class TemporalMetricStorageTest {
 
   @Test
   void asynchronousDelta_dropsStale() {
-    TemporalMetricStorage<DoubleAccumulation> storage =
+    TemporalMetricStorage<DoubleAccumulation, DoubleExemplarData> storage =
         new TemporalMetricStorage<>(ASYNC_SUM, /* isSynchronous= */ false);
 
     // Send in new measurement at time 10 for collector 1, with attr1
@@ -592,7 +593,7 @@ class TemporalMetricStorageTest {
   @Test
   void asynchronousDelta_diffsLastTimestamp() {
     AggregationTemporality temporality = AggregationTemporality.DELTA;
-    TemporalMetricStorage<DoubleAccumulation> storage =
+    TemporalMetricStorage<DoubleAccumulation, DoubleExemplarData> storage =
         new TemporalMetricStorage<>(ASYNC_SUM, /* isSynchronous= */ false);
     // Send in new measurement at time 10 for collector 1
     assertThat(
@@ -666,7 +667,7 @@ class TemporalMetricStorageTest {
 
   @Test
   void asynchronous_DeltaAndCumulative() {
-    TemporalMetricStorage<DoubleAccumulation> storage =
+    TemporalMetricStorage<DoubleAccumulation, DoubleExemplarData> storage =
         new TemporalMetricStorage<>(ASYNC_SUM, /* isSynchronous= */ false);
 
     // Send in new measurement at time 10 for collector 1

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/AbstractPointDataAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/AbstractPointDataAssert.java
@@ -10,7 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.data.PointData;
 import java.util.Arrays;
 import java.util.Map;
@@ -107,15 +106,6 @@ public abstract class AbstractPointDataAssert<
    */
   public final PointAssertT hasAttributesSatisfying(Iterable<AttributeAssertion> assertions) {
     AssertUtil.assertAttributes(actual.getAttributes(), assertions);
-    return myself;
-  }
-
-  /** Asserts the point has the specified exemplars, in any order. */
-  public final PointAssertT hasExemplars(ExemplarData... exemplars) {
-    isNotNull();
-    Assertions.assertThat(actual.getExemplars())
-        .as("exemplars")
-        .containsExactlyInAnyOrder(exemplars);
     return myself;
   }
 

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/DoublePointDataAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/DoublePointDataAssert.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.testing.assertj;
 
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.DoublePointData;
 import javax.annotation.Nullable;
 import org.assertj.core.api.Assertions;
@@ -22,5 +23,14 @@ public final class DoublePointDataAssert
     isNotNull();
     Assertions.assertThat(actual.getValue()).as("value").isEqualTo(expected);
     return this;
+  }
+
+  /** Asserts the point has the specified exemplars, in any order. */
+  public DoublePointDataAssert hasExemplars(DoubleExemplarData... exemplars) {
+    isNotNull();
+    Assertions.assertThat(actual.getExemplars())
+        .as("exemplars")
+        .containsExactlyInAnyOrder(exemplars);
+    return myself;
   }
 }

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LongPointDataAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LongPointDataAssert.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.testing.assertj;
 
+import io.opentelemetry.sdk.metrics.data.LongExemplarData;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
 import javax.annotation.Nullable;
 import org.assertj.core.api.Assertions;
@@ -22,5 +23,14 @@ public final class LongPointDataAssert
     isNotNull();
     Assertions.assertThat(actual.getValue()).as("value").isEqualTo(expected);
     return this;
+  }
+
+  /** Asserts the point has the specified exemplars, in any order. */
+  public LongPointDataAssert hasExemplars(LongExemplarData... exemplars) {
+    isNotNull();
+    Assertions.assertThat(actual.getExemplars())
+        .as("exemplars")
+        .containsExactlyInAnyOrder(exemplars);
+    return myself;
   }
 }


### PR DESCRIPTION
While writing the assertion code, I noticed that we have a public long exemplar type but don't actually use it in the SDK. I'm not so comfortable releasing a public type without us having experience using it in internal code. It also seemed weird that a `LongPointData` can have a `DoubleExemplarData`.

This PR parameterizes many components to allow recording long exemplars from long aggregations. It ended up needing to be a huge PR - I guess we have some tight coupling between exemplars and storage, and perhaps with some time we can find a creative solution to make this a bit simpler. For now, the main change I want to get in by next month is the 3 lines of public API tweaks (ABI compatible, slightly API-incompatible) which notably makes sure long points export with long exemplars, double points with double exemplars. All the other changes were required for these 3 lines, or at least I couldn't find a workaround to get the PR sized down.