### PR TITLE
Allow overriding OTLP gRPC authority.

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
@@ -1,4 +1,14 @@
 Comparing source compatibility of  against 
+***! MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++! NEW METHOD: PUBLIC(+) boolean getBoolean(java.lang.String, boolean)
+	+++! NEW METHOD: PUBLIC(+) double getDouble(java.lang.String, double)
+	+++! NEW METHOD: PUBLIC(+) java.time.Duration getDuration(java.lang.String, java.time.Duration)
+	+++! NEW METHOD: PUBLIC(+) int getInt(java.lang.String, int)
+	+++! NEW METHOD: PUBLIC(+) java.util.List getList(java.lang.String, java.util.List)
+	+++! NEW METHOD: PUBLIC(+) long getLong(java.lang.String, long)
+	+++! NEW METHOD: PUBLIC(+) java.util.Map getMap(java.lang.String, java.util.Map)
+	+++! NEW METHOD: PUBLIC(+) java.lang.String getString(java.lang.String, java.lang.String)
 +++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW SUPERCLASS: java.lang.Object

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/MarshalerCollectorServiceGrpc.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/MarshalerCollectorServiceGrpc.java
@@ -15,6 +15,7 @@ import io.grpc.stub.ClientCalls;
 import io.opentelemetry.exporter.internal.grpc.MarshalerInputStream;
 import io.opentelemetry.exporter.internal.grpc.MarshalerServiceStub;
 import java.io.InputStream;
+import javax.annotation.Nullable;
 
 // Adapted from the protoc generated code for CollectorServiceGrpc.
 final class MarshalerCollectorServiceGrpc {
@@ -56,8 +57,11 @@ final class MarshalerCollectorServiceGrpc {
               .setResponseMarshaller(RESPONSE_MARSHALER)
               .build();
 
-  static CollectorServiceFutureStub newFutureStub(Channel channel) {
-    return CollectorServiceFutureStub.newStub(CollectorServiceFutureStub::new, channel);
+  static CollectorServiceFutureStub newFutureStub(
+      Channel channel, @Nullable String authorityOverride) {
+    return CollectorServiceFutureStub.newStub(
+        (c, options) -> new CollectorServiceFutureStub(c, options.withAuthority(authorityOverride)),
+        channel);
   }
 
   static final class CollectorServiceFutureStub

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/MarshalerMetricsServiceGrpc.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/MarshalerMetricsServiceGrpc.java
@@ -16,6 +16,7 @@ import io.opentelemetry.exporter.internal.grpc.MarshalerInputStream;
 import io.opentelemetry.exporter.internal.grpc.MarshalerServiceStub;
 import io.opentelemetry.exporter.internal.otlp.metrics.MetricsRequestMarshaler;
 import java.io.InputStream;
+import javax.annotation.Nullable;
 
 // Adapted from the protoc generated code for MetricsServiceGrpc.
 final class MarshalerMetricsServiceGrpc {
@@ -59,8 +60,11 @@ final class MarshalerMetricsServiceGrpc {
               .setResponseMarshaller(RESPONSE_MARSHALER)
               .build();
 
-  static MetricsServiceFutureStub newFutureStub(Channel channel) {
-    return MetricsServiceFutureStub.newStub(MetricsServiceFutureStub::new, channel);
+  static MetricsServiceFutureStub newFutureStub(
+      Channel channel, @Nullable String authorityOverride) {
+    return MetricsServiceFutureStub.newStub(
+        (c, options) -> new MetricsServiceFutureStub(c, options.withAuthority(authorityOverride)),
+        channel);
   }
 
   static final class MetricsServiceFutureStub

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/MarshalerTraceServiceGrpc.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/MarshalerTraceServiceGrpc.java
@@ -12,6 +12,7 @@ import io.opentelemetry.exporter.internal.grpc.MarshalerInputStream;
 import io.opentelemetry.exporter.internal.grpc.MarshalerServiceStub;
 import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
 import java.io.InputStream;
+import javax.annotation.Nullable;
 
 // Adapted from the protoc generated code for TraceServiceGrpc.
 final class MarshalerTraceServiceGrpc {
@@ -53,8 +54,11 @@ final class MarshalerTraceServiceGrpc {
               .setResponseMarshaller(RESPONSE_MARSHALER)
               .build();
 
-  static TraceServiceFutureStub newFutureStub(io.grpc.Channel channel) {
-    return TraceServiceFutureStub.newStub(TraceServiceFutureStub::new, channel);
+  static TraceServiceFutureStub newFutureStub(
+      io.grpc.Channel channel, @Nullable String authorityOverride) {
+    return TraceServiceFutureStub.newStub(
+        (c, options) -> new TraceServiceFutureStub(c, options.withAuthority(authorityOverride)),
+        channel);
   }
 
   static final class TraceServiceFutureStub

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporter.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporter.java
@@ -9,7 +9,7 @@ import io.grpc.ManagedChannel;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import java.net.URI;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 /**
@@ -26,7 +26,7 @@ public interface GrpcExporter<T extends Marshaler> {
       String type,
       long defaultTimeoutSecs,
       URI defaultEndpoint,
-      Supplier<Function<ManagedChannel, MarshalerServiceStub<T, ?, ?>>> stubFactory,
+      Supplier<BiFunction<ManagedChannel, String, MarshalerServiceStub<T, ?, ?>>> stubFactory,
       String grpcServiceName,
       String grpcEndpointPath) {
     return GrpcExporterUtil.exporterBuilder(

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterUtil.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterUtil.java
@@ -8,7 +8,7 @@ package io.opentelemetry.exporter.internal.grpc;
 import io.grpc.ManagedChannel;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import java.net.URI;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -35,7 +35,7 @@ final class GrpcExporterUtil {
       String type,
       long defaultTimeoutSecs,
       URI defaultEndpoint,
-      Supplier<Function<ManagedChannel, MarshalerServiceStub<T, ?, ?>>> stubFactory,
+      Supplier<BiFunction<ManagedChannel, String, MarshalerServiceStub<T, ?, ?>>> stubFactory,
       String grpcServiceName,
       String grpcEndpointPath) {
     if (USE_OKHTTP) {

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/retry/RetryUtilTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/retry/RetryUtilTest.java
@@ -24,7 +24,7 @@ class RetryUtilTest {
     RetryPolicy retryPolicy = RetryPolicy.getDefault();
     DefaultGrpcExporterBuilder<?> builder =
         new DefaultGrpcExporterBuilder<>(
-            "otlp", "test", unused -> null, 0, new URI("http://localhost"), "test");
+            "otlp", "test", (u1, u2) -> null, 0, new URI("http://localhost"), "test");
 
     RetryUtil.setRetryPolicyOnDelegate(new WithDelegate(builder), retryPolicy);
 

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/MarshalerLogsServiceGrpc.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/MarshalerLogsServiceGrpc.java
@@ -16,6 +16,7 @@ import io.opentelemetry.exporter.internal.grpc.MarshalerInputStream;
 import io.opentelemetry.exporter.internal.grpc.MarshalerServiceStub;
 import io.opentelemetry.exporter.internal.otlp.logs.LogsRequestMarshaler;
 import java.io.InputStream;
+import javax.annotation.Nullable;
 
 // Adapted from the protoc generated code for LogsServiceGrpc.
 final class MarshalerLogsServiceGrpc {
@@ -57,8 +58,10 @@ final class MarshalerLogsServiceGrpc {
               .setResponseMarshaller(RESPONSE_MARSHALER)
               .build();
 
-  static LogsServiceFutureStub newFutureStub(Channel channel) {
-    return LogsServiceFutureStub.newStub(LogsServiceFutureStub::new, channel);
+  static LogsServiceFutureStub newFutureStub(Channel channel, @Nullable String authorityOverride) {
+    return LogsServiceFutureStub.newStub(
+        (c, options) -> new LogsServiceFutureStub(c, options.withAuthority(authorityOverride)),
+        channel);
   }
 
   static final class LogsServiceFutureStub


### PR DESCRIPTION
Fixes #4513

OkHttp already allows setting the host header to override host on HTTP/1 or :authority on HTTP/2. For the gRPC codepath we need to propagate it through though.