### PR TITLE
Facilitate merging of resource attribute sources

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/DefaultConfigProperties.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/DefaultConfigProperties.java
@@ -74,7 +74,16 @@ final class DefaultConfigProperties implements ConfigProperties {
     this.config = config;
   }
 
-  private Object getValueToWriteAppendingResourceAttributes(
+  private DefaultConfigProperties(
+      DefaultConfigProperties previousProperties, Map<String, String> overrides) {
+    // previousProperties are already normalized, they can be copied as they are
+    Map<String, String> config = new HashMap<>(previousProperties.config);
+    overrides.forEach((name, value) -> config.put(normalize(name), value));
+
+    this.config = config;
+  }
+
+  private static Object getValueToWriteAppendingResourceAttributes(
       Map<String, String> config, Object key, Object value) {
     String normalizedKey = normalize(key.toString());
     if (normalizedKey.equals(ResourceConfiguration.ATTRIBUTE_PROPERTY)
@@ -85,15 +94,6 @@ final class DefaultConfigProperties implements ConfigProperties {
       return existingValue.trim() + "," + value;
     }
     return value;
-  }
-
-  private DefaultConfigProperties(
-      DefaultConfigProperties previousProperties, Map<String, String> overrides) {
-    // previousProperties are already normalized, they can be copied as they are
-    Map<String, String> config = new HashMap<>(previousProperties.config);
-    overrides.forEach((name, value) -> config.put(normalize(name), value));
-
-    this.config = config;
   }
 
   @Override

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/DefaultConfigPropertiesTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/DefaultConfigPropertiesTest.java
@@ -43,4 +43,18 @@ class DefaultConfigPropertiesTest {
 
     assertThat(props.getString("otel.resource.attributes")).isEqualTo(expected);
   }
+
+  @Test
+  void resourceAttributesEmptySyspropCanClobber() {
+    Map<String, String> environment = new HashMap<>();
+    Map<String, String> system = new HashMap<>();
+
+    environment.put("OTEL_RESOURCE_ATTRIBUTES", "service.name=foo,deployment.environment=blah");
+    system.put("otel.resource.attributes", "deployment.environment=");
+    String expected = "service.name=foo,deployment.environment=blah,deployment.environment=";
+
+    ConfigProperties props = DefaultConfigProperties.createForTest(system, environment);
+
+    assertThat(props.getString("otel.resource.attributes")).isEqualTo(expected);
+  }
 }

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/DefaultConfigPropertiesTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/DefaultConfigPropertiesTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class DefaultConfigPropertiesTest {
+
+  @Test
+  void resourceAttributesMerged() {
+    Map<String, String> environment = new HashMap<>();
+    Map<String, String> system = new HashMap<>();
+
+    environment.put(
+        "OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=env,service.name=env.service");
+    system.put("otel.resource.attributes", "deployment.environment=sys");
+    String expected =
+        "deployment.environment=env,service.name=env.service,deployment.environment=sys";
+
+    ConfigProperties props = DefaultConfigProperties.createForTest(system, environment);
+
+    assertThat(props.getString("otel.resource.attributes")).isEqualTo(expected);
+  }
+
+  @Test
+  void resourceAttributesMergedWhenEnvEmpty() {
+    Map<String, String> environment = new HashMap<>();
+    Map<String, String> system = new HashMap<>();
+
+    environment.put("OTEL_RESOURCE_ATTRIBUTES", " ");
+    system.put("otel.resource.attributes", "deployment.environment=sys");
+    String expected = "deployment.environment=sys";
+
+    ConfigProperties props = DefaultConfigProperties.createForTest(system, environment);
+
+    assertThat(props.getString("otel.resource.attributes")).isEqualTo(expected);
+  }
+}

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/DefaultConfigPropertiesTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/DefaultConfigPropertiesTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.sdk.autoconfigure;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.util.HashMap;


### PR DESCRIPTION
So the [spec is pretty clear](https://github.com/open-telemetry/opentelemetry-specification/blob/534d4562b9e4f9ba030146783a1785f94b266862/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable) about the resource attributes env being treated as an otel `Resource` that should be _merged_ with the user-provided resource. 

Currently, in the case where the environment provides `OTEL_RESOURCE_ATTRIBUTES` and the user has provided system property `otel.resource.attributes` the latter completely overwrites the former. Because this is a packed field and we do the blending at the configuration stage (instead of actually merging separate resources from each source), we need to account for this to be spec compliant. Currently, the system property can null out packed fields originating in `OTEL_RESOURCE_ATTRIBUTES` which is effectively an incorrect merge.

This change special cases the resource attribute config item and concatenates the system property onto any existing environment variable field. That way, when the config item is turned into a list, the latter items will replace existing but not null out existing, as is the case today.

I gave some consideration to creating a more sophisticated `ConfigProperties` implementation that held onto both env and system configs and default until it was time to create the resource in `AutoConfiguredOpenTelemetrySdkBuilder` -- but that seemed like a much larger and wide reaching change. Since we're blending configs and losing context pretty early, I thought it made a bit more chance to do this surgical change instead.