### PR TITLE
Rename MetricReader#flush() to forceFlush()

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-metrics.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-metrics.txt
@@ -150,7 +150,7 @@ Comparing source compatibility of  against
 +++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.metrics.export.MetricReader  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW SUPERCLASS: java.lang.Object
-	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.common.CompletableResultCode flush()
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.common.CompletableResultCode forceFlush()
 	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.metrics.data.AggregationTemporality getAggregationTemporality(io.opentelemetry.sdk.metrics.InstrumentType)
 	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) void register(io.opentelemetry.sdk.metrics.export.CollectionRegistration)
 	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.common.CompletableResultCode shutdown()
@@ -160,7 +160,7 @@ Comparing source compatibility of  against
 	+++  NEW SUPERCLASS: java.lang.Object
 	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.export.PeriodicMetricReaderBuilder builder(io.opentelemetry.sdk.metrics.export.MetricExporter)
 	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.export.PeriodicMetricReader create(io.opentelemetry.sdk.metrics.export.MetricExporter)
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.common.CompletableResultCode flush()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.common.CompletableResultCode forceFlush()
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.metrics.data.AggregationTemporality getAggregationTemporality(io.opentelemetry.sdk.metrics.InstrumentType)
 	+++  NEW METHOD: PUBLIC(+) void register(io.opentelemetry.sdk.metrics.export.CollectionRegistration)
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.common.CompletableResultCode shutdown()

--- a/exporters/prometheus/src/integrationTest/java/io/opentelemetry/exporter/prometheus/PrometheusCollector.java
+++ b/exporters/prometheus/src/integrationTest/java/io/opentelemetry/exporter/prometheus/PrometheusCollector.java
@@ -68,7 +68,7 @@ public final class PrometheusCollector implements MetricReader {
 
   // Prometheus cannot flush.
   @Override
-  public CompletableResultCode flush() {
+  public CompletableResultCode forceFlush() {
     return CompletableResultCode.ofSuccess();
   }
 

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServer.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServer.java
@@ -119,7 +119,7 @@ public final class PrometheusHttpServer implements Closeable, MetricReader {
   }
 
   @Override
-  public CompletableResultCode flush() {
+  public CompletableResultCode forceFlush() {
     return CompletableResultCode.ofSuccess();
   }
 

--- a/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/metrics/OpenCensusAttachingMetricReader.java
+++ b/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/metrics/OpenCensusAttachingMetricReader.java
@@ -38,8 +38,8 @@ final class OpenCensusAttachingMetricReader implements MetricReader {
   }
 
   @Override
-  public CompletableResultCode flush() {
-    return adapted.flush();
+  public CompletableResultCode forceFlush() {
+    return adapted.forceFlush();
   }
 
   @Override

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkTest.java
@@ -212,7 +212,7 @@ class AutoConfiguredOpenTelemetrySdkTest {
   @Test
   void builder_addMeterProviderCustomizer() {
     Mockito.lenient().when(metricReader.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
-    when(metricReader.flush()).thenReturn(CompletableResultCode.ofSuccess());
+    when(metricReader.forceFlush()).thenReturn(CompletableResultCode.ofSuccess());
 
     SdkMeterProvider sdkMeterProvider =
         builder
@@ -224,7 +224,7 @@ class AutoConfiguredOpenTelemetrySdkTest {
             .getSdkMeterProvider();
     sdkMeterProvider.forceFlush().join(10, TimeUnit.SECONDS);
 
-    verify(metricReader).flush();
+    verify(metricReader).forceFlush();
   }
 
   // TODO: add test for addMetricExporterCustomizer once OTLP export is enabled by default

--- a/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/exporter/InMemoryMetricReader.java
+++ b/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/exporter/InMemoryMetricReader.java
@@ -80,7 +80,7 @@ public class InMemoryMetricReader implements MetricReader {
   }
 
   @Override
-  public CompletableResultCode flush() {
+  public CompletableResultCode forceFlush() {
     collectAllMetrics();
     return CompletableResultCode.ofSuccess();
   }

--- a/sdk/metrics-testing/src/test/java/io/opentelemetry/sdk/testing/exporter/InMemoryMetricReaderTest.java
+++ b/sdk/metrics-testing/src/test/java/io/opentelemetry/sdk/testing/exporter/InMemoryMetricReaderTest.java
@@ -69,8 +69,8 @@ class InMemoryMetricReaderTest {
     generateFakeMetric(2);
     generateFakeMetric(3);
     // TODO: Better assertions for CompletableResultCode.
-    assertThat(cumulativeReader.flush()).isNotNull();
-    assertThat(deltaReader.flush()).isNotNull();
+    assertThat(cumulativeReader.forceFlush()).isNotNull();
+    assertThat(deltaReader.forceFlush()).isNotNull();
 
     assertThat(cumulativeReader.collectAllMetrics()).hasSize(3);
     assertThat(deltaReader.collectAllMetrics()).hasSize(0);

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProvider.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProvider.java
@@ -98,7 +98,7 @@ public final class SdkMeterProvider implements MeterProvider, Closeable {
   }
 
   /**
-   * Call {@link MetricReader#flush()} on all metric readers associated with this provider. The
+   * Call {@link MetricReader#forceFlush()} on all metric readers associated with this provider. The
    * resulting {@link CompletableResultCode} completes when all complete.
    */
   public CompletableResultCode forceFlush() {
@@ -107,7 +107,7 @@ public final class SdkMeterProvider implements MeterProvider, Closeable {
     }
     List<CompletableResultCode> results = new ArrayList<>();
     for (CollectionInfo collectionInfo : collectionInfoMap.values()) {
-      results.add(collectionInfo.getReader().flush());
+      results.add(collectionInfo.getReader().forceFlush());
     }
     return CompletableResultCode.ofAll(results);
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/MetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/MetricReader.java
@@ -41,7 +41,7 @@ public interface MetricReader {
    *
    * @return the result of the flush.
    */
-  CompletableResultCode flush();
+  CompletableResultCode forceFlush();
 
   /**
    * Shuts down the metric reader.

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
@@ -65,7 +65,7 @@ public final class PeriodicMetricReader implements MetricReader {
   }
 
   @Override
-  public CompletableResultCode flush() {
+  public CompletableResultCode forceFlush() {
     return scheduled.doRun();
   }
 

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderTest.java
@@ -124,7 +124,7 @@ class PeriodicMetricReaderTest {
     reader.register(metricProducer);
 
     try {
-      assertThat(reader.flush().join(10, TimeUnit.SECONDS).isSuccess()).isTrue();
+      assertThat(reader.forceFlush().join(10, TimeUnit.SECONDS).isSuccess()).isTrue();
       verify(metricProducer).collectAllMetrics();
       assertThat(waitingMetricExporter.exportTimes.size()).isEqualTo(0);
     } finally {
@@ -141,7 +141,7 @@ class PeriodicMetricReaderTest {
             .build();
 
     reader.register(metricProducer);
-    assertThat(reader.flush().join(10, TimeUnit.SECONDS).isSuccess()).isTrue();
+    assertThat(reader.forceFlush().join(10, TimeUnit.SECONDS).isSuccess()).isTrue();
 
     try {
       assertThat(waitingMetricExporter.waitForNumberOfExports(1))


### PR DESCRIPTION
Resolves #4434.