### PR TITLE
Implement logging exporter providers

### DIFF
--- a/exporters/logging/build.gradle.kts
+++ b/exporters/logging/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
   api(project(":sdk:metrics"))
   api(project(":sdk:logs"))
 
+  implementation(project(":sdk-extensions:autoconfigure-spi"))
+
   testImplementation(project(":sdk:testing"))
   testImplementation(project(":sdk:logs-testing"))
 }

--- a/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/internal/LoggingLogRecordExporterProvider.java
+++ b/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/internal/LoggingLogRecordExporterProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.logging.internal;
+
+import io.opentelemetry.exporter.logging.SystemOutLogRecordExporter;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+
+/**
+ * {@link LogRecordExporter} SPI implementation for {@link SystemOutLogRecordExporter}.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public class LoggingLogRecordExporterProvider implements ConfigurableLogRecordExporterProvider {
+  @Override
+  public LogRecordExporter createExporter(ConfigProperties config) {
+    return SystemOutLogRecordExporter.create();
+  }
+
+  @Override
+  public String getName() {
+    return "logging";
+  }
+}

--- a/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/internal/LoggingMetricExporterProvider.java
+++ b/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/internal/LoggingMetricExporterProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.logging.internal;
+
+import io.opentelemetry.exporter.logging.LoggingMetricExporter;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+
+/**
+ * {@link MetricExporter} SPI implementation for {@link LoggingMetricExporter}.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public class LoggingMetricExporterProvider implements ConfigurableMetricExporterProvider {
+  @Override
+  public MetricExporter createExporter(ConfigProperties config) {
+    return LoggingMetricExporter.create();
+  }
+
+  @Override
+  public String getName() {
+    return "logging";
+  }
+}

--- a/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/internal/LoggingSpanExporterProvider.java
+++ b/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/internal/LoggingSpanExporterProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.logging.internal;
+
+import io.opentelemetry.exporter.logging.LoggingSpanExporter;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+
+/**
+ * {@link SpanExporter} SPI implementation for {@link LoggingSpanExporter}.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public class LoggingSpanExporterProvider implements ConfigurableSpanExporterProvider {
+  @Override
+  public SpanExporter createExporter(ConfigProperties config) {
+    return LoggingSpanExporter.create();
+  }
+
+  @Override
+  public String getName() {
+    return "logging";
+  }
+}

--- a/exporters/logging/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider
+++ b/exporters/logging/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.exporter.logging.internal.LoggingLogRecordExporterProvider

--- a/exporters/logging/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider
+++ b/exporters/logging/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.exporter.logging.internal.LoggingMetricExporterProvider

--- a/exporters/logging/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider
+++ b/exporters/logging/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.exporter.logging.internal.LoggingSpanExporterProvider

--- a/sdk-extensions/autoconfigure/build.gradle.kts
+++ b/sdk-extensions/autoconfigure/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
   implementation(project(":exporters:common"))
 
   compileOnly(project(":exporters:jaeger"))
-  compileOnly(project(":exporters:logging"))
   compileOnly(project(":exporters:otlp:all"))
   compileOnly(project(":exporters:otlp:logs"))
   compileOnly(project(":exporters:otlp:common"))

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
@@ -10,7 +10,6 @@ import static io.opentelemetry.sdk.autoconfigure.OtlpConfigUtil.PROTOCOL_GRPC;
 import static io.opentelemetry.sdk.autoconfigure.OtlpConfigUtil.PROTOCOL_HTTP_PROTOBUF;
 
 import io.opentelemetry.exporter.internal.retry.RetryUtil;
-import io.opentelemetry.exporter.logging.LoggingMetricExporter;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
@@ -24,12 +23,20 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.metrics.export.MetricReader;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.BiFunction;
 import javax.annotation.Nullable;
 
 final class MetricExporterConfiguration {
 
   private static final Duration DEFAULT_EXPORT_INTERVAL = Duration.ofMinutes(1);
+  private static final Map<String, String> EXPORTER_ARTIFACT_ID_BY_NAME;
+
+  static {
+    EXPORTER_ARTIFACT_ID_BY_NAME = new HashMap<>();
+    EXPORTER_ARTIFACT_ID_BY_NAME.put("logging", "opentelemetry-exporter-logging");
+  }
 
   static MetricReader configureExporter(
       String name,
@@ -46,12 +53,18 @@ final class MetricExporterConfiguration {
       case "otlp":
         metricExporter = configureOtlpMetrics(config);
         break;
-      case "logging":
-        metricExporter = configureLoggingExporter();
-        break;
       default:
         MetricExporter spiExporter = configureSpiExporter(name, config, serviceClassLoader);
         if (spiExporter == null) {
+          String artifactId = EXPORTER_ARTIFACT_ID_BY_NAME.get(name);
+          if (artifactId != null) {
+            throw new ConfigurationException(
+                "otel.metrics.exporter set to \""
+                    + name
+                    + "\" but "
+                    + artifactId
+                    + " not found on classpath. Make sure to add it as a dependency.");
+          }
           throw new ConfigurationException("Unrecognized value for otel.metrics.exporter: " + name);
         }
         metricExporter = spiExporter;
@@ -59,14 +72,6 @@ final class MetricExporterConfiguration {
 
     metricExporter = metricExporterCustomizer.apply(metricExporter, config);
     return configurePeriodicMetricReader(config, metricExporter);
-  }
-
-  private static MetricExporter configureLoggingExporter() {
-    ClasspathUtil.checkClassExists(
-        "io.opentelemetry.exporter.logging.LoggingMetricExporter",
-        "Logging Metrics Exporter",
-        "opentelemetry-exporter-logging");
-    return LoggingMetricExporter.create();
   }
 
   // Visible for testing.

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfiguration.java
@@ -14,7 +14,6 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.internal.retry.RetryUtil;
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter;
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporterBuilder;
-import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
@@ -27,6 +26,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterPro
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -35,6 +35,12 @@ import java.util.function.Function;
 final class SpanExporterConfiguration {
 
   private static final String EXPORTER_NONE = "none";
+  private static final Map<String, String> EXPORTER_ARTIFACT_ID_BY_NAME;
+
+  static {
+    EXPORTER_ARTIFACT_ID_BY_NAME = new HashMap<>();
+    EXPORTER_ARTIFACT_ID_BY_NAME.put("logging", "opentelemetry-exporter-logging");
+  }
 
   // Visible for testing
   static Map<String, SpanExporter> configureSpanExporters(
@@ -92,15 +98,18 @@ final class SpanExporterConfiguration {
         return configureJaeger(config, meterProvider);
       case "zipkin":
         return configureZipkin(config);
-      case "logging":
-        ClasspathUtil.checkClassExists(
-            "io.opentelemetry.exporter.logging.LoggingSpanExporter",
-            "Logging Trace Exporter",
-            "opentelemetry-exporter-logging");
-        return LoggingSpanExporter.create();
       default:
         SpanExporter spiExporter = spiExportersManager.getByName(name);
         if (spiExporter == null) {
+          String artifactId = EXPORTER_ARTIFACT_ID_BY_NAME.get(name);
+          if (artifactId != null) {
+            throw new ConfigurationException(
+                "otel.traces.exporter set to \""
+                    + name
+                    + "\" but "
+                    + artifactId
+                    + " not found on classpath. Make sure to add it as a dependency.");
+          }
           throw new ConfigurationException("Unrecognized value for otel.traces.exporter: " + name);
         }
         return spiExporter;

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/NotOnClasspathTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/NotOnClasspathTest.java
@@ -77,8 +77,8 @@ class NotOnClasspathTest {
                     "logging", EMPTY, NamedSpiManager.createEmpty(), MeterProvider.noop()))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining(
-            "Logging Trace Exporter enabled but opentelemetry-exporter-logging not found on "
-                + "classpath");
+            "otel.traces.exporter set to \"logging\" but opentelemetry-exporter-logging not found on classpath."
+                + " Make sure to add it as a dependency.");
   }
 
   @Test
@@ -92,8 +92,8 @@ class NotOnClasspathTest {
                     (a, unused) -> a))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining(
-            "Logging Metrics Exporter enabled but opentelemetry-exporter-logging not found on "
-                + "classpath");
+            "otel.metrics.exporter set to \"logging\" but opentelemetry-exporter-logging not found on classpath."
+                + " Make sure to add it as a dependency.");
   }
 
   @Test
@@ -104,8 +104,8 @@ class NotOnClasspathTest {
                     "logging", EMPTY, NamedSpiManager.createEmpty(), MeterProvider.noop()))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining(
-            "Logging Log Exporter enabled but opentelemetry-exporter-logging not found on "
-                + "classpath");
+            "otel.logs.exporter set to \"logging\" but opentelemetry-exporter-logging not found on classpath."
+                + " Make sure to add it as a dependency.");
   }
 
   @Test


### PR DESCRIPTION
Related to #4949.

Implements `Configurable{Signal}ExporterProvider` SPIs for the exporters that live in `:exporters:logging`. 