### PR TITLE
Make opentelemetry-bom-alpha depend on opentelemetry-bom

### DIFF
--- a/bom-alpha/build.gradle.kts
+++ b/bom-alpha/build.gradle.kts
@@ -7,3 +7,11 @@ group = "io.opentelemetry"
 base.archivesName.set("opentelemetry-bom-alpha")
 
 otelBom.projectFilter.set { it.findProperty("otel.release") == "alpha" }
+
+// Required to place dependency on opentelemetry-bom
+javaPlatform.allowDependencies()
+
+dependencies {
+  // Add dependency on opentelemetry-bom to ensure synchronization between alpha and stable artifacts
+  api(platform(project(":bom")))
+}


### PR DESCRIPTION
Resolves #4747.

The resulting pom artifact looks like:
```
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <!-- This module was also published with a richer model, Gradle metadata,  -->
  <!-- which should be used instead. Do not delete the following line which  -->
  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
  <!-- that they should prefer consuming it instead. -->
  <!-- do_not_remove: published-with-gradle-metadata -->
  <modelVersion>4.0.0</modelVersion>
  <groupId>io.opentelemetry</groupId>
  <artifactId>opentelemetry-bom-alpha</artifactId>
  <version>1.19.0-alpha-SNAPSHOT</version>
  <packaging>pom</packaging>
  <name>OpenTelemetry Java</name>
  <description>OpenTelemetry Bill of Materials (Alpha)</description>
  <url>https://github.com/open-telemetry/opentelemetry-java</url>
  <licenses>
    <license>
      <name>The Apache License, Version 2.0</name>
      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
    </license>
  </licenses>
  <developers>
    <developer>
      <id>opentelemetry</id>
      <name>OpenTelemetry</name>
      <url>https://github.com/open-telemetry/community</url>
    </developer>
  </developers>
  <scm>
    <connection>scm:git:git@github.com:open-telemetry/opentelemetry-java.git</connection>
    <developerConnection>scm:git:git@github.com:open-telemetry/opentelemetry-java.git</developerConnection>
    <url>git@github.com:open-telemetry/opentelemetry-java.git</url>
  </scm>
  <dependencyManagement>
    <dependencies>
      <dependency>
        <groupId>io.opentelemetry</groupId>
        <artifactId>opentelemetry-exporter-otlp-logs</artifactId>
        <version>1.19.0-alpha-SNAPSHOT</version>
      </dependency>
      <dependency>
        <groupId>io.opentelemetry</groupId>
        <artifactId>opentelemetry-bom</artifactId>
        <version>1.19.0-SNAPSHOT</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
    </dependencies>
  </dependencyManagement>
</project>
```

Notice the dependency of `opentelemetry-bom` is `type=pom`, which means that it should be replaced by dependencies in its bom. I tested this locally and was able to place a dependency on `io.opentelemetry:opentelemetry-bom-alpha:<version>` and have versions managed for both stable and alpha artifacts. 