### PR TITLE
Fix log sdk module name

### DIFF
--- a/sdk/logs/build.gradle.kts
+++ b/sdk/logs/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 description = "OpenTelemetry Contrib Logging Support"
-otelJava.moduleName.set("io.opentelemetry.sdk.extension.logging")
+otelJava.moduleName.set("io.opentelemetry.sdk.logs")
 
 dependencies {
   api(project(":sdk:common"))


### PR DESCRIPTION
This property controls the `Automatic-Module-Name` field in the jar manifest, and the location of the `version.properties` file. It is currently wrong for the log SDK artifact.