### PR TITLE
Apply attribute limits to exception events

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
@@ -124,7 +124,7 @@ final class SdkSpan implements ReadWriteSpan {
    * @param name the displayed name for the new span.
    * @param kind the span kind.
    * @param parentSpan the parent span, or {@link Span#getInvalid()} if this span is a root span.
-   * @param spanLimits trace parameters like sampler and probability.
+   * @param spanLimits limits applied to this span.
    * @param spanProcessor handler called when the span starts and ends.
    * @param tracerClock the tracer's clock
    * @param resource the resource associated with this span.
@@ -399,7 +399,8 @@ final class SdkSpan implements ReadWriteSpan {
       additionalAttributes = Attributes.empty();
     }
 
-    addTimedEvent(ExceptionEventData.create(clock.now(), exception, additionalAttributes));
+    addTimedEvent(
+        ExceptionEventData.create(spanLimits, clock.now(), exception, additionalAttributes));
     return this;
   }
 

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/internal/data/ExceptionEventData.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/internal/data/ExceptionEventData.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.trace.internal.data;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.trace.SpanLimits;
 import io.opentelemetry.sdk.trace.data.EventData;
 
 /**
@@ -19,14 +20,19 @@ public interface ExceptionEventData extends EventData {
   /**
    * Returns a new immutable {@link ExceptionEventData}.
    *
+   * @param spanLimits limits applied to {@link ExceptionEventData}.
    * @param epochNanos epoch timestamp in nanos of the {@link ExceptionEventData}.
    * @param exception the {@link Throwable exception} of the {@code Event}.
    * @param additionalAttributes the additional attributes of the {@link ExceptionEventData}.
    * @return a new immutable {@link ExceptionEventData}
    */
   static ExceptionEventData create(
-      long epochNanos, Throwable exception, Attributes additionalAttributes) {
-    return ImmutableExceptionEventData.create(epochNanos, exception, additionalAttributes);
+      SpanLimits spanLimits,
+      long epochNanos,
+      Throwable exception,
+      Attributes additionalAttributes) {
+    return ImmutableExceptionEventData.create(
+        spanLimits, epochNanos, exception, additionalAttributes);
   }
 
   /**


### PR DESCRIPTION
Resolves open-telemetry/opentelemetry-java#4424