### PR TITLE
Ignore dependabot updates to kotlinx-coroutines-core

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,4 @@ updates:
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "edu.berkeley.cs.jqf:jqf-fuzz"
+      - dependency-name: "org.jetbrains.kotlinx:kotlinx-coroutines-core"


### PR DESCRIPTION
We've intentionally pinned a specific version as discussed [here](https://github.com/open-telemetry/opentelemetry-java/pull/4787#discussion_r981317670). 