### PR TITLE
Add @trask and @mateuszrzeszutek as approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ Approvers ([@open-telemetry/java-approvers](https://github.com/orgs/open-telemet
 - [Christian Neumüller](https://github.com/Oberon00), Dynatrace
 - [Jakub Wach](https://github.com/kubawach), Splunk
 - [Josh Suereth](https://github.com/jsuereth), Google
+- [Mateusz Rzeszutek](https://github.com/mateuszrzeszutek), Splunk
+- [Trask Stalnaker](https://github.com/trask), Microsoft
 
 *Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver).*
 


### PR DESCRIPTION
@mateuszrzeszutek and @trask have been providing very helpful reviews for a while now, and as maintainers of `opentelemetry-java-instrumentation` are probably the biggest users of this repository. 

Your feedback / contributions are much appreciated! 