### PR TITLE
bugfix: fix ImmutableKeyValuePairs bugs

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
@@ -207,6 +207,10 @@ public abstract class ImmutableKeyValuePairs<K, V> {
       // If the previously added key is equal with the current key, we overwrite what we have.
       if (previousKey != null && keyComparator.compare((K) key, (K) previousKey) == 0) {
         size -= 2;
+        // Avoid bugs in some special situation
+        if (size < 0) {
+          size = 0;
+        }
       }
       // Skip entries with null value, we do it here because we want them to overwrite and remove
       // entries with same key that we already added.

--- a/api/all/src/test/java/io/opentelemetry/api/internal/ImmutableKeyValuePairsTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/internal/ImmutableKeyValuePairsTest.java
@@ -21,6 +21,14 @@ class ImmutableKeyValuePairsTest {
     assertThat(new TestPairs(new Object[] {"one", 55, "two", "b"}).get("one")).isEqualTo(55);
     assertThat(new TestPairs(new Object[] {"one", 55, "two", "b"}).get("two")).isEqualTo("b");
     assertThat(new TestPairs(new Object[] {"one", 55, "two", "b"}).get("three")).isNull();
+    assertThat(new TestPairs(new Object[] {"one", 55, "one", null, "one", 66}).get("one"))
+        .isEqualTo(66);
+    assertThat(
+        new TestPairs(new Object[] {"one", 55, "one", null, "one", 66, "one", null}).get("two"))
+        .isNull();
+    assertThat(
+        new TestPairs(new Object[] {"one", 55, "two", "b", "one", null, "one", 66}).get("one"))
+        .isEqualTo(66);
   }
 
   @Test


### PR DESCRIPTION
Fix ImmutableKeyValuePairs bugs: throw `java.lang.ArrayIndexOutOfBoundsException: Index -2 out of bounds for length 6` when the testcase is

```
assertThat(new TestPairs(new Object[] {"one", 55, "one", null, "one", 66}).get("one"))
        .isEqualTo(66);
```