### PR TITLE
Change ubuntu-20.04 to ubuntu-latest

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-20.04
+          - ubuntu-latest
         test-java-version:
           - 8
           - 11
@@ -24,7 +24,7 @@ jobs:
           - 18
         # Collect coverage on latest LTS
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             test-java-version: 17
             coverage: true
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-20.04
+          - ubuntu-latest
         test-java-version:
           - 8
           - 11
@@ -24,7 +24,7 @@ jobs:
           - 18
         # Collect coverage on latest LTS
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             test-java-version: 17
             coverage: true
     steps:
@@ -79,7 +79,7 @@ jobs:
     needs: build
     # skipping release branches because the versions in those branches are not snapshots
     if: ${{ github.ref_name == 'main' && github.repository == 'open-telemetry/opentelemetry-java' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
`ubuntu-latest` currently is the same as `ubuntu-20.04`, I'm not sure if this is intentionally using `ubuntu-20.04` because of previous issues when `ubuntu-latest` was bumped from 18.04 to 20.04