### PR TITLE
Cleanup autoconfigure tests

### DIFF
--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/MeterProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/MeterProviderConfigurationTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.autoconfigure;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.as;
 
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
@@ -25,6 +26,8 @@ import org.junit.jupiter.api.Test;
 class MeterProviderConfigurationTest {
 
   @Test
+  // Suppress log warnings for deprecated exemplar filter options
+  @SuppressLogger(MeterProviderConfiguration.class)
   void configureMeterProvider_ConfiguresExemplarFilter() {
     assertExemplarFilter(Collections.emptyMap()).isInstanceOf(TraceBasedExemplarFilter.class);
     assertExemplarFilter(Collections.singletonMap("otel.metrics.exemplar.filter", "foo"))

--- a/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/provider/FirstCustomizerProvider.java
+++ b/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/provider/FirstCustomizerProvider.java
@@ -3,23 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import static java.util.Collections.singletonMap;
 
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 
-public class ThirdCustomizerProvider implements AutoConfigurationCustomizerProvider {
+public class FirstCustomizerProvider implements AutoConfigurationCustomizerProvider {
 
   @Override
   public void customize(AutoConfigurationCustomizer autoConfiguration) {
-    autoConfiguration.addPropertiesSupplier(
-        () -> singletonMap("otel.from-config", "configured value"));
+    autoConfiguration.addPropertiesSupplier(() -> singletonMap("otel.from-config", "unused"));
   }
 
   @Override
   public int order() {
-    return 3000;
+    return 1000;
   }
 }

--- a/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/provider/FirstResourceProvider.java
+++ b/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/provider/FirstResourceProvider.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
@@ -12,15 +12,20 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
 import io.opentelemetry.sdk.resources.Resource;
 
-public class ThirdResourceProvider implements ResourceProvider {
+public class FirstResourceProvider implements ResourceProvider {
 
   @Override
   public Resource createResource(ConfigProperties config) {
-    return Resource.create(Attributes.of(stringKey("otel.some_resource"), "real value"));
+    return Resource.create(
+        Attributes.of(
+            stringKey("otel.some_resource"),
+            "unused",
+            stringKey("otel.from_config"),
+            config.getString("otel.from-config", "default")));
   }
 
   @Override
   public int order() {
-    return 300;
+    return 100;
   }
 }

--- a/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/provider/SecondCustomizerProvider.java
+++ b/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/provider/SecondCustomizerProvider.java
@@ -3,22 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import static java.util.Collections.singletonMap;
 
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 
-public class FirstCustomizerProvider implements AutoConfigurationCustomizerProvider {
+public class SecondCustomizerProvider implements AutoConfigurationCustomizerProvider {
 
   @Override
   public void customize(AutoConfigurationCustomizer autoConfiguration) {
-    autoConfiguration.addPropertiesSupplier(() -> singletonMap("otel.from-config", "unused"));
+    autoConfiguration.addPropertiesSupplier(() -> singletonMap("otel.from-config", "still unused"));
   }
 
   @Override
   public int order() {
-    return 1000;
+    return 2000;
   }
 }

--- a/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/provider/SecondResourceProvider.java
+++ b/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/provider/SecondResourceProvider.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
@@ -12,20 +12,15 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
 import io.opentelemetry.sdk.resources.Resource;
 
-public class FirstResourceProvider implements ResourceProvider {
+public class SecondResourceProvider implements ResourceProvider {
 
   @Override
   public Resource createResource(ConfigProperties config) {
-    return Resource.create(
-        Attributes.of(
-            stringKey("otel.some_resource"),
-            "unused",
-            stringKey("otel.from_config"),
-            config.getString("otel.from-config", "default")));
+    return Resource.create(Attributes.of(stringKey("otel.some_resource"), "still unused"));
   }
 
   @Override
   public int order() {
-    return 100;
+    return 200;
   }
 }

--- a/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/provider/ThirdCustomizerProvider.java
+++ b/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/provider/ThirdCustomizerProvider.java
@@ -3,22 +3,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import static java.util.Collections.singletonMap;
 
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 
-public class SecondCustomizerProvider implements AutoConfigurationCustomizerProvider {
+public class ThirdCustomizerProvider implements AutoConfigurationCustomizerProvider {
 
   @Override
   public void customize(AutoConfigurationCustomizer autoConfiguration) {
-    autoConfiguration.addPropertiesSupplier(() -> singletonMap("otel.from-config", "still unused"));
+    autoConfiguration.addPropertiesSupplier(
+        () -> singletonMap("otel.from-config", "configured value"));
   }
 
   @Override
   public int order() {
-    return 2000;
+    return 3000;
   }
 }

--- a/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/provider/ThirdResourceProvider.java
+++ b/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/provider/ThirdResourceProvider.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
@@ -12,15 +12,15 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
 import io.opentelemetry.sdk.resources.Resource;
 
-public class SecondResourceProvider implements ResourceProvider {
+public class ThirdResourceProvider implements ResourceProvider {
 
   @Override
   public Resource createResource(ConfigProperties config) {
-    return Resource.create(Attributes.of(stringKey("otel.some_resource"), "still unused"));
+    return Resource.create(Attributes.of(stringKey("otel.some_resource"), "real value"));
   }
 
   @Override
   public int order() {
-    return 200;
+    return 300;
   }
 }

--- a/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider
+++ b/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider
@@ -1,3 +1,3 @@
-io.opentelemetry.sdk.autoconfigure.SecondCustomizerProvider
-io.opentelemetry.sdk.autoconfigure.ThirdCustomizerProvider
-io.opentelemetry.sdk.autoconfigure.FirstCustomizerProvider
+io.opentelemetry.sdk.autoconfigure.provider.SecondCustomizerProvider
+io.opentelemetry.sdk.autoconfigure.provider.ThirdCustomizerProvider
+io.opentelemetry.sdk.autoconfigure.provider.FirstCustomizerProvider

--- a/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
+++ b/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
@@ -1,3 +1,3 @@
-io.opentelemetry.sdk.autoconfigure.ThirdResourceProvider
-io.opentelemetry.sdk.autoconfigure.SecondResourceProvider
-io.opentelemetry.sdk.autoconfigure.FirstResourceProvider
+io.opentelemetry.sdk.autoconfigure.provider.ThirdResourceProvider
+io.opentelemetry.sdk.autoconfigure.provider.SecondResourceProvider
+io.opentelemetry.sdk.autoconfigure.provider.FirstResourceProvider

--- a/sdk-extensions/autoconfigure/src/testConditionalResourceProvider/java/io/opentelemetry/sdk/autoconfigure/provider/FirstResourceProvider.java
+++ b/sdk-extensions/autoconfigure/src/testConditionalResourceProvider/java/io/opentelemetry/sdk/autoconfigure/provider/FirstResourceProvider.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;

--- a/sdk-extensions/autoconfigure/src/testConditionalResourceProvider/java/io/opentelemetry/sdk/autoconfigure/provider/SecondResourceProvider.java
+++ b/sdk-extensions/autoconfigure/src/testConditionalResourceProvider/java/io/opentelemetry/sdk/autoconfigure/provider/SecondResourceProvider.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;

--- a/sdk-extensions/autoconfigure/src/testConditionalResourceProvider/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
+++ b/sdk-extensions/autoconfigure/src/testConditionalResourceProvider/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
@@ -1,2 +1,2 @@
-io.opentelemetry.sdk.autoconfigure.SecondResourceProvider
-io.opentelemetry.sdk.autoconfigure.FirstResourceProvider
+io.opentelemetry.sdk.autoconfigure.provider.SecondResourceProvider
+io.opentelemetry.sdk.autoconfigure.provider.FirstResourceProvider

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableLogRecordExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableLogRecordExporterTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.sdk.autoconfigure.provider.TestConfigurableLogRecordExporterProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableMetricExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableMetricExporterTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
+import io.opentelemetry.sdk.autoconfigure.provider.TestConfigurableMetricExporterProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSamplerTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSamplerTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.sdk.autoconfigure.provider.TestConfigurableSamplerProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
@@ -13,6 +13,7 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
+import io.opentelemetry.sdk.autoconfigure.provider.TestConfigurableSpanExporterProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FullConfigTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FullConfigTest.java
@@ -18,6 +18,7 @@ import io.grpc.stub.StreamObserver;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.logs.GlobalLoggerProvider;
 import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.metrics.Meter;
@@ -156,6 +157,7 @@ class FullConfigTest {
 
     // Initialize here so we can shutdown when done
     GlobalOpenTelemetry.resetForTest();
+    GlobalLoggerProvider.resetForTest();
     autoConfiguredOpenTelemetrySdk = AutoConfiguredOpenTelemetrySdk.initialize();
   }
 
@@ -176,6 +178,8 @@ class FullConfigTest {
         .getSdkTracerProvider()
         .shutdown()
         .join(10, TimeUnit.SECONDS);
+    GlobalOpenTelemetry.resetForTest();
+    GlobalLoggerProvider.resetForTest();
   }
 
   @Test
@@ -210,8 +214,7 @@ class FullConfigTest {
         .add(1, Attributes.builder().put("allowed", "bear").put("not allowed", "dog").build());
     meter.counterBuilder("my-other-metric").build().add(1);
 
-    Logger logger =
-        autoConfiguredOpenTelemetrySdk.getOpenTelemetrySdk().getSdkLoggerProvider().get("test");
+    Logger logger = GlobalLoggerProvider.get().get("test");
     logger.logRecordBuilder().setBody("debug log message").setSeverity(Severity.DEBUG).emit();
     logger.logRecordBuilder().setBody("info log message").setSeverity(Severity.INFO).emit();
 

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
@@ -50,7 +50,7 @@ class ResourceConfigurationTest {
     Map<String, String> customConfigs = new HashMap<>(1);
     customConfigs.put(
         "otel.java.enabled.resource.providers",
-        "io.opentelemetry.sdk.autoconfigure.TestAnimalResourceProvider");
+        "io.opentelemetry.sdk.autoconfigure.provider.TestAnimalResourceProvider");
     Attributes attributes =
         ResourceConfiguration.configureResource(
                 DefaultConfigProperties.create(customConfigs),
@@ -67,7 +67,7 @@ class ResourceConfigurationTest {
     Map<String, String> customConfigs = new HashMap<>(2);
     customConfigs.put(
         "otel.java.enabled.resource.providers",
-        "io.opentelemetry.sdk.autoconfigure.TestAnimalResourceProvider");
+        "io.opentelemetry.sdk.autoconfigure.provider.TestAnimalResourceProvider");
     customConfigs.put(
         "otel.java.disabled.resource.providers",
         "io.opentelemetry.sdk.extension.resources.TestColorResourceProvider");
@@ -87,7 +87,7 @@ class ResourceConfigurationTest {
     Map<String, String> customConfigs = new HashMap<>(1);
     customConfigs.put(
         "otel.java.disabled.resource.providers",
-        "io.opentelemetry.sdk.autoconfigure.TestColorResourceProvider");
+        "io.opentelemetry.sdk.autoconfigure.provider.TestColorResourceProvider");
     Attributes attributes =
         ResourceConfiguration.configureResource(
                 DefaultConfigProperties.create(customConfigs),

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/LogRecordExporterCustomizer.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/LogRecordExporterCustomizer.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/MetricCustomizer.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/MetricCustomizer.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/NotEnabledConfigurablePropagatorProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/NotEnabledConfigurablePropagatorProvider.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/SpanExporterCustomizer.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/SpanExporterCustomizer.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestAnimalResourceProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestAnimalResourceProvider.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestColorResourceProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestColorResourceProvider.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestConfigurableLogRecordExporterProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestConfigurableLogRecordExporterProvider.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestConfigurableMetricExporterProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestConfigurableMetricExporterProvider.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestConfigurablePropagatorProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestConfigurablePropagatorProvider.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestConfigurableSamplerProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestConfigurableSamplerProvider.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestConfigurableSpanExporterProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestConfigurableSpanExporterProvider.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestTracerProviderConfigurer.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestTracerProviderConfigurer.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/ThrowingConfigurableLogRecordExporterProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/ThrowingConfigurableLogRecordExporterProvider.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/ThrowingConfigurableMetricExporterProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/ThrowingConfigurableMetricExporterProvider.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/ThrowingConfigurablePropagatorProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/ThrowingConfigurablePropagatorProvider.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/ThrowingConfigurableSamplerProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/ThrowingConfigurableSamplerProvider.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/ThrowingConfigurableSpanExporterProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/ThrowingConfigurableSpanExporterProvider.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.autoconfigure.provider;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider
@@ -1,3 +1,3 @@
-io.opentelemetry.sdk.autoconfigure.SpanExporterCustomizer
-io.opentelemetry.sdk.autoconfigure.MetricCustomizer
-io.opentelemetry.sdk.autoconfigure.LogRecordExporterCustomizer
+io.opentelemetry.sdk.autoconfigure.provider.SpanExporterCustomizer
+io.opentelemetry.sdk.autoconfigure.provider.MetricCustomizer
+io.opentelemetry.sdk.autoconfigure.provider.LogRecordExporterCustomizer

--- a/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider
@@ -1,2 +1,2 @@
-io.opentelemetry.sdk.autoconfigure.TestConfigurablePropagatorProvider
-io.opentelemetry.sdk.autoconfigure.ThrowingConfigurablePropagatorProvider
+io.opentelemetry.sdk.autoconfigure.provider.TestConfigurablePropagatorProvider
+io.opentelemetry.sdk.autoconfigure.provider.ThrowingConfigurablePropagatorProvider

--- a/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
@@ -1,2 +1,2 @@
-io.opentelemetry.sdk.autoconfigure.TestAnimalResourceProvider
-io.opentelemetry.sdk.autoconfigure.TestColorResourceProvider
+io.opentelemetry.sdk.autoconfigure.provider.TestAnimalResourceProvider
+io.opentelemetry.sdk.autoconfigure.provider.TestColorResourceProvider

--- a/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider
@@ -1,2 +1,2 @@
-io.opentelemetry.sdk.autoconfigure.TestConfigurableLogRecordExporterProvider
-io.opentelemetry.sdk.autoconfigure.ThrowingConfigurableLogRecordExporterProvider
+io.opentelemetry.sdk.autoconfigure.provider.TestConfigurableLogRecordExporterProvider
+io.opentelemetry.sdk.autoconfigure.provider.ThrowingConfigurableLogRecordExporterProvider

--- a/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider
@@ -1,2 +1,2 @@
-io.opentelemetry.sdk.autoconfigure.TestConfigurableMetricExporterProvider
-io.opentelemetry.sdk.autoconfigure.ThrowingConfigurableMetricExporterProvider
+io.opentelemetry.sdk.autoconfigure.provider.TestConfigurableMetricExporterProvider
+io.opentelemetry.sdk.autoconfigure.provider.ThrowingConfigurableMetricExporterProvider

--- a/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider
@@ -1,2 +1,2 @@
-io.opentelemetry.sdk.autoconfigure.TestConfigurableSamplerProvider
-io.opentelemetry.sdk.autoconfigure.ThrowingConfigurableSamplerProvider
+io.opentelemetry.sdk.autoconfigure.provider.TestConfigurableSamplerProvider
+io.opentelemetry.sdk.autoconfigure.provider.ThrowingConfigurableSamplerProvider

--- a/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider
@@ -1,2 +1,2 @@
-io.opentelemetry.sdk.autoconfigure.TestConfigurableSpanExporterProvider
-io.opentelemetry.sdk.autoconfigure.ThrowingConfigurableSpanExporterProvider
+io.opentelemetry.sdk.autoconfigure.provider.TestConfigurableSpanExporterProvider
+io.opentelemetry.sdk.autoconfigure.provider.ThrowingConfigurableSpanExporterProvider

--- a/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer
@@ -1,1 +1,1 @@
-io.opentelemetry.sdk.autoconfigure.TestTracerProviderConfigurer
+io.opentelemetry.sdk.autoconfigure.provider.TestTracerProviderConfigurer


### PR DESCRIPTION
- Move test SPI implementations to `*.provider` package. There's a lot of implementations which make it hard to evaluate which classes actually contain test code. 
- Suppress logs from code testing deprecated exemplar filter options
- Cleanup global after test in FullConfigTest