### PR TITLE
Suppress logs in logger tests

### DIFF
--- a/api/logs/src/test/java/io/opentelemetry/api/logs/DefaultLoggerProviderTest.java
+++ b/api/logs/src/test/java/io/opentelemetry/api/logs/DefaultLoggerProviderTest.java
@@ -5,14 +5,17 @@
 
 package io.opentelemetry.api.logs;
 
+import static io.opentelemetry.api.internal.ValidationUtil.API_USAGE_LOGGER_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import org.junit.jupiter.api.Test;
 
 class DefaultLoggerProviderTest {
 
   @Test
+  @SuppressLogger(loggerName = API_USAGE_LOGGER_NAME)
   void noopLoggerProvider_doesNotThrow() {
     LoggerProvider provider = LoggerProvider.noop();
 

--- a/api/logs/src/test/java/io/opentelemetry/api/logs/DefaultLoggerTest.java
+++ b/api/logs/src/test/java/io/opentelemetry/api/logs/DefaultLoggerTest.java
@@ -13,6 +13,7 @@ import io.github.netmikey.logunit.api.LogCapturer;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,7 @@ class DefaultLoggerTest {
   LogCapturer apiUsageLogs = LogCapturer.create().captureForLogger(API_USAGE_LOGGER_NAME);
 
   @Test
+  @SuppressLogger(loggerName = API_USAGE_LOGGER_NAME)
   void buildAndEmit() {
     // Logger with no event.domain
     assertThatCode(

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerTest.java
@@ -24,6 +24,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.internal.StringUtils;
 import io.opentelemetry.api.logs.LogRecordBuilder;
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
@@ -143,6 +144,7 @@ class SdkLoggerTest {
   }
 
   @Test
+  @SuppressLogger(loggerName = API_USAGE_LOGGER_NAME)
   void eventBuilder() {
     AtomicReference<ReadWriteLogRecord> seenLog = new AtomicReference<>();
     SdkLoggerProvider loggerProvider =


### PR DESCRIPTION
I introduced some new tests in a recent PR that create noisy expected logs. This suppresses them.