### PR TITLE
OT Shim: Use 'opentracing-shim' as instrumentation scope name.

### DIFF
--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/OpenTracingShim.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/OpenTracingShim.java
@@ -65,6 +65,6 @@ public final class OpenTracingShim {
   }
 
   private static Tracer getTracer(TracerProvider tracerProvider) {
-    return tracerProvider.get("opentracingshim");
+    return tracerProvider.get("opentracing-shim");
   }
 }

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/OpenTracingShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/OpenTracingShimTest.java
@@ -28,7 +28,7 @@ class OpenTracingShimTest {
   @Test
   void createTracerShim_default() {
     TracerShim tracerShim = (TracerShim) OpenTracingShim.createTracerShim();
-    assertThat(tracerShim.tracer()).isEqualTo(GlobalOpenTelemetry.getTracer("opentracingshim"));
+    assertThat(tracerShim.tracer()).isEqualTo(GlobalOpenTelemetry.getTracer("opentracing-shim"));
   }
 
   @Test
@@ -41,7 +41,7 @@ class OpenTracingShimTest {
     when(openTelemetry.getPropagators()).thenReturn(contextPropagators);
 
     TracerShim tracerShim = (TracerShim) OpenTracingShim.createTracerShim(openTelemetry);
-    assertThat(tracerShim.tracer()).isEqualTo(sdk.get("opentracingshim"));
+    assertThat(tracerShim.tracer()).isEqualTo(sdk.get("opentracing-shim"));
   }
 
   @Test


### PR DESCRIPTION
This matches the expected name from the [related Spec section](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/opentracing.md#create-an-opentracing-tracer-shim).