### PR TITLE
Remove legacy approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,8 +287,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 Approvers ([@open-telemetry/java-approvers](https://github.com/orgs/open-telemetry/teams/java-approvers)):
 
-- [Christian Neumüller](https://github.com/Oberon00), Dynatrace
-- [Jakub Wach](https://github.com/kubawach), Splunk
 - [Josh Suereth](https://github.com/jsuereth), Google
 - [Mateusz Rzeszutek](https://github.com/mateuszrzeszutek), Splunk
 - [Trask Stalnaker](https://github.com/trask), Microsoft


### PR DESCRIPTION
@jkwatson and I spoke and decided to trim the approvers to better reflect the set of people who are active in reviewing for the project. 

Thanks @Oberon00 and @kubawach for your contributions and let us know if you plan on becoming more active in the project again. 