### PR TITLE
Solve the duplicate metrics definition issue in Micrometer shim

### DIFF
--- a/micrometer1-shim/src/main/java/io/opentelemetry/micrometer1shim/Bridging.java
+++ b/micrometer1-shim/src/main/java/io/opentelemetry/micrometer1shim/Bridging.java
@@ -11,8 +11,12 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 final class Bridging {
+
+  private static final ConcurrentMap<String, String> descriptionsCache = new ConcurrentHashMap<>();
 
   static Attributes tagsAsAttributes(Meter.Id id, NamingConvention namingConvention) {
     Iterable<Tag> tags = id.getTagsAsIterable();
@@ -33,8 +37,12 @@ final class Bridging {
   }
 
   static String description(Meter.Id id) {
-    String description = id.getDescription();
-    return description != null ? description : "";
+    return descriptionsCache.computeIfAbsent(
+        id.getName(),
+        n -> {
+          String description = id.getDescription();
+          return description != null ? description : "";
+        });
   }
 
   static String baseUnit(Meter.Id id) {

--- a/micrometer1-shim/src/test/java/io/opentelemetry/micrometer1shim/FunctionCounterTest.java
+++ b/micrometer1-shim/src/test/java/io/opentelemetry/micrometer1shim/FunctionCounterTest.java
@@ -58,14 +58,14 @@ class FunctionCounterTest {
 
   @Test
   @SuppressLogger(MetricStorageRegistry.class)
-  void functionCountersWithSameNameAndDifferentDescriptions() {
+  void functionCountersWithSameNameAndDifferentTags() {
     FunctionCounter.builder("testFunctionCounterWithTags", num, AtomicLong::get)
         .description("First description")
         .tags("tag", "1")
         .baseUnit("items")
         .register(Metrics.globalRegistry);
     FunctionCounter.builder("testFunctionCounterWithTags", anotherNum, AtomicLong::get)
-        .description("Second description")
+        .description("ignored")
         .tags("tag", "2")
         .baseUnit("items")
         .register(Metrics.globalRegistry);
@@ -84,16 +84,7 @@ class FunctionCounterTest {
                                     point ->
                                         point
                                             .hasValue(12)
-                                            .hasAttributes(attributeEntry("tag", "1")))),
-            metric ->
-                assertThat(metric)
-                    .hasName("testFunctionCounterWithTags")
-                    .hasDescription("Second description")
-                    .hasUnit("items")
-                    .hasDoubleSumSatisfying(
-                        sum ->
-                            sum.isMonotonic()
-                                .hasPointsSatisfying(
+                                            .hasAttributes(attributeEntry("tag", "1")),
                                     point ->
                                         point
                                             .hasValue(13)

--- a/micrometer1-shim/src/test/java/io/opentelemetry/micrometer1shim/GaugeTest.java
+++ b/micrometer1-shim/src/test/java/io/opentelemetry/micrometer1shim/GaugeTest.java
@@ -14,7 +14,6 @@ import io.micrometer.core.instrument.Metrics;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import java.lang.ref.WeakReference;
 import java.util.concurrent.atomic.AtomicLong;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -57,8 +56,6 @@ class GaugeTest {
   }
 
   @Test
-  // TODO(anuraaga): Enable after https://github.com/open-telemetry/opentelemetry-java/pull/4222
-  @Disabled
   void gaugesWithSameNameAndDifferentTags() {
     Gauge.builder("testGaugeWithTags", () -> 12)
         .description("First description wins")


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java/issues/4381

I added a descriptions cache, only the first description seen will be used, the rest will just get ignored (pretty much the same behavior as `PrometheusMeterRegistry`). I tried to use the `MeterFilter` for that at first, but it turned out `Meter.Id` does not have any method for overriding the description.