### PR TITLE
Disable compression in collector exporter

### DIFF
--- a/integration-tests/otlp/src/main/resources/otel-config.yaml
+++ b/integration-tests/otlp/src/main/resources/otel-config.yaml
@@ -28,6 +28,7 @@ exporters:
     endpoint: $OTLP_EXPORTER_ENDPOINT
     tls:
       insecure: true
+    compression: none
 service:
   extensions: [health_check]
   pipelines:


### PR DESCRIPTION
The build has consistently failing lately on ubuntu. See [here](https://github.com/open-telemetry/opentelemetry-java/runs/7584652594?check_suite_focus=true) and [here](https://github.com/open-telemetry/opentelemetry-java/runs/7584652594?check_suite_focus=true) for examples.

I was able to reproduce it locally, but only after I pulled down the `ghcr.io/open-telemetry/opentelemetry-java/otel-collector` image used in the integration test, and found messages like this in the collector logs:
```
2022-08-01T21:06:02.015Z	error	exporterhelper/queued_retry.go:183	Exporting failed. The error is not retryable. Dropping data.	{"kind": "exporter", "name": "otlp", "error": "Permanent error: rpc error: code = Internal desc = com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer: Can't decode compressed frame as compression not configured.", "dropped_items": 1}
```
We haven't done anything recently to change the compression settings of the ameria gRPC server that accepts OTLP messages from the collector. However, I did find that the [AbstractUnsafeUnaryGrpcService](https://github.com/line/armeria/blob/master/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnsafeUnaryGrpcService.java#L68-L69) we use to accept gRPC requests doesn't support compression. 

My best guess at what has been going on is that the github action runners have very old cached copies of the `ghcr.io/open-telemetry/opentelemetry-java/otel-collector` image, back from when the collector did not enable compression by default. If this is indeed the case we should address this to make sure we're running with the latest like intended. My fix is to change the collector config to disable compression, which isn't required or related to the functionality being tested. 