### PR TITLE
Add toString method to AbstractInstrument

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/AbstractInstrument.java
@@ -39,4 +39,9 @@ abstract class AbstractInstrument {
   public int hashCode() {
     return descriptor.hashCode();
   }
+
+  @Override
+  public String toString() {
+    return this.getClass().getSimpleName() + "{" + "descriptor=" + getDescriptor() + '}';
+  }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentTest.java
@@ -22,6 +22,13 @@ class AbstractInstrumentTest {
     assertThat(testInstrument.getDescriptor()).isSameAs(INSTRUMENT_DESCRIPTOR);
   }
 
+  @Test
+  void testToString() {
+    TestInstrument testInstrument = new TestInstrument(INSTRUMENT_DESCRIPTOR);
+    assertThat(testInstrument.toString())
+        .isEqualTo("TestInstrument{descriptor=" + INSTRUMENT_DESCRIPTOR + "}");
+  }
+
   private static final class TestInstrument extends AbstractInstrument {
     TestInstrument(InstrumentDescriptor descriptor) {
       super(descriptor);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentTest.java
@@ -25,8 +25,8 @@ class AbstractInstrumentTest {
   @Test
   void testToString() {
     TestInstrument testInstrument = new TestInstrument(INSTRUMENT_DESCRIPTOR);
-    assertThat(testInstrument.toString())
-        .isEqualTo("TestInstrument{descriptor=" + INSTRUMENT_DESCRIPTOR + "}");
+    assertThat(testInstrument)
+        .hasToString("TestInstrument{descriptor=" + INSTRUMENT_DESCRIPTOR + "}");
   }
 
   private static final class TestInstrument extends AbstractInstrument {


### PR DESCRIPTION
Partially resolves: #4829

I have added a `toString` method to the abstract class to make it available for every implementation of the AbstractInstrument. I believe the better way would be adding toString method to each the subclasses, but I would appreciate a piece of advice here.

Sample toString for the SdkDoubleHistogram is:
```
SdkDoubleHistogram{descriptor=InstrumentDescriptor{name=testHistogram, description=, unit=, type=HISTOGRAM, valueType=DOUBLE}}
```