### PR TITLE
Fix skipped name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,9 @@ jobs:
     #
     # and the name is updated when the steps below are skipped which makes what's happening clearer
     # in the GitHub UI
-    name: publish-snapshots${{ github.ref_name == 'main' && github.repository == 'open-telemetry/opentelemetry-java' && '' || ' (skipped)' }}
+    #
+    # note: need to use single space ' ' below since empty string '' resolves to false
+    name: publish-snapshots${{ github.ref_name == 'main' && github.repository == 'open-telemetry/opentelemetry-java' && ' ' || ' (skipped)' }}
     # intentionally not blocking snapshot publishing on markdown-link-check or misspell-check
     needs: build
     runs-on: ubuntu-20.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,8 +99,9 @@ jobs:
     # and the name is updated when the steps below are skipped which makes what's happening clearer
     # in the GitHub UI
     #
-    # note: need to use single space ' ' below since empty string '' resolves to false
-    name: publish-snapshots${{ github.ref_name == 'main' && github.repository == 'open-telemetry/opentelemetry-java' && ' ' || ' (skipped)' }}
+    # note: the condition below has to be written so that '' is last since it resolves to false
+    # and so would not short-circuit if used in the second-last position
+    name: publish-snapshots${{ (github.ref_name != 'main' || github.repository != 'open-telemetry/opentelemetry-java') && ' (skipped)' || '' }}
     # intentionally not blocking snapshot publishing on markdown-link-check or misspell-check
     needs: build
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Noticed the job name was showing up as " (skipped)" on `main` even though it wasn't really