### PR TITLE
Add context argument to LogRecordProcessor#onEmit

### DIFF
--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/LogRecordProcessor.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/LogRecordProcessor.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.logs;
 
 import io.opentelemetry.api.logs.LogRecordBuilder;
 import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import java.io.Closeable;
 import java.util.ArrayList;
@@ -52,8 +53,10 @@ public interface LogRecordProcessor extends Closeable {
    * Called when a {@link Logger} {@link LogRecordBuilder#emit()}s a log record.
    *
    * @param logRecord the log record
+   * @param context the context set via {@link LogRecordBuilder#setContext(Context)}, or {@link
+   *     Context#current()} if not explicitly set
    */
-  void onEmit(ReadWriteLogRecord logRecord);
+  void onEmit(ReadWriteLogRecord logRecord, Context context);
 
   /**
    * Shutdown the log processor.

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/LogRecordProcessor.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/LogRecordProcessor.java
@@ -52,11 +52,11 @@ public interface LogRecordProcessor extends Closeable {
   /**
    * Called when a {@link Logger} {@link LogRecordBuilder#emit()}s a log record.
    *
-   * @param logRecord the log record
    * @param context the context set via {@link LogRecordBuilder#setContext(Context)}, or {@link
    *     Context#current()} if not explicitly set
+   * @param logRecord the log record
    */
-  void onEmit(ReadWriteLogRecord logRecord, Context context);
+  void onEmit(Context context, ReadWriteLogRecord logRecord);
 
   /**
    * Shutdown the log processor.

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/MultiLogRecordProcessor.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/MultiLogRecordProcessor.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.logs;
 
+import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,9 +34,9 @@ final class MultiLogRecordProcessor implements LogRecordProcessor {
   }
 
   @Override
-  public void onEmit(ReadWriteLogRecord logRecord) {
+  public void onEmit(ReadWriteLogRecord logRecord, Context context) {
     for (LogRecordProcessor logRecordProcessor : logRecordProcessors) {
-      logRecordProcessor.onEmit(logRecord);
+      logRecordProcessor.onEmit(logRecord, context);
     }
   }
 

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/MultiLogRecordProcessor.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/MultiLogRecordProcessor.java
@@ -34,9 +34,9 @@ final class MultiLogRecordProcessor implements LogRecordProcessor {
   }
 
   @Override
-  public void onEmit(ReadWriteLogRecord logRecord, Context context) {
+  public void onEmit(Context context, ReadWriteLogRecord logRecord) {
     for (LogRecordProcessor logRecordProcessor : logRecordProcessors) {
-      logRecordProcessor.onEmit(logRecord, context);
+      logRecordProcessor.onEmit(context, logRecord);
     }
   }
 

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/NoopLogRecordProcessor.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/NoopLogRecordProcessor.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.sdk.logs;
 
+import io.opentelemetry.context.Context;
+
 final class NoopLogRecordProcessor implements LogRecordProcessor {
   private static final NoopLogRecordProcessor INSTANCE = new NoopLogRecordProcessor();
 
@@ -15,5 +17,5 @@ final class NoopLogRecordProcessor implements LogRecordProcessor {
   private NoopLogRecordProcessor() {}
 
   @Override
-  public void onEmit(ReadWriteLogRecord logRecord) {}
+  public void onEmit(ReadWriteLogRecord logRecord, Context context) {}
 }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/NoopLogRecordProcessor.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/NoopLogRecordProcessor.java
@@ -17,5 +17,5 @@ final class NoopLogRecordProcessor implements LogRecordProcessor {
   private NoopLogRecordProcessor() {}
 
   @Override
-  public void onEmit(ReadWriteLogRecord logRecord, Context context) {}
+  public void onEmit(Context context, ReadWriteLogRecord logRecord) {}
 }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogRecordBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogRecordBuilder.java
@@ -98,6 +98,7 @@ final class SdkLogRecordBuilder implements EventBuilder {
     loggerSharedState
         .getLogRecordProcessor()
         .onEmit(
+            context,
             SdkReadWriteLogRecord.create(
                 loggerSharedState.getLogLimits(),
                 loggerSharedState.getResource(),
@@ -107,7 +108,6 @@ final class SdkLogRecordBuilder implements EventBuilder {
                 severity,
                 severityText,
                 body,
-                attributes),
-            context);
+                attributes));
   }
 }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerProviderBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerProviderBuilder.java
@@ -9,6 +9,7 @@ import static java.util.Objects.requireNonNull;
 
 import io.opentelemetry.api.logs.LogRecordBuilder;
 import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.resources.Resource;
@@ -57,8 +58,9 @@ public final class SdkLoggerProviderBuilder {
   }
 
   /**
-   * Add a log processor. {@link LogRecordProcessor#onEmit(ReadWriteLogRecord)} will be called each
-   * time a log is emitted by {@link Logger} instances obtained from the {@link SdkLoggerProvider}.
+   * Add a log processor. {@link LogRecordProcessor#onEmit(ReadWriteLogRecord, Context)} will be
+   * called each time a log is emitted by {@link Logger} instances obtained from the {@link
+   * SdkLoggerProvider}.
    *
    * @param processor the log processor
    * @return this

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerProviderBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerProviderBuilder.java
@@ -58,7 +58,7 @@ public final class SdkLoggerProviderBuilder {
   }
 
   /**
-   * Add a log processor. {@link LogRecordProcessor#onEmit(ReadWriteLogRecord, Context)} will be
+   * Add a log processor. {@link LogRecordProcessor#onEmit(Context, ReadWriteLogRecord)} will be
    * called each time a log is emitted by {@link Logger} instances obtained from the {@link
    * SdkLoggerProvider}.
    *

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessor.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessor.java
@@ -82,7 +82,7 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
   }
 
   @Override
-  public void onEmit(ReadWriteLogRecord logRecord, Context context) {
+  public void onEmit(Context context, ReadWriteLogRecord logRecord) {
     if (logRecord == null) {
       return;
     }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessor.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessor.java
@@ -10,6 +10,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.internal.DaemonThreadFactory;
 import io.opentelemetry.sdk.logs.LogRecordProcessor;
@@ -81,7 +82,7 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
   }
 
   @Override
-  public void onEmit(ReadWriteLogRecord logRecord) {
+  public void onEmit(ReadWriteLogRecord logRecord, Context context) {
     if (logRecord == null) {
       return;
     }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/SimpleLogRecordProcessor.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/SimpleLogRecordProcessor.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.logs.export;
 
 import static java.util.Objects.requireNonNull;
 
+import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.logs.LogRecordProcessor;
 import io.opentelemetry.sdk.logs.ReadWriteLogRecord;
@@ -58,7 +59,7 @@ public final class SimpleLogRecordProcessor implements LogRecordProcessor {
   }
 
   @Override
-  public void onEmit(ReadWriteLogRecord logRecord) {
+  public void onEmit(ReadWriteLogRecord logRecord, Context context) {
     try {
       List<LogRecordData> logs = Collections.singletonList(logRecord.toLogRecordData());
       CompletableResultCode result = logRecordExporter.export(logs);

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/SimpleLogRecordProcessor.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/SimpleLogRecordProcessor.java
@@ -59,7 +59,7 @@ public final class SimpleLogRecordProcessor implements LogRecordProcessor {
   }
 
   @Override
-  public void onEmit(ReadWriteLogRecord logRecord, Context context) {
+  public void onEmit(Context context, ReadWriteLogRecord logRecord) {
     try {
       List<LogRecordData> logs = Collections.singletonList(logRecord.toLogRecordData());
       CompletableResultCode result = logRecordExporter.export(logs);

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/MultiLogRecordProcessorTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/MultiLogRecordProcessorTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,7 @@ class MultiLogRecordProcessorTest {
   void empty() {
     LogRecordProcessor multiLogRecordProcessor = LogRecordProcessor.composite();
     assertThat(multiLogRecordProcessor).isInstanceOf(NoopLogRecordProcessor.class);
-    multiLogRecordProcessor.onEmit(logRecord);
+    multiLogRecordProcessor.onEmit(logRecord, Context.current());
     multiLogRecordProcessor.shutdown();
   }
 
@@ -53,9 +54,10 @@ class MultiLogRecordProcessorTest {
   void twoLogRecordProcessor() {
     LogRecordProcessor multiLogRecordProcessor =
         LogRecordProcessor.composite(logRecordProcessor1, logRecordProcessor2);
-    multiLogRecordProcessor.onEmit(logRecord);
-    verify(logRecordProcessor1).onEmit(same(logRecord));
-    verify(logRecordProcessor2).onEmit(same(logRecord));
+    Context context = Context.current();
+    multiLogRecordProcessor.onEmit(logRecord, context);
+    verify(logRecordProcessor1).onEmit(same(logRecord), same(context));
+    verify(logRecordProcessor2).onEmit(same(logRecord), same(context));
 
     multiLogRecordProcessor.forceFlush();
     verify(logRecordProcessor1).forceFlush();

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/MultiLogRecordProcessorTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/MultiLogRecordProcessorTest.java
@@ -40,7 +40,7 @@ class MultiLogRecordProcessorTest {
   void empty() {
     LogRecordProcessor multiLogRecordProcessor = LogRecordProcessor.composite();
     assertThat(multiLogRecordProcessor).isInstanceOf(NoopLogRecordProcessor.class);
-    multiLogRecordProcessor.onEmit(logRecord, Context.current());
+    multiLogRecordProcessor.onEmit(Context.current(), logRecord);
     multiLogRecordProcessor.shutdown();
   }
 
@@ -55,9 +55,9 @@ class MultiLogRecordProcessorTest {
     LogRecordProcessor multiLogRecordProcessor =
         LogRecordProcessor.composite(logRecordProcessor1, logRecordProcessor2);
     Context context = Context.current();
-    multiLogRecordProcessor.onEmit(logRecord, context);
-    verify(logRecordProcessor1).onEmit(same(logRecord), same(context));
-    verify(logRecordProcessor2).onEmit(same(logRecord), same(context));
+    multiLogRecordProcessor.onEmit(context, logRecord);
+    verify(logRecordProcessor1).onEmit(same(context), same(logRecord));
+    verify(logRecordProcessor2).onEmit(same(context), same(logRecord));
 
     multiLogRecordProcessor.forceFlush();
     verify(logRecordProcessor1).forceFlush();

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/NoopLogRecordProcessorTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/NoopLogRecordProcessorTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.logs;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import io.opentelemetry.context.Context;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -20,7 +21,7 @@ class NoopLogRecordProcessorTest {
   @Test
   void noCrash() {
     LogRecordProcessor logRecordProcessor = NoopLogRecordProcessor.getInstance();
-    logRecordProcessor.onEmit(logRecord);
+    logRecordProcessor.onEmit(logRecord, Context.current());
     assertThat(logRecordProcessor.forceFlush().isSuccess()).isEqualTo(true);
     assertThat(logRecordProcessor.shutdown().isSuccess()).isEqualTo(true);
   }

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/NoopLogRecordProcessorTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/NoopLogRecordProcessorTest.java
@@ -21,7 +21,7 @@ class NoopLogRecordProcessorTest {
   @Test
   void noCrash() {
     LogRecordProcessor logRecordProcessor = NoopLogRecordProcessor.getInstance();
-    logRecordProcessor.onEmit(logRecord, Context.current());
+    logRecordProcessor.onEmit(Context.current(), logRecord);
     assertThat(logRecordProcessor.forceFlush().isSuccess()).isEqualTo(true);
     assertThat(logRecordProcessor.shutdown().isSuccess()).isEqualTo(true);
   }

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLogRecordBuilderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLogRecordBuilderTest.java
@@ -48,7 +48,7 @@ class SdkLogRecordBuilderTest {
   void setup() {
     when(loggerSharedState.getLogLimits()).thenReturn(LogLimits.getDefault());
     when(loggerSharedState.getLogRecordProcessor())
-        .thenReturn((logRecord, context) -> emittedLog.set(logRecord));
+        .thenReturn((context, logRecord) -> emittedLog.set(logRecord));
     when(loggerSharedState.getResource()).thenReturn(RESOURCE);
     when(loggerSharedState.getClock()).thenReturn(Clock.getDefault());
 

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLogRecordBuilderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLogRecordBuilderTest.java
@@ -47,7 +47,8 @@ class SdkLogRecordBuilderTest {
   @BeforeEach
   void setup() {
     when(loggerSharedState.getLogLimits()).thenReturn(LogLimits.getDefault());
-    when(loggerSharedState.getLogRecordProcessor()).thenReturn(emittedLog::set);
+    when(loggerSharedState.getLogRecordProcessor())
+        .thenReturn((logRecord, context) -> emittedLog.set(logRecord));
     when(loggerSharedState.getResource()).thenReturn(RESOURCE);
     when(loggerSharedState.getClock()).thenReturn(Clock.getDefault());
 

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerProviderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerProviderTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.logs;
 
 import static io.opentelemetry.sdk.testing.assertj.LogAssertions.assertThat;
 import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -21,6 +22,8 @@ import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;
@@ -29,6 +32,7 @@ import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -222,7 +226,7 @@ class SdkLoggerProviderTest {
         SdkLoggerProvider.builder()
             .setResource(resource)
             .addLogRecordProcessor(
-                logRecord -> {
+                (logRecord, unused) -> {
                   logRecord.setAttribute(null, null);
                   // Overwrite k1
                   logRecord.setAttribute(AttributeKey.stringKey("k1"), "new-v1");
@@ -263,6 +267,50 @@ class SdkLoggerProviderTest {
   }
 
   @Test
+  void loggerBuilder_ProcessorWithContext() {
+    ContextKey<String> contextKey = ContextKey.named("my-context-key");
+    AtomicReference<LogRecordData> logRecordData = new AtomicReference<>();
+
+    sdkLoggerProvider =
+        SdkLoggerProvider.builder()
+            .addLogRecordProcessor(
+                (logRecord, context) ->
+                    logRecord.setAttribute(
+                        AttributeKey.stringKey("my-context-key"),
+                        Optional.ofNullable(context.get(contextKey)).orElse("")))
+            .addLogRecordProcessor(
+                (logRecord, unused) -> logRecordData.set(logRecord.toLogRecordData()))
+            .build();
+
+    // With implicit context
+    try (Scope unused = Context.current().with(contextKey, "context-value1").makeCurrent()) {
+      sdkLoggerProvider
+          .loggerBuilder("test")
+          .build()
+          .logRecordBuilder()
+          .setBody("log message1")
+          .emit();
+    }
+    assertThat(logRecordData.get())
+        .hasBody("log message1")
+        .hasAttributes(entry(AttributeKey.stringKey("my-context-key"), "context-value1"));
+
+    // With explicit context
+    try (Scope unused = Context.current().with(contextKey, "context-value2").makeCurrent()) {
+      sdkLoggerProvider
+          .loggerBuilder("test")
+          .build()
+          .logRecordBuilder()
+          .setContext(Context.current())
+          .setBody("log message2")
+          .emit();
+    }
+    assertThat(logRecordData.get())
+        .hasBody("log message2")
+        .hasAttributes(entry(AttributeKey.stringKey("my-context-key"), "context-value2"));
+  }
+
+  @Test
   void forceFlush() {
     sdkLoggerProvider.forceFlush();
     verify(logRecordProcessor).forceFlush();
@@ -288,7 +336,7 @@ class SdkLoggerProviderTest {
     Clock clock = mock(Clock.class);
     when(clock.now()).thenReturn(now);
     List<ReadWriteLogRecord> seenLogs = new ArrayList<>();
-    logRecordProcessor = seenLogs::add;
+    logRecordProcessor = (logRecord, context) -> seenLogs.add(logRecord);
     sdkLoggerProvider =
         SdkLoggerProvider.builder()
             .setClock(clock)

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerProviderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerProviderTest.java
@@ -226,7 +226,7 @@ class SdkLoggerProviderTest {
         SdkLoggerProvider.builder()
             .setResource(resource)
             .addLogRecordProcessor(
-                (logRecord, unused) -> {
+                (unused, logRecord) -> {
                   logRecord.setAttribute(null, null);
                   // Overwrite k1
                   logRecord.setAttribute(AttributeKey.stringKey("k1"), "new-v1");
@@ -274,12 +274,12 @@ class SdkLoggerProviderTest {
     sdkLoggerProvider =
         SdkLoggerProvider.builder()
             .addLogRecordProcessor(
-                (logRecord, context) ->
+                (context, logRecord) ->
                     logRecord.setAttribute(
                         AttributeKey.stringKey("my-context-key"),
                         Optional.ofNullable(context.get(contextKey)).orElse("")))
             .addLogRecordProcessor(
-                (logRecord, unused) -> logRecordData.set(logRecord.toLogRecordData()))
+                (unused, logRecord) -> logRecordData.set(logRecord.toLogRecordData()))
             .build();
 
     // With implicit context
@@ -336,7 +336,7 @@ class SdkLoggerProviderTest {
     Clock clock = mock(Clock.class);
     when(clock.now()).thenReturn(now);
     List<ReadWriteLogRecord> seenLogs = new ArrayList<>();
-    logRecordProcessor = (logRecord, context) -> seenLogs.add(logRecord);
+    logRecordProcessor = (context, logRecord) -> seenLogs.add(logRecord);
     sdkLoggerProvider =
         SdkLoggerProvider.builder()
             .setClock(clock)

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerTest.java
@@ -46,7 +46,7 @@ class SdkLoggerTest {
     LoggerSharedState state = mock(LoggerSharedState.class);
     InstrumentationScopeInfo info = InstrumentationScopeInfo.create("foo");
     AtomicReference<ReadWriteLogRecord> seenLog = new AtomicReference<>();
-    LogRecordProcessor logRecordProcessor = (logRecord, context) -> seenLog.set(logRecord);
+    LogRecordProcessor logRecordProcessor = (context, logRecord) -> seenLog.set(logRecord);
     Clock clock = mock(Clock.class);
     when(clock.now()).thenReturn(5L);
 
@@ -69,7 +69,7 @@ class SdkLoggerTest {
     AtomicReference<ReadWriteLogRecord> seenLog = new AtomicReference<>();
     SdkLoggerProvider loggerProvider =
         SdkLoggerProvider.builder()
-            .addLogRecordProcessor((logRecord, context) -> seenLog.set(logRecord))
+            .addLogRecordProcessor((context, logRecord) -> seenLog.set(logRecord))
             .setLogLimits(() -> LogLimits.builder().setMaxAttributeValueLength(maxLength).build())
             .build();
     LogRecordBuilder logRecordBuilder = loggerProvider.get("test").logRecordBuilder();
@@ -109,7 +109,7 @@ class SdkLoggerTest {
     AtomicReference<ReadWriteLogRecord> seenLog = new AtomicReference<>();
     SdkLoggerProvider loggerProvider =
         SdkLoggerProvider.builder()
-            .addLogRecordProcessor((logRecord, context) -> seenLog.set(logRecord))
+            .addLogRecordProcessor((context, logRecord) -> seenLog.set(logRecord))
             .setLogLimits(
                 () -> LogLimits.builder().setMaxNumberOfAttributes(maxNumberOfAttrs).build())
             .build();
@@ -149,7 +149,7 @@ class SdkLoggerTest {
     AtomicReference<ReadWriteLogRecord> seenLog = new AtomicReference<>();
     SdkLoggerProvider loggerProvider =
         SdkLoggerProvider.builder()
-            .addLogRecordProcessor((logRecord, context) -> seenLog.set(logRecord))
+            .addLogRecordProcessor((context, logRecord) -> seenLog.set(logRecord))
             .build();
 
     // Emit event from logger with name and add event domain

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerTest.java
@@ -46,7 +46,7 @@ class SdkLoggerTest {
     LoggerSharedState state = mock(LoggerSharedState.class);
     InstrumentationScopeInfo info = InstrumentationScopeInfo.create("foo");
     AtomicReference<ReadWriteLogRecord> seenLog = new AtomicReference<>();
-    LogRecordProcessor logRecordProcessor = seenLog::set;
+    LogRecordProcessor logRecordProcessor = (logRecord, context) -> seenLog.set(logRecord);
     Clock clock = mock(Clock.class);
     when(clock.now()).thenReturn(5L);
 
@@ -69,7 +69,7 @@ class SdkLoggerTest {
     AtomicReference<ReadWriteLogRecord> seenLog = new AtomicReference<>();
     SdkLoggerProvider loggerProvider =
         SdkLoggerProvider.builder()
-            .addLogRecordProcessor(seenLog::set)
+            .addLogRecordProcessor((logRecord, context) -> seenLog.set(logRecord))
             .setLogLimits(() -> LogLimits.builder().setMaxAttributeValueLength(maxLength).build())
             .build();
     LogRecordBuilder logRecordBuilder = loggerProvider.get("test").logRecordBuilder();
@@ -109,7 +109,7 @@ class SdkLoggerTest {
     AtomicReference<ReadWriteLogRecord> seenLog = new AtomicReference<>();
     SdkLoggerProvider loggerProvider =
         SdkLoggerProvider.builder()
-            .addLogRecordProcessor(seenLog::set)
+            .addLogRecordProcessor((logRecord, context) -> seenLog.set(logRecord))
             .setLogLimits(
                 () -> LogLimits.builder().setMaxNumberOfAttributes(maxNumberOfAttrs).build())
             .build();
@@ -140,7 +140,7 @@ class SdkLoggerTest {
     loggerProvider.shutdown().join(10, TimeUnit.SECONDS);
     loggerProvider.get("test").logRecordBuilder().emit();
 
-    verify(logRecordProcessor, never()).onEmit(any());
+    verify(logRecordProcessor, never()).onEmit(any(), any());
   }
 
   @Test
@@ -148,7 +148,9 @@ class SdkLoggerTest {
   void eventBuilder() {
     AtomicReference<ReadWriteLogRecord> seenLog = new AtomicReference<>();
     SdkLoggerProvider loggerProvider =
-        SdkLoggerProvider.builder().addLogRecordProcessor(seenLog::set).build();
+        SdkLoggerProvider.builder()
+            .addLogRecordProcessor((logRecord, context) -> seenLog.set(logRecord))
+            .build();
 
     // Emit event from logger with name and add event domain
     loggerProvider

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessorTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessorTest.java
@@ -291,7 +291,7 @@ class BatchLogRecordProcessorTest {
     BatchLogRecordProcessor processor =
         BatchLogRecordProcessor.builder(mockLogRecordExporter).build();
     try {
-      assertThatCode(() -> processor.onEmit(null)).doesNotThrowAnyException();
+      assertThatCode(() -> processor.onEmit(null, null)).doesNotThrowAnyException();
     } finally {
       processor.shutdown();
     }

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/export/SimpleLogRecordProcessorTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/export/SimpleLogRecordProcessorTest.java
@@ -59,7 +59,7 @@ class SimpleLogRecordProcessorTest {
 
   @Test
   void onEmit() {
-    logRecordProcessor.onEmit(readWriteLogRecord, Context.current());
+    logRecordProcessor.onEmit(Context.current(), readWriteLogRecord);
     verify(logRecordExporter).export(Collections.singletonList(LOG_RECORD_DATA));
   }
 
@@ -67,8 +67,8 @@ class SimpleLogRecordProcessorTest {
   @SuppressLogger(SimpleLogRecordProcessor.class)
   void onEmit_ExporterError() {
     when(logRecordExporter.export(any())).thenThrow(new RuntimeException("Exporter error!"));
-    logRecordProcessor.onEmit(readWriteLogRecord, Context.current());
-    logRecordProcessor.onEmit(readWriteLogRecord, Context.current());
+    logRecordProcessor.onEmit(Context.current(), readWriteLogRecord);
+    logRecordProcessor.onEmit(Context.current(), readWriteLogRecord);
     verify(logRecordExporter, times(2)).export(anyList());
   }
 
@@ -79,8 +79,8 @@ class SimpleLogRecordProcessorTest {
 
     when(logRecordExporter.export(any())).thenReturn(export1, export2);
 
-    logRecordProcessor.onEmit(readWriteLogRecord, Context.current());
-    logRecordProcessor.onEmit(readWriteLogRecord, Context.current());
+    logRecordProcessor.onEmit(Context.current(), readWriteLogRecord);
+    logRecordProcessor.onEmit(Context.current(), readWriteLogRecord);
 
     verify(logRecordExporter, times(2)).export(Collections.singletonList(LOG_RECORD_DATA));
 
@@ -102,8 +102,8 @@ class SimpleLogRecordProcessorTest {
 
     when(logRecordExporter.export(any())).thenReturn(export1, export2);
 
-    logRecordProcessor.onEmit(readWriteLogRecord, Context.current());
-    logRecordProcessor.onEmit(readWriteLogRecord, Context.current());
+    logRecordProcessor.onEmit(Context.current(), readWriteLogRecord);
+    logRecordProcessor.onEmit(Context.current(), readWriteLogRecord);
 
     verify(logRecordExporter, times(2)).export(Collections.singletonList(LOG_RECORD_DATA));
 

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/export/SimpleLogRecordProcessorTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/export/SimpleLogRecordProcessorTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.opentelemetry.context.Context;
 import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.logs.LogRecordProcessor;
@@ -58,7 +59,7 @@ class SimpleLogRecordProcessorTest {
 
   @Test
   void onEmit() {
-    logRecordProcessor.onEmit(readWriteLogRecord);
+    logRecordProcessor.onEmit(readWriteLogRecord, Context.current());
     verify(logRecordExporter).export(Collections.singletonList(LOG_RECORD_DATA));
   }
 
@@ -66,8 +67,8 @@ class SimpleLogRecordProcessorTest {
   @SuppressLogger(SimpleLogRecordProcessor.class)
   void onEmit_ExporterError() {
     when(logRecordExporter.export(any())).thenThrow(new RuntimeException("Exporter error!"));
-    logRecordProcessor.onEmit(readWriteLogRecord);
-    logRecordProcessor.onEmit(readWriteLogRecord);
+    logRecordProcessor.onEmit(readWriteLogRecord, Context.current());
+    logRecordProcessor.onEmit(readWriteLogRecord, Context.current());
     verify(logRecordExporter, times(2)).export(anyList());
   }
 
@@ -78,8 +79,8 @@ class SimpleLogRecordProcessorTest {
 
     when(logRecordExporter.export(any())).thenReturn(export1, export2);
 
-    logRecordProcessor.onEmit(readWriteLogRecord);
-    logRecordProcessor.onEmit(readWriteLogRecord);
+    logRecordProcessor.onEmit(readWriteLogRecord, Context.current());
+    logRecordProcessor.onEmit(readWriteLogRecord, Context.current());
 
     verify(logRecordExporter, times(2)).export(Collections.singletonList(LOG_RECORD_DATA));
 
@@ -101,8 +102,8 @@ class SimpleLogRecordProcessorTest {
 
     when(logRecordExporter.export(any())).thenReturn(export1, export2);
 
-    logRecordProcessor.onEmit(readWriteLogRecord);
-    logRecordProcessor.onEmit(readWriteLogRecord);
+    logRecordProcessor.onEmit(readWriteLogRecord, Context.current());
+    logRecordProcessor.onEmit(readWriteLogRecord, Context.current());
 
     verify(logRecordExporter, times(2)).export(Collections.singletonList(LOG_RECORD_DATA));
 


### PR DESCRIPTION
Alternative to #4888 which adds context as an argument to processor. This allows context to be garbage collected sooner than with #4888 as described [here](https://github.com/open-telemetry/opentelemetry-java/pull/4888#discussion_r1005948699). 

Resolves #4147.