### PR TITLE
Add support for new system property otel.sdk.disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Autoconfigure now supports an option to disable the SDK.
-  If `otel.sdk.disabled=false`, `AutoConfiguredOpenTelemetrySdk#getOpenTelemetrySdk()`
+  If `otel.sdk.disabled=true`, `AutoConfiguredOpenTelemetrySdk#getOpenTelemetrySdk()`
   returns a minimal (but not noop) `OpenTelemetrySdk` with noop tracing, metric and logging providers. The same minimal instance is set
   to `GlobalOpenTelemetry`. The now deprecated property `otel.experimental.sdk.enabled` will continue to work in the same way during a transition period.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Autoconfigure now supports an option to disable the SDK.
+  If `otel.sdk.disabled=false`, `AutoConfiguredOpenTelemetrySdk#getOpenTelemetrySdk()`
+  returns a minimal (but not noop) `OpenTelemetrySdk` with noop tracing, metric and logging providers. The same minimal instance is set
+  to `GlobalOpenTelemetry`. The now deprecated property `otel.experimental.sdk.enabled` will continue to work in the same way during a transition period.
+
 ## Version 1.18.0 (2022-09-09)
 
 ### SDK

--- a/sdk-extensions/autoconfigure/README.md
+++ b/sdk-extensions/autoconfigure/README.md
@@ -39,9 +39,9 @@ for more details.
 
 The OpenTelemetry SDK can be disabled entirely. If disabled, `AutoConfiguredOpenTelemetrySdk#getOpenTelemetrySdk()` will return a minimally configured instance (i.e. `OpenTelemetrySdk.builder().build()`).
 
-| System property               | Environment variable          | Purpose                                                        |
-|-------------------------------|-------------------------------|----------------------------------------------------------------|
-| otel.experimental.sdk.enabled | OTEL_EXPERIMENTAL_SDK_ENABLED | If `false`, disable the OpenTelemetry SDK. Defaults to `true`. |
+| System property   | Environment variable | Purpose                                                                                                                                                                                      |
+|-------------------|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| otel.sdk.disabled | OTEL_SDK_DISABLED    | If `true`, disable the OpenTelemetry SDK. Defaults to `false`. The now legacy property `otel.experimental.sdk.enabled` will continue to work with default `true` during a transition period. |
 
 ## Exporters
 

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -33,7 +33,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -333,13 +332,9 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
 
     OpenTelemetrySdk openTelemetrySdk = OpenTelemetrySdk.builder().build();
     boolean sdkEnabled =
-        Optional.ofNullable(config.getBoolean("otel.sdk.disabled"))
-            // default is false, therefore enabled
-            .map(disabled -> !disabled)
-            .orElseGet(
-                () ->
-                    Optional.ofNullable(config.getBoolean("otel.experimental.sdk.enabled"))
-                        .orElse(true));
+        !config.getBoolean(
+            "otel.sdk.disabled", !config.getBoolean("otel.experimental.sdk.enabled", true));
+
     if (sdkEnabled) {
       SdkMeterProviderBuilder meterProviderBuilder = SdkMeterProvider.builder();
       meterProviderBuilder.setResource(resource);

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -333,7 +333,13 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
 
     OpenTelemetrySdk openTelemetrySdk = OpenTelemetrySdk.builder().build();
     boolean sdkEnabled =
-        Optional.ofNullable(config.getBoolean("otel.experimental.sdk.enabled")).orElse(true);
+        Optional.ofNullable(config.getBoolean("otel.sdk.disabled"))
+            // default is false, therefore enabled
+            .map(disabled -> !disabled)
+            .orElseGet(
+                () ->
+                    Optional.ofNullable(config.getBoolean("otel.experimental.sdk.enabled"))
+                        .orElse(true));
     if (sdkEnabled) {
       SdkMeterProviderBuilder meterProviderBuilder = SdkMeterProvider.builder();
       meterProviderBuilder.setResource(resource);


### PR DESCRIPTION
This provides support to the new `otel.sdk.disabled=false` system property recently added to the OTel specification here: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration
