### PR TITLE
Add default getters to ConfigProperties

### DIFF
--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java
@@ -23,6 +23,8 @@ public interface ConfigProperties {
   String getString(String name);
 
   /**
+   * Returns a string-valued configuration property.
+   *
    * @return a string-valued configuration property or {@code defaultValue} if a property with
    *     {@code name} has not been configured.
    * @throws ConfigurationException if the property is not a valid string.
@@ -42,6 +44,8 @@ public interface ConfigProperties {
   Boolean getBoolean(String name);
 
   /**
+   * Returns a boolean-valued configuration property.
+   *
    * @return a Boolean-valued configuration property or {@code defaultValue} if a property with
    *     {@code name} has not been configured.
    * @throws ConfigurationException if the property is not a valid string.
@@ -60,6 +64,8 @@ public interface ConfigProperties {
   Integer getInt(String name);
 
   /**
+   * Returns an Integer-valued configuration property.
+   *
    * @return an Integer-valued configuration property or {@code defaultValue} if a property with
    *     {@code name} has not been configured.
    * @throws ConfigurationException if the property is not a valid string.
@@ -78,6 +84,8 @@ public interface ConfigProperties {
   Long getLong(String name);
 
   /**
+   * Returns a Long-valued configuration property.
+   *
    * @return a Long-valued configuration property or {@code defaultValue} if a property with {@code
    *     name} has not been configured.
    * @throws ConfigurationException if the property is not a valid string.
@@ -96,6 +104,8 @@ public interface ConfigProperties {
   Double getDouble(String name);
 
   /**
+   * Returns a double-valued configuration property.
+   *
    * @return a Double-valued configuration property or {@code defaultValue} if a property with
    *     {@code name} has not been configured.
    * @throws ConfigurationException if the property is not a valid string.
@@ -129,6 +139,8 @@ public interface ConfigProperties {
   Duration getDuration(String name);
 
   /**
+   * Returns a Duration value configuration property.
+   *
    * @see ConfigProperties#getDuration(String name)
    * @return a Double-valued configuration property or {@code defaultValue} if a property with name
    *     {@code name} has not been configured.
@@ -148,6 +160,8 @@ public interface ConfigProperties {
   List<String> getList(String name);
 
   /**
+   * Returns a List value configuration property.
+   *
    * @see ConfigProperties#getList(String name)
    * @return a List configuration property or {@code defaultValue} if a property with {@code name}
    *     has not been configured.
@@ -169,6 +183,8 @@ public interface ConfigProperties {
   Map<String, String> getMap(String name);
 
   /**
+   * Returns a Map value configuration property.
+   *
    * @see ConfigProperties#getMap(String name)
    * @return a Double-valued configuration property or {@code defaultValue} if a property with
    *     {@code name} has not been configured.

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java
@@ -169,7 +169,7 @@ public interface ConfigProperties {
    */
   default List<String> getList(String name, List<String> defaultValue) {
     List<String> value = getList(name);
-    return (value == null || value.isEmpty()) ? defaultValue : value;
+    return value.isEmpty() ? defaultValue : value;
   }
 
   /**
@@ -192,7 +192,7 @@ public interface ConfigProperties {
    */
   default Map<String, String> getMap(String name, Map<String, String> defaultValue) {
     Map<String, String> value = getMap(name);
-    return (value == null || value.isEmpty()) ? defaultValue : value;
+    return value.isEmpty() ? defaultValue : value;
   }
 
   /**

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java
@@ -30,7 +30,7 @@ public interface ConfigProperties {
    * @throws ConfigurationException if the property is not a valid string.
    */
   default String getString(String name, String defaultValue) {
-    return _defaultIfNull(getString(name), defaultValue);
+    return defaultIfNull(getString(name), defaultValue);
   }
 
   /**
@@ -51,7 +51,7 @@ public interface ConfigProperties {
    * @throws ConfigurationException if the property is not a valid string.
    */
   default Boolean getBoolean(String name, Boolean defaultValue) {
-    return _defaultIfNull(getBoolean(name), defaultValue);
+    return defaultIfNull(getBoolean(name), defaultValue);
   }
 
   /**
@@ -71,7 +71,7 @@ public interface ConfigProperties {
    * @throws ConfigurationException if the property is not a valid string.
    */
   default Integer getInt(String name, Integer defaultValue) {
-    return _defaultIfNull(getInt(name), defaultValue);
+    return defaultIfNull(getInt(name), defaultValue);
   }
 
   /**
@@ -91,7 +91,7 @@ public interface ConfigProperties {
    * @throws ConfigurationException if the property is not a valid string.
    */
   default Long getLong(String name, Long defaultValue) {
-    return _defaultIfNull(getLong(name), defaultValue);
+    return defaultIfNull(getLong(name), defaultValue);
   }
 
   /**
@@ -111,7 +111,7 @@ public interface ConfigProperties {
    * @throws ConfigurationException if the property is not a valid string.
    */
   default Double getDouble(String name, Double defaultValue) {
-    return _defaultIfNull(getDouble(name), defaultValue);
+    return defaultIfNull(getDouble(name), defaultValue);
   }
 
   /**
@@ -147,7 +147,7 @@ public interface ConfigProperties {
    * @throws ConfigurationException if the property is not a valid string.
    */
   default Duration getDuration(String name, Duration defaultValue) {
-    return _defaultIfNull(getDuration(name), defaultValue);
+    return defaultIfNull(getDuration(name), defaultValue);
   }
 
   /**
@@ -199,7 +199,7 @@ public interface ConfigProperties {
    * Returns defaultValue if value is null, otherwise value. This is an internal method that should
    * not be broadly used.
    */
-  default <T> T _defaultIfNull(@Nullable T value, T defaultValue) {
+  default <T> T defaultIfNull(@Nullable T value, T defaultValue) {
     return value == null ? defaultValue : value;
   }
 }

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.sdk.autoconfigure.spi;
 
-import static io.opentelemetry.sdk.autoconfigure.spi.NullDefaultUtility.defaultIfNull;
+import static io.opentelemetry.sdk.autoconfigure.spi.ConfigUtil.defaultIfNull;
 
 import java.time.Duration;
 import java.util.List;

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java
@@ -23,6 +23,15 @@ public interface ConfigProperties {
   String getString(String name);
 
   /**
+   * @return a string-valued configuration property or {@code defaultValue} if a property with
+   *     {@code name} has not been configured.
+   * @throws ConfigurationException if the property is not a valid string.
+   */
+  default String getString(String name, String defaultValue) {
+    return _defaultIfNull(getString(name), defaultValue);
+  }
+
+  /**
    * Returns a boolean-valued configuration property. Implementations should use the same rules as
    * {@link Boolean#parseBoolean(String)} for handling the values.
    *
@@ -33,7 +42,16 @@ public interface ConfigProperties {
   Boolean getBoolean(String name);
 
   /**
-   * Returns a integer-valued configuration property.
+   * @return a Boolean-valued configuration property or {@code defaultValue} if a property with
+   *     {@code name} has not been configured.
+   * @throws ConfigurationException if the property is not a valid string.
+   */
+  default Boolean getBoolean(String name, Boolean defaultValue) {
+    return _defaultIfNull(getBoolean(name), defaultValue);
+  }
+
+  /**
+   * Returns an Integer-valued configuration property.
    *
    * @return null if the property has not been configured.
    * @throws ConfigurationException if the property is not a valid integer.
@@ -42,13 +60,31 @@ public interface ConfigProperties {
   Integer getInt(String name);
 
   /**
-   * Returns a long-valued configuration property.
+   * @return an Integer-valued configuration property or {@code defaultValue} if a property with
+   *     {@code name} has not been configured.
+   * @throws ConfigurationException if the property is not a valid string.
+   */
+  default Integer getInt(String name, Integer defaultValue) {
+    return _defaultIfNull(getInt(name), defaultValue);
+  }
+
+  /**
+   * Returns a Long-valued configuration property.
    *
    * @return null if the property has not been configured.
    * @throws ConfigurationException if the property is not a valid long.
    */
   @Nullable
   Long getLong(String name);
+
+  /**
+   * @return a Long-valued configuration property or {@code defaultValue} if a property with {@code
+   *     name} has not been configured.
+   * @throws ConfigurationException if the property is not a valid string.
+   */
+  default Long getLong(String name, Long defaultValue) {
+    return _defaultIfNull(getLong(name), defaultValue);
+  }
 
   /**
    * Returns a double-valued configuration property.
@@ -58,6 +94,15 @@ public interface ConfigProperties {
    */
   @Nullable
   Double getDouble(String name);
+
+  /**
+   * @return a Double-valued configuration property or {@code defaultValue} if a property with
+   *     {@code name} has not been configured.
+   * @throws ConfigurationException if the property is not a valid string.
+   */
+  default Double getDouble(String name, Double defaultValue) {
+    return _defaultIfNull(getDouble(name), defaultValue);
+  }
 
   /**
    * Returns a duration property from the map, or {@code null} if it cannot be found or it has a
@@ -84,6 +129,16 @@ public interface ConfigProperties {
   Duration getDuration(String name);
 
   /**
+   * @see ConfigProperties#getDuration(String name)
+   * @return a Double-valued configuration property or {@code defaultValue} if a property with name
+   *     {@code name} has not been configured.
+   * @throws ConfigurationException if the property is not a valid string.
+   */
+  default Duration getDuration(String name, Duration defaultValue) {
+    return _defaultIfNull(getDuration(name), defaultValue);
+  }
+
+  /**
    * Returns a list-valued configuration property. The format of the original value must be
    * comma-separated. Empty values will be removed.
    *
@@ -93,12 +148,42 @@ public interface ConfigProperties {
   List<String> getList(String name);
 
   /**
-   * Returns a map-valued configuration property. The format of the original value must be
-   * comma-separated for each key, with an '=' separating the key and value. For instance, <code>
+   * @see ConfigProperties#getList(String name)
+   * @return a List configuration property or {@code defaultValue} if a property with {@code name}
+   *     has not been configured.
+   * @throws ConfigurationException if the property is not a valid string.
+   */
+  default List<String> getList(String name, List<String> defaultValue) {
+    List<String> value = getList(name);
+    return (value == null || value.isEmpty()) ? defaultValue : value;
+  }
+
+  /**
+   * Returns a Map configuration property. The format of the original value must be comma-separated
+   * for each key, with an '=' separating the key and value. For instance, <code>
    * service.name=Greatest Service,host.name=localhost</code> Empty values will be removed.
    *
    * @return an empty map if the property has not been configured.
    * @throws ConfigurationException for malformed map strings.
    */
   Map<String, String> getMap(String name);
+
+  /**
+   * @see ConfigProperties#getMap(String name)
+   * @return a Double-valued configuration property or {@code defaultValue} if a property with
+   *     {@code name} has not been configured.
+   * @throws ConfigurationException if the property is not a valid string.
+   */
+  default Map<String, String> getMap(String name, Map<String, String> defaultValue) {
+    Map<String, String> value = getMap(name);
+    return (value == null || value.isEmpty()) ? defaultValue : value;
+  }
+
+  /**
+   * Returns defaultValue if value is null, otherwise value. This is an internal method that should
+   * not be broadly used.
+   */
+  default <T> T _defaultIfNull(@Nullable T value, T defaultValue) {
+    return value == null ? defaultValue : value;
+  }
 }

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.sdk.autoconfigure.spi;
 
+import static io.opentelemetry.sdk.autoconfigure.spi.NullDefaultUtility.defaultIfNull;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -193,13 +195,5 @@ public interface ConfigProperties {
   default Map<String, String> getMap(String name, Map<String, String> defaultValue) {
     Map<String, String> value = getMap(name);
     return value.isEmpty() ? defaultValue : value;
-  }
-
-  /**
-   * Returns defaultValue if value is null, otherwise value. This is an internal method that should
-   * not be broadly used.
-   */
-  default <T> T defaultIfNull(@Nullable T value, T defaultValue) {
-    return value == null ? defaultValue : value;
   }
 }

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java
@@ -50,7 +50,7 @@ public interface ConfigProperties {
    *     {@code name} has not been configured.
    * @throws ConfigurationException if the property is not a valid string.
    */
-  default Boolean getBoolean(String name, Boolean defaultValue) {
+  default boolean getBoolean(String name, boolean defaultValue) {
     return defaultIfNull(getBoolean(name), defaultValue);
   }
 
@@ -70,7 +70,7 @@ public interface ConfigProperties {
    *     {@code name} has not been configured.
    * @throws ConfigurationException if the property is not a valid string.
    */
-  default Integer getInt(String name, Integer defaultValue) {
+  default int getInt(String name, int defaultValue) {
     return defaultIfNull(getInt(name), defaultValue);
   }
 
@@ -90,7 +90,7 @@ public interface ConfigProperties {
    *     name} has not been configured.
    * @throws ConfigurationException if the property is not a valid string.
    */
-  default Long getLong(String name, Long defaultValue) {
+  default long getLong(String name, long defaultValue) {
     return defaultIfNull(getLong(name), defaultValue);
   }
 
@@ -110,7 +110,7 @@ public interface ConfigProperties {
    *     {@code name} has not been configured.
    * @throws ConfigurationException if the property is not a valid string.
    */
-  default Double getDouble(String name, Double defaultValue) {
+  default double getDouble(String name, double defaultValue) {
     return defaultIfNull(getDouble(name), defaultValue);
   }
 

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigUtil.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigUtil.java
@@ -11,12 +11,12 @@ import javax.annotation.Nullable;
  * Holder for the non-public defaultIfNull method. This serves only to mitigate the method being on
  * a public interface.
  */
-final class NullDefaultUtility {
+final class ConfigUtil {
 
   /** Returns defaultValue if value is null, otherwise value. This is an internal method. */
   static <T> T defaultIfNull(@Nullable T value, T defaultValue) {
     return value == null ? defaultValue : value;
   }
 
-  private NullDefaultUtility() {}
+  private ConfigUtil() {}
 }

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/NullDefaultUtility.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/NullDefaultUtility.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure.spi;
+
+import javax.annotation.Nullable;
+
+/**
+ * Holder for the non-public defaultIfNull method. This serves only to mitigate the method being on
+ * a public interface.
+ */
+final class NullDefaultUtility {
+
+  /** Returns defaultValue if value is null, otherwise value. This is an internal method. */
+  static <T> T defaultIfNull(@Nullable T value, T defaultValue) {
+    return value == null ? defaultValue : value;
+  }
+
+  private NullDefaultUtility() {}
+}

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MeterProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MeterProviderConfiguration.java
@@ -28,10 +28,7 @@ final class MeterProviderConfiguration {
           metricExporterCustomizer) {
 
     // Configure default exemplar filters.
-    String exemplarFilter = config.getString("otel.metrics.exemplar.filter");
-    if (exemplarFilter == null) {
-      exemplarFilter = "with_sampled_trace";
-    }
+    String exemplarFilter = config.getString("otel.metrics.exemplar.filter", "with_sampled_trace");
     switch (exemplarFilter) {
       case "none":
         SdkMeterProviderUtil.setExemplarFilter(meterProviderBuilder, ExemplarFilter.neverSample());

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
@@ -28,6 +28,9 @@ import java.util.function.BiFunction;
 import javax.annotation.Nullable;
 
 final class MetricExporterConfiguration {
+
+  private static final Duration DEFAULT_EXPORT_INTERVAL = Duration.ofMinutes(1);
+
   static MetricReader configureExporter(
       String name,
       ConfigProperties config,
@@ -134,12 +137,9 @@ final class MetricExporterConfiguration {
   private static PeriodicMetricReader configurePeriodicMetricReader(
       ConfigProperties config, MetricExporter exporter) {
 
-    Duration exportInterval = config.getDuration("otel.metric.export.interval");
-    if (exportInterval == null) {
-      exportInterval = Duration.ofMinutes(1);
-    }
-
-    return PeriodicMetricReader.builder(exporter).setInterval(exportInterval).build();
+    return PeriodicMetricReader.builder(exporter)
+        .setInterval(config.getDuration("otel.metric.export.interval", DEFAULT_EXPORT_INTERVAL))
+        .build();
   }
 
   private static PrometheusHttpServer configurePrometheusMetricReader(ConfigProperties config) {

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtil.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtil.java
@@ -32,9 +32,11 @@ final class OtlpConfigUtil {
   static final String PROTOCOL_HTTP_PROTOBUF = "http/protobuf";
 
   static String getOtlpProtocol(String dataType, ConfigProperties config) {
-    String configKey = "otel.exporter.otlp." + dataType + ".protocol";
-    String fallback = config.getString("otel.exporter.otlp.protocol", PROTOCOL_GRPC);
-    return config.getString(configKey, fallback);
+    String protocol = config.getString("otel.exporter.otlp." + dataType + ".protocol");
+    if (protocol != null) {
+      return protocol;
+    }
+    return config.getString("otel.exporter.otlp.protocol", PROTOCOL_GRPC);
   }
 
   static void configureOtlpExporterBuilder(

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtil.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtil.java
@@ -120,7 +120,7 @@ final class OtlpConfigUtil {
       setClientTls.accept(clientKeyBytes, clientKeyChainBytes);
     }
 
-    Boolean retryEnabled =
+    boolean retryEnabled =
         config.getBoolean("otel.experimental.exporter.otlp.retry.enabled", false);
     if (retryEnabled) {
       setRetryPolicy.accept(RetryPolicy.getDefault());

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtil.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/OtlpConfigUtil.java
@@ -73,9 +73,10 @@ final class OtlpConfigUtil {
       setEndpoint.accept(endpoint.toString());
     }
 
-    Map<String, String> fallbackHeaders = config.getMap("otel.exporter.otlp.headers");
-    Map<String, String> headers =
-        config.getMap("otel.exporter.otlp." + dataType + ".headers", fallbackHeaders);
+    Map<String, String> headers = config.getMap("otel.exporter.otlp." + dataType + ".headers");
+    if (headers.isEmpty()) {
+      headers = config.getMap("otel.exporter.otlp.headers");
+    }
     headers.forEach(addHeader);
 
     String compression = config.getString("otel.exporter.otlp." + dataType + ".compression");

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/PropagatorConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/PropagatorConfiguration.java
@@ -20,7 +20,7 @@ import java.util.function.BiFunction;
 
 final class PropagatorConfiguration {
 
-  public static final List<String> DEFAULT_PROPAGATORS = Arrays.asList("tracecontext", "baggage");
+  private static final List<String> DEFAULT_PROPAGATORS = Arrays.asList("tracecontext", "baggage");
 
   static ContextPropagators configurePropagators(
       ConfigProperties config,

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/PropagatorConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/PropagatorConfiguration.java
@@ -20,16 +20,15 @@ import java.util.function.BiFunction;
 
 final class PropagatorConfiguration {
 
+  public static final List<String> DEFAULT_PROPAGATORS = Arrays.asList("tracecontext", "baggage");
+
   static ContextPropagators configurePropagators(
       ConfigProperties config,
       ClassLoader serviceClassLoader,
       BiFunction<? super TextMapPropagator, ConfigProperties, ? extends TextMapPropagator>
           propagatorCustomizer) {
     Set<TextMapPropagator> propagators = new LinkedHashSet<>();
-    List<String> requestedPropagators = config.getList("otel.propagators");
-    if (requestedPropagators.isEmpty()) {
-      requestedPropagators = Arrays.asList("tracecontext", "baggage");
-    }
+    List<String> requestedPropagators = config.getList("otel.propagators", DEFAULT_PROPAGATORS);
 
     NamedSpiManager<TextMapPropagator> spiPropagatorsManager =
         SpiUtil.loadConfigurable(

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
@@ -27,8 +27,8 @@ import java.util.function.BiFunction;
 
 final class TracerProviderConfiguration {
 
-  private static final double DEFAULT_SAMPLE_RATIO = 1.0d;
-  private static final String DEFAULT_SAMPLER = "parentbased_always_on";
+  private static final double DEFAULT_TRACEIDRATIO_SAMPLE_RATIO = 1.0d;
+  private static final String PARENTBASED_ALWAYS_ON = "parentbased_always_on";
 
   static void configureTracerProvider(
       SdkTracerProviderBuilder tracerProviderBuilder,
@@ -41,7 +41,7 @@ final class TracerProviderConfiguration {
 
     tracerProviderBuilder.setSpanLimits(configureSpanLimits(config));
 
-    String sampler = config.getString("otel.traces.sampler", DEFAULT_SAMPLER);
+    String sampler = config.getString("otel.traces.sampler", PARENTBASED_ALWAYS_ON);
     tracerProviderBuilder.setSampler(
         samplerCustomizer.apply(configureSampler(sampler, config, serviceClassLoader), config));
 
@@ -157,16 +157,18 @@ final class TracerProviderConfiguration {
         return Sampler.alwaysOff();
       case "traceidratio":
         {
-          double ratio = config.getDouble("otel.traces.sampler.arg", DEFAULT_SAMPLE_RATIO);
+          double ratio =
+              config.getDouble("otel.traces.sampler.arg", DEFAULT_TRACEIDRATIO_SAMPLE_RATIO);
           return Sampler.traceIdRatioBased(ratio);
         }
-      case DEFAULT_SAMPLER:
+      case PARENTBASED_ALWAYS_ON:
         return Sampler.parentBased(Sampler.alwaysOn());
       case "parentbased_always_off":
         return Sampler.parentBased(Sampler.alwaysOff());
       case "parentbased_traceidratio":
         {
-          double ratio = config.getDouble("otel.traces.sampler.arg", DEFAULT_SAMPLE_RATIO);
+          double ratio =
+              config.getDouble("otel.traces.sampler.arg", DEFAULT_TRACEIDRATIO_SAMPLE_RATIO);
           return Sampler.parentBased(Sampler.traceIdRatioBased(ratio));
         }
       default:

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
@@ -27,6 +27,9 @@ import java.util.function.BiFunction;
 
 final class TracerProviderConfiguration {
 
+  private static final double DEFAULT_SAMPLE_RATIO = 1.0d;
+  private static final String DEFAULT_SAMPLER = "parentbased_always_on";
+
   static void configureTracerProvider(
       SdkTracerProviderBuilder tracerProviderBuilder,
       ConfigProperties config,
@@ -38,10 +41,7 @@ final class TracerProviderConfiguration {
 
     tracerProviderBuilder.setSpanLimits(configureSpanLimits(config));
 
-    String sampler = config.getString("otel.traces.sampler");
-    if (sampler == null) {
-      sampler = "parentbased_always_on";
-    }
+    String sampler = config.getString("otel.traces.sampler", DEFAULT_SAMPLER);
     tracerProviderBuilder.setSampler(
         samplerCustomizer.apply(configureSampler(sampler, config, serviceClassLoader), config));
 
@@ -157,22 +157,16 @@ final class TracerProviderConfiguration {
         return Sampler.alwaysOff();
       case "traceidratio":
         {
-          Double ratio = config.getDouble("otel.traces.sampler.arg");
-          if (ratio == null) {
-            ratio = 1.0d;
-          }
+          Double ratio = config.getDouble("otel.traces.sampler.arg", DEFAULT_SAMPLE_RATIO);
           return Sampler.traceIdRatioBased(ratio);
         }
-      case "parentbased_always_on":
+      case DEFAULT_SAMPLER:
         return Sampler.parentBased(Sampler.alwaysOn());
       case "parentbased_always_off":
         return Sampler.parentBased(Sampler.alwaysOff());
       case "parentbased_traceidratio":
         {
-          Double ratio = config.getDouble("otel.traces.sampler.arg");
-          if (ratio == null) {
-            ratio = 1.0d;
-          }
+          Double ratio = config.getDouble("otel.traces.sampler.arg", DEFAULT_SAMPLE_RATIO);
           return Sampler.parentBased(Sampler.traceIdRatioBased(ratio));
         }
       default:

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
@@ -157,7 +157,7 @@ final class TracerProviderConfiguration {
         return Sampler.alwaysOff();
       case "traceidratio":
         {
-          Double ratio = config.getDouble("otel.traces.sampler.arg", DEFAULT_SAMPLE_RATIO);
+          double ratio = config.getDouble("otel.traces.sampler.arg", DEFAULT_SAMPLE_RATIO);
           return Sampler.traceIdRatioBased(ratio);
         }
       case DEFAULT_SAMPLER:
@@ -166,7 +166,7 @@ final class TracerProviderConfiguration {
         return Sampler.parentBased(Sampler.alwaysOff());
       case "parentbased_traceidratio":
         {
-          Double ratio = config.getDouble("otel.traces.sampler.arg", DEFAULT_SAMPLE_RATIO);
+          double ratio = config.getDouble("otel.traces.sampler.arg", DEFAULT_SAMPLE_RATIO);
           return Sampler.parentBased(Sampler.traceIdRatioBased(ratio));
         }
       default:

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ConfigPropertiesTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ConfigPropertiesTest.java
@@ -253,8 +253,8 @@ class ConfigPropertiesTest {
     Map<String, String> defaultMap = new HashMap<>();
     defaultMap.put("one", "1");
     defaultMap.put("two", "2");
-    assertThat(properties.getMap("foo", defaultMap)).containsExactly(
-      entry("one", "1"), entry("two", "2"));
+    assertThat(properties.getMap("foo", defaultMap))
+        .containsExactly(entry("one", "1"), entry("two", "2"));
     assertThat(properties.getMap("foo")).isEmpty();
   }
 

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ConfigPropertiesTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ConfigPropertiesTest.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.sdk.autoconfigure;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -234,7 +233,8 @@ class ConfigPropertiesTest {
   @Test
   void defaultCollectionTypes() {
     ConfigProperties properties = DefaultConfigProperties.get(emptyMap());
-    assertThat(properties.getList("foo", Arrays.asList("1", "2", "3"))).containsExactly("1", "2", "3");
+    assertThat(properties.getList("foo", Arrays.asList("1", "2", "3")))
+        .containsExactly("1", "2", "3");
     assertThat(properties.getList("foo")).isEmpty();
     Map<String, String> defaultMap = new HashMap<>();
     defaultMap.put("one", "1");

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ConfigPropertiesTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ConfigPropertiesTest.java
@@ -5,13 +5,17 @@
 
 package io.opentelemetry.sdk.autoconfigure;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -43,7 +47,7 @@ class ConfigPropertiesTest {
 
   @Test
   void allMissing() {
-    ConfigProperties config = DefaultConfigProperties.createForTest(Collections.emptyMap());
+    ConfigProperties config = DefaultConfigProperties.createForTest(emptyMap());
     assertThat(config.getString("string")).isNull();
     assertThat(config.getInt("int")).isNull();
     assertThat(config.getLong("long")).isNull();
@@ -215,5 +219,32 @@ class ConfigPropertiesTest {
             DefaultConfigProperties.createForTest(Collections.singletonMap("duration", "8   ms"))
                 .getDuration("duration"))
         .isEqualTo(Duration.ofMillis(8));
+  }
+
+  @Test
+  void defaultMethods() {
+    ConfigProperties properties = DefaultConfigProperties.get(emptyMap());
+    assertEquals(true, properties.getBoolean("foo", true));
+    assertEquals("bar", properties.getString("foo", "bar"));
+    assertEquals(65.535, properties.getDouble("foo", 65.535));
+    assertEquals(21, properties.getInt("foo", 21));
+    assertEquals(123L, properties.getLong("foo", 123L));
+    assertEquals(Duration.ofDays(13), properties.getDuration("foo", Duration.ofDays(13)));
+  }
+
+  @Test
+  void defaultCollectionTypes() {
+    ConfigProperties properties = DefaultConfigProperties.get(emptyMap());
+    assertEquals(
+        Arrays.asList("1", "2", "3"), properties.getList("foo", Arrays.asList("1", "2", "3")));
+    assertEquals(emptyList(), properties.getList("foo"));
+    Map<String, String> defaultMap = new HashMap<>();
+    defaultMap.put("one", "1");
+    defaultMap.put("two", "2");
+    Map<String, String> expected = new HashMap<>();
+    expected.put("one", "1");
+    expected.put("two", "2");
+    assertEquals(expected, properties.getMap("foo", defaultMap));
+    assertEquals(emptyMap(), properties.getMap("foo"));
   }
 }

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ConfigPropertiesTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ConfigPropertiesTest.java
@@ -253,10 +253,8 @@ class ConfigPropertiesTest {
     Map<String, String> defaultMap = new HashMap<>();
     defaultMap.put("one", "1");
     defaultMap.put("two", "2");
-    Map<String, String> expected = new HashMap<>();
-    expected.put("one", "1");
-    expected.put("two", "2");
-    assertThat(properties.getMap("foo", defaultMap)).containsExactlyEntriesOf(expected);
+    assertThat(properties.getMap("foo", defaultMap)).containsExactly(
+      entry("one", "1"), entry("two", "2"));
     assertThat(properties.getMap("foo")).isEmpty();
   }
 

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ConfigPropertiesTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ConfigPropertiesTest.java
@@ -10,7 +10,6 @@ import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
@@ -224,27 +223,26 @@ class ConfigPropertiesTest {
   @Test
   void defaultMethods() {
     ConfigProperties properties = DefaultConfigProperties.get(emptyMap());
-    assertEquals(true, properties.getBoolean("foo", true));
-    assertEquals("bar", properties.getString("foo", "bar"));
-    assertEquals(65.535, properties.getDouble("foo", 65.535));
-    assertEquals(21, properties.getInt("foo", 21));
-    assertEquals(123L, properties.getLong("foo", 123L));
-    assertEquals(Duration.ofDays(13), properties.getDuration("foo", Duration.ofDays(13)));
+    assertThat(properties.getBoolean("foo", true)).isTrue();
+    assertThat(properties.getString("foo", "bar")).isEqualTo("bar");
+    assertThat(properties.getDouble("foo", 65.535)).isEqualTo(65.535);
+    assertThat(properties.getInt("foo", 21)).isEqualTo(21);
+    assertThat(properties.getLong("foo", 123L)).isEqualTo(123L);
+    assertThat(properties.getDuration("foo", Duration.ofDays(13))).isEqualTo(Duration.ofDays(13));
   }
 
   @Test
   void defaultCollectionTypes() {
     ConfigProperties properties = DefaultConfigProperties.get(emptyMap());
-    assertEquals(
-        Arrays.asList("1", "2", "3"), properties.getList("foo", Arrays.asList("1", "2", "3")));
-    assertEquals(emptyList(), properties.getList("foo"));
+    assertThat(properties.getList("foo", Arrays.asList("1", "2", "3"))).containsExactly("1", "2", "3");
+    assertThat(properties.getList("foo")).isEmpty();
     Map<String, String> defaultMap = new HashMap<>();
     defaultMap.put("one", "1");
     defaultMap.put("two", "2");
     Map<String, String> expected = new HashMap<>();
     expected.put("one", "1");
     expected.put("two", "2");
-    assertEquals(expected, properties.getMap("foo", defaultMap));
-    assertEquals(emptyMap(), properties.getMap("foo"));
+    assertThat(properties.getMap("foo", defaultMap)).containsExactlyEntriesOf(expected);
+    assertThat(properties.getMap("foo")).isEmpty();
   }
 }

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ConfigPropertiesTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ConfigPropertiesTest.java
@@ -258,7 +258,7 @@ class ConfigPropertiesTest {
     assertThat(properties.getMap("foo")).isEmpty();
   }
 
-  private Map<String, String> makeTestProps() {
+  private static Map<String, String> makeTestProps() {
     Map<String, String> properties = new HashMap<>();
     properties.put("string", "str");
     properties.put("int", "10");


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/4925

This adds several default-capable get* methods to `ConfigProperties`. This can help to reduce the number of null checks. These defaults are then wired up in several places.