### PR TITLE
Remove @anuraaga from CODEOWNERS :(

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
  # For anything not explicitly taken by someone else:
-*  @anuraaga @jack-berg @jkwatson @jsuereth @kubawach @Oberon00
+*  @jack-berg @jkwatson @jsuereth @kubawach @Oberon00


### PR DESCRIPTION
Saddens me to do this, but apparently it's now an error to leave @anuraaga in there. 😿 

<img width="754" alt="image" src="https://user-images.githubusercontent.com/75337021/178363300-0f98867b-a228-4d2e-9590-48689a5138db.png">
