### PR TITLE
Add AutoConfigurationCustomizer#addPropertiesCustomizer() extension p…

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
@@ -1,4 +1,7 @@
 Comparing source compatibility of  against 
+***! MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++! NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer addPropertiesCustomizer(java.util.function.Function)
 ***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW INTERFACE: io.opentelemetry.sdk.autoconfigure.spi.Ordered

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizer.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizer.java
@@ -16,6 +16,7 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.util.Map;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /** A builder for customizing OpenTelemetry auto-configuration. */
@@ -71,6 +72,19 @@ public interface AutoConfigurationCustomizer {
    */
   AutoConfigurationCustomizer addPropertiesSupplier(
       Supplier<Map<String, String>> propertiesSupplier);
+
+  /**
+   * Adds a {@link Function} to invoke the with the {@link ConfigProperties} to allow customization.
+   * The return value of the {@link Function} will be merged into the {@link ConfigProperties}
+   * before it is used for auto-configuration, overwriting the properties that are already there.
+   *
+   * <p>Multiple calls will cause properties to be merged in order, with later ones overwriting
+   * duplicate keys in earlier ones.
+   */
+  default AutoConfigurationCustomizer addPropertiesCustomizer(
+      Function<ConfigProperties, Map<String, String>> propertiesCustomizer) {
+    return this;
+  }
 
   /**
    * Adds a {@link BiFunction} to invoke the with the {@link SdkTracerProviderBuilder} to allow

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizer.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizer.java
@@ -80,6 +80,8 @@ public interface AutoConfigurationCustomizer {
    *
    * <p>Multiple calls will cause properties to be merged in order, with later ones overwriting
    * duplicate keys in earlier ones.
+   *
+   * @since 1.17.0
    */
   default AutoConfigurationCustomizer addPropertiesCustomizer(
       Function<ConfigProperties, Map<String, String>> propertiesCustomizer) {

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -77,6 +78,9 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
 
   private Supplier<Map<String, String>> propertiesSupplier = Collections::emptyMap;
 
+  private final List<Function<ConfigProperties, Map<String, String>>> propertiesCustomizers =
+      new ArrayList<>();
+
   private ClassLoader serviceClassLoader =
       AutoConfiguredOpenTelemetrySdkBuilder.class.getClassLoader();
 
@@ -90,7 +94,8 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
 
   /**
    * Sets the {@link ConfigProperties} to use when resolving properties for auto-configuration.
-   * {@link #addPropertiesSupplier(Supplier)} will have no effect if this method is used.
+   * {@link #addPropertiesSupplier(Supplier)} and {@link #addPropertiesCustomizer(Function)} will
+   * have no effect if this method is used.
    */
   AutoConfiguredOpenTelemetrySdkBuilder setConfig(ConfigProperties config) {
     requireNonNull(config, "config");
@@ -188,6 +193,21 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
       Supplier<Map<String, String>> propertiesSupplier) {
     requireNonNull(propertiesSupplier, "propertiesSupplier");
     this.propertiesSupplier = mergeProperties(this.propertiesSupplier, propertiesSupplier);
+    return this;
+  }
+
+  /**
+   * Adds a {@link Function} to invoke the with the {@link ConfigProperties} to allow customization.
+   * The return value of the {@link Function} will be merged into the {@link ConfigProperties}
+   * before it is used for auto-configuration, overwriting the properties that are already there.
+   *
+   * <p>Multiple calls will cause properties to be merged in order, with later ones overwriting
+   * duplicate keys in earlier ones.
+   */
+  @Override
+  public AutoConfiguredOpenTelemetrySdkBuilder addPropertiesCustomizer(
+      Function<ConfigProperties, Map<String, String>> propertiesCustomizer) {
+    this.propertiesCustomizers.add(propertiesCustomizer);
     return this;
   }
 
@@ -396,9 +416,18 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
   private ConfigProperties getConfig() {
     ConfigProperties config = this.config;
     if (config == null) {
-      config = DefaultConfigProperties.get(propertiesSupplier.get());
+      config = computeConfigProperties();
     }
     return config;
+  }
+
+  private ConfigProperties computeConfigProperties() {
+    DefaultConfigProperties properties = DefaultConfigProperties.get(propertiesSupplier.get());
+    for (Function<ConfigProperties, Map<String, String>> customizer : propertiesCustomizers) {
+      Map<String, String> overrides = customizer.apply(properties);
+      properties = DefaultConfigProperties.customize(properties, overrides);
+    }
+    return properties;
   }
 
   private static <I, O1, O2> BiFunction<I, ConfigProperties, O2> mergeCustomizer(

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -207,6 +207,7 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
   @Override
   public AutoConfiguredOpenTelemetrySdkBuilder addPropertiesCustomizer(
       Function<ConfigProperties, Map<String, String>> propertiesCustomizer) {
+    requireNonNull(propertiesCustomizer, "propertiesCustomizer");
     this.propertiesCustomizers.add(propertiesCustomizer);
     return this;
   }

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/DefaultConfigProperties.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/DefaultConfigProperties.java
@@ -36,8 +36,13 @@ final class DefaultConfigProperties implements ConfigProperties {
 
   private final Map<String, String> config;
 
-  static ConfigProperties get(Map<String, String> defaultProperties) {
+  static DefaultConfigProperties get(Map<String, String> defaultProperties) {
     return new DefaultConfigProperties(System.getProperties(), System.getenv(), defaultProperties);
+  }
+
+  static DefaultConfigProperties customize(
+      DefaultConfigProperties previousProperties, Map<String, String> overrides) {
+    return new DefaultConfigProperties(previousProperties, overrides);
   }
 
   // Visible for testing
@@ -55,6 +60,15 @@ final class DefaultConfigProperties implements ConfigProperties {
         (name, value) -> config.put(name.toLowerCase(Locale.ROOT).replace('_', '.'), value));
     systemProperties.forEach(
         (key, value) -> config.put(normalize(key.toString()), value.toString()));
+
+    this.config = config;
+  }
+
+  private DefaultConfigProperties(
+      DefaultConfigProperties previousProperties, Map<String, String> overrides) {
+    // previousProperties are already normalized, they can be copied as they are
+    Map<String, String> config = new HashMap<>(previousProperties.config);
+    overrides.forEach((name, value) -> config.put(normalize(name), value));
 
     this.config = config;
   }


### PR DESCRIPTION
…oint

As described in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/6285#discussion_r916409381 (and earlier in the SIG)

This is needed so that we can deprecate the [`ConfigCustomizer`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/config/ConfigCustomizer.java#L38) agent SPI, and fully rely on the SDK SPIs to manipulate config.