### PR TITLE
bugfix: fix ImmutableKeyValuePairs bugs

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
@@ -214,8 +214,8 @@ public abstract class ImmutableKeyValuePairs<K, V> {
         // When the value is null, there are two cases:
         // 1. next key is the same as the current one, it may cause ArrayIndexOutOfBoundsException,
         // so we reset the previous key to null to avoid this
-        // 2. next key is different than the current one; In this case, whether the previous key is null or not will 
-        // have no impact.
+        // 2. next key is different than the current one; In this case, whether the previous key is
+        // null or not will have no impact.
         previousKey = null;
         continue;
       }

--- a/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
@@ -205,14 +205,18 @@ public abstract class ImmutableKeyValuePairs<K, V> {
         continue;
       }
       // If the previously added key is equal with the current key, we overwrite what we have.
-      if (previousKey != null
-          && keyComparator.compare((K) key, (K) previousKey) == 0
-          && size >= 2) {
+      if (previousKey != null && keyComparator.compare((K) key, (K) previousKey) == 0) {
         size -= 2;
       }
       // Skip entries with null value, we do it here because we want them to overwrite and remove
       // entries with same key that we already added.
       if (value == null) {
+        // When the value is null, there are two cases:
+        // 1. next key is the same as the current one, it may cause ArrayIndexOutOfBoundsException,
+        // so we reset the previews key to null to avoid this
+        // 2. next key is different as the current one, previews key is null or not will cause no
+        // different
+        previousKey = null;
         continue;
       }
       previousKey = key;

--- a/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
@@ -205,12 +205,10 @@ public abstract class ImmutableKeyValuePairs<K, V> {
         continue;
       }
       // If the previously added key is equal with the current key, we overwrite what we have.
-      if (previousKey != null && keyComparator.compare((K) key, (K) previousKey) == 0) {
+      if (previousKey != null
+          && keyComparator.compare((K) key, (K) previousKey) == 0
+          && size >= 2) {
         size -= 2;
-        // Avoid bugs in some special situation
-        if (size < 0) {
-          size = 0;
-        }
       }
       // Skip entries with null value, we do it here because we want them to overwrite and remove
       // entries with same key that we already added.

--- a/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
@@ -214,8 +214,8 @@ public abstract class ImmutableKeyValuePairs<K, V> {
         // When the value is null, there are two cases:
         // 1. next key is the same as the current one, it may cause ArrayIndexOutOfBoundsException,
         // so we reset the previous key to null to avoid this
-        // 2. next key is different as the current one, previews key is null or not will cause no
-        // different
+        // 2. next key is different than the current one; In this case, whether the previous key is null or not will 
+        // have no impact.
         previousKey = null;
         continue;
       }

--- a/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
@@ -213,7 +213,7 @@ public abstract class ImmutableKeyValuePairs<K, V> {
       if (value == null) {
         // When the value is null, there are two cases:
         // 1. next key is the same as the current one, it may cause ArrayIndexOutOfBoundsException,
-        // so we reset the previews key to null to avoid this
+        // so we reset the previous key to null to avoid this
         // 2. next key is different as the current one, previews key is null or not will cause no
         // different
         previousKey = null;

--- a/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
@@ -207,6 +207,10 @@ public abstract class ImmutableKeyValuePairs<K, V> {
       // If the previously added key is equal with the current key, we overwrite what we have.
       if (previousKey != null && keyComparator.compare((K) key, (K) previousKey) == 0) {
         size -= 2;
+        // Avoid bugs in some special situation
+        if (size < 0) {
+          size = 0;
+        }
       }
       // Skip entries with null value, we do it here because we want them to overwrite and remove
       // entries with same key that we already added.

--- a/api/all/src/test/java/io/opentelemetry/api/internal/ImmutableKeyValuePairsTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/internal/ImmutableKeyValuePairsTest.java
@@ -21,6 +21,14 @@ class ImmutableKeyValuePairsTest {
     assertThat(new TestPairs(new Object[] {"one", 55, "two", "b"}).get("one")).isEqualTo(55);
     assertThat(new TestPairs(new Object[] {"one", 55, "two", "b"}).get("two")).isEqualTo("b");
     assertThat(new TestPairs(new Object[] {"one", 55, "two", "b"}).get("three")).isNull();
+    assertThat(new TestPairs(new Object[] {"one", 55, "one", null, "one", 66}).get("one"))
+        .isEqualTo(66);
+    assertThat(
+            new TestPairs(new Object[] {"one", 55, "one", null, "one", 66, "one", null}).get("two"))
+        .isNull();
+    assertThat(
+            new TestPairs(new Object[] {"one", 55, "two", "b", "one", null, "one", 66}).get("one"))
+        .isEqualTo(66);
   }
 
   @Test

--- a/api/all/src/test/java/io/opentelemetry/api/internal/ImmutableKeyValuePairsTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/internal/ImmutableKeyValuePairsTest.java
@@ -29,6 +29,9 @@ class ImmutableKeyValuePairsTest {
     assertThat(
             new TestPairs(new Object[] {"one", 55, "two", "b", "one", null, "one", 66}).get("one"))
         .isEqualTo(66);
+    assertThat(
+            new TestPairs(new Object[] {"one", 55, "two", 66, "two", null, "two", 77}).get("two"))
+        .isEqualTo(77);
   }
 
   @Test
@@ -36,6 +39,14 @@ class ImmutableKeyValuePairsTest {
     assertThat(new TestPairs(new Object[0]).size()).isEqualTo(0);
     assertThat(new TestPairs(new Object[] {"one", 55}).size()).isEqualTo(1);
     assertThat(new TestPairs(new Object[] {"one", 55, "two", "b"}).size()).isEqualTo(2);
+    assertThat(new TestPairs(new Object[] {"one", 55, "one", null, "one", 66}).size()).isEqualTo(1);
+    assertThat(new TestPairs(new Object[] {"one", 55, "one", null, "one", 66, "one", null}).size())
+        .isEqualTo(0);
+    assertThat(new TestPairs(new Object[] {"one", 55, "two", "b", "one", null, "one", 66}).size())
+        .isEqualTo(2);
+    assertThat(new TestPairs(new Object[] {"one", 55, "two", 66, "two", null}).size()).isEqualTo(1);
+    assertThat(new TestPairs(new Object[] {"one", 55, "two", 66, "two", null, "two", 77}).size())
+        .isEqualTo(2);
   }
 
   @Test


### PR DESCRIPTION
Fix ImmutableKeyValuePairs bugs: throw `java.lang.ArrayIndexOutOfBoundsException: Index -2 out of bounds for length 6` when the testcase is

```
assertThat(new TestPairs(new Object[] {"one", 55, "one", null, "one", 66}).get("one"))
        .isEqualTo(66);
```