### PR TITLE
Return early if merging empty resource

### DIFF
--- a/sdk/common/src/main/java/io/opentelemetry/sdk/resources/Resource.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/resources/Resource.java
@@ -155,7 +155,7 @@ public abstract class Resource {
    * @return the newly merged {@code Resource}.
    */
   public Resource merge(@Nullable Resource other) {
-    if (other == null) {
+    if (other == null || other == EMPTY) {
       return this;
     }
 


### PR DESCRIPTION
We can return early when the `EMPTY` resource instance is passed to merge in order to shave a few allocations/checks.