### PR TITLE
Update bot branch names

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -33,7 +33,7 @@ jobs:
           commit=$(gh pr view $NUMBER --json mergeCommit --jq .mergeCommit.oid)
           title=$(gh pr view $NUMBER --json title --jq .title)
 
-          branch="backport-${NUMBER}-to-${GITHUB_REF_NAME//\//-}"
+          branch="opentelemetrybot/backport-${NUMBER}-to-${GITHUB_REF_NAME//\//-}"
 
           git cherry-pick $commit
           git push origin HEAD:$branch

--- a/.github/workflows/prepare-patch-release.yml
+++ b/.github/workflows/prepare-patch-release.yml
@@ -48,7 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           message="Prepare release $VERSION"
-          branch="prepare-release-${VERSION}"
+          branch="opentelemetrybot/prepare-release-${VERSION}"
 
           git commit -a -m "$message"
           git push origin HEAD:$branch

--- a/.github/workflows/prepare-release-branch.yml
+++ b/.github/workflows/prepare-release-branch.yml
@@ -58,7 +58,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           message="Prepare release $VERSION"
-          branch="prepare-release-${VERSION}"
+          branch="opentelemetrybot/prepare-release-${VERSION}"
 
           git commit -a -m "$message"
           git push origin HEAD:$branch
@@ -106,7 +106,7 @@ jobs:
         run: |
           message="Update version to $NEXT_VERSION"
           body="Update version to \`$NEXT_VERSION\`."
-          branch="update-version-to-${NEXT_VERSION}"
+          branch="opentelemetrybot/update-version-to-${NEXT_VERSION}"
 
           git commit -a -m "$message"
           git push origin HEAD:$branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,7 @@ jobs:
         run: |
           message="Copy change log updates from $GITHUB_REF_NAME"
           body="Copy log updates from \`$GITHUB_REF_NAME\`."
-          branch="copy-change-log-updates-from-${GITHUB_REF_NAME//\//-}"
+          branch="opentelemetrybot/copy-change-log-updates-from-${GITHUB_REF_NAME//\//-}"
 
           if [[ $VERSION == *.0 ]]; then
             if git diff --quiet; then


### PR DESCRIPTION
similar to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/6862

@jack-berg it may be worth comparing this repo's branch protections against https://github.com/open-telemetry/opentelemetry-java-contrib/settings/branches