### PR TITLE
Add ordering to autoconfigure SPIs

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
@@ -1,2 +1,11 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW INTERFACE: io.opentelemetry.sdk.autoconfigure.spi.Ordered
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.autoconfigure.spi.Ordered  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) int order()
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW INTERFACE: io.opentelemetry.sdk.autoconfigure.spi.Ordered

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizerProvider.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizerProvider.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.sdk.autoconfigure.spi;
 
 /** A service provider interface (SPI) for customizing auto-configuration. */
-public interface AutoConfigurationCustomizerProvider {
+public interface AutoConfigurationCustomizerProvider extends Ordered {
 
   /**
    * Method invoked when auto-configuring the SDK to allow further customization of

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/Ordered.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/Ordered.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure.spi;
+
+/** Interface to be extended by SPIs that need to guarantee ordering during loading. */
+public interface Ordered {
+
+  /**
+   * Returns the order of applying the SPI implementing this interface. Higher values are added
+   * later, for example: an SPI with order=1 will run after an SPI with order=0.
+   */
+  default int order() {
+    return 0;
+  }
+}

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/Ordered.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/Ordered.java
@@ -5,12 +5,17 @@
 
 package io.opentelemetry.sdk.autoconfigure.spi;
 
-/** Interface to be extended by SPIs that need to guarantee ordering during loading. */
+/**
+ * Interface to be extended by SPIs that need to guarantee ordering during loading.
+ *
+ * @since 1.17.0
+ */
 public interface Ordered {
 
   /**
-   * Returns the order of applying the SPI implementing this interface. Higher values are added
-   * later, for example: an SPI with order=1 will run after an SPI with order=0.
+   * Returns the order of applying the SPI implementing this interface. Higher values are applied
+   * later, for example: an SPI with order=1 will run after an SPI with order=0. SPI implementations
+   * with equal values will be run in a non-deterministic order.
    */
   default int order() {
     return 0;

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ResourceProvider.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ResourceProvider.java
@@ -11,7 +11,7 @@ import io.opentelemetry.sdk.resources.Resource;
  * A service provider interface (SPI) for providing a {@link Resource} that is merged into the
  * {@linkplain Resource#getDefault() default resource}.
  */
-public interface ResourceProvider {
+public interface ResourceProvider extends Ordered {
 
   Resource createResource(ConfigProperties config);
 }

--- a/sdk-extensions/autoconfigure/build.gradle.kts
+++ b/sdk-extensions/autoconfigure/build.gradle.kts
@@ -35,6 +35,17 @@ dependencies {
 
 testing {
   suites {
+    val testAutoConfigureOrder by registering(JvmTestSuite::class) {
+      targets {
+        all {
+          testTask {
+            environment("OTEL_TRACES_EXPORTER", "none")
+            environment("OTEL_METRICS_EXPORTER", "none")
+            environment("OTEL_LOGS_EXPORTER", "none")
+          }
+        }
+      }
+    }
     val testConfigError by registering(JvmTestSuite::class) {
       dependencies {
         implementation(project(":extensions:trace-propagators"))

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -298,7 +298,7 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
       customized = true;
       mergeSdkTracerProviderConfigurer();
       for (AutoConfigurationCustomizerProvider customizer :
-          ServiceLoader.load(AutoConfigurationCustomizerProvider.class, serviceClassLoader)) {
+          SpiUtil.loadOrdered(AutoConfigurationCustomizerProvider.class, serviceClassLoader)) {
         customizer.customize(this);
       }
     }

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ResourceConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ResourceConfiguration.java
@@ -13,7 +13,6 @@ import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.resources.ResourceBuilder;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.util.HashSet;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.BiFunction;
 
@@ -39,7 +38,7 @@ final class ResourceConfiguration {
     Set<String> disabledProviders =
         new HashSet<>(config.getList("otel.java.disabled.resource.providers"));
     for (ResourceProvider resourceProvider :
-        ServiceLoader.load(ResourceProvider.class, serviceClassLoader)) {
+        SpiUtil.loadOrdered(ResourceProvider.class, serviceClassLoader)) {
       if (!enabledProviders.isEmpty()
           && !enabledProviders.contains(resourceProvider.getClass().getName())) {
         continue;

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/SpiUtilTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/SpiUtilTest.java
@@ -5,8 +5,9 @@
 
 package io.opentelemetry.sdk.autoconfigure;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -14,7 +15,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
 import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class SpiUtilTest {
@@ -105,6 +108,26 @@ public class SpiUtilTest {
     assertThatThrownBy(() -> spiProvider.getByName("init-failure-example"))
         .withFailMessage(exceptionMessage)
         .isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  void loadsOrderedSpi() {
+    ResourceProvider spi1 = mock(ResourceProvider.class);
+    ResourceProvider spi2 = mock(ResourceProvider.class);
+    ResourceProvider spi3 = mock(ResourceProvider.class);
+
+    when(spi1.order()).thenReturn(2);
+    when(spi2.order()).thenReturn(0);
+    when(spi3.order()).thenReturn(1);
+
+    SpiUtil.ServiceLoaderFinder mockFinder = mock(SpiUtil.ServiceLoaderFinder.class);
+    when(mockFinder.load(ResourceProvider.class, SpiUtil.class.getClassLoader()))
+        .thenReturn(asList(spi1, spi2, spi3));
+
+    List<ResourceProvider> loadedSpi =
+        SpiUtil.loadOrdered(ResourceProvider.class, SpiUtil.class.getClassLoader(), mockFinder);
+
+    assertThat(loadedSpi).containsExactly(spi2, spi3, spi1);
   }
 
   private interface SpiExampleProvider {

--- a/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/FirstCustomizerProvider.java
+++ b/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/FirstCustomizerProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import static java.util.Collections.singletonMap;
+
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+
+public class FirstCustomizerProvider implements AutoConfigurationCustomizerProvider {
+
+  @Override
+  public void customize(AutoConfigurationCustomizer autoConfiguration) {
+    autoConfiguration.addPropertiesSupplier(() -> singletonMap("otel.from-config", "unused"));
+  }
+
+  @Override
+  public int order() {
+    return 1000;
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/FirstResourceProvider.java
+++ b/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/FirstResourceProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.sdk.resources.Resource;
+
+public class FirstResourceProvider implements ResourceProvider {
+
+  @Override
+  public Resource createResource(ConfigProperties config) {
+    return Resource.create(
+        Attributes.of(
+            stringKey("otel.some_resource"),
+            "unused",
+            stringKey("otel.from_config"),
+            config.getString("otel.from-config", "default")));
+  }
+
+  @Override
+  public int order() {
+    return 100;
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/OrderedSpiTest.java
+++ b/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/OrderedSpiTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import org.junit.jupiter.api.Test;
+
+class OrderedSpiTest {
+
+  @Test
+  void shouldLoadSpiImplementationsInOrder() {
+    AutoConfiguredOpenTelemetrySdk sdk =
+        AutoConfiguredOpenTelemetrySdk.builder()
+            .setResultAsGlobal(false)
+            .registerShutdownHook(false)
+            .build();
+
+    assertThat(sdk.getResource().getAttributes().asMap())
+        .contains(
+            entry(stringKey("otel.some_resource"), "real value"),
+            entry(stringKey("otel.from_config"), "configured value"));
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/SecondCustomizerProvider.java
+++ b/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/SecondCustomizerProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import static java.util.Collections.singletonMap;
+
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+
+public class SecondCustomizerProvider implements AutoConfigurationCustomizerProvider {
+
+  @Override
+  public void customize(AutoConfigurationCustomizer autoConfiguration) {
+    autoConfiguration.addPropertiesSupplier(() -> singletonMap("otel.from-config", "still unused"));
+  }
+
+  @Override
+  public int order() {
+    return 2000;
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/SecondResourceProvider.java
+++ b/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/SecondResourceProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.sdk.resources.Resource;
+
+public class SecondResourceProvider implements ResourceProvider {
+
+  @Override
+  public Resource createResource(ConfigProperties config) {
+    return Resource.create(Attributes.of(stringKey("otel.some_resource"), "still unused"));
+  }
+
+  @Override
+  public int order() {
+    return 200;
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/ThirdCustomizerProvider.java
+++ b/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/ThirdCustomizerProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import static java.util.Collections.singletonMap;
+
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+
+public class ThirdCustomizerProvider implements AutoConfigurationCustomizerProvider {
+
+  @Override
+  public void customize(AutoConfigurationCustomizer autoConfiguration) {
+    autoConfiguration.addPropertiesSupplier(
+        () -> singletonMap("otel.from-config", "configured value"));
+  }
+
+  @Override
+  public int order() {
+    return 3000;
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/ThirdResourceProvider.java
+++ b/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/ThirdResourceProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.sdk.resources.Resource;
+
+public class ThirdResourceProvider implements ResourceProvider {
+
+  @Override
+  public Resource createResource(ConfigProperties config) {
+    return Resource.create(Attributes.of(stringKey("otel.some_resource"), "real value"));
+  }
+
+  @Override
+  public int order() {
+    return 300;
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider
+++ b/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider
@@ -1,0 +1,3 @@
+io.opentelemetry.sdk.autoconfigure.SecondCustomizerProvider
+io.opentelemetry.sdk.autoconfigure.ThirdCustomizerProvider
+io.opentelemetry.sdk.autoconfigure.FirstCustomizerProvider

--- a/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
+++ b/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
@@ -1,0 +1,3 @@
+io.opentelemetry.sdk.autoconfigure.ThirdResourceProvider
+io.opentelemetry.sdk.autoconfigure.SecondResourceProvider
+io.opentelemetry.sdk.autoconfigure.FirstResourceProvider


### PR DESCRIPTION
Resolves #4555

I copied the javaagent's [`Ordered`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/Ordered.java) interface into the autoconfigure-spi module; in the future we'll remove the agent one and use the SDK `Ordered` uniformly across all SPIs.