### PR TITLE
Add setter for MeterProvider to JaegerGrpcSpanExporterBuilder

### DIFF
--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterBuilder.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterBuilder.java
@@ -33,6 +33,7 @@ public final class JaegerGrpcSpanExporterBuilder {
   JaegerGrpcSpanExporterBuilder() {
     delegate =
         GrpcExporter.builder(
+            "jaeger",
             "span",
             DEFAULT_TIMEOUT_SECS,
             DEFAULT_ENDPOINT,

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterBuilder.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterBuilder.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.api.internal.Utils.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import io.grpc.ManagedChannel;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.internal.grpc.GrpcExporter;
 import io.opentelemetry.exporter.internal.grpc.GrpcExporterBuilder;
 import java.net.URI;
@@ -99,6 +100,16 @@ public final class JaegerGrpcSpanExporterBuilder {
   /** Sets the client key and chain to use for verifying servers when mTLS is enabled. */
   public JaegerGrpcSpanExporterBuilder setClientTls(byte[] privateKeyPem, byte[] certificatePem) {
     delegate.setClientTls(privateKeyPem, certificatePem);
+    return this;
+  }
+
+  /**
+   * Sets the {@link MeterProvider} to use to collect metrics related to export. If not set, metrics
+   * will not be collected.
+   */
+  public JaegerGrpcSpanExporterBuilder setMeterProvider(MeterProvider meterProvider) {
+    requireNonNull(meterProvider, "meterProvider");
+    delegate.setMeterProvider(meterProvider);
     return this;
   }
 

--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterTest.java
@@ -17,6 +17,7 @@ import com.linecorp.armeria.server.grpc.protocol.AbstractUnaryGrpcService;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.SpanKind;
@@ -88,7 +89,11 @@ class JaegerGrpcSpanExporterTest {
 
   @BeforeAll
   static void setUp() {
-    exporter = JaegerGrpcSpanExporter.builder().setEndpoint(server.httpUri().toString()).build();
+    exporter =
+        JaegerGrpcSpanExporter.builder()
+            .setEndpoint(server.httpUri().toString())
+            .setMeterProvider(MeterProvider.noop())
+            .build();
   }
 
   @AfterAll

--- a/exporters/otlp-http/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogExporterBuilder.java
+++ b/exporters/otlp-http/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogExporterBuilder.java
@@ -22,7 +22,7 @@ public final class OtlpHttpLogExporterBuilder {
   private final OkHttpExporterBuilder<LogsRequestMarshaler> delegate;
 
   OtlpHttpLogExporterBuilder() {
-    delegate = new OkHttpExporterBuilder<>("log", DEFAULT_ENDPOINT);
+    delegate = new OkHttpExporterBuilder<>("otlp", "log", DEFAULT_ENDPOINT);
   }
 
   /**

--- a/exporters/otlp-http/metrics/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp-http/metrics/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -29,7 +29,7 @@ public final class OtlpHttpMetricExporterBuilder {
       DEFAULT_AGGREGATION_TEMPORALITY_SELECTOR;
 
   OtlpHttpMetricExporterBuilder() {
-    delegate = new OkHttpExporterBuilder<>("metric", DEFAULT_ENDPOINT);
+    delegate = new OkHttpExporterBuilder<>("otlp", "metric", DEFAULT_ENDPOINT);
   }
 
   /**

--- a/exporters/otlp-http/trace/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp-http/trace/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -22,7 +22,7 @@ public final class OtlpHttpSpanExporterBuilder {
   private final OkHttpExporterBuilder<TraceRequestMarshaler> delegate;
 
   OtlpHttpSpanExporterBuilder() {
-    delegate = new OkHttpExporterBuilder<>("span", DEFAULT_ENDPOINT);
+    delegate = new OkHttpExporterBuilder<>("otlp", "span", DEFAULT_ENDPOINT);
   }
 
   /**

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/ExporterMetrics.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/ExporterMetrics.java
@@ -15,7 +15,7 @@ import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterProvider;
 
 /**
- * Helper for recording metrics from OTLP exporters.
+ * Helper for recording metrics from exporters.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
@@ -32,10 +32,13 @@ public class ExporterMetrics {
   private final Attributes successAttrs;
   private final Attributes failedAttrs;
 
-  private ExporterMetrics(Meter meter, String type) {
+  private ExporterMetrics(
+      MeterProvider meterProvider, String exporterName, String type, String transportName) {
+    Meter meter =
+        meterProvider.get("io.opentelemetry.exporters." + exporterName + "-" + transportName);
     seenAttrs = Attributes.builder().put(ATTRIBUTE_KEY_TYPE, type).build();
-    seen = meter.counterBuilder("otlp.exporter.seen").build();
-    exported = meter.counterBuilder("otlp.exporter.exported").build();
+    seen = meter.counterBuilder(exporterName + ".exporter.seen").build();
+    exported = meter.counterBuilder(exporterName + ".exporter.exported").build();
     successAttrs = seenAttrs.toBuilder().put(ATTRIBUTE_KEY_SUCCESS, true).build();
     failedAttrs = seenAttrs.toBuilder().put(ATTRIBUTE_KEY_SUCCESS, false).build();
   }
@@ -55,19 +58,21 @@ public class ExporterMetrics {
     exported.add(value, failedAttrs);
   }
 
-  /** Create an instance for recording OTLP gRPC exporter metrics. */
-  public static ExporterMetrics createGrpc(String type, MeterProvider meterProvider) {
-    return new ExporterMetrics(meterProvider.get("io.opentelemetry.exporters.otlp-grpc"), type);
+  /** Create an instance for recording gRPC exporter metrics. */
+  public static ExporterMetrics createGrpc(
+      String exporterName, String type, MeterProvider meterProvider) {
+    return new ExporterMetrics(meterProvider, exporterName, type, "grpc");
   }
 
-  /** Create an instance for recording OTLP gRPC OkHttp exporter metrics. */
-  public static ExporterMetrics createGrpcOkHttp(String type, MeterProvider meterProvider) {
-    return new ExporterMetrics(
-        meterProvider.get("io.opentelemetry.exporters.otlp-grpc-okhttp"), type);
+  /** Create an instance for recording gRPC OkHttp exporter metrics. */
+  public static ExporterMetrics createGrpcOkHttp(
+      String exporterName, String type, MeterProvider meterProvider) {
+    return new ExporterMetrics(meterProvider, exporterName, type, "grpc-okhttp");
   }
 
-  /** Create an instance for recording OTLP http/protobuf exporter metrics. */
-  public static ExporterMetrics createHttpProtobuf(String type, MeterProvider meterProvider) {
-    return new ExporterMetrics(meterProvider.get("io.opentelemetry.exporters.otlp-http"), type);
+  /** Create an instance for recording http/protobuf exporter metrics. */
+  public static ExporterMetrics createHttpProtobuf(
+      String exporterName, String type, MeterProvider meterProvider) {
+    return new ExporterMetrics(meterProvider, exporterName, type, "http");
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/DefaultGrpcExporter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/DefaultGrpcExporter.java
@@ -45,13 +45,14 @@ public final class DefaultGrpcExporter<T extends Marshaler> implements GrpcExpor
 
   /** Creates a new {@link DefaultGrpcExporter}. */
   DefaultGrpcExporter(
+      String exporterName,
       String type,
       ManagedChannel channel,
       MarshalerServiceStub<T, ?, ?> stub,
       MeterProvider meterProvider,
       long timeoutNanos) {
     this.type = type;
-    this.exporterMetrics = ExporterMetrics.createGrpc(type, meterProvider);
+    this.exporterMetrics = ExporterMetrics.createGrpc(exporterName, type, meterProvider);
     this.managedChannel = channel;
     this.timeoutNanos = timeoutNanos;
     this.stub = stub;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/DefaultGrpcExporterBuilder.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/DefaultGrpcExporterBuilder.java
@@ -33,6 +33,7 @@ import javax.net.ssl.SSLException;
 public final class DefaultGrpcExporterBuilder<T extends Marshaler>
     implements GrpcExporterBuilder<T> {
 
+  private final String exporterName;
   private final String type;
   private final Function<ManagedChannel, MarshalerServiceStub<T, ?, ?>> stubFactory;
   private final String grpcServiceName;
@@ -51,11 +52,13 @@ public final class DefaultGrpcExporterBuilder<T extends Marshaler>
   /** Creates a new {@link DefaultGrpcExporterBuilder}. */
   // Visible for testing
   public DefaultGrpcExporterBuilder(
+      String exporterName,
       String type,
       Function<ManagedChannel, MarshalerServiceStub<T, ?, ?>> stubFactory,
       long defaultTimeoutSecs,
       URI defaultEndpoint,
       String grpcServiceName) {
+    this.exporterName = exporterName;
     this.type = type;
     this.stubFactory = stubFactory;
     this.grpcServiceName = grpcServiceName;
@@ -165,6 +168,7 @@ public final class DefaultGrpcExporterBuilder<T extends Marshaler>
     Codec codec = compressionEnabled ? new Codec.Gzip() : Codec.Identity.NONE;
     MarshalerServiceStub<T, ?, ?> stub =
         stubFactory.apply(channel).withCompression(codec.getMessageEncoding());
-    return new DefaultGrpcExporter<>(type, channel, stub, meterProvider, timeoutNanos);
+    return new DefaultGrpcExporter<>(
+        exporterName, type, channel, stub, meterProvider, timeoutNanos);
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporter.java
@@ -22,6 +22,7 @@ public interface GrpcExporter<T extends Marshaler> {
 
   /** Returns a new {@link GrpcExporterBuilder}. */
   static <T extends Marshaler> GrpcExporterBuilder<T> builder(
+      String exporterName,
       String type,
       long defaultTimeoutSecs,
       URI defaultEndpoint,
@@ -29,7 +30,13 @@ public interface GrpcExporter<T extends Marshaler> {
       String grpcServiceName,
       String grpcEndpointPath) {
     return GrpcExporterUtil.exporterBuilder(
-        type, defaultTimeoutSecs, defaultEndpoint, stubFactory, grpcServiceName, grpcEndpointPath);
+        exporterName,
+        type,
+        defaultTimeoutSecs,
+        defaultEndpoint,
+        stubFactory,
+        grpcServiceName,
+        grpcEndpointPath);
   }
 
   /**

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterUtil.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterUtil.java
@@ -31,6 +31,7 @@ final class GrpcExporterUtil {
   }
 
   static <T extends Marshaler> GrpcExporterBuilder<T> exporterBuilder(
+      String exporterName,
       String type,
       long defaultTimeoutSecs,
       URI defaultEndpoint,
@@ -39,10 +40,15 @@ final class GrpcExporterUtil {
       String grpcEndpointPath) {
     if (USE_OKHTTP) {
       return new OkHttpGrpcExporterBuilder<>(
-          type, grpcEndpointPath, defaultTimeoutSecs, defaultEndpoint);
+          exporterName, type, grpcEndpointPath, defaultTimeoutSecs, defaultEndpoint);
     } else {
       return new DefaultGrpcExporterBuilder<>(
-          type, stubFactory.get(), defaultTimeoutSecs, defaultEndpoint, grpcServiceName);
+          exporterName,
+          type,
+          stubFactory.get(),
+          defaultTimeoutSecs,
+          defaultEndpoint,
+          grpcServiceName);
     }
   }
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/OkHttpGrpcExporter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/OkHttpGrpcExporter.java
@@ -71,6 +71,7 @@ public final class OkHttpGrpcExporter<T extends Marshaler> implements GrpcExport
 
   /** Creates a new {@link OkHttpGrpcExporter}. */
   OkHttpGrpcExporter(
+      String exporterName,
       String type,
       OkHttpClient client,
       MeterProvider meterProvider,
@@ -78,7 +79,7 @@ public final class OkHttpGrpcExporter<T extends Marshaler> implements GrpcExport
       Headers headers,
       boolean compressionEnabled) {
     this.type = type;
-    this.exporterMetrics = ExporterMetrics.createGrpcOkHttp(type, meterProvider);
+    this.exporterMetrics = ExporterMetrics.createGrpcOkHttp(exporterName, type, meterProvider);
     this.client = client;
     this.endpoint = endpoint;
     this.headers = headers;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/OkHttpGrpcExporterBuilder.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/OkHttpGrpcExporterBuilder.java
@@ -35,6 +35,7 @@ import okhttp3.Protocol;
 public final class OkHttpGrpcExporterBuilder<T extends Marshaler>
     implements GrpcExporterBuilder<T> {
 
+  private final String exporterName;
   private final String type;
   private final String grpcEndpointPath;
 
@@ -51,7 +52,12 @@ public final class OkHttpGrpcExporterBuilder<T extends Marshaler>
   /** Creates a new {@link OkHttpGrpcExporterBuilder}. */
   // Visible for testing
   public OkHttpGrpcExporterBuilder(
-      String type, String grpcEndpointPath, long defaultTimeoutSecs, URI defaultEndpoint) {
+      String exporterName,
+      String type,
+      String grpcEndpointPath,
+      long defaultTimeoutSecs,
+      URI defaultEndpoint) {
+    this.exporterName = exporterName;
     this.type = type;
     this.grpcEndpointPath = grpcEndpointPath;
     timeoutNanos = TimeUnit.SECONDS.toNanos(defaultTimeoutSecs);
@@ -157,6 +163,12 @@ public final class OkHttpGrpcExporterBuilder<T extends Marshaler>
     }
 
     return new OkHttpGrpcExporter<>(
-        type, clientBuilder.build(), meterProvider, endpoint, headers.build(), compressionEnabled);
+        exporterName,
+        type,
+        clientBuilder.build(),
+        meterProvider,
+        endpoint,
+        headers.build(),
+        compressionEnabled);
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/OkHttpExporter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/OkHttpExporter.java
@@ -53,6 +53,7 @@ public final class OkHttpExporter<T extends Marshaler> {
   private final ExporterMetrics exporterMetrics;
 
   OkHttpExporter(
+      String exporterName,
       String type,
       OkHttpClient client,
       MeterProvider meterProvider,
@@ -66,7 +67,7 @@ public final class OkHttpExporter<T extends Marshaler> {
     this.headers = headers;
     this.compressionEnabled = compressionEnabled;
     this.requestBodyCreator = exportAsJson ? JsonRequestBody::new : ProtoRequestBody::new;
-    this.exporterMetrics = ExporterMetrics.createHttpProtobuf(type, meterProvider);
+    this.exporterMetrics = ExporterMetrics.createHttpProtobuf(exporterName, type, meterProvider);
   }
 
   public CompletableResultCode export(T exportRequest, int numItems) {

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/OkHttpExporterBuilder.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/OkHttpExporterBuilder.java
@@ -31,6 +31,7 @@ import okhttp3.OkHttpClient;
 public final class OkHttpExporterBuilder<T extends Marshaler> {
   public static final long DEFAULT_TIMEOUT_SECS = 10;
 
+  private final String exporterName;
   private final String type;
 
   private String endpoint;
@@ -45,7 +46,8 @@ public final class OkHttpExporterBuilder<T extends Marshaler> {
   @Nullable private RetryPolicy retryPolicy;
   private MeterProvider meterProvider = MeterProvider.noop();
 
-  public OkHttpExporterBuilder(String type, String defaultEndpoint) {
+  public OkHttpExporterBuilder(String exporterName, String type, String defaultEndpoint) {
+    this.exporterName = exporterName;
     this.type = type;
 
     endpoint = defaultEndpoint;
@@ -136,6 +138,7 @@ public final class OkHttpExporterBuilder<T extends Marshaler> {
     }
 
     return new OkHttpExporter<>(
+        exporterName,
         type,
         clientBuilder.build(),
         meterProvider,

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/retry/RetryUtilTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/retry/RetryUtilTest.java
@@ -24,7 +24,7 @@ class RetryUtilTest {
     RetryPolicy retryPolicy = RetryPolicy.getDefault();
     DefaultGrpcExporterBuilder<?> builder =
         new DefaultGrpcExporterBuilder<>(
-            "test", unused -> null, 0, new URI("http://localhost"), "test");
+            "otlp", "test", unused -> null, 0, new URI("http://localhost"), "test");
 
     RetryUtil.setRetryPolicyOnDelegate(new WithDelegate(builder), retryPolicy);
 
@@ -37,7 +37,7 @@ class RetryUtilTest {
   void setRetryPolicyOnDelegate_OkHttpGrpcExporterBuilder() throws URISyntaxException {
     RetryPolicy retryPolicy = RetryPolicy.getDefault();
     OkHttpGrpcExporterBuilder<?> builder =
-        new OkHttpGrpcExporterBuilder<>("test", "/test", 0, new URI("http://localhost"));
+        new OkHttpGrpcExporterBuilder<>("otlp", "test", "/test", 0, new URI("http://localhost"));
 
     RetryUtil.setRetryPolicyOnDelegate(new WithDelegate(builder), retryPolicy);
 
@@ -50,7 +50,7 @@ class RetryUtilTest {
   void setRetryPolicyOnDelegate_OkHttpExporterBuilder() {
     RetryPolicy retryPolicy = RetryPolicy.getDefault();
     OkHttpExporterBuilder<?> builder =
-        new OkHttpExporterBuilder<>("test", "http://localhost:4318/test");
+        new OkHttpExporterBuilder<>("otlp", "test", "http://localhost:4318/test");
     RetryUtil.setRetryPolicyOnDelegate(new WithDelegate(builder), retryPolicy);
 
     assertThat(builder)

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogExporterBuilder.java
@@ -35,6 +35,7 @@ public final class OtlpGrpcLogExporterBuilder {
   OtlpGrpcLogExporterBuilder() {
     delegate =
         GrpcExporter.builder(
+            "otlp",
             "log",
             DEFAULT_TIMEOUT_SECS,
             DEFAULT_ENDPOINT,

--- a/exporters/otlp/metrics/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
+++ b/exporters/otlp/metrics/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
@@ -42,6 +42,7 @@ public final class OtlpGrpcMetricExporterBuilder {
   OtlpGrpcMetricExporterBuilder() {
     delegate =
         GrpcExporter.builder(
+            "otlp",
             "metric",
             DEFAULT_TIMEOUT_SECS,
             DEFAULT_ENDPOINT,

--- a/exporters/otlp/trace/src/jmh/java/io/opentelemetry/exporter/otlp/trace/GrpcExporterBenchmark.java
+++ b/exporters/otlp/trace/src/jmh/java/io/opentelemetry/exporter/otlp/trace/GrpcExporterBenchmark.java
@@ -65,6 +65,7 @@ public class GrpcExporterBenchmark {
 
     defaultGrpcExporter =
         new DefaultGrpcExporterBuilder<>(
+                "otlp",
                 "span",
                 MarshalerTraceServiceGrpc::newFutureStub,
                 10,
@@ -74,6 +75,7 @@ public class GrpcExporterBenchmark {
 
     okhttpGrpcExporter =
         new OkHttpGrpcExporterBuilder<TraceRequestMarshaler>(
+                "otlp",
                 "span",
                 OtlpGrpcSpanExporterBuilder.GRPC_ENDPOINT_PATH,
                 10,

--- a/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
+++ b/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
@@ -35,6 +35,7 @@ public final class OtlpGrpcSpanExporterBuilder {
   OtlpGrpcSpanExporterBuilder() {
     delegate =
         GrpcExporter.builder(
+            "otlp",
             "span",
             DEFAULT_TIMEOUT_SECS,
             DEFAULT_ENDPOINT,

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfiguration.java
@@ -89,7 +89,7 @@ final class SpanExporterConfiguration {
       case "otlp":
         return configureOtlp(config, meterProvider);
       case "jaeger":
-        return configureJaeger(config);
+        return configureJaeger(config, meterProvider);
       case "zipkin":
         return configureZipkin(config);
       case "logging":
@@ -157,7 +157,8 @@ final class SpanExporterConfiguration {
     }
   }
 
-  private static SpanExporter configureJaeger(ConfigProperties config) {
+  private static SpanExporter configureJaeger(
+      ConfigProperties config, MeterProvider meterProvider) {
     ClasspathUtil.checkClassExists(
         "io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter",
         "Jaeger gRPC Exporter",
@@ -173,6 +174,8 @@ final class SpanExporterConfiguration {
     if (timeout != null) {
       builder.setTimeout(timeout);
     }
+
+    builder.setMeterProvider(meterProvider);
 
     return builder.build();
   }


### PR DESCRIPTION
`GrpcExporterBuilder` supports to set a custom `MeterProvider`, which is exposed in the [OtlpGrpcSpanExporterBuilder](https://github.com/open-telemetry/opentelemetry-java/blob/main/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java#L140). The `JaegerGrpcSpanExporterBuilder` should have the same functionality.

I could not find a dedicated tests for the `OtlpGrpcSpanExporterBuilder` using a `MeterProvider` implementation beside NOOP. I guess this is part of the underlying `GrpcExporterBuilder`.