### PR TITLE
OpenTracing Shim: Do not map semconv values from OT to OTel.

### DIFF
--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
@@ -15,7 +15,6 @@ import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.baggage.BaggageBuilder;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
@@ -44,7 +43,6 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
   private final List<AttributeKey> spanBuilderAttributeKeys = new ArrayList<>();
 
   private final List<Object> spanBuilderAttributeValues = new ArrayList<>();
-  @Nullable private SpanKind spanKind;
   @Nullable private Boolean error;
   private long startTimestampMicros;
 
@@ -119,25 +117,7 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
 
   @Override
   public SpanBuilder withTag(String key, String value) {
-    if (Tags.SPAN_KIND.getKey().equals(key)) {
-      switch (value) {
-        case Tags.SPAN_KIND_CLIENT:
-          spanKind = SpanKind.CLIENT;
-          break;
-        case Tags.SPAN_KIND_SERVER:
-          spanKind = SpanKind.SERVER;
-          break;
-        case Tags.SPAN_KIND_PRODUCER:
-          spanKind = SpanKind.PRODUCER;
-          break;
-        case Tags.SPAN_KIND_CONSUMER:
-          spanKind = SpanKind.CONSUMER;
-          break;
-        default:
-          spanKind = SpanKind.INTERNAL;
-          break;
-      }
-    } else if (Tags.ERROR.getKey().equals(key)) {
+    if (Tags.ERROR.getKey().equals(key)) {
       error = Boolean.parseBoolean(value);
     } else {
       this.spanBuilderAttributeKeys.add(stringKey(key));
@@ -228,10 +208,6 @@ final class SpanBuilderShim extends BaseShimObject implements SpanBuilder {
       builder.addLink(
           parentInfo.getSpanContext(),
           parentInfo.getRefType() == ReferenceType.CHILD_OF ? CHILD_OF_ATTR : FOLLOWS_FROM_ATTR);
-    }
-
-    if (spanKind != null) {
-      builder.setSpanKind(spanKind);
     }
 
     if (startTimestampMicros > 0) {

--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/SpanShim.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/SpanShim.java
@@ -82,10 +82,7 @@ final class SpanShim extends BaseShimObject implements Span, ImplicitContextKeye
 
   @Override
   public Span setTag(String key, String value) {
-    if (Tags.SPAN_KIND.getKey().equals(key)) {
-      // TODO: confirm we can safely ignore span.kind after Span was created
-      // https://github.com/bogdandrutu/opentelemetry/issues/42
-    } else if (Tags.ERROR.getKey().equals(key)) {
+    if (Tags.ERROR.getKey().equals(key)) {
       StatusCode canonicalCode = Boolean.parseBoolean(value) ? StatusCode.ERROR : StatusCode.OK;
       span.setStatus(canonicalCode);
     } else {

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/actorpropagation/ActorPropagationTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/actorpropagation/ActorPropagationTest.java
@@ -5,11 +5,8 @@
 
 package io.opentelemetry.opentracingshim.testbed.actorpropagation;
 
-import static io.opentelemetry.opentracingshim.testbed.TestUtils.getByKind;
-import static io.opentelemetry.opentracingshim.testbed.TestUtils.getOneByKind;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -67,14 +64,11 @@ class ActorPropagationTest {
       phaser.arriveAndAwaitAdvance(); // continue...
       phaser.arriveAndAwaitAdvance(); // child tracer finished
       assertThat(otelTesting.getSpans().size()).isEqualTo(3);
-      assertThat(getByKind(otelTesting.getSpans(), SpanKind.CONSUMER)).hasSize(2);
       phaser.arriveAndDeregister(); // continue...
 
       List<SpanData> finished = otelTesting.getSpans();
       assertThat(finished.size()).isEqualTo(3);
       assertThat(finished.get(0).getTraceId()).isEqualTo(finished.get(1).getTraceId());
-      assertThat(getByKind(finished, SpanKind.CONSUMER)).hasSize(2);
-      assertThat(getOneByKind(finished, SpanKind.PRODUCER)).isNotNull();
 
       assertThat(tracer.scopeManager().activeSpan()).isNull();
     }
@@ -103,7 +97,6 @@ class ActorPropagationTest {
       phaser.arriveAndAwaitAdvance(); // continue...
       phaser.arriveAndAwaitAdvance(); // child tracer finished
       assertThat(otelTesting.getSpans().size()).isEqualTo(3);
-      assertThat(getByKind(otelTesting.getSpans(), SpanKind.CONSUMER)).hasSize(2);
       phaser.arriveAndDeregister(); // continue...
 
       List<SpanData> finished = otelTesting.getSpans();
@@ -114,8 +107,6 @@ class ActorPropagationTest {
 
       assertThat(finished.size()).isEqualTo(3);
       assertThat(finished.get(0).getTraceId()).isEqualTo(finished.get(1).getTraceId());
-      assertThat(getByKind(finished, SpanKind.CONSUMER)).hasSize(2);
-      assertThat(getOneByKind(finished, SpanKind.PRODUCER)).isNotNull();
 
       assertThat(tracer.scopeManager().activeSpan()).isNull();
     }

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/clientserver/TestClientServerTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/clientserver/TestClientServerTest.java
@@ -7,7 +7,6 @@ package io.opentelemetry.opentracingshim.testbed.clientserver;
 
 import static io.opentelemetry.opentracingshim.testbed.TestUtils.finishedSpansSize;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -65,17 +64,8 @@ class TestClientServerTest {
     assertThat(finished).hasSize(2);
 
     assertThat(finished.get(1).getTraceId()).isEqualTo(finished.get(0).getTraceId());
-    SpanKind firstSpanKind = finished.get(0).getKind();
-    switch (firstSpanKind) {
-      case CLIENT:
-        assertThat(finished.get(1).getKind()).isEqualTo(SpanKind.SERVER);
-        break;
-      case SERVER:
-        assertThat(finished.get(1).getKind()).isEqualTo(SpanKind.CLIENT);
-        break;
-      default:
-        fail("Unexpected first span kind: " + firstSpanKind);
-    }
+    assertThat(finished.get(0).getKind()).isEqualTo(SpanKind.INTERNAL); // No semconv mapping.
+    assertThat(finished.get(1).getKind()).isEqualTo(SpanKind.INTERNAL);
 
     assertThat(tracer.scopeManager().activeSpan()).isNull();
   }

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/concurrentcommonrequesthandler/HandlerTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/concurrentcommonrequesthandler/HandlerTest.java
@@ -10,7 +10,6 @@ import static io.opentelemetry.opentracingshim.testbed.TestUtils.sortByStartTime
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanId;
-import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -45,10 +44,6 @@ class HandlerTest {
 
     List<SpanData> finished = otelTesting.getSpans();
     assertThat(finished).hasSize(2);
-
-    for (SpanData spanData : finished) {
-      assertThat(spanData.getKind()).isEqualTo(SpanKind.CLIENT);
-    }
 
     assertThat(finished.get(1).getTraceId()).isNotEqualTo(finished.get(0).getTraceId());
     assertThat(SpanId.isValid(finished.get(0).getParentSpanId())).isFalse();

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/listenerperrequest/ListenerTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/testbed/listenerperrequest/ListenerTest.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.opentracingshim.testbed.listenerperrequest;
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.opentracingshim.OpenTracingShim;
@@ -31,7 +30,6 @@ class ListenerTest {
 
     List<SpanData> finished = otelTesting.getSpans();
     assertThat(finished).hasSize(1);
-    assertThat(CLIENT).isEqualTo(finished.get(0).getKind());
 
     assertThat(tracer.scopeManager().activeSpan()).isNull();
   }


### PR DESCRIPTION
Fixes #5004 

Also removed related redundant assertions (i.e. `SpanKind` checks) for a few test cases in the testbed.