### PR TITLE
Decrease logging level for no metric data exported

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
@@ -135,7 +135,7 @@ public final class PeriodicMetricReader implements MetricReader {
         try {
           Collection<MetricData> metricData = metricProducer.collectAllMetrics();
           if (metricData.isEmpty()) {
-            logger.log(Level.FINE, "No metric data to export - skipping export.");
+            logger.log(Level.FINEST, "No metric data to export - skipping export.");
             flushResult.succeed();
             exportAvailable.set(true);
           } else {


### PR DESCRIPTION
For testing agent configures `PeriodicMetricReader` to run with a short interval. Due to this it may log `No metric data to export - skipping export.` multiple times for each test. Decreasing the log level to `FINEST` should keep it out from agent debug logs.