### PR TITLE
Dependabot for gradle plugins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,20 @@
 version: 2
+registries:
+  gradle-plugin-portal:
+    type: maven-repository
+    url: https://plugins.gradle.org/m2
+    username: dummy # Required by dependabot
+    password: dummy # Required by dependabot
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    allow:
+      - dependency-name: "com.gradle*"
+    registries:
+      - gradle-plugin-portal
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Same as used in java-instrumentation, here's example PRs: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pulls?q=is%3Apr+author%3Aapp%2Fdependabot+is%3Aclosed