### PR TITLE
Simplify queue drain with a consumer

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -19,6 +19,7 @@ import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.internal.JcTools;
+import org.jctools.queues.MessagePassingQueue;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Queue;

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -237,9 +237,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
         if (flushRequested.get() != null) {
           flush();
         }
-        while (!queue.isEmpty() && batch.size() < maxExportBatchSize) {
-          batch.add(queue.poll().toSpanData());
-        }
+        queue.drain(span -> batch.add(span.toSpanData()), maxExportBatchSize);
         if (batch.size() >= maxExportBatchSize || System.nanoTime() >= nextExportTime) {
           exportCurrentBatch();
           updateNextExportTime();


### PR DESCRIPTION
* Remove unnecessary "queue.isEmpty()"  check while adding each span to batch list.
* Use MpscArrayQueue drain util method, which handle all cases when queue is empty or size > maxExportBatchSize