### PR TITLE
Improve single responsibility of ZipkinSpanExporter.

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-zipkin.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-zipkin.txt
@@ -1,4 +1,12 @@
 Comparing source compatibility of  against 
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.exporter.zipkin.OtelToZipkinSpanTransformer  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: java.util.function.Function
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW FIELD: PUBLIC(+) STATIC(+) FINAL(+) java.util.logging.Logger logger
+	+++  NEW CONSTRUCTOR: PUBLIC(+) OtelToZipkinSpanTransformer()
+	+++  NEW CONSTRUCTOR: PUBLIC(+) OtelToZipkinSpanTransformer(java.net.InetAddress)
+	+++  NEW METHOD: PUBLIC(+) zipkin2.Span apply(io.opentelemetry.sdk.trace.data.SpanData)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder setMeterProvider(io.opentelemetry.api.metrics.MeterProvider)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder setOtelToZipkinTransformer(java.util.function.Function)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-zipkin.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-zipkin.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder setMeterProvider(io.opentelemetry.api.metrics.MeterProvider)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-zipkin.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-zipkin.txt
@@ -2,9 +2,8 @@ Comparing source compatibility of  against
 +++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.exporter.zipkin.OtelToZipkinSpanTransformer  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW SUPERCLASS: java.lang.Object
-	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.exporter.zipkin.OtelToZipkinSpanTransformer create()
 	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.exporter.zipkin.OtelToZipkinSpanTransformer create(java.util.function.Supplier)
 	+++  NEW METHOD: PUBLIC(+) zipkin2.Span generateSpan(io.opentelemetry.sdk.trace.data.SpanData)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder setTransformer(io.opentelemetry.exporter.zipkin.OtelToZipkinSpanTransformer)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder setLocalIpAddressSupplier(java.util.function.Supplier)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-zipkin.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-zipkin.txt
@@ -3,7 +3,6 @@ Comparing source compatibility of  against
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW INTERFACE: java.util.function.Function
 	+++  NEW SUPERCLASS: java.lang.Object
-	+++  NEW FIELD: PUBLIC(+) STATIC(+) FINAL(+) java.util.logging.Logger logger
 	+++  NEW CONSTRUCTOR: PUBLIC(+) OtelToZipkinSpanTransformer()
 	+++  NEW CONSTRUCTOR: PUBLIC(+) OtelToZipkinSpanTransformer(java.net.InetAddress)
 	+++  NEW METHOD: PUBLIC(+) zipkin2.Span apply(io.opentelemetry.sdk.trace.data.SpanData)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-zipkin.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-zipkin.txt
@@ -1,11 +1,10 @@
 Comparing source compatibility of  against 
 +++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.exporter.zipkin.OtelToZipkinSpanTransformer  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
-	+++  NEW INTERFACE: java.util.function.Function
 	+++  NEW SUPERCLASS: java.lang.Object
-	+++  NEW CONSTRUCTOR: PUBLIC(+) OtelToZipkinSpanTransformer(java.util.function.Supplier)
-	+++  NEW CONSTRUCTOR: PUBLIC(+) OtelToZipkinSpanTransformer()
-	+++  NEW METHOD: PUBLIC(+) zipkin2.Span apply(io.opentelemetry.sdk.trace.data.SpanData)
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.exporter.zipkin.OtelToZipkinSpanTransformer create()
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.exporter.zipkin.OtelToZipkinSpanTransformer create(java.util.function.Supplier)
+	+++  NEW METHOD: PUBLIC(+) zipkin2.Span generateSpan(io.opentelemetry.sdk.trace.data.SpanData)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder setOtelToZipkinTransformer(java.util.function.Function)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder setTransformer(io.opentelemetry.exporter.zipkin.OtelToZipkinSpanTransformer)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-zipkin.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-zipkin.txt
@@ -1,9 +1,4 @@
 Comparing source compatibility of  against 
-+++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.exporter.zipkin.OtelToZipkinSpanTransformer  (not serializable)
-	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
-	+++  NEW SUPERCLASS: java.lang.Object
-	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.exporter.zipkin.OtelToZipkinSpanTransformer create(java.util.function.Supplier)
-	+++  NEW METHOD: PUBLIC(+) zipkin2.Span generateSpan(io.opentelemetry.sdk.trace.data.SpanData)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder setLocalIpAddressSupplier(java.util.function.Supplier)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-zipkin.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-zipkin.txt
@@ -3,8 +3,8 @@ Comparing source compatibility of  against
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW INTERFACE: java.util.function.Function
 	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW CONSTRUCTOR: PUBLIC(+) OtelToZipkinSpanTransformer(java.util.function.Supplier)
 	+++  NEW CONSTRUCTOR: PUBLIC(+) OtelToZipkinSpanTransformer()
-	+++  NEW CONSTRUCTOR: PUBLIC(+) OtelToZipkinSpanTransformer(java.net.InetAddress)
 	+++  NEW METHOD: PUBLIC(+) zipkin2.Span apply(io.opentelemetry.sdk.trace.data.SpanData)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/LocalInetAddressSupplier.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/LocalInetAddressSupplier.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.zipkin;
+
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.util.Enumeration;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+class LocalInetAddressSupplier implements Supplier<InetAddress> {
+
+  private static final Logger logger = Logger.getLogger(LocalInetAddressSupplier.class.getName());
+  static final LocalInetAddressSupplier INSTANCE = new LocalInetAddressSupplier(findLocalIp());
+  @Nullable private final InetAddress inetAddress;
+
+  private LocalInetAddressSupplier(@Nullable InetAddress inetAddress) {
+    this.inetAddress = inetAddress;
+  }
+
+  @Nullable
+  @Override
+  public InetAddress get() {
+    return inetAddress;
+  }
+
+  /** Logic borrowed from brave.internal.Platform.produceLocalEndpoint */
+  @Nullable
+  private static InetAddress findLocalIp() {
+    try {
+      Enumeration<NetworkInterface> nics = NetworkInterface.getNetworkInterfaces();
+      while (nics.hasMoreElements()) {
+        NetworkInterface nic = nics.nextElement();
+        Enumeration<InetAddress> addresses = nic.getInetAddresses();
+        while (addresses.hasMoreElements()) {
+          InetAddress address = addresses.nextElement();
+          if (address.isSiteLocalAddress()) {
+            return address;
+          }
+        }
+      }
+    } catch (Exception e) {
+      // don't crash the caller if there was a problem reading nics.
+      logger.log(Level.FINE, "error reading nics", e);
+    }
+    return null;
+  }
+}

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/LocalInetAddressSupplier.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/LocalInetAddressSupplier.java
@@ -16,7 +16,8 @@ import javax.annotation.Nullable;
 class LocalInetAddressSupplier implements Supplier<InetAddress> {
 
   private static final Logger logger = Logger.getLogger(LocalInetAddressSupplier.class.getName());
-  static final LocalInetAddressSupplier INSTANCE = new LocalInetAddressSupplier(findLocalIp());
+  private static final LocalInetAddressSupplier INSTANCE =
+      new LocalInetAddressSupplier(findLocalIp());
   @Nullable private final InetAddress inetAddress;
 
   private LocalInetAddressSupplier(@Nullable InetAddress inetAddress) {
@@ -49,5 +50,9 @@ class LocalInetAddressSupplier implements Supplier<InetAddress> {
       logger.log(Level.FINE, "error reading nics", e);
     }
     return null;
+  }
+
+  static LocalInetAddressSupplier getInstance() {
+    return INSTANCE;
   }
 }

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
@@ -43,7 +43,7 @@ public final class OtelToZipkinSpanTransformer implements Function<SpanData, Spa
   static final String OTEL_DROPPED_ATTRIBUTES_COUNT = "otel.dropped_attributes_count";
   static final String OTEL_DROPPED_EVENTS_COUNT = "otel.dropped_events_count";
   static final String OTEL_STATUS_CODE = "otel.status_code";
-  public static final Logger logger = Logger.getLogger(ZipkinSpanExporter.class.getName());
+  private static final Logger logger = Logger.getLogger(ZipkinSpanExporter.class.getName());
   static final AttributeKey<String> STATUS_ERROR = stringKey("error");
   @Nullable private final InetAddress localAddress;
 

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
@@ -23,7 +23,6 @@ import java.net.NetworkInterface;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -36,7 +35,7 @@ import zipkin2.Span;
  * a Zipkin Span. It is based, in part, on code from
  * https://github.com/census-instrumentation/opencensus-java/tree/c960b19889de5e4a7b25f90919d28b066590d4f0/exporters/trace/zipkin
  */
-public final class OtelToZipkinSpanTransformer implements Function<SpanData, Span> {
+public final class OtelToZipkinSpanTransformer {
 
   static final String KEY_INSTRUMENTATION_SCOPE_NAME = "otel.scope.name";
   static final String KEY_INSTRUMENTATION_SCOPE_VERSION = "otel.scope.version";
@@ -69,12 +68,7 @@ public final class OtelToZipkinSpanTransformer implements Function<SpanData, Spa
     this.ipAddressSupplier = ipAddressSupplier;
   }
 
-  @Override
-  public Span apply(SpanData spanData) {
-    return generateSpan(spanData);
-  }
-
-  Span generateSpan(SpanData spanData) {
+  public Span generateSpan(SpanData spanData) {
     Endpoint endpoint = getEndpoint(spanData);
 
     long startTimestamp = toEpochMicros(spanData.getStartEpochNanos());

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
@@ -48,19 +48,18 @@ public final class OtelToZipkinSpanTransformer implements Function<SpanData, Spa
   @Nullable private final InetAddress localAddress;
 
   /**
-   * Creates a new instance of an OtelToZipkinSpanTransformer with the
-   * local IP address fetched from the network interfaces at construction
-   * time.
+   * Creates a new instance of an OtelToZipkinSpanTransformer with the local IP address fetched from
+   * the network interfaces at construction time.
    */
   public OtelToZipkinSpanTransformer() {
     this(produceLocalIp());
   }
 
   /**
-   * Creates a new instance of an OtelToZipkinSpanTransformer with the given
-   * local IP address.
-   * @param localAddress - The local IP address. If not null, the localAddress will be
-   * included in Zipkin spans as part of the localEndpoint.
+   * Creates a new instance of an OtelToZipkinSpanTransformer with the given local IP address.
+   *
+   * @param localAddress - The local IP address. If not null, the localAddress will be included in
+   *     Zipkin spans as part of the localEndpoint.
    */
   public OtelToZipkinSpanTransformer(@Nullable InetAddress localAddress) {
     this.localAddress = localAddress;

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
@@ -52,9 +52,9 @@ public final class OtelToZipkinSpanTransformer {
    * Creates a new instance of an OtelToZipkinSpanTransformer. This version of the constructor will
    * use a fixed IP address that is fetched from the network interfaces at construction time.
    */
-  public OtelToZipkinSpanTransformer() {
+  public static OtelToZipkinSpanTransformer create() {
     Optional<InetAddress> inetAddress = produceLocalIp();
-    this.ipAddressSupplier = () -> inetAddress;
+    return new OtelToZipkinSpanTransformer(() -> inetAddress);
   }
 
   /**
@@ -64,7 +64,18 @@ public final class OtelToZipkinSpanTransformer {
    *
    * @param ipAddressSupplier - A Supplier of an Optional InetAddress
    */
-  public OtelToZipkinSpanTransformer(Supplier<Optional<InetAddress>> ipAddressSupplier) {
+  public static OtelToZipkinSpanTransformer create(Supplier<Optional<InetAddress>> ipAddressSupplier) {
+    return new OtelToZipkinSpanTransformer(ipAddressSupplier);
+  }
+
+  /**
+   * Creates an instance of an OtelToZipkinSpanTransformer with the given Supplier that can produce
+   * an optional InetAddress. This value from this Supplier will be used when creating the local
+   * zipkin Endpoint for each Span.
+   *
+   * @param ipAddressSupplier - A Supplier of an Optional InetAddress
+   */
+  private OtelToZipkinSpanTransformer(Supplier<Optional<InetAddress>> ipAddressSupplier) {
     this.ipAddressSupplier = ipAddressSupplier;
   }
 

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
@@ -43,17 +43,10 @@ public final class OtelToZipkinSpanTransformer {
   private final Supplier<InetAddress> ipAddressSupplier;
 
   /**
-   * Creates a new instance of an OtelToZipkinSpanTransformer. This version of the constructor will
-   * use a fixed IP address that is fetched from the network interfaces at construction time.
-   */
-  public static OtelToZipkinSpanTransformer create() {
-    return new OtelToZipkinSpanTransformer(LocalInetAddressSupplier.getInstance());
-  }
-
-  /**
    * Creates an instance of an OtelToZipkinSpanTransformer with the given Supplier that can produce
    * an InetAddress, which may be null. This value from this Supplier will be used when creating the
-   * local zipkin Endpoint for each Span.
+   * local zipkin Endpoint for each Span. The default implementation uses
+   * LocalInetAddressSupplier.getInstance().
    *
    * @param ipAddressSupplier - A Supplier of an InetAddress.
    */

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
@@ -30,7 +30,7 @@ import zipkin2.Span;
  * a Zipkin Span. It is based, in part, on code from
  * https://github.com/census-instrumentation/opencensus-java/tree/c960b19889de5e4a7b25f90919d28b066590d4f0/exporters/trace/zipkin
  */
-public final class OtelToZipkinSpanTransformer {
+final class OtelToZipkinSpanTransformer {
 
   static final String KEY_INSTRUMENTATION_SCOPE_NAME = "otel.scope.name";
   static final String KEY_INSTRUMENTATION_SCOPE_VERSION = "otel.scope.version";
@@ -50,7 +50,7 @@ public final class OtelToZipkinSpanTransformer {
    *
    * @param ipAddressSupplier - A Supplier of an InetAddress.
    */
-  public static OtelToZipkinSpanTransformer create(Supplier<InetAddress> ipAddressSupplier) {
+  static OtelToZipkinSpanTransformer create(Supplier<InetAddress> ipAddressSupplier) {
     return new OtelToZipkinSpanTransformer(ipAddressSupplier);
   }
 
@@ -71,7 +71,7 @@ public final class OtelToZipkinSpanTransformer {
    * @param spanData an OpenTelemetry spanData instance
    * @return a new Zipkin Span
    */
-  public Span generateSpan(SpanData spanData) {
+  Span generateSpan(SpanData spanData) {
     Endpoint endpoint = getEndpoint(spanData);
 
     long startTimestamp = toEpochMicros(spanData.getStartEpochNanos());

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
@@ -80,6 +80,12 @@ public final class OtelToZipkinSpanTransformer {
     this.ipAddressSupplier = ipAddressSupplier;
   }
 
+  /**
+   * Creates an instance of a Zipkin Span from an OpenTelemetry SpanData instance
+   *
+   * @param spanData an OpenTelemetry spanData instance
+   * @return a new Zipkin Span
+   */
   public Span generateSpan(SpanData spanData) {
     Endpoint endpoint = getEndpoint(spanData);
 

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
@@ -34,7 +34,7 @@ import zipkin2.Span;
  * a Zipkin Span. It is based, in part, on code from
  * https://github.com/census-instrumentation/opencensus-java/tree/c960b19889de5e4a7b25f90919d28b066590d4f0/exporters/trace/zipkin
  */
-public class OtelToZipkinSpanTransformer implements Function<SpanData, Span> {
+public final class OtelToZipkinSpanTransformer implements Function<SpanData, Span> {
 
   static final String KEY_INSTRUMENTATION_SCOPE_NAME = "otel.scope.name";
   static final String KEY_INSTRUMENTATION_SCOPE_VERSION = "otel.scope.version";

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
@@ -81,7 +81,7 @@ public final class OtelToZipkinSpanTransformer {
   }
 
   /**
-   * Creates an instance of a Zipkin Span from an OpenTelemetry SpanData instance
+   * Creates an instance of a Zipkin Span from an OpenTelemetry SpanData instance.
    *
    * @param spanData an OpenTelemetry spanData instance
    * @return a new Zipkin Span

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
@@ -64,7 +64,8 @@ public final class OtelToZipkinSpanTransformer {
    *
    * @param ipAddressSupplier - A Supplier of an Optional InetAddress
    */
-  public static OtelToZipkinSpanTransformer create(Supplier<Optional<InetAddress>> ipAddressSupplier) {
+  public static OtelToZipkinSpanTransformer create(
+      Supplier<Optional<InetAddress>> ipAddressSupplier) {
     return new OtelToZipkinSpanTransformer(ipAddressSupplier);
   }
 

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
@@ -47,10 +47,21 @@ public final class OtelToZipkinSpanTransformer implements Function<SpanData, Spa
   static final AttributeKey<String> STATUS_ERROR = stringKey("error");
   @Nullable private final InetAddress localAddress;
 
+  /**
+   * Creates a new instance of an OtelToZipkinSpanTransformer with the
+   * local IP address fetched from the network interfaces at construction
+   * time.
+   */
   public OtelToZipkinSpanTransformer() {
     this(produceLocalIp());
   }
 
+  /**
+   * Creates a new instance of an OtelToZipkinSpanTransformer with the given
+   * local IP address.
+   * @param localAddress - The local IP address. If not null, the localAddress will be
+   * included in Zipkin spans as part of the localEndpoint.
+   */
   public OtelToZipkinSpanTransformer(@Nullable InetAddress localAddress) {
     this.localAddress = localAddress;
   }

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
@@ -47,7 +47,7 @@ public final class OtelToZipkinSpanTransformer {
    * use a fixed IP address that is fetched from the network interfaces at construction time.
    */
   public static OtelToZipkinSpanTransformer create() {
-    return new OtelToZipkinSpanTransformer(LocalInetAddressSupplier.INSTANCE);
+    return new OtelToZipkinSpanTransformer(LocalInetAddressSupplier.getInstance());
   }
 
   /**

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformer.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.zipkin;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.AttributeType;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+
+/**
+ * This class is responsible for transforming an OpenTelemetry SpanData instance into an instance of
+ * a Zipkin Span. It is based, in part, on code from
+ * https://github.com/census-instrumentation/opencensus-java/tree/c960b19889de5e4a7b25f90919d28b066590d4f0/exporters/trace/zipkin
+ */
+public class OtelToZipkinSpanTransformer implements Function<SpanData, Span> {
+
+  static final String KEY_INSTRUMENTATION_SCOPE_NAME = "otel.scope.name";
+  static final String KEY_INSTRUMENTATION_SCOPE_VERSION = "otel.scope.version";
+  static final String KEY_INSTRUMENTATION_LIBRARY_NAME = "otel.library.name";
+  static final String KEY_INSTRUMENTATION_LIBRARY_VERSION = "otel.library.version";
+  static final String OTEL_DROPPED_ATTRIBUTES_COUNT = "otel.dropped_attributes_count";
+  static final String OTEL_DROPPED_EVENTS_COUNT = "otel.dropped_events_count";
+  static final String OTEL_STATUS_CODE = "otel.status_code";
+  public static final Logger logger = Logger.getLogger(ZipkinSpanExporter.class.getName());
+  static final AttributeKey<String> STATUS_ERROR = stringKey("error");
+  @Nullable private final InetAddress localAddress;
+
+  public OtelToZipkinSpanTransformer() {
+    this(produceLocalIp());
+  }
+
+  public OtelToZipkinSpanTransformer(@Nullable InetAddress localAddress) {
+    this.localAddress = localAddress;
+  }
+
+  @Override
+  public Span apply(SpanData spanData) {
+    return generateSpan(spanData);
+  }
+
+  Span generateSpan(SpanData spanData) {
+    Endpoint endpoint = getEndpoint(spanData);
+
+    long startTimestamp = toEpochMicros(spanData.getStartEpochNanos());
+    long endTimestamp = toEpochMicros(spanData.getEndEpochNanos());
+
+    Span.Builder spanBuilder =
+        Span.newBuilder()
+            .traceId(spanData.getTraceId())
+            .id(spanData.getSpanId())
+            .kind(toSpanKind(spanData))
+            .name(spanData.getName())
+            .timestamp(toEpochMicros(spanData.getStartEpochNanos()))
+            .duration(Math.max(1, endTimestamp - startTimestamp))
+            .localEndpoint(endpoint);
+
+    if (spanData.getParentSpanContext().isValid()) {
+      spanBuilder.parentId(spanData.getParentSpanId());
+    }
+
+    Attributes spanAttributes = spanData.getAttributes();
+    spanAttributes.forEach(
+        (key, value) -> spanBuilder.putTag(key.getKey(), valueToString(key, value)));
+    int droppedAttributes = spanData.getTotalAttributeCount() - spanAttributes.size();
+    if (droppedAttributes > 0) {
+      spanBuilder.putTag(OTEL_DROPPED_ATTRIBUTES_COUNT, String.valueOf(droppedAttributes));
+    }
+
+    StatusData status = spanData.getStatus();
+
+    // include status code & error.
+    if (status.getStatusCode() != StatusCode.UNSET) {
+      spanBuilder.putTag(OTEL_STATUS_CODE, status.getStatusCode().toString());
+
+      // add the error tag, if it isn't already in the source span.
+      if (status.getStatusCode() == StatusCode.ERROR && spanAttributes.get(STATUS_ERROR) == null) {
+        spanBuilder.putTag(STATUS_ERROR.getKey(), nullToEmpty(status.getDescription()));
+      }
+    }
+
+    InstrumentationScopeInfo instrumentationScopeInfo = spanData.getInstrumentationScopeInfo();
+
+    if (!instrumentationScopeInfo.getName().isEmpty()) {
+      spanBuilder.putTag(KEY_INSTRUMENTATION_SCOPE_NAME, instrumentationScopeInfo.getName());
+      // Include instrumentation library name for backwards compatibility
+      spanBuilder.putTag(KEY_INSTRUMENTATION_LIBRARY_NAME, instrumentationScopeInfo.getName());
+    }
+    if (instrumentationScopeInfo.getVersion() != null) {
+      spanBuilder.putTag(KEY_INSTRUMENTATION_SCOPE_VERSION, instrumentationScopeInfo.getVersion());
+      // Include instrumentation library name for backwards compatibility
+      spanBuilder.putTag(
+          KEY_INSTRUMENTATION_LIBRARY_VERSION, instrumentationScopeInfo.getVersion());
+    }
+
+    for (EventData annotation : spanData.getEvents()) {
+      spanBuilder.addAnnotation(toEpochMicros(annotation.getEpochNanos()), annotation.getName());
+    }
+    int droppedEvents = spanData.getTotalRecordedEvents() - spanData.getEvents().size();
+    if (droppedEvents > 0) {
+      spanBuilder.putTag(OTEL_DROPPED_EVENTS_COUNT, String.valueOf(droppedEvents));
+    }
+
+    return spanBuilder.build();
+  }
+
+  private static String nullToEmpty(String value) {
+    return value != null ? value : "";
+  }
+
+  private Endpoint getEndpoint(SpanData spanData) {
+    Attributes resourceAttributes = spanData.getResource().getAttributes();
+
+    Endpoint.Builder endpoint = Endpoint.newBuilder().ip(localAddress);
+
+    // use the service.name from the Resource, if it's been set.
+    String serviceNameValue = resourceAttributes.get(ResourceAttributes.SERVICE_NAME);
+    if (serviceNameValue == null) {
+      serviceNameValue = Resource.getDefault().getAttribute(ResourceAttributes.SERVICE_NAME);
+    }
+    // In practice should never be null unless the default Resource spec is changed.
+    if (serviceNameValue != null) {
+      endpoint.serviceName(serviceNameValue);
+    }
+    return endpoint.build();
+  }
+
+  @Nullable
+  private static Span.Kind toSpanKind(SpanData spanData) {
+    switch (spanData.getKind()) {
+      case SERVER:
+        return Span.Kind.SERVER;
+      case CLIENT:
+        return Span.Kind.CLIENT;
+      case PRODUCER:
+        return Span.Kind.PRODUCER;
+      case CONSUMER:
+        return Span.Kind.CONSUMER;
+      case INTERNAL:
+        return null;
+    }
+    return null;
+  }
+
+  private static long toEpochMicros(long epochNanos) {
+    return NANOSECONDS.toMicros(epochNanos);
+  }
+
+  private static String valueToString(AttributeKey<?> key, Object attributeValue) {
+    AttributeType type = key.getType();
+    switch (type) {
+      case STRING:
+      case BOOLEAN:
+      case LONG:
+      case DOUBLE:
+        return String.valueOf(attributeValue);
+      case STRING_ARRAY:
+      case BOOLEAN_ARRAY:
+      case LONG_ARRAY:
+      case DOUBLE_ARRAY:
+        return commaSeparated((List<?>) attributeValue);
+    }
+    throw new IllegalStateException("Unknown attribute type: " + type);
+  }
+
+  private static String commaSeparated(List<?> values) {
+    StringBuilder builder = new StringBuilder();
+    for (Object value : values) {
+      if (builder.length() != 0) {
+        builder.append(',');
+      }
+      builder.append(value);
+    }
+    return builder.toString();
+  }
+
+  /** Logic borrowed from brave.internal.Platform.produceLocalEndpoint */
+  @Nullable
+  static InetAddress produceLocalIp() {
+    try {
+      Enumeration<NetworkInterface> nics = NetworkInterface.getNetworkInterfaces();
+      while (nics.hasMoreElements()) {
+        NetworkInterface nic = nics.nextElement();
+        Enumeration<InetAddress> addresses = nic.getInetAddresses();
+        while (addresses.hasMoreElements()) {
+          InetAddress address = addresses.nextElement();
+          if (address.isSiteLocalAddress()) {
+            return address;
+          }
+        }
+      }
+    } catch (Exception e) {
+      // don't crash the caller if there was a problem reading nics.
+      logger.log(Level.FINE, "error reading nics", e);
+    }
+    return null;
+  }
+}

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
@@ -42,11 +42,14 @@ public final class ZipkinSpanExporter implements SpanExporter {
   private final OtelToZipkinSpanTransformer transformer;
 
   ZipkinSpanExporter(BytesEncoder<Span> encoder, Sender sender, MeterProvider meterProvider) {
-    this(encoder, sender, OtelToZipkinSpanTransformer.create());
+    this(encoder, sender, meterProvider, OtelToZipkinSpanTransformer.create());
   }
 
   ZipkinSpanExporter(
-      BytesEncoder<Span> encoder, Sender sender, OtelToZipkinSpanTransformer transformer) {
+      BytesEncoder<Span> encoder,
+      Sender sender,
+      MeterProvider meterProvider,
+      OtelToZipkinSpanTransformer transformer) {
     this.encoder = encoder;
     this.sender = sender;
     this.exporterMetrics =

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
@@ -5,36 +5,20 @@
 
 package io.opentelemetry.exporter.zipkin;
 
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
-
-import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.common.AttributeType;
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.MeterProvider;
-import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.exporter.internal.ExporterMetrics;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.internal.ThrottlingLogger;
-import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.sdk.trace.data.StatusData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.NetworkInterface;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Enumeration;
 import java.util.List;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nullable;
 import zipkin2.Callback;
-import zipkin2.Endpoint;
 import zipkin2.Span;
 import zipkin2.codec.BytesEncoder;
 import zipkin2.codec.Encoding;
@@ -51,185 +35,26 @@ public final class ZipkinSpanExporter implements SpanExporter {
 
   public static final String DEFAULT_ENDPOINT = "http://localhost:9411/api/v2/spans";
 
-  static final String OTEL_DROPPED_ATTRIBUTES_COUNT = "otel.dropped_attributes_count";
-  static final String OTEL_DROPPED_EVENTS_COUNT = "otel.dropped_events_count";
-  static final String OTEL_STATUS_CODE = "otel.status_code";
-  static final AttributeKey<String> STATUS_ERROR = stringKey("error");
-
-  static final String KEY_INSTRUMENTATION_SCOPE_NAME = "otel.scope.name";
-  static final String KEY_INSTRUMENTATION_SCOPE_VERSION = "otel.scope.version";
-  static final String KEY_INSTRUMENTATION_LIBRARY_NAME = "otel.library.name";
-  static final String KEY_INSTRUMENTATION_LIBRARY_VERSION = "otel.library.version";
-
   private final ThrottlingLogger logger = new ThrottlingLogger(baseLogger);
-
   private final BytesEncoder<Span> encoder;
   private final Sender sender;
   private final ExporterMetrics exporterMetrics;
-  @Nullable private final InetAddress localAddress;
+
+  private final Function<SpanData, Span> otelToZipkin;
 
   ZipkinSpanExporter(BytesEncoder<Span> encoder, Sender sender, MeterProvider meterProvider) {
+    this(encoder, sender, new OtelToZipkinSpanTransformer());
+  }
+
+  ZipkinSpanExporter(
+      BytesEncoder<Span> encoder, Sender sender, Function<SpanData, Span> otelToZipkin) {
     this.encoder = encoder;
     this.sender = sender;
     this.exporterMetrics =
         sender.encoding() == Encoding.JSON
             ? ExporterMetrics.createHttpJson("zipkin", "span", meterProvider)
             : ExporterMetrics.createHttpProtobuf("zipkin", "span", meterProvider);
-    localAddress = produceLocalIp();
-  }
-
-  /** Logic borrowed from brave.internal.Platform.produceLocalEndpoint */
-  @Nullable
-  static InetAddress produceLocalIp() {
-    try {
-      Enumeration<NetworkInterface> nics = NetworkInterface.getNetworkInterfaces();
-      while (nics.hasMoreElements()) {
-        NetworkInterface nic = nics.nextElement();
-        Enumeration<InetAddress> addresses = nic.getInetAddresses();
-        while (addresses.hasMoreElements()) {
-          InetAddress address = addresses.nextElement();
-          if (address.isSiteLocalAddress()) {
-            return address;
-          }
-        }
-      }
-    } catch (Exception e) {
-      // don't crash the caller if there was a problem reading nics
-      baseLogger.log(Level.FINE, "error reading nics", e);
-    }
-    return null;
-  }
-
-  // VisibleForTesting
-  Span generateSpan(SpanData spanData) {
-    Endpoint endpoint = getEndpoint(spanData);
-
-    long startTimestamp = toEpochMicros(spanData.getStartEpochNanos());
-    long endTimestamp = toEpochMicros(spanData.getEndEpochNanos());
-
-    Span.Builder spanBuilder =
-        Span.newBuilder()
-            .traceId(spanData.getTraceId())
-            .id(spanData.getSpanId())
-            .kind(toSpanKind(spanData))
-            .name(spanData.getName())
-            .timestamp(toEpochMicros(spanData.getStartEpochNanos()))
-            .duration(Math.max(1, endTimestamp - startTimestamp))
-            .localEndpoint(endpoint);
-
-    if (spanData.getParentSpanContext().isValid()) {
-      spanBuilder.parentId(spanData.getParentSpanId());
-    }
-
-    Attributes spanAttributes = spanData.getAttributes();
-    spanAttributes.forEach(
-        (key, value) -> spanBuilder.putTag(key.getKey(), valueToString(key, value)));
-    int droppedAttributes = spanData.getTotalAttributeCount() - spanAttributes.size();
-    if (droppedAttributes > 0) {
-      spanBuilder.putTag(OTEL_DROPPED_ATTRIBUTES_COUNT, String.valueOf(droppedAttributes));
-    }
-
-    StatusData status = spanData.getStatus();
-
-    // include status code & error
-    if (status.getStatusCode() != StatusCode.UNSET) {
-      spanBuilder.putTag(OTEL_STATUS_CODE, status.getStatusCode().toString());
-
-      // add the error tag, if it isn't already in the source span
-      if (status.getStatusCode() == StatusCode.ERROR && spanAttributes.get(STATUS_ERROR) == null) {
-        spanBuilder.putTag(STATUS_ERROR.getKey(), status.getDescription());
-      }
-    }
-
-    InstrumentationScopeInfo instrumentationScopeInfo = spanData.getInstrumentationScopeInfo();
-
-    if (!instrumentationScopeInfo.getName().isEmpty()) {
-      spanBuilder.putTag(KEY_INSTRUMENTATION_SCOPE_NAME, instrumentationScopeInfo.getName());
-      // include instrumentation library name for backwards compatibility
-      spanBuilder.putTag(KEY_INSTRUMENTATION_LIBRARY_NAME, instrumentationScopeInfo.getName());
-    }
-    if (instrumentationScopeInfo.getVersion() != null) {
-      spanBuilder.putTag(KEY_INSTRUMENTATION_SCOPE_VERSION, instrumentationScopeInfo.getVersion());
-      // include instrumentation library name for backwards compatibility
-      spanBuilder.putTag(
-          KEY_INSTRUMENTATION_LIBRARY_VERSION, instrumentationScopeInfo.getVersion());
-    }
-
-    for (EventData annotation : spanData.getEvents()) {
-      spanBuilder.addAnnotation(toEpochMicros(annotation.getEpochNanos()), annotation.getName());
-    }
-    int droppedEvents = spanData.getTotalRecordedEvents() - spanData.getEvents().size();
-    if (droppedEvents > 0) {
-      spanBuilder.putTag(OTEL_DROPPED_EVENTS_COUNT, String.valueOf(droppedEvents));
-    }
-
-    return spanBuilder.build();
-  }
-
-  private Endpoint getEndpoint(SpanData spanData) {
-    Attributes resourceAttributes = spanData.getResource().getAttributes();
-
-    Endpoint.Builder endpoint = Endpoint.newBuilder().ip(localAddress);
-
-    // use the service.name from the Resource, if it's been set
-    String serviceNameValue = resourceAttributes.get(ResourceAttributes.SERVICE_NAME);
-    if (serviceNameValue == null) {
-      serviceNameValue = Resource.getDefault().getAttribute(ResourceAttributes.SERVICE_NAME);
-    }
-    // in practice should never be null unless the default Resource spec is changed
-    if (serviceNameValue != null) {
-      endpoint.serviceName(serviceNameValue);
-    }
-    return endpoint.build();
-  }
-
-  @Nullable
-  private static Span.Kind toSpanKind(SpanData spanData) {
-    switch (spanData.getKind()) {
-      case SERVER:
-        return Span.Kind.SERVER;
-      case CLIENT:
-        return Span.Kind.CLIENT;
-      case PRODUCER:
-        return Span.Kind.PRODUCER;
-      case CONSUMER:
-        return Span.Kind.CONSUMER;
-      case INTERNAL:
-        return null;
-    }
-    return null;
-  }
-
-  private static long toEpochMicros(long epochNanos) {
-    return NANOSECONDS.toMicros(epochNanos);
-  }
-
-  private static String valueToString(AttributeKey<?> key, Object attributeValue) {
-    AttributeType type = key.getType();
-    switch (type) {
-      case STRING:
-      case BOOLEAN:
-      case LONG:
-      case DOUBLE:
-        return String.valueOf(attributeValue);
-      case STRING_ARRAY:
-      case BOOLEAN_ARRAY:
-      case LONG_ARRAY:
-      case DOUBLE_ARRAY:
-        return commaSeparated((List<?>) attributeValue);
-    }
-    throw new IllegalStateException("Unknown attribute type: " + type);
-  }
-
-  private static String commaSeparated(List<?> values) {
-    StringBuilder builder = new StringBuilder();
-    for (Object value : values) {
-      if (builder.length() != 0) {
-        builder.append(',');
-      }
-      builder.append(value);
-    }
-    return builder.toString();
+    this.otelToZipkin = otelToZipkin;
   }
 
   @Override
@@ -239,7 +64,8 @@ public final class ZipkinSpanExporter implements SpanExporter {
 
     List<byte[]> encodedSpans = new ArrayList<>(numItems);
     for (SpanData spanData : spanDataList) {
-      encodedSpans.add(encoder.encode(generateSpan(spanData)));
+      Span zipkinSpan = otelToZipkin.apply(spanData);
+      encodedSpans.add(encoder.encode(zipkinSpan));
     }
 
     CompletableResultCode result = new CompletableResultCode();
@@ -286,11 +112,5 @@ public final class ZipkinSpanExporter implements SpanExporter {
    */
   public static ZipkinSpanExporterBuilder builder() {
     return new ZipkinSpanExporterBuilder();
-  }
-
-  // VisibleForTesting
-  @Nullable
-  InetAddress getLocalAddressForTest() {
-    return localAddress;
   }
 }

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
@@ -42,7 +42,7 @@ public final class ZipkinSpanExporter implements SpanExporter {
   private final OtelToZipkinSpanTransformer transformer;
 
   ZipkinSpanExporter(BytesEncoder<Span> encoder, Sender sender, MeterProvider meterProvider) {
-    this(encoder, sender, new OtelToZipkinSpanTransformer());
+    this(encoder, sender, OtelToZipkinSpanTransformer.create());
   }
 
   ZipkinSpanExporter(

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
@@ -41,10 +41,6 @@ public final class ZipkinSpanExporter implements SpanExporter {
 
   private final OtelToZipkinSpanTransformer transformer;
 
-  ZipkinSpanExporter(BytesEncoder<Span> encoder, Sender sender, MeterProvider meterProvider) {
-    this(encoder, sender, meterProvider, OtelToZipkinSpanTransformer.create());
-  }
-
   ZipkinSpanExporter(
       BytesEncoder<Span> encoder,
       Sender sender,

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import zipkin2.Callback;
@@ -40,14 +39,14 @@ public final class ZipkinSpanExporter implements SpanExporter {
   private final Sender sender;
   private final ExporterMetrics exporterMetrics;
 
-  private final Function<SpanData, Span> transformer;
+  private final OtelToZipkinSpanTransformer transformer;
 
   ZipkinSpanExporter(BytesEncoder<Span> encoder, Sender sender, MeterProvider meterProvider) {
     this(encoder, sender, new OtelToZipkinSpanTransformer());
   }
 
   ZipkinSpanExporter(
-      BytesEncoder<Span> encoder, Sender sender, Function<SpanData, Span> transformer) {
+      BytesEncoder<Span> encoder, Sender sender, OtelToZipkinSpanTransformer transformer) {
     this.encoder = encoder;
     this.sender = sender;
     this.exporterMetrics =
@@ -64,7 +63,7 @@ public final class ZipkinSpanExporter implements SpanExporter {
 
     List<byte[]> encodedSpans = new ArrayList<>(numItems);
     for (SpanData spanData : spanDataList) {
-      Span zipkinSpan = transformer.apply(spanData);
+      Span zipkinSpan = transformer.generateSpan(spanData);
       encodedSpans.add(encoder.encode(zipkinSpan));
     }
 

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
@@ -12,7 +12,6 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import javax.annotation.Nullable;
 import zipkin2.Span;
 import zipkin2.codec.BytesEncoder;
@@ -23,7 +22,7 @@ import zipkin2.reporter.okhttp3.OkHttpSender;
 /** Builder class for {@link ZipkinSpanExporter}. */
 public final class ZipkinSpanExporterBuilder {
   private BytesEncoder<Span> encoder = SpanBytesEncoder.JSON_V2;
-  private Function<SpanData, Span> transformer = new OtelToZipkinSpanTransformer();
+  private OtelToZipkinSpanTransformer transformer = new OtelToZipkinSpanTransformer();
   @Nullable private Sender sender;
   private String endpoint = ZipkinSpanExporter.DEFAULT_ENDPOINT;
   private long readTimeoutMillis = TimeUnit.SECONDS.toMillis(10);
@@ -59,16 +58,16 @@ public final class ZipkinSpanExporterBuilder {
   }
 
   /**
-   * Sets the Function that is responsible for transforming an OpenTelemetry {@link SpanData} into
-   * an instance of a Zipkin {@link Span}. The default Function is an instance of {@link
+   * Sets the OtelToZipkinSpanTransformer that is responsible for transforming an OpenTelemetry {@link SpanData} into
+   * an instance of a Zipkin {@link Span}. The default is an instance of {@link
    * OtelToZipkinSpanTransformer} configured with the local IP address at the time of creation.
    *
-   * @param transformer the Function used to transform a SpanData to a Zipkin Span instance
+   * @param transformer the OtelToZipkinSpanTransformer used to transform a SpanData to a Zipkin Span instance
    * @return this
    * @see OtelToZipkinSpanTransformer
    */
   public ZipkinSpanExporterBuilder setTransformer(
-      Function<SpanData, Span> transformer) {
+      OtelToZipkinSpanTransformer transformer) {
     requireNonNull(transformer, "encoder");
     this.transformer = transformer;
     return this;

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
@@ -23,7 +23,7 @@ import zipkin2.reporter.okhttp3.OkHttpSender;
 /** Builder class for {@link ZipkinSpanExporter}. */
 public final class ZipkinSpanExporterBuilder {
   private BytesEncoder<Span> encoder = SpanBytesEncoder.JSON_V2;
-  private Function<SpanData, Span> otelToZipkinTransformer = new OtelToZipkinSpanTransformer();
+  private Function<SpanData, Span> transformer = new OtelToZipkinSpanTransformer();
   @Nullable private Sender sender;
   private String endpoint = ZipkinSpanExporter.DEFAULT_ENDPOINT;
   private long readTimeoutMillis = TimeUnit.SECONDS.toMillis(10);
@@ -67,10 +67,10 @@ public final class ZipkinSpanExporterBuilder {
    * @return this
    * @see OtelToZipkinSpanTransformer
    */
-  public ZipkinSpanExporterBuilder setOtelToZipkinTransformer(
+  public ZipkinSpanExporterBuilder setTransformer(
       Function<SpanData, Span> transformer) {
     requireNonNull(transformer, "encoder");
-    this.otelToZipkinTransformer = transformer;
+    this.transformer = transformer;
     return this;
   }
 
@@ -137,6 +137,6 @@ public final class ZipkinSpanExporterBuilder {
       sender =
           OkHttpSender.newBuilder().endpoint(endpoint).readTimeout((int) readTimeoutMillis).build();
     }
-    return new ZipkinSpanExporter(encoder, sender, otelToZipkinTransformer);
+    return new ZipkinSpanExporter(encoder, sender, transformer);
   }
 }

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
@@ -60,7 +60,9 @@ public final class ZipkinSpanExporterBuilder {
 
   /**
    * Sets the Function that is responsible for transforming an OpenTelemetry {@link SpanData} into
-   * an instance of a Zipkin {@link Span}.
+   * an instance of a Zipkin {@link Span}. The default Function is an instance of
+   * {@link OtelToZipkinSpanTransformer} configured with the local IP address at the time
+   * of creation.
    *
    * @param transformer the Function used to transform a SpanData to a Zipkin Span instance
    * @return this

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
@@ -60,7 +60,9 @@ public final class ZipkinSpanExporterBuilder {
 
   /**
    * Sets the Supplier of InetAddress. This Supplier will be used by the {@link
-   * OtelToZipkinSpanTransformer} when creating the Zipkin local endpoint.
+   * OtelToZipkinSpanTransformer} when creating the Zipkin local endpoint. The default
+   * implementation uses a Supplier that returns a single unchanging IP address that is captured at
+   * creation time.
    *
    * @param supplier - A supplier that returns an InetAddress that may be null.
    * @return this

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
@@ -58,6 +58,14 @@ public final class ZipkinSpanExporterBuilder {
     return this;
   }
 
+  /**
+   * Sets the Function that is responsible for transforming an OpenTelemetry {@link SpanData} into
+   * an instance of a Zipkin {@link Span}.
+   *
+   * @param transformer the Function used to transform a SpanData to a Zipkin Span instance
+   * @return this
+   * @see OtelToZipkinSpanTransformer
+   */
   public ZipkinSpanExporterBuilder setOtelToZipkinTransformer(
       Function<SpanData, Span> transformer) {
     requireNonNull(transformer, "encoder");

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
@@ -22,7 +22,7 @@ import zipkin2.reporter.okhttp3.OkHttpSender;
 /** Builder class for {@link ZipkinSpanExporter}. */
 public final class ZipkinSpanExporterBuilder {
   private BytesEncoder<Span> encoder = SpanBytesEncoder.JSON_V2;
-  private OtelToZipkinSpanTransformer transformer = new OtelToZipkinSpanTransformer();
+  private OtelToZipkinSpanTransformer transformer = OtelToZipkinSpanTransformer.create();
   @Nullable private Sender sender;
   private String endpoint = ZipkinSpanExporter.DEFAULT_ENDPOINT;
   private long readTimeoutMillis = TimeUnit.SECONDS.toMillis(10);

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
@@ -58,16 +58,17 @@ public final class ZipkinSpanExporterBuilder {
   }
 
   /**
-   * Sets the OtelToZipkinSpanTransformer that is responsible for transforming an OpenTelemetry {@link SpanData} into
-   * an instance of a Zipkin {@link Span}. The default is an instance of {@link
-   * OtelToZipkinSpanTransformer} configured with the local IP address at the time of creation.
+   * Sets the OtelToZipkinSpanTransformer that is responsible for transforming an OpenTelemetry
+   * {@link SpanData} into an instance of a Zipkin {@link Span}. The default is an instance of
+   * {@link OtelToZipkinSpanTransformer} configured with the local IP address at the time of
+   * creation.
    *
-   * @param transformer the OtelToZipkinSpanTransformer used to transform a SpanData to a Zipkin Span instance
+   * @param transformer the OtelToZipkinSpanTransformer used to transform a SpanData to a Zipkin
+   *     Span instance
    * @return this
    * @see OtelToZipkinSpanTransformer
    */
-  public ZipkinSpanExporterBuilder setTransformer(
-      OtelToZipkinSpanTransformer transformer) {
+  public ZipkinSpanExporterBuilder setTransformer(OtelToZipkinSpanTransformer transformer) {
     requireNonNull(transformer, "encoder");
     this.transformer = transformer;
     return this;
@@ -136,6 +137,6 @@ public final class ZipkinSpanExporterBuilder {
       sender =
           OkHttpSender.newBuilder().endpoint(endpoint).readTimeout((int) readTimeoutMillis).build();
     }
-    return new ZipkinSpanExporter(encoder, sender, transformer);
+    return new ZipkinSpanExporter(encoder, sender, meterProvider, transformer);
   }
 }

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
@@ -23,7 +23,7 @@ import zipkin2.reporter.okhttp3.OkHttpSender;
 /** Builder class for {@link ZipkinSpanExporter}. */
 public final class ZipkinSpanExporterBuilder {
   private BytesEncoder<Span> encoder = SpanBytesEncoder.JSON_V2;
-  private Supplier<InetAddress> localIpAddressSupplier = LocalInetAddressSupplier.INSTANCE;
+  private Supplier<InetAddress> localIpAddressSupplier = LocalInetAddressSupplier.getInstance();
   @Nullable private Sender sender;
   private String endpoint = ZipkinSpanExporter.DEFAULT_ENDPOINT;
   private long readTimeoutMillis = TimeUnit.SECONDS.toMillis(10);

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
@@ -60,9 +60,8 @@ public final class ZipkinSpanExporterBuilder {
 
   /**
    * Sets the Function that is responsible for transforming an OpenTelemetry {@link SpanData} into
-   * an instance of a Zipkin {@link Span}. The default Function is an instance of
-   * {@link OtelToZipkinSpanTransformer} configured with the local IP address at the time
-   * of creation.
+   * an instance of a Zipkin {@link Span}. The default Function is an instance of {@link
+   * OtelToZipkinSpanTransformer} configured with the local IP address at the time of creation.
    *
    * @param transformer the Function used to transform a SpanData to a Zipkin Span instance
    * @return this

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformerTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformerTest.java
@@ -29,6 +29,7 @@ import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import zipkin2.Endpoint;
 import zipkin2.Span;
@@ -36,7 +37,7 @@ import zipkin2.Span;
 class OtelToZipkinSpanTransformerTest {
 
   private final OtelToZipkinSpanTransformer transformer =
-      new OtelToZipkinSpanTransformer(ZipkinTestSpan.localAddressForTesting);
+      new OtelToZipkinSpanTransformer(() -> Optional.of(ZipkinTestSpan.localAddressForTesting));
 
   @Test
   void generateSpan_remoteParent() {

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformerTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformerTest.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.zipkin;
+
+import static io.opentelemetry.api.common.AttributeKey.booleanArrayKey;
+import static io.opentelemetry.api.common.AttributeKey.booleanKey;
+import static io.opentelemetry.api.common.AttributeKey.doubleArrayKey;
+import static io.opentelemetry.api.common.AttributeKey.doubleKey;
+import static io.opentelemetry.api.common.AttributeKey.longArrayKey;
+import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.exporter.zipkin.ZipkinTestSpan.buildStandardSpan;
+import static io.opentelemetry.exporter.zipkin.ZipkinTestSpan.buildZipkinSpan;
+import static io.opentelemetry.exporter.zipkin.ZipkinTestSpan.standardZipkinSpanBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+
+class OtelToZipkinSpanTransformerTest {
+
+  private final OtelToZipkinSpanTransformer transformer =
+      new OtelToZipkinSpanTransformer(ZipkinTestSpan.localAddressForTesting);
+
+  @Test
+  void generateSpan_remoteParent() {
+    SpanData data = buildStandardSpan().build();
+
+    assertThat(transformer.generateSpan(data))
+        .isEqualTo(
+            standardZipkinSpanBuilder(Span.Kind.SERVER)
+                .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "OK")
+                .build());
+  }
+
+  @Test
+  void generateSpan_subMicroDurations() {
+    SpanData data =
+        buildStandardSpan()
+            .setStartEpochNanos(1505855794_194009601L)
+            .setEndEpochNanos(1505855794_194009999L)
+            .build();
+
+    Span expected =
+        standardZipkinSpanBuilder(Span.Kind.SERVER)
+            .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "OK")
+            .duration(1)
+            .build();
+    assertThat(transformer.generateSpan(data)).isEqualTo(expected);
+  }
+
+  @Test
+  void generateSpan_ServerKind() {
+    SpanData data = buildStandardSpan().setKind(SpanKind.SERVER).build();
+
+    assertThat(transformer.generateSpan(data))
+        .isEqualTo(
+            standardZipkinSpanBuilder(Span.Kind.SERVER)
+                .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "OK")
+                .build());
+  }
+
+  @Test
+  void generateSpan_ClientKind() {
+    SpanData data = buildStandardSpan().setKind(SpanKind.CLIENT).build();
+
+    assertThat(transformer.generateSpan(data))
+        .isEqualTo(
+            standardZipkinSpanBuilder(Span.Kind.CLIENT)
+                .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "OK")
+                .build());
+  }
+
+  @Test
+  void generateSpan_InternalKind() {
+    SpanData data = buildStandardSpan().setKind(SpanKind.INTERNAL).build();
+
+    assertThat(transformer.generateSpan(data))
+        .isEqualTo(
+            standardZipkinSpanBuilder(null)
+                .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "OK")
+                .build());
+  }
+
+  @Test
+  void generateSpan_ConsumeKind() {
+    SpanData data = buildStandardSpan().setKind(SpanKind.CONSUMER).build();
+
+    assertThat(transformer.generateSpan(data))
+        .isEqualTo(
+            standardZipkinSpanBuilder(Span.Kind.CONSUMER)
+                .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "OK")
+                .build());
+  }
+
+  @Test
+  void generateSpan_ProducerKind() {
+    SpanData data = buildStandardSpan().setKind(SpanKind.PRODUCER).build();
+
+    assertThat(transformer.generateSpan(data))
+        .isEqualTo(
+            standardZipkinSpanBuilder(Span.Kind.PRODUCER)
+                .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "OK")
+                .build());
+  }
+
+  @Test
+  void generateSpan_ResourceServiceNameMapping() {
+    Resource resource =
+        Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, "super-zipkin-service"));
+    SpanData data = buildStandardSpan().setResource(resource).build();
+
+    Endpoint expectedEndpoint =
+        Endpoint.newBuilder()
+            .serviceName("super-zipkin-service")
+            .ip(ZipkinTestSpan.localAddressForTesting)
+            .build();
+    Span expectedZipkinSpan =
+        buildZipkinSpan(Span.Kind.SERVER).toBuilder()
+            .localEndpoint(expectedEndpoint)
+            .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "OK")
+            .build();
+    assertThat(transformer.generateSpan(data)).isEqualTo(expectedZipkinSpan);
+  }
+
+  @Test
+  void generateSpan_defaultResourceServiceName() {
+    SpanData data = buildStandardSpan().setResource(Resource.empty()).build();
+
+    Endpoint expectedEndpoint =
+        Endpoint.newBuilder()
+            .serviceName(Resource.getDefault().getAttribute(ResourceAttributes.SERVICE_NAME))
+            .ip(ZipkinTestSpan.localAddressForTesting)
+            .build();
+    Span expectedZipkinSpan =
+        buildZipkinSpan(Span.Kind.SERVER).toBuilder()
+            .localEndpoint(expectedEndpoint)
+            .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "OK")
+            .build();
+    assertThat(transformer.generateSpan(data)).isEqualTo(expectedZipkinSpan);
+  }
+
+  @Test
+  void generateSpan_WithAttributes() {
+    Attributes attributes =
+        Attributes.builder()
+            .put(stringKey("string"), "string value")
+            .put(booleanKey("boolean"), false)
+            .put(longKey("long"), 9999L)
+            .put(doubleKey("double"), 222.333d)
+            .put(booleanArrayKey("booleanArray"), Arrays.asList(true, false))
+            .put(stringArrayKey("stringArray"), Collections.singletonList("Hello"))
+            .put(doubleArrayKey("doubleArray"), Arrays.asList(32.33d, -98.3d))
+            .put(longArrayKey("longArray"), Arrays.asList(33L, 999L))
+            .build();
+    SpanData data =
+        buildStandardSpan()
+            .setAttributes(attributes)
+            .setTotalAttributeCount(28)
+            .setTotalRecordedEvents(3)
+            .setKind(SpanKind.CLIENT)
+            .build();
+
+    assertThat(transformer.generateSpan(data))
+        .isEqualTo(
+            buildZipkinSpan(Span.Kind.CLIENT).toBuilder()
+                .putTag("string", "string value")
+                .putTag("boolean", "false")
+                .putTag("long", "9999")
+                .putTag("double", "222.333")
+                .putTag("booleanArray", "true,false")
+                .putTag("stringArray", "Hello")
+                .putTag("doubleArray", "32.33,-98.3")
+                .putTag("longArray", "33,999")
+                .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "OK")
+                .putTag(OtelToZipkinSpanTransformer.OTEL_DROPPED_ATTRIBUTES_COUNT, "20")
+                .putTag(OtelToZipkinSpanTransformer.OTEL_DROPPED_EVENTS_COUNT, "1")
+                .build());
+  }
+
+  @Test
+  void generateSpan_WithInstrumentationLibraryInfo() {
+    SpanData data =
+        buildStandardSpan()
+            .setInstrumentationScopeInfo(
+                InstrumentationScopeInfo.create("io.opentelemetry.auto", "1.0.0", null))
+            .setKind(SpanKind.CLIENT)
+            .build();
+
+    assertThat(transformer.generateSpan(data))
+        .isEqualTo(
+            buildZipkinSpan(Span.Kind.CLIENT).toBuilder()
+                .putTag("otel.scope.name", "io.opentelemetry.auto")
+                .putTag("otel.scope.version", "1.0.0")
+                .putTag("otel.library.name", "io.opentelemetry.auto")
+                .putTag("otel.library.version", "1.0.0")
+                .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "OK")
+                .build());
+  }
+
+  @Test
+  void generateSpan_AlreadyHasHttpStatusInfo() {
+    Attributes attributeMap =
+        Attributes.of(
+            SemanticAttributes.HTTP_STATUS_CODE, 404L, stringKey("error"), "A user provided error");
+    SpanData data =
+        buildStandardSpan()
+            .setAttributes(attributeMap)
+            .setKind(SpanKind.CLIENT)
+            .setStatus(StatusData.error())
+            .setTotalAttributeCount(2)
+            .build();
+
+    assertThat(transformer.generateSpan(data))
+        .isEqualTo(
+            buildZipkinSpan(Span.Kind.CLIENT).toBuilder()
+                .clearTags()
+                .putTag(SemanticAttributes.HTTP_STATUS_CODE.getKey(), "404")
+                .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "ERROR")
+                .putTag("error", "A user provided error")
+                .build());
+  }
+
+  @Test
+  void generateSpan_WithRpcTimeoutErrorStatus_WithTimeoutErrorDescription() {
+    Attributes attributeMap = Attributes.of(SemanticAttributes.RPC_SERVICE, "my service name");
+
+    String errorMessage = "timeout";
+
+    SpanData data =
+        buildStandardSpan()
+            .setStatus(StatusData.create(StatusCode.ERROR, errorMessage))
+            .setAttributes(attributeMap)
+            .setTotalAttributeCount(1)
+            .build();
+
+    assertThat(transformer.generateSpan(data))
+        .isEqualTo(
+            buildZipkinSpan(Span.Kind.SERVER).toBuilder()
+                .putTag(SemanticAttributes.RPC_SERVICE.getKey(), "my service name")
+                .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "ERROR")
+                .putTag(OtelToZipkinSpanTransformer.STATUS_ERROR.getKey(), errorMessage)
+                .build());
+  }
+
+  @Test
+  void generateSpan_WithRpcErrorStatus_WithEmptyErrorDescription() {
+    Attributes attributeMap = Attributes.of(SemanticAttributes.RPC_SERVICE, "my service name");
+
+    SpanData data =
+        buildStandardSpan()
+            .setStatus(StatusData.create(StatusCode.ERROR, ""))
+            .setAttributes(attributeMap)
+            .setTotalAttributeCount(1)
+            .build();
+
+    assertThat(transformer.generateSpan(data))
+        .isEqualTo(
+            buildZipkinSpan(Span.Kind.SERVER).toBuilder()
+                .putTag(SemanticAttributes.RPC_SERVICE.getKey(), "my service name")
+                .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "ERROR")
+                .putTag(OtelToZipkinSpanTransformer.STATUS_ERROR.getKey(), "")
+                .build());
+  }
+
+  @Test
+  void generateSpan_WithRpcUnsetStatus() {
+    Attributes attributeMap = Attributes.of(SemanticAttributes.RPC_SERVICE, "my service name");
+
+    SpanData data =
+        buildStandardSpan()
+            .setStatus(StatusData.create(StatusCode.UNSET, ""))
+            .setAttributes(attributeMap)
+            .setTotalAttributeCount(1)
+            .build();
+
+    assertThat(transformer.generateSpan(data))
+        .isEqualTo(
+            buildZipkinSpan(Span.Kind.SERVER).toBuilder()
+                .putTag(SemanticAttributes.RPC_SERVICE.getKey(), "my service name")
+                .build());
+  }
+}

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformerTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformerTest.java
@@ -31,7 +31,6 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import zipkin2.Endpoint;
@@ -45,7 +44,7 @@ class OtelToZipkinSpanTransformerTest {
   @BeforeEach
   void setup() {
     localIp = mock(InetAddress.class);
-    transformer = OtelToZipkinSpanTransformer.create(() -> Optional.of(localIp));
+    transformer = OtelToZipkinSpanTransformer.create(() -> localIp);
   }
 
   @Test

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformerTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformerTest.java
@@ -217,12 +217,12 @@ class OtelToZipkinSpanTransformerTest {
 
   @Test
   void generateSpan_AlreadyHasHttpStatusInfo() {
-    Attributes attributeMap =
+    Attributes attributes =
         Attributes.of(
             SemanticAttributes.HTTP_STATUS_CODE, 404L, stringKey("error"), "A user provided error");
     SpanData data =
         spanBuilder()
-            .setAttributes(attributeMap)
+            .setAttributes(attributes)
             .setKind(SpanKind.CLIENT)
             .setStatus(StatusData.error())
             .setTotalAttributeCount(2)
@@ -240,14 +240,14 @@ class OtelToZipkinSpanTransformerTest {
 
   @Test
   void generateSpan_WithRpcTimeoutErrorStatus_WithTimeoutErrorDescription() {
-    Attributes attributeMap = Attributes.of(SemanticAttributes.RPC_SERVICE, "my service name");
+    Attributes attributes = Attributes.of(SemanticAttributes.RPC_SERVICE, "my service name");
 
     String errorMessage = "timeout";
 
     SpanData data =
         spanBuilder()
             .setStatus(StatusData.create(StatusCode.ERROR, errorMessage))
-            .setAttributes(attributeMap)
+            .setAttributes(attributes)
             .setTotalAttributeCount(1)
             .build();
 
@@ -262,12 +262,12 @@ class OtelToZipkinSpanTransformerTest {
 
   @Test
   void generateSpan_WithRpcErrorStatus_WithEmptyErrorDescription() {
-    Attributes attributeMap = Attributes.of(SemanticAttributes.RPC_SERVICE, "my service name");
+    Attributes attributes = Attributes.of(SemanticAttributes.RPC_SERVICE, "my service name");
 
     SpanData data =
         spanBuilder()
             .setStatus(StatusData.create(StatusCode.ERROR, ""))
-            .setAttributes(attributeMap)
+            .setAttributes(attributes)
             .setTotalAttributeCount(1)
             .build();
 
@@ -282,12 +282,12 @@ class OtelToZipkinSpanTransformerTest {
 
   @Test
   void generateSpan_WithRpcUnsetStatus() {
-    Attributes attributeMap = Attributes.of(SemanticAttributes.RPC_SERVICE, "my service name");
+    Attributes attributes = Attributes.of(SemanticAttributes.RPC_SERVICE, "my service name");
 
     SpanData data =
         spanBuilder()
             .setStatus(StatusData.create(StatusCode.UNSET, ""))
-            .setAttributes(attributeMap)
+            .setAttributes(attributes)
             .setTotalAttributeCount(1)
             .build();
 

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
@@ -104,6 +104,7 @@ class ZipkinSpanExporterEndToEndHttpTest {
             .setEndpoint(zipkinUrl(ENDPOINT_V2_SPANS))
             .setMeterProvider(sdkMeterProvider)
             .setOtelToZipkinTransformer(otelToZipkinTransformer)
+            .setTransformer(otelToZipkinTransformer)
             .build();
     exportAndVerify(exporter);
 

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
@@ -89,7 +89,7 @@ class ZipkinSpanExporterEndToEndHttpTest {
   private final SdkMeterProvider sdkMeterProvider =
       SdkMeterProvider.builder().registerMetricReader(sdkMeterReader).build();
 
-  private static final OtelToZipkinSpanTransformer otelToZipkinTransformer =
+  private static final OtelToZipkinSpanTransformer transformer =
       OtelToZipkinSpanTransformer.create(() -> Optional.of(ZipkinTestUtil.localAddressForTesting));
 
   @AfterEach
@@ -103,8 +103,7 @@ class ZipkinSpanExporterEndToEndHttpTest {
         ZipkinSpanExporter.builder()
             .setEndpoint(zipkinUrl(ENDPOINT_V2_SPANS))
             .setMeterProvider(sdkMeterProvider)
-            .setOtelToZipkinTransformer(otelToZipkinTransformer)
-            .setTransformer(otelToZipkinTransformer)
+            .setTransformer(transformer)
             .build();
     exportAndVerify(exporter);
 
@@ -179,7 +178,9 @@ class ZipkinSpanExporterEndToEndHttpTest {
         .setSender(OkHttpSender.newBuilder().endpoint(endpoint).encoding(encoding).build())
         .setEncoder(encoder)
         .setMeterProvider(meterProvider)
-        .setOtelToZipkinTransformer(otelToZipkinTransformer)
+        .setTransformer(
+            OtelToZipkinSpanTransformer.create(
+                () -> Optional.of(ZipkinTestUtil.localAddressForTesting)))
         .build();
   }
 

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
@@ -90,7 +90,7 @@ class ZipkinSpanExporterEndToEndHttpTest {
       SdkMeterProvider.builder().registerMetricReader(sdkMeterReader).build();
 
   private static final OtelToZipkinSpanTransformer otelToZipkinTransformer =
-      new OtelToZipkinSpanTransformer(() -> Optional.of(ZipkinTestSpan.localAddressForTesting));
+      OtelToZipkinSpanTransformer.create(() -> Optional.of(ZipkinTestUtil.localAddressForTesting));
 
   @AfterEach
   void tearDown() {
@@ -199,7 +199,7 @@ class ZipkinSpanExporterEndToEndHttpTest {
     assertThat(zipkinSpans).isNotNull();
     assertThat(zipkinSpans.size()).isEqualTo(1);
     assertThat(zipkinSpans.get(0))
-        .isEqualTo(buildZipkinSpan(ZipkinTestSpan.localAddressForTesting, traceId));
+        .isEqualTo(buildZipkinSpan(ZipkinTestUtil.localAddressForTesting, traceId));
   }
 
   private static TestSpanData.Builder buildStandardSpan(String traceId) {

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
@@ -33,6 +33,7 @@ import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -89,7 +90,7 @@ class ZipkinSpanExporterEndToEndHttpTest {
       SdkMeterProvider.builder().registerMetricReader(sdkMeterReader).build();
 
   private static final OtelToZipkinSpanTransformer otelToZipkinTransformer =
-      new OtelToZipkinSpanTransformer(ZipkinTestSpan.localAddressForTesting);
+      new OtelToZipkinSpanTransformer(() -> Optional.of(ZipkinTestSpan.localAddressForTesting));
 
   @AfterEach
   void tearDown() {

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
@@ -34,7 +34,6 @@ import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -91,8 +90,6 @@ class ZipkinSpanExporterEndToEndHttpTest {
       SdkMeterProvider.builder().registerMetricReader(sdkMeterReader).build();
 
   private static final InetAddress localIp = mock(InetAddress.class);
-  private static final OtelToZipkinSpanTransformer transformer =
-      OtelToZipkinSpanTransformer.create(() -> Optional.of(localIp));
 
   @AfterEach
   void tearDown() {
@@ -105,7 +102,7 @@ class ZipkinSpanExporterEndToEndHttpTest {
         ZipkinSpanExporter.builder()
             .setEndpoint(zipkinUrl(ENDPOINT_V2_SPANS))
             .setMeterProvider(sdkMeterProvider)
-            .setTransformer(transformer)
+            .setLocalIpAddressSupplier(() -> localIp)
             .build();
     exportAndVerify(exporter);
 
@@ -180,7 +177,7 @@ class ZipkinSpanExporterEndToEndHttpTest {
         .setSender(OkHttpSender.newBuilder().endpoint(endpoint).encoding(encoding).build())
         .setEncoder(encoder)
         .setMeterProvider(meterProvider)
-        .setTransformer(OtelToZipkinSpanTransformer.create(() -> Optional.of(localIp)))
+        .setLocalIpAddressSupplier(() -> localIp)
         .build();
   }
 

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.exporter.zipkin;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
@@ -89,8 +90,9 @@ class ZipkinSpanExporterEndToEndHttpTest {
   private final SdkMeterProvider sdkMeterProvider =
       SdkMeterProvider.builder().registerMetricReader(sdkMeterReader).build();
 
+  private static final InetAddress localIp = mock(InetAddress.class);
   private static final OtelToZipkinSpanTransformer transformer =
-      OtelToZipkinSpanTransformer.create(() -> Optional.of(ZipkinTestUtil.localAddressForTesting));
+      OtelToZipkinSpanTransformer.create(() -> Optional.of(localIp));
 
   @AfterEach
   void tearDown() {
@@ -178,9 +180,7 @@ class ZipkinSpanExporterEndToEndHttpTest {
         .setSender(OkHttpSender.newBuilder().endpoint(endpoint).encoding(encoding).build())
         .setEncoder(encoder)
         .setMeterProvider(meterProvider)
-        .setTransformer(
-            OtelToZipkinSpanTransformer.create(
-                () -> Optional.of(ZipkinTestUtil.localAddressForTesting)))
+        .setTransformer(OtelToZipkinSpanTransformer.create(() -> Optional.of(localIp)))
         .build();
   }
 
@@ -199,8 +199,7 @@ class ZipkinSpanExporterEndToEndHttpTest {
 
     assertThat(zipkinSpans).isNotNull();
     assertThat(zipkinSpans.size()).isEqualTo(1);
-    assertThat(zipkinSpans.get(0))
-        .isEqualTo(buildZipkinSpan(ZipkinTestUtil.localAddressForTesting, traceId));
+    assertThat(zipkinSpans.get(0)).isEqualTo(buildZipkinSpan(localIp, traceId));
   }
 
   private static TestSpanData.Builder buildStandardSpan(String traceId) {

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterTest.java
@@ -5,14 +5,8 @@
 
 package io.opentelemetry.exporter.zipkin;
 
-import static io.opentelemetry.api.common.AttributeKey.booleanArrayKey;
-import static io.opentelemetry.api.common.AttributeKey.booleanKey;
-import static io.opentelemetry.api.common.AttributeKey.doubleArrayKey;
-import static io.opentelemetry.api.common.AttributeKey.doubleKey;
-import static io.opentelemetry.api.common.AttributeKey.longArrayKey;
-import static io.opentelemetry.api.common.AttributeKey.longKey;
-import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.exporter.zipkin.ZipkinTestSpan.buildStandardSpan;
+import static io.opentelemetry.exporter.zipkin.ZipkinTestSpan.standardZipkinSpanBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -20,35 +14,21 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.MeterProvider;
-import io.opentelemetry.api.trace.SpanContext;
-import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.api.trace.StatusCode;
-import io.opentelemetry.api.trace.TraceFlags;
-import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
-import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.trace.TestSpanData;
-import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import zipkin2.Call;
 import zipkin2.Callback;
-import zipkin2.Endpoint;
 import zipkin2.Span;
 import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.reporter.Sender;
@@ -59,289 +39,22 @@ class ZipkinSpanExporterTest {
   @Mock private Sender mockSender;
   @Mock private SpanBytesEncoder mockEncoder;
   @Mock private Call<Void> mockZipkinCall;
-
-  private static final String TRACE_ID = "d239036e7d5cec116b562147388b35bf";
-  private static final String SPAN_ID = "9cc1e3049173be09";
-  private static final String PARENT_SPAN_ID = "8b03ab423da481c5";
-  private static final Attributes attributes = Attributes.empty();
-  private static final List<EventData> annotations =
-      Collections.unmodifiableList(
-          Arrays.asList(
-              EventData.create(1505855799_433901068L, "RECEIVED", Attributes.empty()),
-              EventData.create(1505855799_459486280L, "SENT", Attributes.empty())));
-
-  private final ZipkinSpanExporter exporter = ZipkinSpanExporter.builder().build();
-
-  @Test
-  void generateSpan_remoteParent() {
-    SpanData data = buildStandardSpan().build();
-
-    assertThat(exporter.generateSpan(data))
-        .isEqualTo(
-            standardZipkinSpanBuilder(Span.Kind.SERVER)
-                .putTag(ZipkinSpanExporter.OTEL_STATUS_CODE, "OK")
-                .build());
-  }
-
-  @Test
-  void generateSpan_subMicroDurations() {
-    SpanData data =
-        buildStandardSpan()
-            .setStartEpochNanos(1505855794_194009601L)
-            .setEndEpochNanos(1505855794_194009999L)
-            .build();
-
-    Span expected =
-        standardZipkinSpanBuilder(Span.Kind.SERVER)
-            .putTag(ZipkinSpanExporter.OTEL_STATUS_CODE, "OK")
-            .duration(1)
-            .build();
-    assertThat(exporter.generateSpan(data)).isEqualTo(expected);
-  }
-
-  @Test
-  void generateSpan_ServerKind() {
-    SpanData data = buildStandardSpan().setKind(SpanKind.SERVER).build();
-
-    assertThat(exporter.generateSpan(data))
-        .isEqualTo(
-            standardZipkinSpanBuilder(Span.Kind.SERVER)
-                .putTag(ZipkinSpanExporter.OTEL_STATUS_CODE, "OK")
-                .build());
-  }
-
-  @Test
-  void generateSpan_ClientKind() {
-    SpanData data = buildStandardSpan().setKind(SpanKind.CLIENT).build();
-
-    assertThat(exporter.generateSpan(data))
-        .isEqualTo(
-            standardZipkinSpanBuilder(Span.Kind.CLIENT)
-                .putTag(ZipkinSpanExporter.OTEL_STATUS_CODE, "OK")
-                .build());
-  }
-
-  @Test
-  void generateSpan_InternalKind() {
-    SpanData data = buildStandardSpan().setKind(SpanKind.INTERNAL).build();
-
-    assertThat(exporter.generateSpan(data))
-        .isEqualTo(
-            standardZipkinSpanBuilder(null)
-                .putTag(ZipkinSpanExporter.OTEL_STATUS_CODE, "OK")
-                .build());
-  }
-
-  @Test
-  void generateSpan_ConsumeKind() {
-    SpanData data = buildStandardSpan().setKind(SpanKind.CONSUMER).build();
-
-    assertThat(exporter.generateSpan(data))
-        .isEqualTo(
-            standardZipkinSpanBuilder(Span.Kind.CONSUMER)
-                .putTag(ZipkinSpanExporter.OTEL_STATUS_CODE, "OK")
-                .build());
-  }
-
-  @Test
-  void generateSpan_ProducerKind() {
-    SpanData data = buildStandardSpan().setKind(SpanKind.PRODUCER).build();
-
-    assertThat(exporter.generateSpan(data))
-        .isEqualTo(
-            standardZipkinSpanBuilder(Span.Kind.PRODUCER)
-                .putTag(ZipkinSpanExporter.OTEL_STATUS_CODE, "OK")
-                .build());
-  }
-
-  @Test
-  void generateSpan_ResourceServiceNameMapping() {
-    Resource resource =
-        Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, "super-zipkin-service"));
-    SpanData data = buildStandardSpan().setResource(resource).build();
-
-    Endpoint expectedEndpoint =
-        Endpoint.newBuilder()
-            .serviceName("super-zipkin-service")
-            .ip(exporter.getLocalAddressForTest())
-            .build();
-    Span expectedZipkinSpan =
-        buildZipkinSpan(Span.Kind.SERVER).toBuilder()
-            .localEndpoint(expectedEndpoint)
-            .putTag(ZipkinSpanExporter.OTEL_STATUS_CODE, "OK")
-            .build();
-    assertThat(exporter.generateSpan(data)).isEqualTo(expectedZipkinSpan);
-  }
-
-  @Test
-  void generateSpan_defaultResourceServiceName() {
-    SpanData data = buildStandardSpan().setResource(Resource.empty()).build();
-
-    Endpoint expectedEndpoint =
-        Endpoint.newBuilder()
-            .serviceName(Resource.getDefault().getAttribute(ResourceAttributes.SERVICE_NAME))
-            .ip(exporter.getLocalAddressForTest())
-            .build();
-    Span expectedZipkinSpan =
-        buildZipkinSpan(Span.Kind.SERVER).toBuilder()
-            .localEndpoint(expectedEndpoint)
-            .putTag(ZipkinSpanExporter.OTEL_STATUS_CODE, "OK")
-            .build();
-    assertThat(exporter.generateSpan(data)).isEqualTo(expectedZipkinSpan);
-  }
-
-  @Test
-  void generateSpan_WithAttributes() {
-    Attributes attributes =
-        Attributes.builder()
-            .put(stringKey("string"), "string value")
-            .put(booleanKey("boolean"), false)
-            .put(longKey("long"), 9999L)
-            .put(doubleKey("double"), 222.333d)
-            .put(booleanArrayKey("booleanArray"), Arrays.asList(true, false))
-            .put(stringArrayKey("stringArray"), Collections.singletonList("Hello"))
-            .put(doubleArrayKey("doubleArray"), Arrays.asList(32.33d, -98.3d))
-            .put(longArrayKey("longArray"), Arrays.asList(33L, 999L))
-            .build();
-    SpanData data =
-        buildStandardSpan()
-            .setAttributes(attributes)
-            .setTotalAttributeCount(28)
-            .setTotalRecordedEvents(3)
-            .setKind(SpanKind.CLIENT)
-            .build();
-
-    assertThat(exporter.generateSpan(data))
-        .isEqualTo(
-            buildZipkinSpan(Span.Kind.CLIENT).toBuilder()
-                .putTag("string", "string value")
-                .putTag("boolean", "false")
-                .putTag("long", "9999")
-                .putTag("double", "222.333")
-                .putTag("booleanArray", "true,false")
-                .putTag("stringArray", "Hello")
-                .putTag("doubleArray", "32.33,-98.3")
-                .putTag("longArray", "33,999")
-                .putTag(ZipkinSpanExporter.OTEL_STATUS_CODE, "OK")
-                .putTag(ZipkinSpanExporter.OTEL_DROPPED_ATTRIBUTES_COUNT, "20")
-                .putTag(ZipkinSpanExporter.OTEL_DROPPED_EVENTS_COUNT, "1")
-                .build());
-  }
-
-  @Test
-  void generateSpan_WithInstrumentationLibraryInfo() {
-    SpanData data =
-        buildStandardSpan()
-            .setInstrumentationScopeInfo(
-                InstrumentationScopeInfo.create("io.opentelemetry.auto", "1.0.0", null))
-            .setKind(SpanKind.CLIENT)
-            .build();
-
-    assertThat(exporter.generateSpan(data))
-        .isEqualTo(
-            buildZipkinSpan(Span.Kind.CLIENT).toBuilder()
-                .putTag("otel.scope.name", "io.opentelemetry.auto")
-                .putTag("otel.scope.version", "1.0.0")
-                .putTag("otel.library.name", "io.opentelemetry.auto")
-                .putTag("otel.library.version", "1.0.0")
-                .putTag(ZipkinSpanExporter.OTEL_STATUS_CODE, "OK")
-                .build());
-  }
-
-  @Test
-  void generateSpan_AlreadyHasHttpStatusInfo() {
-    Attributes attributeMap =
-        Attributes.of(
-            SemanticAttributes.HTTP_STATUS_CODE, 404L, stringKey("error"), "A user provided error");
-    SpanData data =
-        buildStandardSpan()
-            .setAttributes(attributeMap)
-            .setKind(SpanKind.CLIENT)
-            .setStatus(StatusData.error())
-            .setTotalAttributeCount(2)
-            .build();
-
-    assertThat(exporter.generateSpan(data))
-        .isEqualTo(
-            buildZipkinSpan(Span.Kind.CLIENT).toBuilder()
-                .clearTags()
-                .putTag(SemanticAttributes.HTTP_STATUS_CODE.getKey(), "404")
-                .putTag(ZipkinSpanExporter.OTEL_STATUS_CODE, "ERROR")
-                .putTag("error", "A user provided error")
-                .build());
-  }
-
-  @Test
-  void generateSpan_WithRpcTimeoutErrorStatus_WithTimeoutErrorDescription() {
-    Attributes attributeMap = Attributes.of(SemanticAttributes.RPC_SERVICE, "my service name");
-
-    String errorMessage = "timeout";
-
-    SpanData data =
-        buildStandardSpan()
-            .setStatus(StatusData.create(StatusCode.ERROR, errorMessage))
-            .setAttributes(attributeMap)
-            .setTotalAttributeCount(1)
-            .build();
-
-    assertThat(exporter.generateSpan(data))
-        .isEqualTo(
-            buildZipkinSpan(Span.Kind.SERVER).toBuilder()
-                .putTag(SemanticAttributes.RPC_SERVICE.getKey(), "my service name")
-                .putTag(ZipkinSpanExporter.OTEL_STATUS_CODE, "ERROR")
-                .putTag(ZipkinSpanExporter.STATUS_ERROR.getKey(), errorMessage)
-                .build());
-  }
-
-  @Test
-  void generateSpan_WithRpcErrorStatus_WithEmptyErrorDescription() {
-    Attributes attributeMap = Attributes.of(SemanticAttributes.RPC_SERVICE, "my service name");
-
-    SpanData data =
-        buildStandardSpan()
-            .setStatus(StatusData.create(StatusCode.ERROR, ""))
-            .setAttributes(attributeMap)
-            .setTotalAttributeCount(1)
-            .build();
-
-    assertThat(exporter.generateSpan(data))
-        .isEqualTo(
-            buildZipkinSpan(Span.Kind.SERVER).toBuilder()
-                .putTag(SemanticAttributes.RPC_SERVICE.getKey(), "my service name")
-                .putTag(ZipkinSpanExporter.OTEL_STATUS_CODE, "ERROR")
-                .putTag(ZipkinSpanExporter.STATUS_ERROR.getKey(), "")
-                .build());
-  }
-
-  @Test
-  void generateSpan_WithRpcUnsetStatus() {
-    Attributes attributeMap = Attributes.of(SemanticAttributes.RPC_SERVICE, "my service name");
-
-    SpanData data =
-        buildStandardSpan()
-            .setStatus(StatusData.create(StatusCode.UNSET, ""))
-            .setAttributes(attributeMap)
-            .setTotalAttributeCount(1)
-            .build();
-
-    assertThat(exporter.generateSpan(data))
-        .isEqualTo(
-            buildZipkinSpan(Span.Kind.SERVER).toBuilder()
-                .putTag(SemanticAttributes.RPC_SERVICE.getKey(), "my service name")
-                .build());
-  }
+  @Mock private Function<SpanData, Span> mockTransformer;
 
   @Test
   void testExport() {
+    TestSpanData testSpanData = buildStandardSpan().build();
+
     ZipkinSpanExporter zipkinSpanExporter =
-        new ZipkinSpanExporter(mockEncoder, mockSender, MeterProvider.noop());
+        new ZipkinSpanExporter(mockEncoder, mockSender, MeterProvider.noop(), mockTransformer);
 
     byte[] someBytes = new byte[0];
-    when(mockEncoder.encode(
-            standardZipkinSpanBuilder(Span.Kind.SERVER)
-                .putTag(ZipkinSpanExporter.OTEL_STATUS_CODE, "OK")
-                .build()))
-        .thenReturn(someBytes);
+    Span zipkinSpan =
+        standardZipkinSpanBuilder(Span.Kind.SERVER)
+            .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "OK")
+            .build();
+    when(mockTransformer.apply(testSpanData)).thenReturn(zipkinSpan);
+    when(mockEncoder.encode(zipkinSpan)).thenReturn(someBytes);
     when(mockSender.sendSpans(Collections.singletonList(someBytes))).thenReturn(mockZipkinCall);
     doAnswer(
             invocation -> {
@@ -353,7 +66,7 @@ class ZipkinSpanExporterTest {
         .enqueue(any());
 
     CompletableResultCode resultCode =
-        zipkinSpanExporter.export(Collections.singleton(buildStandardSpan().build()));
+        zipkinSpanExporter.export(Collections.singleton(testSpanData));
 
     assertThat(resultCode.isSuccess()).isTrue();
   }
@@ -361,15 +74,17 @@ class ZipkinSpanExporterTest {
   @Test
   @SuppressLogger(ZipkinSpanExporter.class)
   void testExport_failed() {
+    TestSpanData testSpanData = buildStandardSpan().build();
     ZipkinSpanExporter zipkinSpanExporter =
-        new ZipkinSpanExporter(mockEncoder, mockSender, MeterProvider.noop());
+        new ZipkinSpanExporter(mockEncoder, mockSender, MeterProvider.noop(), mockTransformer);
 
     byte[] someBytes = new byte[0];
-    when(mockEncoder.encode(
-            standardZipkinSpanBuilder(Span.Kind.SERVER)
-                .putTag(ZipkinSpanExporter.OTEL_STATUS_CODE, "OK")
-                .build()))
-        .thenReturn(someBytes);
+    Span zipkinSpan =
+        standardZipkinSpanBuilder(Span.Kind.SERVER)
+            .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "OK")
+            .build();
+    when(mockTransformer.apply(testSpanData)).thenReturn(zipkinSpan);
+    when(mockEncoder.encode(zipkinSpan)).thenReturn(someBytes);
     when(mockSender.sendSpans(Collections.singletonList(someBytes))).thenReturn(mockZipkinCall);
     doAnswer(
             invocation -> {
@@ -381,7 +96,7 @@ class ZipkinSpanExporterTest {
         .enqueue(any());
 
     CompletableResultCode resultCode =
-        zipkinSpanExporter.export(Collections.singleton(buildStandardSpan().build()));
+        zipkinSpanExporter.export(Collections.singleton(testSpanData));
 
     assertThat(resultCode.isSuccess()).isFalse();
   }
@@ -399,51 +114,6 @@ class ZipkinSpanExporterTest {
 
     exporter.shutdown();
     verify(mockSender).close();
-  }
-
-  private static TestSpanData.Builder buildStandardSpan() {
-    return TestSpanData.builder()
-        .setSpanContext(
-            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()))
-        .setParentSpanContext(
-            SpanContext.create(
-                TRACE_ID, PARENT_SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()))
-        .setResource(
-            Resource.create(
-                Attributes.builder().put(ResourceAttributes.SERVICE_NAME, "tweetiebird").build()))
-        .setStatus(StatusData.ok())
-        .setKind(SpanKind.SERVER)
-        .setName("Recv.helloworld.Greeter.SayHello")
-        .setStartEpochNanos(1505855794_194009601L)
-        .setEndEpochNanos(1505855799_465726528L)
-        .setAttributes(attributes)
-        .setTotalAttributeCount(attributes.size())
-        .setTotalRecordedEvents(annotations.size())
-        .setEvents(annotations)
-        .setLinks(Collections.emptyList())
-        .setHasEnded(true);
-  }
-
-  private Span buildZipkinSpan(Span.Kind kind) {
-    return standardZipkinSpanBuilder(kind).build();
-  }
-
-  private Span.Builder standardZipkinSpanBuilder(Span.Kind kind) {
-    return Span.newBuilder()
-        .traceId(TRACE_ID)
-        .parentId(PARENT_SPAN_ID)
-        .id(SPAN_ID)
-        .kind(kind)
-        .name("Recv.helloworld.Greeter.SayHello")
-        .timestamp(1505855794000000L + 194009601L / 1000)
-        .duration((1505855799000000L + 465726528L / 1000) - (1505855794000000L + 194009601L / 1000))
-        .localEndpoint(
-            Endpoint.newBuilder()
-                .ip(exporter.getLocalAddressForTest())
-                .serviceName("tweetiebird")
-                .build())
-        .addAnnotation(1505855799000000L + 433901068L / 1000, "RECEIVED")
-        .addAnnotation(1505855799000000L + 459486280L / 1000, "SENT");
   }
 
   @Test

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterTest.java
@@ -19,6 +19,7 @@ import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.testing.trace.TestSpanData;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
@@ -38,6 +39,7 @@ class ZipkinSpanExporterTest {
   @Mock private SpanBytesEncoder mockEncoder;
   @Mock private Call<Void> mockZipkinCall;
   @Mock private OtelToZipkinSpanTransformer mockTransformer;
+  @Mock private InetAddress localIp;
 
   @Test
   void testExport() {
@@ -48,7 +50,7 @@ class ZipkinSpanExporterTest {
 
     byte[] someBytes = new byte[0];
     Span zipkinSpan =
-        zipkinSpanBuilder(Span.Kind.SERVER)
+        zipkinSpanBuilder(Span.Kind.SERVER, localIp)
             .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "OK")
             .build();
     when(mockTransformer.generateSpan(testSpanData)).thenReturn(zipkinSpan);
@@ -73,12 +75,13 @@ class ZipkinSpanExporterTest {
   @SuppressLogger(ZipkinSpanExporter.class)
   void testExport_failed() {
     TestSpanData testSpanData = spanBuilder().build();
+
     ZipkinSpanExporter zipkinSpanExporter =
         new ZipkinSpanExporter(mockEncoder, mockSender, MeterProvider.noop(), mockTransformer);
 
     byte[] someBytes = new byte[0];
     Span zipkinSpan =
-        zipkinSpanBuilder(Span.Kind.SERVER)
+        zipkinSpanBuilder(Span.Kind.SERVER, localIp)
             .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "OK")
             .build();
     when(mockTransformer.generateSpan(testSpanData)).thenReturn(zipkinSpan);

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterTest.java
@@ -5,8 +5,8 @@
 
 package io.opentelemetry.exporter.zipkin;
 
-import static io.opentelemetry.exporter.zipkin.ZipkinTestSpan.buildStandardSpan;
-import static io.opentelemetry.exporter.zipkin.ZipkinTestSpan.standardZipkinSpanBuilder;
+import static io.opentelemetry.exporter.zipkin.ZipkinTestUtil.spanBuilder;
+import static io.opentelemetry.exporter.zipkin.ZipkinTestUtil.zipkinSpanBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -41,14 +41,14 @@ class ZipkinSpanExporterTest {
 
   @Test
   void testExport() {
-    TestSpanData testSpanData = buildStandardSpan().build();
+    TestSpanData testSpanData = spanBuilder().build();
 
     ZipkinSpanExporter zipkinSpanExporter =
         new ZipkinSpanExporter(mockEncoder, mockSender, MeterProvider.noop(), mockTransformer);
 
     byte[] someBytes = new byte[0];
     Span zipkinSpan =
-        standardZipkinSpanBuilder(Span.Kind.SERVER)
+        zipkinSpanBuilder(Span.Kind.SERVER)
             .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "OK")
             .build();
     when(mockTransformer.generateSpan(testSpanData)).thenReturn(zipkinSpan);
@@ -72,13 +72,13 @@ class ZipkinSpanExporterTest {
   @Test
   @SuppressLogger(ZipkinSpanExporter.class)
   void testExport_failed() {
-    TestSpanData testSpanData = buildStandardSpan().build();
+    TestSpanData testSpanData = spanBuilder().build();
     ZipkinSpanExporter zipkinSpanExporter =
         new ZipkinSpanExporter(mockEncoder, mockSender, MeterProvider.noop(), mockTransformer);
 
     byte[] someBytes = new byte[0];
     Span zipkinSpan =
-        standardZipkinSpanBuilder(Span.Kind.SERVER)
+        zipkinSpanBuilder(Span.Kind.SERVER)
             .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "OK")
             .build();
     when(mockTransformer.generateSpan(testSpanData)).thenReturn(zipkinSpan);

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterTest.java
@@ -18,11 +18,9 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.testing.trace.TestSpanData;
-import io.opentelemetry.sdk.trace.data.SpanData;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -39,7 +37,7 @@ class ZipkinSpanExporterTest {
   @Mock private Sender mockSender;
   @Mock private SpanBytesEncoder mockEncoder;
   @Mock private Call<Void> mockZipkinCall;
-  @Mock private Function<SpanData, Span> mockTransformer;
+  @Mock private OtelToZipkinSpanTransformer mockTransformer;
 
   @Test
   void testExport() {
@@ -53,7 +51,7 @@ class ZipkinSpanExporterTest {
         standardZipkinSpanBuilder(Span.Kind.SERVER)
             .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "OK")
             .build();
-    when(mockTransformer.apply(testSpanData)).thenReturn(zipkinSpan);
+    when(mockTransformer.generateSpan(testSpanData)).thenReturn(zipkinSpan);
     when(mockEncoder.encode(zipkinSpan)).thenReturn(someBytes);
     when(mockSender.sendSpans(Collections.singletonList(someBytes))).thenReturn(mockZipkinCall);
     doAnswer(
@@ -83,7 +81,7 @@ class ZipkinSpanExporterTest {
         standardZipkinSpanBuilder(Span.Kind.SERVER)
             .putTag(OtelToZipkinSpanTransformer.OTEL_STATUS_CODE, "OK")
             .build();
-    when(mockTransformer.apply(testSpanData)).thenReturn(zipkinSpan);
+    when(mockTransformer.generateSpan(testSpanData)).thenReturn(zipkinSpan);
     when(mockEncoder.encode(zipkinSpan)).thenReturn(someBytes);
     when(mockSender.sendSpans(Collections.singletonList(someBytes))).thenReturn(mockZipkinCall);
     doAnswer(

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinTestSpan.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinTestSpan.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.zipkin;
+
+import static org.mockito.Mockito.mock;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.testing.trace.TestSpanData;
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+
+public class ZipkinTestSpan {
+
+  static final String TRACE_ID = "d239036e7d5cec116b562147388b35bf";
+  static final String SPAN_ID = "9cc1e3049173be09";
+  static final String PARENT_SPAN_ID = "8b03ab423da481c5";
+
+  static final InetAddress localAddressForTesting = mock(InetAddress.class);
+
+  private static final Attributes attributes = Attributes.empty();
+  private static final List<EventData> annotations =
+      Collections.unmodifiableList(
+          Arrays.asList(
+              EventData.create(1505855799_433901068L, "RECEIVED", Attributes.empty()),
+              EventData.create(1505855799_459486280L, "SENT", Attributes.empty())));
+
+  static TestSpanData.Builder buildStandardSpan() {
+    return TestSpanData.builder()
+        .setSpanContext(
+            SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()))
+        .setParentSpanContext(
+            SpanContext.create(
+                TRACE_ID, PARENT_SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()))
+        .setResource(
+            Resource.create(
+                Attributes.builder().put(ResourceAttributes.SERVICE_NAME, "tweetiebird").build()))
+        .setStatus(StatusData.ok())
+        .setKind(SpanKind.SERVER)
+        .setName("Recv.helloworld.Greeter.SayHello")
+        .setStartEpochNanos(1505855794_194009601L)
+        .setEndEpochNanos(1505855799_465726528L)
+        .setAttributes(attributes)
+        .setTotalAttributeCount(attributes.size())
+        .setTotalRecordedEvents(annotations.size())
+        .setEvents(annotations)
+        .setLinks(Collections.emptyList())
+        .setHasEnded(true);
+  }
+
+  static Span buildZipkinSpan(Span.Kind kind) {
+    return standardZipkinSpanBuilder(kind).build();
+  }
+
+  static Span.Builder standardZipkinSpanBuilder(Span.Kind kind) {
+    return Span.newBuilder()
+        .traceId(TRACE_ID)
+        .parentId(PARENT_SPAN_ID)
+        .id(SPAN_ID)
+        .kind(kind)
+        .name("Recv.helloworld.Greeter.SayHello")
+        .timestamp(1505855794000000L + 194009601L / 1000)
+        .duration((1505855799000000L + 465726528L / 1000) - (1505855794000000L + 194009601L / 1000))
+        .localEndpoint(
+            Endpoint.newBuilder()
+                //                .ip(exporter.getLocalAddressForTest())
+                .ip(localAddressForTesting)
+                .serviceName("tweetiebird")
+                .build())
+        .addAnnotation(1505855799000000L + 433901068L / 1000, "RECEIVED")
+        .addAnnotation(1505855799000000L + 459486280L / 1000, "SENT");
+  }
+}

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinTestSpan.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinTestSpan.java
@@ -39,6 +39,8 @@ public class ZipkinTestSpan {
               EventData.create(1505855799_433901068L, "RECEIVED", Attributes.empty()),
               EventData.create(1505855799_459486280L, "SENT", Attributes.empty())));
 
+  private ZipkinTestSpan() {}
+
   static TestSpanData.Builder buildStandardSpan() {
     return TestSpanData.builder()
         .setSpanContext(

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinTestSpan.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinTestSpan.java
@@ -24,7 +24,7 @@ import java.util.List;
 import zipkin2.Endpoint;
 import zipkin2.Span;
 
-public class ZipkinTestSpan {
+class ZipkinTestSpan {
 
   static final String TRACE_ID = "d239036e7d5cec116b562147388b35bf";
   static final String SPAN_ID = "9cc1e3049173be09";

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinTestSpan.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinTestSpan.java
@@ -79,7 +79,6 @@ class ZipkinTestSpan {
         .duration((1505855799000000L + 465726528L / 1000) - (1505855794000000L + 194009601L / 1000))
         .localEndpoint(
             Endpoint.newBuilder()
-                //                .ip(exporter.getLocalAddressForTest())
                 .ip(localAddressForTesting)
                 .serviceName("tweetiebird")
                 .build())

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinTestUtil.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinTestUtil.java
@@ -78,10 +78,7 @@ class ZipkinTestUtil {
         .timestamp(1505855794000000L + 194009601L / 1000)
         .duration((1505855799000000L + 465726528L / 1000) - (1505855794000000L + 194009601L / 1000))
         .localEndpoint(
-            Endpoint.newBuilder()
-                .ip(localAddressForTesting)
-                .serviceName("tweetiebird")
-                .build())
+            Endpoint.newBuilder().ip(localAddressForTesting).serviceName("tweetiebird").build())
         .addAnnotation(1505855799000000L + 433901068L / 1000, "RECEIVED")
         .addAnnotation(1505855799000000L + 459486280L / 1000, "SENT");
   }

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinTestUtil.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinTestUtil.java
@@ -24,7 +24,7 @@ import java.util.List;
 import zipkin2.Endpoint;
 import zipkin2.Span;
 
-class ZipkinTestSpan {
+class ZipkinTestUtil {
 
   static final String TRACE_ID = "d239036e7d5cec116b562147388b35bf";
   static final String SPAN_ID = "9cc1e3049173be09";
@@ -39,9 +39,9 @@ class ZipkinTestSpan {
               EventData.create(1505855799_433901068L, "RECEIVED", Attributes.empty()),
               EventData.create(1505855799_459486280L, "SENT", Attributes.empty())));
 
-  private ZipkinTestSpan() {}
+  private ZipkinTestUtil() {}
 
-  static TestSpanData.Builder buildStandardSpan() {
+  static TestSpanData.Builder spanBuilder() {
     return TestSpanData.builder()
         .setSpanContext(
             SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()))
@@ -64,11 +64,11 @@ class ZipkinTestSpan {
         .setHasEnded(true);
   }
 
-  static Span buildZipkinSpan(Span.Kind kind) {
-    return standardZipkinSpanBuilder(kind).build();
+  static Span zipkinSpan(Span.Kind kind) {
+    return zipkinSpanBuilder(kind).build();
   }
 
-  static Span.Builder standardZipkinSpanBuilder(Span.Kind kind) {
+  static Span.Builder zipkinSpanBuilder(Span.Kind kind) {
     return Span.newBuilder()
         .traceId(TRACE_ID)
         .parentId(PARENT_SPAN_ID)

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinTestUtil.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinTestUtil.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.exporter.zipkin;
 
-import static org.mockito.Mockito.mock;
-
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
@@ -29,8 +27,6 @@ class ZipkinTestUtil {
   static final String TRACE_ID = "d239036e7d5cec116b562147388b35bf";
   static final String SPAN_ID = "9cc1e3049173be09";
   static final String PARENT_SPAN_ID = "8b03ab423da481c5";
-
-  static final InetAddress localAddressForTesting = mock(InetAddress.class);
 
   private static final Attributes attributes = Attributes.empty();
   private static final List<EventData> annotations =
@@ -64,11 +60,11 @@ class ZipkinTestUtil {
         .setHasEnded(true);
   }
 
-  static Span zipkinSpan(Span.Kind kind) {
-    return zipkinSpanBuilder(kind).build();
+  static Span zipkinSpan(Span.Kind kind, InetAddress localIp) {
+    return zipkinSpanBuilder(kind, localIp).build();
   }
 
-  static Span.Builder zipkinSpanBuilder(Span.Kind kind) {
+  static Span.Builder zipkinSpanBuilder(Span.Kind kind, InetAddress localIp) {
     return Span.newBuilder()
         .traceId(TRACE_ID)
         .parentId(PARENT_SPAN_ID)
@@ -77,8 +73,7 @@ class ZipkinTestUtil {
         .name("Recv.helloworld.Greeter.SayHello")
         .timestamp(1505855794000000L + 194009601L / 1000)
         .duration((1505855799000000L + 465726528L / 1000) - (1505855794000000L + 194009601L / 1000))
-        .localEndpoint(
-            Endpoint.newBuilder().ip(localAddressForTesting).serviceName("tweetiebird").build())
+        .localEndpoint(Endpoint.newBuilder().ip(localIp).serviceName("tweetiebird").build())
         .addAnnotation(1505855799000000L + 433901068L / 1000, "RECEIVED")
         .addAnnotation(1505855799000000L + 459486280L / 1000, "SENT");
   }


### PR DESCRIPTION
This factors out a new class called `OtelToZipkinSpanTransformer` to improve the single responsibility of the `ZipkinSpanExporter`. Before this change, the exporter was both a transformer and an exporter.

For context -- This need arose from a request to filter the local IP address from exported Spans in Splunk's Android SDK. Currently, the `ZipkinExporter` really only made that possible by filtering at the encoder, rather than the data model itself. That felt clunky, and this change helps to improve that by allowing a the transformer to be injected into the exporter, and transformer is the unit that is IP aware (and can be created without one).

Should be API backwards compatible, but please keep me honest.

Related: It occurred to me that the current implementation (even with this PR merged) will hold onto the local IP address indefinitely. That's not great -- because in the real world IP addresses can change over time. I will file an issue about that so we don't lose sight of it.