### PR TITLE
Mark :extensions:annotations as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,14 +230,14 @@ dependency as follows, replacing `{{artifact-id}}` with the value from the "Arti
 
 ### API Extensions
 
-| Component                                                     | Description                                                                    | Artifact ID                                 | Version                                                     |
-|---------------------------------------------------------------|--------------------------------------------------------------------------------|---------------------------------------------|-------------------------------------------------------------|
-| [Annotations Extension](./extensions/annotations)             | Instrumentation annotations, used in conjunction with OpenTelemetry java agent | `opentelemetry-extension-annotations`       | <!--VERSION_STABLE-->1.16.0<!--/VERSION_STABLE-->           |
-| [AWS Extension](./extensions/aws)                             | AWS Xray propagator                                                            | `opentelemetry-extension-aws`               | <!--VERSION_STABLE-->1.16.0<!--/VERSION_STABLE-->           |
-| [Kotlin Extension](./extensions/kotlin)                       | Context extension for coroutines                                               | `opentelemetry-extension-kotlin`            | <!--VERSION_STABLE-->1.16.0<!--/VERSION_STABLE-->           |
-| [Trace Propagators Extension](./extensions/trace-propagators) | Trace propagators, including B3, Jaeger, OT Trace                              | `opentelemetry-extension-trace-propagators` | <!--VERSION_STABLE-->1.16.0<!--/VERSION_STABLE-->           |
-| [Incubator Extension](./extensions/incubator)                 | API incubator, including pass through propagator, and extended tracer          | `opentelemetry-extension-incubator`         | <!--VERSION_UNSTABLE-->1.16.0-alpha<!--/VERSION_UNSTABLE--> |
-| [Noop API Extension](./extensions/noop-api)                   | A noop OpenTelemetry implementation which ignores context                      | `opentelemetry-extension-noop-api`          | <!--VERSION_UNSTABLE-->1.16.0-alpha<!--/VERSION_UNSTABLE--> |
+| Component                                                     | Description                                                                                 | Artifact ID                                 | Version                                                     |
+|---------------------------------------------------------------|---------------------------------------------------------------------------------------------|---------------------------------------------|-------------------------------------------------------------|
+| [AWS Extension](./extensions/aws)                             | AWS Xray propagator                                                                         | `opentelemetry-extension-aws`               | <!--VERSION_STABLE-->1.16.0<!--/VERSION_STABLE-->           |
+| [Kotlin Extension](./extensions/kotlin)                       | Context extension for coroutines                                                            | `opentelemetry-extension-kotlin`            | <!--VERSION_STABLE-->1.16.0<!--/VERSION_STABLE-->           |
+| [Trace Propagators Extension](./extensions/trace-propagators) | Trace propagators, including B3, Jaeger, OT Trace                                           | `opentelemetry-extension-trace-propagators` | <!--VERSION_STABLE-->1.16.0<!--/VERSION_STABLE-->           |
+| [Incubator Extension](./extensions/incubator)                 | API incubator, including pass through propagator, and extended tracer                       | `opentelemetry-extension-incubator`         | <!--VERSION_UNSTABLE-->1.16.0-alpha<!--/VERSION_UNSTABLE--> |
+| [Noop API Extension](./extensions/noop-api)                   | A noop OpenTelemetry implementation which ignores context                                   | `opentelemetry-extension-noop-api`          | <!--VERSION_UNSTABLE-->1.16.0-alpha<!--/VERSION_UNSTABLE--> |
+| [Annotations Extension](./extensions/annotations)             | Instrumentation annotations, used in conjunction with OpenTelemetry java agent (deprecated) | `opentelemetry-extension-annotations`       | <!--VERSION_STABLE-->1.16.0<!--/VERSION_STABLE-->           |
 
 ### SDK
 

--- a/docs/apidiffs/current_vs_latest/opentelemetry-extension-annotations.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-extension-annotations.txt
@@ -1,2 +1,7 @@
 Comparing source compatibility of  against 
-No changes.
+===  UNCHANGED ANNOTATION: PUBLIC ABSTRACT io.opentelemetry.extension.annotations.SpanAttribute  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW ANNOTATION: java.lang.Deprecated
+===  UNCHANGED ANNOTATION: PUBLIC ABSTRACT io.opentelemetry.extension.annotations.WithSpan  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW ANNOTATION: java.lang.Deprecated

--- a/exporters/jaeger-proto/README.md
+++ b/exporters/jaeger-proto/README.md
@@ -1,6 +1,6 @@
-# OpenTelemetry - Jaeger Proto
+# OpenTelemetry - Jaeger Proto (DEPRECATED)
 
-External use of this artifact is deprecated. It will not have any changes in the future but will continue to be published as is until 2.0.0.
+> **NOTICE**: External use of this artifact is deprecated. It will not have any changes in the future but will continue to be published as is until 2.0.0.
 
 [![Javadocs][javadoc-image]][javadoc-url]
 

--- a/extensions/annotations/README.md
+++ b/extensions/annotations/README.md
@@ -1,10 +1,12 @@
-OpenTelemetry Extension Annotations
-======================================================
+# OpenTelemetry Extension Annotations (DEPRECATED)
 
 [![Javadocs][javadoc-image]][javadoc-url]
+
+> **NOTICE**: This artifact is deprecated and its contents have been moved to [opentelemetry-instrumentation-annotations] starting with version 1.17.0. It will not have any changes in the future but will continue to be published as is until 2.0.0.
 
 This module contains various annotations that can be used by clients of OpenTelemetry API.
 Please see [Javadocs][javadoc-url] for more information.
 
 [javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-extension-annotations.svg
 [javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-extension-annotations
+[opentelemetry-instrumentation-annotations]: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation-annotations

--- a/extensions/annotations/src/main/java/io/opentelemetry/extension/annotations/SpanAttribute.java
+++ b/extensions/annotations/src/main/java/io/opentelemetry/extension/annotations/SpanAttribute.java
@@ -26,7 +26,11 @@ import java.lang.annotation.Target;
  * @see <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation">OpenTelemetry
  *     OpenTelemetry Instrumentation for Java</a>
  * @since 1.4.0
+ * @deprecated Moved to {@code
+ *     io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:<version>} in
+ *     version 1.17.0+.
  */
+@Deprecated
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface SpanAttribute {

--- a/extensions/annotations/src/main/java/io/opentelemetry/extension/annotations/WithSpan.java
+++ b/extensions/annotations/src/main/java/io/opentelemetry/extension/annotations/WithSpan.java
@@ -24,7 +24,11 @@ import java.lang.annotation.Target;
  *
  * @see <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation">OpenTelemetry
  *     OpenTelemetry Instrumentation for Java</a>
+ * @deprecated Moved to {@code
+ *     io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:<version>} in
+ *     version 1.17.0+.
  */
+@Deprecated
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface WithSpan {

--- a/extensions/annotations/src/test/java/io/opentelemetry/extension/annotations/WithSpanUsageExamples.java
+++ b/extensions/annotations/src/test/java/io/opentelemetry/extension/annotations/WithSpanUsageExamples.java
@@ -13,7 +13,7 @@ import io.opentelemetry.api.trace.SpanKind;
  * WithSpan} annotation together with some explanations. The goal of this class is to serve as an
  * early detection system for inconvenient API and unintended API breakage.
  */
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "deprecation"}) // Testing deprecated code
 public class WithSpanUsageExamples {
 
   /**


### PR DESCRIPTION
As discussed in this PR #4260 [comment](https://github.com/open-telemetry/opentelemetry-java/pull/4260#issuecomment-1159292041), we want to move `:extensions:annoations` to `opentelemetry-java-instrumentation` so it can live along side its primary implementation in the java agent. 

The work to move has been completed in [#6245](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6245). This is a followup to indicate that the `:extensions:annotations` is deprecated. We'll continue to publish until 2.0.0 but will not make future changes. 

cc @trask 