### PR TITLE
Implement jaeger exporter provider

### DIFF
--- a/exporters/jaeger/build.gradle.kts
+++ b/exporters/jaeger/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
 
   implementation(project(":exporters:common"))
   implementation(project(":semconv"))
+  implementation(project(":sdk-extensions:autoconfigure-spi"))
 
   compileOnly("io.grpc:grpc-stub")
 

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/internal/JaegerGrpcSpanExporterProvider.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/internal/JaegerGrpcSpanExporterProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.jaeger.internal;
+
+import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter;
+import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporterBuilder;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.time.Duration;
+
+/**
+ * {@link SpanExporter} SPI implementation for {@link JaegerGrpcSpanExporter}.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public class JaegerGrpcSpanExporterProvider implements ConfigurableSpanExporterProvider {
+  @Override
+  public String getName() {
+    return "jaeger";
+  }
+
+  @Override
+  public SpanExporter createExporter(ConfigProperties config) {
+    JaegerGrpcSpanExporterBuilder builder = JaegerGrpcSpanExporter.builder();
+
+    String endpoint = config.getString("otel.exporter.jaeger.endpoint");
+    if (endpoint != null) {
+      builder.setEndpoint(endpoint);
+    }
+
+    Duration timeout = config.getDuration("otel.exporter.jaeger.timeout");
+    if (timeout != null) {
+      builder.setTimeout(timeout);
+    }
+
+    return builder.build();
+  }
+}

--- a/exporters/jaeger/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider
+++ b/exporters/jaeger/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.exporter.jaeger.internal.JaegerGrpcSpanExporterProvider

--- a/sdk-extensions/autoconfigure/build.gradle.kts
+++ b/sdk-extensions/autoconfigure/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
   implementation(project(":semconv"))
   implementation(project(":exporters:common"))
 
-  compileOnly(project(":exporters:jaeger"))
   compileOnly(project(":exporters:otlp:all"))
   compileOnly(project(":exporters:otlp:logs"))
   compileOnly(project(":exporters:otlp:common"))

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/NotOnClasspathTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/NotOnClasspathTest.java
@@ -51,11 +51,15 @@ class NotOnClasspathTest {
     assertThatThrownBy(
             () ->
                 SpanExporterConfiguration.configureExporter(
-                    "jaeger", EMPTY, NamedSpiManager.createEmpty(), MeterProvider.noop()))
+                    "jaeger",
+                    EMPTY,
+                    SpanExporterConfiguration.spanExporterSpiManager(
+                        EMPTY, NotOnClasspathTest.class.getClassLoader()),
+                    MeterProvider.noop()))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining(
-            "Jaeger gRPC Exporter enabled but opentelemetry-exporter-jaeger not found on "
-                + "classpath");
+            "otel.traces.exporter set to \"jaeger\" but opentelemetry-exporter-jaeger not found on classpath."
+                + " Make sure to add it as a dependency.");
   }
 
   @Test

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfigurationTest.java
@@ -56,12 +56,15 @@ class SpanExporterConfigurationTest {
   // Timeout difficult to test using real exports so just check implementation detail here.
   @Test
   void configureJaegerTimeout() {
+    ConfigProperties config =
+        DefaultConfigProperties.createForTest(
+            Collections.singletonMap("otel.exporter.jaeger.timeout", "10"));
     SpanExporter exporter =
         SpanExporterConfiguration.configureExporter(
             "jaeger",
-            DefaultConfigProperties.createForTest(
-                Collections.singletonMap("otel.exporter.jaeger.timeout", "10")),
-            NamedSpiManager.createEmpty(),
+            config,
+            SpanExporterConfiguration.spanExporterSpiManager(
+                config, SpanExporterConfigurationTest.class.getClassLoader()),
             MeterProvider.noop());
     try {
       assertThat(exporter)


### PR DESCRIPTION
Related to #4949.

Depends on #4993 since the existing jaeger exporter configuration configures `JaegerSpanExporterBuilder#setMeterProvider`. 