### PR TITLE
Add shouldApply to ResourceProvider interface

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+***! MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++! NEW METHOD: PUBLIC(+) boolean shouldApply(io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties, io.opentelemetry.sdk.resources.Resource)

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ResourceProvider.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ResourceProvider.java
@@ -14,4 +14,16 @@ import io.opentelemetry.sdk.resources.Resource;
 public interface ResourceProvider extends Ordered {
 
   Resource createResource(ConfigProperties config);
+
+  /**
+   * If an implementation needs to apply only under certain conditions related to the config or the
+   * existing state of the Resource being built, they can choose to override this default.
+   *
+   * @param config The auto configuration properties
+   * @param existing The current state of the Resource being created
+   * @return false to skip over this ResourceProvider, or true to use it
+   */
+  default boolean shouldApply(ConfigProperties config, Resource existing) {
+    return true;
+  }
 }

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ResourceConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ResourceConfiguration.java
@@ -46,7 +46,9 @@ final class ResourceConfiguration {
       if (disabledProviders.contains(resourceProvider.getClass().getName())) {
         continue;
       }
-      result = result.merge(resourceProvider.createResource(config));
+      if (resourceProvider.shouldApply(config, result)) {
+        result = result.merge(resourceProvider.createResource(config));
+      }
     }
 
     result = result.merge(createEnvironmentResource(config));


### PR DESCRIPTION
Opening this draft to start a conversation.

So, instrumentation agents may be built with many various `ResourceProvider` implementations. Some of these are _optimistic_ implementations that will only return data (a non-empty `Resource`) when running under certain conditions. Examples of this include: running in a containerized environment, running in a specific cloud provider, or running in a certain type of web/servlet container. 

To further complicate things, `ResourceProviders` can vary in quality/accuracy and might want to act as a "fallback strategy". For example, one `ResourceProvider` might populate the `webengine.name` attribute by reading a file from the classpath (fast) while another, more complicated implementation might attempt to find the same attribute by performing a sophisticated series of http requests. We generally wouldn't want to perform the expensive/slow strategy if the earlier/faster one is successful. In our specific case, we have some fallback strategies that attempt to populate the `service.name` attribute via a variety of strategies. 

While the `order()` is useful to perform these strategies in a predetermined and consistent order, scenarios can exist that introduce conflicts in certain environments...and we only want the later `ResourceProviders` to return data iff a prior one has not yet returned certain data. The current API is insufficient -- there's no real means for a `ResourceProvider` to determine if an attribute has already been set. 

So this adds a new method called `shouldApply(config, resource)` to the `ResourceDetector` interface. It defaults to returning `true`, so existing implementations are unchanged. The `shouldApply` method is checked and only if it returns true does `createResource()` get called.

I don't think this change is destabilizing or wide reaching -- it doesn't modify or remove any existing APIs/SPIs, but it does add one small SPI.

Definitely curious what other folks think or ideas they have about solving the broader problem. Thanks for looking!