### PR TITLE
Move AttributesMap to :sdk:common

### DIFF
--- a/sdk/common/src/test/java/io/opentelemetry/sdk/internal/AttributesMapTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/internal/AttributesMapTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.trace;
+package io.opentelemetry.sdk.internal;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,7 +15,7 @@ class AttributesMapTest {
 
   @Test
   void asMap() {
-    AttributesMap attributesMap = new AttributesMap(2, Integer.MAX_VALUE);
+    AttributesMap attributesMap = AttributesMap.create(2, Integer.MAX_VALUE);
     attributesMap.put(longKey("one"), 1L);
     attributesMap.put(longKey("two"), 2L);
 

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
@@ -16,6 +16,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.internal.AttributeUtil;
+import io.opentelemetry.sdk.internal.AttributesMap;
 import io.opentelemetry.sdk.internal.InstrumentationScopeUtil;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.EventData;
@@ -287,7 +288,7 @@ final class SdkSpan implements ReadWriteSpan {
       }
       if (attributes == null) {
         attributes =
-            new AttributesMap(
+            AttributesMap.create(
                 spanLimits.getMaxNumberOfAttributes(), spanLimits.getMaxAttributeValueLength());
       }
 

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java
@@ -22,6 +22,7 @@ import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.internal.AttributeUtil;
+import io.opentelemetry.sdk.internal.AttributesMap;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;
@@ -236,7 +237,7 @@ final class SdkSpanBuilder implements SpanBuilder {
     AttributesMap attributes = this.attributes;
     if (attributes == null) {
       this.attributes =
-          new AttributesMap(
+          AttributesMap.create(
               spanLimits.getMaxNumberOfAttributes(), spanLimits.getMaxAttributeValueLength());
       attributes = this.attributes;
     }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanTest.java
@@ -29,6 +29,7 @@ import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.internal.AttributesMap;
 import io.opentelemetry.sdk.internal.InstrumentationScopeUtil;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.time.TestClock;
@@ -1043,7 +1044,7 @@ class SdkSpanTest {
   private SdkSpan createTestSpanWithAttributes(Map<AttributeKey, Object> attributes) {
     SpanLimits spanLimits = SpanLimits.getDefault();
     AttributesMap attributesMap =
-        new AttributesMap(
+        AttributesMap.create(
             spanLimits.getMaxNumberOfAttributes(), spanLimits.getMaxAttributeValueLength());
     attributes.forEach(attributesMap::put);
     return createTestSpan(
@@ -1159,8 +1160,8 @@ class SdkSpanTest {
     TestClock clock = TestClock.create();
     Resource resource = this.resource;
     Attributes attributes = TestUtils.generateRandomAttributes();
-    AttributesMap attributesWithCapacity = new AttributesMap(32, Integer.MAX_VALUE);
-    attributes.forEach((key, value) -> attributesWithCapacity.put((AttributeKey) key, value));
+    AttributesMap attributesWithCapacity = AttributesMap.create(32, Integer.MAX_VALUE);
+    attributes.forEach(attributesWithCapacity::put);
     Attributes event1Attributes = TestUtils.generateRandomAttributes();
     Attributes event2Attributes = TestUtils.generateRandomAttributes();
     SpanContext context =


### PR DESCRIPTION
The log SDK needs a mutable `Attributes` implementation to avoid excess allocations. Moving `AttributesMap` to `:sdk:common` rather than reimplementing. 