### PR TITLE
Tighten up exponential histogram implementation

### DIFF
--- a/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/internal/aggregator/HistogramAggregationParam.java
+++ b/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/internal/aggregator/HistogramAggregationParam.java
@@ -25,16 +25,16 @@ public enum HistogramAggregationParam {
       new DoubleExponentialHistogramAggregator(
           ExemplarReservoir::doubleNoSamples,
           ExponentialBucketStrategy.newStrategy(
-              20, 20, ExponentialCounterFactory.circularBufferCounter()))),
+              20, ExponentialCounterFactory.circularBufferCounter()))),
   EXPONENTIAL_CIRCULAR_BUFFER(
       new DoubleExponentialHistogramAggregator(
           ExemplarReservoir::doubleNoSamples,
           ExponentialBucketStrategy.newStrategy(
-              20, 320, ExponentialCounterFactory.circularBufferCounter()))),
+              160, ExponentialCounterFactory.circularBufferCounter()))),
   EXPONENTIAL_MAP_COUNTER(
       new DoubleExponentialHistogramAggregator(
           ExemplarReservoir::doubleNoSamples,
-          ExponentialBucketStrategy.newStrategy(20, 320, ExponentialCounterFactory.mapCounter())));
+          ExponentialBucketStrategy.newStrategy(160, ExponentialCounterFactory.mapCounter())));
 
   private final Aggregator<?, ?> aggregator;
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramAggregator.java
@@ -35,19 +35,14 @@ public final class DoubleExponentialHistogramAggregator
   /**
    * Constructs an exponential histogram aggregator.
    *
-   * @param scale the starting scale.
-   * @param maxBuckets the maximum number of buckets that will be used for positive or negative
-   *     recordings.
    * @param reservoirSupplier Supplier of exemplar reservoirs per-stream.
    */
   public DoubleExponentialHistogramAggregator(
-      Supplier<ExemplarReservoir<DoubleExemplarData>> reservoirSupplier,
-      int scale,
-      int maxBuckets) {
+      Supplier<ExemplarReservoir<DoubleExemplarData>> reservoirSupplier, int maxBuckets) {
     this(
         reservoirSupplier,
         ExponentialBucketStrategy.newStrategy(
-            scale, maxBuckets, ExponentialCounterFactory.circularBufferCounter()));
+            maxBuckets, ExponentialCounterFactory.circularBufferCounter()));
   }
 
   DoubleExponentialHistogramAggregator(

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/ExponentialBucketStrategy.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/ExponentialBucketStrategy.java
@@ -9,28 +9,27 @@ import io.opentelemetry.sdk.metrics.internal.state.ExponentialCounterFactory;
 
 /** The configuration for how to create exponential histogram buckets. */
 final class ExponentialBucketStrategy {
-  /** Starting scale of exponential buckets. */
-  private final int scale;
+
+  private static final int STARTING_SCALE = 20;
+
   /** The maximum number of buckets that will be used for positive or negative recordings. */
   private final int maxBuckets;
   /** The mechanism of constructing and copying buckets. */
   private final ExponentialCounterFactory counterFactory;
 
-  private ExponentialBucketStrategy(
-      int scale, int maxBuckets, ExponentialCounterFactory counterFactory) {
-    this.scale = scale;
+  private ExponentialBucketStrategy(int maxBuckets, ExponentialCounterFactory counterFactory) {
     this.maxBuckets = maxBuckets;
     this.counterFactory = counterFactory;
   }
 
   /** Constructs fresh new buckets with default settings. */
   DoubleExponentialHistogramBuckets newBuckets() {
-    return new DoubleExponentialHistogramBuckets(scale, maxBuckets, counterFactory);
+    return new DoubleExponentialHistogramBuckets(STARTING_SCALE, maxBuckets, counterFactory);
   }
 
   /** Create a new strategy for generating Exponential Buckets. */
   static ExponentialBucketStrategy newStrategy(
-      int scale, int maxBuckets, ExponentialCounterFactory counterFactory) {
-    return new ExponentialBucketStrategy(scale, maxBuckets, counterFactory);
+      int maxBuckets, ExponentialCounterFactory counterFactory) {
+    return new ExponentialBucketStrategy(maxBuckets, counterFactory);
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/ExponentialHistogramAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/ExponentialHistogramAggregation.java
@@ -26,13 +26,14 @@ import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
  */
 public final class ExponentialHistogramAggregation implements Aggregation, AggregatorFactory {
 
-  private static final Aggregation DEFAULT = new ExponentialHistogramAggregation(20, 320);
+  private static final int DEFAULT_MAX_BUCKETS = 160;
 
-  private final int startingScale;
+  private static final Aggregation DEFAULT =
+      new ExponentialHistogramAggregation(DEFAULT_MAX_BUCKETS);
+
   private final int maxBuckets;
 
-  private ExponentialHistogramAggregation(int startingScale, int maxBuckets) {
-    this.startingScale = startingScale;
+  private ExponentialHistogramAggregation(int maxBuckets) {
     this.maxBuckets = maxBuckets;
   }
 
@@ -40,9 +41,9 @@ public final class ExponentialHistogramAggregation implements Aggregation, Aggre
     return DEFAULT;
   }
 
-  public static Aggregation create(int scale, int maxBuckets) {
-    checkArgument(maxBuckets >= 0, "maxBuckets must be >= 0");
-    return new ExponentialHistogramAggregation(scale, maxBuckets);
+  public static Aggregation create(int maxBuckets) {
+    checkArgument(maxBuckets >= 1, "maxBuckets must be > 0");
+    return new ExponentialHistogramAggregation(maxBuckets);
   }
 
   @Override
@@ -58,7 +59,6 @@ public final class ExponentialHistogramAggregation implements Aggregation, Aggre
                         Clock.getDefault(),
                         Runtime.getRuntime().availableProcessors(),
                         RandomSupplier.platformDefault())),
-            startingScale,
             maxBuckets);
   }
 
@@ -75,10 +75,6 @@ public final class ExponentialHistogramAggregation implements Aggregation, Aggre
 
   @Override
   public String toString() {
-    return "ExponentialHistogramAggregation{startingScale="
-        + startingScale
-        + ",maxBuckets="
-        + maxBuckets
-        + "}";
+    return "ExponentialHistogramAggregation{maxBuckets=" + maxBuckets + "}";
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AggregationTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AggregationTest.java
@@ -31,10 +31,10 @@ class AggregationTest {
     // TODO(jack-berg): Use Aggregation.exponentialHistogram() when available
     assertThat(ExponentialHistogramAggregation.getDefault())
         .asString()
-        .isEqualTo("ExponentialHistogramAggregation{startingScale=20,maxBuckets=320}");
-    assertThat(ExponentialHistogramAggregation.create(1, 1))
+        .isEqualTo("ExponentialHistogramAggregation{maxBuckets=160}");
+    assertThat(ExponentialHistogramAggregation.create(1))
         .asString()
-        .isEqualTo("ExponentialHistogramAggregation{startingScale=1,maxBuckets=1}");
+        .isEqualTo("ExponentialHistogramAggregation{maxBuckets=1}");
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleHistogramTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleHistogramTest.java
@@ -24,6 +24,7 @@ import io.opentelemetry.sdk.testing.assertj.MetricAssertions;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.opentelemetry.sdk.testing.time.TestClock;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -207,9 +208,7 @@ class SdkDoubleHistogramTest {
             .registerMetricReader(sdkMeterReader)
             .registerView(
                 InstrumentSelector.builder().setType(InstrumentType.HISTOGRAM).build(),
-                View.builder()
-                    .setAggregation(ExponentialHistogramAggregation.create(-1, 5))
-                    .build())
+                View.builder().setAggregation(ExponentialHistogramAggregation.create(5)).build())
             .build();
     DoubleHistogram doubleHistogram =
         sdkMeterProvider
@@ -244,11 +243,11 @@ class SdkDoubleHistogramTest {
                               .hasSum(25)
                               .hasMin(12)
                               .hasMax(13)
-                              .hasScale(-1)
+                              .hasScale(5)
                               .hasZeroCount(0);
                           MetricAssertions.assertThat(point.getPositiveBuckets())
-                              .hasOffset(1)
-                              .hasCounts(Collections.singletonList(2L));
+                              .hasOffset(114)
+                              .hasCounts(Arrays.asList(1L, 0L, 0L, 0L, 1L));
                           MetricAssertions.assertThat(point.getNegativeBuckets())
                               .hasOffset(0)
                               .hasCounts(Collections.emptyList());
@@ -262,10 +261,10 @@ class SdkDoubleHistogramTest {
                               .hasSum(12)
                               .hasMin(12)
                               .hasMax(12)
-                              .hasScale(-1)
+                              .hasScale(20)
                               .hasZeroCount(0);
                           MetricAssertions.assertThat(point.getPositiveBuckets())
-                              .hasOffset(1)
+                              .hasOffset(3759105)
                               .hasCounts(Collections.singletonList(1L));
                           MetricAssertions.assertThat(point.getNegativeBuckets())
                               .hasOffset(0)

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkLongHistogramTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkLongHistogramTest.java
@@ -24,6 +24,7 @@ import io.opentelemetry.sdk.testing.assertj.MetricAssertions;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.opentelemetry.sdk.testing.time.TestClock;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -207,9 +208,7 @@ class SdkLongHistogramTest {
             .registerMetricReader(sdkMeterReader)
             .registerView(
                 InstrumentSelector.builder().setType(InstrumentType.HISTOGRAM).build(),
-                View.builder()
-                    .setAggregation(ExponentialHistogramAggregation.create(-1, 5))
-                    .build())
+                View.builder().setAggregation(ExponentialHistogramAggregation.create(5)).build())
             .build();
     LongHistogram longHistogram =
         sdkMeterProvider
@@ -245,11 +244,11 @@ class SdkLongHistogramTest {
                               .hasSum(25)
                               .hasMin(12)
                               .hasMax(13)
-                              .hasScale(-1)
+                              .hasScale(5)
                               .hasZeroCount(0);
                           MetricAssertions.assertThat(point.getPositiveBuckets())
-                              .hasOffset(1)
-                              .hasCounts(Collections.singletonList(2L));
+                              .hasOffset(114)
+                              .hasCounts(Arrays.asList(1L, 0L, 0L, 0L, 1L));
                           MetricAssertions.assertThat(point.getNegativeBuckets())
                               .hasOffset(0)
                               .hasCounts(Collections.emptyList());
@@ -263,10 +262,10 @@ class SdkLongHistogramTest {
                               .hasSum(12)
                               .hasMin(12)
                               .hasMax(12)
-                              .hasScale(-1)
+                              .hasScale(20)
                               .hasZeroCount(0);
                           MetricAssertions.assertThat(point.getPositiveBuckets())
-                              .hasOffset(1)
+                              .hasOffset(3759105)
                               .hasCounts(Collections.singletonList(1L));
                           MetricAssertions.assertThat(point.getNegativeBuckets())
                               .hasOffset(0)

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramBucketsTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramBucketsTest.java
@@ -24,9 +24,9 @@ class DoubleExponentialHistogramBucketsTest {
 
   static Stream<ExponentialBucketStrategy> bucketStrategies() {
     return Stream.of(
-        ExponentialBucketStrategy.newStrategy(20, 320, ExponentialCounterFactory.mapCounter()),
+        ExponentialBucketStrategy.newStrategy(160, ExponentialCounterFactory.mapCounter()),
         ExponentialBucketStrategy.newStrategy(
-            20, 320, ExponentialCounterFactory.circularBufferCounter()));
+            160, ExponentialCounterFactory.circularBufferCounter()));
   }
 
   @ParameterizedTest

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/ExponentialCounterTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/ExponentialCounterTest.java
@@ -33,7 +33,7 @@ public class ExponentialCounterTest {
   @ParameterizedTest
   @MethodSource("counterProviders")
   void expandLower(ExponentialCounterFactory counterFactory) {
-    ExponentialCounter counter = counterFactory.newCounter(320);
+    ExponentialCounter counter = counterFactory.newCounter(160);
     assertThat(counter.increment(10, 1)).isTrue();
     // Add BEFORE the initial see (array index 0) and make sure we wrap around the datastructure.
     assertThat(counter.increment(0, 1)).isTrue();
@@ -53,14 +53,14 @@ public class ExponentialCounterTest {
   @ParameterizedTest
   @MethodSource("counterProviders")
   void shouldFailAtLimit(ExponentialCounterFactory counterFactory) {
-    ExponentialCounter counter = counterFactory.newCounter(320);
+    ExponentialCounter counter = counterFactory.newCounter(160);
     assertThat(counter.increment(0, 1)).isTrue();
-    assertThat(counter.increment(319, 1)).isTrue();
+    assertThat(counter.increment(120, 1)).isTrue();
     // Check state
     assertThat(counter.getIndexStart()).as("index start").isEqualTo(0);
-    assertThat(counter.getIndexEnd()).as("index start").isEqualTo(319);
+    assertThat(counter.getIndexEnd()).as("index start").isEqualTo(120);
     assertThat(counter.get(0)).as("counter[0]").isEqualTo(1);
-    assertThat(counter.get(319)).as("counter[319]").isEqualTo(1);
+    assertThat(counter.get(120)).as("counter[120]").isEqualTo(1);
     // Adding over the maximum # of buckets
     assertThat(counter.increment(3000, 1)).isFalse();
   }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/view/ExponentialHistogramAggregationTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/view/ExponentialHistogramAggregationTest.java
@@ -15,13 +15,13 @@ class ExponentialHistogramAggregationTest {
   @Test
   void goodConfig() {
     assertThat(ExponentialHistogramAggregation.getDefault()).isNotNull();
-    assertThat(ExponentialHistogramAggregation.create(10, 10)).isNotNull();
+    assertThat(ExponentialHistogramAggregation.create(10)).isNotNull();
   }
 
   @Test
   void badBuckets_throwArgumentException() {
-    assertThatThrownBy(() -> ExponentialHistogramAggregation.create(1, -1))
+    assertThatThrownBy(() -> ExponentialHistogramAggregation.create(0))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("maxBuckets must be >= 0");
+        .hasMessage("maxBuckets must be > 0");
   }
 }


### PR DESCRIPTION
- Set default positive and negative buckets to 160 to reflect [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#exponential-histogram-aggregation)
- Remove scale as a configurable parameter. to reflect the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#exponential-histogram-aggregation). Scale always starts at 20, reduces down to reflect the range of recorded measurements.
- Minimum number of buckets is 1 instead of 0. Configuring buckets to 0 causes exceptions to be thrown at runtime.