### PR TITLE
improve span order

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.TracesAssert  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.TracesAssert assertThat(java.util.List)

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtension.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtension.java
@@ -23,11 +23,7 @@ import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -124,15 +120,7 @@ public final class OpenTelemetryExtension
    * requires AssertJ to be on the classpath.
    */
   public TracesAssert assertTraces() {
-    Map<String, List<SpanData>> traces =
-        getSpans().stream()
-            .collect(
-                Collectors.groupingBy(
-                    SpanData::getTraceId, LinkedHashMap::new, Collectors.toList()));
-    for (List<SpanData> trace : traces.values()) {
-      trace.sort(Comparator.comparing(SpanData::getStartEpochNanos));
-    }
-    return assertThat(traces.values());
+    return assertThat(spanExporter.getFinishedSpanItems());
   }
 
   /**

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/TracesAssertTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/TracesAssertTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.testing.assertj;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceId;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.sdk.testing.trace.TestSpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TracesAssertTest {
+  @Test
+  void spanDataComparator() {
+    TestSpanData before = createBasicSpanBuilder().setStartEpochNanos(9).build();
+
+    String traceId = TraceId.fromLongs(1, 2);
+    TestSpanData parent =
+        createBasicSpanBuilder()
+            .setName("parent")
+            .setSpanContext(
+                SpanContext.create(
+                    traceId, SpanId.fromLong(1), TraceFlags.getDefault(), TraceState.getDefault()))
+            .setStartEpochNanos(10)
+            .build();
+    TestSpanData child =
+        createBasicSpanBuilder()
+            .setName("child")
+            .setSpanContext(
+                SpanContext.create(
+                    traceId, SpanId.fromLong(2), TraceFlags.getDefault(), TraceState.getDefault()))
+            .setStartEpochNanos(10)
+            .setParentSpanContext(parent.getSpanContext())
+            .build();
+
+    TestSpanData sameTime1 =
+        createBasicSpanBuilder().setName("sameTime1").setStartEpochNanos(11).build();
+    TestSpanData sameTime2 =
+        createBasicSpanBuilder().setName("sameTime2").setStartEpochNanos(11).build();
+
+    assertSort(Arrays.asList(child, parent, before), before, parent, child);
+    assertSort(Arrays.asList(parent, child, before), before, parent, child);
+
+    assertSort(Arrays.asList(sameTime1, sameTime2, before), before, sameTime1, sameTime2);
+    assertSort(Arrays.asList(sameTime2, sameTime1, before), before, sameTime2, sameTime1);
+  }
+
+  private static void assertSort(List<TestSpanData> spanData, TestSpanData... expected) {
+    ArrayList<TestSpanData> list = new ArrayList<>(spanData);
+    list.sort(TracesAssert.SPAN_DATA_COMPARATOR);
+    assertThat(list).containsExactly(expected);
+  }
+
+  private static TestSpanData.Builder createBasicSpanBuilder() {
+    return TestSpanData.builder()
+        .setHasEnded(true)
+        .setName("spanName")
+        .setEndEpochNanos(100)
+        .setKind(SpanKind.SERVER)
+        .setStatus(StatusData.ok())
+        .setTotalRecordedEvents(0)
+        .setTotalRecordedLinks(0);
+  }
+}

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/junit5/OpenTelemetryExtensionTest.java
@@ -17,6 +17,7 @@ import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -58,9 +59,9 @@ class OpenTelemetryExtensionTest {
 
   @Test
   public void assertTraces() {
-    Span span = tracer.spanBuilder("testa1").startSpan();
+    Span span = tracer.spanBuilder("testa1").setStartTimestamp(1000, TimeUnit.SECONDS).startSpan();
     try (Scope ignored = span.makeCurrent()) {
-      tracer.spanBuilder("testa2").startSpan().end();
+      tracer.spanBuilder("testa2").setStartTimestamp(1000, TimeUnit.SECONDS).startSpan().end();
     } finally {
       span.end();
     }


### PR DESCRIPTION
- sort spans by start time (parents before children as tiebreaker) to avoid common causes for flaky tests