### PR TITLE
Fix release contributors script

### DIFF
--- a/.github/scripts/generate-release-contributors.sh
+++ b/.github/scripts/generate-release-contributors.sh
@@ -72,7 +72,7 @@ query($q: String!, $endCursor: String) {
   }
 }
 ' --jq '.data.search.edges.[].node.body' \
-  | grep -oE "#[0-9]{4,}|$GITHUB_REPOSITORY/issues/[0-9]{4,}" \
+  | grep -oE "#[0-9]{4,}$|#[0-9]{4,}[^0-9<]|$GITHUB_REPOSITORY/issues/[0-9]{4,}" \
   | grep -oE "[0-9]{4,}" \
   | xargs -I{} gh issue view {} --json 'author,url' --jq '[.author.login,.url]' \
   | grep -v '/pull/' \


### PR DESCRIPTION
Similar to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/6879

@jack-berg I re-ran the release contributor script locally and it matched, so doesn't look like this issue affected 1.19.0 (and I doubt any prior since it's only really started affecting us since enabling dependabot)