### PR TITLE
opentracing-shim: support span wrappers

### DIFF
--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/ScopeManagerShim.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/ScopeManagerShim.java
@@ -55,11 +55,6 @@ final class ScopeManagerShim extends BaseShimObject implements ScopeManager {
     if (span == null) {
       return new ScopeShim(Context.current().with(NOOP_SPANSHIM).makeCurrent());
     }
-    if (!(span instanceof SpanShim)) {
-      throw new IllegalArgumentException("span is not a valid SpanShim object");
-    }
-
-    SpanShim spanShim = (SpanShim) span;
-    return new ScopeShim(Context.current().with(spanShim).makeCurrent());
+    return new ScopeShim(Context.current().with(ShimUtil.getSpanShim(span)).makeCurrent());
   }
 }

--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/ShimUtil.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/ShimUtil.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.opentracingshim;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+
+class ShimUtil {
+
+  private ShimUtil() {}
+
+  static SpanContextShim getContextShim(SpanContext context) {
+    if (!(context instanceof SpanContextShim)) {
+      throw new IllegalArgumentException(
+          "context is not a valid SpanContextShim object: " + className(context));
+    }
+
+    return (SpanContextShim) context;
+  }
+
+  static SpanShim getSpanShim(Span span) {
+    if (!(span instanceof SpanShim)) {
+      if (span instanceof Supplier<?>) {
+        // allow libraries to implement a delegate span,
+        // such as https://github.com/zalando/opentracing-toolbox/tree/main/opentracing-proxy
+        Object wrapped = ((Supplier<?>) span).get();
+        if (wrapped instanceof Span) {
+          return getSpanShim((Span) wrapped);
+        } else {
+          throw new IllegalArgumentException(
+              "span wrapper didn't return a span: " + className(wrapped));
+        }
+      }
+      throw new IllegalArgumentException("span is not a valid SpanShim object: " + className(span));
+    }
+
+    return (SpanShim) span;
+  }
+
+  private static String className(@Nullable Object o) {
+    return o == null ? "null" : o.getClass().getName();
+  }
+}

--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
@@ -56,7 +56,7 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
     }
 
     // TODO - Verify we handle a no-op Span
-    SpanShim spanShim = getSpanShim(parent);
+    SpanShim spanShim = ShimUtil.getSpanShim(parent);
 
     if (parentSpan == null && parentSpanContext == null) {
       parentSpan = spanShim;
@@ -79,7 +79,7 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
     }
 
     // TODO - Use referenceType
-    SpanContextShim contextShim = getContextShim(referencedContext);
+    SpanContextShim contextShim = ShimUtil.getContextShim(referencedContext);
 
     if (parentSpan == null && parentSpanContext == null) {
       parentSpanContext = contextShim;
@@ -235,21 +235,5 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
     }
 
     return spanShim;
-  }
-
-  private static SpanShim getSpanShim(Span span) {
-    if (!(span instanceof SpanShim)) {
-      throw new IllegalArgumentException("span is not a valid SpanShim object");
-    }
-
-    return (SpanShim) span;
-  }
-
-  private static SpanContextShim getContextShim(SpanContext context) {
-    if (!(context instanceof SpanContextShim)) {
-      throw new IllegalArgumentException("context is not a valid SpanContextShim object");
-    }
-
-    return (SpanContextShim) context;
   }
 }

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/ShimUtilTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/ShimUtilTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.opentracingshim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ShimUtilTest {
+
+  private final SdkTracerProvider tracerSdkFactory = SdkTracerProvider.builder().build();
+  private final Tracer tracer = tracerSdkFactory.get("SpanShimTest");
+  private final TelemetryInfo telemetryInfo =
+      new TelemetryInfo(tracer, OpenTracingPropagators.builder().build());
+  private Span span;
+
+  private static final String SPAN_NAME = "Span";
+
+  @BeforeEach
+  void setUp() {
+    span = telemetryInfo.tracer().spanBuilder(SPAN_NAME).startSpan();
+  }
+
+  @AfterEach
+  void tearDown() {
+    span.end();
+  }
+
+  @Test
+  void spanWrapper() {
+    SpanShim shim = new SpanShim(telemetryInfo, span);
+    assertThat(ShimUtil.getSpanShim(shim)).isEqualTo(shim);
+    assertThat(ShimUtil.getSpanShim(new SpanWrapper(shim))).isEqualTo(shim);
+    assertThatThrownBy(() -> ShimUtil.getSpanShim(new SpanWrapper("not a span")))
+        .hasMessage("span wrapper didn't return a span: java.lang.String");
+    assertThatThrownBy(() -> ShimUtil.getSpanShim(null))
+        .hasMessage("span is not a valid SpanShim object: null");
+  }
+
+  @Test
+  void getContextShim() {
+    SpanContextShim contextShim = new SpanContextShim(new SpanShim(telemetryInfo, span));
+    assertThat(ShimUtil.getContextShim(contextShim)).isEqualTo(contextShim);
+    assertThatThrownBy(() -> ShimUtil.getContextShim(null))
+        .hasMessage("context is not a valid SpanContextShim object: null");
+  }
+}

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanWrapper.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanWrapper.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.opentracingshim;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.tag.Tag;
+import java.util.Map;
+import java.util.function.Supplier;
+
+class SpanWrapper implements Span, Supplier<Object> {
+  // it's Object to simulate errors
+  private final Object span;
+
+  public SpanWrapper(Object span) {
+    this.span = span;
+  }
+
+  @Override
+  public Object get() {
+    return span;
+  }
+
+  @Override
+  public SpanContext context() {
+    return null;
+  }
+
+  @Override
+  public Span setTag(String key, String value) {
+    return null;
+  }
+
+  @Override
+  public Span setTag(String key, boolean value) {
+    return null;
+  }
+
+  @Override
+  public Span setTag(String key, Number value) {
+    return null;
+  }
+
+  @Override
+  public <T> Span setTag(Tag<T> tag, T value) {
+    return null;
+  }
+
+  @Override
+  public Span log(Map<String, ?> fields) {
+    return null;
+  }
+
+  @Override
+  public Span log(long timestampMicroseconds, Map<String, ?> fields) {
+    return null;
+  }
+
+  @Override
+  public Span log(String event) {
+    return null;
+  }
+
+  @Override
+  public Span log(long timestampMicroseconds, String event) {
+    return null;
+  }
+
+  @Override
+  public Span setBaggageItem(String key, String value) {
+    return null;
+  }
+
+  @Override
+  public String getBaggageItem(String key) {
+    return null;
+  }
+
+  @Override
+  public Span setOperationName(String operationName) {
+    return null;
+  }
+
+  @Override
+  public void finish() {}
+
+  @Override
+  public void finish(long finishMicros) {}
+}


### PR DESCRIPTION
make the tracing shim compatible with span wrappers, such as https://github.com/zalando/opentracing-toolbox/tree/main/opentracing-proxy