### PR TITLE
Add test for jaeger-thrift over UDP

### DIFF
--- a/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftIntegrationTest.java
+++ b/exporters/jaeger-thrift/src/test/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftIntegrationTest.java
@@ -8,20 +8,22 @@ package io.opentelemetry.exporter.jaeger.thrift;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.stree.JacksonJrsTreeCodec;
+import io.jaegertracing.thrift.internal.senders.UdpSender;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
-import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.time.Duration;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.apache.thrift.transport.TTransportException;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
@@ -35,6 +37,8 @@ class JaegerThriftIntegrationTest {
 
   private static final int QUERY_PORT = 16686;
   private static final int THRIFT_HTTP_PORT = 14268;
+
+  private static final int THRIFT_UDP_PORT = 6831;
   private static final int HEALTH_PORT = 14269;
   private static final String SERVICE_NAME = "E2E-test";
   private static final String JAEGER_URL = "http://localhost";
@@ -42,30 +46,39 @@ class JaegerThriftIntegrationTest {
   @Container
   public static GenericContainer<?> jaegerContainer =
       new GenericContainer<>("ghcr.io/open-telemetry/opentelemetry-java/jaeger:1.32")
-          .withExposedPorts(THRIFT_HTTP_PORT, QUERY_PORT, HEALTH_PORT)
+          .withExposedPorts(THRIFT_HTTP_PORT, THRIFT_UDP_PORT, QUERY_PORT, HEALTH_PORT)
           .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("jaeger")))
           .waitingFor(Wait.forHttp("/").forPort(HEALTH_PORT));
 
-  @Test
-  void testJaegerIntegration() {
-    OpenTelemetry openTelemetry = initOpenTelemetry();
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void testJaegerIntegration(boolean udp) {
+    OpenTelemetry openTelemetry = initOpenTelemetry(udp);
     imitateWork(openTelemetry);
     Awaitility.await()
         .atMost(Duration.ofSeconds(30))
         .until(JaegerThriftIntegrationTest::assertJaegerHasATrace);
   }
 
-  private static OpenTelemetry initOpenTelemetry() {
-    Integer mappedPort = jaegerContainer.getMappedPort(THRIFT_HTTP_PORT);
+  private static OpenTelemetry initOpenTelemetry(boolean udp) {
+    JaegerThriftSpanExporterBuilder jaegerExporter = JaegerThriftSpanExporter.builder();
 
-    SpanExporter jaegerExporter =
-        JaegerThriftSpanExporter.builder()
-            .setEndpoint(JAEGER_URL + ":" + mappedPort + "/api/traces")
-            .build();
+    if (udp) {
+      int mappedPort = jaegerContainer.getMappedPort(THRIFT_UDP_PORT);
+      try {
+        jaegerExporter.setThriftSender(new UdpSender("localhost", mappedPort, 0));
+      } catch (TTransportException e) {
+        throw new IllegalStateException(e);
+      }
+    } else {
+      int mappedPort = jaegerContainer.getMappedPort(THRIFT_HTTP_PORT);
+      jaegerExporter.setEndpoint(JAEGER_URL + ":" + mappedPort + "/api/traces");
+    }
+
     return OpenTelemetrySdk.builder()
         .setTracerProvider(
             SdkTracerProvider.builder()
-                .addSpanProcessor(SimpleSpanProcessor.create(jaegerExporter))
+                .addSpanProcessor(SimpleSpanProcessor.create(jaegerExporter.build()))
                 .setResource(
                     Resource.getDefault().toBuilder()
                         .put(ResourceAttributes.SERVICE_NAME, SERVICE_NAME)


### PR DESCRIPTION
I'm no advocate of jaeger-thrift :P But I figure it's worth understanding what works and doesn't. Specifically, I remember hearing users using this exporter with UDP, even if our intent wasn't to support that.

See #4577

