### PR TITLE
[enh] Make maxAccumulations configurable and add remove method for meters

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DefaultMeter.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DefaultMeter.java
@@ -112,6 +112,11 @@ class DefaultMeter implements Meter {
     }
 
     @Override
+    public LongCounterBuilder setMaxAccumulations(int maxAccumulations) {
+      return this;
+    }
+
+    @Override
     public DoubleCounterBuilder ofDoubles() {
       return NOOP_DOUBLE_COUNTER_BUILDER;
     }
@@ -145,6 +150,11 @@ class DefaultMeter implements Meter {
     @Override
     public DoubleCounterBuilder setUnit(String unit) {
       ValidationUtil.checkValidInstrumentUnit(unit);
+      return this;
+    }
+
+    @Override
+    public DoubleCounterBuilder setMaxAccumulations(int maxAccumulations) {
       return this;
     }
 
@@ -206,6 +216,11 @@ class DefaultMeter implements Meter {
     }
 
     @Override
+    public LongUpDownCounterBuilder setMaxAccumulations(int maxAccumulations) {
+      return this;
+    }
+
+    @Override
     public DoubleUpDownCounterBuilder ofDoubles() {
       return NOOP_DOUBLE_UP_DOWN_COUNTER_BUILDER;
     }
@@ -241,6 +256,11 @@ class DefaultMeter implements Meter {
     @Override
     public DoubleUpDownCounterBuilder setUnit(String unit) {
       ValidationUtil.checkValidInstrumentUnit(unit);
+      return this;
+    }
+
+    @Override
+    public DoubleUpDownCounterBuilder setMaxAccumulations(int maxAccumulations) {
       return this;
     }
 
@@ -300,6 +320,11 @@ class DefaultMeter implements Meter {
     }
 
     @Override
+    public DoubleHistogramBuilder setMaxAccumulations(int maxAccumulations) {
+      return this;
+    }
+
+    @Override
     public LongHistogramBuilder ofLongs() {
       return NOOP_LONG_HISTOGRAM_BUILDER;
     }
@@ -325,6 +350,11 @@ class DefaultMeter implements Meter {
     }
 
     @Override
+    public LongHistogramBuilder setMaxAccumulations(int maxAccumulations) {
+      return this;
+    }
+
+    @Override
     public LongHistogram build() {
       return NOOP;
     }
@@ -342,6 +372,11 @@ class DefaultMeter implements Meter {
     @Override
     public DoubleGaugeBuilder setUnit(String unit) {
       ValidationUtil.checkValidInstrumentUnit(unit);
+      return this;
+    }
+
+    @Override
+    public DoubleGaugeBuilder setMaxAccumulations(int maxAccumulations) {
       return this;
     }
 
@@ -372,6 +407,11 @@ class DefaultMeter implements Meter {
     @Override
     public LongGaugeBuilder setUnit(String unit) {
       ValidationUtil.checkValidInstrumentUnit(unit);
+      return this;
+    }
+
+    @Override
+    public LongGaugeBuilder setMaxAccumulations(int maxAccumulations) {
       return this;
     }
 

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DefaultMeter.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DefaultMeter.java
@@ -80,6 +80,9 @@ class DefaultMeter implements Meter {
 
     @Override
     public void add(long value) {}
+
+    @Override
+    public void remove(Attributes attributes) {}
   }
 
   private static class NoopDoubleCounter implements DoubleCounter {
@@ -91,6 +94,9 @@ class DefaultMeter implements Meter {
 
     @Override
     public void add(double value) {}
+
+    @Override
+    public void remove(Attributes attributes) {}
   }
 
   private static class NoopLongCounterBuilder implements LongCounterBuilder {
@@ -184,6 +190,9 @@ class DefaultMeter implements Meter {
 
     @Override
     public void add(long value) {}
+
+    @Override
+    public void remove(Attributes attributes) {}
   }
 
   private static class NoopDoubleUpDownCounter implements DoubleUpDownCounter {
@@ -195,6 +204,9 @@ class DefaultMeter implements Meter {
 
     @Override
     public void add(double value) {}
+
+    @Override
+    public void remove(Attributes attributes) {}
   }
 
   private static class NoopLongUpDownCounterBuilder implements LongUpDownCounterBuilder {
@@ -290,6 +302,9 @@ class DefaultMeter implements Meter {
 
     @Override
     public void record(double value) {}
+
+    @Override
+    public void remove(Attributes attributes) {}
   }
 
   private static class NoopLongHistogram implements LongHistogram {
@@ -301,6 +316,9 @@ class DefaultMeter implements Meter {
 
     @Override
     public void record(long value) {}
+
+    @Override
+    public void remove(Attributes attributes) {}
   }
 
   private static class NoopDoubleHistogramBuilder implements DoubleHistogramBuilder {
@@ -432,6 +450,9 @@ class DefaultMeter implements Meter {
 
     @Override
     public void record(double value, Attributes attributes) {}
+
+    @Override
+    public void remove(Attributes attributes) {}
   }
 
   private static class NoopObservableLongMeasurement implements ObservableLongMeasurement {
@@ -440,5 +461,8 @@ class DefaultMeter implements Meter {
 
     @Override
     public void record(long value, Attributes attributes) {}
+
+    @Override
+    public void remove(Attributes attributes) {}
   }
 }

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleCounter.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleCounter.java
@@ -45,4 +45,11 @@ public interface DoubleCounter {
    * @param context The explicit context to associate with this measurement.
    */
   void add(double value, Attributes attributes, Context context);
+
+  /**
+   * Remove the handle/measurement from the storage.
+   *
+   * @param attributes A set of attributes.
+   */
+  void remove(Attributes attributes);
 }

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleCounterBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleCounterBuilder.java
@@ -33,7 +33,11 @@ public interface DoubleCounterBuilder {
    */
   DoubleCounterBuilder setUnit(String unit);
 
-
+  /**
+   * Sets the max accumulations.
+   *
+   * @param maxAccumulations Max accumulations for the meter.
+   */
   DoubleCounterBuilder setMaxAccumulations(int maxAccumulations);
 
   /**

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleCounterBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleCounterBuilder.java
@@ -33,6 +33,9 @@ public interface DoubleCounterBuilder {
    */
   DoubleCounterBuilder setUnit(String unit);
 
+
+  DoubleCounterBuilder setMaxAccumulations(int maxAccumulations);
+
   /**
    * Builds and returns a Counter instrument with the configuration.
    *

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleGaugeBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleGaugeBuilder.java
@@ -33,8 +33,11 @@ public interface DoubleGaugeBuilder {
    */
   DoubleGaugeBuilder setUnit(String unit);
 
-
-
+  /**
+   * Sets the max accumulations.
+   *
+   * @param maxAccumulations Max accumulations for the meter.
+   */
   DoubleGaugeBuilder setMaxAccumulations(int maxAccumulations);
 
   /** Sets the Gauge for recording {@code long} values. */

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleGaugeBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleGaugeBuilder.java
@@ -33,6 +33,10 @@ public interface DoubleGaugeBuilder {
    */
   DoubleGaugeBuilder setUnit(String unit);
 
+
+
+  DoubleGaugeBuilder setMaxAccumulations(int maxAccumulations);
+
   /** Sets the Gauge for recording {@code long} values. */
   LongGaugeBuilder ofLongs();
 

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleHistogram.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleHistogram.java
@@ -46,4 +46,11 @@ public interface DoubleHistogram {
    * @param context The explicit context to associate with this measurement.
    */
   void record(double value, Attributes attributes, Context context);
+
+  /**
+   * Remove the handle/measurement from the storage.
+   *
+   * @param attributes A set of attributes.
+   */
+  void remove(Attributes attributes);
 }

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleHistogramBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleHistogramBuilder.java
@@ -32,6 +32,10 @@ public interface DoubleHistogramBuilder {
    */
   DoubleHistogramBuilder setUnit(String unit);
 
+
+
+  DoubleHistogramBuilder setMaxAccumulations(int maxAccumulations);
+
   /** Sets the Counter for recording {@code long} values. */
   LongHistogramBuilder ofLongs();
 

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleHistogramBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleHistogramBuilder.java
@@ -32,8 +32,11 @@ public interface DoubleHistogramBuilder {
    */
   DoubleHistogramBuilder setUnit(String unit);
 
-
-
+  /**
+   * Sets the max accumulations.
+   *
+   * @param maxAccumulations Max accumulations for the meter.
+   */
   DoubleHistogramBuilder setMaxAccumulations(int maxAccumulations);
 
   /** Sets the Counter for recording {@code long} values. */

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleUpDownCounter.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleUpDownCounter.java
@@ -45,4 +45,11 @@ public interface DoubleUpDownCounter {
    * @param context The explicit context to associate with this measurement.
    */
   void add(double value, Attributes attributes, Context context);
+
+  /**
+   * Remove the handle/measurement from the storage.
+   *
+   * @param attributes A set of attributes.
+   */
+  void remove(Attributes attributes);
 }

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleUpDownCounterBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleUpDownCounterBuilder.java
@@ -33,8 +33,11 @@ public interface DoubleUpDownCounterBuilder {
    */
   DoubleUpDownCounterBuilder setUnit(String unit);
 
-
-
+  /**
+   * Sets the max accumulations.
+   *
+   * @param maxAccumulations Max accumulations for the meter.
+   */
   DoubleUpDownCounterBuilder setMaxAccumulations(int maxAccumulations);
 
   /**

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleUpDownCounterBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleUpDownCounterBuilder.java
@@ -33,6 +33,10 @@ public interface DoubleUpDownCounterBuilder {
    */
   DoubleUpDownCounterBuilder setUnit(String unit);
 
+
+
+  DoubleUpDownCounterBuilder setMaxAccumulations(int maxAccumulations);
+
   /**
    * Builds and returns an UpDownCounter instrument with the configuration.
    *

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/LongCounter.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/LongCounter.java
@@ -46,4 +46,11 @@ public interface LongCounter {
    * @param context The explicit context to associate with this measurement.
    */
   void add(long value, Attributes attributes, Context context);
+
+  /**
+   * Remove the handle/measurement from the storage.
+   *
+   * @param attributes A set of attributes.
+   */
+  void remove(Attributes attributes);
 }

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/LongCounterBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/LongCounterBuilder.java
@@ -34,9 +34,11 @@ public interface LongCounterBuilder {
    */
   LongCounterBuilder setUnit(String unit);
 
-
-
-
+  /**
+   * Sets the max accumulations.
+   *
+   * @param maxAccumulations Max accumulations for the meter.
+   */
   LongCounterBuilder setMaxAccumulations(int maxAccumulations);
 
   /** Sets the Counter for recording {@code double} values. */

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/LongCounterBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/LongCounterBuilder.java
@@ -34,6 +34,11 @@ public interface LongCounterBuilder {
    */
   LongCounterBuilder setUnit(String unit);
 
+
+
+
+  LongCounterBuilder setMaxAccumulations(int maxAccumulations);
+
   /** Sets the Counter for recording {@code double} values. */
   DoubleCounterBuilder ofDoubles();
 

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/LongGaugeBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/LongGaugeBuilder.java
@@ -33,6 +33,11 @@ public interface LongGaugeBuilder {
    */
   LongGaugeBuilder setUnit(String unit);
 
+
+
+
+  LongGaugeBuilder setMaxAccumulations(int maxAccumulations);
+
   /**
    * Builds an Asynchronous Gauge instrument with the given callback.
    *

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/LongGaugeBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/LongGaugeBuilder.java
@@ -33,9 +33,11 @@ public interface LongGaugeBuilder {
    */
   LongGaugeBuilder setUnit(String unit);
 
-
-
-
+  /**
+   * Sets the max accumulations.
+   *
+   * @param maxAccumulations Max accumulations for the meter.
+   */
   LongGaugeBuilder setMaxAccumulations(int maxAccumulations);
 
   /**

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/LongHistogram.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/LongHistogram.java
@@ -46,4 +46,11 @@ public interface LongHistogram {
    * @param context The explicit context to associate with this measurement.
    */
   void record(long value, Attributes attributes, Context context);
+
+  /**
+   * Remove the handle/measurement from the storage.
+   *
+   * @param attributes A set of attributes.
+   */
+  void remove(Attributes attributes);
 }

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/LongHistogramBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/LongHistogramBuilder.java
@@ -31,9 +31,11 @@ public interface LongHistogramBuilder {
    */
   LongHistogramBuilder setUnit(String unit);
 
-
-
-
+  /**
+   * Sets the max accumulations.
+   *
+   * @param maxAccumulations Max accumulations for the meter.
+   */
   LongHistogramBuilder setMaxAccumulations(int maxAccumulations);
 
   /**

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/LongHistogramBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/LongHistogramBuilder.java
@@ -31,6 +31,11 @@ public interface LongHistogramBuilder {
    */
   LongHistogramBuilder setUnit(String unit);
 
+
+
+
+  LongHistogramBuilder setMaxAccumulations(int maxAccumulations);
+
   /**
    * Builds and returns a Histogram instrument with the configuration.
    *

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/LongUpDownCounter.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/LongUpDownCounter.java
@@ -45,4 +45,11 @@ public interface LongUpDownCounter {
    * @param context The explicit context to associate with this measurement.
    */
   void add(long value, Attributes attributes, Context context);
+
+  /**
+   * Remove the handle/measurement from the storage.
+   *
+   * @param attributes A set of attributes.
+   */
+  void remove(Attributes attributes);
 }

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/LongUpDownCounterBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/LongUpDownCounterBuilder.java
@@ -33,6 +33,10 @@ public interface LongUpDownCounterBuilder {
    */
   LongUpDownCounterBuilder setUnit(String unit);
 
+
+
+  LongUpDownCounterBuilder setMaxAccumulations(int maxAccumulations);
+
   /** Sets the Counter for recording {@code double} values. */
   DoubleUpDownCounterBuilder ofDoubles();
 

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/LongUpDownCounterBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/LongUpDownCounterBuilder.java
@@ -33,8 +33,11 @@ public interface LongUpDownCounterBuilder {
    */
   LongUpDownCounterBuilder setUnit(String unit);
 
-
-
+  /**
+   * Sets the max accumulations.
+   *
+   * @param maxAccumulations Max accumulations for the meter.
+   */
   LongUpDownCounterBuilder setMaxAccumulations(int maxAccumulations);
 
   /** Sets the Counter for recording {@code double} values. */

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/ObservableDoubleMeasurement.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/ObservableDoubleMeasurement.java
@@ -28,4 +28,11 @@ public interface ObservableDoubleMeasurement extends ObservableMeasurement {
    * @param attributes A set of attributes to associate with the value.
    */
   void record(double value, Attributes attributes);
+
+  /**
+   * Remove the handle/measurement from the storage.
+   *
+   * @param attributes A set of attributes.
+   */
+  void remove(Attributes attributes);
 }

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/ObservableLongMeasurement.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/ObservableLongMeasurement.java
@@ -28,4 +28,11 @@ public interface ObservableLongMeasurement extends ObservableMeasurement {
    * @param attributes A set of attributes to associate with the value.
    */
   void record(long value, Attributes attributes);
+
+  /**
+   * Remove the handle/measurement from the storage.
+   *
+   * @param attributes A set of attributes.
+   */
+  void remove(Attributes attributes);
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilder.java
@@ -18,16 +18,17 @@ import java.util.Collections;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
+import static io.opentelemetry.sdk.metrics.SdkMeterProvider.MAX_ACCUMULATIONS;
+
 /** Helper to make implementing builders easier. */
 abstract class AbstractInstrumentBuilder<BuilderT extends AbstractInstrumentBuilder<?>> {
 
   static final String DEFAULT_UNIT = "";
-  static final int MAX_ACCUMULATIONS = 2000;
 
   private final MeterProviderSharedState meterProviderSharedState;
   private String description;
   private String unit;
-  private int maxAccumulations;
+  private int maxAccumulations = MAX_ACCUMULATIONS;
 
   protected final MeterSharedState meterSharedState;
   protected final String instrumentName;
@@ -37,14 +38,12 @@ abstract class AbstractInstrumentBuilder<BuilderT extends AbstractInstrumentBuil
       MeterSharedState meterSharedState,
       String name,
       String description,
-      String unit,
-      int maxAccumulations) {
+      String unit) {
     this.instrumentName = name;
     this.description = description;
     this.unit = unit;
     this.meterProviderSharedState = meterProviderSharedState;
     this.meterSharedState = meterSharedState;
-    this.maxAccumulations = maxAccumulations;
   }
 
   protected abstract BuilderT getThis();
@@ -115,7 +114,9 @@ abstract class AbstractInstrumentBuilder<BuilderT extends AbstractInstrumentBuil
 
   final SdkObservableMeasurement buildObservableMeasurement(
       InstrumentType type, InstrumentValueType valueType) {
-    return meterSharedState.registerObservableMeasurement(makeDescriptor(type, valueType));
+    return meterSharedState.registerObservableMeasurement(
+        makeDescriptor(type, valueType),
+        maxAccumulations);
   }
 
   @FunctionalInterface

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilder.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import static io.opentelemetry.sdk.metrics.SdkMeterProvider.MAX_ACCUMULATIONS;
 import io.opentelemetry.api.internal.ValidationUtil;
 import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
@@ -17,8 +18,6 @@ import io.opentelemetry.sdk.metrics.internal.state.WriteableMetricStorage;
 import java.util.Collections;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
-
-import static io.opentelemetry.sdk.metrics.SdkMeterProvider.MAX_ACCUMULATIONS;
 
 /** Helper to make implementing builders easier. */
 abstract class AbstractInstrumentBuilder<BuilderT extends AbstractInstrumentBuilder<?>> {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilder.java
@@ -22,10 +22,12 @@ import java.util.function.Consumer;
 abstract class AbstractInstrumentBuilder<BuilderT extends AbstractInstrumentBuilder<?>> {
 
   static final String DEFAULT_UNIT = "";
+  static final int MAX_ACCUMULATIONS = 2000;
 
   private final MeterProviderSharedState meterProviderSharedState;
   private String description;
   private String unit;
+  private int maxAccumulations;
 
   protected final MeterSharedState meterSharedState;
   protected final String instrumentName;
@@ -35,12 +37,14 @@ abstract class AbstractInstrumentBuilder<BuilderT extends AbstractInstrumentBuil
       MeterSharedState meterSharedState,
       String name,
       String description,
-      String unit) {
+      String unit,
+      int maxAccumulations) {
     this.instrumentName = name;
     this.description = description;
     this.unit = unit;
     this.meterProviderSharedState = meterProviderSharedState;
     this.meterSharedState = meterSharedState;
+    this.maxAccumulations = maxAccumulations;
   }
 
   protected abstract BuilderT getThis();
@@ -53,6 +57,11 @@ abstract class AbstractInstrumentBuilder<BuilderT extends AbstractInstrumentBuil
     } else {
       this.unit = unit;
     }
+    return getThis();
+  }
+
+  public BuilderT setMaxAccumulations(int maxAccumulations) {
+    this.maxAccumulations = maxAccumulations;
     return getThis();
   }
 
@@ -76,7 +85,9 @@ abstract class AbstractInstrumentBuilder<BuilderT extends AbstractInstrumentBuil
       BiFunction<InstrumentDescriptor, WriteableMetricStorage, I> instrumentFactory) {
     InstrumentDescriptor descriptor = makeDescriptor(type, valueType);
     WriteableMetricStorage storage =
-        meterSharedState.registerSynchronousMetricStorage(descriptor, meterProviderSharedState);
+        meterSharedState.registerSynchronousMetricStorage(descriptor,
+            meterProviderSharedState,
+            maxAccumulations);
     return instrumentFactory.apply(descriptor, storage);
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleCounter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleCounter.java
@@ -56,6 +56,11 @@ final class SdkDoubleCounter extends AbstractInstrument implements DoubleCounter
     add(increment, Attributes.empty());
   }
 
+  @Override
+  public void remove(Attributes attributes) {
+    storage.unBind(attributes);
+  }
+
   BoundDoubleCounter bind(Attributes attributes) {
     return new BoundInstrument(getDescriptor(), storage.bind(attributes), attributes);
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleHistogram.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleHistogram.java
@@ -54,6 +54,11 @@ final class SdkDoubleHistogram extends AbstractInstrument implements DoubleHisto
     record(value, Attributes.empty());
   }
 
+  @Override
+  public void remove(Attributes attributes) {
+    storage.unBind(attributes);
+  }
+
   BoundDoubleHistogram bind(Attributes attributes) {
     return new BoundInstrument(getDescriptor(), storage.bind(attributes), attributes);
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleUpDownCounter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleUpDownCounter.java
@@ -43,6 +43,11 @@ final class SdkDoubleUpDownCounter extends AbstractInstrument implements DoubleU
     add(increment, Attributes.empty());
   }
 
+  @Override
+  public void remove(Attributes attributes) {
+    storage.unBind(attributes);
+  }
+
   BoundDoubleUpDownCounter bind(Attributes attributes) {
     return new BoundInstrument(storage.bind(attributes), attributes);
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongCounter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongCounter.java
@@ -58,6 +58,11 @@ final class SdkLongCounter extends AbstractInstrument implements LongCounter {
     add(increment, Attributes.empty());
   }
 
+  @Override
+  public void remove(Attributes attributes) {
+    storage.unBind(attributes);
+  }
+
   BoundLongCounter bind(Attributes attributes) {
     return new BoundInstrument(getDescriptor(), storage.bind(attributes), attributes);
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongHistogram.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongHistogram.java
@@ -53,6 +53,11 @@ final class SdkLongHistogram extends AbstractInstrument implements LongHistogram
     record(value, Attributes.empty());
   }
 
+  @Override
+  public void remove(Attributes attributes) {
+    storage.unBind(attributes);
+  }
+
   BoundLongHistogram bind(Attributes attributes) {
     return new BoundInstrument(getDescriptor(), storage.bind(attributes), attributes);
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongUpDownCounter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongUpDownCounter.java
@@ -44,6 +44,12 @@ final class SdkLongUpDownCounter extends AbstractInstrument implements LongUpDow
     add(increment, Attributes.empty());
   }
 
+
+  @Override
+  public void remove(Attributes attributes) {
+    storage.unBind(attributes);
+  }
+
   BoundLongUpDownCounter bind(Attributes attributes) {
     return new BoundInstrument(storage.bind(attributes), attributes);
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProvider.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProvider.java
@@ -19,6 +19,7 @@ import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.internal.export.MetricProducer;
 import io.opentelemetry.sdk.metrics.internal.export.RegisteredReader;
 import io.opentelemetry.sdk.metrics.internal.state.MeterProviderSharedState;
+import io.opentelemetry.sdk.metrics.internal.state.MetricStorage;
 import io.opentelemetry.sdk.metrics.internal.view.RegisteredView;
 import io.opentelemetry.sdk.metrics.internal.view.ViewRegistry;
 import io.opentelemetry.sdk.resources.Resource;
@@ -40,6 +41,8 @@ public final class SdkMeterProvider implements MeterProvider, Closeable {
 
   private static final Logger LOGGER = Logger.getLogger(SdkMeterProvider.class.getName());
   static final String DEFAULT_METER_NAME = "unknown";
+  /** The max number of metric accumulations for a particular {@link MetricStorage}. */
+  public static final int MAX_ACCUMULATIONS = 2000;
 
   private final List<RegisteredView> registeredViews;
   private final List<RegisteredReader> registeredReaders;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorage.java
@@ -102,6 +102,11 @@ final class AsynchronousMetricStorage<T, U extends ExemplarData> implements Metr
     }
   }
 
+
+  void unbind(Attributes attributes) {
+    this.accumulations.remove(attributes);
+  }
+
   /** Record callback double measurements from {@link ObservableDoubleMeasurement}. */
   void recordDouble(double value, Attributes attributes) {
     T accumulation = aggregator.accumulateDoubleMeasurement(value, attributes, Context.current());

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.sdk.metrics.internal.state;
 
-import static io.opentelemetry.sdk.metrics.internal.state.MetricStorageUtils.MAX_ACCUMULATIONS;
-
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
@@ -110,13 +108,13 @@ public final class DefaultSynchronousMetricStorage<T, U extends ExemplarData>
     // Missing entry or no longer mapped. Try to add a new one if not exceeded cardinality limits.
     aggregatorHandle = aggregator.createHandle();
     while (true) {
-      if (activeCollectionStorage.size() >= this.maxAccumulations) {
+      if (activeCollectionStorage.size() >= maxAccumulations) {
         logger.log(
             Level.WARNING,
             "Instrument "
                 + metricDescriptor.getSourceInstrument().getName()
                 + " has exceeded the maximum allowed accumulations ("
-                + MAX_ACCUMULATIONS
+                + maxAccumulations
                 + ").");
         return NOOP_STORAGE_HANDLE;
       }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java
@@ -98,6 +98,11 @@ public final class DefaultSynchronousMetricStorage<T, U extends ExemplarData>
     return doBind(attributesProcessor.process(attributes, Context.current()));
   }
 
+  @Override
+  public void unBind(Attributes attributes) {
+    activeCollectionStorage.remove(attributes);
+  }
+
   private BoundStorageHandle doBind(Attributes attributes) {
     AggregatorHandle<T, U> aggregatorHandle = activeCollectionStorage.get(attributes);
     if (aggregatorHandle != null && aggregatorHandle.acquire()) {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java
@@ -47,12 +47,14 @@ public final class DefaultSynchronousMetricStorage<T, U extends ExemplarData>
       new ConcurrentHashMap<>();
   private final TemporalMetricStorage<T, U> temporalMetricStorage;
   private final AttributesProcessor attributesProcessor;
+  private final int maxAccumulations;
 
   DefaultSynchronousMetricStorage(
       RegisteredReader registeredReader,
       MetricDescriptor metricDescriptor,
       Aggregator<T, U> aggregator,
-      AttributesProcessor attributesProcessor) {
+      AttributesProcessor attributesProcessor,
+      int maxAccumulations) {
     this.registeredReader = registeredReader;
     this.metricDescriptor = metricDescriptor;
     AggregationTemporality aggregationTemporality =
@@ -68,6 +70,7 @@ public final class DefaultSynchronousMetricStorage<T, U extends ExemplarData>
             aggregationTemporality,
             metricDescriptor);
     this.attributesProcessor = attributesProcessor;
+    this.maxAccumulations = maxAccumulations;
   }
 
   // This is a storage handle to use when the attributes processor requires
@@ -107,7 +110,7 @@ public final class DefaultSynchronousMetricStorage<T, U extends ExemplarData>
     // Missing entry or no longer mapped. Try to add a new one if not exceeded cardinality limits.
     aggregatorHandle = aggregator.createHandle();
     while (true) {
-      if (activeCollectionStorage.size() >= MAX_ACCUMULATIONS) {
+      if (activeCollectionStorage.size() >= this.maxAccumulations) {
         logger.log(
             Level.WARNING,
             "Instrument "

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/EmptyMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/EmptyMetricStorage.java
@@ -84,6 +84,9 @@ final class EmptyMetricStorage implements SynchronousMetricStorage {
   }
 
   @Override
+  public void unBind(Attributes attributes) {}
+
+  @Override
   public MetricData collectAndReset(
       Resource resource,
       InstrumentationScopeInfo instrumentationScopeInfo,

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MeterSharedState.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MeterSharedState.java
@@ -162,7 +162,7 @@ public class MeterSharedState {
 
   /** Register new asynchronous storage associated with a given instrument. */
   public final SdkObservableMeasurement registerObservableMeasurement(
-      InstrumentDescriptor instrumentDescriptor) {
+      InstrumentDescriptor instrumentDescriptor, int maxAccumulations) {
     List<AsynchronousMetricStorage<?, ?>> registeredStorages = new ArrayList<>();
     for (Map.Entry<RegisteredReader, MetricStorageRegistry> entry :
         readerStorageRegistries.entrySet()) {
@@ -175,7 +175,8 @@ public class MeterSharedState {
         }
         registeredStorages.add(
             registry.register(
-                AsynchronousMetricStorage.create(reader, registeredView, instrumentDescriptor)));
+                AsynchronousMetricStorage.create(
+                    reader, registeredView, instrumentDescriptor, maxAccumulations)));
       }
     }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MeterSharedState.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MeterSharedState.java
@@ -128,7 +128,9 @@ public class MeterSharedState {
 
   /** Registers new synchronous storage associated with a given instrument. */
   public final WriteableMetricStorage registerSynchronousMetricStorage(
-      InstrumentDescriptor instrument, MeterProviderSharedState meterProviderSharedState) {
+      InstrumentDescriptor instrument,
+      MeterProviderSharedState meterProviderSharedState,
+      int maxAccumulations) {
 
     List<SynchronousMetricStorage> registeredStorages = new ArrayList<>();
     for (Map.Entry<RegisteredReader, MetricStorageRegistry> entry :
@@ -146,7 +148,8 @@ public class MeterSharedState {
                     reader,
                     registeredView,
                     instrument,
-                    meterProviderSharedState.getExemplarFilter())));
+                    meterProviderSharedState.getExemplarFilter(),
+                    maxAccumulations)));
       }
     }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageUtils.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageUtils.java
@@ -13,8 +13,6 @@ import java.util.function.BiFunction;
 
 /** Utilities to help deal w/ {@code Map<Attributes, Accumulation>} in metric storage. */
 final class MetricStorageUtils {
-  /** The max number of metric accumulations for a particular {@link MetricStorage}. */
-  static final int MAX_ACCUMULATIONS = 2000;
 
   private MetricStorageUtils() {}
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MultiWritableMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MultiWritableMetricStorage.java
@@ -24,4 +24,11 @@ class MultiWritableMetricStorage implements WriteableMetricStorage {
     }
     return new MultiBoundStorageHandle(handles);
   }
+
+  @Override
+  public void unBind(Attributes attributes) {
+    for (WriteableMetricStorage metric : underlyingMetrics) {
+      metric.unBind(attributes);
+    }
+  }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/SdkObservableMeasurement.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/SdkObservableMeasurement.java
@@ -120,4 +120,23 @@ public final class SdkObservableMeasurement
       }
     }
   }
+
+
+  @Override
+  public void remove(Attributes attributes) {
+    RegisteredReader activeReader = this.activeReader;
+    if (activeReader == null) {
+      throttlingLogger.log(
+          Level.FINE,
+          "Measurement recorded for instrument "
+              + instrumentDescriptor.getName()
+              + " outside callback registered to instrument. Dropping measurement.");
+      return;
+    }
+    for (AsynchronousMetricStorage<?, ?> storage : storages) {
+      if (storage.getRegisteredReader().equals(activeReader)) {
+        storage.unbind(attributes);
+      }
+    }
+  }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorage.java
@@ -39,7 +39,8 @@ public interface SynchronousMetricStorage extends MetricStorage, WriteableMetric
       RegisteredReader registeredReader,
       RegisteredView registeredView,
       InstrumentDescriptor instrumentDescriptor,
-      ExemplarFilter exemplarFilter) {
+      ExemplarFilter exemplarFilter,
+      int maxAccumulations) {
     View view = registeredView.getView();
     MetricDescriptor metricDescriptor =
         MetricDescriptor.create(view, registeredView.getViewSourceInfo(), instrumentDescriptor);
@@ -54,6 +55,7 @@ public interface SynchronousMetricStorage extends MetricStorage, WriteableMetric
         registeredReader,
         metricDescriptor,
         aggregator,
-        registeredView.getViewAttributesProcessor());
+        registeredView.getViewAttributesProcessor(),
+        maxAccumulations);
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorage.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.metrics.internal.state;
 
+import static io.opentelemetry.sdk.metrics.SdkMeterProvider.MAX_ACCUMULATIONS;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
@@ -18,8 +19,6 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
-
-import static io.opentelemetry.sdk.metrics.SdkMeterProvider.MAX_ACCUMULATIONS;
 
 /** Stores last reported time and (optional) accumulation for metrics. */
 @ThreadSafe

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/WriteableMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/WriteableMetricStorage.java
@@ -19,6 +19,8 @@ public interface WriteableMetricStorage {
   /** Bind an efficient storage handle for a set of attributes. */
   BoundStorageHandle bind(Attributes attributes);
 
+  void unBind(Attributes attributes);
+
   /** Records a measurement. */
   default void recordLong(long value, Attributes attributes, Context context) {
     BoundStorageHandle handle = bind(attributes);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorageTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorageTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.metrics.internal.state;
 
+import static io.opentelemetry.sdk.metrics.SdkMeterProvider.MAX_ACCUMULATIONS;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.attributeEntry;
 import static org.mockito.ArgumentMatchers.any;
@@ -70,7 +71,8 @@ class AsynchronousMetricStorageTest {
                 "description",
                 "unit",
                 InstrumentType.COUNTER,
-                InstrumentValueType.LONG));
+                InstrumentValueType.LONG),
+            MAX_ACCUMULATIONS);
     doubleCounterStorage =
         AsynchronousMetricStorage.create(
             registeredReader,
@@ -80,7 +82,8 @@ class AsynchronousMetricStorageTest {
                 "description",
                 "unit",
                 InstrumentType.COUNTER,
-                InstrumentValueType.DOUBLE));
+                InstrumentValueType.DOUBLE),
+            MAX_ACCUMULATIONS);
   }
 
   @Test
@@ -140,7 +143,8 @@ class AsynchronousMetricStorageTest {
                 AttributesProcessor.filterByKeyName(key -> key.equals("key1")),
                 SourceInfo.noSourceInfo()),
             InstrumentDescriptor.create(
-                "name", "description", "unit", InstrumentType.COUNTER, InstrumentValueType.LONG));
+                "name", "description", "unit", InstrumentType.COUNTER, InstrumentValueType.LONG),
+            MAX_ACCUMULATIONS);
 
     storage.recordLong(1, Attributes.builder().put("key1", "a").put("key2", "b").build());
 
@@ -158,7 +162,7 @@ class AsynchronousMetricStorageTest {
 
   @Test
   void record_MaxAccumulations() {
-    for (int i = 0; i <= MetricStorageUtils.MAX_ACCUMULATIONS + 1; i++) {
+    for (int i = 0; i <= MAX_ACCUMULATIONS + 1; i++) {
       longCounterStorage.recordLong(1, Attributes.builder().put("key" + i, "val").build());
     }
 
@@ -166,7 +170,7 @@ class AsynchronousMetricStorageTest {
         .satisfies(
             metricData ->
                 assertThat(metricData.getLongSumData().getPoints())
-                    .hasSize(MetricStorageUtils.MAX_ACCUMULATIONS));
+                    .hasSize(MAX_ACCUMULATIONS));
     logs.assertContains("Instrument long-counter has exceeded the maximum allowed accumulations");
   }
 

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageRegistryTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageRegistryTest.java
@@ -142,5 +142,8 @@ class MetricStorageRegistryTest {
     public BoundStorageHandle bind(Attributes attributes) {
       return null;
     }
+
+    @Override
+    public void unBind(Attributes attributes) {}
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorageTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/TemporalMetricStorageTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.metrics.internal.state;
 
+import static io.opentelemetry.sdk.metrics.SdkMeterProvider.MAX_ACCUMULATIONS;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
@@ -120,7 +121,7 @@ class TemporalMetricStorageTest {
 
     // Send in new measurement at time 10, with attr1
     Map<Attributes, DoubleAccumulation> measurement1 = new HashMap<>();
-    for (int i = 0; i < MetricStorageUtils.MAX_ACCUMULATIONS; i++) {
+    for (int i = 0; i < MAX_ACCUMULATIONS; i++) {
       Attributes attr1 = Attributes.builder().put("key", "value" + i).build();
       measurement1.put(attr1, DoubleAccumulation.create(3));
     }
@@ -133,7 +134,7 @@ class TemporalMetricStorageTest {
                     .satisfies(
                         sumData ->
                             assertThat(sumData.getPoints())
-                                .hasSize(MetricStorageUtils.MAX_ACCUMULATIONS)
+                                .hasSize(MAX_ACCUMULATIONS)
                                 .allSatisfy(
                                     point -> {
                                       assertThat(point.getStartEpochNanos()).isEqualTo(0);
@@ -147,7 +148,7 @@ class TemporalMetricStorageTest {
     Map<Attributes, DoubleAccumulation> measurement2 = new HashMap<>();
     Attributes attr2 =
         Attributes.builder()
-            .put("key", "value" + (MetricStorageUtils.MAX_ACCUMULATIONS + 1))
+            .put("key", "value" + (MAX_ACCUMULATIONS + 1))
             .build();
     measurement2.put(attr2, DoubleAccumulation.create(3));
     assertThat(


### PR DESCRIPTION
Motivation:
1. Currently, a meter(COUNTER/GAUGE/HISTOGRAM, etc.) could only have 2000 children, which means it couldn't cover some situations (such as there are 10000 topics in a broker, and they all have a COUNTER named `publish_messages_count`).
2. For a meter, I think it should have a `remove` method to discard unused ACCUMULATIONS. (such as a user deletes a broker, so we need to remove it from `publish_messages_count`).