### PR TITLE
Add benchmark for log sdk

### DIFF
--- a/sdk/logs/build.gradle.kts
+++ b/sdk/logs/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
   id("otel.java-conventions")
   id("otel.publish-conventions")
 
+  id("otel.jmh-conventions")
   id("otel.animalsniffer-conventions")
 }
 

--- a/sdk/logs/src/jmh/java/io/opentelemetry/sdk/logs/LogsBenchmarks.java
+++ b/sdk/logs/src/jmh/java/io/opentelemetry/sdk/logs/LogsBenchmarks.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.logs;
+
+import static java.util.stream.Collectors.joining;
+
+import io.opentelemetry.api.logs.Severity;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode({Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(1)
+public class LogsBenchmarks {
+
+  private static final Random RANDOM = new Random();
+
+  @State(Scope.Benchmark)
+  public static class BenchmarkState {
+
+    private final SdkLoggerProvider sdk =
+        SdkLoggerProvider.builder()
+            .addLogRecordProcessor(
+                logRecord -> {
+                  // Do nothing
+                })
+            .build();
+
+    private List<String> loggerNames;
+
+    @Setup
+    public void setup() {
+      int numLoggers = 100;
+      loggerNames = new ArrayList<>(numLoggers);
+      for (int i = 0; i < numLoggers; i++) {
+        loggerNames.add(
+            IntStream.range(0, 50)
+                .mapToObj(unused -> String.valueOf((char) RANDOM.nextInt(26)))
+                .collect(joining()));
+      }
+    }
+  }
+
+  /**
+   * Simulates the behavior of a log appender implementation, which has to bridge logs from logging
+   * frameworks (Log4j, Logback, etc). The name of the logger being bridged is used as the
+   * OpenTelemetry logger name. Therefore, each log processed has to obtain a logger.
+   */
+  @Benchmark
+  @Threads(1)
+  public void emitSimpleLog(BenchmarkState benchmarkState) {
+    String loggerName =
+        benchmarkState.loggerNames.get(RANDOM.nextInt(benchmarkState.loggerNames.size()));
+    benchmarkState
+        .sdk
+        .get(loggerName)
+        .logRecordBuilder()
+        .setBody("log message body")
+        .setSeverity(Severity.DEBUG)
+        .emit();
+  }
+}


### PR DESCRIPTION
The typical usage for logs presents the opportunity for hotspots that don't exist in traces or metrics. 

The main use case we want to support is writing log appenders, which bridge other log APIs / frameworks into opentelemetry. Its very typical for these frameworks to have the notion of named loggers, which maps nicely to OpenTelemetry instrumentation scope name. However, this requires that appender implementations obtain a `Logger` instance for each log record processed. [Here's](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppender.java#L143-L144) an example. Its not typical to obtain a new tracer or meter for each span / measurement, so optimizing this area has not been a priority.

This code path is currently suboptimal, particularly in terms of allocations, since it requires creating a new [SdkLoggerBuilder](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerBuilder.java), which creates a new [InstrumentationScopeInfoBuilder](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerBuilder.java#L22) and a new [InstrumentationScopeInfo](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerBuilder.java#L45). 

There are a couple of obvious ways to optimize this. This PR establishes a benchmark representative of the typical appender use case to evaluate potential performance improvements. 

Baseline performance on my machine:
```
Benchmark                                                  Mode  Cnt     Score     Error   Units
LogsBenchmarks.emitSimpleLog                               avgt   10    35.035 ±   0.732   ns/op
LogsBenchmarks.emitSimpleLog:·gc.alloc.rate                avgt   10  2173.006 ±  43.649  MB/sec
LogsBenchmarks.emitSimpleLog:·gc.alloc.rate.norm           avgt   10   120.000 ±   0.001    B/op
LogsBenchmarks.emitSimpleLog:·gc.churn.G1_Eden_Space       avgt   10  2191.457 ± 429.679  MB/sec
LogsBenchmarks.emitSimpleLog:·gc.churn.G1_Eden_Space.norm  avgt   10   120.983 ±  23.200    B/op
LogsBenchmarks.emitSimpleLog:·gc.count                     avgt   10    37.000            counts
LogsBenchmarks.emitSimpleLog:·gc.time                      avgt   10    30.000                ms
```