### PR TITLE
OpenTracing Shim: Handle unsupported types when setting Attributes.

### DIFF
--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
@@ -164,7 +164,7 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
     if (value == null) {
       return this;
     }
-    // TODO - Verify only the 'basic' types are supported/used.
+
     if (value instanceof Integer
         || value instanceof Long
         || value instanceof Short
@@ -175,7 +175,8 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
       this.spanBuilderAttributeKeys.add(doubleKey(key));
       this.spanBuilderAttributeValues.add(value.doubleValue());
     } else {
-      throw new IllegalArgumentException("Number type not supported");
+      this.spanBuilderAttributeKeys.add(stringKey(key));
+      this.spanBuilderAttributeValues.add(value.toString());
     }
 
     return this;

--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/SpanShim.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/SpanShim.java
@@ -112,7 +112,7 @@ final class SpanShim extends BaseShimObject implements Span, ImplicitContextKeye
     if (value == null) {
       return this;
     }
-    // TODO - Verify only the 'basic' types are supported/used.
+
     if (value instanceof Integer
         || value instanceof Long
         || value instanceof Short
@@ -121,7 +121,7 @@ final class SpanShim extends BaseShimObject implements Span, ImplicitContextKeye
     } else if (value instanceof Float || value instanceof Double) {
       span.setAttribute(key, value.doubleValue());
     } else {
-      throw new IllegalArgumentException("Number type not supported");
+      span.setAttribute(key, value.toString());
     }
 
     return this;

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanBuilderShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanBuilderShimTest.java
@@ -22,6 +22,7 @@ import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import io.opentracing.References;
+import java.math.BigInteger;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -294,6 +295,21 @@ class SpanBuilderShimTest {
         (SpanShim) new SpanBuilderShim(telemetryInfo, SPAN_NAME).withStartTimestamp(micros).start();
     SpanData spanData = ((ReadableSpan) spanShim.getSpan()).toSpanData();
     assertThat(spanData.getStartEpochNanos()).isEqualTo(micros * 1000L);
+  }
+
+  @Test
+  void setAttribute_unrecognizedType() {
+    SpanShim span =
+        (SpanShim)
+            new SpanBuilderShim(telemetryInfo, SPAN_NAME).withTag("foo", BigInteger.TEN).start();
+    try {
+      SpanData spanData = ((ReadableSpan) span.getSpan()).toSpanData();
+      assertThat(spanData.getAttributes().size()).isEqualTo(1);
+      assertThat(spanData.getAttributes().get(AttributeKey.stringKey("foo")))
+          .isEqualTo(BigInteger.TEN.toString());
+    } finally {
+      span.finish();
+    }
   }
 
   @Test

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanBuilderShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanBuilderShimTest.java
@@ -305,8 +305,7 @@ class SpanBuilderShimTest {
     try {
       SpanData spanData = ((ReadableSpan) span.getSpan()).toSpanData();
       assertThat(spanData.getAttributes().size()).isEqualTo(1);
-      assertThat(spanData.getAttributes().get(AttributeKey.stringKey("foo")))
-          .isEqualTo(BigInteger.TEN.toString());
+      assertThat(spanData.getAttributes().get(AttributeKey.stringKey("foo"))).isEqualTo("10");
     } finally {
       span.finish();
     }

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
@@ -17,6 +17,7 @@ import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import io.opentracing.log.Fields;
+import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -57,6 +58,17 @@ class SpanShimTest {
     assertThat(span.getSpanContext().getTraceId().toString()).isEqualTo(contextShim.toTraceId());
     assertThat(span.getSpanContext().getSpanId().toString()).isEqualTo(contextShim.toSpanId());
     assertThat(contextShim.baggageItems().iterator().hasNext()).isFalse();
+  }
+
+  @Test
+  void setAttribute_unrecognizedType() {
+    SpanShim spanShim = new SpanShim(telemetryInfo, span);
+    spanShim.setTag("foo", BigInteger.ONE);
+
+    SpanData spanData = ((ReadableSpan) span).toSpanData();
+    assertThat(spanData.getAttributes().size()).isEqualTo(1);
+    assertThat(spanData.getAttributes().get(AttributeKey.stringKey("foo")))
+        .isEqualTo(BigInteger.ONE.toString());
   }
 
   @Test

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanShimTest.java
@@ -67,8 +67,7 @@ class SpanShimTest {
 
     SpanData spanData = ((ReadableSpan) span).toSpanData();
     assertThat(spanData.getAttributes().size()).isEqualTo(1);
-    assertThat(spanData.getAttributes().get(AttributeKey.stringKey("foo")))
-        .isEqualTo(BigInteger.ONE.toString());
+    assertThat(spanData.getAttributes().get(AttributeKey.stringKey("foo"))).isEqualTo("1");
   }
 
   @Test


### PR DESCRIPTION
Fixes #4908 

This happens via:

* SpanBuilder.withTag()
* Span.setTag()