### PR TITLE
Disable jApiCmp diff check on release branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,8 @@ jobs:
             -Porg.gradle.java.installations.paths=${{ steps.setup-java-test.outputs.path }},${{ steps.setup-java.outputs.path }}
 
       - name: Check for diff
+        # The jApiCmp diff compares current to latest, which isn't appropriate for release branches
+        if: ${{ !startsWith(github.ref_name, 'release/') }}
         run: |
           if git diff --quiet
           then 


### PR DESCRIPTION
Failure example [here](https://github.com/open-telemetry/opentelemetry-java/actions/runs/3472564107/jobs/5803557611). 