### PR TITLE
Drop outdated metrics sdk readme

### DIFF
--- a/sdk/metrics/README.md
+++ b/sdk/metrics/README.md
@@ -2,19 +2,5 @@
 
 [![Javadocs][javadoc-image]][javadoc-url]
 
-The code in this directory is currently the legacy implementation of the previous experimental metrics SDK specification.
-
-
-The following set of known issues will be fixed aas the new SDK specification stabilizes:
-
-- The names of SDK instruments do not line up with API instruments.
-- Baggage / Context are not available to metrics / views.
-- The View API still uses the term LabelsProcessor.
-- Only one exporter is allowed.
-- Histograms are generating summaries.
-- Exemplars are not sampled
-- The set of Aggregators goes well beyond the expected "stable" list and (likely) will have some moved to extensions.
-- There is no exposed `MetricProcessor` interface.
-
 [javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-sdk-metrics.svg
 [javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-metrics


### PR DESCRIPTION
These are really out of date. Also, docs should live on opentelemetry.io, which I've recently updated to include an introduction to [metrics](https://opentelemetry.io/docs/instrumentation/java/manual/#metrics).