### PR TITLE
Add experimental method to reset SdkMeterProvider

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java
@@ -55,6 +55,11 @@ final class SdkMeter implements Meter {
         collectionInfo, meterProviderSharedState, epochNanos, suppressSynchronousCollection);
   }
 
+  /** Reset the meter, clearing all registered instruments. */
+  void resetForTest() {
+    this.meterSharedState.resetForTest();
+  }
+
   @Override
   public LongCounterBuilder counterBuilder(String name) {
     return !ValidationUtil.checkValidInstrumentName(name, NOOP_INSTRUMENT_WARNING)

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProvider.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProvider.java
@@ -97,6 +97,11 @@ public final class SdkMeterProvider implements MeterProvider, Closeable {
     return new SdkMeterBuilder(registry, instrumentationScopeName);
   }
 
+  /** Reset the provider, clearing all registered instruments. */
+  void resetForTest() {
+    registry.getComponents().forEach(SdkMeter::resetForTest);
+  }
+
   /**
    * Call {@link MetricReader#forceFlush()} on all metric readers associated with this provider. The
    * resulting {@link CompletableResultCode} completes when all complete.

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/SdkMeterProviderUtil.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/SdkMeterProviderUtil.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.metrics.internal;
 
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
 import io.opentelemetry.sdk.metrics.ViewBuilder;
 import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
@@ -99,6 +100,17 @@ public final class SdkMeterProviderUtil {
       method.invoke(viewBuilder, attributesProcessor);
     } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
       throw new IllegalStateException("Error adding AttributesProcessor to ViewBuilder", e);
+    }
+  }
+
+  /** Reflectively reset the {@link SdkMeterProvider}, clearing all registered instruments. */
+  public static void resetForTest(SdkMeterProvider sdkMeterProvider) {
+    try {
+      Method method = SdkMeterProvider.class.getDeclaredMethod("resetForTest");
+      method.setAccessible(true);
+      method.invoke(sdkMeterProvider);
+    } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+      throw new IllegalStateException("Error calling resetForTest on SdkMeterProvider", e);
     }
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MeterSharedState.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MeterSharedState.java
@@ -109,6 +109,16 @@ public class MeterSharedState {
     }
   }
 
+  /** Reset the meter state, clearing all registered callbacks and storages. */
+  public void resetForTest() {
+    synchronized (collectLock) {
+      synchronized (callbackLock) {
+        callbackRegistrations.clear();
+      }
+      this.metricStorageRegistry.resetForTest();
+    }
+  }
+
   /** Registers new synchronous storage associated with a given instrument. */
   public final WriteableMetricStorage registerSynchronousMetricStorage(
       InstrumentDescriptor instrument, MeterProviderSharedState meterProviderSharedState) {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageRegistry.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageRegistry.java
@@ -85,4 +85,11 @@ public class MetricStorageRegistry {
     // Finally, return the storage
     return oldOrNewStorage;
   }
+
+  /** Reset the storage registry, clearing all storages. */
+  void resetForTest() {
+    synchronized (lock) {
+      registry.clear();
+    }
+  }
 }


### PR DESCRIPTION
Adds a testing utility method that allows `SdkMeterProvider` to be reset, which clears all registered instruments and storages. The initially configured resource, views, and readers are left alone. Any calls to record measurements to existing instruments after reset don't do anything, and those resource can be garbage collected as soon as there are no remaining referenced.

Originally discussed in the Java SIG for assisting in testing `opentelemetry-java-instrumentation`, but also necessary for a complete solution in #4459.