### PR TITLE
Ensure done before checking success to help troubleshoot timeout issues

### DIFF
--- a/sdk-extensions/autoconfigure/src/testOtlp/java/io/opentelemetry/sdk/autoconfigure/OtlpGrpcRetryTest.java
+++ b/sdk-extensions/autoconfigure/src/testOtlp/java/io/opentelemetry/sdk/autoconfigure/OtlpGrpcRetryTest.java
@@ -156,6 +156,9 @@ class OtlpGrpcRetryTest {
     // Result should be failure, sever should have received maxAttempts requests
     CompletableResultCode resultCode =
         exporter.apply(dataSupplier.get()).join(10, TimeUnit.SECONDS);
+    assertThat(resultCode.isDone())
+        .as("Exporter didn't complete in time. Consider increasing join timeout?")
+        .isTrue();
     assertThat(resultCode.isSuccess()).isFalse();
     assertThat(serverRequestCountSupplier.get()).isEqualTo(maxAttempts);
   }

--- a/sdk-extensions/autoconfigure/src/testOtlp/java/io/opentelemetry/sdk/autoconfigure/OtlpGrpcRetryTest.java
+++ b/sdk-extensions/autoconfigure/src/testOtlp/java/io/opentelemetry/sdk/autoconfigure/OtlpGrpcRetryTest.java
@@ -120,6 +120,10 @@ class OtlpGrpcRetryTest {
 
       CompletableResultCode resultCode =
           exporter.apply(dataSupplier.get()).join(10, TimeUnit.SECONDS);
+      assertThat(resultCode.isDone())
+          .as("Exporter didn't complete in time. Consider increasing join timeout?")
+          .isTrue();
+
       boolean retryable =
           RetryUtil.retryableGrpcStatusCodes().contains(String.valueOf(code.value()));
       boolean expectedResult = retryable || code == Status.Code.OK;

--- a/sdk-extensions/autoconfigure/src/testOtlp/java/io/opentelemetry/sdk/autoconfigure/OtlpHttpRetryTest.java
+++ b/sdk-extensions/autoconfigure/src/testOtlp/java/io/opentelemetry/sdk/autoconfigure/OtlpHttpRetryTest.java
@@ -129,6 +129,10 @@ class OtlpHttpRetryTest {
 
       CompletableResultCode resultCode =
           exporter.apply(dataSupplier.get()).join(10, TimeUnit.SECONDS);
+      assertThat(resultCode.isDone())
+          .as("Exporter didn't complete in time. Consider increasing join timeout?")
+          .isTrue();
+
       boolean retryable = code != 200 && RetryUtil.retryableHttpResponseCodes().contains(code);
       boolean expectedResult = retryable || code == 200;
       assertThat(resultCode.isSuccess())
@@ -159,6 +163,9 @@ class OtlpHttpRetryTest {
     // Result should be failure, sever should have received maxAttempts requests
     CompletableResultCode resultCode =
         exporter.apply(dataSupplier.get()).join(10, TimeUnit.SECONDS);
+    assertThat(resultCode.isDone())
+        .as("Exporter didn't complete in time. Consider increasing join timeout?")
+        .isTrue();
     assertThat(resultCode.isSuccess()).isFalse();
     assertThat(serverRequestCountSupplier.get()).isEqualTo(maxAttempts);
   }


### PR DESCRIPTION
I think this can help with #4624. 

It's a little delicate here, but in the case of a "bad" error code that we don't expect a retry for, we try and verify that it both failed and that the attempt was just 1. In the flaky example run linked in #4624, the attempt count was 0, which strongly suggests a race condition. That is, I think we were checking the count before the operation has completed.

I think what happened is that the `.isSuccess()` call fails both when the underlying call fails but also when the call has not completed. By putting an explicit `.isDone()` check after the `.join()` we can then tell if/when this happens again and then bump up the wait time. I suspect we just hit a cloud glitch and got stalled/lags, as happens sometimes. With this change, we should know.