### PR TITLE
adds resource to logging span exporter

### DIFF
--- a/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/LoggingSpanExporter.java
+++ b/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/LoggingSpanExporter.java
@@ -54,7 +54,9 @@ public final class LoggingSpanExporter implements SpanExporter {
                   ? ""
                   : instrumentationScopeInfo.getVersion())
           .append("] ")
-          .append(span.getAttributes());
+          .append(span.getAttributes())
+          .append(" ")
+          .append(span.getResource().getAttributes());
       logger.log(Level.INFO, sb.toString());
     }
     return CompletableResultCode.ofSuccess();


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
When trying to debug building a custom distribution I was testing things using the logging span exporter so I didn't have any other dependencies. I was struggling to see the changes which I believe is due to the logging span exporter not logging the resource attributes.

**Describe the solution you'd like**
I would like the logging span exporter to also log resource attributes

**Describe alternatives you've considered**
We could create another logging span exporter which also logs resources
