### PR TITLE
Use ConfigUtil internally

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
@@ -225,7 +225,7 @@ public final class GlobalOpenTelemetry {
 
     // If autoconfigure module is present but global autoconfigure disabled log a warning and return
     boolean globalAutoconfigureEnabled =
-        Boolean.parseBoolean(ConfigUtil.getString(GLOBAL_AUTOCONFIGURE_ENABLED_PROPERTY));
+        Boolean.parseBoolean(ConfigUtil.getString(GLOBAL_AUTOCONFIGURE_ENABLED_PROPERTY, "false"));
     if (!globalAutoconfigureEnabled) {
       logger.log(
           Level.INFO,

--- a/api/all/src/main/java/io/opentelemetry/api/internal/ConfigUtil.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/ConfigUtil.java
@@ -28,10 +28,10 @@ public final class ConfigUtil {
    * properties take priority over environment variables.
    *
    * @param key the property key
-   * @return the system property if not null, or the environment variable if not null, or null
+   * @return the system property if not null, or the environment variable if not null, or {@code
+   *     defaultValue}
    */
-  @Nullable
-  public static String getString(String key) {
+  public static String getString(String key, String defaultValue) {
     String normalizedKey = normalizePropertyKey(key);
     String systemProperty =
         System.getProperties().entrySet().stream()
@@ -46,7 +46,7 @@ public final class ConfigUtil {
         .filter(entry -> normalizedKey.equals(normalizeEnvironmentVariableKey(entry.getKey())))
         .map(Map.Entry::getValue)
         .findFirst()
-        .orElse(null);
+        .orElse(defaultValue);
   }
 
   /**

--- a/api/all/src/test/java/io/opentelemetry/api/internal/ConfigUtilTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/internal/ConfigUtilTest.java
@@ -16,23 +16,23 @@ class ConfigUtilTest {
   @Test
   @SetSystemProperty(key = "config.key", value = "system")
   void getString_SystemPropertyPriority() {
-    assertThat(ConfigUtil.getString("config.key")).isEqualTo("system");
-    assertThat(ConfigUtil.getString("config-key")).isEqualTo("system");
-    assertThat(ConfigUtil.getString("other.config.key")).isEqualTo(null);
+    assertThat(ConfigUtil.getString("config.key", "default")).isEqualTo("system");
+    assertThat(ConfigUtil.getString("config-key", "default")).isEqualTo("system");
+    assertThat(ConfigUtil.getString("other.config.key", "default")).isEqualTo("default");
   }
 
   @Test
   @SetSystemProperty(key = "CONFIG-KEY", value = "system")
   void getString_SystemPropertyNormalized() {
-    assertThat(ConfigUtil.getString("config.key")).isEqualTo("system");
-    assertThat(ConfigUtil.getString("config-key")).isEqualTo("system");
-    assertThat(ConfigUtil.getString("other.config.key")).isEqualTo(null);
+    assertThat(ConfigUtil.getString("config.key", "default")).isEqualTo("system");
+    assertThat(ConfigUtil.getString("config-key", "default")).isEqualTo("system");
+    assertThat(ConfigUtil.getString("other.config.key", "default")).isEqualTo("default");
   }
 
   @Test
   void getString_EnvironmentVariable() {
-    assertThat(ConfigUtil.getString("config.key")).isEqualTo("environment");
-    assertThat(ConfigUtil.getString("other.config.key")).isEqualTo(null);
+    assertThat(ConfigUtil.getString("config.key", "default")).isEqualTo("environment");
+    assertThat(ConfigUtil.getString("other.config.key", "default")).isEqualTo("default");
   }
 
   @Test

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/CodedOutputStream.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/CodedOutputStream.java
@@ -41,6 +41,7 @@ import static io.opentelemetry.exporter.internal.marshal.WireFormat.FIXED64_SIZE
 import static io.opentelemetry.exporter.internal.marshal.WireFormat.MAX_VARINT32_SIZE;
 import static io.opentelemetry.exporter.internal.marshal.WireFormat.MAX_VARINT_SIZE;
 
+import io.opentelemetry.api.internal.ConfigUtil;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -71,7 +72,10 @@ public abstract class CodedOutputStream {
   static {
     int bufferSize = 50 * 1024;
     try {
-      bufferSize = Integer.parseInt(System.getProperty("otel.experimental.otlp.buffer-size"));
+      String bufferSizeConfig = ConfigUtil.getString("otel.experimental.otlp.buffer-size", "");
+      if (!bufferSizeConfig.isEmpty()) {
+        bufferSize = Integer.parseInt(bufferSizeConfig);
+      }
     } catch (Throwable t) {
       // Ignore.
     }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/debug/DebugConfig.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/debug/DebugConfig.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.sdk.metrics.internal.debug;
 
-import java.util.Locale;
+import io.opentelemetry.api.internal.ConfigUtil;
 
 /**
  * Determines if the SDK is in debugging mode (captures stack traces) or not.
@@ -20,13 +20,7 @@ public final class DebugConfig {
   private DebugConfig() {}
 
   static {
-    // Attempt to mirror the logic in DefaultConfigProperties here...
-    enabled =
-        "true".equalsIgnoreCase(System.getProperty(ENABLE_METRICS_DEBUG_PROPERTY))
-            || "true"
-                .equalsIgnoreCase(
-                    System.getenv(
-                        ENABLE_METRICS_DEBUG_PROPERTY.toLowerCase(Locale.ROOT).replace('.', '_')));
+    enabled = Boolean.parseBoolean(ConfigUtil.getString(ENABLE_METRICS_DEBUG_PROPERTY, "false"));
   }
 
   /**


### PR DESCRIPTION
There are a few places where we read from system properties. This adjusts those to use ConfigUtil so that property names normalization occurs in a standard way.