### PR TITLE
Avoid unnecessary stack trace capture

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/internal/ValidationUtil.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/ValidationUtil.java
@@ -51,7 +51,9 @@ public final class ValidationUtil {
    * <p>Log includes a stack trace.
    */
   public static void log(String message, Level level) {
-    API_USAGE_LOGGER.log(level, message, new AssertionError());
+    if (API_USAGE_LOGGER.isLoggable(level)) {
+      API_USAGE_LOGGER.log(level, message, new AssertionError());
+    }
   }
 
   /** Check if the instrument name is valid. If invalid, log a warning. */


### PR DESCRIPTION
Constructing an `AssertionError` is rather expensive, and pointless in
cases that we're not even going to log it. With this commit we skip all
this unnecessary work.

Relates https://github.com/elastic/elasticsearch/issues/89107