### PR TITLE
Added a static method "drain" under JcTools with a generic consumer

### DIFF
--- a/sdk/trace-shaded-deps/src/main/java/io/opentelemetry/sdk/trace/internal/JcTools.java
+++ b/sdk/trace-shaded-deps/src/main/java/io/opentelemetry/sdk/trace/internal/JcTools.java
@@ -50,19 +50,18 @@ public final class JcTools {
    * @throws IllegalArgumentException if maxExportBatchSize is negative
    */
   @SuppressWarnings("unchecked")
-  public static <SpanT> void drain(
-      Queue<SpanT> queue, int maxExportBatchSize, Consumer<SpanT> consumer) {
+  public static <T> void drain(Queue<T> queue, int maxExportBatchSize, Consumer<T> consumer) {
     if (queue instanceof MessagePassingQueue) {
-      ((MessagePassingQueue<SpanT>) queue).drain(consumer::accept, maxExportBatchSize);
+      ((MessagePassingQueue<T>) queue).drain(consumer::accept, maxExportBatchSize);
     } else {
       drainNonJcQueue(queue, maxExportBatchSize, consumer);
     }
   }
 
-  private static <SpanT> void drainNonJcQueue(
-      Queue<SpanT> queue, int maxExportBatchSize, Consumer<SpanT> consumer) {
+  private static <T> void drainNonJcQueue(
+      Queue<T> queue, int maxExportBatchSize, Consumer<T> consumer) {
     int polledCount = 0;
-    SpanT span;
+    T span;
     while (polledCount++ < maxExportBatchSize && (span = queue.poll()) != null) {
       consumer.accept(span);
     }

--- a/sdk/trace-shaded-deps/src/main/java/io/opentelemetry/sdk/trace/internal/JcTools.java
+++ b/sdk/trace-shaded-deps/src/main/java/io/opentelemetry/sdk/trace/internal/JcTools.java
@@ -44,17 +44,17 @@ public final class JcTools {
   }
 
   /**
-   * Remove up to <i>maxExportBatchSize</i> elements from the {@link Queue} and hand to consume.
+   * Remove up to <i>limit</i> elements from the {@link Queue} and hand to consume.
    *
    * @throws IllegalArgumentException consumer is {@code null}
    * @throws IllegalArgumentException if maxExportBatchSize is negative
    */
   @SuppressWarnings("unchecked")
-  public static <T> void drain(Queue<T> queue, int maxExportBatchSize, Consumer<T> consumer) {
+  public static <T> void drain(Queue<T> queue, int limit, Consumer<T> consumer) {
     if (queue instanceof MessagePassingQueue) {
-      ((MessagePassingQueue<T>) queue).drain(consumer::accept, maxExportBatchSize);
+      ((MessagePassingQueue<T>) queue).drain(consumer::accept, limit);
     } else {
-      drainNonJcQueue(queue, maxExportBatchSize, consumer);
+      drainNonJcQueue(queue, limit, consumer);
     }
   }
 

--- a/sdk/trace-shaded-deps/src/main/java/io/opentelemetry/sdk/trace/internal/JcTools.java
+++ b/sdk/trace-shaded-deps/src/main/java/io/opentelemetry/sdk/trace/internal/JcTools.java
@@ -61,9 +61,9 @@ public final class JcTools {
   private static <T> void drainNonJcQueue(
       Queue<T> queue, int maxExportBatchSize, Consumer<T> consumer) {
     int polledCount = 0;
-    T span;
-    while (polledCount++ < maxExportBatchSize && (span = queue.poll()) != null) {
-      consumer.accept(span);
+    T item;
+    while (polledCount++ < maxExportBatchSize && (item = queue.poll()) != null) {
+      consumer.accept(item);
     }
   }
 

--- a/sdk/trace-shaded-deps/src/test/java/io/opentelemetry/sdk/trace/internal/JcToolsTest.java
+++ b/sdk/trace-shaded-deps/src/test/java/io/opentelemetry/sdk/trace/internal/JcToolsTest.java
@@ -24,7 +24,7 @@ class JcToolsTest {
   ArrayList<String> batch = new ArrayList<>(10);
 
   @Test
-  void drainArrayBlockingQueue() {
+  void drain_ArrayBlockingQueue() {
     // Arrange
     batch.add("Test3");
     Queue<String> queue = new ArrayBlockingQueue<>(10);
@@ -40,7 +40,7 @@ class JcToolsTest {
   }
 
   @Test
-  void drainMessagePassingQueue() {
+  void drain_MessagePassingQueue() {
     // Arrange
     batch.add("Test3");
     Queue<String> queue = new MpscArrayQueue<>(10);
@@ -56,7 +56,7 @@ class JcToolsTest {
   }
 
   @Test
-  void drainMaxBatch() {
+  void drain_MaxBatch() {
     // Arrange
     Queue<String> queue = new MpscArrayQueue<>(10);
     queue.add("Test1");
@@ -71,7 +71,7 @@ class JcToolsTest {
   }
 
   @Test
-  void newFixedSizeMpscQueue() {
+  void newFixedSize_MpscQueue() {
     // Arrange
     int capacity = 10;
 
@@ -83,7 +83,7 @@ class JcToolsTest {
   }
 
   @Test
-  void getCapacityMpscQueue() {
+  void capacity_MpscQueue() {
     // Arrange
     int capacity = 10;
     Queue<Object> queue = JcTools.newFixedSizeQueue(capacity);
@@ -96,7 +96,7 @@ class JcToolsTest {
   }
 
   @Test
-  void getCapacityArrayBlockingQueue() {
+  void capacity_ArrayBlockingQueue() {
     // Arrange
     Queue<String> queue = new ArrayBlockingQueue<>(10);
 

--- a/sdk/trace-shaded-deps/src/test/java/io/opentelemetry/sdk/trace/internal/JcToolsTest.java
+++ b/sdk/trace-shaded-deps/src/test/java/io/opentelemetry/sdk/trace/internal/JcToolsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.trace.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import org.jctools.queues.MpscArrayQueue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class JcToolsTest {
+
+  ArrayList<String> batch = new ArrayList<>(10);
+
+  @Test
+  void drainArrayBlockingQueue() {
+    // Arrange
+    batch.add("Test3");
+    Queue<String> queue = new ArrayBlockingQueue<>(10);
+    queue.add("Test1");
+    queue.add("Test2");
+
+    // Act
+    JcTools.drain(queue, 5, batch::add);
+
+    // Assert
+    assertThat(batch).hasSize(3);
+    assertThat(queue).hasSize(0);
+  }
+
+  @Test
+  void drainMessagePassingQueue() {
+    // Arrange
+    batch.add("Test3");
+    Queue<String> queue = new MpscArrayQueue<>(10);
+    queue.add("Test1");
+    queue.add("Test2");
+
+    // Act
+    JcTools.drain(queue, 5, batch::add);
+
+    // Assert
+    assertThat(batch).hasSize(3);
+    assertThat(queue).hasSize(0);
+  }
+
+  @Test
+  void drainMaxBatch() {
+    // Arrange
+    Queue<String> queue = new MpscArrayQueue<>(10);
+    queue.add("Test1");
+    queue.add("Test2");
+
+    // Act
+    JcTools.drain(queue, 1, batch::add);
+
+    // Assert
+    assertThat(batch).hasSize(1);
+    assertThat(queue).hasSize(1);
+  }
+
+  @Test
+  void newFixedSizeMpscQueue() {
+    // Arrange
+    int capacity = 10;
+
+    // Act
+    Queue<Object> objects = JcTools.newFixedSizeQueue(capacity);
+
+    // Assert
+    assertThat(objects).isInstanceOf(MpscArrayQueue.class);
+  }
+
+  @Test
+  void getCapacityMpscQueue() {
+    // Arrange
+    int capacity = 10;
+    Queue<Object> queue = JcTools.newFixedSizeQueue(capacity);
+
+    // Act
+    long queueSize = JcTools.capacity(queue);
+
+    // Assert
+    assertThat(queueSize).isGreaterThan(capacity);
+  }
+
+  @Test
+  void getCapacityArrayBlockingQueue() {
+    // Arrange
+    Queue<String> queue = new ArrayBlockingQueue<>(10);
+
+    // Act
+    long queueSize = JcTools.capacity(queue);
+
+    // Assert
+    assertThat(queueSize).isEqualTo(10);
+  }
+}

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -237,9 +237,9 @@ public final class BatchSpanProcessor implements SpanProcessor {
         if (flushRequested.get() != null) {
           flush();
         }
-        while (!queue.isEmpty() && batch.size() < maxExportBatchSize) {
-          batch.add(queue.poll().toSpanData());
-        }
+        JcTools.drain(
+            queue, maxExportBatchSize - batch.size(), span -> batch.add(span.toSpanData()));
+
         if (batch.size() >= maxExportBatchSize || System.nanoTime() >= nextExportTime) {
           exportCurrentBatch();
           updateNextExportTime();


### PR DESCRIPTION
# Changes 

* Remove unnecessary "queue.isEmpty()" check while adding each span to batch list.
* Use MpscArrayQueue drain util method, which handle all cases when queue is empty or size > maxExportBatchSize
* Added a static method "drain" under JcTools with a generic consumer to handle cases for any type of Queue or span. 
* This PR is basically improving testing coverage and minor code-efficiency  for feature added  through https://github.com/open-telemetry/opentelemetry-java/pull/2983  & https://github.com/open-telemetry/opentelemetry-java/pull/3034 

# Test/Benchmarking
* All existing Unit Test are passing (no regression)
* Added a new test class for JCTool.


#### Ran a local test with both flavor of Queue (``ArrayBlockingQueue`` &  ``MpscArrayQueue``)

-------
> Happy Case:  (Queue with N size containing N item, and maxExportBatchSize = N)  ✅

Step1: Added 10000000 (N) items to both queue.
Step2: Create two Runnable task to call ``drain`` method, each with one of the queue type.
Step3: Submitted both task to a fixed threadpool executor service.
Step4: Measured total duration to drain 10000000 (N) from each task.

> Result ::

### ``MpscArrayQueue``      Duration:: ``141 ms``  added 10000000 to batch. 🏆
### ``ArrayBlockingQueue`` Duration:: ``495 ms`` added 10000000 to batch.


-------
> 2nd Case:  (Queue with N+100 size containing N+100 item, and maxExportBatchSize = N)  ✅

> Result ::

``MpscArrayQueue``      Added N item to batch.
``ArrayBlockingQueue``  Added N item to batch.

-------
> 3rd Case:  (Queue with N size containing N-100 item, and maxExportBatchSize = N)  ✅

> Result ::

``MpscArrayQueue``      Added N-100 item to batch.
``ArrayBlockingQueue``  Added N-100 item to batch.

-------
> 4th Case:  (Queue with N size containing 0 item, and maxExportBatchSize = N )  ✅

> Result ::

``MpscArrayQueue``      Added 0 item to batch.
``ArrayBlockingQueue``  Added 0 item to batch.

