### PR TITLE
Update to semconv 1.12.0, build tools 0.8.0

### DIFF
--- a/buildscripts/semantic-convention/generate.sh
+++ b/buildscripts/semantic-convention/generate.sh
@@ -4,10 +4,10 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../../"
 
 # freeze the spec & generator tools versions to make SemanticAttributes generation reproducible
-SEMCONV_VERSION=1.9.0
+SEMCONV_VERSION=1.12.0
 SPEC_VERSION=v$SEMCONV_VERSION
 SCHEMA_URL=https://opentelemetry.io/schemas/$SEMCONV_VERSION
-GENERATOR_VERSION=0.7.0
+GENERATOR_VERSION=0.8.0
 
 cd ${SCRIPT_DIR}
 

--- a/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/SemanticAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/SemanticAttributes.java
@@ -18,7 +18,7 @@ import java.util.List;
 // buildscripts/semantic-convention/templates/SemanticAttributes.java.j2
 public final class SemanticAttributes {
   /** The URL of the OpenTelemetry schema for these keys and values. */
-  public static final String SCHEMA_URL = "https://opentelemetry.io/schemas/1.9.0";
+  public static final String SCHEMA_URL = "https://opentelemetry.io/schemas/1.12.0";
 
   /**
    * The full invoked ARN as provided on the {@code Context} passed to the function ({@code
@@ -33,6 +33,45 @@ public final class SemanticAttributes {
    */
   public static final AttributeKey<String> AWS_LAMBDA_INVOKED_ARN =
       stringKey("aws.lambda.invoked_arn");
+
+  /**
+   * The <a
+   * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#id">event_id</a>
+   * uniquely identifies the event.
+   */
+  public static final AttributeKey<String> CLOUDEVENTS_EVENT_ID = stringKey("cloudevents.event_id");
+
+  /**
+   * The <a
+   * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#source-1">source</a>
+   * identifies the context in which an event happened.
+   */
+  public static final AttributeKey<String> CLOUDEVENTS_EVENT_SOURCE =
+      stringKey("cloudevents.event_source");
+
+  /**
+   * The <a
+   * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#specversion">version
+   * of the CloudEvents specification</a> which the event uses.
+   */
+  public static final AttributeKey<String> CLOUDEVENTS_EVENT_SPEC_VERSION =
+      stringKey("cloudevents.event_spec_version");
+
+  /**
+   * The <a
+   * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type">event_type</a>
+   * contains a value describing the type of event related to the originating occurrence.
+   */
+  public static final AttributeKey<String> CLOUDEVENTS_EVENT_TYPE =
+      stringKey("cloudevents.event_type");
+
+  /**
+   * The <a
+   * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#subject">subject</a>
+   * of the event in the context of the event producer (identified by source).
+   */
+  public static final AttributeKey<String> CLOUDEVENTS_EVENT_SUBJECT =
+      stringKey("cloudevents.event_subject");
 
   /**
    * Parent-child Reference type
@@ -227,7 +266,7 @@ public final class SemanticAttributes {
    *   <li>It is usually not possible to determine at the point where an exception is thrown whether
    *       it will escape the scope of a span. However, it is trivial to know that an exception will
    *       escape, if one checks for an active exception just before ending the span, as done in the
-   *       <a href="#exception-end-example">example above</a>.
+   *       <a href="#recording-an-exception">example above</a>.
    *   <li>It follows that an exception may still escape the scope of the span even if the {@code
    *       exception.escaped} attribute was not set or set to false, since the event might have been
    *       recorded at a time where it was not clear whether the exception will escape.
@@ -344,7 +383,16 @@ public final class SemanticAttributes {
   /** Remote port number. */
   public static final AttributeKey<Long> NET_PEER_PORT = longKey("net.peer.port");
 
-  /** Remote hostname or similar, see note below. */
+  /**
+   * Remote hostname or similar, see note below.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>{@code net.peer.name} SHOULD NOT be set if capturing it would require an extra DNS
+   *       lookup.
+   * </ul>
+   */
   public static final AttributeKey<String> NET_PEER_NAME = stringKey("net.peer.name");
 
   /** Like {@code net.peer.ip} but for the host IP. Useful in case of a multi-IP host. */
@@ -531,6 +579,9 @@ public final class SemanticAttributes {
    */
   public static final AttributeKey<Long> HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED =
       longKey("http.response_content_length_uncompressed");
+
+  /** The ordinal number of request re-sending attempt. */
+  public static final AttributeKey<Long> HTTP_RETRY_COUNT = longKey("http.retry_count");
 
   /**
    * The primary server name of the matched virtual host. This should be obtained via configuration.
@@ -794,7 +845,7 @@ public final class SemanticAttributes {
   public static final AttributeKey<String> MESSAGING_ROCKETMQ_CONSUMPTION_MODEL =
       stringKey("messaging.rocketmq.consumption_model");
 
-  /** A string identifying the remoting system. */
+  /** A string identifying the remoting system. See below for a list of well-known identifiers. */
   public static final AttributeKey<String> RPC_SYSTEM = stringKey("rpc.system");
 
   /**
@@ -1137,12 +1188,14 @@ public final class SemanticAttributes {
   }
 
   public static final class HttpFlavorValues {
-    /** HTTP 1.0. */
+    /** HTTP/1.0. */
     public static final String HTTP_1_0 = "1.0";
-    /** HTTP 1.1. */
+    /** HTTP/1.1. */
     public static final String HTTP_1_1 = "1.1";
-    /** HTTP 2. */
+    /** HTTP/2. */
     public static final String HTTP_2_0 = "2.0";
+    /** HTTP/3. */
+    public static final String HTTP_3_0 = "3.0";
     /** SPDY protocol. */
     public static final String SPDY = "SPDY";
     /** QUIC protocol. */
@@ -1189,6 +1242,19 @@ public final class SemanticAttributes {
     public static final String BROADCASTING = "broadcasting";
 
     private MessagingRocketmqConsumptionModelValues() {}
+  }
+
+  public static final class RpcSystemValues {
+    /** gRPC. */
+    public static final String GRPC = "grpc";
+    /** Java RMI. */
+    public static final String JAVA_RMI = "java_rmi";
+    /** .NET WCF. */
+    public static final String DOTNET_WCF = "dotnet_wcf";
+    /** Apache Dubbo. */
+    public static final String APACHE_DUBBO = "apache_dubbo";
+
+    private RpcSystemValues() {}
   }
 
   public static final class RpcGrpcStatusCodeValues {


### PR DESCRIPTION
Build tools latest is at version 0.12.1 but that references semantic convention schema key `requirement_level` which will be released in the next version of the specification. 