### PR TITLE
Update to otlp proto 0.17.0

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -89,7 +89,7 @@ val DEPENDENCIES = listOf(
   "eu.rekawek.toxiproxy:toxiproxy-java:2.1.5",
   "io.github.netmikey.logunit:logunit-jul:1.1.3",
   "io.jaegertracing:jaeger-client:1.8.0",
-  "io.opentelemetry.proto:opentelemetry-proto:0.16.0-alpha",
+  "io.opentelemetry.proto:opentelemetry-proto:0.17.0-alpha",
   "io.opentracing:opentracing-api:0.33.0",
   "junit:junit:4.13.2",
   "nl.jqno.equalsverifier:equalsverifier:3.10",

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExponentialHistogramDataPointMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExponentialHistogramDataPointMarshaler.java
@@ -26,6 +26,10 @@ public class ExponentialHistogramDataPointMarshaler extends MarshalerWithSize {
   private final long count;
   private final long zeroCount;
   private final double sum;
+  private final boolean hasMin;
+  private final double min;
+  private final boolean hasMax;
+  private final double max;
   private final ExponentialHistogramBucketsMarshaler positiveBuckets;
   private final ExponentialHistogramBucketsMarshaler negativeBuckets;
   private final ExemplarMarshaler[] exemplars;
@@ -37,6 +41,10 @@ public class ExponentialHistogramDataPointMarshaler extends MarshalerWithSize {
       int scale,
       long count,
       double sum,
+      boolean hasMin,
+      double min,
+      boolean hasMax,
+      double max,
       long zeroCount,
       ExponentialHistogramBucketsMarshaler positiveBuckets,
       ExponentialHistogramBucketsMarshaler negativeBuckets,
@@ -49,6 +57,10 @@ public class ExponentialHistogramDataPointMarshaler extends MarshalerWithSize {
             scale,
             count,
             sum,
+            hasMin,
+            min,
+            hasMax,
+            max,
             zeroCount,
             positiveBuckets,
             negativeBuckets,
@@ -58,6 +70,10 @@ public class ExponentialHistogramDataPointMarshaler extends MarshalerWithSize {
     this.timeUnixNano = epochNanos;
     this.scale = scale;
     this.sum = sum;
+    this.hasMin = hasMin;
+    this.min = min;
+    this.hasMax = hasMax;
+    this.max = max;
     this.count = count;
     this.zeroCount = zeroCount;
     this.positiveBuckets = positiveBuckets;
@@ -81,6 +97,10 @@ public class ExponentialHistogramDataPointMarshaler extends MarshalerWithSize {
         point.getScale(),
         point.getCount(),
         point.getSum(),
+        point.hasMin(),
+        point.getMin(),
+        point.hasMax(),
+        point.getMax(),
         point.getZeroCount(),
         positiveBuckets,
         negativeBuckets,
@@ -105,6 +125,12 @@ public class ExponentialHistogramDataPointMarshaler extends MarshalerWithSize {
     output.serializeFixed64(ExponentialHistogramDataPoint.TIME_UNIX_NANO, timeUnixNano);
     output.serializeFixed64(ExponentialHistogramDataPoint.COUNT, count);
     output.serializeDouble(ExponentialHistogramDataPoint.SUM, sum);
+    if (hasMin) {
+      output.serializeDoubleOptional(ExponentialHistogramDataPoint.MIN, min);
+    }
+    if (hasMax) {
+      output.serializeDoubleOptional(ExponentialHistogramDataPoint.MAX, max);
+    }
     output.serializeSInt32(ExponentialHistogramDataPoint.SCALE, scale);
     output.serializeFixed64(ExponentialHistogramDataPoint.ZERO_COUNT, zeroCount);
     output.serializeMessage(ExponentialHistogramDataPoint.POSITIVE, positiveBuckets);
@@ -119,6 +145,10 @@ public class ExponentialHistogramDataPointMarshaler extends MarshalerWithSize {
       int scale,
       long count,
       double sum,
+      boolean hasMin,
+      double min,
+      boolean hasMax,
+      double max,
       long zeroCount,
       ExponentialHistogramBucketsMarshaler positiveBucketMarshaler,
       ExponentialHistogramBucketsMarshaler negativeBucketMarshaler,
@@ -132,6 +162,12 @@ public class ExponentialHistogramDataPointMarshaler extends MarshalerWithSize {
     size += MarshalerUtil.sizeSInt32(ExponentialHistogramDataPoint.SCALE, scale);
     size += MarshalerUtil.sizeFixed64(ExponentialHistogramDataPoint.COUNT, count);
     size += MarshalerUtil.sizeDouble(ExponentialHistogramDataPoint.SUM, sum);
+    if (hasMin) {
+      size += MarshalerUtil.sizeDoubleOptional(ExponentialHistogramDataPoint.MIN, min);
+    }
+    if (hasMax) {
+      size += MarshalerUtil.sizeDoubleOptional(ExponentialHistogramDataPoint.MAX, max);
+    }
     size += MarshalerUtil.sizeFixed64(ExponentialHistogramDataPoint.ZERO_COUNT, zeroCount);
     size +=
         MarshalerUtil.sizeMessage(ExponentialHistogramDataPoint.POSITIVE, positiveBucketMarshaler);

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/HistogramDataPointMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/HistogramDataPointMarshaler.java
@@ -21,6 +21,10 @@ final class HistogramDataPointMarshaler extends MarshalerWithSize {
   private final long timeUnixNano;
   private final long count;
   private final double sum;
+  private final boolean hasMin;
+  private final double min;
+  private final boolean hasMax;
+  private final double max;
   private final List<Long> bucketCounts;
   private final List<Double> explicitBounds;
   private final ExemplarMarshaler[] exemplars;
@@ -45,6 +49,10 @@ final class HistogramDataPointMarshaler extends MarshalerWithSize {
         point.getEpochNanos(),
         point.getCount(),
         point.getSum(),
+        point.hasMin(),
+        point.getMin(),
+        point.hasMax(),
+        point.getMax(),
         point.getCounts(),
         point.getBoundaries(),
         exemplarMarshalers,
@@ -56,6 +64,10 @@ final class HistogramDataPointMarshaler extends MarshalerWithSize {
       long timeUnixNano,
       long count,
       double sum,
+      boolean hasMin,
+      double min,
+      boolean hasMax,
+      double max,
       List<Long> bucketCounts,
       List<Double> explicitBounds,
       ExemplarMarshaler[] exemplars,
@@ -66,6 +78,10 @@ final class HistogramDataPointMarshaler extends MarshalerWithSize {
             timeUnixNano,
             count,
             sum,
+            hasMin,
+            min,
+            hasMax,
+            max,
             bucketCounts,
             explicitBounds,
             exemplars,
@@ -74,6 +90,10 @@ final class HistogramDataPointMarshaler extends MarshalerWithSize {
     this.timeUnixNano = timeUnixNano;
     this.count = count;
     this.sum = sum;
+    this.hasMin = hasMin;
+    this.min = min;
+    this.hasMax = hasMax;
+    this.max = max;
     this.bucketCounts = bucketCounts;
     this.explicitBounds = explicitBounds;
     this.exemplars = exemplars;
@@ -86,6 +106,12 @@ final class HistogramDataPointMarshaler extends MarshalerWithSize {
     output.serializeFixed64(HistogramDataPoint.TIME_UNIX_NANO, timeUnixNano);
     output.serializeFixed64(HistogramDataPoint.COUNT, count);
     output.serializeDoubleOptional(HistogramDataPoint.SUM, sum);
+    if (hasMin) {
+      output.serializeDoubleOptional(HistogramDataPoint.MIN, min);
+    }
+    if (hasMax) {
+      output.serializeDoubleOptional(HistogramDataPoint.MAX, max);
+    }
     output.serializeRepeatedFixed64(
         HistogramDataPoint.BUCKET_COUNTS, PrimitiveLongList.toArray(bucketCounts));
     output.serializeRepeatedDouble(HistogramDataPoint.EXPLICIT_BOUNDS, explicitBounds);
@@ -98,6 +124,10 @@ final class HistogramDataPointMarshaler extends MarshalerWithSize {
       long timeUnixNano,
       long count,
       double sum,
+      boolean hasMin,
+      double min,
+      boolean hasMax,
+      double max,
       List<Long> bucketCounts,
       List<Double> explicitBounds,
       ExemplarMarshaler[] exemplars,
@@ -107,6 +137,12 @@ final class HistogramDataPointMarshaler extends MarshalerWithSize {
     size += MarshalerUtil.sizeFixed64(HistogramDataPoint.TIME_UNIX_NANO, timeUnixNano);
     size += MarshalerUtil.sizeFixed64(HistogramDataPoint.COUNT, count);
     size += MarshalerUtil.sizeDoubleOptional(HistogramDataPoint.SUM, sum);
+    if (hasMin) {
+      size += MarshalerUtil.sizeDoubleOptional(HistogramDataPoint.MIN, min);
+    }
+    if (hasMax) {
+      size += MarshalerUtil.sizeDoubleOptional(HistogramDataPoint.MAX, max);
+    }
     size += MarshalerUtil.sizeRepeatedFixed64(HistogramDataPoint.BUCKET_COUNTS, bucketCounts);
     size += MarshalerUtil.sizeRepeatedDouble(HistogramDataPoint.EXPLICIT_BOUNDS, explicitBounds);
     size += MarshalerUtil.sizeRepeatedMessage(HistogramDataPoint.EXEMPLARS, exemplars);

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/metrics/MetricsRequestMarshalerTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/metrics/MetricsRequestMarshalerTest.java
@@ -349,8 +349,8 @@ class MetricsRequestMarshalerTest {
                         456,
                         KV_ATTR,
                         14.2,
-                        4.1,
-                        10.1,
+                        null,
+                        null,
                         ImmutableList.of(1.0),
                         ImmutableList.of(1L, 5L)),
                     ImmutableHistogramPointData.create(
@@ -390,6 +390,8 @@ class MetricsRequestMarshalerTest {
                 .setTimeUnixNano(456)
                 .setCount(7)
                 .setSum(15.3)
+                .setMin(3.3)
+                .setMax(12.0)
                 .addBucketCounts(7)
                 .addExemplars(
                     Exemplar.newBuilder()
@@ -417,6 +419,20 @@ class MetricsRequestMarshalerTest {
                         0,
                         123.4,
                         1,
+                        null,
+                        null,
+                        new TestExponentialHistogramBuckets(0, Collections.emptyList()),
+                        new TestExponentialHistogramBuckets(0, Collections.emptyList()),
+                        123,
+                        456,
+                        Attributes.empty(),
+                        Collections.emptyList()),
+                    ExponentialHistogramPointData.create(
+                        0,
+                        123.4,
+                        1,
+                        3.3,
+                        80.1,
                         new TestExponentialHistogramBuckets(1, ImmutableList.of(1L, 0L, 2L)),
                         new TestExponentialHistogramBuckets(0, Collections.emptyList()),
                         123,
@@ -436,12 +452,26 @@ class MetricsRequestMarshalerTest {
             ExponentialHistogramDataPoint.newBuilder()
                 .setStartTimeUnixNano(123)
                 .setTimeUnixNano(456)
+                .setCount(1)
+                .setScale(0)
+                .setSum(123.4)
+                .setZeroCount(1)
+                .setPositive(
+                    ExponentialHistogramDataPoint.Buckets.newBuilder().setOffset(0)) // no buckets
+                .setNegative(
+                    ExponentialHistogramDataPoint.Buckets.newBuilder().setOffset(0)) // no buckets
+                .build(),
+            ExponentialHistogramDataPoint.newBuilder()
+                .setStartTimeUnixNano(123)
+                .setTimeUnixNano(456)
                 .setCount(4) // Counts in positive, negative, and zero count.
                 .addAllAttributes(
                     singletonList(
                         KeyValue.newBuilder().setKey("key").setValue(stringValue("value")).build()))
                 .setScale(0)
                 .setSum(123.4)
+                .setMin(3.3)
+                .setMax(80.1)
                 .setZeroCount(1)
                 .setPositive(
                     ExponentialHistogramDataPoint.Buckets.newBuilder()
@@ -779,6 +809,8 @@ class MetricsRequestMarshalerTest {
                                             .build()))
                                 .setCount(33)
                                 .setSum(4.0)
+                                .setMin(1.0)
+                                .setMax(3.0)
                                 .addBucketCounts(33)
                                 .build())
                         .build())
@@ -802,6 +834,8 @@ class MetricsRequestMarshalerTest {
                                 20,
                                 123.4,
                                 257,
+                                20.1,
+                                44.3,
                                 new TestExponentialHistogramBuckets(
                                     -1, ImmutableList.of(0L, 128L, 1L << 32)),
                                 new TestExponentialHistogramBuckets(
@@ -834,6 +868,8 @@ class MetricsRequestMarshalerTest {
                                 .setScale(20)
                                 .setSum(123.4)
                                 .setZeroCount(257)
+                                .setMin(20.1)
+                                .setMax(44.3)
                                 .setPositive(
                                     ExponentialHistogramDataPoint.Buckets.newBuilder()
                                         .setOffset(-1)

--- a/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/ExponentialHistogramPointDataAssert.java
+++ b/sdk/metrics-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/ExponentialHistogramPointDataAssert.java
@@ -23,6 +23,20 @@ public class ExponentialHistogramPointDataAssert
     return this;
   }
 
+  /** Ensures the {@code min} field matches the expected value. */
+  public ExponentialHistogramPointDataAssert hasMin(double expected) {
+    isNotNull();
+    Assertions.assertThat(actual.getMin()).as("min").isEqualTo(expected);
+    return this;
+  }
+
+  /** Ensures the {@code min} field matches the expected value. */
+  public ExponentialHistogramPointDataAssert hasMax(double expected) {
+    isNotNull();
+    Assertions.assertThat(actual.getMax()).as("max").isEqualTo(expected);
+    return this;
+  }
+
   /** Ensures the {@code count} field matches the expected value. */
   public ExponentialHistogramPointDataAssert hasCount(long expected) {
     isNotNull();

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/Aggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/Aggregator.java
@@ -91,11 +91,15 @@ public interface Aggregator<T, U extends ExemplarData> {
   /**
    * Returns a new DELTA aggregation by comparing two cumulative measurements.
    *
+   * <p>Aggregators MUST implement diff if it can be used with asynchronous instruments.
+   *
    * @param previousCumulative the previously captured accumulation.
    * @param currentCumulative the newly captured (cumulative) accumulation.
    * @return The resulting delta accumulation.
    */
-  T diff(T previousCumulative, T currentCumulative);
+  default T diff(T previousCumulative, T currentCumulative) {
+    throw new UnsupportedOperationException("This aggregator does not support diff.");
+  }
 
   /**
    * Returns the {@link MetricData} that this {@code Aggregation} will produce.

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExplicitBucketHistogramAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExplicitBucketHistogramAggregator.java
@@ -97,23 +97,6 @@ public final class DoubleExplicitBucketHistogramAggregator
   }
 
   @Override
-  public ExplicitBucketHistogramAccumulation diff(
-      ExplicitBucketHistogramAccumulation previous, ExplicitBucketHistogramAccumulation current) {
-    long[] previousCounts = previous.getCounts();
-    long[] diffedCounts = new long[previousCounts.length];
-    for (int i = 0; i < previousCounts.length; ++i) {
-      diffedCounts[i] = current.getCounts()[i] - previousCounts[i];
-    }
-    return ExplicitBucketHistogramAccumulation.create(
-        current.getSum() - previous.getSum(),
-        /* hasMinMax= */ false,
-        -1,
-        -1,
-        diffedCounts,
-        current.getExemplars());
-  }
-
-  @Override
   public MetricData toMetricData(
       Resource resource,
       InstrumentationScopeInfo instrumentationScopeInfo,

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramBuckets.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramBuckets.java
@@ -135,20 +135,6 @@ final class DoubleExponentialHistogramBuckets implements ExponentialHistogramBuc
   }
 
   /**
-   * Return buckets a subtracted by buckets b. May perform downscaling if required.
-   *
-   * @param a the minuend of the subtraction.
-   * @param b the subtrahend of the subtraction.
-   * @return buckets a subtracted by buckets b.
-   */
-  static DoubleExponentialHistogramBuckets diff(
-      DoubleExponentialHistogramBuckets a, DoubleExponentialHistogramBuckets b) {
-    DoubleExponentialHistogramBuckets copy = a.copy();
-    copy.mergeWith(b, /* additive= */ false);
-    return copy;
-  }
-
-  /**
    * Immutable method for merging. This method copies the first set of buckets, performs the merge
    * on the copy, and returns the copy.
    *

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DropAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DropAggregator.java
@@ -55,11 +55,6 @@ public final class DropAggregator implements Aggregator<Object, DoubleExemplarDa
   }
 
   @Override
-  public Object diff(Object previousAccumulation, Object accumulation) {
-    return ACCUMULATION;
-  }
-
-  @Override
   public MetricData toMetricData(
       Resource resource,
       InstrumentationScopeInfo instrumentationScopeInfo,

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/ExponentialHistogramAccumulation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/ExponentialHistogramAccumulation.java
@@ -8,37 +8,35 @@ package io.opentelemetry.sdk.metrics.internal.aggregator;
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import java.util.List;
-import javax.annotation.Nonnull;
 
 @AutoValue
 abstract class ExponentialHistogramAccumulation {
   ExponentialHistogramAccumulation() {}
 
-  /**
-   * Creates a new {@link ExponentialHistogramAccumulation} with the given values.
-   *
-   * @param scale the scale of the exponential histogram.
-   * @param sum the sum of all the recordings of the histogram.
-   * @param positiveBuckets the buckets counting positive recordings.
-   * @param negativeBuckets the buckets counting negative recordings.
-   * @param zeroCount The amount of time zero was recorded.
-   * @param exemplars The exemplars.
-   * @return a new {@link ExponentialHistogramAccumulation} with the given values.
-   */
+  /** Creates a new {@link ExponentialHistogramAccumulation} with the given values. */
   static ExponentialHistogramAccumulation create(
       int scale,
       double sum,
-      @Nonnull DoubleExponentialHistogramBuckets positiveBuckets,
-      @Nonnull DoubleExponentialHistogramBuckets negativeBuckets,
+      boolean hasMinMax,
+      double min,
+      double max,
+      DoubleExponentialHistogramBuckets positiveBuckets,
+      DoubleExponentialHistogramBuckets negativeBuckets,
       long zeroCount,
       List<DoubleExemplarData> exemplars) {
     return new AutoValue_ExponentialHistogramAccumulation(
-        scale, sum, positiveBuckets, negativeBuckets, zeroCount, exemplars);
+        scale, sum, hasMinMax, min, max, positiveBuckets, negativeBuckets, zeroCount, exemplars);
   }
 
   abstract int getScale();
 
   abstract double getSum();
+
+  abstract boolean hasMinMax();
+
+  abstract double getMin();
+
+  abstract double getMax();
 
   abstract DoubleExponentialHistogramBuckets getPositiveBuckets();
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/MetricDataUtils.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/MetricDataUtils.java
@@ -97,6 +97,8 @@ final class MetricDataUtils {
                     aggregator.getScale(),
                     aggregator.getSum(),
                     aggregator.getZeroCount(),
+                    aggregator.getMin(),
+                    aggregator.getMax(),
                     aggregator.getPositiveBuckets(),
                     aggregator.getNegativeBuckets(),
                     startEpochNanos,

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/exponentialhistogram/ExponentialHistogramPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/exponentialhistogram/ExponentialHistogramPointData.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.PointData;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -33,10 +34,13 @@ public interface ExponentialHistogramPointData extends PointData {
    *
    * @return an ExponentialHistogramPointData.
    */
+  @SuppressWarnings("TooManyParameters")
   static ExponentialHistogramPointData create(
       int scale,
       double sum,
       long zeroCount,
+      @Nullable Double min,
+      @Nullable Double max,
       ExponentialHistogramBuckets positiveBuckets,
       ExponentialHistogramBuckets negativeBuckets,
       long startEpochNanos,
@@ -48,6 +52,8 @@ public interface ExponentialHistogramPointData extends PointData {
         scale,
         sum,
         zeroCount,
+        min,
+        max,
         positiveBuckets,
         negativeBuckets,
         startEpochNanos,
@@ -87,6 +93,24 @@ public interface ExponentialHistogramPointData extends PointData {
    * @return the number of values equal to zero.
    */
   long getZeroCount();
+
+  /** Return {@code true} if {@link #getMin()} is set. */
+  boolean hasMin();
+
+  /**
+   * The min of all measurements recorded, if {@link #hasMin()} is {@code true}. If {@link
+   * #hasMin()} is {@code false}, the response should be ignored.
+   */
+  double getMin();
+
+  /** Return {@code true} if {@link #getMax()} is set. */
+  boolean hasMax();
+
+  /**
+   * The max of all measurements recorded, if {@link #hasMax()} is {@code true}. If {@link
+   * #hasMax()} is {@code false}, the response should be ignored.
+   */
+  double getMax();
 
   /**
    * Return the {@link ExponentialHistogramBuckets} representing the positive measurements taken for

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/exponentialhistogram/ImmutableExponentialHistogramPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/exponentialhistogram/ImmutableExponentialHistogramPointData.java
@@ -9,6 +9,7 @@ import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -33,6 +34,8 @@ abstract class ImmutableExponentialHistogramPointData implements ExponentialHist
       int scale,
       double sum,
       long zeroCount,
+      @Nullable Double min,
+      @Nullable Double max,
       ExponentialHistogramBuckets positiveBuckets,
       ExponentialHistogramBuckets negativeBuckets,
       long startEpochNanos,
@@ -43,45 +46,19 @@ abstract class ImmutableExponentialHistogramPointData implements ExponentialHist
     long count = zeroCount + positiveBuckets.getTotalCount() + negativeBuckets.getTotalCount();
 
     return new AutoValue_ImmutableExponentialHistogramPointData(
+        startEpochNanos,
+        epochNanos,
+        attributes,
         scale,
         sum,
         count,
         zeroCount,
+        min != null,
+        min != null ? min : -1,
+        max != null,
+        max != null ? max : -1,
         positiveBuckets,
         negativeBuckets,
-        startEpochNanos,
-        epochNanos,
-        attributes,
         exemplars);
   }
-
-  @Override
-  public abstract int getScale();
-
-  @Override
-  public abstract double getSum();
-
-  @Override
-  public abstract long getCount();
-
-  @Override
-  public abstract long getZeroCount();
-
-  @Override
-  public abstract ExponentialHistogramBuckets getPositiveBuckets();
-
-  @Override
-  public abstract ExponentialHistogramBuckets getNegativeBuckets();
-
-  @Override
-  public abstract long getStartEpochNanos();
-
-  @Override
-  public abstract long getEpochNanos();
-
-  @Override
-  public abstract Attributes getAttributes();
-
-  @Override
-  public abstract List<DoubleExemplarData> getExemplars();
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleHistogramTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleHistogramTest.java
@@ -242,6 +242,8 @@ class SdkDoubleHistogramTest {
                               .hasAttributes(Attributes.empty())
                               .hasCount(2)
                               .hasSum(25)
+                              .hasMin(12)
+                              .hasMax(13)
                               .hasScale(-1)
                               .hasZeroCount(0);
                           MetricAssertions.assertThat(point.getPositiveBuckets())
@@ -258,6 +260,8 @@ class SdkDoubleHistogramTest {
                               .hasAttributes(Attributes.builder().put("key", "value").build())
                               .hasCount(1)
                               .hasSum(12)
+                              .hasMin(12)
+                              .hasMax(12)
                               .hasScale(-1)
                               .hasZeroCount(0);
                           MetricAssertions.assertThat(point.getPositiveBuckets())

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkLongHistogramTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkLongHistogramTest.java
@@ -243,6 +243,8 @@ class SdkLongHistogramTest {
                               .hasAttributes(Attributes.empty())
                               .hasCount(2)
                               .hasSum(25)
+                              .hasMin(12)
+                              .hasMax(13)
                               .hasScale(-1)
                               .hasZeroCount(0);
                           MetricAssertions.assertThat(point.getPositiveBuckets())
@@ -259,6 +261,8 @@ class SdkLongHistogramTest {
                               .hasAttributes(Attributes.builder().put("key", "value").build())
                               .hasCount(1)
                               .hasSum(12)
+                              .hasMin(12)
+                              .hasMax(12)
                               .hasScale(-1)
                               .hasZeroCount(0);
                           MetricAssertions.assertThat(point.getPositiveBuckets())

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExplicitBucketHistogramAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExplicitBucketHistogramAggregatorTest.java
@@ -172,12 +172,12 @@ class DoubleExplicitBucketHistogramAggregatorTest {
     assertThat(
             aggregator.merge(
                 ExplicitBucketHistogramAccumulation.create(
-                    0, /* hasMinMax= */ true, 1d, 2d, new long[] {}, Collections.emptyList()),
+                    0, /* hasMinMax= */ false, 0, 0, new long[] {}, Collections.emptyList()),
                 ExplicitBucketHistogramAccumulation.create(
                     0, /* hasMinMax= */ false, 0, 0, new long[] {}, Collections.emptyList())))
         .isEqualTo(
             ExplicitBucketHistogramAccumulation.create(
-                0, /* hasMinMax= */ true, 1d, 2d, new long[] {}, Collections.emptyList()));
+                0, /* hasMinMax= */ false, -1, -1, new long[] {}, Collections.emptyList()));
     // If min / max is non-null for only one accumulation set min / max to it
     assertThat(
             aggregator.merge(
@@ -207,44 +207,6 @@ class DoubleExplicitBucketHistogramAggregatorTest {
         .isEqualTo(
             ExplicitBucketHistogramAccumulation.create(
                 0, /* hasMinMax= */ true, 1d, 2d, new long[] {}, Collections.emptyList()));
-  }
-
-  @Test
-  void diffAccumulation() {
-    Attributes attributes = Attributes.builder().put("test", "value").build();
-    DoubleExemplarData exemplar =
-        ImmutableDoubleExemplarData.create(
-            attributes,
-            2L,
-            SpanContext.create(
-                "00000000000000000000000000000001",
-                "0000000000000002",
-                TraceFlags.getDefault(),
-                TraceState.getDefault()),
-            1);
-    List<DoubleExemplarData> exemplars = Collections.singletonList(exemplar);
-    List<DoubleExemplarData> previousExemplars =
-        Collections.singletonList(
-            ImmutableDoubleExemplarData.create(
-                attributes,
-                1L,
-                SpanContext.create(
-                    "00000000000000000000000000000001",
-                    "0000000000000002",
-                    TraceFlags.getDefault(),
-                    TraceState.getDefault()),
-                2));
-    ExplicitBucketHistogramAccumulation previousAccumulation =
-        ExplicitBucketHistogramAccumulation.create(
-            2, /* hasMinMax= */ true, 1d, 2d, new long[] {1, 1, 2}, previousExemplars);
-    ExplicitBucketHistogramAccumulation nextAccumulation =
-        ExplicitBucketHistogramAccumulation.create(
-            5, /* hasMinMax= */ true, 2d, 3d, new long[] {2, 2, 2}, exemplars);
-    // Assure most recent exemplars are kept.
-    assertThat(aggregator.diff(previousAccumulation, nextAccumulation))
-        .isEqualTo(
-            ExplicitBucketHistogramAccumulation.create(
-                3, /* hasMinMax= */ false, -1, -1, new long[] {1, 1, 0}, exemplars));
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramBucketsTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramBucketsTest.java
@@ -102,19 +102,6 @@ class DoubleExponentialHistogramBucketsTest {
     // Record can fail if scale is not set correctly.
     assertThat(c.record(3)).isTrue();
     assertThat(c.getTotalCount()).isEqualTo(2);
-
-    DoubleExponentialHistogramBuckets resultCc = DoubleExponentialHistogramBuckets.diff(c, c);
-    assertThat(c).isNotEqualTo(resultCc);
-    assertEquals(resultCc, empty);
-    assertThat(resultCc).hasSameHashCodeAs(empty);
-
-    DoubleExponentialHistogramBuckets d = buckets.newBuckets();
-    d.record(1);
-    // Downscale d to be the same as C but do NOT record the value 3.
-    d.downscale(20);
-    DoubleExponentialHistogramBuckets resultCd = DoubleExponentialHistogramBuckets.diff(c, d);
-    assertThat(c).isNotEqualTo(d);
-    assertThat(resultCd).isNotEqualTo(empty);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
- Update to otlp proto 0.17.0
- Add min and max support to exponential histogram aggregation, and exponential histogram point data
- Add otlp min and max serialization support for explicit bucket histograms and exponential histograms
- Remove unused `Aggregator#diff` implementation from explicit bucket histogram and exponential histogram aggregators. This code path is only used when an asynchronous instrument is aggregated in delta temporality, which is not supported for histograms. 

Resolves #4267.