### PR TITLE
Fix container detection fails in k8s with containerd v1.5.0+ environments

### DIFF
--- a/sdk-extensions/resources/src/main/java/io/opentelemetry/sdk/extension/resources/ContainerResource.java
+++ b/sdk-extensions/resources/src/main/java/io/opentelemetry/sdk/extension/resources/ContainerResource.java
@@ -92,9 +92,11 @@ public final class ContainerResource {
     int colonIdx = lastSection.lastIndexOf(':');
 
     if (colonIdx != -1) {
-      // since k8s v1.24+, containerId is divided by the last colon when container is containerd and cgroupDriver is systemd
-      // case: 'kubepods-pod87a18a64_b74a_454a_b10b_a4a36059d0a3.slice:cri-containerd:05c48c82caff3be3d7f1e896981dd410e81487538936914f32b624d168de9db0'
-      containerId = lastSection.substring(colonIdx+1);
+      // since k8s v1.24+, containerId is divided by the last colon when container is containerd and
+      // cgroupDriver is systemd
+      // case:
+      // 'kubepods-pod87a18a64_b74a_454a_b10b_a4a36059d0a3.slice:cri-containerd:05c48c82caff3be3d7f1e896981dd410e81487538936914f32b624d168de9db0'
+      containerId = lastSection.substring(colonIdx + 1);
     } else {
       int startIdx = lastSection.lastIndexOf('-');
       int endIdx = lastSection.lastIndexOf('.');

--- a/sdk-extensions/resources/src/main/java/io/opentelemetry/sdk/extension/resources/ContainerResource.java
+++ b/sdk-extensions/resources/src/main/java/io/opentelemetry/sdk/extension/resources/ContainerResource.java
@@ -92,10 +92,8 @@ public final class ContainerResource {
     int colonIdx = lastSection.lastIndexOf(':');
 
     if (colonIdx != -1) {
-      // since k8s v1.24+, containerId is divided by the last colon when container is containerd and
-      // cgroupDriver is systemd
-      // case:
-      // 'kubepods-pod87a18a64_b74a_454a_b10b_a4a36059d0a3.slice:cri-containerd:05c48c82caff3be3d7f1e896981dd410e81487538936914f32b624d168de9db0'
+      // since containerd v1.5.0+, containerId is divided by the last colon when the cgroupDriver is systemd:
+      // https://github.com/containerd/containerd/blob/release/1.5/pkg/cri/server/helpers_linux.go#L64
       containerId = lastSection.substring(colonIdx + 1);
     } else {
       int startIdx = lastSection.lastIndexOf('-');

--- a/sdk-extensions/resources/src/main/java/io/opentelemetry/sdk/extension/resources/ContainerResource.java
+++ b/sdk-extensions/resources/src/main/java/io/opentelemetry/sdk/extension/resources/ContainerResource.java
@@ -92,7 +92,8 @@ public final class ContainerResource {
     int colonIdx = lastSection.lastIndexOf(':');
 
     if (colonIdx != -1) {
-      // since containerd v1.5.0+, containerId is divided by the last colon when the cgroupDriver is systemd:
+      // since containerd v1.5.0+, containerId is divided by the last colon when the cgroupDriver is
+      // systemd:
       // https://github.com/containerd/containerd/blob/release/1.5/pkg/cri/server/helpers_linux.go#L64
       containerId = lastSection.substring(colonIdx + 1);
     } else {

--- a/sdk-extensions/resources/src/main/java/io/opentelemetry/sdk/extension/resources/ContainerResource.java
+++ b/sdk-extensions/resources/src/main/java/io/opentelemetry/sdk/extension/resources/ContainerResource.java
@@ -86,19 +86,30 @@ public final class ContainerResource {
       return null;
     }
 
+    String containerId;
+
     String lastSection = line.substring(lastSlashIdx + 1);
-    int startIdx = lastSection.lastIndexOf('-');
-    int endIdx = lastSection.lastIndexOf('.');
+    int colonIdx = lastSection.lastIndexOf(':');
 
-    startIdx = startIdx == -1 ? 0 : startIdx + 1;
-    if (endIdx == -1) {
-      endIdx = lastSection.length();
-    }
-    if (startIdx > endIdx) {
-      return null;
+    if (colonIdx != -1) {
+      // since k8s v1.24+, containerId is divided by the last colon when container is containerd and cgroupDriver is systemd
+      // case: 'kubepods-pod87a18a64_b74a_454a_b10b_a4a36059d0a3.slice:cri-containerd:05c48c82caff3be3d7f1e896981dd410e81487538936914f32b624d168de9db0'
+      containerId = lastSection.substring(colonIdx+1);
+    } else {
+      int startIdx = lastSection.lastIndexOf('-');
+      int endIdx = lastSection.lastIndexOf('.');
+
+      startIdx = startIdx == -1 ? 0 : startIdx + 1;
+      if (endIdx == -1) {
+        endIdx = lastSection.length();
+      }
+      if (startIdx > endIdx) {
+        return null;
+      }
+
+      containerId = lastSection.substring(startIdx, endIdx);
     }
 
-    String containerId = lastSection.substring(startIdx, endIdx);
     if (OtelEncodingUtils.isValidBase16String(containerId) && !containerId.isEmpty()) {
       return containerId;
     } else {

--- a/sdk-extensions/resources/src/test/java/io/opentelemetry/sdk/extension/resources/ContainerResourceTest.java
+++ b/sdk-extensions/resources/src/test/java/io/opentelemetry/sdk/extension/resources/ContainerResourceTest.java
@@ -85,7 +85,8 @@ class ContainerResourceTest {
     assertThat(getContainerId(buildResource(cgroup5)))
         .isEqualTo("713a77a26fe2a38ebebd5709604a048c3d380db1eb16aa43aca0b2499e54733c");
 
-    // with colon, env: k8s v1.24.0, the cgroupDriver by systemd(default), and container is cri-containerd(default)
+    // with colon, env: k8s v1.24.0, the cgroupDriver by systemd(default), and container is
+    // cri-containerd v1.6.8
     Path cgroup6 =
         createCGroup(
             tempFolder.resolve("cgroup6"),

--- a/sdk-extensions/resources/src/test/java/io/opentelemetry/sdk/extension/resources/ContainerResourceTest.java
+++ b/sdk-extensions/resources/src/test/java/io/opentelemetry/sdk/extension/resources/ContainerResourceTest.java
@@ -84,6 +84,14 @@ class ContainerResourceTest {
             "11:perf_event:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod4415fd05_2c0f_4533_909b_f2180dca8d7c.slice/cri-containerd-713a77a26fe2a38ebebd5709604a048c3d380db1eb16aa43aca0b2499e54733c.scope");
     assertThat(getContainerId(buildResource(cgroup5)))
         .isEqualTo("713a77a26fe2a38ebebd5709604a048c3d380db1eb16aa43aca0b2499e54733c");
+
+    // with colon, env: k8s v1.24.0, the cgroupDriver by systemd(default), and container is cri-containerd(default)
+    Path cgroup6 =
+        createCGroup(
+            tempFolder.resolve("cgroup6"),
+            "11:devices:/system.slice/containerd.service/kubepods-pod87a18a64_b74a_454a_b10b_a4a36059d0a3.slice:cri-containerd:05c48c82caff3be3d7f1e896981dd410e81487538936914f32b624d168de9db0");
+    assertThat(getContainerId(buildResource(cgroup6)))
+        .isEqualTo("05c48c82caff3be3d7f1e896981dd410e81487538936914f32b624d168de9db0");
   }
 
   private static String getContainerId(Resource resource) {


### PR DESCRIPTION
PR for [issue#4730](https://github.com/open-telemetry/opentelemetry-java/issues/4730).

Since k8s v1.24+, dockerShim is removed, and you can check the method of containerd generating CGroup path [here](https://github.com/containerd/containerd/blob/bbe46b8c43fc2febe316775bc2d4b9d697bbf05c/pkg/cri/server/helpers_linux.go#L63). before containerd v1.5.0, generating CGroup path method with systemd look [this](https://github.com/containerd/containerd/blob/release/1.4/cmd/ctr/commands/run/run_unix.go#L254).

If the cgroupDriver is `systemd` and the container is `cri-contrainerd v1.6.8`, the cgroup line like:
'11:devices:/system.slice/containerd.service/kubepods-pod87a18a64_b74a_454a_b10b_a4a36059d0a3.slice:cri-containerd:05c48c82caff3be3d7f1e896981dd410e81487538936914f32b624d168de9db0'.

If the `cgroupDriver` is systemd and the container is `cri-docker v0.25.0`, the cgroup line like: '11:pids:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod82f40de6_1226_4577_ab35_2f378b9f5e49.slice/docker-ca0587256640e2964fb4656da0d99828966f90ba96a29a650860e0ca63e8eced.scope'.

If the cgroupDriver is `cgroupfs` and the container is `cri-contrainerd v1.6.8`, the cgroup no has change:
'12:memory:/kubepods/pod3e9ee100-e307-4474-8c4c-e97428ebaacd/9e5be931ec7edbc65dd2d67f55e4125e253e94430365dcaf01505cf5e1873517'.
