### PR TITLE
Fix misspellings in log message envvar suggestions

### DIFF
--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterUtil.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterUtil.java
@@ -15,13 +15,13 @@ final class GrpcExporterUtil {
     String envVar;
     switch (type) {
       case "span":
-        envVar = "OTLP_TRACES_EXPORTER";
+        envVar = "OTEL_TRACES_EXPORTER";
         break;
       case "metric":
-        envVar = "OTLP_METRICS_EXPORTER";
+        envVar = "OTEL_METRICS_EXPORTER";
         break;
       case "log":
-        envVar = "OTLP_LOGS_EXPORTER";
+        envVar = "OTEL_LOGS_EXPORTER";
         break;
       default:
         throw new IllegalStateException(

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
@@ -447,13 +447,13 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
     String envVar;
     switch (type) {
       case "span":
-        envVar = "OTLP_TRACES_EXPORTER";
+        envVar = "OTEL_TRACES_EXPORTER";
         break;
       case "metric":
-        envVar = "OTLP_METRICS_EXPORTER";
+        envVar = "OTEL_METRICS_EXPORTER";
         break;
       case "log":
-        envVar = "OTLP_LOGS_EXPORTER";
+        envVar = "OTEL_LOGS_EXPORTER";
         break;
       default:
         throw new AssertionError();


### PR DESCRIPTION
Fix some small mispellings where OTLP should be OTEL in these strings
in log messages that are emitted when gRPC unimplemented responses are
received when exporting:
- OTLP_TRACES_EXPORTER -> OTEL_TRACES_EXPORTER
- OTLP_METRICS_EXPORTER -> OTEL_METRICS_EXPORTER
- OTLP_LOGS_EXPORTER -> OTEL_LOGS_EXPORTER

This will match the environement variables listed here:
https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md