### PR TITLE
Drop reference to OTEL_EXPORTER_LOGGING_PREFIX

### DIFF
--- a/sdk-extensions/autoconfigure/README.md
+++ b/sdk-extensions/autoconfigure/README.md
@@ -144,7 +144,6 @@ The logging exporter prints the name of the span along with its attributes to st
 | otel.traces.exporter=logging  | OTEL_TRACES_EXPORTER=logging  | Select the logging exporter for tracing                              |
 | otel.metrics.exporter=logging | OTEL_METRICS_EXPORTER=logging | Select the logging exporter for metrics                              |
 | otel.logs.exporter=logging    | OTEL_LOGS_EXPORTER=logging    | Select the logging exporter for logs                                 |
-| otel.exporter.logging.prefix  | OTEL_EXPORTER_LOGGING_PREFIX  | An optional string printed in front of the span name and attributes. |
 
 ## Propagator
 


### PR DESCRIPTION
Removed unused property referenced in autoconfigure docs. Referenced in #4448. 