### PR TITLE
jApiCmp: check if source is compatible 

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,6 +12,7 @@ repositories {
 }
 
 dependencies {
+  implementation("com.google.auto.value:auto-value-annotations:1.9")
   // When updating, update above in plugins too
   implementation("com.diffplug.spotless:spotless-plugin-gradle:6.4.2")
   // Needed for japicmp but not automatically brought in for some reason.

--- a/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
@@ -46,8 +46,10 @@ class AllowDefaultMethodRule : AbstractRecordingSeenMembers() {
         // change.
         continue
       }
-
-      if (!change.isSourceCompatible && !isAbstractMethodOnAutoValue(member, change)) {
+      if (!isAbstractMethodOnAutoValue(member, change)) {
+        continue;
+      }
+      if (!change.isSourceCompatible) {
         return Violation.error(member, "Not source compatible")
       }
       if (!change.isBinaryCompatible) {

--- a/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
@@ -46,8 +46,8 @@ class AllowDefaultMethodRule : AbstractRecordingSeenMembers() {
         // change.
         continue
       }
-      if (!isAbstractMethodOnAutoValue(member, change)) {
-        continue;
+      if (isAbstractMethodOnAutoValue(member, change)) {
+        continue
       }
       if (!change.isSourceCompatible) {
         return Violation.error(member, "Not source compatible")

--- a/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
@@ -61,8 +61,8 @@ class AllowDefaultMethodRule : AbstractRecordingSeenMembers() {
 
   /**
    * Checks if the change is an abstract method on a class annotated with AutoValue.
-   * AutoValues need to override default interface implementations and declare them abstract again
-   * Which causes METHOD_ABSTRACT_ADDED_TO_CLASS no source-compatible change. It's
+   * AutoValues need to override default interface methods and declare them abstract again.
+   * It causes METHOD_ABSTRACT_ADDED_TO_CLASS - source-incompatible change. It's
    * false-positive since AutoValue will generate implementation anyway.
    */
   fun isAbstractMethodOnAutoValue(member: JApiCompatibility, change: JApiCompatibilityChange): Boolean {

--- a/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
@@ -44,7 +44,7 @@ class AllowDefaultMethodRule : AbstractRecordingSeenMembers() {
         // change.
         continue
       }
-      if (!change.isBinaryCompatible) {
+      if (!change.isBinaryCompatible || !change.isSourceCompatible) {
         return Violation.notBinaryCompatible(member, Severity.error)
       }
     }


### PR DESCRIPTION
Adds a check for API change source compatibility. Could prevent issues like #4639

 I couldn't find documentation on it though except [corresponding test](https://github.com/siom79/japicmp/blob/ec933f5bb5d6ee3d3a343a75d1aef03106add8c5/japicmp/src/test/java/japicmp/compat/CompatibilityChangesTest.java#L986).

Tried it by adding a new method to a public interface. Without this change build passes, with this change it fails.