### PR TITLE
Use the HTTP_TARGET attribute for sampling decisions in the Jaeger Remote Sampler

### DIFF
--- a/sdk-extensions/jaeger-remote-sampler/build.gradle.kts
+++ b/sdk-extensions/jaeger-remote-sampler/build.gradle.kts
@@ -12,6 +12,7 @@ otelJava.moduleName.set("io.opentelemetry.sdk.extension.trace.jaeger")
 
 dependencies {
   api(project(":sdk:all"))
+  implementation(project(":semconv"))
   compileOnly(project(":sdk-extensions:autoconfigure"))
 
   implementation(project(":sdk:all"))

--- a/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/PerOperationSampler.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/PerOperationSampler.java
@@ -11,6 +11,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,9 @@ class PerOperationSampler implements Sampler {
       Attributes attributes,
       List<LinkData> parentLinks) {
     Sampler sampler = this.perOperationSampler.get(name);
+    if (sampler == null) {
+      sampler = this.perOperationSampler.get(attributes.get(SemanticAttributes.HTTP_TARGET));
+    }
     if (sampler == null) {
       sampler = this.defaultSampler;
     }

--- a/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/PerOperationSampler.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/PerOperationSampler.java
@@ -44,6 +44,8 @@ class PerOperationSampler implements Sampler {
       Attributes attributes,
       List<LinkData> parentLinks) {
     Sampler sampler = this.perOperationSampler.get(name);
+    // The name for spans started in HTTP servers is always "HTTP <method>".
+    // For these spans, using the HTTP target may be more useful.
     if (sampler == null) {
       sampler = this.perOperationSampler.get(attributes.get(SemanticAttributes.HTTP_TARGET));
     }


### PR DESCRIPTION
The starting span name for spans that derive from HTTP requests is
always `HTTP <method>`, which is not very useful for sampling
decisions.  Using the http target if the name is not matched allows
for things like health checks to be suppressed.