### PR TITLE
Add repository settings

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -1,0 +1,51 @@
+# Repository settings
+
+Repository settings in addition to what's documented already at
+<https://github.com/open-telemetry/community/blob/main/docs/how-to-configure-new-repository.md>.
+
+## Actions > General
+
+* Fork pull request workflows from outside collaborators:
+  "Require approval for first-time contributors who are new to GitHub"
+
+  (To reduce friction for new contributors,
+  as the default is "Require approval for first-time contributors")
+
+## Branch protections
+
+### `main`
+
+* Require branches to be up to date before merging: UNCHECKED
+
+  (PR jobs take too long, and leaving this unchecked has not been a significant problem)
+
+* Status checks that are required:
+
+  * EasyCLA
+  * required-status-check
+
+### `release/*`
+
+Same settings as above for `main`, except:
+
+* Restrict pushes that create matching branches: UNCHECKED
+
+  (So that opentelemetrybot can create release branches)
+
+### `dependabot/**/**` and `opentelemetrybot/*`
+
+* Require status checks to pass before merging: UNCHECKED
+
+  (So that dependabot PRs can be rebased)
+
+* Restrict who can push to matching branches: UNCHECKED
+
+  (So that bots can create PR branches in this repository)
+
+* Allow force pushes > Everyone
+
+  (So that dependabot PRs can be rebased)
+
+* Allow deletions: CHECKED
+
+  (So that bot PR branches can be deleted)


### PR DESCRIPTION
**EDIT**: Adds `.github/repository-settings.md` documenting differences in repository setting from those specified in the [community repo](https://github.com/open-telemetry/community/blob/main/docs/how-to-configure-new-repository.md#branches). Documenting these differences is [required](https://github.com/open-telemetry/community/blame/main/docs/how-to-configure-new-repository.md#L43-L47).

cc @trask 