### PR TITLE
Stop extra copy of exponential histogram buckets

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramBuckets.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramBuckets.java
@@ -133,29 +133,8 @@ final class DoubleExponentialHistogramBuckets implements ExponentialHistogramBuc
   }
 
   /**
-   * Immutable method for merging. This method copies the first set of buckets, performs the merge
-   * on the copy, and returns the copy.
-   *
-   * @param a first buckets
-   * @param b second buckets
-   * @return A new set of buckets, the result
-   */
-  static DoubleExponentialHistogramBuckets merge(
-      DoubleExponentialHistogramBuckets a, DoubleExponentialHistogramBuckets b) {
-    if (b.counts.isEmpty()) {
-      return a;
-    } else if (a.counts.isEmpty()) {
-      return b;
-    }
-    DoubleExponentialHistogramBuckets copy = a.copy();
-    copy.mergeWith(b/* additive= */ );
-    return copy;
-  }
-
-  /**
    * This method merges this instance with another set of buckets. It alters the underlying bucket
-   * counts and scale of this instance only, so it is to be used with caution. For immutability, use
-   * the static merge() method.
+   * counts and scale of this instance only, so it is to be used with caution.
    *
    * <p>The bucket counts of this instance will be added to or subtracted from depending on the
    * additive parameter.
@@ -164,7 +143,7 @@ final class DoubleExponentialHistogramBuckets implements ExponentialHistogramBuc
    *
    * @param other the histogram that will be merged into this one
    */
-  private void mergeWith(DoubleExponentialHistogramBuckets other) {
+  void mergeInto(DoubleExponentialHistogramBuckets other) {
     if (other.counts.isEmpty()) {
       return;
     }
@@ -195,7 +174,7 @@ final class DoubleExponentialHistogramBuckets implements ExponentialHistogramBuc
     // since we changed scale of this, we need to know the new difference between the two scales
     deltaOther = other.scale - this.scale;
 
-    // do actual merging of other into this. Will decrement or increment depending on sign.
+    // do actual merging of other into this.
     for (int i = other.getOffset(); i <= other.counts.getIndexEnd(); i++) {
       if (!this.counts.increment(i >> deltaOther, other.counts.get(i))) {
         // This should never occur if scales and windows are calculated without bugs


### PR DESCRIPTION
Currently an extra copy of exponential histogram buckets is made during collection, which causes extra memory allocation when temporality is cumulative.

This PR addresses it by mutating the buckets instead of operating on a copy.

Here's the the `HistogramCollectBenchmark` before:
```
Benchmark                                                                      (aggregationGenerator)  (aggregationTemporality)  Mode  Cnt           Score           Error   Units
HistogramCollectBenchmark.recordAndCollect                               EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5  9507808383.600 ± 160312845.363   ns/op
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate                EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5           3.493 ±         0.090  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate.norm           EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5    36675027.200 ±    794113.234    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.churn.G1_Eden_Space       EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5           3.673 ±        15.302  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.churn.G1_Eden_Space.norm  EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5    38587596.800 ± 160860384.216    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.count                     EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5           3.000                  counts
HistogramCollectBenchmark.recordAndCollect:·gc.time                      EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5           6.000                      ms
HistogramCollectBenchmark.recordAndCollect                               EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5  9350454516.600 ± 292150521.432   ns/op
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate                EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           4.355 ±         0.149  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate.norm           EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5    45011481.600 ±    224644.078    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.churn.G1_Eden_Space       EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           3.889 ±        15.728  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.churn.G1_Eden_Space.norm  EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5    40265318.400 ± 162152456.251    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.count                     EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           3.000                  counts
HistogramCollectBenchmark.recordAndCollect:·gc.time                      EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           6.000                      ms
```
And after:
```
Benchmark                                                                          (aggregationGenerator)  (aggregationTemporality)  Mode  Cnt           Score           Error   Units
HistogramCollectBenchmark.recordAndCollect                                   EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5  9197564316.600 ± 157971347.306   ns/op
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate                    EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5           3.764 ±         0.040  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate.norm               EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5    38305473.600 ±    816439.674    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.churn.G1_Eden_Space           EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5           3.949 ±        15.903  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.churn.G1_Eden_Space.norm      EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5    40265318.400 ± 162152456.251    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.churn.G1_Survivor_Space       EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5          ≈ 10⁻³                  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.churn.G1_Survivor_Space.norm  EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5        3412.800 ±     29385.237    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.count                         EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5           3.000                  counts
HistogramCollectBenchmark.recordAndCollect:·gc.time                          EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5           5.000                      ms
HistogramCollectBenchmark.recordAndCollect                                   EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5  9216800908.200 ±  31120256.517   ns/op
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate                    EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           3.806 ±         0.089  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate.norm               EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5    38807947.200 ±    830507.303    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.churn.G1_Eden_Space           EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           3.783 ±        15.757  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.churn.G1_Eden_Space.norm      EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5    38587596.800 ± 160860384.216    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.count                         EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           3.000                  counts
HistogramCollectBenchmark.recordAndCollect:·gc.time                          EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           7.000                      ms
```
The key bit is a reduction in `HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate` for `CUMULATIVE` temporality from `4.355 MB/sec` to `3.806 MB/sec`. A modest but non-negligible improvement. 