### PR TITLE
Update to proto 0.18.0

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -89,7 +89,7 @@ val DEPENDENCIES = listOf(
   "eu.rekawek.toxiproxy:toxiproxy-java:2.1.5",
   "io.github.netmikey.logunit:logunit-jul:1.1.3",
   "io.jaegertracing:jaeger-client:1.8.0",
-  "io.opentelemetry.proto:opentelemetry-proto:0.17.0-alpha",
+  "io.opentelemetry.proto:opentelemetry-proto:0.18.0-alpha",
   "io.opentracing:opentracing-api:0.33.0",
   "junit:junit:4.13.2",
   "nl.jqno.equalsverifier:equalsverifier:3.10",

--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-jaeger.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-jaeger.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporterBuilder setMeterProvider(io.opentelemetry.api.metrics.MeterProvider)


### PR DESCRIPTION
No code changes, but still good to update to latest version which marks logs as stable. 