### PR TITLE
Make ArrayBackedAttributes be public

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedAttributes.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedAttributes.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
-final class ArrayBackedAttributes extends ImmutableKeyValuePairs<AttributeKey<?>, Object>
+public final class ArrayBackedAttributes extends ImmutableKeyValuePairs<AttributeKey<?>, Object>
     implements Attributes {
 
   // We only compare the key name, not type, when constructing, to allow deduping keys with the

--- a/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedAttributesBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedAttributesBuilder.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 
-class ArrayBackedAttributesBuilder implements AttributesBuilder {
+public class ArrayBackedAttributesBuilder implements AttributesBuilder {
   private final List<Object> data;
 
   ArrayBackedAttributesBuilder() {


### PR DESCRIPTION
when i use jdk1.6 , i can not get Attributes instance with method `Attributes.of(...)` 
<img width="644" alt="image" src="https://user-images.githubusercontent.com/12369652/169501744-abfa1a30-3434-4065-8afe-94133f278a98.png">


solution 1 :  i custom implements myself `Attributes` ;  it make code redundant

solution2： i want new instance of ArrayBackedAttributes ; but it not public class

