### PR TITLE
Migrate sum, histogram, summary assert to stable testing.

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
@@ -23,6 +23,15 @@ Comparing source compatibility of  against
 	+++  NEW SUPERCLASS: io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.DoublePointDataAssert hasExemplars(io.opentelemetry.sdk.metrics.data.DoubleExemplarData[])
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.DoublePointDataAssert hasValue(double)
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.DoubleSumAssert  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.DoubleSumAssert hasPointsSatisfying(java.util.function.Consumer[])
+		+++  NEW ANNOTATION: java.lang.SafeVarargs
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.DoubleSumAssert hasPointsSatisfying(java.lang.Iterable)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.DoubleSumAssert isCumulative()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.DoubleSumAssert isDelta()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.DoubleSumAssert isMonotonic()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.DoubleSumAssert isNotMonotonic()
 +++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.ExemplarDataAssert  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.ExemplarDataAssert hasEpochNanos(long)
@@ -36,6 +45,23 @@ Comparing source compatibility of  against
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.ExemplarDataAssert hasSpanId(java.lang.String)
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.ExemplarDataAssert hasTraceId(java.lang.String)
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.ExemplarDataAssert hasValue(double)
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.HistogramAssert  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.HistogramAssert hasPointsSatisfying(java.util.function.Consumer[])
+		+++  NEW ANNOTATION: java.lang.SafeVarargs
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.HistogramAssert hasPointsSatisfying(java.lang.Iterable)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.HistogramAssert isCumulative()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.HistogramAssert isDelta()
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.HistogramPointAssert  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.HistogramPointAssert hasBucketBoundaries(double[])
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.HistogramPointAssert hasBucketCounts(long[])
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.HistogramPointAssert hasCount(long)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.HistogramPointAssert hasMax(double)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.HistogramPointAssert hasMin(double)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.HistogramPointAssert hasSum(double)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.HistogramPointAssert hasSumGreaterThan(double)
 +++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.LongGaugeAssert  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.LongGaugeAssert hasPointsSatisfying(java.util.function.Consumer[])
@@ -46,15 +72,46 @@ Comparing source compatibility of  against
 	+++  NEW SUPERCLASS: io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LongPointDataAssert hasExemplars(io.opentelemetry.sdk.metrics.data.LongExemplarData[])
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LongPointDataAssert hasValue(long)
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.LongSumAssert  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.LongSumAssert hasPointsSatisfying(java.util.function.Consumer[])
+		+++  NEW ANNOTATION: java.lang.SafeVarargs
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LongSumAssert hasPointsSatisfying(java.lang.Iterable)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LongSumAssert isCumulative()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LongSumAssert isDelta()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LongSumAssert isMonotonic()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LongSumAssert isNotMonotonic()
 +++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasDescription(java.lang.String)
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasDoubleGaugeSatisfying(java.util.function.Consumer)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasDoubleSumSatisfying(java.util.function.Consumer)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasHistogramSatisfying(java.util.function.Consumer)
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasInstrumentationScope(io.opentelemetry.sdk.common.InstrumentationScopeInfo)
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasLongGaugeSatisfying(java.util.function.Consumer)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasLongSumSatisfying(java.util.function.Consumer)
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasName(java.lang.String)
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasResource(io.opentelemetry.sdk.resources.Resource)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasSummarySatisfying(java.util.function.Consumer)
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasUnit(java.lang.String)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert assertThat(io.opentelemetry.sdk.metrics.data.MetricData)
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.SummaryAssert  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.SummaryAssert hasPointsSatisfying(java.util.function.Consumer[])
+		+++  NEW ANNOTATION: java.lang.SafeVarargs
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.SummaryAssert hasPointsSatisfying(java.lang.Iterable)
+	+++  NEW METHOD: PUBLIC(+) org.assertj.core.api.AbstractIterableAssert points()
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.SummaryPointAssert  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.SummaryPointAssert hasCount(long)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.SummaryPointAssert hasSum(double)
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.SummaryPointAssert hasValuesSatisfying(java.util.function.Consumer[])
+		+++  NEW ANNOTATION: java.lang.SafeVarargs
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.SummaryPointAssert hasValuesSatisfying(java.lang.Iterable)
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.ValueAtQuantileAssert  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.ValueAtQuantileAssert hasQuantile(double)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.ValueAtQuantileAssert hasValue(double)

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/DoubleSumAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/DoubleSumAssert.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.testing.assertj;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.SumData;
+import java.util.Arrays;
+import java.util.function.Consumer;
+import org.assertj.core.api.AbstractAssert;
+
+/** Test assertions for double {@link SumData}. */
+public final class DoubleSumAssert
+    extends AbstractAssert<DoubleSumAssert, SumData<DoublePointData>> {
+  DoubleSumAssert(SumData<DoublePointData> actual) {
+    super(actual, DoubleSumAssert.class);
+  }
+
+  /** Ensures that {@code is_monotonic} field is true. */
+  public DoubleSumAssert isMonotonic() {
+    isNotNull();
+    if (!actual.isMonotonic()) {
+      failWithActualExpectedAndMessage(
+          actual, "monotonic: true", "Expected Sum to be monotonic", true, actual.isMonotonic());
+    }
+    return myself;
+  }
+
+  /** Ensures that {@code is_monotonic} field is false. */
+  public DoubleSumAssert isNotMonotonic() {
+    isNotNull();
+    if (actual.isMonotonic()) {
+      failWithActualExpectedAndMessage(
+          actual,
+          "monotonic: fail",
+          "Expected Sum to be non-monotonic, found: %s",
+          actual.isMonotonic());
+    }
+    return myself;
+  }
+
+  /** Ensures that {@code aggregation_temporality} field is {@code CUMULATIVE}. */
+  public DoubleSumAssert isCumulative() {
+    isNotNull();
+    if (actual.getAggregationTemporality() != AggregationTemporality.CUMULATIVE) {
+      failWithActualExpectedAndMessage(
+          actual,
+          "aggregationTemporality: CUMULATIVE",
+          "Expected Sum to have cumulative aggregation but found <%s>",
+          actual.getAggregationTemporality());
+    }
+    return myself;
+  }
+
+  /** Ensures that {@code aggregation_temporality} field is {@code DELTA}. */
+  public DoubleSumAssert isDelta() {
+    isNotNull();
+    if (actual.getAggregationTemporality() != AggregationTemporality.DELTA) {
+      failWithActualExpectedAndMessage(
+          actual,
+          "aggregationTemporality: DELTA",
+          "Expected Sum to have delta aggregation but found <%s>",
+          actual.getAggregationTemporality());
+    }
+    return myself;
+  }
+
+  /** Asserts the sum has points matching all of the given assertions and no more, in any order. */
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  public final DoubleSumAssert hasPointsSatisfying(Consumer<DoublePointDataAssert>... assertions) {
+    return hasPointsSatisfying(Arrays.asList(assertions));
+  }
+
+  /** Asserts the sum has points matching all of the given assertions and no more, in any order. */
+  public DoubleSumAssert hasPointsSatisfying(
+      Iterable<? extends Consumer<DoublePointDataAssert>> assertions) {
+    assertThat(actual.getPoints())
+        .satisfiesExactlyInAnyOrder(AssertUtil.toConsumers(assertions, DoublePointDataAssert::new));
+    return this;
+  }
+}

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/HistogramAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/HistogramAssert.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.testing.assertj;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.HistogramData;
+import java.util.Arrays;
+import java.util.function.Consumer;
+import org.assertj.core.api.AbstractAssert;
+
+/** Test assertions for {@link HistogramData}. */
+public final class HistogramAssert extends AbstractAssert<HistogramAssert, HistogramData> {
+
+  HistogramAssert(HistogramData actual) {
+    super(actual, HistogramAssert.class);
+  }
+
+  /** Ensures that {@code aggregation_temporality} field is {@code CUMULATIVE}. */
+  public HistogramAssert isCumulative() {
+    isNotNull();
+    if (actual.getAggregationTemporality() != AggregationTemporality.CUMULATIVE) {
+      failWithActualExpectedAndMessage(
+          actual,
+          "aggregationTemporality: CUMULATIVE",
+          "Expected Histogram to have cumulative aggregation but found <%s>",
+          AggregationTemporality.CUMULATIVE,
+          actual.getAggregationTemporality());
+    }
+    return this;
+  }
+
+  /** Ensures that {@code aggregation_temporality} field is {@code DELTA}. */
+  public HistogramAssert isDelta() {
+    isNotNull();
+    if (actual.getAggregationTemporality() != AggregationTemporality.DELTA) {
+      failWithActualExpectedAndMessage(
+          actual,
+          "aggregationTemporality: DELTA",
+          "Expected Histgram to have cumulative aggregation but found <%s>",
+          AggregationTemporality.DELTA,
+          actual.getAggregationTemporality());
+    }
+    return this;
+  }
+
+  /**
+   * Asserts the histogram has points matching all of the given assertions and no more, in any
+   * order.
+   */
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  public final HistogramAssert hasPointsSatisfying(Consumer<HistogramPointAssert>... assertions) {
+    return hasPointsSatisfying(Arrays.asList(assertions));
+  }
+
+  /**
+   * Asserts the histogram has points matching all of the given assertions and no more, in any
+   * order.
+   */
+  public HistogramAssert hasPointsSatisfying(
+      Iterable<? extends Consumer<HistogramPointAssert>> assertions) {
+    assertThat(actual.getPoints())
+        .satisfiesExactlyInAnyOrder(AssertUtil.toConsumers(assertions, HistogramPointAssert::new));
+    return this;
+  }
+}

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/HistogramPointAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/HistogramPointAssert.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.testing.assertj;
+
+import io.opentelemetry.sdk.metrics.data.HistogramPointData;
+import java.util.Arrays;
+import org.assertj.core.api.Assertions;
+
+/** Test assertions for {@link HistogramPointData}. */
+public final class HistogramPointAssert
+    extends AbstractPointDataAssert<HistogramPointAssert, HistogramPointData> {
+
+  HistogramPointAssert(HistogramPointData actual) {
+    super(actual, HistogramPointAssert.class);
+  }
+
+  /** Asserts the {@code sum} field matches the expected value. */
+  public HistogramPointAssert hasSum(double expected) {
+    isNotNull();
+    Assertions.assertThat(actual.getSum()).as("sum").isEqualTo(expected);
+    return this;
+  }
+
+  /** Asserts the {@code sum} field contains a greater value than the passed {@code boundary}. */
+  public HistogramPointAssert hasSumGreaterThan(double boundary) {
+    isNotNull();
+    Assertions.assertThat(actual.getSum()).as("sum").isGreaterThan(boundary);
+    return this;
+  }
+
+  /** Asserts the {@code min} field matches the expected value. */
+  public HistogramPointAssert hasMin(double expected) {
+    isNotNull();
+    Assertions.assertThat(actual.hasMin()).isTrue();
+    Assertions.assertThat(actual.getMin()).as("min").isEqualTo(expected);
+    return this;
+  }
+
+  /** Asserts the {@code max} field matches the expected value. */
+  public HistogramPointAssert hasMax(double expected) {
+    isNotNull();
+    Assertions.assertThat(actual.hasMax()).isTrue();
+    Assertions.assertThat(actual.getMax()).as("max").isEqualTo(expected);
+    return this;
+  }
+
+  /** Asserts the {@code count} field matches the expected value. */
+  public HistogramPointAssert hasCount(long expected) {
+    isNotNull();
+    Assertions.assertThat(actual.getCount()).as("count").isEqualTo(expected);
+    return this;
+  }
+
+  /**
+   * Asserts the {@code boundaries} field matches the expected value.
+   *
+   * @param boundaries The set of bucket boundaries in the same order as the expected collection.
+   */
+  public HistogramPointAssert hasBucketBoundaries(double... boundaries) {
+    isNotNull();
+    Double[] bigBoundaries = Arrays.stream(boundaries).boxed().toArray(Double[]::new);
+    Assertions.assertThat(actual.getBoundaries()).as("boundaries").containsExactly(bigBoundaries);
+    return this;
+  }
+
+  /**
+   * Asserts the {@code counts} field matches the expected value.
+   *
+   * @param counts The set of bucket counts in the same order as the expected collection.
+   */
+  public HistogramPointAssert hasBucketCounts(long... counts) {
+    isNotNull();
+    Long[] bigCounts = Arrays.stream(counts).boxed().toArray(Long[]::new);
+    Assertions.assertThat(actual.getCounts()).as("bucketCounts").containsExactly(bigCounts);
+    return this;
+  }
+}

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LongSumAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LongSumAssert.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.testing.assertj;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.SumData;
+import java.util.Arrays;
+import java.util.function.Consumer;
+import org.assertj.core.api.AbstractAssert;
+
+/** Test assertions for long {@link SumData}. */
+public final class LongSumAssert extends AbstractAssert<LongSumAssert, SumData<LongPointData>> {
+  LongSumAssert(SumData<LongPointData> actual) {
+    super(actual, LongSumAssert.class);
+  }
+
+  /** Ensures that {@code is_monotonic} field is true. */
+  public LongSumAssert isMonotonic() {
+    isNotNull();
+    if (!actual.isMonotonic()) {
+      failWithActualExpectedAndMessage(
+          actual, "monotonic: true", "Expected Sum to be monotonic", true, actual.isMonotonic());
+    }
+    return myself;
+  }
+
+  /** Ensures that {@code is_monotonic} field is false. */
+  public LongSumAssert isNotMonotonic() {
+    isNotNull();
+    if (actual.isMonotonic()) {
+      failWithActualExpectedAndMessage(
+          actual,
+          "monotonic: fail",
+          "Expected Sum to be non-monotonic, found: %s",
+          actual.isMonotonic());
+    }
+    return myself;
+  }
+
+  /** Ensures that {@code aggregation_temporality} field is {@code CUMULATIVE}. */
+  public LongSumAssert isCumulative() {
+    isNotNull();
+    if (actual.getAggregationTemporality() != AggregationTemporality.CUMULATIVE) {
+      failWithActualExpectedAndMessage(
+          actual,
+          "aggregationTemporality: CUMULATIVE",
+          "Expected Sum to have cumulative aggregation but found <%s>",
+          actual.getAggregationTemporality());
+    }
+    return myself;
+  }
+
+  /** Ensures that {@code aggregation_temporality} field is {@code DELTA}. */
+  public LongSumAssert isDelta() {
+    isNotNull();
+    if (actual.getAggregationTemporality() != AggregationTemporality.DELTA) {
+      failWithActualExpectedAndMessage(
+          actual,
+          "aggregationTemporality: DELTA",
+          "Expected Sum to have delta aggregation but found <%s>",
+          actual.getAggregationTemporality());
+    }
+    return myself;
+  }
+
+  /** Asserts the sum has points matching all of the given assertions and no more, in any order. */
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  public final LongSumAssert hasPointsSatisfying(Consumer<LongPointDataAssert>... assertions) {
+    return hasPointsSatisfying(Arrays.asList(assertions));
+  }
+
+  /** Asserts the sum has points matching all of the given assertions and no more, in any order. */
+  public LongSumAssert hasPointsSatisfying(
+      Iterable<? extends Consumer<LongPointDataAssert>> assertions) {
+    assertThat(actual.getPoints())
+        .satisfiesExactlyInAnyOrder(AssertUtil.toConsumers(assertions, LongPointDataAssert::new));
+    return this;
+  }
+}

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/MetricDataAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/MetricDataAssert.java
@@ -123,4 +123,64 @@ public final class MetricDataAssert extends AbstractAssert<MetricDataAssert, Met
     assertion.accept(new LongGaugeAssert(actual.getLongGaugeData()));
     return this;
   }
+
+  /** Asserts this {@link MetricData} is a double sum that satisfies the provided assertion. */
+  public MetricDataAssert hasDoubleSumSatisfying(Consumer<DoubleSumAssert> assertion) {
+    isNotNull();
+    if (actual.getType() != MetricDataType.DOUBLE_SUM) {
+      failWithActualExpectedAndMessage(
+          actual,
+          "type: DOULE_SUM",
+          "Expected MetricData to have type <%s> but found <%s>",
+          MetricDataType.DOUBLE_SUM,
+          actual.getType());
+    }
+    assertion.accept(new DoubleSumAssert(actual.getDoubleSumData()));
+    return this;
+  }
+
+  /** Asserts this {@link MetricData} is a long sum that satisfies the provided assertion. */
+  public MetricDataAssert hasLongSumSatisfying(Consumer<LongSumAssert> assertion) {
+    isNotNull();
+    if (actual.getType() != MetricDataType.LONG_SUM) {
+      failWithActualExpectedAndMessage(
+          actual,
+          "type: LONG_SUM",
+          "Expected MetricData to have type <%s> but found <%s>",
+          MetricDataType.LONG_SUM,
+          actual.getType());
+    }
+    assertion.accept(new LongSumAssert(actual.getLongSumData()));
+    return this;
+  }
+
+  /** Asserts this {@link MetricData} is a histogram that satisfies the provided assertion. */
+  public MetricDataAssert hasHistogramSatisfying(Consumer<HistogramAssert> assertion) {
+    isNotNull();
+    if (actual.getType() != MetricDataType.HISTOGRAM) {
+      failWithActualExpectedAndMessage(
+          actual,
+          "type: HISTOGRAM",
+          "Expected MetricData to have type <%s> but found <%s>",
+          MetricDataType.HISTOGRAM,
+          actual.getType());
+    }
+    assertion.accept(new HistogramAssert(actual.getHistogramData()));
+    return this;
+  }
+
+  /** Asserts this {@link MetricData} is a summary that satisfies the provided assertion. */
+  public MetricDataAssert hasSummarySatisfying(Consumer<SummaryAssert> assertion) {
+    isNotNull();
+    if (actual.getType() != MetricDataType.SUMMARY) {
+      failWithActualExpectedAndMessage(
+          actual,
+          "type: SUMMARY",
+          "Expected MetricData to have type <%s> but found <%s>",
+          MetricDataType.SUMMARY,
+          actual.getType());
+    }
+    assertion.accept(new SummaryAssert(actual.getSummaryData()));
+    return this;
+  }
 }

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SummaryAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SummaryAssert.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.testing.assertj;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.sdk.metrics.data.SummaryData;
+import io.opentelemetry.sdk.metrics.data.SummaryPointData;
+import java.util.Arrays;
+import java.util.function.Consumer;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractIterableAssert;
+import org.assertj.core.api.Assertions;
+
+/** Test assertions for {@link SummaryData}. */
+public final class SummaryAssert extends AbstractAssert<SummaryAssert, SummaryData> {
+
+  SummaryAssert(SummaryData actual) {
+    super(actual, SummaryAssert.class);
+  }
+
+  /** Returns convenience API to assert against the {@code points} field. */
+  public AbstractIterableAssert<
+          ?, ? extends Iterable<? extends SummaryPointData>, SummaryPointData, ?>
+      points() {
+    isNotNull();
+    return Assertions.assertThat(actual.getPoints());
+  }
+
+  /**
+   * Asserts the summary has points matching all of the given assertions and no more, in any order.
+   */
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  public final SummaryAssert hasPointsSatisfying(Consumer<SummaryPointAssert>... assertions) {
+    return hasPointsSatisfying(Arrays.asList(assertions));
+  }
+
+  /**
+   * Asserts the summary has points matching all of the given assertions and no more, in any order.
+   */
+  public SummaryAssert hasPointsSatisfying(
+      Iterable<? extends Consumer<SummaryPointAssert>> assertions) {
+    assertThat(actual.getPoints())
+        .satisfiesExactlyInAnyOrder(AssertUtil.toConsumers(assertions, SummaryPointAssert::new));
+    return this;
+  }
+}

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SummaryPointAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SummaryPointAssert.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.testing.assertj;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.sdk.metrics.data.SummaryPointData;
+import java.util.Arrays;
+import java.util.function.Consumer;
+import org.assertj.core.api.Assertions;
+
+/** Test assertions for (deprecated) {@link SummaryPointData}. */
+public final class SummaryPointAssert
+    extends AbstractPointDataAssert<SummaryPointAssert, SummaryPointData> {
+
+  SummaryPointAssert(SummaryPointData actual) {
+    super(actual, SummaryPointAssert.class);
+  }
+
+  /** Asserts the summary has seen the expected count of measurements. */
+  public SummaryPointAssert hasCount(long expected) {
+    isNotNull();
+    Assertions.assertThat(actual.getCount()).as("count").isEqualTo(expected);
+    return this;
+  }
+
+  /** Asserts the summary has the expected sum across all observed measurements. */
+  public SummaryPointAssert hasSum(double expected) {
+    isNotNull();
+    Assertions.assertThat(actual.getSum()).as("sum").isEqualTo(expected);
+    return this;
+  }
+
+  /**
+   * Asserts the point has values matching all of the given assertions and no more, in any order.
+   */
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  public final SummaryPointAssert hasValuesSatisfying(
+      Consumer<ValueAtQuantileAssert>... assertions) {
+    return hasValuesSatisfying(Arrays.asList(assertions));
+  }
+
+  /**
+   * Asserts the point has values matching all of the given assertions and no more, in any order.
+   */
+  public SummaryPointAssert hasValuesSatisfying(
+      Iterable<? extends Consumer<ValueAtQuantileAssert>> assertions) {
+    assertThat(actual.getValues())
+        .satisfiesExactlyInAnyOrder(AssertUtil.toConsumers(assertions, ValueAtQuantileAssert::new));
+    return this;
+  }
+}

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/ValueAtQuantileAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/ValueAtQuantileAssert.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.testing.assertj;
+
+import io.opentelemetry.sdk.metrics.data.ValueAtQuantile;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+
+/** Test assertions for (deprecated) {@link ValueAtQuantile}. */
+public final class ValueAtQuantileAssert
+    extends AbstractAssert<ValueAtQuantileAssert, ValueAtQuantile> {
+
+  ValueAtQuantileAssert(ValueAtQuantile actual) {
+    super(actual, ValueAtQuantileAssert.class);
+  }
+
+  /** Asserts the given quantile. */
+  public ValueAtQuantileAssert hasQuantile(double expected) {
+    isNotNull();
+    Assertions.assertThat(actual.getQuantile()).as("quantile").isEqualTo(expected);
+    return this;
+  }
+
+  /** Asserts the given value. */
+  public ValueAtQuantileAssert hasValue(double expected) {
+    isNotNull();
+    Assertions.assertThat(actual.getValue()).as("value").isEqualTo(expected);
+    return this;
+  }
+}

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/MetricAssertionsTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/MetricAssertionsTest.java
@@ -157,6 +157,19 @@ class MetricAssertionsTest {
               // Points
               Arrays.asList(DOUBLE_POINT_DATA, DOUBLE_POINT_DATA_WITH_EXEMPLAR)));
 
+  private static final MetricData DOUBLE_SUM_METRIC_DELTA_NONMONOTONIC =
+      ImmutableMetricData.createDoubleSum(
+          RESOURCE,
+          INSTRUMENTATION_SCOPE_INFO,
+          /* name= */ "sum",
+          /* description= */ "a sum",
+          /* unit= */ "1",
+          ImmutableSumData.create(
+              false,
+              AggregationTemporality.DELTA,
+              // Points
+              Arrays.asList(DOUBLE_POINT_DATA, DOUBLE_POINT_DATA_WITH_EXEMPLAR)));
+
   private static final MetricData LONG_SUM_METRIC =
       ImmutableMetricData.createLongSum(
           RESOURCE,
@@ -167,6 +180,19 @@ class MetricAssertionsTest {
           ImmutableSumData.create(
               true,
               AggregationTemporality.CUMULATIVE,
+              // Points
+              Arrays.asList(LONG_POINT_DATA, LONG_POINT_DATA_WITH_EXEMPLAR)));
+
+  private static final MetricData LONG_SUM_METRIC_DELTA_NONMONOTONIC =
+      ImmutableMetricData.createLongSum(
+          RESOURCE,
+          INSTRUMENTATION_SCOPE_INFO,
+          /* name= */ "sum",
+          /* description= */ "a sum",
+          /* unit= */ "1",
+          ImmutableSumData.create(
+              false,
+              AggregationTemporality.DELTA,
               // Points
               Arrays.asList(LONG_POINT_DATA, LONG_POINT_DATA_WITH_EXEMPLAR)));
 
@@ -190,6 +216,18 @@ class MetricAssertionsTest {
           /* unit= */ "1",
           ImmutableHistogramData.create(
               AggregationTemporality.CUMULATIVE,
+              // Points
+              Arrays.asList(HISTOGRAM_POINT_DATA)));
+
+  private static final MetricData HISTOGRAM_METRIC_DELTA =
+      ImmutableMetricData.createDoubleHistogram(
+          RESOURCE,
+          INSTRUMENTATION_SCOPE_INFO,
+          /* name= */ "histogram",
+          /* description= */ "a histogram",
+          /* unit= */ "1",
+          ImmutableHistogramData.create(
+              AggregationTemporality.DELTA,
               // Points
               Arrays.asList(HISTOGRAM_POINT_DATA)));
 
@@ -620,6 +658,9 @@ class MetricAssertionsTest {
     assertThat(DOUBLE_SUM_METRIC)
         .hasDoubleSumSatisfying(
             sum -> sum.isMonotonic().isCumulative().hasPointsSatisfying(point -> {}, point -> {}));
+    assertThat(DOUBLE_SUM_METRIC_DELTA_NONMONOTONIC)
+        .hasDoubleSumSatisfying(
+            sum -> sum.isNotMonotonic().isDelta().hasPointsSatisfying(point -> {}, point -> {}));
   }
 
   @Test
@@ -641,6 +682,16 @@ class MetricAssertionsTest {
     assertThatThrownBy(
             () -> assertThat(DOUBLE_SUM_METRIC).hasDoubleSumSatisfying(sum -> sum.isDelta()))
         .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(DOUBLE_SUM_METRIC_DELTA_NONMONOTONIC)
+                    .hasDoubleSumSatisfying(sum -> sum.isMonotonic()))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(DOUBLE_SUM_METRIC_DELTA_NONMONOTONIC)
+                    .hasDoubleSumSatisfying(sum -> sum.isCumulative()))
+        .isInstanceOf(AssertionError.class);
   }
 
   @Test
@@ -648,6 +699,9 @@ class MetricAssertionsTest {
     assertThat(LONG_SUM_METRIC)
         .hasLongSumSatisfying(
             sum -> sum.isMonotonic().isCumulative().hasPointsSatisfying(point -> {}, point -> {}));
+    assertThat(LONG_SUM_METRIC_DELTA_NONMONOTONIC)
+        .hasLongSumSatisfying(
+            sum -> sum.isNotMonotonic().isDelta().hasPointsSatisfying(point -> {}, point -> {}));
   }
 
   @Test
@@ -668,6 +722,16 @@ class MetricAssertionsTest {
         .isInstanceOf(AssertionError.class);
     assertThatThrownBy(() -> assertThat(LONG_SUM_METRIC).hasLongSumSatisfying(sum -> sum.isDelta()))
         .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(LONG_SUM_METRIC_DELTA_NONMONOTONIC)
+                    .hasLongSumSatisfying(sum -> sum.isMonotonic()))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(LONG_SUM_METRIC_DELTA_NONMONOTONIC)
+                    .hasLongSumSatisfying(sum -> sum.isCumulative()))
+        .isInstanceOf(AssertionError.class);
   }
 
   @Test
@@ -686,6 +750,7 @@ class MetricAssertionsTest {
                                 .hasMin(4.0)
                                 .hasCount(3)
                                 .hasBucketBoundaries(10.0)));
+    assertThat(HISTOGRAM_METRIC_DELTA).hasHistogramSatisfying(histogram -> histogram.isDelta());
   }
 
   @Test
@@ -696,6 +761,11 @@ class MetricAssertionsTest {
             () ->
                 assertThat(HISTOGRAM_METRIC)
                     .hasHistogramSatisfying(histogram -> histogram.isDelta()))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(HISTOGRAM_METRIC_DELTA)
+                    .hasHistogramSatisfying(histogram -> histogram.isCumulative()))
         .isInstanceOf(AssertionError.class);
     assertThatThrownBy(
             () ->

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/MetricAssertionsTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/MetricAssertionsTest.java
@@ -18,17 +18,26 @@ import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.HistogramPointData;
 import io.opentelemetry.sdk.metrics.data.LongExemplarData;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.SummaryPointData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoubleExemplarData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoublePointData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableGaugeData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableHistogramData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableHistogramPointData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableLongExemplarData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableLongPointData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableSumData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableSummaryData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableSummaryPointData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableValueAtQuantile;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Arrays;
 import java.util.Collections;
@@ -134,6 +143,75 @@ class MetricAssertionsTest {
           ImmutableGaugeData.create(
               // Points
               Arrays.asList(LONG_POINT_DATA, LONG_POINT_DATA_WITH_EXEMPLAR)));
+
+  private static final MetricData DOUBLE_SUM_METRIC =
+      ImmutableMetricData.createDoubleSum(
+          RESOURCE,
+          INSTRUMENTATION_SCOPE_INFO,
+          /* name= */ "sum",
+          /* description= */ "a sum",
+          /* unit= */ "1",
+          ImmutableSumData.create(
+              true,
+              AggregationTemporality.CUMULATIVE,
+              // Points
+              Arrays.asList(DOUBLE_POINT_DATA, DOUBLE_POINT_DATA_WITH_EXEMPLAR)));
+
+  private static final MetricData LONG_SUM_METRIC =
+      ImmutableMetricData.createLongSum(
+          RESOURCE,
+          INSTRUMENTATION_SCOPE_INFO,
+          /* name= */ "sum",
+          /* description= */ "a sum",
+          /* unit= */ "1",
+          ImmutableSumData.create(
+              true,
+              AggregationTemporality.CUMULATIVE,
+              // Points
+              Arrays.asList(LONG_POINT_DATA, LONG_POINT_DATA_WITH_EXEMPLAR)));
+
+  private static final HistogramPointData HISTOGRAM_POINT_DATA =
+      ImmutableHistogramPointData.create(
+          1,
+          2,
+          Attributes.empty(),
+          15,
+          4.0,
+          7.0,
+          Collections.singletonList(10.0),
+          Arrays.asList(1L, 2L));
+
+  private static final MetricData HISTOGRAM_METRIC =
+      ImmutableMetricData.createDoubleHistogram(
+          RESOURCE,
+          INSTRUMENTATION_SCOPE_INFO,
+          /* name= */ "histogram",
+          /* description= */ "a histogram",
+          /* unit= */ "1",
+          ImmutableHistogramData.create(
+              AggregationTemporality.CUMULATIVE,
+              // Points
+              Arrays.asList(HISTOGRAM_POINT_DATA)));
+
+  private static final SummaryPointData SUMMARY_POINT_DATA =
+      ImmutableSummaryPointData.create(
+          1,
+          2,
+          Attributes.empty(),
+          1,
+          2,
+          Collections.singletonList(ImmutableValueAtQuantile.create(0, 1)));
+
+  private static final MetricData SUMMARY_METRIC =
+      ImmutableMetricData.createDoubleSummary(
+          RESOURCE,
+          INSTRUMENTATION_SCOPE_INFO,
+          /* name= */ "summary",
+          /* description= */ "a summary",
+          /* unit= */ "1",
+          ImmutableSummaryData.create(
+              // Points
+              Arrays.asList(SUMMARY_POINT_DATA)));
 
   @Test
   void doubleGauge() {
@@ -534,6 +612,197 @@ class MetricAssertionsTest {
                                     point.hasExemplarsSatisfying(
                                         exemplar -> exemplar.hasValue(100), exemplar -> {}),
                                 point -> point.hasValue(1))))
+        .isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  void duobleSum() {
+    assertThat(DOUBLE_SUM_METRIC)
+        .hasDoubleSumSatisfying(
+            sum -> sum.isMonotonic().isCumulative().hasPointsSatisfying(point -> {}, point -> {}));
+  }
+
+  @Test
+  void doubleSumFailure() {
+    assertThatThrownBy(() -> assertThat(DOUBLE_SUM_METRIC).hasLongSumSatisfying(sum -> {}))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(DOUBLE_SUM_METRIC)
+                    .hasDoubleSumSatisfying(
+                        sum ->
+                            sum.hasPointsSatisfying(
+                                // Not enough points
+                                point -> {})))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () -> assertThat(DOUBLE_SUM_METRIC).hasDoubleSumSatisfying(sum -> sum.isNotMonotonic()))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () -> assertThat(DOUBLE_SUM_METRIC).hasDoubleSumSatisfying(sum -> sum.isDelta()))
+        .isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  void longSum() {
+    assertThat(LONG_SUM_METRIC)
+        .hasLongSumSatisfying(
+            sum -> sum.isMonotonic().isCumulative().hasPointsSatisfying(point -> {}, point -> {}));
+  }
+
+  @Test
+  void longSumFailure() {
+    assertThatThrownBy(() -> assertThat(LONG_SUM_METRIC).hasDoubleSumSatisfying(sum -> {}))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(LONG_SUM_METRIC)
+                    .hasLongSumSatisfying(
+                        sum ->
+                            sum.hasPointsSatisfying(
+                                // Not enough points
+                                point -> {})))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () -> assertThat(LONG_SUM_METRIC).hasLongSumSatisfying(sum -> sum.isNotMonotonic()))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> assertThat(LONG_SUM_METRIC).hasLongSumSatisfying(sum -> sum.isDelta()))
+        .isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  void histogram() {
+    assertThat(HISTOGRAM_METRIC)
+        .hasHistogramSatisfying(
+            histogram ->
+                histogram
+                    .isCumulative()
+                    .hasPointsSatisfying(
+                        point ->
+                            point
+                                .hasSum(15.0)
+                                .hasSumGreaterThan(10.1)
+                                .hasMax(7.0)
+                                .hasMin(4.0)
+                                .hasCount(3)
+                                .hasBucketBoundaries(10.0)));
+  }
+
+  @Test
+  void histogram_failure() {
+    assertThatThrownBy(() -> assertThat(HISTOGRAM_METRIC).hasDoubleGaugeSatisfying(gauge -> {}))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(HISTOGRAM_METRIC)
+                    .hasHistogramSatisfying(histogram -> histogram.isDelta()))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(HISTOGRAM_METRIC)
+                    .hasHistogramSatisfying(
+                        histogram -> histogram.hasPointsSatisfying(point -> {}, point -> {})))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(HISTOGRAM_METRIC)
+                    .hasHistogramSatisfying(
+                        histogram -> histogram.hasPointsSatisfying(point -> point.hasSum(14.0))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(HISTOGRAM_METRIC)
+                    .hasHistogramSatisfying(
+                        histogram ->
+                            histogram.hasPointsSatisfying(point -> point.hasSumGreaterThan(16.0))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(HISTOGRAM_METRIC)
+                    .hasHistogramSatisfying(
+                        histogram -> histogram.hasPointsSatisfying(point -> point.hasMax(8.0))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(HISTOGRAM_METRIC)
+                    .hasHistogramSatisfying(
+                        histogram -> histogram.hasPointsSatisfying(point -> point.hasMin(5.0))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(HISTOGRAM_METRIC)
+                    .hasHistogramSatisfying(
+                        histogram -> histogram.hasPointsSatisfying(point -> point.hasCount(4))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(HISTOGRAM_METRIC)
+                    .hasHistogramSatisfying(
+                        histogram ->
+                            histogram.hasPointsSatisfying(
+                                point -> point.hasBucketBoundaries(11.0))))
+        .isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  void summary() {
+    assertThat(SUMMARY_METRIC)
+        .hasSummarySatisfying(
+            summary ->
+                summary.hasPointsSatisfying(
+                    point ->
+                        point
+                            .hasSum(2.0)
+                            .hasCount(1)
+                            .hasValuesSatisfying(value -> value.hasQuantile(0.0).hasValue(1.0))));
+  }
+
+  @Test
+  void summary_failure() {
+    assertThatThrownBy(() -> assertThat(SUMMARY_METRIC).hasHistogramSatisfying(histogram -> {}))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(SUMMARY_METRIC)
+                    .hasSummarySatisfying(
+                        summary -> summary.hasPointsSatisfying(point -> {}, point -> {})))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(SUMMARY_METRIC)
+                    .hasSummarySatisfying(
+                        summary -> summary.hasPointsSatisfying(point -> point.hasSum(1.0))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(SUMMARY_METRIC)
+                    .hasSummarySatisfying(
+                        summary -> summary.hasPointsSatisfying(point -> point.hasCount(2))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(SUMMARY_METRIC)
+                    .hasSummarySatisfying(
+                        summary ->
+                            summary.hasPointsSatisfying(
+                                point -> point.hasValuesSatisfying(value -> {}, value -> {}))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(SUMMARY_METRIC)
+                    .hasSummarySatisfying(
+                        summary ->
+                            summary.hasPointsSatisfying(
+                                point ->
+                                    point.hasValuesSatisfying(value -> value.hasQuantile(1.0)))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(SUMMARY_METRIC)
+                    .hasSummarySatisfying(
+                        summary ->
+                            summary.hasPointsSatisfying(
+                                point -> point.hasValuesSatisfying(value -> value.hasValue(3.0)))))
         .isInstanceOf(AssertionError.class);
   }
 }


### PR DESCRIPTION
Didn't migrate exponential histogram yet since it's still internal. Will probably migrate the assertions themselves to internal in the future.