### PR TITLE
Simple OTLP HTTP authentication - otel internal api

### DIFF
--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/auth/Authenticator.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/auth/Authenticator.java
@@ -1,0 +1,32 @@
+package io.opentelemetry.exporter.internal.auth;
+
+import io.opentelemetry.exporter.internal.grpc.GrpcExporterBuilder;
+import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public interface Authenticator {
+
+    void getHeaders(Consumer<Map<String, String>> headers);
+
+    public static void setAuthenticatorOnDelegate(Object builder, Authenticator authenticator) {
+    try {
+      Field field = builder.getClass().getDeclaredField("delegate");
+      field.setAccessible(true);
+      Object value = field.get(builder);
+      if (value instanceof GrpcExporterBuilder) {
+        throw new IllegalArgumentException(
+            "DefaultGrpcExporterBuilder not supported yet.");
+//        ((GrpcExporterBuilder<?>) value).setRetryPolicy(retryPolicy);
+      } else if (value instanceof OkHttpExporterBuilder) {
+        ((OkHttpExporterBuilder<?>) value).setAuthenticator(authenticator);
+      } else {
+        throw new IllegalArgumentException(
+            "Delegate field is not type DefaultGrpcExporterBuilder or OkHttpGrpcExporterBuilder.");
+      }
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new IllegalArgumentException("Unable to access delegate reflectively.", e);
+    }
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/auth/Authenticator.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/auth/Authenticator.java
@@ -25,7 +25,7 @@ public interface Authenticator {
 
   /**
    * Reflectively access a {@link GrpcExporterBuilder}, or {@link OkHttpExporterBuilder} instance in
-   * field called "delegate" of the instance, and set the {@link RetryPolicy}.
+   * field called "delegate" of the instance, and set the {@link Authenticator}.
    *
    * @throws IllegalArgumentException if the instance does not contain a field called "delegate" of
    *     a supported type.

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/auth/Authenticator.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/auth/Authenticator.java
@@ -11,15 +11,20 @@ import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.function.Consumer;
 
-/** Internal class to allow users of OTLP-OkHttp exporters to add support for authentication. */
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ *
+ * <p>Allow users of OTLP-OkHttp exporters to add support for authentication.
+ */
 public interface Authenticator {
 
   /**
    * Method called by the exporter to get headers to be used on a request that requires
    * authentication.
    *
-   * @param headers Consumer callback to be used to propagate headers to the underlying OTLP HTTP
-   *     exporter implementation.
+   * @param headersConsumer Consumer callback to be used to propagate headers to the underlying OTLP
+   *     HTTP exporter implementation.
    */
   void getHeaders(Consumer<Map<String, String>> headersConsumer);
 
@@ -27,10 +32,12 @@ public interface Authenticator {
    * Reflectively access a {@link GrpcExporterBuilder}, or {@link OkHttpExporterBuilder} instance in
    * field called "delegate" of the instance, and set the {@link Authenticator}.
    *
+   * @param builder export builder to modify
+   * @param authenticator authenticator to set on builder
    * @throws IllegalArgumentException if the instance does not contain a field called "delegate" of
    *     a supported type.
    */
- static void setAuthenticatorOnDelegate(Object builder, Authenticator authenticator) {
+  static void setAuthenticatorOnDelegate(Object builder, Authenticator authenticator) {
     try {
       Field field = builder.getClass().getDeclaredField("delegate");
       field.setAccessible(true);

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/auth/Authenticator.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/auth/Authenticator.java
@@ -9,7 +9,6 @@ import io.opentelemetry.exporter.internal.grpc.GrpcExporterBuilder;
 import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
 import java.lang.reflect.Field;
 import java.util.Map;
-import java.util.function.Consumer;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
@@ -23,10 +22,9 @@ public interface Authenticator {
    * Method called by the exporter to get headers to be used on a request that requires
    * authentication.
    *
-   * @param headersConsumer Consumer callback to be used to propagate headers to the underlying OTLP
-   *     HTTP exporter implementation.
+   * @return Headers to add to the request
    */
-  void getHeaders(Consumer<Map<String, String>> headersConsumer);
+  Map<String, String> getHeaders();
 
   /**
    * Reflectively access a {@link GrpcExporterBuilder}, or {@link OkHttpExporterBuilder} instance in

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/auth/Authenticator.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/auth/Authenticator.java
@@ -36,7 +36,7 @@ public interface Authenticator {
       field.setAccessible(true);
       Object value = field.get(builder);
       if (value instanceof GrpcExporterBuilder) {
-        throw new IllegalArgumentException("DefaultGrpcExporterBuilder not supported yet.");
+        throw new IllegalArgumentException("GrpcExporterBuilder not supported yet.");
       } else if (value instanceof OkHttpExporterBuilder) {
         ((OkHttpExporterBuilder<?>) value).setAuthenticator(authenticator);
       } else {

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/auth/Authenticator.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/auth/Authenticator.java
@@ -30,7 +30,7 @@ public interface Authenticator {
    * @throws IllegalArgumentException if the instance does not contain a field called "delegate" of
    *     a supported type.
    */
-  public static void setAuthenticatorOnDelegate(Object builder, Authenticator authenticator) {
+ static void setAuthenticatorOnDelegate(Object builder, Authenticator authenticator) {
     try {
       Field field = builder.getClass().getDeclaredField("delegate");
       field.setAccessible(true);

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/auth/Authenticator.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/auth/Authenticator.java
@@ -21,7 +21,7 @@ public interface Authenticator {
    * @param headers Consumer callback to be used to propagate headers to the underlying OTLP HTTP
    *     exporter implementation.
    */
-  void getHeaders(Consumer<Map<String, String>> headers);
+  void getHeaders(Consumer<Map<String, String>> headersConsumer);
 
   /**
    * Reflectively access a {@link GrpcExporterBuilder}, or {@link OkHttpExporterBuilder} instance in

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/auth/Authenticator.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/auth/Authenticator.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.exporter.internal.auth;
 
 import io.opentelemetry.exporter.internal.grpc.GrpcExporterBuilder;
@@ -6,19 +11,32 @@ import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.function.Consumer;
 
+/** Internal class to allow users of OTLP-OkHttp exporters to add support for authentication. */
 public interface Authenticator {
 
-    void getHeaders(Consumer<Map<String, String>> headers);
+  /**
+   * Method called by the exporter to get headers to be used on a request that requires
+   * authentication.
+   *
+   * @param headers Consumer callback to be used to propagate headers to the underlying OTLP HTTP
+   *     exporter implementation.
+   */
+  void getHeaders(Consumer<Map<String, String>> headers);
 
-    public static void setAuthenticatorOnDelegate(Object builder, Authenticator authenticator) {
+  /**
+   * Reflectively access a {@link GrpcExporterBuilder}, or {@link OkHttpExporterBuilder} instance in
+   * field called "delegate" of the instance, and set the {@link RetryPolicy}.
+   *
+   * @throws IllegalArgumentException if the instance does not contain a field called "delegate" of
+   *     a supported type.
+   */
+  public static void setAuthenticatorOnDelegate(Object builder, Authenticator authenticator) {
     try {
       Field field = builder.getClass().getDeclaredField("delegate");
       field.setAccessible(true);
       Object value = field.get(builder);
       if (value instanceof GrpcExporterBuilder) {
-        throw new IllegalArgumentException(
-            "DefaultGrpcExporterBuilder not supported yet.");
-//        ((GrpcExporterBuilder<?>) value).setRetryPolicy(retryPolicy);
+        throw new IllegalArgumentException("DefaultGrpcExporterBuilder not supported yet.");
       } else if (value instanceof OkHttpExporterBuilder) {
         ((OkHttpExporterBuilder<?>) value).setAuthenticator(authenticator);
       } else {

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/OkHttpExporterBuilder.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/OkHttpExporterBuilder.java
@@ -149,15 +149,17 @@ public final class OkHttpExporterBuilder<T extends Marshaler> {
 
     if (authenticator != null) {
       Authenticator finalAuthenticator = authenticator;
-      clientBuilder.authenticator((Route route, Response rspns) -> {
-
-          Request.Builder requestBuilder = rspns.request().newBuilder();
-          finalAuthenticator.getHeaders(ah -> {
-              ah.entrySet().stream()
+      // Generate and attach OkHttp Authenticator implementation
+      clientBuilder.authenticator(
+          (Route route, Response rspns) -> {
+            Request.Builder requestBuilder = rspns.request().newBuilder();
+            finalAuthenticator.getHeaders(
+                ah -> {
+                  ah.entrySet().stream()
                       .forEach(e -> requestBuilder.header(e.getKey(), e.getValue()));
+                });
+            return requestBuilder.build();
           });
-          return requestBuilder.build();
-      });
     }
 
     return new OkHttpExporter<>(

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/OkHttpExporterBuilder.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/OkHttpExporterBuilder.java
@@ -151,7 +151,7 @@ public final class OkHttpExporterBuilder<T extends Marshaler> {
       Authenticator finalAuthenticator = authenticator;
       // Generate and attach OkHttp Authenticator implementation
       clientBuilder.authenticator(
-          (Route route, Response rspns) -> {
+          (route, response) -> {
             Request.Builder requestBuilder = rspns.request().newBuilder();
             finalAuthenticator.getHeaders(
                 ah -> {

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/OkHttpExporterBuilder.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/OkHttpExporterBuilder.java
@@ -22,8 +22,6 @@ import javax.net.ssl.X509TrustManager;
 import okhttp3.Headers;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.Route;
 
 /**
  * A builder for {@link OkHttpExporter}.
@@ -152,12 +150,9 @@ public final class OkHttpExporterBuilder<T extends Marshaler> {
       // Generate and attach OkHttp Authenticator implementation
       clientBuilder.authenticator(
           (route, response) -> {
-            Request.Builder requestBuilder = rspns.request().newBuilder();
+            Request.Builder requestBuilder = response.request().newBuilder();
             finalAuthenticator.getHeaders(
-                ah -> {
-                  ah.entrySet().stream()
-                      .forEach(e -> requestBuilder.header(e.getKey(), e.getValue()));
-                });
+                authHeaders -> authHeaders.forEach(requestBuilder::header));
             return requestBuilder.build();
           });
     }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/OkHttpExporterBuilder.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/OkHttpExporterBuilder.java
@@ -151,8 +151,7 @@ public final class OkHttpExporterBuilder<T extends Marshaler> {
       clientBuilder.authenticator(
           (route, response) -> {
             Request.Builder requestBuilder = response.request().newBuilder();
-            finalAuthenticator.getHeaders(
-                authHeaders -> authHeaders.forEach(requestBuilder::header));
+            finalAuthenticator.getHeaders().forEach(requestBuilder::header);
             return requestBuilder.build();
           });
     }

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatingExporterTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatingExporterTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.testing.junit5.server.mock.MockWebServerExtension;
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RetryInterceptorTest {
+
+  @RegisterExtension static final MockWebServerExtension server = new MockWebServerExtension();
+
+  @Mock private RetryInterceptor.Sleeper sleeper;
+  @Mock private RetryInterceptor.BoundedLongGenerator random;
+  private Function<IOException, Boolean> isRetryableException;
+
+  private RetryInterceptor retrier;
+  private OkHttpClient client;
+
+  @BeforeEach
+  void setUp() {
+    // Note: cannot replace this with lambda or method reference because we need to spy on it
+    isRetryableException =
+        spy(
+            new Function<IOException, Boolean>() {
+              @Override
+              public Boolean apply(IOException exception) {
+                return RetryInterceptor.isRetryableException(exception);
+              }
+            });
+    retrier =
+        new RetryInterceptor(
+            RetryPolicy.builder()
+                .setBackoffMultiplier(1.6)
+                .setInitialBackoff(Duration.ofSeconds(1))
+                .setMaxBackoff(Duration.ofSeconds(2))
+                .setMaxAttempts(5)
+                .build(),
+            r -> !r.isSuccessful(),
+            isRetryableException,
+            sleeper,
+            random);
+    client = new OkHttpClient.Builder().addInterceptor(retrier).build();
+  }
+
+  @Test
+  void noRetry() throws Exception {
+    server.enqueue(HttpResponse.of(HttpStatus.OK));
+
+    try (Response response = sendRequest()) {
+      assertThat(response.isSuccessful()).isTrue();
+    }
+
+    verifyNoInteractions(random);
+    verifyNoInteractions(sleeper);
+  }
+
+  @ParameterizedTest
+  // Test is mostly same for 5 or more attempts since it's the max. We check the backoff timings and
+  // handling of max attempts by checking both.
+  @ValueSource(ints = {5, 6})
+  void backsOff(int attempts) throws Exception {
+    succeedOnAttempt(attempts);
+
+    // Will backoff 4 times
+    when(random.get((long) (TimeUnit.SECONDS.toNanos(1) * Math.pow(1.6, 0)))).thenReturn(100L);
+    when(random.get((long) (TimeUnit.SECONDS.toNanos(1) * Math.pow(1.6, 1)))).thenReturn(50L);
+    // Capped
+    when(random.get(TimeUnit.SECONDS.toNanos(2))).thenReturn(500L).thenReturn(510L);
+
+    doNothing().when(sleeper).sleep(100);
+    doNothing().when(sleeper).sleep(50);
+    doNothing().when(sleeper).sleep(500);
+    doNothing().when(sleeper).sleep(510);
+
+    try (Response response = sendRequest()) {
+      if (attempts <= 5) {
+        assertThat(response.isSuccessful()).isTrue();
+      } else {
+        assertThat(response.isSuccessful()).isFalse();
+      }
+    }
+
+    for (int i = 0; i < 5; i++) {
+      server.takeRequest(0, TimeUnit.NANOSECONDS);
+    }
+  }
+
+  @Test
+  void interrupted() throws Exception {
+    succeedOnAttempt(5);
+
+    // Backs off twice, second is interrupted
+    when(random.get((long) (TimeUnit.SECONDS.toNanos(1) * Math.pow(1.6, 0)))).thenReturn(100L);
+    when(random.get((long) (TimeUnit.SECONDS.toNanos(1) * Math.pow(1.6, 1)))).thenReturn(50L);
+
+    doNothing().when(sleeper).sleep(100);
+    doThrow(new InterruptedException()).when(sleeper).sleep(50);
+
+    try (Response response = sendRequest()) {
+      assertThat(response.isSuccessful()).isFalse();
+    }
+
+    for (int i = 0; i < 2; i++) {
+      server.takeRequest(0, TimeUnit.NANOSECONDS);
+    }
+  }
+
+  @Test
+  void connectTimeout() throws Exception {
+    client = connectTimeoutClient();
+    when(random.get(anyLong())).thenReturn(1L);
+    doNothing().when(sleeper).sleep(anyLong());
+
+    // Connecting to a non-routable IP address to trigger connection error
+    assertThatThrownBy(
+            () ->
+                client.newCall(new Request.Builder().url("http://10.255.255.1").build()).execute())
+        .isInstanceOf(SocketTimeoutException.class);
+
+    verify(isRetryableException, times(5)).apply(any());
+    // Should retry maxAttempts, and sleep maxAttempts - 1 times
+    verify(sleeper, times(4)).sleep(anyLong());
+  }
+
+  @Test
+  void nonRetryableException() throws InterruptedException {
+    client = connectTimeoutClient();
+    // Override isRetryableException so that no exception is retryable
+    when(isRetryableException.apply(any())).thenReturn(false);
+
+    // Connecting to a non-routable IP address to trigger connection timeout
+    assertThatThrownBy(
+            () ->
+                client.newCall(new Request.Builder().url("http://10.255.255.1").build()).execute())
+        .isInstanceOf(SocketTimeoutException.class);
+
+    verify(isRetryableException, times(1)).apply(any());
+    verify(sleeper, never()).sleep(anyLong());
+  }
+
+  private OkHttpClient connectTimeoutClient() {
+    return new OkHttpClient.Builder()
+        .connectTimeout(Duration.ofMillis(10))
+        .addInterceptor(retrier)
+        .build();
+  }
+
+  @Test
+  void isRetryableException() {
+    // Should retry on connection timeouts, where error message is "Connect timed out" or "connect
+    // timed out"
+    assertThat(
+            RetryInterceptor.isRetryableException(new SocketTimeoutException("Connect timed out")))
+        .isTrue();
+    assertThat(
+            RetryInterceptor.isRetryableException(new SocketTimeoutException("connect timed out")))
+        .isTrue();
+    // Shouldn't retry on read timeouts, where error message is "Read timed out"
+    assertThat(RetryInterceptor.isRetryableException(new SocketTimeoutException("Read timed out")))
+        .isFalse();
+    // Shouldn't retry on write timeouts, where error message is "timeout", or other IOException
+    assertThat(RetryInterceptor.isRetryableException(new SocketTimeoutException("timeout")))
+        .isFalse();
+    assertThat(RetryInterceptor.isRetryableException(new SocketTimeoutException())).isTrue();
+    assertThat(RetryInterceptor.isRetryableException(new IOException("error"))).isFalse();
+  }
+
+  private Response sendRequest() throws IOException {
+    return client.newCall(new Request.Builder().url(server.httpUri().toString()).build()).execute();
+  }
+
+  private static void succeedOnAttempt(int attempt) {
+    for (int i = 1; i < attempt; i++) {
+      server.enqueue(HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR));
+    }
+    server.enqueue(HttpResponse.of(HttpStatus.OK));
+  }
+}

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatingExporterTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatingExporterTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+/** Test Authentication in an exporter. */
 @ExtendWith(MockitoExtension.class)
 class AuthenticatingExporterTest {
 
@@ -66,8 +67,8 @@ class AuthenticatingExporterTest {
     assertTrue(result.isSuccess());
   }
 
+  /** Ensure that exporter gives up if a request is always considered UNAUTHORIZED. */
   @Test
-  @SuppressWarnings("SystemOut")
   void export_giveup() throws Exception {
     OkHttpExporter<Marshaler> exporter =
         new OkHttpExporterBuilder<>("otlp", "test", server.httpUri().toASCIIString())

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatingExporterTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatingExporterTest.java
@@ -3,210 +3,80 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.exporter.internal.retry;
+package io.opentelemetry.exporter.internal.auth;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
-import static org.mockito.internal.verification.VerificationModeFactory.times;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.testing.junit5.server.mock.MockWebServerExtension;
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.okhttp.OkHttpExporter;
+import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
+import io.opentelemetry.sdk.common.CompletableResultCode;
 import java.io.IOException;
-import java.net.SocketTimeoutException;
-import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class RetryInterceptorTest {
+class AuthenticatingExporterTest {
 
   @RegisterExtension static final MockWebServerExtension server = new MockWebServerExtension();
+  private final Marshaler marshaler =
+      new Marshaler() {
+        @Override
+        public int getBinarySerializedSize() {
+          return 0;
+        }
 
-  @Mock private RetryInterceptor.Sleeper sleeper;
-  @Mock private RetryInterceptor.BoundedLongGenerator random;
-  private Function<IOException, Boolean> isRetryableException;
-
-  private RetryInterceptor retrier;
-  private OkHttpClient client;
-
-  @BeforeEach
-  void setUp() {
-    // Note: cannot replace this with lambda or method reference because we need to spy on it
-    isRetryableException =
-        spy(
-            new Function<IOException, Boolean>() {
-              @Override
-              public Boolean apply(IOException exception) {
-                return RetryInterceptor.isRetryableException(exception);
-              }
-            });
-    retrier =
-        new RetryInterceptor(
-            RetryPolicy.builder()
-                .setBackoffMultiplier(1.6)
-                .setInitialBackoff(Duration.ofSeconds(1))
-                .setMaxBackoff(Duration.ofSeconds(2))
-                .setMaxAttempts(5)
-                .build(),
-            r -> !r.isSuccessful(),
-            isRetryableException,
-            sleeper,
-            random);
-    client = new OkHttpClient.Builder().addInterceptor(retrier).build();
-  }
+        @Override
+        protected void writeTo(Serializer output) throws IOException {}
+      };
 
   @Test
-  void noRetry() throws Exception {
+  void export() throws Exception {
+    OkHttpExporter<Marshaler> exporter =
+        new OkHttpExporterBuilder<>("otlp", "test", server.httpUri().toASCIIString())
+            .setAuthenticator(
+                (j) -> {
+                  Map<String, String> headers = new HashMap<>();
+                  headers.put("Authorization", "auth");
+                  j.accept(headers);
+                })
+            .build();
+
+    server.enqueue(HttpResponse.of(HttpStatus.UNAUTHORIZED));
     server.enqueue(HttpResponse.of(HttpStatus.OK));
 
-    try (Response response = sendRequest()) {
-      assertThat(response.isSuccessful()).isTrue();
-    }
+    CompletableResultCode result = exporter.export(marshaler, 0);
 
-    verifyNoInteractions(random);
-    verifyNoInteractions(sleeper);
-  }
+    assertNull(server.takeRequest().request().headers().get("Authorization"));
+    assertEquals("auth", server.takeRequest().request().headers().get("Authorization"));
 
-  @ParameterizedTest
-  // Test is mostly same for 5 or more attempts since it's the max. We check the backoff timings and
-  // handling of max attempts by checking both.
-  @ValueSource(ints = {5, 6})
-  void backsOff(int attempts) throws Exception {
-    succeedOnAttempt(attempts);
-
-    // Will backoff 4 times
-    when(random.get((long) (TimeUnit.SECONDS.toNanos(1) * Math.pow(1.6, 0)))).thenReturn(100L);
-    when(random.get((long) (TimeUnit.SECONDS.toNanos(1) * Math.pow(1.6, 1)))).thenReturn(50L);
-    // Capped
-    when(random.get(TimeUnit.SECONDS.toNanos(2))).thenReturn(500L).thenReturn(510L);
-
-    doNothing().when(sleeper).sleep(100);
-    doNothing().when(sleeper).sleep(50);
-    doNothing().when(sleeper).sleep(500);
-    doNothing().when(sleeper).sleep(510);
-
-    try (Response response = sendRequest()) {
-      if (attempts <= 5) {
-        assertThat(response.isSuccessful()).isTrue();
-      } else {
-        assertThat(response.isSuccessful()).isFalse();
-      }
-    }
-
-    for (int i = 0; i < 5; i++) {
-      server.takeRequest(0, TimeUnit.NANOSECONDS);
-    }
+    result.join(1, TimeUnit.MINUTES);
+    assertTrue(result.isSuccess());
   }
 
   @Test
-  void interrupted() throws Exception {
-    succeedOnAttempt(5);
-
-    // Backs off twice, second is interrupted
-    when(random.get((long) (TimeUnit.SECONDS.toNanos(1) * Math.pow(1.6, 0)))).thenReturn(100L);
-    when(random.get((long) (TimeUnit.SECONDS.toNanos(1) * Math.pow(1.6, 1)))).thenReturn(50L);
-
-    doNothing().when(sleeper).sleep(100);
-    doThrow(new InterruptedException()).when(sleeper).sleep(50);
-
-    try (Response response = sendRequest()) {
-      assertThat(response.isSuccessful()).isFalse();
-    }
-
-    for (int i = 0; i < 2; i++) {
-      server.takeRequest(0, TimeUnit.NANOSECONDS);
-    }
-  }
-
-  @Test
-  void connectTimeout() throws Exception {
-    client = connectTimeoutClient();
-    when(random.get(anyLong())).thenReturn(1L);
-    doNothing().when(sleeper).sleep(anyLong());
-
-    // Connecting to a non-routable IP address to trigger connection error
-    assertThatThrownBy(
-            () ->
-                client.newCall(new Request.Builder().url("http://10.255.255.1").build()).execute())
-        .isInstanceOf(SocketTimeoutException.class);
-
-    verify(isRetryableException, times(5)).apply(any());
-    // Should retry maxAttempts, and sleep maxAttempts - 1 times
-    verify(sleeper, times(4)).sleep(anyLong());
-  }
-
-  @Test
-  void nonRetryableException() throws InterruptedException {
-    client = connectTimeoutClient();
-    // Override isRetryableException so that no exception is retryable
-    when(isRetryableException.apply(any())).thenReturn(false);
-
-    // Connecting to a non-routable IP address to trigger connection timeout
-    assertThatThrownBy(
-            () ->
-                client.newCall(new Request.Builder().url("http://10.255.255.1").build()).execute())
-        .isInstanceOf(SocketTimeoutException.class);
-
-    verify(isRetryableException, times(1)).apply(any());
-    verify(sleeper, never()).sleep(anyLong());
-  }
-
-  private OkHttpClient connectTimeoutClient() {
-    return new OkHttpClient.Builder()
-        .connectTimeout(Duration.ofMillis(10))
-        .addInterceptor(retrier)
-        .build();
-  }
-
-  @Test
-  void isRetryableException() {
-    // Should retry on connection timeouts, where error message is "Connect timed out" or "connect
-    // timed out"
-    assertThat(
-            RetryInterceptor.isRetryableException(new SocketTimeoutException("Connect timed out")))
-        .isTrue();
-    assertThat(
-            RetryInterceptor.isRetryableException(new SocketTimeoutException("connect timed out")))
-        .isTrue();
-    // Shouldn't retry on read timeouts, where error message is "Read timed out"
-    assertThat(RetryInterceptor.isRetryableException(new SocketTimeoutException("Read timed out")))
-        .isFalse();
-    // Shouldn't retry on write timeouts, where error message is "timeout", or other IOException
-    assertThat(RetryInterceptor.isRetryableException(new SocketTimeoutException("timeout")))
-        .isFalse();
-    assertThat(RetryInterceptor.isRetryableException(new SocketTimeoutException())).isTrue();
-    assertThat(RetryInterceptor.isRetryableException(new IOException("error"))).isFalse();
-  }
-
-  private Response sendRequest() throws IOException {
-    return client.newCall(new Request.Builder().url(server.httpUri().toString()).build()).execute();
-  }
-
-  private static void succeedOnAttempt(int attempt) {
-    for (int i = 1; i < attempt; i++) {
-      server.enqueue(HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR));
-    }
-    server.enqueue(HttpResponse.of(HttpStatus.OK));
+  @SuppressWarnings("SystemOut")
+  void export_giveup() throws Exception {
+    OkHttpExporter<Marshaler> exporter =
+        new OkHttpExporterBuilder<>("otlp", "test", server.httpUri().toASCIIString())
+            .setAuthenticator(
+                (j) -> {
+                  server.enqueue(HttpResponse.of(HttpStatus.UNAUTHORIZED));
+                })
+            .build();
+    server.enqueue(HttpResponse.of(HttpStatus.UNAUTHORIZED));
+    assertFalse(exporter.export(marshaler, 0).join(1, TimeUnit.MINUTES).isSuccess());
   }
 }

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatingExporterTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatingExporterTest.java
@@ -16,6 +16,7 @@ import io.opentelemetry.exporter.internal.okhttp.OkHttpExporter;
 import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -45,10 +46,10 @@ class AuthenticatingExporterTest {
     OkHttpExporter<Marshaler> exporter =
         new OkHttpExporterBuilder<>("otlp", "test", server.httpUri().toASCIIString())
             .setAuthenticator(
-                (j) -> {
+                () -> {
                   Map<String, String> headers = new HashMap<>();
                   headers.put("Authorization", "auth");
-                  j.accept(headers);
+                  return headers;
                 })
             .build();
 
@@ -70,8 +71,9 @@ class AuthenticatingExporterTest {
     OkHttpExporter<Marshaler> exporter =
         new OkHttpExporterBuilder<>("otlp", "test", server.httpUri().toASCIIString())
             .setAuthenticator(
-                (j) -> {
+                () -> {
                   server.enqueue(HttpResponse.of(HttpStatus.UNAUTHORIZED));
+                  return Collections.emptyMap();
                 })
             .build();
     server.enqueue(HttpResponse.of(HttpStatus.UNAUTHORIZED));

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatingExporterTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatingExporterTest.java
@@ -5,10 +5,7 @@
 
 package io.opentelemetry.exporter.internal.auth;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -60,11 +57,11 @@ class AuthenticatingExporterTest {
 
     CompletableResultCode result = exporter.export(marshaler, 0);
 
-    assertNull(server.takeRequest().request().headers().get("Authorization"));
-    assertEquals("auth", server.takeRequest().request().headers().get("Authorization"));
+    assertThat(server.takeRequest().request().headers().get("Authorization")).isNull();
+    assertThat(server.takeRequest().request().headers().get("Authorization")).isEqualTo("auth");
 
     result.join(1, TimeUnit.MINUTES);
-    assertTrue(result.isSuccess());
+    assertThat(result.isSuccess()).isTrue();
   }
 
   /** Ensure that exporter gives up if a request is always considered UNAUTHORIZED. */
@@ -78,6 +75,6 @@ class AuthenticatingExporterTest {
                 })
             .build();
     server.enqueue(HttpResponse.of(HttpStatus.UNAUTHORIZED));
-    assertFalse(exporter.export(marshaler, 0).join(1, TimeUnit.MINUTES).isSuccess());
+    assertThat(exporter.export(marshaler, 0).join(1, TimeUnit.MINUTES).isSuccess()).isFalse();
   }
 }

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatorTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatorTest.java
@@ -8,7 +8,6 @@ package io.opentelemetry.exporter.internal.auth;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.exporter.internal.grpc.GrpcExporter;
 import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
@@ -22,7 +21,7 @@ import org.junit.jupiter.api.Test;
 class AuthenticatorTest {
 
   @Test
-  void testGetHeaders() {
+  void getHeaders() {
     Map<String, String> input = new HashMap<>();
     input.put("key1", "value1");
     input.put("key2", "value2");
@@ -33,11 +32,11 @@ class AuthenticatorTest {
           headers.accept(input);
         };
     authenticator.getHeaders(result::putAll);
-    assertEquals(input, result);
+    assertThat(result).isEqualTo(input);
   }
 
   @Test
-  void testSetAuthenticatorOnDelegate_Success() {
+  void setAuthenticatorOnDelegate_Success() {
     OkHttpExporterBuilder<?> builder =
         new OkHttpExporterBuilder<>("otlp", "test", "http://localhost:4318/test");
 
@@ -53,7 +52,7 @@ class AuthenticatorTest {
   }
 
   @Test
-  void testSetAuthenticatorOnDelegate_Fail() {
+  void setAuthenticatorOnDelegate_Fail() {
 
     Authenticator authenticator = (Consumer<Map<String, String>> headers) -> {};
 

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatorTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatorTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.opentelemetry.exporter.internal.grpc.GrpcExporter;
 import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
 import java.util.HashMap;
 import java.util.Map;
@@ -57,6 +58,17 @@ class AuthenticatorTest {
     Authenticator authenticator = (Consumer<Map<String, String>> headers) -> {};
 
     assertThatThrownBy(() -> Authenticator.setAuthenticatorOnDelegate(new Object(), authenticator))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () ->
+                Authenticator.setAuthenticatorOnDelegate(
+                    new WithDelegate(new Object()), authenticator))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () ->
+                Authenticator.setAuthenticatorOnDelegate(
+                    new WithDelegate(GrpcExporter.builder(null, null, 0, null, null, null)),
+                    authenticator))
         .isInstanceOf(IllegalArgumentException.class);
   }
 

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatorTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.auth;
+
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+
+/** Authenticator tests */
+class AuthenticatorTest {
+
+  /** Test of getHeaders method, of class Authenticator. */
+  @Test
+  void testGetHeaders() {
+    Map<String, String> input = new HashMap<>();
+    input.put("key1", "value1");
+    input.put("key2", "value2");
+    Map<String, String> result = new HashMap<>();
+
+    Authenticator authenticator =
+        (Consumer<Map<String, String>> headers) -> {
+          headers.accept(input);
+        };
+    authenticator.getHeaders(result::putAll);
+    assertEquals(input, result);
+  }
+
+  /** Test of setAuthenticatorOnDelegate method, of class Authenticator. */
+  @Test
+  void testSetAuthenticatorOnDelegate_Success() {
+    OkHttpExporterBuilder<?> builder =
+        new OkHttpExporterBuilder<>("otlp", "test", "http://localhost:4318/test");
+
+    assertThat(builder).extracting("authenticator").isNull();
+
+    Authenticator authenticator = (Consumer<Map<String, String>> headers) -> {};
+
+    Authenticator.setAuthenticatorOnDelegate(new WithDelegate(builder), authenticator);
+
+    assertThat(builder)
+        .extracting("authenticator", as(InstanceOfAssertFactories.type(Authenticator.class)))
+        .isSameAs(authenticator);
+  }
+
+  @Test
+  void testSetAuthenticatorOnDelegate_Fail() {
+
+    Authenticator authenticator = (Consumer<Map<String, String>> headers) -> {};
+
+    assertThatThrownBy(() -> Authenticator.setAuthenticatorOnDelegate(new Object(), authenticator))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @SuppressWarnings({"UnusedVariable", "FieldCanBeLocal"})
+  private static class WithDelegate {
+
+    private final Object delegate;
+
+    private WithDelegate(Object delegate) {
+      this.delegate = delegate;
+    }
+  }
+}

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatorTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatorTest.java
@@ -17,10 +17,9 @@ import java.util.function.Consumer;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
-/** Authenticator tests */
+/** Authenticator tests. */
 class AuthenticatorTest {
 
-  /** Test of getHeaders method, of class Authenticator. */
   @Test
   void testGetHeaders() {
     Map<String, String> input = new HashMap<>();
@@ -36,7 +35,6 @@ class AuthenticatorTest {
     assertEquals(input, result);
   }
 
-  /** Test of setAuthenticatorOnDelegate method, of class Authenticator. */
   @Test
   void testSetAuthenticatorOnDelegate_Success() {
     OkHttpExporterBuilder<?> builder =

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatorTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatorTest.java
@@ -17,7 +17,6 @@ import java.util.function.Consumer;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
-/** Authenticator tests. */
 class AuthenticatorTest {
 
   @Test

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatorTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatorTest.java
@@ -52,7 +52,6 @@ class AuthenticatorTest {
 
   @Test
   void setAuthenticatorOnDelegate_Fail() {
-
     Authenticator authenticator = (Consumer<Map<String, String>> headers) -> {};
 
     assertThatThrownBy(() -> Authenticator.setAuthenticatorOnDelegate(new Object(), authenticator))

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatorTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/auth/AuthenticatorTest.java
@@ -11,9 +11,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.exporter.internal.grpc.GrpcExporter;
 import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
@@ -24,14 +24,9 @@ class AuthenticatorTest {
     Map<String, String> input = new HashMap<>();
     input.put("key1", "value1");
     input.put("key2", "value2");
-    Map<String, String> result = new HashMap<>();
 
-    Authenticator authenticator =
-        (Consumer<Map<String, String>> headers) -> {
-          headers.accept(input);
-        };
-    authenticator.getHeaders(result::putAll);
-    assertThat(result).isEqualTo(input);
+    Authenticator authenticator = () -> new HashMap<>(input);
+    assertThat(authenticator.getHeaders()).isEqualTo(input);
   }
 
   @Test
@@ -41,7 +36,7 @@ class AuthenticatorTest {
 
     assertThat(builder).extracting("authenticator").isNull();
 
-    Authenticator authenticator = (Consumer<Map<String, String>> headers) -> {};
+    Authenticator authenticator = Collections::emptyMap;
 
     Authenticator.setAuthenticatorOnDelegate(new WithDelegate(builder), authenticator);
 
@@ -52,7 +47,7 @@ class AuthenticatorTest {
 
   @Test
   void setAuthenticatorOnDelegate_Fail() {
-    Authenticator authenticator = (Consumer<Map<String, String>> headers) -> {};
+    Authenticator authenticator = Collections::emptyMap;
 
     assertThatThrownBy(() -> Authenticator.setAuthenticatorOnDelegate(new Object(), authenticator))
         .isInstanceOf(IllegalArgumentException.class);


### PR DESCRIPTION
Support simple authentication protocols on OTLP HTTP exporters as discussed in, https://github.com/open-telemetry/opentelemetry-java/issues/4590