### PR TITLE
Fix misleading javadoc

### DIFF
--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SummaryPointAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SummaryPointAssert.java
@@ -13,7 +13,7 @@ import java.util.function.Consumer;
 import org.assertj.core.api.Assertions;
 
 /**
- * Test assertions for (deprecated) {@link SummaryPointData}.
+ * Test assertions for {@link SummaryPointData}.
  *
  * @since 1.14.0
  */

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/ValueAtQuantileAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/ValueAtQuantileAssert.java
@@ -10,7 +10,7 @@ import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
 
 /**
- * Test assertions for (deprecated) {@link ValueAtQuantile}.
+ * Test assertions for {@link ValueAtQuantile}.
  *
  * @since 1.14.0
  */


### PR DESCRIPTION
`SummaryPointData` and `ValueAtQuantile` are _not_ deprecated. 