### PR TITLE
feat: `otel.metrics.exporter` setting support multiple values

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
@@ -20,24 +20,22 @@ import io.opentelemetry.exporter.prometheus.PrometheusHttpServerBuilder;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider;
-import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.opentelemetry.sdk.metrics.export.MetricReader;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
 import java.time.Duration;
 import java.util.function.BiFunction;
 import javax.annotation.Nullable;
 
 final class MetricExporterConfiguration {
-  static void configureExporter(
+  static MetricReader configureExporter(
       String name,
       ConfigProperties config,
       ClassLoader serviceClassLoader,
-      SdkMeterProviderBuilder sdkMeterProviderBuilder,
       BiFunction<? super MetricExporter, ConfigProperties, ? extends MetricExporter>
           metricExporterCustomizer) {
     if (name.equals("prometheus")) {
-      sdkMeterProviderBuilder.registerMetricReader(configurePrometheusMetricReader(config));
-      return;
+      return configurePrometheusMetricReader(config);
     }
 
     MetricExporter metricExporter;
@@ -57,8 +55,7 @@ final class MetricExporterConfiguration {
     }
 
     metricExporter = metricExporterCustomizer.apply(metricExporter, config);
-    sdkMeterProviderBuilder.registerMetricReader(
-        configurePeriodicMetricReader(config, metricExporter));
+    return configurePeriodicMetricReader(config, metricExporter);
   }
 
   private static MetricExporter configureLoggingExporter() {

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/NotOnClasspathTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/NotOnClasspathTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
-import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
@@ -90,7 +89,6 @@ class NotOnClasspathTest {
                     "logging",
                     EMPTY,
                     MetricExporterConfiguration.class.getClassLoader(),
-                    SdkMeterProvider.builder(),
                     (a, unused) -> a))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining(
@@ -117,7 +115,6 @@ class NotOnClasspathTest {
                     "otlp",
                     EMPTY,
                     MetricExporterConfiguration.class.getClassLoader(),
-                    SdkMeterProvider.builder(),
                     (a, unused) -> a))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining(
@@ -136,7 +133,6 @@ class NotOnClasspathTest {
                     "otlp",
                     config,
                     MetricExporterConfiguration.class.getClassLoader(),
-                    SdkMeterProvider.builder(),
                     (a, unused) -> a))
         .hasMessageContaining(
             "OTLP HTTP Metrics Exporter enabled but opentelemetry-exporter-otlp-http-metrics not found on classpath");
@@ -150,7 +146,6 @@ class NotOnClasspathTest {
                     "prometheus",
                     EMPTY,
                     MetricExporterConfiguration.class.getClassLoader(),
-                    SdkMeterProvider.builder(),
                     (a, unused) -> a))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining(

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableMetricExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableMetricExporterTest.java
@@ -9,14 +9,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.exporter.prometheus.PrometheusHttpServer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.opentelemetry.sdk.metrics.export.MetricReader;
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class ConfigurableMetricExporterTest {
 
@@ -60,5 +68,74 @@ public class ConfigurableMetricExporterTest {
                     (a, unused) -> a))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("catExporter");
+  }
+
+  @Test
+  void configureMetricExporters_multipleWithNone() {
+    ConfigProperties config =
+        DefaultConfigProperties.createForTest(
+            ImmutableMap.of("otel.metrics.exporter", "otlp,none"));
+
+    assertThatThrownBy(
+            () ->
+                MeterProviderConfiguration.configureMeterProvider(
+                    SdkMeterProvider.builder(),
+                    config,
+                    MetricExporterConfiguration.class.getClassLoader(),
+                    (a, unused) -> a))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("otel.metrics.exporter contains none along with other exporters");
+  }
+
+  @Test
+  void defaultExporter() {
+    ConfigProperties config = DefaultConfigProperties.createForTest(Collections.emptyMap());
+
+    SdkMeterProviderBuilder builder = Mockito.mock(SdkMeterProviderBuilder.class);
+    List<MetricReader> metricReaders = new ArrayList<>();
+    Mockito.when(builder.registerMetricReader(Mockito.any()))
+        .thenAnswer(
+            invocation -> {
+              metricReaders.add(invocation.getArgument(0));
+              return builder;
+            });
+    MeterProviderConfiguration.configureMeterProvider(
+        builder,
+        config,
+        MetricExporterConfiguration.class.getClassLoader(),
+        (metricExporter, unused) -> metricExporter);
+
+    Mockito.verify(builder)
+        .registerMetricReader(
+            Mockito.argThat(argument -> argument instanceof PeriodicMetricReader));
+    metricReaders.forEach(metricReader -> metricReader.shutdown().join(10, TimeUnit.SECONDS));
+  }
+
+  @Test
+  void configureMultipleMetricExporters() {
+    ConfigProperties config =
+        DefaultConfigProperties.createForTest(
+            ImmutableMap.of("otel.metrics.exporter", "otlp,prometheus"));
+    SdkMeterProviderBuilder builder = Mockito.mock(SdkMeterProviderBuilder.class);
+    List<MetricReader> metricReaders = new ArrayList<>();
+    Mockito.when(builder.registerMetricReader(Mockito.any()))
+        .thenAnswer(
+            invocation -> {
+              metricReaders.add(invocation.getArgument(0));
+              return builder;
+            });
+    MeterProviderConfiguration.configureMeterProvider(
+        builder,
+        config,
+        MetricExporterConfiguration.class.getClassLoader(),
+        (metricExporter, unused) -> metricExporter);
+
+    Mockito.verify(builder)
+        .registerMetricReader(
+            Mockito.argThat(argument -> argument instanceof PeriodicMetricReader));
+    Mockito.verify(builder)
+        .registerMetricReader(
+            Mockito.argThat(argument -> argument instanceof PrometheusHttpServer));
+    metricReaders.forEach(metricReader -> metricReader.shutdown().join(10, TimeUnit.SECONDS));
   }
 }


### PR DESCRIPTION
`otel.metrics.exporter` setting support multiple values. 

close #4195 