### PR TITLE
Lazily initialize exponential histogram buckets

### DIFF
--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/metrics/MetricsRequestMarshalerTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/metrics/MetricsRequestMarshalerTest.java
@@ -421,8 +421,8 @@ class MetricsRequestMarshalerTest {
                         1,
                         null,
                         null,
-                        new TestExponentialHistogramBuckets(0, Collections.emptyList()),
-                        new TestExponentialHistogramBuckets(0, Collections.emptyList()),
+                        new TestExponentialHistogramBuckets(0, 0, Collections.emptyList()),
+                        new TestExponentialHistogramBuckets(0, 0, Collections.emptyList()),
                         123,
                         456,
                         Attributes.empty(),
@@ -433,8 +433,8 @@ class MetricsRequestMarshalerTest {
                         1,
                         3.3,
                         80.1,
-                        new TestExponentialHistogramBuckets(1, ImmutableList.of(1L, 0L, 2L)),
-                        new TestExponentialHistogramBuckets(0, Collections.emptyList()),
+                        new TestExponentialHistogramBuckets(0, 1, ImmutableList.of(1L, 0L, 2L)),
+                        new TestExponentialHistogramBuckets(0, 0, Collections.emptyList()),
                         123,
                         456,
                         Attributes.of(stringKey("key"), "value"),
@@ -837,9 +837,9 @@ class MetricsRequestMarshalerTest {
                                 20.1,
                                 44.3,
                                 new TestExponentialHistogramBuckets(
-                                    -1, ImmutableList.of(0L, 128L, 1L << 32)),
+                                    20, -1, ImmutableList.of(0L, 128L, 1L << 32)),
                                 new TestExponentialHistogramBuckets(
-                                    1, ImmutableList.of(0L, 128L, 1L << 32)),
+                                    20, 1, ImmutableList.of(0L, 128L, 1L << 32)),
                                 123,
                                 456,
                                 KV_ATTR,
@@ -1155,12 +1155,19 @@ class MetricsRequestMarshalerTest {
    */
   private static class TestExponentialHistogramBuckets implements ExponentialHistogramBuckets {
 
+    private final int scale;
     private final int offset;
     private final List<Long> bucketCounts;
 
-    TestExponentialHistogramBuckets(int offset, List<Long> bucketCounts) {
+    TestExponentialHistogramBuckets(int scale, int offset, List<Long> bucketCounts) {
+      this.scale = scale;
       this.offset = offset;
       this.bucketCounts = bucketCounts;
+    }
+
+    @Override
+    public int getScale() {
+      return scale;
     }
 
     @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramAggregator.java
@@ -5,20 +5,25 @@
 
 package io.opentelemetry.sdk.metrics.internal.aggregator;
 
+import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
+import io.opentelemetry.sdk.metrics.internal.data.exponentialhistogram.ExponentialHistogramBuckets;
 import io.opentelemetry.sdk.metrics.internal.data.exponentialhistogram.ExponentialHistogramData;
 import io.opentelemetry.sdk.metrics.internal.descriptor.MetricDescriptor;
 import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoir;
 import io.opentelemetry.sdk.metrics.internal.state.ExponentialCounterFactory;
 import io.opentelemetry.sdk.resources.Resource;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 
 /**
  * Aggregator that generates exponential histograms.
@@ -68,15 +73,15 @@ public final class DoubleExponentialHistogramAggregator
       ExponentialHistogramAccumulation previous, ExponentialHistogramAccumulation current) {
 
     // Create merged buckets
-    DoubleExponentialHistogramBuckets posBuckets =
+    ExponentialHistogramBuckets posBuckets =
         merge(previous.getPositiveBuckets(), current.getPositiveBuckets());
-    DoubleExponentialHistogramBuckets negBuckets =
+    ExponentialHistogramBuckets negBuckets =
         merge(previous.getNegativeBuckets(), current.getNegativeBuckets());
 
     // resolve possible scale difference due to merge
     int commonScale = Math.min(posBuckets.getScale(), negBuckets.getScale());
-    posBuckets.downscale(posBuckets.getScale() - commonScale);
-    negBuckets.downscale(negBuckets.getScale() - commonScale);
+    posBuckets = downscale(posBuckets, commonScale);
+    negBuckets = downscale(negBuckets, commonScale);
     double min = -1;
     double max = -1;
     if (previous.hasMinMax() && current.hasMinMax()) {
@@ -104,16 +109,50 @@ public final class DoubleExponentialHistogramAggregator
   /**
    * Merge the exponential histogram buckets. If {@code a} is empty, return {@code b}. If {@code b}
    * is empty, return {@code a}. Else merge {@code b} into {@code a}.
+   *
+   * <p>Assumes {@code a} and {@code b} are either {@link DoubleExponentialHistogramBuckets} or
+   * {@link EmptyExponentialHistogramBuckets}.
    */
-  private static DoubleExponentialHistogramBuckets merge(
-      DoubleExponentialHistogramBuckets a, DoubleExponentialHistogramBuckets b) {
-    if (b.getTotalCount() == 0) {
-      return a;
-    } else if (a.getTotalCount() == 0) {
+  private static ExponentialHistogramBuckets merge(
+      ExponentialHistogramBuckets a, ExponentialHistogramBuckets b) {
+    if (a instanceof EmptyExponentialHistogramBuckets || a.getTotalCount() == 0) {
       return b;
     }
-    a.mergeInto(b);
-    return a;
+    if (b instanceof EmptyExponentialHistogramBuckets || b.getTotalCount() == 0) {
+      return a;
+    }
+    if ((a instanceof DoubleExponentialHistogramBuckets)
+        && (b instanceof DoubleExponentialHistogramBuckets)) {
+      DoubleExponentialHistogramBuckets a1 = (DoubleExponentialHistogramBuckets) a;
+      DoubleExponentialHistogramBuckets b2 = (DoubleExponentialHistogramBuckets) b;
+      a1.mergeInto(b2);
+      return a1;
+    }
+    throw new IllegalStateException(
+        "Unable to merge ExponentialHistogramBuckets. Unrecognized implementation.");
+  }
+
+  /**
+   * Downscale the {@code buckets} to the {@code targetScale}.
+   *
+   * <p>Assumes {@code a} and {@code b} are either {@link DoubleExponentialHistogramBuckets} or
+   * {@link EmptyExponentialHistogramBuckets}.
+   */
+  private static ExponentialHistogramBuckets downscale(
+      ExponentialHistogramBuckets buckets, int targetScale) {
+    if (buckets.getScale() == targetScale) {
+      return buckets;
+    }
+    if (buckets instanceof EmptyExponentialHistogramBuckets) {
+      return EmptyExponentialHistogramBuckets.get(targetScale);
+    }
+    if (buckets instanceof DoubleExponentialHistogramBuckets) {
+      DoubleExponentialHistogramBuckets buckets1 = (DoubleExponentialHistogramBuckets) buckets;
+      buckets1.downscale(buckets1.getScale() - targetScale);
+      return buckets1;
+    }
+    throw new IllegalStateException(
+        "Unable to merge ExponentialHistogramBuckets. Unrecognized implementation");
   }
 
   @Override
@@ -144,38 +183,54 @@ public final class DoubleExponentialHistogramAggregator
 
   static final class Handle
       extends AggregatorHandle<ExponentialHistogramAccumulation, DoubleExemplarData> {
-    private final DoubleExponentialHistogramBuckets positiveBuckets;
-    private final DoubleExponentialHistogramBuckets negativeBuckets;
+    private final ExponentialBucketStrategy bucketStrategy;
+    @Nullable private DoubleExponentialHistogramBuckets positiveBuckets;
+    @Nullable private DoubleExponentialHistogramBuckets negativeBuckets;
     private long zeroCount;
     private double sum;
     private double min;
     private double max;
     private long count;
+    private int scale;
 
     Handle(
         ExemplarReservoir<DoubleExemplarData> reservoir, ExponentialBucketStrategy bucketStrategy) {
       super(reservoir);
+      this.bucketStrategy = bucketStrategy;
       this.sum = 0;
       this.zeroCount = 0;
       this.min = Double.MAX_VALUE;
       this.max = -1;
       this.count = 0;
-      this.positiveBuckets = bucketStrategy.newBuckets();
-      this.negativeBuckets = bucketStrategy.newBuckets();
+      this.scale = bucketStrategy.getStartingScale();
     }
 
     @Override
     protected synchronized ExponentialHistogramAccumulation doAccumulateThenReset(
         List<DoubleExemplarData> exemplars) {
+      ExponentialHistogramBuckets positiveBuckets;
+      ExponentialHistogramBuckets negativeBuckets;
+      if (this.positiveBuckets != null) {
+        positiveBuckets = this.positiveBuckets.copy();
+        this.positiveBuckets.clear();
+      } else {
+        positiveBuckets = EmptyExponentialHistogramBuckets.get(scale);
+      }
+      if (this.negativeBuckets != null) {
+        negativeBuckets = this.negativeBuckets.copy();
+        this.negativeBuckets.clear();
+      } else {
+        negativeBuckets = EmptyExponentialHistogramBuckets.get(scale);
+      }
       ExponentialHistogramAccumulation acc =
           ExponentialHistogramAccumulation.create(
-              this.positiveBuckets.getScale(),
+              scale,
               sum,
               this.count > 0,
               this.count > 0 ? this.min : -1,
               this.count > 0 ? this.max : -1,
-              positiveBuckets.copy(),
-              negativeBuckets.copy(),
+              positiveBuckets,
+              negativeBuckets,
               zeroCount,
               exemplars);
       this.sum = 0;
@@ -183,14 +238,11 @@ public final class DoubleExponentialHistogramAggregator
       this.min = Double.MAX_VALUE;
       this.max = -1;
       this.count = 0;
-      this.positiveBuckets.clear();
-      this.negativeBuckets.clear();
       return acc;
     }
 
     @Override
     protected synchronized void doRecordDouble(double value) {
-
       // ignore NaN and infinity
       if (!Double.isFinite(value)) {
         return;
@@ -203,14 +255,28 @@ public final class DoubleExponentialHistogramAggregator
       count++;
 
       int c = Double.compare(value, 0);
+      DoubleExponentialHistogramBuckets buckets;
       if (c == 0) {
         zeroCount++;
         return;
+      } else if (c > 0) {
+        // Initialize positive buckets if needed, adjusting to current scale
+        if (positiveBuckets == null) {
+          positiveBuckets = bucketStrategy.newBuckets();
+          positiveBuckets.downscale(positiveBuckets.getScale() - scale);
+        }
+        buckets = positiveBuckets;
+      } else {
+        // Initialize negative buckets if needed, adjusting to current scale
+        if (negativeBuckets == null) {
+          negativeBuckets = bucketStrategy.newBuckets();
+          negativeBuckets.downscale(negativeBuckets.getScale() - scale);
+        }
+        buckets = negativeBuckets;
       }
 
       // Record; If recording fails, calculate scale reduction and scale down to fit new value.
       // 2nd attempt at recording should work with new scale
-      DoubleExponentialHistogramBuckets buckets = (c > 0) ? positiveBuckets : negativeBuckets;
       // TODO: We should experiment with downscale on demand during sync execution and only
       // unifying scale factor between positive/negative at collection time (doAccumulate).
       if (!buckets.record(value)) {
@@ -227,8 +293,31 @@ public final class DoubleExponentialHistogramAggregator
     }
 
     void downScale(int by) {
-      positiveBuckets.downscale(by);
-      negativeBuckets.downscale(by);
+      if (positiveBuckets != null) {
+        positiveBuckets.downscale(by);
+        scale = positiveBuckets.getScale();
+      }
+      if (negativeBuckets != null) {
+        negativeBuckets.downscale(by);
+        scale = negativeBuckets.getScale();
+      }
+    }
+  }
+
+  @AutoValue
+  abstract static class EmptyExponentialHistogramBuckets implements ExponentialHistogramBuckets {
+
+    private static final Map<Integer, ExponentialHistogramBuckets> ZERO_BUCKETS =
+        new ConcurrentHashMap<>();
+
+    EmptyExponentialHistogramBuckets() {}
+
+    static ExponentialHistogramBuckets get(int scale) {
+      return ZERO_BUCKETS.computeIfAbsent(
+          scale,
+          scale1 ->
+              new AutoValue_DoubleExponentialHistogramAggregator_EmptyExponentialHistogramBuckets(
+                  scale1, 0, Collections.emptyList(), 0));
     }
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramBuckets.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramBuckets.java
@@ -184,7 +184,8 @@ final class DoubleExponentialHistogramBuckets implements ExponentialHistogramBuc
     this.totalCount += other.totalCount;
   }
 
-  int getScale() {
+  @Override
+  public int getScale() {
     return scale;
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/ExponentialBucketStrategy.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/ExponentialBucketStrategy.java
@@ -30,6 +30,10 @@ final class ExponentialBucketStrategy {
     return new DoubleExponentialHistogramBuckets(startingScale, maxBuckets, counterFactory);
   }
 
+  int getStartingScale() {
+    return startingScale;
+  }
+
   /** Create a new strategy for generating Exponential Buckets. */
   static ExponentialBucketStrategy newStrategy(
       int maxBuckets, ExponentialCounterFactory counterFactory) {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/ExponentialHistogramAccumulation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/ExponentialHistogramAccumulation.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.metrics.internal.aggregator;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
+import io.opentelemetry.sdk.metrics.internal.data.exponentialhistogram.ExponentialHistogramBuckets;
 import java.util.List;
 
 @AutoValue
@@ -20,8 +21,8 @@ abstract class ExponentialHistogramAccumulation {
       boolean hasMinMax,
       double min,
       double max,
-      DoubleExponentialHistogramBuckets positiveBuckets,
-      DoubleExponentialHistogramBuckets negativeBuckets,
+      ExponentialHistogramBuckets positiveBuckets,
+      ExponentialHistogramBuckets negativeBuckets,
       long zeroCount,
       List<DoubleExemplarData> exemplars) {
     return new AutoValue_ExponentialHistogramAccumulation(
@@ -38,9 +39,9 @@ abstract class ExponentialHistogramAccumulation {
 
   abstract double getMax();
 
-  abstract DoubleExponentialHistogramBuckets getPositiveBuckets();
+  abstract ExponentialHistogramBuckets getPositiveBuckets();
 
-  abstract DoubleExponentialHistogramBuckets getNegativeBuckets();
+  abstract ExponentialHistogramBuckets getNegativeBuckets();
 
   abstract long getZeroCount();
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/exponentialhistogram/ExponentialHistogramBuckets.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/exponentialhistogram/ExponentialHistogramBuckets.java
@@ -26,6 +26,9 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public interface ExponentialHistogramBuckets {
 
+  /** The scale of the buckets. Must align with {@link ExponentialHistogramPointData#getScale()}. */
+  int getScale();
+
   /**
    * The offset shifts the bucket boundaries according to <code>lower_bound = base^(offset+i).
    * </code>.


### PR DESCRIPTION
Exponential histograms separately track bucket counts in the negative and positive range. Currently, histograms are not permitted to record negative measurements, yet we allocate memory to negative buckets anyway. The exponential histogram aggregation logic works with negative measurements in anticipation of them being permitted in the future, but even when they are permitted, many instruments will only record positive values. 

This PR adjusts the exponential histogram aggregation to lazily instantiate both positive and negative buckets.

Here are the results of the `HistogramCollectBenchmark` before:
```
Benchmark                                                                          (aggregationGenerator)  (aggregationTemporality)  Mode  Cnt           Score           Error   Units
HistogramCollectBenchmark.recordAndCollect                                   EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5  9197564316.600 ± 157971347.306   ns/op
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate                    EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5           3.764 ±         0.040  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate.norm               EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5    38305473.600 ±    816439.674    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.churn.G1_Eden_Space           EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5           3.949 ±        15.903  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.churn.G1_Eden_Space.norm      EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5    40265318.400 ± 162152456.251    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.churn.G1_Survivor_Space       EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5          ≈ 10⁻³                  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.churn.G1_Survivor_Space.norm  EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5        3412.800 ±     29385.237    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.count                         EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5           3.000                  counts
HistogramCollectBenchmark.recordAndCollect:·gc.time                          EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5           5.000                      ms
HistogramCollectBenchmark.recordAndCollect                                   EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5  9216800908.200 ±  31120256.517   ns/op
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate                    EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           3.806 ±         0.089  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate.norm               EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5    38807947.200 ±    830507.303    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.churn.G1_Eden_Space           EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           3.783 ±        15.757  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.churn.G1_Eden_Space.norm      EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5    38587596.800 ± 160860384.216    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.count                         EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           3.000                  counts
HistogramCollectBenchmark.recordAndCollect:·gc.time                          EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           7.000                      ms
```
And after:
```
HistogramCollectBenchmark.recordAndCollect                               EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5  9363457049.800 ± 348621966.366   ns/op
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate                EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5           3.069 ±         0.125  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate.norm           EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5    31767908.800 ±    760387.947    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.churn.G1_Eden_Space       EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5           1.946 ±        10.261  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.churn.G1_Eden_Space.norm  EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5    20132659.200 ± 106153700.699    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.count                     EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5           2.000                  counts
HistogramCollectBenchmark.recordAndCollect:·gc.time                      EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5           6.000                      ms
HistogramCollectBenchmark.recordAndCollect                               EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5  9282971800.200 ± 643932624.558   ns/op
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate                EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           3.136 ±         0.119  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate.norm           EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5    32196094.400 ±    868793.468    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.churn.G1_Eden_Space       EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           1.939 ±        10.229  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.churn.G1_Eden_Space.norm  EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5    20132659.200 ± 106153700.699    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.count                     EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           2.000                  counts
HistogramCollectBenchmark.recordAndCollect:·gc.time                      EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           5.000                      ms
```
**Edit** 
Was comparing `gc.alloc.rate` when I should be comparing `gc.alloc.rate.norm`. Comparing the bytes allocated for second doesn't account for a speed increase in the number of operations per second, which may increase the allocation rate. `gc.alloc.rate.norm` improves from 38_305_473 B/op to 31_767_908 B/op (~17% reduction) for delta temporality, and 38_807_947 B/op to 32_196_094 B/op (~17%) for cumulative temporality.