### PR TITLE
Disable japicmp when base_ref is release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Check for diff
         # The jApiCmp diff compares current to latest, which isn't appropriate for release branches
-        if: ${{ !startsWith(github.ref_name, 'release/') }}
+        if: ${{ !startsWith(github.ref_name, 'release/') && !startsWith(github.base_ref, 'release/') }}
         run: |
           if git diff --quiet
           then 


### PR DESCRIPTION
Additional change needed to skip japicmp on release branches.