### PR TITLE
[OT Shim] Fully support Baggage-only propagation.

### DIFF
--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/Propagation.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/Propagation.java
@@ -41,11 +41,12 @@ final class Propagation extends BaseShimObject {
     Context context = getPropagator(format).extract(Context.current(), carrierMap, GETTER_INSTANCE);
 
     Span span = Span.fromContext(context);
-    if (!span.getSpanContext().isValid()) {
+    Baggage baggage = Baggage.fromContext(context);
+    if (!span.getSpanContext().isValid() && baggage.isEmpty()) {
       return null;
     }
 
-    return new SpanContextShim(telemetryInfo, span.getSpanContext(), Baggage.fromContext(context));
+    return new SpanContextShim(telemetryInfo, span.getSpanContext(), baggage);
   }
 
   private <C> TextMapPropagator getPropagator(Format<C> format) {

--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/ScopeManagerShim.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/ScopeManagerShim.java
@@ -35,7 +35,7 @@ final class ScopeManagerShim extends BaseShimObject implements ScopeManager {
         return null;
       }
 
-      return new SpanShim(telemetryInfo(), baggage);
+      return new SpanShim(telemetryInfo(), io.opentelemetry.api.trace.Span.getInvalid(), baggage);
     }
 
     // If there's a SpanShim for the *actual* active Span, simply return it.

--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
@@ -200,6 +200,7 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
               .with(io.opentelemetry.api.trace.Span.wrap(parentSpanContext.getSpanContext())));
       baggage = parentSpanContext.getBaggage();
     } else {
+      // No explicit parent Span, but extracted baggage may be available.
       baggage = Baggage.current();
     }
 

--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/SpanShim.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/SpanShim.java
@@ -47,10 +47,6 @@ final class SpanShim extends BaseShimObject implements Span, ImplicitContextKeye
     this(telemetryInfo, span, Baggage.empty());
   }
 
-  public SpanShim(TelemetryInfo telemetryInfo, io.opentelemetry.api.baggage.Baggage baggage) {
-    this(telemetryInfo, io.opentelemetry.api.trace.Span.getInvalid(), baggage);
-  }
-
   public SpanShim(
       TelemetryInfo telemetryInfo, io.opentelemetry.api.trace.Span span, Baggage baggage) {
     super(telemetryInfo);

--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/SpanShim.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/SpanShim.java
@@ -47,6 +47,10 @@ final class SpanShim extends BaseShimObject implements Span, ImplicitContextKeye
     this(telemetryInfo, span, Baggage.empty());
   }
 
+  public SpanShim(TelemetryInfo telemetryInfo, io.opentelemetry.api.baggage.Baggage baggage) {
+    this(telemetryInfo, io.opentelemetry.api.trace.Span.getInvalid(), baggage);
+  }
+
   public SpanShim(
       TelemetryInfo telemetryInfo, io.opentelemetry.api.trace.Span span, Baggage baggage) {
     super(telemetryInfo);
@@ -57,6 +61,10 @@ final class SpanShim extends BaseShimObject implements Span, ImplicitContextKeye
 
   io.opentelemetry.api.trace.Span getSpan() {
     return span;
+  }
+
+  io.opentelemetry.api.baggage.Baggage getBaggage() {
+    return spanContextShim.getBaggage();
   }
 
   @Nullable

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanBuilderShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanBuilderShimTest.java
@@ -80,6 +80,31 @@ class SpanBuilderShimTest {
   }
 
   @Test
+  void baggage_spanWithInvalidSpan() {
+    io.opentelemetry.api.baggage.Baggage baggage =
+        io.opentelemetry.api.baggage.Baggage.builder().put("foo", "bar").build();
+    SpanShim span =
+        new SpanShim(telemetryInfo, io.opentelemetry.api.trace.Span.getInvalid(), baggage);
+
+    SpanShim childSpan =
+        (SpanShim) new SpanBuilderShim(telemetryInfo, SPAN_NAME).asChildOf(span).start();
+    assertThat(childSpan.getBaggage()).isEqualTo(baggage);
+  }
+
+  @Test
+  void baggage_spanContextWithInvalidSpan() {
+    io.opentelemetry.api.baggage.Baggage baggage =
+        io.opentelemetry.api.baggage.Baggage.builder().put("foo", "bar").build();
+    SpanContextShim spanContext =
+        new SpanContextShim(
+            telemetryInfo, io.opentelemetry.api.trace.Span.getInvalid().getSpanContext(), baggage);
+
+    SpanShim childSpan =
+        (SpanShim) new SpanBuilderShim(telemetryInfo, SPAN_NAME).asChildOf(spanContext).start();
+    assertThat(childSpan.getBaggage()).isEqualTo(baggage);
+  }
+
+  @Test
   void parent_NullContextShim() {
     /* SpanContextShim is null until Span.context() or Span.getBaggageItem() are called.
      * Verify a null SpanContextShim in the parent is handled properly. */


### PR DESCRIPTION
`Baggage` without a valid `Span` should still be properly propagated in inter-process and in-process operations.

This is part of the [OT compatibility section](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/opentracing.md) - essentially, the changes are:

1) [ActiveSpan()](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/opentracing.md#get-the-active-span): 

> If the current OpenTelemetry Span's SpanContext is invalid but the current Baggage is not empty, this operation MUST return a new Span Shim containing a no-op OpenTelemetry Span and the non-empty Baggage.

2) [Tracer.Extract()](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/opentracing.md#extract)

> If the extracted SpanContext is invalid AND the extracted Baggage is empty, this operation MUST return a null value, and otherwise it MUST return a SpanContext Shim instance with the extracted values.

cc @zeitlinger 

