### PR TITLE
WIP:Add OSGi support to OpenTelemetry project

### DIFF
--- a/api/all/build.gradle.kts
+++ b/api/all/build.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
 
   annotationProcessor("com.google.auto.value:auto-value")
 
+  compileOnly("org.osgi:osgi.annotation")
+
   testImplementation("edu.berkeley.cs.jqf:jqf-fuzz")
   testImplementation("com.google.guava:guava-testlib")
 }

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/package-info.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/package-info.java
@@ -15,6 +15,8 @@
  */
 // TODO: Add code examples.
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.api.baggage;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/package-info.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/package-info.java
@@ -5,6 +5,8 @@
 
 /** Default OpenTelemetry remote baggage propagators. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.api.baggage.propagation;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/api/all/src/main/java/io/opentelemetry/api/common/package-info.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/package-info.java
@@ -8,6 +8,8 @@
  * io.opentelemetry.api.common.Attributes} and classes/utilities for interacting with them.
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.api.common;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/api/all/src/main/java/io/opentelemetry/api/internal/package-info.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/package-info.java
@@ -10,6 +10,8 @@
  * API, and must not be used by users of the OpenTelemetry library.
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.api.internal;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/package-info.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/package-info.java
@@ -15,6 +15,8 @@
  * scenarios where instrumentation authors are unable to obtain one by other means.
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.api.metrics;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/api/all/src/main/java/io/opentelemetry/api/package-info.java
+++ b/api/all/src/main/java/io/opentelemetry/api/package-info.java
@@ -10,6 +10,8 @@
  * methods on {@link io.opentelemetry.api.OpenTelemetry}.
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.api;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/api/all/src/main/java/io/opentelemetry/api/trace/package-info.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/package-info.java
@@ -20,6 +20,8 @@
  */
 // TODO: Add code examples.
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.api.trace;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/api/all/src/main/java/io/opentelemetry/api/trace/propagation/internal/package-info.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/propagation/internal/package-info.java
@@ -10,6 +10,8 @@
  * API, and must not be used by users of the OpenTelemetry library.
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.api.trace.propagation.internal;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/api/all/src/main/java/io/opentelemetry/api/trace/propagation/package-info.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/propagation/package-info.java
@@ -5,6 +5,8 @@
 
 /** Default OpenTelemetry remote trace propagators. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.api.trace.propagation;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,6 +13,7 @@ repositories {
 
 dependencies {
   // When updating, update above in plugins too
+  implementation("biz.aQute.bnd:biz.aQute.bnd.gradle:6.3.1")
   implementation("com.diffplug.spotless:spotless-plugin-gradle:6.4.2")
   // Needed for japicmp but not automatically brought in for some reason.
   implementation("com.google.guava:guava:31.1-jre")

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -8,6 +8,7 @@ plugins {
   eclipse
   idea
 
+  id("biz.aQute.bnd.builder")
   id("otel.errorprone-conventions")
   id("otel.jacoco-conventions")
   id("otel.spotless-conventions")

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -113,16 +113,25 @@ tasks {
     }
   }
 
+  withType<Jar>().configureEach {
+    inputs.property("moduleName", otelJava.moduleName)
+
+    manifest {
+      attributes(
+        "Built-By" to System.getProperty("user.name"),
+        "Built-JDK" to System.getProperty("java.version"),
+        "Implementation-Title" to project.name,
+        "Implementation-Version" to project.version
+      )
+    }
+  }
+
   named("jar", Jar::class.java) {
     bundle {
       bnd(
         """
         -fixupmessages "Classes found in the wrong directory"; restrict:=error; is:=ignore
         Automatic-Module-Name: \${otelJava.moduleName.get()}
-        Built-By: \${System.getProperty("user.name")}
-        Built-JDK: \${System.getProperty("java.version")}
-        Implementation-Title: \${project.name}
-        Implementation-Version: \${project.version}
         """.trimIndent()
       )
     }

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -128,12 +128,8 @@ tasks {
     inputs.property("moduleName", otelJava.moduleName)
 
     bundle {
-      bnd(
-        """
-        -fixupmessages "Classes found in the wrong directory"; restrict:=error; is:=ignore
-        Automatic-Module-Name: \${otelJava.moduleName.get()}
-        """.trimIndent()
-      )
+      bnd("-fixupmessages \"Classes found in the wrong directory\"; restrict:=error; is:=ignore")
+      bnd("Automatic-Module-Name: ${otelJava.moduleName.get()}")
     }
   }
 

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -114,8 +114,6 @@ tasks {
   }
 
   withType<Jar>().configureEach {
-    inputs.property("moduleName", otelJava.moduleName)
-
     manifest {
       attributes(
         "Built-By" to System.getProperty("user.name"),
@@ -127,6 +125,8 @@ tasks {
   }
 
   named("jar", Jar::class.java) {
+    inputs.property("moduleName", otelJava.moduleName)
+
     bundle {
       bnd(
         """

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -117,15 +117,16 @@ tasks {
     bundle {
       bnd(
         """
-        Automatic-Module-Name: \${otelJava.moduleName.get()} \n
-        Built-By: \${System.getProperty("user.name")} \n
-        Built-JDK: \${System.getProperty("java.version")} \n
-        Implementation-Title: \${project.name} \n
-        Implementation-Version: \${project.version} \n
-        """
+        -fixupmessages "Classes found in the wrong directory"; restrict:=error; is:=ignore
+        Automatic-Module-Name: \${otelJava.moduleName.get()}
+        Built-By: \${System.getProperty("user.name")}
+        Built-JDK: \${System.getProperty("java.version")}
+        Implementation-Title: \${project.name}
+        Implementation-Version: \${project.version}
+        """.trimIndent()
       )
     }
-  }
+  }.
 
   afterEvaluate {
     withType<Javadoc>().configureEach {

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -117,7 +117,7 @@ tasks {
     bundle {
       bnd(
         """
-        Automatic-Module-Name: \${'$'}{otelJava.moduleName.get()} \n
+        Automatic-Module-Name: \${otelJava.moduleName.get()} \n
         Built-By: \${System.getProperty("user.name")} \n
         Built-JDK: \${System.getProperty("java.version")} \n
         Implementation-Title: \${project.name} \n

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -126,7 +126,7 @@ tasks {
         """.trimIndent()
       )
     }
-  }.
+  }
 
   afterEvaluate {
     withType<Javadoc>().configureEach {

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -113,16 +113,16 @@ tasks {
     }
   }
 
-  withType<Jar>().configureEach {
-    inputs.property("moduleName", otelJava.moduleName)
-
-    manifest {
-      attributes(
-        "Automatic-Module-Name" to otelJava.moduleName,
-        "Built-By" to System.getProperty("user.name"),
-        "Built-JDK" to System.getProperty("java.version"),
-        "Implementation-Title" to project.name,
-        "Implementation-Version" to project.version
+  named("jar", Jar::class.java) {
+    bundle {
+      bnd(
+        """
+        Automatic-Module-Name: \${'$'}{otelJava.moduleName.get()} \n
+        Built-By: \${System.getProperty("user.name")} \n
+        Built-JDK: \${System.getProperty("java.version")} \n
+        Implementation-Title: \${project.name} \n
+        Implementation-Version: \${project.version} \n
+        """
       )
     }
   }

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -129,7 +129,7 @@ tasks {
 
     bundle {
       bnd("-fixupmessages \"Classes found in the wrong directory\"; restrict:=error; is:=ignore")
-      bnd("Automatic-Module-Name: ${otelJava.moduleName.get()}")
+      bnd(otelJava.moduleName.map { moduleName -> "Automatic-Module-Name: $moduleName" })
     }
   }
 

--- a/context/build.gradle.kts
+++ b/context/build.gradle.kts
@@ -10,6 +10,7 @@ description = "OpenTelemetry Context (Incubator)"
 otelJava.moduleName.set("io.opentelemetry.context")
 
 dependencies {
+  compileOnly("org.osgi:osgi.annotation")
   // MustBeClosed
   compileOnly("com.google.errorprone:error_prone_annotations")
 

--- a/context/src/main/java/io/opentelemetry/context/internal/shaded/package-info.java
+++ b/context/src/main/java/io/opentelemetry/context/internal/shaded/package-info.java
@@ -4,4 +4,7 @@
  * <p>All the content under this package and its subpackages are considered not part of the public
  * API, and must not be used by users of the OpenTelemetry library.
  */
+@Export
 package io.opentelemetry.context.internal.shaded;
+
+import org.osgi.annotation.bundle.Export;

--- a/context/src/main/java/io/opentelemetry/context/package-info.java
+++ b/context/src/main/java/io/opentelemetry/context/package-info.java
@@ -10,6 +10,8 @@
  * @see io.opentelemetry.context.Context
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.context;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/context/src/main/java/io/opentelemetry/context/propagation/package-info.java
+++ b/context/src/main/java/io/opentelemetry/context/propagation/package-info.java
@@ -9,6 +9,8 @@
  * remote server.
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.context.propagation;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -99,6 +99,7 @@ val DEPENDENCIES = listOf(
   "org.codehaus.mojo:animal-sniffer-annotations:1.21",
   "org.jctools:jctools-core:3.3.0",
   "org.junit-pioneer:junit-pioneer:1.7.1",
+  "org.osgi:osgi.annotation:8.1.0",
   "org.skyscreamer:jsonassert:1.5.0",
 )
 

--- a/exporters/jaeger-thrift/build.gradle.kts
+++ b/exporters/jaeger-thrift/build.gradle.kts
@@ -11,6 +11,8 @@ otelJava.moduleName.set("io.opentelemetry.exporter.jaeger.thrift")
 dependencies {
   api(project(":sdk:all"))
 
+  compileOnly("org.osgi:osgi.annotation")
+
   implementation(project(":sdk:all"))
   implementation(project(":semconv"))
 

--- a/exporters/jaeger-thrift/src/main/java/io/opentelemetry/exporter/jaeger/thrift/package-info.java
+++ b/exporters/jaeger-thrift/src/main/java/io/opentelemetry/exporter/jaeger/thrift/package-info.java
@@ -4,6 +4,8 @@
  */
 
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.exporter.jaeger.thrift;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/jaeger/build.gradle.kts
+++ b/exporters/jaeger/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
   implementation(project(":exporters:otlp:common"))
   implementation(project(":semconv"))
 
+  compileOnly("org.osgi:osgi.annotation")
   compileOnly("io.grpc:grpc-stub")
 
   implementation("com.fasterxml.jackson.jr:jackson-jr-objects")

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/package-info.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/package-info.java
@@ -4,6 +4,8 @@
  */
 
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.exporter.jaeger;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/logging-otlp/build.gradle.kts
+++ b/exporters/logging-otlp/build.gradle.kts
@@ -9,6 +9,8 @@ description = "OpenTelemetry Protocol JSON Logging Exporters"
 otelJava.moduleName.set("io.opentelemetry.exporter.logging.otlp")
 
 dependencies {
+  compileOnly("org.osgi:osgi.annotation")
+
   compileOnly(project(":sdk:trace"))
   compileOnly(project(":sdk:metrics"))
   compileOnly(project(":sdk:logs"))

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/package-info.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/package-info.java
@@ -5,6 +5,8 @@
 
 /** OpenTelemetry exporters which writes spans or metrics to log using OTLP JSON format. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.exporter.logging.otlp;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/logging/build.gradle.kts
+++ b/exporters/logging/build.gradle.kts
@@ -13,5 +13,7 @@ dependencies {
   api(project(":sdk:metrics"))
   api(project(":sdk:logs"))
 
+  compileOnly("org.osgi:osgi.annotation")
+
   testImplementation(project(":sdk:testing"))
 }

--- a/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/package-info.java
+++ b/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/package-info.java
@@ -4,6 +4,8 @@
  */
 
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.exporter.logging;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/otlp/all/build.gradle.kts
+++ b/exporters/otlp/all/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
 
   implementation(project(":exporters:otlp:common"))
 
+  compileOnly("org.osgi:osgi.annotation")
   compileOnly("io.grpc:grpc-stub")
 
   testImplementation(project(":exporters:otlp:testing-internal"))

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/package-info.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/package-info.java
@@ -5,6 +5,8 @@
 
 /** OpenTelemetry exporter which sends metric data to OpenTelemetry collector via OTLP HTTP. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.exporter.otlp.http.metrics;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/package-info.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/package-info.java
@@ -5,6 +5,8 @@
 
 /** OpenTelemetry exporter which sends span data to OpenTelemetry collector via OTLP HTTP. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.exporter.otlp.http.trace;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/package-info.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/package-info.java
@@ -5,6 +5,8 @@
 
 /** OpenTelemetry exporter which sends metric data to OpenTelemetry collector via OTLP gRPC. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.exporter.otlp.metrics;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/package-info.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/package-info.java
@@ -5,6 +5,8 @@
 
 /** OpenTelemetry exporter which sends span data to OpenTelemetry collector via OTLP gRPC. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.exporter.otlp.trace;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/otlp/common/build.gradle.kts
+++ b/exporters/otlp/common/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
 
   api(project(":api:all"))
 
+  compileOnly("org.osgi:osgi.annotation")
   compileOnly(project(":sdk:metrics"))
   compileOnly(project(":sdk:trace"))
   compileOnly(project(":sdk:logs"))

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/package-info.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/package-info.java
@@ -5,6 +5,8 @@
 
 /** Utilities for gRPC exporters. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.exporter.internal.grpc;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/marshal/package-info.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/marshal/package-info.java
@@ -5,6 +5,8 @@
 
 /** Marshaling framework for serializing data to protobuf format. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.exporter.internal.marshal;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/package-info.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/package-info.java
@@ -5,6 +5,8 @@
 
 /** Utilities for HTTP exporters. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.exporter.internal.okhttp;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/logs/package-info.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/logs/package-info.java
@@ -5,6 +5,8 @@
 
 /** Marshaling of OTLP logs. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.exporter.internal.otlp.logs;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/package-info.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/package-info.java
@@ -5,6 +5,8 @@
 
 /** Marshaling of OTLP metrics. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.exporter.internal.otlp.metrics;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/package-info.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/package-info.java
@@ -10,6 +10,8 @@
  * at any time.
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.exporter.internal.otlp;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/package-info.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/package-info.java
@@ -5,6 +5,8 @@
 
 /** Marshaling of OTLP traces. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.exporter.internal.otlp.traces;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/package-info.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/package-info.java
@@ -5,6 +5,8 @@
 
 /** Internal utilities for exporters. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.exporter.internal;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/retry/package-info.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/retry/package-info.java
@@ -5,6 +5,8 @@
 
 /** Logic for retrying of export requests. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.exporter.internal.retry;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/otlp/logs/build.gradle.kts
+++ b/exporters/otlp/logs/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
 
   implementation(project(":exporters:otlp:common"))
 
+  compileOnly("org.osgi:osgi.annotation")
   compileOnly("io.grpc:grpc-stub")
 
   testImplementation(project(":exporters:otlp:testing-internal"))

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/package-info.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/package-info.java
@@ -5,6 +5,8 @@
 
 /** OpenTelemetry exporter which sends log data to OpenTelemetry collector via OTLP HTTP. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.exporter.otlp.http.logs;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/package-info.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/package-info.java
@@ -5,6 +5,8 @@
 
 /** OpenTelemetry exporter which sends span data to OpenTelemetry collector via OTLP gRPC. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.exporter.otlp.logs;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/exporters/prometheus/build.gradle.kts
+++ b/exporters/prometheus/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
   api(project(":sdk:metrics"))
 
   compileOnly("com.sun.net.httpserver:http")
+  compileOnly("org.osgi:osgi.annotation")
 
   testImplementation("com.google.guava:guava")
   testImplementation("com.linecorp.armeria:armeria")

--- a/exporters/zipkin/build.gradle.kts
+++ b/exporters/zipkin/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
 
   api("io.zipkin.reporter2:zipkin-reporter")
 
+  compileOnly("org.osgi:osgi.annotation")
+
   implementation(project(":semconv"))
 
   implementation("io.zipkin.reporter2:zipkin-sender-okhttp3")

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/package-info.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/package-info.java
@@ -4,6 +4,8 @@
  */
 
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.exporter.zipkin;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk-extensions/autoconfigure-spi/build.gradle.kts
+++ b/sdk-extensions/autoconfigure-spi/build.gradle.kts
@@ -9,6 +9,8 @@ otelJava.moduleName.set("io.opentelemetry.sdk.autoconfigure.spi")
 dependencies {
   api(project(":sdk:all"))
 
+  compileOnly("org.osgi:osgi.annotation")
+
   // implementation dependency to require users to add the artifact directly to their build to use
   // SdkMeterProviderBuilder.
   implementation(project(":sdk:metrics"))

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/metrics/package-info.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/metrics/package-info.java
@@ -8,6 +8,8 @@
  * metrics.
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.autoconfigure.spi.metrics;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/package-info.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/package-info.java
@@ -5,6 +5,8 @@
 
 /** Java SPI (Service Provider Interface) for implementing extensions to SDK autoconfiguration. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.autoconfigure.spi;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/traces/package-info.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/traces/package-info.java
@@ -8,6 +8,8 @@
  * traces.
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.autoconfigure.spi.traces;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk-extensions/autoconfigure/build.gradle.kts
+++ b/sdk-extensions/autoconfigure/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
 
   implementation(project(":semconv"))
 
+  compileOnly("org.osgi:osgi.annotation")
+
   compileOnly(project(":exporters:jaeger"))
   compileOnly(project(":exporters:logging"))
   compileOnly(project(":exporters:otlp:all"))

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/package-info.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/package-info.java
@@ -4,6 +4,8 @@
  */
 
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.autoconfigure;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk-extensions/aws/build.gradle.kts
+++ b/sdk-extensions/aws/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
   api(project(":api:all"))
   api(project(":sdk:all"))
 
+  compileOnly("org.osgi:osgi.annotation")
   compileOnly(project(":sdk-extensions:autoconfigure"))
 
   annotationProcessor("com.google.auto.value:auto-value")

--- a/sdk-extensions/aws/src/main/java/io/opentelemetry/sdk/extension/aws/resource/package-info.java
+++ b/sdk-extensions/aws/src/main/java/io/opentelemetry/sdk/extension/aws/resource/package-info.java
@@ -8,6 +8,8 @@
  * resource information for AWS services.
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.extension.aws.resource;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk-extensions/aws/src/main/java/io/opentelemetry/sdk/extension/aws/trace/package-info.java
+++ b/sdk-extensions/aws/src/main/java/io/opentelemetry/sdk/extension/aws/trace/package-info.java
@@ -5,6 +5,8 @@
 
 /** Provides implementations of SDK interfaces which integrate natively with AWS infrastructure. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.extension.aws.trace;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk-extensions/jaeger-remote-sampler/build.gradle.kts
+++ b/sdk-extensions/jaeger-remote-sampler/build.gradle.kts
@@ -13,6 +13,7 @@ otelJava.moduleName.set("io.opentelemetry.sdk.extension.trace.jaeger")
 dependencies {
   api(project(":sdk:all"))
   compileOnly(project(":sdk-extensions:autoconfigure"))
+  compileOnly("org.osgi:osgi.annotation")
 
   implementation(project(":sdk:all"))
 

--- a/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/package-info.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/package-info.java
@@ -5,6 +5,8 @@
 
 /** Support for the Jaeger remote sampler. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.extension.trace.jaeger.sampler;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk-extensions/jfr-events/build.gradle.kts
+++ b/sdk-extensions/jfr-events/build.gradle.kts
@@ -7,6 +7,8 @@ description = "OpenTelemetry SDK Extension JFR"
 otelJava.moduleName.set("io.opentelemetry.sdk.extension.jfr")
 
 dependencies {
+  compileOnly("org.osgi:osgi.annotation")
+
   implementation(project(":api:all"))
   implementation(project(":sdk:all"))
 }

--- a/sdk-extensions/jfr-events/src/main/java/io/opentelemetry/sdk/extension/jfr/package-info.java
+++ b/sdk-extensions/jfr-events/src/main/java/io/opentelemetry/sdk/extension/jfr/package-info.java
@@ -9,6 +9,8 @@
  * @see io.opentelemetry.sdk.extension.jfr.JfrSpanProcessor
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.extension.jfr;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk-extensions/resources/build.gradle.kts
+++ b/sdk-extensions/resources/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
   implementation(project(":semconv"))
 
   compileOnly(project(":sdk-extensions:autoconfigure"))
+  compileOnly("org.osgi:osgi.annotation")
 
   compileOnly("org.codehaus.mojo:animal-sniffer-annotations")
 }

--- a/sdk-extensions/resources/src/main/java/io/opentelemetry/sdk/extension/resources/package-info.java
+++ b/sdk-extensions/resources/src/main/java/io/opentelemetry/sdk/extension/resources/package-info.java
@@ -8,6 +8,8 @@
  * resource information.
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.extension.resources;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk-extensions/zpages/build.gradle.kts
+++ b/sdk-extensions/zpages/build.gradle.kts
@@ -16,5 +16,6 @@ dependencies {
 
   testImplementation("com.google.guava:guava")
 
+  compileOnly("org.osgi:osgi.annotation")
   compileOnly("com.sun.net.httpserver:http")
 }

--- a/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/package-info.java
+++ b/sdk-extensions/zpages/src/main/java/io/opentelemetry/sdk/extension/zpages/package-info.java
@@ -7,6 +7,8 @@
  * The ZPages endpoint for providing debug information about an app instrumented with OpenTelemetry.
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.extension.zpages;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/all/build.gradle.kts
+++ b/sdk/all/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
   api(project(":sdk:trace"))
   api(project(":sdk:metrics"))
 
+  compileOnly("org.osgi:osgi.annotation")
+
   // implementation dependency to require users to add the artifact directly to their build to use
   // SdkLogEmitterProvider.
   implementation(project(":sdk:logs"))

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/package-info.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/package-info.java
@@ -9,6 +9,8 @@
  * @see io.opentelemetry.sdk.OpenTelemetrySdk
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/common/bnd.bnd
+++ b/sdk/common/bnd.bnd
@@ -1,1 +1,0 @@
--fixupmessages "Classes found in the wrong directory"; restrict:=error; is:=ignore

--- a/sdk/common/bnd.bnd
+++ b/sdk/common/bnd.bnd
@@ -1,0 +1,1 @@
+-fixupmessages "Classes found in the wrong directory"; restrict:=error; is:=ignore

--- a/sdk/common/build.gradle.kts
+++ b/sdk/common/build.gradle.kts
@@ -1,3 +1,4 @@
+
 plugins {
   id("otel.java-conventions")
   id("otel.publish-conventions")
@@ -12,6 +13,8 @@ val mrJarVersions = listOf(9)
 
 dependencies {
   api(project(":api:all"))
+
+  compileOnly("org.osgi:osgi.annotation")
 
   implementation(project(":semconv"))
 

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/export/package-info.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/export/package-info.java
@@ -5,6 +5,8 @@
 
 /** Common utilities used by SDK exporters. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.common.export;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/package-info.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/package-info.java
@@ -5,6 +5,8 @@
 
 /** Common utilities used by all SDK components. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.common;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/package-info.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/package-info.java
@@ -10,6 +10,8 @@
  * API, and must not be used by users of the OpenTelemetry library.
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.internal;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/resources/package-info.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/resources/package-info.java
@@ -17,6 +17,8 @@
  * k8s.io/namespace/name.
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.resources;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/logs/build.gradle.kts
+++ b/sdk/logs/build.gradle.kts
@@ -11,6 +11,8 @@ otelJava.moduleName.set("io.opentelemetry.sdk.extension.logging")
 dependencies {
   api(project(":sdk:common"))
 
+  compileOnly("org.osgi:osgi.annotation")
+
   testImplementation(project(":sdk:logs-testing"))
 
   testImplementation("org.awaitility:awaitility")

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/data/package-info.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/data/package-info.java
@@ -5,6 +5,8 @@
 
 /** The data format to model logs for export. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.logs.data;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/package-info.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/package-info.java
@@ -5,6 +5,8 @@
 
 /** Log exporters. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.logs.export;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/package-info.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/package-info.java
@@ -9,6 +9,8 @@
  * @see io.opentelemetry.sdk.logs.SdkLogEmitterProvider
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.logs;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/metrics/build.gradle.kts
+++ b/sdk/metrics/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
   api(project(":sdk:common"))
 
   compileOnly("org.codehaus.mojo:animal-sniffer-annotations")
+  compileOnly("org.osgi:osgi.annotation")
 
   annotationProcessor("com.google.auto.value:auto-value")
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/package-info.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/package-info.java
@@ -5,6 +5,8 @@
 
 /** Classes which form the in-memory representation of the OpenTelemetry metrics data model. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.metrics.data;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/package-info.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/package-info.java
@@ -8,6 +8,8 @@
  * io.opentelemetry.sdk.metrics.SdkMeterProvider}.
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.metrics.export;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/exponentialhistogram/package-info.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/exponentialhistogram/package-info.java
@@ -5,6 +5,8 @@
 
 /** The data format to model exponential histograms for export. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.metrics.internal.data.exponentialhistogram;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/package-info.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/package-info.java
@@ -5,6 +5,8 @@
 
 /** The data format to model metrics for export. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.metrics.internal.data;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/package-info.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/package-info.java
@@ -5,6 +5,8 @@
 
 /** Metric exemplar extension points. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.metrics.internal.exemplar;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/export/package-info.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/export/package-info.java
@@ -1,0 +1,7 @@
+
+@ParametersAreNonnullByDefault
+@Export
+package io.opentelemetry.sdk.metrics.internal.export;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.osgi.annotation.bundle.Export;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/package-info.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/package-info.java
@@ -4,13 +4,11 @@
  */
 
 /**
- * The SDK implementation of metrics.
+ * The SDK implementation of metrics internal.
  *
  * @see io.opentelemetry.sdk.metrics.SdkMeterProvider
  */
-@ParametersAreNonnullByDefault
 @Export
-package io.opentelemetry.sdk.metrics;
+package io.opentelemetry.sdk.metrics.internal;
 
 import org.osgi.annotation.bundle.Export;
-import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/package-info.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * The SDK internal state for metrics.
+ *
+ * Note: This package is under an internal path however classes within this package
+ * such as CallbackRegistration are present on public constructors such as SdkObservableInstrument
+ */
+@ParametersAreNonnullByDefault
+@Export
+package io.opentelemetry.sdk.metrics.internal.state;
+
+import org.osgi.annotation.bundle.Export;
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/package-info.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/package-info.java
@@ -1,11 +1,8 @@
-/*
- * Copyright The OpenTelemetry Authors
- * SPDX-License-Identifier: Apache-2.0
- */
 
 @ParametersAreNonnullByDefault
 @Export
-package io.opentelemetry.exporter.prometheus;
+package io.opentelemetry.sdk.metrics.internal.view;
 
 import org.osgi.annotation.bundle.Export;
+
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/trace/build.gradle.kts
+++ b/sdk/trace/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
   api(project(":api:all"))
   api(project(":sdk:common"))
 
+  compileOnly("org.osgi:osgi.annotation")
   compileOnly(project(":sdk:trace-shaded-deps"))
 
   implementation(project(":semconv"))

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/package-info.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/package-info.java
@@ -5,6 +5,8 @@
 
 /** The data format to model traces for export. */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.trace.data;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/package-info.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/package-info.java
@@ -20,6 +20,8 @@
  * environment variables with the use of the opentelemetry-autoconfiguration module.
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.trace.export;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/internal/data/package-info.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/internal/data/package-info.java
@@ -10,6 +10,8 @@
  * API, and must not be used by users of the OpenTelemetry library.
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.trace.internal.data;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/package-info.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/package-info.java
@@ -9,6 +9,8 @@
  * @see io.opentelemetry.sdk.trace.SdkTracerProvider
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.trace;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/package-info.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/package-info.java
@@ -35,6 +35,8 @@
  * method.
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.sdk.trace.samplers;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/semconv/build.gradle.kts
+++ b/semconv/build.gradle.kts
@@ -10,4 +10,5 @@ otelJava.moduleName.set("io.opentelemetry.semconv")
 
 dependencies {
   api(project(":api:all"))
+  compileOnly("org.osgi:osgi.annotation")
 }

--- a/semconv/src/main/java/io/opentelemetry/semconv/resource/attributes/package-info.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/resource/attributes/package-info.java
@@ -9,6 +9,8 @@
  * @see io.opentelemetry.semconv.resource.attributes.ResourceAttributes
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.semconv.resource.attributes;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/package-info.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/package-info.java
@@ -9,6 +9,8 @@
  * @see io.opentelemetry.semconv.trace.attributes.SemanticAttributes
  */
 @ParametersAreNonnullByDefault
+@Export
 package io.opentelemetry.semconv.trace.attributes;
 
+import org.osgi.annotation.bundle.Export;
 import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
Use bnd plugin to add OSGi metdata to manifest files to allow them to be used within an OSGi framework