### PR TITLE
Optimize log hot path

### DIFF
--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/ComponentRegistry.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/ComponentRegistry.java
@@ -98,7 +98,7 @@ public final class ComponentRegistry<V> {
                       .setSchemaUrl(schemaUrl1)
                       .setAttributes(attributes)
                       .build()));
-    } else { // schemaUrl != null && version != null
+    } else { // schemaUrl == null && version == null
       return componentByName.computeIfAbsent(
           name,
           name1 ->

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/ComponentRegistry.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/ComponentRegistry.java
@@ -5,17 +5,31 @@
 
 package io.opentelemetry.sdk.internal;
 
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
+import javax.annotation.Nullable;
 
 /**
  * Component (tracer, meter, etc) registry class for all the provider classes (TracerProvider,
  * MeterProvider, etc.).
+ *
+ * <p>Components are identified by name, version, and schema. Name is required, but version and
+ * schema are optional. Therefore, we have 4 possible scenarios for component keys:
+ *
+ * <ol>
+ *   <li>Only name is provided, represented by {@link #componentByName}
+ *   <li>Name and version are provided, represented by {@link #componentByNameAndVersion}
+ *   <li>Name and schema are provided, represented by {@link #componentByNameAndSchema}
+ *   <li>Name, version and schema are provided, represented by {@link
+ *       #componentByNameVersionAndSchema}
+ * </ol>
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
@@ -24,7 +38,14 @@ import java.util.function.Function;
  */
 public final class ComponentRegistry<V> {
 
-  private final ConcurrentMap<InstrumentationScopeInfo, V> registry = new ConcurrentHashMap<>();
+  private final Map<String, V> componentByName = new ConcurrentHashMap<>();
+  private final Map<String, Map<String, V>> componentByNameAndVersion = new ConcurrentHashMap<>();
+  private final Map<String, Map<String, V>> componentByNameAndSchema = new ConcurrentHashMap<>();
+  private final Map<String, Map<String, Map<String, V>>> componentByNameVersionAndSchema =
+      new ConcurrentHashMap<>();
+
+  private final Set<V> allComponents = Collections.newSetFromMap(new IdentityHashMap<>());
+
   private final Function<InstrumentationScopeInfo, V> factory;
 
   public ComponentRegistry(Function<InstrumentationScopeInfo, V> factory) {
@@ -32,19 +53,64 @@ public final class ComponentRegistry<V> {
   }
 
   /**
-   * Returns the registered value associated with this {@link InstrumentationScopeInfo scope} if
-   * any, otherwise creates a new instance and associates it with the given scope.
+   * Returns the component associated with the {@code name}, {@code version}, and {@code schemaUrl}.
+   * {@link Attributes} are not part of component identity. Behavior is undefined when different
+   * {@link Attributes} are provided where {@code name}, {@code version}, and {@code schemaUrl} are
+   * identical.
    */
-  public V get(InstrumentationScopeInfo instrumentationScopeInfo) {
-    // Optimistic lookup, before creating the new component.
-    V component = registry.get(instrumentationScopeInfo);
-    if (component != null) {
-      return component;
+  public V get(
+      String name, @Nullable String version, @Nullable String schemaUrl, Attributes attributes) {
+    if (version != null && schemaUrl != null) {
+      Map<String, Map<String, V>> componentByVersionAndSchema =
+          componentByNameVersionAndSchema.computeIfAbsent(
+              name, unused -> new ConcurrentHashMap<>());
+      Map<String, V> componentBySchema =
+          componentByVersionAndSchema.computeIfAbsent(version, unused -> new ConcurrentHashMap<>());
+      return componentBySchema.computeIfAbsent(
+          schemaUrl,
+          schemaUrl1 ->
+              buildComponent(
+                  InstrumentationScopeInfo.builder(name)
+                      .setVersion(version)
+                      .setSchemaUrl(schemaUrl1)
+                      .setAttributes(attributes)
+                      .build()));
+    } else if (version != null) { // schemaUrl == null
+      Map<String, V> componentByVersion =
+          componentByNameAndVersion.computeIfAbsent(name, unused -> new ConcurrentHashMap<>());
+      return componentByVersion.computeIfAbsent(
+          version,
+          version1 ->
+              buildComponent(
+                  InstrumentationScopeInfo.builder(name)
+                      .setVersion(version1)
+                      .setAttributes(attributes)
+                      .build()));
     }
+    if (schemaUrl != null) { // version == null
+      Map<String, V> componentBySchema =
+          componentByNameAndSchema.computeIfAbsent(name, unused -> new ConcurrentHashMap<>());
+      return componentBySchema.computeIfAbsent(
+          schemaUrl,
+          schemaUrl1 ->
+              buildComponent(
+                  InstrumentationScopeInfo.builder(name)
+                      .setSchemaUrl(schemaUrl1)
+                      .setAttributes(attributes)
+                      .build()));
+    } else { // schemaUrl != null && version != null
+      return componentByName.computeIfAbsent(
+          name,
+          name1 ->
+              buildComponent(
+                  InstrumentationScopeInfo.builder(name1).setAttributes(attributes).build()));
+    }
+  }
 
-    V newComponent = factory.apply(instrumentationScopeInfo);
-    V oldComponent = registry.putIfAbsent(instrumentationScopeInfo, newComponent);
-    return oldComponent != null ? oldComponent : newComponent;
+  private V buildComponent(InstrumentationScopeInfo instrumentationScopeInfo) {
+    V component = factory.apply(instrumentationScopeInfo);
+    allComponents.add(component);
+    return component;
   }
 
   /**
@@ -53,6 +119,6 @@ public final class ComponentRegistry<V> {
    * @return a {@code Collection} view of the registered components.
    */
   public Collection<V> getComponents() {
-    return Collections.unmodifiableCollection(new ArrayList<>(registry.values()));
+    return Collections.unmodifiableCollection(allComponents);
   }
 }

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/internal/ComponentRegistryTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/internal/ComponentRegistryTest.java
@@ -8,7 +8,6 @@ package io.opentelemetry.sdk.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import org.junit.jupiter.api.Test;
 
 class ComponentRegistryTest {
@@ -22,83 +21,35 @@ class ComponentRegistryTest {
 
   @Test
   void get_SameInstance() {
-    assertThat(registry.get(InstrumentationScopeInfo.builder(NAME).build()))
-        .isSameAs(registry.get(InstrumentationScopeInfo.builder(NAME).build()));
-    assertThat(registry.get(InstrumentationScopeInfo.builder(NAME).setVersion(VERSION).build()))
-        .isSameAs(registry.get(InstrumentationScopeInfo.builder(NAME).setVersion(VERSION).build()));
-    assertThat(
-            registry.get(InstrumentationScopeInfo.builder(NAME).setSchemaUrl(SCHEMA_URL).build()))
+    assertThat(registry.get(NAME, null, null, Attributes.empty()))
+        .isSameAs(registry.get(NAME, null, null, Attributes.empty()))
+        .isSameAs(registry.get(NAME, null, null, Attributes.builder().put("k1", "v2").build()));
+
+    assertThat(registry.get(NAME, VERSION, null, Attributes.empty()))
+        .isSameAs(registry.get(NAME, VERSION, null, Attributes.empty()))
+        .isSameAs(registry.get(NAME, VERSION, null, Attributes.builder().put("k1", "v2").build()));
+    assertThat(registry.get(NAME, null, SCHEMA_URL, Attributes.empty()))
+        .isSameAs(registry.get(NAME, null, SCHEMA_URL, Attributes.empty()))
         .isSameAs(
-            registry.get(InstrumentationScopeInfo.builder(NAME).setSchemaUrl(SCHEMA_URL).build()));
-    assertThat(
-            registry.get(InstrumentationScopeInfo.builder(NAME).setAttributes(ATTRIBUTES).build()))
+            registry.get(NAME, null, SCHEMA_URL, Attributes.builder().put("k1", "v2").build()));
+    assertThat(registry.get(NAME, VERSION, SCHEMA_URL, Attributes.empty()))
+        .isSameAs(registry.get(NAME, VERSION, SCHEMA_URL, Attributes.empty()))
         .isSameAs(
-            registry.get(InstrumentationScopeInfo.builder(NAME).setAttributes(ATTRIBUTES).build()));
-    assertThat(
-            registry.get(
-                InstrumentationScopeInfo.builder(NAME)
-                    .setVersion(VERSION)
-                    .setSchemaUrl(SCHEMA_URL)
-                    .setAttributes(ATTRIBUTES)
-                    .build()))
-        .isSameAs(
-            registry.get(
-                InstrumentationScopeInfo.builder(NAME)
-                    .setVersion(VERSION)
-                    .setSchemaUrl(SCHEMA_URL)
-                    .setAttributes(ATTRIBUTES)
-                    .build()));
+            registry.get(NAME, VERSION, SCHEMA_URL, Attributes.builder().put("k1", "v2").build()));
   }
 
   @Test
   void get_DifferentInstance() {
-    InstrumentationScopeInfo allFields =
-        InstrumentationScopeInfo.builder(NAME)
-            .setVersion(VERSION)
-            .setSchemaUrl(SCHEMA_URL)
-            .setAttributes(ATTRIBUTES)
-            .build();
+    assertThat(registry.get(NAME, VERSION, SCHEMA_URL, ATTRIBUTES))
+        .isNotSameAs(registry.get(NAME + "_1", VERSION, SCHEMA_URL, ATTRIBUTES))
+        .isNotSameAs(registry.get(NAME, VERSION + "_1", SCHEMA_URL, ATTRIBUTES))
+        .isNotSameAs(registry.get(NAME, VERSION, SCHEMA_URL + "_1", ATTRIBUTES));
 
-    assertThat(registry.get(allFields))
-        .isNotSameAs(
-            registry.get(
-                InstrumentationScopeInfo.builder(NAME + "_1")
-                    .setVersion(VERSION)
-                    .setSchemaUrl(SCHEMA_URL)
-                    .setAttributes(ATTRIBUTES)
-                    .build()));
-    assertThat(registry.get(allFields))
-        .isNotSameAs(
-            registry.get(
-                InstrumentationScopeInfo.builder(NAME)
-                    .setVersion(VERSION + "_1")
-                    .setSchemaUrl(SCHEMA_URL)
-                    .setAttributes(ATTRIBUTES)
-                    .build()));
-    assertThat(registry.get(allFields))
-        .isNotSameAs(
-            registry.get(
-                InstrumentationScopeInfo.builder(NAME)
-                    .setVersion(VERSION)
-                    .setSchemaUrl(SCHEMA_URL + "_1")
-                    .setAttributes(ATTRIBUTES)
-                    .build()));
-    assertThat(registry.get(allFields))
-        .isNotSameAs(
-            registry.get(
-                InstrumentationScopeInfo.builder(NAME)
-                    .setVersion(VERSION)
-                    .setSchemaUrl(SCHEMA_URL)
-                    .setAttributes(Attributes.builder().put("k1", "v2").build())
-                    .build()));
-    assertThat(registry.get(InstrumentationScopeInfo.builder(NAME).setVersion(VERSION).build()))
-        .isNotSameAs(registry.get(InstrumentationScopeInfo.builder(NAME).build()));
-    assertThat(
-            registry.get(InstrumentationScopeInfo.builder(NAME).setSchemaUrl(SCHEMA_URL).build()))
-        .isNotSameAs(registry.get(InstrumentationScopeInfo.builder(NAME).build()));
-    assertThat(
-            registry.get(InstrumentationScopeInfo.builder(NAME).setAttributes(ATTRIBUTES).build()))
-        .isNotSameAs(registry.get(InstrumentationScopeInfo.builder(NAME).build()));
+    assertThat(registry.get(NAME, VERSION, null, Attributes.empty()))
+        .isNotSameAs(registry.get(NAME, null, null, Attributes.empty()));
+
+    assertThat(registry.get(NAME, null, SCHEMA_URL, Attributes.empty()))
+        .isNotSameAs(registry.get(NAME, null, null, Attributes.empty()));
   }
 
   private static final class TestComponent {}

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerBuilder.java
@@ -5,21 +5,22 @@
 
 package io.opentelemetry.sdk.logs;
 
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.logs.LoggerBuilder;
-import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
-import io.opentelemetry.sdk.common.InstrumentationScopeInfoBuilder;
 import io.opentelemetry.sdk.internal.ComponentRegistry;
 import javax.annotation.Nullable;
 
 final class SdkLoggerBuilder implements LoggerBuilder {
 
   private final ComponentRegistry<SdkLogger> registry;
-  private final InstrumentationScopeInfoBuilder scopeBuilder;
+  private final String instrumentationScopeName;
+  @Nullable private String instrumentationScopeVersion;
+  @Nullable private String schemaUrl;
   @Nullable private String eventDomain;
 
   SdkLoggerBuilder(ComponentRegistry<SdkLogger> registry, String instrumentationScopeName) {
     this.registry = registry;
-    this.scopeBuilder = InstrumentationScopeInfo.builder(instrumentationScopeName);
+    this.instrumentationScopeName = instrumentationScopeName;
   }
 
   @Override
@@ -30,19 +31,21 @@ final class SdkLoggerBuilder implements LoggerBuilder {
 
   @Override
   public SdkLoggerBuilder setSchemaUrl(String schemaUrl) {
-    scopeBuilder.setSchemaUrl(schemaUrl);
+    this.schemaUrl = schemaUrl;
     return this;
   }
 
   @Override
   public SdkLoggerBuilder setInstrumentationVersion(String instrumentationScopeVersion) {
-    scopeBuilder.setVersion(instrumentationScopeVersion);
+    this.instrumentationScopeVersion = instrumentationScopeVersion;
     return this;
   }
 
   @Override
   public SdkLogger build() {
-    SdkLogger logger = registry.get(scopeBuilder.build());
+    SdkLogger logger =
+        registry.get(
+            instrumentationScopeName, instrumentationScopeVersion, schemaUrl, Attributes.empty());
     return eventDomain == null ? logger : logger.withEventDomain(eventDomain);
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterBuilder.java
@@ -5,36 +5,39 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterBuilder;
-import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
-import io.opentelemetry.sdk.common.InstrumentationScopeInfoBuilder;
 import io.opentelemetry.sdk.internal.ComponentRegistry;
+import javax.annotation.Nullable;
 
 class SdkMeterBuilder implements MeterBuilder {
 
   private final ComponentRegistry<SdkMeter> registry;
-  private final InstrumentationScopeInfoBuilder scopeBuilder;
+  private final String instrumentationScopeName;
+  @Nullable private String instrumentationScopeVersion;
+  @Nullable private String schemaUrl;
 
   SdkMeterBuilder(ComponentRegistry<SdkMeter> registry, String instrumentationScopeName) {
     this.registry = registry;
-    this.scopeBuilder = InstrumentationScopeInfo.builder(instrumentationScopeName);
+    this.instrumentationScopeName = instrumentationScopeName;
   }
 
   @Override
   public MeterBuilder setSchemaUrl(String schemaUrl) {
-    scopeBuilder.setSchemaUrl(schemaUrl);
+    this.schemaUrl = schemaUrl;
     return this;
   }
 
   @Override
   public MeterBuilder setInstrumentationVersion(String instrumentationScopeVersion) {
-    scopeBuilder.setVersion(instrumentationScopeVersion);
+    this.instrumentationScopeVersion = instrumentationScopeVersion;
     return this;
   }
 
   @Override
   public Meter build() {
-    return registry.get(scopeBuilder.build());
+    return registry.get(
+        instrumentationScopeName, instrumentationScopeVersion, schemaUrl, Attributes.empty());
   }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerBuilder.java
@@ -5,36 +5,39 @@
 
 package io.opentelemetry.sdk.trace;
 
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerBuilder;
-import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
-import io.opentelemetry.sdk.common.InstrumentationScopeInfoBuilder;
 import io.opentelemetry.sdk.internal.ComponentRegistry;
+import javax.annotation.Nullable;
 
 class SdkTracerBuilder implements TracerBuilder {
 
   private final ComponentRegistry<SdkTracer> registry;
-  private final InstrumentationScopeInfoBuilder scopeBuilder;
+  private final String instrumentationScopeName;
+  @Nullable private String instrumentationScopeVersion;
+  @Nullable private String schemaUrl;
 
   SdkTracerBuilder(ComponentRegistry<SdkTracer> registry, String instrumentationScopeName) {
     this.registry = registry;
-    this.scopeBuilder = InstrumentationScopeInfo.builder(instrumentationScopeName);
+    this.instrumentationScopeName = instrumentationScopeName;
   }
 
   @Override
   public TracerBuilder setSchemaUrl(String schemaUrl) {
-    scopeBuilder.setSchemaUrl(schemaUrl);
+    this.schemaUrl = schemaUrl;
     return this;
   }
 
   @Override
   public TracerBuilder setInstrumentationVersion(String instrumentationScopeVersion) {
-    scopeBuilder.setVersion(instrumentationScopeVersion);
+    this.instrumentationScopeVersion = instrumentationScopeVersion;
     return this;
   }
 
   @Override
   public Tracer build() {
-    return registry.get(scopeBuilder.build());
+    return registry.get(
+        instrumentationScopeName, instrumentationScopeVersion, schemaUrl, Attributes.empty());
   }
 }


### PR DESCRIPTION
Followup to #4891.

Reduces allocations on happy path by avoiding creation of extra `InstrumentationScopeInfo` / `InstrumentationScopeInfoBuilder` instances that aren't strictly needed. Does this by adjusting changing `ComponentRegistry#get(InstrumentationScopeInfo)` to `ComponentRegistry#get(String name, @Nullable String version, @Nullable String schemaUrl, Attributes attributes)`, and only building `InstrumentationScopeInfo` the first time we see a component with a particular identity. 

Benchmark before:
```
Benchmark                                                  Mode  Cnt     Score     Error   Units
LogsBenchmarks.emitSimpleLog                               avgt   10    35.035 ±   0.732   ns/op
LogsBenchmarks.emitSimpleLog:·gc.alloc.rate                avgt   10  2173.006 ±  43.649  MB/sec
LogsBenchmarks.emitSimpleLog:·gc.alloc.rate.norm           avgt   10   120.000 ±   0.001    B/op
LogsBenchmarks.emitSimpleLog:·gc.churn.G1_Eden_Space       avgt   10  2191.457 ± 429.679  MB/sec
LogsBenchmarks.emitSimpleLog:·gc.churn.G1_Eden_Space.norm  avgt   10   120.983 ±  23.200    B/op
LogsBenchmarks.emitSimpleLog:·gc.count                     avgt   10    37.000            counts
LogsBenchmarks.emitSimpleLog:·gc.time                      avgt   10    30.000                ms
```

Benchmark after:
```
Benchmark                                                  Mode  Cnt     Score     Error   Units
LogsBenchmarks.emitSimpleLog                               avgt   10    29.155 ±   1.023   ns/op
LogsBenchmarks.emitSimpleLog:·gc.alloc.rate                avgt   10  1220.007 ±  36.921  MB/sec
LogsBenchmarks.emitSimpleLog:·gc.alloc.rate.norm           avgt   10    56.048 ±   0.231    B/op
LogsBenchmarks.emitSimpleLog:·gc.churn.G1_Eden_Space       avgt   10  1241.334 ± 191.229  MB/sec
LogsBenchmarks.emitSimpleLog:·gc.churn.G1_Eden_Space.norm  avgt   10    57.041 ±   8.784    B/op
LogsBenchmarks.emitSimpleLog:·gc.count                     avgt   10    31.000            counts
LogsBenchmarks.emitSimpleLog:·gc.time                      avgt   10    27.000                ms
```

Notice the significant reduction in allocation rate. 