### PR TITLE
Revert PeriodicMetricReader logging level change

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
@@ -135,7 +135,7 @@ public final class PeriodicMetricReader implements MetricReader {
         try {
           Collection<MetricData> metricData = metricProducer.collectAllMetrics();
           if (metricData.isEmpty()) {
-            logger.log(Level.FINEST, "No metric data to export - skipping export.");
+            logger.log(Level.FINE, "No metric data to export - skipping export.");
             flushResult.succeed();
             exportAvailable.set(true);
           } else {


### PR DESCRIPTION
Revert https://github.com/open-telemetry/opentelemetry-java/pull/4405 as @anuraaga believes it is better to suppress this on the agent side.