### PR TITLE
Add hasSpansSatisfyingExactlyInAnyOrder

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
@@ -111,6 +111,11 @@ Comparing source compatibility of  against
 	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.SummaryPointAssert hasValuesSatisfying(java.util.function.Consumer[])
 		+++  NEW ANNOTATION: java.lang.SafeVarargs
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.SummaryPointAssert hasValuesSatisfying(java.lang.Iterable)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.TraceAssert  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.TraceAssert hasSpansSatisfyingExactlyInAnyOrder(java.util.function.Consumer[])
+		+++  NEW ANNOTATION: java.lang.SafeVarargs
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.TraceAssert hasSpansSatisfyingExactlyInAnyOrder(java.lang.Iterable)
 +++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.ValueAtQuantileAssert  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.ValueAtQuantileAssert hasQuantile(double)

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TraceAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TraceAssert.java
@@ -67,6 +67,42 @@ public final class TraceAssert
   }
 
   /**
+   * Asserts that the trace under assertion has the same number of spans as provided {@code
+   * assertions} and verifies that there is a combination of spans that satisfies specified {@link
+   * SpanDataAssert} {@code assertions} in the given order. This is a variation of {@link
+   * #hasSpansSatisfyingExactly(Consumer...)} where order does not matter.
+   */
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  public final TraceAssert hasSpansSatisfyingExactlyInAnyOrder(
+      Consumer<SpanDataAssert>... assertions) {
+    return hasSpansSatisfyingExactlyInAnyOrder(Arrays.asList(assertions));
+  }
+
+  /**
+   * Asserts that the trace under assertion has the same number of spans as provided {@code
+   * assertions} and verifies that there is a combination of spans that satisfies specified {@link
+   * SpanDataAssert} {@code assertions} in the given order. This is a variation of {@link
+   * #hasSpansSatisfyingExactly(Iterable)} where order does not matter.
+   */
+  public TraceAssert hasSpansSatisfyingExactlyInAnyOrder(
+      Iterable<? extends Consumer<SpanDataAssert>> assertions) {
+    @SuppressWarnings("unchecked")
+    Consumer<SpanData>[] spanDataAsserts =
+        (Consumer<SpanData>[])
+            StreamSupport.stream(assertions.spliterator(), false)
+                .map(TraceAssert::toSpanDataConsumer)
+                .toArray(Consumer[]::new);
+
+    return satisfiesExactlyInAnyOrder(spanDataAsserts);
+  }
+
+  private static Consumer<SpanData> toSpanDataConsumer(
+      Consumer<SpanDataAssert> spanDataAssertConsumer) {
+    return spanData -> spanDataAssertConsumer.accept(new SpanDataAssert(spanData));
+  }
+
+  /**
    * Returns the {@linkplain SpanData span} at the {@code index} within the trace. This can be
    * useful for asserting the parent of a span.
    */

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TraceAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/TraceAssert.java
@@ -87,19 +87,8 @@ public final class TraceAssert
    */
   public TraceAssert hasSpansSatisfyingExactlyInAnyOrder(
       Iterable<? extends Consumer<SpanDataAssert>> assertions) {
-    @SuppressWarnings("unchecked")
-    Consumer<SpanData>[] spanDataAsserts =
-        (Consumer<SpanData>[])
-            StreamSupport.stream(assertions.spliterator(), false)
-                .map(TraceAssert::toSpanDataConsumer)
-                .toArray(Consumer[]::new);
-
+    Consumer<SpanData>[] spanDataAsserts = AssertUtil.toConsumers(assertions, SpanDataAssert::new);
     return satisfiesExactlyInAnyOrder(spanDataAsserts);
-  }
-
-  private static Consumer<SpanData> toSpanDataConsumer(
-      Consumer<SpanDataAssert> spanDataAssertConsumer) {
-    return spanData -> spanDataAssertConsumer.accept(new SpanDataAssert(spanData));
   }
 
   /**

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/TraceAssertionsTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/TraceAssertionsTest.java
@@ -527,12 +527,14 @@ class TraceAssertionsTest {
                     span -> span.hasSpanId(SPAN_ID1), span -> span.hasSpanId(SPAN_ID2)));
     // test asserting spans in wrong oder
     assertThatThrownBy(
-        () ->
-            TracesAssert.assertThat(traces)
-                .hasTracesSatisfyingExactly(
-                    trace ->
-                        trace.hasSpansSatisfyingExactly(
-                            span -> span.hasSpanId(SPAN_ID2), span -> span.hasSpanId(SPAN_ID1))));
+            () ->
+                TracesAssert.assertThat(traces)
+                    .hasTracesSatisfyingExactly(
+                        trace ->
+                            trace.hasSpansSatisfyingExactly(
+                                span -> span.hasSpanId(SPAN_ID2),
+                                span -> span.hasSpanId(SPAN_ID1))))
+        .isInstanceOf(AssertionError.class);
 
     // test asserting spans in any order
     TracesAssert.assertThat(traces)
@@ -547,11 +549,13 @@ class TraceAssertionsTest {
                     span -> span.hasSpanId(SPAN_ID2), span -> span.hasSpanId(SPAN_ID1)));
     // test not asserting all spans
     assertThatThrownBy(
-        () ->
-            TracesAssert.assertThat(traces)
-                .hasTracesSatisfyingExactly(
-                    trace ->
-                        trace.hasSpansSatisfyingExactlyInAnyOrder(
-                            span -> span.hasSpanId(SPAN_ID1), span -> span.hasSpanId(SPAN_ID1))));
+            () ->
+                TracesAssert.assertThat(traces)
+                    .hasTracesSatisfyingExactly(
+                        trace ->
+                            trace.hasSpansSatisfyingExactlyInAnyOrder(
+                                span -> span.hasSpanId(SPAN_ID1),
+                                span -> span.hasSpanId(SPAN_ID1))))
+        .isInstanceOf(AssertionError.class);
   }
 }


### PR DESCRIPTION
In some agent test spans don't appear in a fixed order. It would be nice to have a version of `hasSpansSatisfyingExactly` that ignores the oder of the spans.