### PR TITLE
Add OSGi metadata to the API and SDK packages

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+  id("biz.aQute.bnd.builder")
+}
+
 subprojects {
   // Workaround https://github.com/gradle/gradle/issues/847
   group = "io.opentelemetry.api"
@@ -6,5 +10,8 @@ subprojects {
     configure<BasePluginExtension> {
       archivesName.set("opentelemetry-api-${proj.name}")
     }
+  }
+  apply{
+    plugin("biz.aQute.bnd.builder")
   }
 }

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+  id("biz.aQute.bnd.builder")
+}
+
 subprojects {
   // Workaround https://github.com/gradle/gradle/issues/847
   group = "io.opentelemetry.sdk"
@@ -6,5 +10,8 @@ subprojects {
     configure<BasePluginExtension> {
       archivesName.set("opentelemetry-sdk-${proj.name}")
     }
+  }
+  apply{
+    plugin("biz.aQute.bnd.builder")
   }
 }

--- a/sdk/common/bnd.bnd
+++ b/sdk/common/bnd.bnd
@@ -1,0 +1,1 @@
+-fixupmessages "Classes found in the wrong directory"; restrict:=error; is:=ignore

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 pluginManagement {
   plugins {
+    id("biz.aQute.bnd.builder") version "6.3.1"
     id("com.github.ben-manes.versions") version "0.42.0"
     id("com.github.johnrengelman.shadow") version "7.1.2"
     id("com.gradle.enterprise") version "3.10.3"


### PR DESCRIPTION
Use the BND plugin to add OSGi metadata to the manifest files of jars.