### PR TITLE
Remove Data from metric assertion class names

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
@@ -1,28 +1,28 @@
 Comparing source compatibility of  against 
-+++  NEW CLASS: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert  (not serializable)
++++  NEW CLASS: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.testing.assertj.AbstractPointAssert  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
-	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert hasAttribute(io.opentelemetry.api.common.AttributeKey, java.lang.Object)
-	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert hasAttribute(io.opentelemetry.sdk.testing.assertj.AttributeAssertion)
-	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert hasAttributes(io.opentelemetry.api.common.Attributes)
-	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert hasAttributes(java.util.Map$Entry[])
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointAssert hasAttribute(io.opentelemetry.api.common.AttributeKey, java.lang.Object)
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointAssert hasAttribute(io.opentelemetry.sdk.testing.assertj.AttributeAssertion)
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointAssert hasAttributes(io.opentelemetry.api.common.Attributes)
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointAssert hasAttributes(java.util.Map$Entry[])
 		+++  NEW ANNOTATION: java.lang.SafeVarargs
-	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert hasAttributesSatisfying(io.opentelemetry.sdk.testing.assertj.AttributeAssertion[])
-	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert hasAttributesSatisfying(java.lang.Iterable)
-	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert hasEpochNanos(long)
-	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert hasExemplarsSatisfying(java.util.function.Consumer[])
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointAssert hasAttributesSatisfying(io.opentelemetry.sdk.testing.assertj.AttributeAssertion[])
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointAssert hasAttributesSatisfying(java.lang.Iterable)
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointAssert hasEpochNanos(long)
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointAssert hasExemplarsSatisfying(java.util.function.Consumer[])
 		+++  NEW ANNOTATION: java.lang.SafeVarargs
-	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert hasExemplarsSatisfying(java.lang.Iterable)
-	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert hasStartEpochNanos(long)
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointAssert hasExemplarsSatisfying(java.lang.Iterable)
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.AbstractPointAssert hasStartEpochNanos(long)
 +++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.DoubleGaugeAssert  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.DoubleGaugeAssert hasPointsSatisfying(java.util.function.Consumer[])
 		+++  NEW ANNOTATION: java.lang.SafeVarargs
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.DoubleGaugeAssert hasPointsSatisfying(java.lang.Iterable)
-+++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.DoublePointDataAssert  (not serializable)
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.DoublePointAssert  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
-	+++  NEW SUPERCLASS: io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.DoublePointDataAssert hasExemplars(io.opentelemetry.sdk.metrics.data.DoubleExemplarData[])
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.DoublePointDataAssert hasValue(double)
+	+++  NEW SUPERCLASS: io.opentelemetry.sdk.testing.assertj.AbstractPointAssert
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.DoublePointAssert hasExemplars(io.opentelemetry.sdk.metrics.data.DoubleExemplarData[])
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.DoublePointAssert hasValue(double)
 +++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.DoubleSumAssert  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.DoubleSumAssert hasPointsSatisfying(java.util.function.Consumer[])
@@ -54,7 +54,7 @@ Comparing source compatibility of  against
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.HistogramAssert isDelta()
 +++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.HistogramPointAssert  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
-	+++  NEW SUPERCLASS: io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert
+	+++  NEW SUPERCLASS: io.opentelemetry.sdk.testing.assertj.AbstractPointAssert
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.HistogramPointAssert hasBucketBoundaries(double[])
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.HistogramPointAssert hasBucketCounts(long[])
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.HistogramPointAssert hasCount(long)
@@ -67,11 +67,11 @@ Comparing source compatibility of  against
 	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.LongGaugeAssert hasPointsSatisfying(java.util.function.Consumer[])
 		+++  NEW ANNOTATION: java.lang.SafeVarargs
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LongGaugeAssert hasPointsSatisfying(java.lang.Iterable)
-+++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.LongPointDataAssert  (not serializable)
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.LongPointAssert  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
-	+++  NEW SUPERCLASS: io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LongPointDataAssert hasExemplars(io.opentelemetry.sdk.metrics.data.LongExemplarData[])
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LongPointDataAssert hasValue(long)
+	+++  NEW SUPERCLASS: io.opentelemetry.sdk.testing.assertj.AbstractPointAssert
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LongPointAssert hasExemplars(io.opentelemetry.sdk.metrics.data.LongExemplarData[])
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LongPointAssert hasValue(long)
 +++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.LongSumAssert  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.LongSumAssert hasPointsSatisfying(java.util.function.Consumer[])
@@ -81,22 +81,22 @@ Comparing source compatibility of  against
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LongSumAssert isDelta()
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LongSumAssert isMonotonic()
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LongSumAssert isNotMonotonic()
-+++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert  (not serializable)
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.MetricAssert  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasDescription(java.lang.String)
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasDoubleGaugeSatisfying(java.util.function.Consumer)
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasDoubleSumSatisfying(java.util.function.Consumer)
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasHistogramSatisfying(java.util.function.Consumer)
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasInstrumentationScope(io.opentelemetry.sdk.common.InstrumentationScopeInfo)
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasLongGaugeSatisfying(java.util.function.Consumer)
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasLongSumSatisfying(java.util.function.Consumer)
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasName(java.lang.String)
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasResource(io.opentelemetry.sdk.resources.Resource)
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasSummarySatisfying(java.util.function.Consumer)
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert hasUnit(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricAssert hasDescription(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricAssert hasDoubleGaugeSatisfying(java.util.function.Consumer)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricAssert hasDoubleSumSatisfying(java.util.function.Consumer)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricAssert hasHistogramSatisfying(java.util.function.Consumer)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricAssert hasInstrumentationScope(io.opentelemetry.sdk.common.InstrumentationScopeInfo)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricAssert hasLongGaugeSatisfying(java.util.function.Consumer)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricAssert hasLongSumSatisfying(java.util.function.Consumer)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricAssert hasName(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricAssert hasResource(io.opentelemetry.sdk.resources.Resource)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricAssert hasSummarySatisfying(java.util.function.Consumer)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricAssert hasUnit(java.lang.String)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.MetricDataAssert assertThat(io.opentelemetry.sdk.metrics.data.MetricData)
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.MetricAssert assertThat(io.opentelemetry.sdk.metrics.data.MetricData)
 +++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.SummaryAssert  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.SummaryAssert hasPointsSatisfying(java.util.function.Consumer[])
@@ -105,7 +105,7 @@ Comparing source compatibility of  against
 	+++  NEW METHOD: PUBLIC(+) org.assertj.core.api.AbstractIterableAssert points()
 +++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.SummaryPointAssert  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
-	+++  NEW SUPERCLASS: io.opentelemetry.sdk.testing.assertj.AbstractPointDataAssert
+	+++  NEW SUPERCLASS: io.opentelemetry.sdk.testing.assertj.AbstractPointAssert
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.SummaryPointAssert hasCount(long)
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.SummaryPointAssert hasSum(double)
 	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.SummaryPointAssert hasValuesSatisfying(java.util.function.Consumer[])

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/AbstractPointAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/AbstractPointAssert.java
@@ -20,12 +20,11 @@ import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
 
 /** Assertions for an exported {@link PointData}. */
-public abstract class AbstractPointDataAssert<
-        PointAssertT extends AbstractPointDataAssert<PointAssertT, PointT>,
-        PointT extends PointData>
+public abstract class AbstractPointAssert<
+        PointAssertT extends AbstractPointAssert<PointAssertT, PointT>, PointT extends PointData>
     extends AbstractAssert<PointAssertT, PointT> {
 
-  AbstractPointDataAssert(@Nullable PointT actual, Class<PointAssertT> assertClass) {
+  AbstractPointAssert(@Nullable PointT actual, Class<PointAssertT> assertClass) {
     super(actual, assertClass);
   }
 

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/DoubleGaugeAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/DoubleGaugeAssert.java
@@ -27,8 +27,7 @@ public final class DoubleGaugeAssert
    */
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final DoubleGaugeAssert hasPointsSatisfying(
-      Consumer<DoublePointDataAssert>... assertions) {
+  public final DoubleGaugeAssert hasPointsSatisfying(Consumer<DoublePointAssert>... assertions) {
     return hasPointsSatisfying(Arrays.asList(assertions));
   }
 
@@ -36,10 +35,10 @@ public final class DoubleGaugeAssert
    * Asserts the gauge has points matching all of the given assertions and no more, in any order.
    */
   public DoubleGaugeAssert hasPointsSatisfying(
-      Iterable<? extends Consumer<DoublePointDataAssert>> assertions) {
+      Iterable<? extends Consumer<DoublePointAssert>> assertions) {
     isNotNull();
     assertThat(actual.getPoints())
-        .satisfiesExactlyInAnyOrder(AssertUtil.toConsumers(assertions, DoublePointDataAssert::new));
+        .satisfiesExactlyInAnyOrder(AssertUtil.toConsumers(assertions, DoublePointAssert::new));
     return this;
   }
 }

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/DoublePointAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/DoublePointAssert.java
@@ -5,28 +5,28 @@
 
 package io.opentelemetry.sdk.testing.assertj;
 
-import io.opentelemetry.sdk.metrics.data.LongExemplarData;
-import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
 import javax.annotation.Nullable;
 import org.assertj.core.api.Assertions;
 
-/** Assertions for an exported {@link LongPointData}. */
-public final class LongPointDataAssert
-    extends AbstractPointDataAssert<LongPointDataAssert, LongPointData> {
+/** Test assertions for {@link DoublePointData}. */
+public final class DoublePointAssert
+    extends AbstractPointAssert<DoublePointAssert, DoublePointData> {
 
-  LongPointDataAssert(@Nullable LongPointData actual) {
-    super(actual, LongPointDataAssert.class);
+  DoublePointAssert(@Nullable DoublePointData actual) {
+    super(actual, DoublePointAssert.class);
   }
 
   /** Asserts the point has the given value. */
-  public LongPointDataAssert hasValue(long expected) {
+  public DoublePointAssert hasValue(double expected) {
     isNotNull();
     Assertions.assertThat(actual.getValue()).as("value").isEqualTo(expected);
     return this;
   }
 
   /** Asserts the point has the specified exemplars, in any order. */
-  public LongPointDataAssert hasExemplars(LongExemplarData... exemplars) {
+  public DoublePointAssert hasExemplars(DoubleExemplarData... exemplars) {
     isNotNull();
     Assertions.assertThat(actual.getExemplars())
         .as("exemplars")

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/DoubleSumAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/DoubleSumAssert.java
@@ -73,15 +73,15 @@ public final class DoubleSumAssert
   /** Asserts the sum has points matching all of the given assertions and no more, in any order. */
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final DoubleSumAssert hasPointsSatisfying(Consumer<DoublePointDataAssert>... assertions) {
+  public final DoubleSumAssert hasPointsSatisfying(Consumer<DoublePointAssert>... assertions) {
     return hasPointsSatisfying(Arrays.asList(assertions));
   }
 
   /** Asserts the sum has points matching all of the given assertions and no more, in any order. */
   public DoubleSumAssert hasPointsSatisfying(
-      Iterable<? extends Consumer<DoublePointDataAssert>> assertions) {
+      Iterable<? extends Consumer<DoublePointAssert>> assertions) {
     assertThat(actual.getPoints())
-        .satisfiesExactlyInAnyOrder(AssertUtil.toConsumers(assertions, DoublePointDataAssert::new));
+        .satisfiesExactlyInAnyOrder(AssertUtil.toConsumers(assertions, DoublePointAssert::new));
     return this;
   }
 }

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/HistogramPointAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/HistogramPointAssert.java
@@ -11,7 +11,7 @@ import org.assertj.core.api.Assertions;
 
 /** Test assertions for {@link HistogramPointData}. */
 public final class HistogramPointAssert
-    extends AbstractPointDataAssert<HistogramPointAssert, HistogramPointData> {
+    extends AbstractPointAssert<HistogramPointAssert, HistogramPointData> {
 
   HistogramPointAssert(HistogramPointData actual) {
     super(actual, HistogramPointAssert.class);

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LongGaugeAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LongGaugeAssert.java
@@ -27,7 +27,7 @@ public final class LongGaugeAssert
    */
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final LongGaugeAssert hasPointsSatisfying(Consumer<LongPointDataAssert>... assertions) {
+  public final LongGaugeAssert hasPointsSatisfying(Consumer<LongPointAssert>... assertions) {
     return hasPointsSatisfying(Arrays.asList(assertions));
   }
 
@@ -35,9 +35,9 @@ public final class LongGaugeAssert
    * Asserts the gauge has points matching all of the given assertions and no more, in any order.
    */
   public LongGaugeAssert hasPointsSatisfying(
-      Iterable<? extends Consumer<LongPointDataAssert>> assertions) {
+      Iterable<? extends Consumer<LongPointAssert>> assertions) {
     assertThat(actual.getPoints())
-        .satisfiesExactlyInAnyOrder(AssertUtil.toConsumers(assertions, LongPointDataAssert::new));
+        .satisfiesExactlyInAnyOrder(AssertUtil.toConsumers(assertions, LongPointAssert::new));
     return this;
   }
 }

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LongPointAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LongPointAssert.java
@@ -5,28 +5,27 @@
 
 package io.opentelemetry.sdk.testing.assertj;
 
-import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
-import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.LongExemplarData;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
 import javax.annotation.Nullable;
 import org.assertj.core.api.Assertions;
 
-/** Test assertions for {@link DoublePointData}. */
-public final class DoublePointDataAssert
-    extends AbstractPointDataAssert<DoublePointDataAssert, DoublePointData> {
+/** Assertions for an exported {@link LongPointData}. */
+public final class LongPointAssert extends AbstractPointAssert<LongPointAssert, LongPointData> {
 
-  DoublePointDataAssert(@Nullable DoublePointData actual) {
-    super(actual, DoublePointDataAssert.class);
+  LongPointAssert(@Nullable LongPointData actual) {
+    super(actual, LongPointAssert.class);
   }
 
   /** Asserts the point has the given value. */
-  public DoublePointDataAssert hasValue(double expected) {
+  public LongPointAssert hasValue(long expected) {
     isNotNull();
     Assertions.assertThat(actual.getValue()).as("value").isEqualTo(expected);
     return this;
   }
 
   /** Asserts the point has the specified exemplars, in any order. */
-  public DoublePointDataAssert hasExemplars(DoubleExemplarData... exemplars) {
+  public LongPointAssert hasExemplars(LongExemplarData... exemplars) {
     isNotNull();
     Assertions.assertThat(actual.getExemplars())
         .as("exemplars")

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LongSumAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LongSumAssert.java
@@ -72,15 +72,15 @@ public final class LongSumAssert extends AbstractAssert<LongSumAssert, SumData<L
   /** Asserts the sum has points matching all of the given assertions and no more, in any order. */
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final LongSumAssert hasPointsSatisfying(Consumer<LongPointDataAssert>... assertions) {
+  public final LongSumAssert hasPointsSatisfying(Consumer<LongPointAssert>... assertions) {
     return hasPointsSatisfying(Arrays.asList(assertions));
   }
 
   /** Asserts the sum has points matching all of the given assertions and no more, in any order. */
   public LongSumAssert hasPointsSatisfying(
-      Iterable<? extends Consumer<LongPointDataAssert>> assertions) {
+      Iterable<? extends Consumer<LongPointAssert>> assertions) {
     assertThat(actual.getPoints())
-        .satisfiesExactlyInAnyOrder(AssertUtil.toConsumers(assertions, LongPointDataAssert::new));
+        .satisfiesExactlyInAnyOrder(AssertUtil.toConsumers(assertions, LongPointAssert::new));
     return this;
   }
 }

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/MetricAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/MetricAssert.java
@@ -14,13 +14,13 @@ import javax.annotation.Nullable;
 import org.assertj.core.api.AbstractAssert;
 
 /** Assertions for an exported {@link MetricData}. */
-public final class MetricDataAssert extends AbstractAssert<MetricDataAssert, MetricData> {
-  MetricDataAssert(@Nullable MetricData actual) {
-    super(actual, MetricDataAssert.class);
+public final class MetricAssert extends AbstractAssert<MetricAssert, MetricData> {
+  MetricAssert(@Nullable MetricData actual) {
+    super(actual, MetricAssert.class);
   }
 
   /** Asserts the metric has the given {@link Resource}. */
-  public MetricDataAssert hasResource(Resource resource) {
+  public MetricAssert hasResource(Resource resource) {
     isNotNull();
     if (!actual.getResource().equals(resource)) {
       failWithActualExpectedAndMessage(
@@ -34,8 +34,7 @@ public final class MetricDataAssert extends AbstractAssert<MetricDataAssert, Met
   }
 
   /** Asserts the metric has the given the {@link InstrumentationScopeInfo}. */
-  public MetricDataAssert hasInstrumentationScope(
-      InstrumentationScopeInfo instrumentationScopeInfo) {
+  public MetricAssert hasInstrumentationScope(InstrumentationScopeInfo instrumentationScopeInfo) {
     isNotNull();
     if (!actual.getInstrumentationScopeInfo().equals(instrumentationScopeInfo)) {
       failWithActualExpectedAndMessage(
@@ -49,7 +48,7 @@ public final class MetricDataAssert extends AbstractAssert<MetricDataAssert, Met
   }
 
   /** Asserts the metric has the given name. */
-  public MetricDataAssert hasName(String name) {
+  public MetricAssert hasName(String name) {
     isNotNull();
     if (!actual.getName().equals(name)) {
       failWithActualExpectedAndMessage(
@@ -63,7 +62,7 @@ public final class MetricDataAssert extends AbstractAssert<MetricDataAssert, Met
   }
 
   /** Asserts the metric has the given description. */
-  public MetricDataAssert hasDescription(String description) {
+  public MetricAssert hasDescription(String description) {
     isNotNull();
     if (!actual.getDescription().equals(description)) {
       failWithActualExpectedAndMessage(
@@ -77,7 +76,7 @@ public final class MetricDataAssert extends AbstractAssert<MetricDataAssert, Met
   }
 
   /** Asserts the metric has the given unit. */
-  public MetricDataAssert hasUnit(String unit) {
+  public MetricAssert hasUnit(String unit) {
     isNotNull();
     if (!actual.getUnit().equals(unit)) {
       failWithActualExpectedAndMessage(
@@ -93,7 +92,7 @@ public final class MetricDataAssert extends AbstractAssert<MetricDataAssert, Met
   /**
    * Asserts this {@link MetricData} is a {@code DoubleGauge} that satisfies the provided assertion.
    */
-  public MetricDataAssert hasDoubleGaugeSatisfying(Consumer<DoubleGaugeAssert> assertion) {
+  public MetricAssert hasDoubleGaugeSatisfying(Consumer<DoubleGaugeAssert> assertion) {
     isNotNull();
     if (actual.getType() != MetricDataType.DOUBLE_GAUGE) {
       failWithActualExpectedAndMessage(
@@ -110,7 +109,7 @@ public final class MetricDataAssert extends AbstractAssert<MetricDataAssert, Met
   /**
    * Asserts this {@link MetricData} is a {@code LongGauge} that satisfies the provided assertion.
    */
-  public MetricDataAssert hasLongGaugeSatisfying(Consumer<LongGaugeAssert> assertion) {
+  public MetricAssert hasLongGaugeSatisfying(Consumer<LongGaugeAssert> assertion) {
     isNotNull();
     if (actual.getType() != MetricDataType.LONG_GAUGE) {
       failWithActualExpectedAndMessage(
@@ -125,7 +124,7 @@ public final class MetricDataAssert extends AbstractAssert<MetricDataAssert, Met
   }
 
   /** Asserts this {@link MetricData} is a double sum that satisfies the provided assertion. */
-  public MetricDataAssert hasDoubleSumSatisfying(Consumer<DoubleSumAssert> assertion) {
+  public MetricAssert hasDoubleSumSatisfying(Consumer<DoubleSumAssert> assertion) {
     isNotNull();
     if (actual.getType() != MetricDataType.DOUBLE_SUM) {
       failWithActualExpectedAndMessage(
@@ -140,7 +139,7 @@ public final class MetricDataAssert extends AbstractAssert<MetricDataAssert, Met
   }
 
   /** Asserts this {@link MetricData} is a long sum that satisfies the provided assertion. */
-  public MetricDataAssert hasLongSumSatisfying(Consumer<LongSumAssert> assertion) {
+  public MetricAssert hasLongSumSatisfying(Consumer<LongSumAssert> assertion) {
     isNotNull();
     if (actual.getType() != MetricDataType.LONG_SUM) {
       failWithActualExpectedAndMessage(
@@ -155,7 +154,7 @@ public final class MetricDataAssert extends AbstractAssert<MetricDataAssert, Met
   }
 
   /** Asserts this {@link MetricData} is a histogram that satisfies the provided assertion. */
-  public MetricDataAssert hasHistogramSatisfying(Consumer<HistogramAssert> assertion) {
+  public MetricAssert hasHistogramSatisfying(Consumer<HistogramAssert> assertion) {
     isNotNull();
     if (actual.getType() != MetricDataType.HISTOGRAM) {
       failWithActualExpectedAndMessage(
@@ -170,7 +169,7 @@ public final class MetricDataAssert extends AbstractAssert<MetricDataAssert, Met
   }
 
   /** Asserts this {@link MetricData} is a summary that satisfies the provided assertion. */
-  public MetricDataAssert hasSummarySatisfying(Consumer<SummaryAssert> assertion) {
+  public MetricAssert hasSummarySatisfying(Consumer<SummaryAssert> assertion) {
     isNotNull();
     if (actual.getType() != MetricDataType.SUMMARY) {
       failWithActualExpectedAndMessage(

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertions.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertions.java
@@ -42,8 +42,8 @@ public final class OpenTelemetryAssertions extends Assertions {
   }
 
   /** Returns an assertion for {@link MetricData}. */
-  public static MetricDataAssert assertThat(@Nullable MetricData metricData) {
-    return new MetricDataAssert(metricData);
+  public static MetricAssert assertThat(@Nullable MetricData metricData) {
+    return new MetricAssert(metricData);
   }
 
   /** Returns an assertion for {@link EventDataAssert}. */

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SummaryPointAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SummaryPointAssert.java
@@ -14,7 +14,7 @@ import org.assertj.core.api.Assertions;
 
 /** Test assertions for (deprecated) {@link SummaryPointData}. */
 public final class SummaryPointAssert
-    extends AbstractPointDataAssert<SummaryPointAssert, SummaryPointData> {
+    extends AbstractPointAssert<SummaryPointAssert, SummaryPointData> {
 
   SummaryPointAssert(SummaryPointData actual) {
     super(actual, SummaryPointAssert.class);


### PR DESCRIPTION
Trace assertions have some mix of `Data` or not on whether there is a corresponding SDK class for it, but this isn't really very helpful. An assertion is an assertion and there's not much need for the word - for metrics we can clean up a bit