### PR TITLE
Add toString to SdkMeter, SdkObservableInstrument, AbstractInstrumentBuilder

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleCounter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleCounter.java
@@ -97,41 +97,44 @@ final class SdkDoubleCounter extends AbstractInstrument implements DoubleCounter
     }
   }
 
-  static final class Builder extends AbstractInstrumentBuilder<SdkDoubleCounter.Builder>
-      implements DoubleCounterBuilder {
+  static final class SdkDoubleCounterBuilder
+      extends AbstractInstrumentBuilder<SdkDoubleCounterBuilder> implements DoubleCounterBuilder {
 
-    Builder(
+    SdkDoubleCounterBuilder(
         MeterProviderSharedState meterProviderSharedState,
         MeterSharedState sharedState,
         String name,
         String description,
         String unit) {
-      super(meterProviderSharedState, sharedState, name, description, unit);
+      super(
+          meterProviderSharedState,
+          sharedState,
+          InstrumentType.COUNTER,
+          InstrumentValueType.DOUBLE,
+          name,
+          description,
+          unit);
     }
 
     @Override
-    protected Builder getThis() {
+    protected SdkDoubleCounterBuilder getThis() {
       return this;
     }
 
     @Override
     public SdkDoubleCounter build() {
-      return buildSynchronousInstrument(
-          InstrumentType.COUNTER, InstrumentValueType.DOUBLE, SdkDoubleCounter::new);
+      return buildSynchronousInstrument(SdkDoubleCounter::new);
     }
 
     @Override
     public ObservableDoubleCounter buildWithCallback(
         Consumer<ObservableDoubleMeasurement> callback) {
-      return new SdkObservableInstrument(
-          meterSharedState,
-          registerDoubleAsynchronousInstrument(InstrumentType.OBSERVABLE_COUNTER, callback));
+      return registerDoubleAsynchronousInstrument(InstrumentType.OBSERVABLE_COUNTER, callback);
     }
 
     @Override
     public ObservableDoubleMeasurement buildObserver() {
-      return buildObservableMeasurement(
-          InstrumentType.OBSERVABLE_COUNTER, InstrumentValueType.DOUBLE);
+      return buildObservableMeasurement(InstrumentType.OBSERVABLE_COUNTER);
     }
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleGaugeBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleGaugeBuilder.java
@@ -20,7 +20,14 @@ final class SdkDoubleGaugeBuilder extends AbstractInstrumentBuilder<SdkDoubleGau
       MeterProviderSharedState meterProviderSharedState,
       MeterSharedState meterSharedState,
       String name) {
-    super(meterProviderSharedState, meterSharedState, name, "", DEFAULT_UNIT);
+    super(
+        meterProviderSharedState,
+        meterSharedState,
+        InstrumentType.OBSERVABLE_GAUGE,
+        InstrumentValueType.DOUBLE,
+        name,
+        "",
+        DEFAULT_UNIT);
   }
 
   @Override
@@ -35,13 +42,11 @@ final class SdkDoubleGaugeBuilder extends AbstractInstrumentBuilder<SdkDoubleGau
 
   @Override
   public ObservableDoubleGauge buildWithCallback(Consumer<ObservableDoubleMeasurement> callback) {
-    return new SdkObservableInstrument(
-        meterSharedState,
-        registerDoubleAsynchronousInstrument(InstrumentType.OBSERVABLE_GAUGE, callback));
+    return registerDoubleAsynchronousInstrument(InstrumentType.OBSERVABLE_GAUGE, callback);
   }
 
   @Override
   public ObservableDoubleMeasurement buildObserver() {
-    return buildObservableMeasurement(InstrumentType.OBSERVABLE_GAUGE, InstrumentValueType.DOUBLE);
+    return buildObservableMeasurement(InstrumentType.OBSERVABLE_GAUGE);
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleHistogram.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleHistogram.java
@@ -95,30 +95,37 @@ final class SdkDoubleHistogram extends AbstractInstrument implements DoubleHisto
     }
   }
 
-  static final class Builder extends AbstractInstrumentBuilder<SdkDoubleHistogram.Builder>
+  static final class SdkDoubleHistogramBuilder
+      extends AbstractInstrumentBuilder<SdkDoubleHistogramBuilder>
       implements DoubleHistogramBuilder {
 
-    Builder(
+    SdkDoubleHistogramBuilder(
         MeterProviderSharedState meterProviderSharedState,
         MeterSharedState meterSharedState,
         String name) {
-      super(meterProviderSharedState, meterSharedState, name, "", DEFAULT_UNIT);
+      super(
+          meterProviderSharedState,
+          meterSharedState,
+          InstrumentType.HISTOGRAM,
+          InstrumentValueType.DOUBLE,
+          name,
+          "",
+          DEFAULT_UNIT);
     }
 
     @Override
-    protected Builder getThis() {
+    protected SdkDoubleHistogramBuilder getThis() {
       return this;
     }
 
     @Override
     public SdkDoubleHistogram build() {
-      return buildSynchronousInstrument(
-          InstrumentType.HISTOGRAM, InstrumentValueType.DOUBLE, SdkDoubleHistogram::new);
+      return buildSynchronousInstrument(SdkDoubleHistogram::new);
     }
 
     @Override
     public LongHistogramBuilder ofLongs() {
-      return swapBuilder(SdkLongHistogram.Builder::new);
+      return swapBuilder(SdkLongHistogram.SdkLongHistogramBuilder::new);
     }
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleUpDownCounter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleUpDownCounter.java
@@ -72,42 +72,46 @@ final class SdkDoubleUpDownCounter extends AbstractInstrument implements DoubleU
     }
   }
 
-  static final class Builder extends AbstractInstrumentBuilder<SdkDoubleUpDownCounter.Builder>
+  static final class SdkDoubleUpDownCounterBuilder
+      extends AbstractInstrumentBuilder<SdkDoubleUpDownCounterBuilder>
       implements DoubleUpDownCounterBuilder {
 
-    Builder(
+    SdkDoubleUpDownCounterBuilder(
         MeterProviderSharedState meterProviderSharedState,
         MeterSharedState sharedState,
         String name,
         String description,
         String unit) {
-      super(meterProviderSharedState, sharedState, name, description, unit);
+      super(
+          meterProviderSharedState,
+          sharedState,
+          InstrumentType.UP_DOWN_COUNTER,
+          InstrumentValueType.DOUBLE,
+          name,
+          description,
+          unit);
     }
 
     @Override
-    protected Builder getThis() {
+    protected SdkDoubleUpDownCounterBuilder getThis() {
       return this;
     }
 
     @Override
     public DoubleUpDownCounter build() {
-      return buildSynchronousInstrument(
-          InstrumentType.UP_DOWN_COUNTER, InstrumentValueType.DOUBLE, SdkDoubleUpDownCounter::new);
+      return buildSynchronousInstrument(SdkDoubleUpDownCounter::new);
     }
 
     @Override
     public ObservableDoubleUpDownCounter buildWithCallback(
         Consumer<ObservableDoubleMeasurement> callback) {
-      return new SdkObservableInstrument(
-          meterSharedState,
-          registerDoubleAsynchronousInstrument(
-              InstrumentType.OBSERVABLE_UP_DOWN_COUNTER, callback));
+      return registerDoubleAsynchronousInstrument(
+          InstrumentType.OBSERVABLE_UP_DOWN_COUNTER, callback);
     }
 
     @Override
     public ObservableDoubleMeasurement buildObserver() {
-      return buildObservableMeasurement(
-          InstrumentType.OBSERVABLE_UP_DOWN_COUNTER, InstrumentValueType.DOUBLE);
+      return buildObservableMeasurement(InstrumentType.OBSERVABLE_UP_DOWN_COUNTER);
     }
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongCounter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongCounter.java
@@ -99,43 +99,46 @@ final class SdkLongCounter extends AbstractInstrument implements LongCounter {
     }
   }
 
-  static final class Builder extends AbstractInstrumentBuilder<Builder>
+  static final class SdkLongCounterBuilder extends AbstractInstrumentBuilder<SdkLongCounterBuilder>
       implements LongCounterBuilder {
 
-    Builder(
+    SdkLongCounterBuilder(
         MeterProviderSharedState meterProviderSharedState,
         MeterSharedState meterSharedState,
         String name) {
-      super(meterProviderSharedState, meterSharedState, name, "", DEFAULT_UNIT);
+      super(
+          meterProviderSharedState,
+          meterSharedState,
+          InstrumentType.COUNTER,
+          InstrumentValueType.LONG,
+          name,
+          "",
+          DEFAULT_UNIT);
     }
 
     @Override
-    protected Builder getThis() {
+    protected SdkLongCounterBuilder getThis() {
       return this;
     }
 
     @Override
     public SdkLongCounter build() {
-      return buildSynchronousInstrument(
-          InstrumentType.COUNTER, InstrumentValueType.LONG, SdkLongCounter::new);
+      return buildSynchronousInstrument(SdkLongCounter::new);
     }
 
     @Override
     public DoubleCounterBuilder ofDoubles() {
-      return swapBuilder(SdkDoubleCounter.Builder::new);
+      return swapBuilder(SdkDoubleCounter.SdkDoubleCounterBuilder::new);
     }
 
     @Override
     public ObservableLongCounter buildWithCallback(Consumer<ObservableLongMeasurement> callback) {
-      return new SdkObservableInstrument(
-          meterSharedState,
-          registerLongAsynchronousInstrument(InstrumentType.OBSERVABLE_COUNTER, callback));
+      return registerLongAsynchronousInstrument(InstrumentType.OBSERVABLE_COUNTER, callback);
     }
 
     @Override
     public ObservableLongMeasurement buildObserver() {
-      return buildObservableMeasurement(
-          InstrumentType.OBSERVABLE_COUNTER, InstrumentValueType.LONG);
+      return buildObservableMeasurement(InstrumentType.OBSERVABLE_COUNTER);
     }
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongGaugeBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongGaugeBuilder.java
@@ -21,7 +21,14 @@ final class SdkLongGaugeBuilder extends AbstractInstrumentBuilder<SdkLongGaugeBu
       String name,
       String description,
       String unit) {
-    super(meterProviderSharedState, sharedState, name, description, unit);
+    super(
+        meterProviderSharedState,
+        sharedState,
+        InstrumentType.OBSERVABLE_GAUGE,
+        InstrumentValueType.LONG,
+        name,
+        description,
+        unit);
   }
 
   @Override
@@ -31,13 +38,11 @@ final class SdkLongGaugeBuilder extends AbstractInstrumentBuilder<SdkLongGaugeBu
 
   @Override
   public ObservableLongGauge buildWithCallback(Consumer<ObservableLongMeasurement> callback) {
-    return new SdkObservableInstrument(
-        meterSharedState,
-        registerLongAsynchronousInstrument(InstrumentType.OBSERVABLE_GAUGE, callback));
+    return registerLongAsynchronousInstrument(InstrumentType.OBSERVABLE_GAUGE, callback);
   }
 
   @Override
   public ObservableLongMeasurement buildObserver() {
-    return buildObservableMeasurement(InstrumentType.OBSERVABLE_GAUGE, InstrumentValueType.LONG);
+    return buildObservableMeasurement(InstrumentType.OBSERVABLE_GAUGE);
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongHistogram.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongHistogram.java
@@ -94,27 +94,33 @@ final class SdkLongHistogram extends AbstractInstrument implements LongHistogram
     }
   }
 
-  static final class Builder extends AbstractInstrumentBuilder<SdkLongHistogram.Builder>
-      implements LongHistogramBuilder {
+  static final class SdkLongHistogramBuilder
+      extends AbstractInstrumentBuilder<SdkLongHistogramBuilder> implements LongHistogramBuilder {
 
-    Builder(
+    SdkLongHistogramBuilder(
         MeterProviderSharedState meterProviderSharedState,
         MeterSharedState sharedState,
         String name,
         String description,
         String unit) {
-      super(meterProviderSharedState, sharedState, name, description, unit);
+      super(
+          meterProviderSharedState,
+          sharedState,
+          InstrumentType.HISTOGRAM,
+          InstrumentValueType.LONG,
+          name,
+          description,
+          unit);
     }
 
     @Override
-    protected Builder getThis() {
+    protected SdkLongHistogramBuilder getThis() {
       return this;
     }
 
     @Override
     public SdkLongHistogram build() {
-      return buildSynchronousInstrument(
-          InstrumentType.HISTOGRAM, InstrumentValueType.LONG, SdkLongHistogram::new);
+      return buildSynchronousInstrument(SdkLongHistogram::new);
     }
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongUpDownCounter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongUpDownCounter.java
@@ -73,44 +73,49 @@ final class SdkLongUpDownCounter extends AbstractInstrument implements LongUpDow
     }
   }
 
-  static final class Builder extends AbstractInstrumentBuilder<SdkLongUpDownCounter.Builder>
+  static final class SdkLongUpDownCounterBuilder
+      extends AbstractInstrumentBuilder<SdkLongUpDownCounterBuilder>
       implements LongUpDownCounterBuilder {
 
-    Builder(
+    SdkLongUpDownCounterBuilder(
         MeterProviderSharedState meterProviderSharedState,
         MeterSharedState meterSharedState,
         String name) {
-      super(meterProviderSharedState, meterSharedState, name, "", DEFAULT_UNIT);
+      super(
+          meterProviderSharedState,
+          meterSharedState,
+          InstrumentType.UP_DOWN_COUNTER,
+          InstrumentValueType.LONG,
+          name,
+          "",
+          DEFAULT_UNIT);
     }
 
     @Override
-    protected Builder getThis() {
+    protected SdkLongUpDownCounterBuilder getThis() {
       return this;
     }
 
     @Override
     public LongUpDownCounter build() {
-      return buildSynchronousInstrument(
-          InstrumentType.UP_DOWN_COUNTER, InstrumentValueType.LONG, SdkLongUpDownCounter::new);
+      return buildSynchronousInstrument(SdkLongUpDownCounter::new);
     }
 
     @Override
     public DoubleUpDownCounterBuilder ofDoubles() {
-      return swapBuilder(SdkDoubleUpDownCounter.Builder::new);
+      return swapBuilder(SdkDoubleUpDownCounter.SdkDoubleUpDownCounterBuilder::new);
     }
 
     @Override
     public ObservableLongUpDownCounter buildWithCallback(
         Consumer<ObservableLongMeasurement> callback) {
-      return new SdkObservableInstrument(
-          meterSharedState,
-          registerLongAsynchronousInstrument(InstrumentType.OBSERVABLE_UP_DOWN_COUNTER, callback));
+      return registerLongAsynchronousInstrument(
+          InstrumentType.OBSERVABLE_UP_DOWN_COUNTER, callback);
     }
 
     @Override
     public ObservableLongMeasurement buildObserver() {
-      return buildObservableMeasurement(
-          InstrumentType.OBSERVABLE_UP_DOWN_COUNTER, InstrumentValueType.LONG);
+      return buildObservableMeasurement(InstrumentType.OBSERVABLE_UP_DOWN_COUNTER);
     }
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java
@@ -76,21 +76,24 @@ final class SdkMeter implements Meter {
   public LongCounterBuilder counterBuilder(String name) {
     return !ValidationUtil.checkValidInstrumentName(name, NOOP_INSTRUMENT_WARNING)
         ? NOOP_METER.counterBuilder(NOOP_INSTRUMENT_NAME)
-        : new SdkLongCounter.Builder(meterProviderSharedState, meterSharedState, name);
+        : new SdkLongCounter.SdkLongCounterBuilder(
+            meterProviderSharedState, meterSharedState, name);
   }
 
   @Override
   public LongUpDownCounterBuilder upDownCounterBuilder(String name) {
     return !ValidationUtil.checkValidInstrumentName(name, NOOP_INSTRUMENT_WARNING)
         ? NOOP_METER.upDownCounterBuilder(NOOP_INSTRUMENT_NAME)
-        : new SdkLongUpDownCounter.Builder(meterProviderSharedState, meterSharedState, name);
+        : new SdkLongUpDownCounter.SdkLongUpDownCounterBuilder(
+            meterProviderSharedState, meterSharedState, name);
   }
 
   @Override
   public DoubleHistogramBuilder histogramBuilder(String name) {
     return !ValidationUtil.checkValidInstrumentName(name, NOOP_INSTRUMENT_WARNING)
         ? NOOP_METER.histogramBuilder(NOOP_INSTRUMENT_NAME)
-        : new SdkDoubleHistogram.Builder(meterProviderSharedState, meterSharedState, name);
+        : new SdkDoubleHistogram.SdkDoubleHistogramBuilder(
+            meterProviderSharedState, meterSharedState, name);
   }
 
   @Override
@@ -133,5 +136,10 @@ final class SdkMeter implements Meter {
         CallbackRegistration.create(sdkMeasurements, callback);
     meterSharedState.registerCallback(callbackRegistration);
     return new SdkObservableInstrument(meterSharedState, callbackRegistration);
+  }
+
+  @Override
+  public String toString() {
+    return "SdkMeter{instrumentationScopeInfo=" + instrumentationScopeInfo + "}";
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkObservableInstrument.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkObservableInstrument.java
@@ -45,10 +45,14 @@ class SdkObservableInstrument
   public void close() {
     if (!removed.compareAndSet(false, true)) {
       throttlingLogger.log(
-          Level.WARNING,
-          callbackRegistration.getCallbackDescription() + " has called close() multiple times.");
+          Level.WARNING, callbackRegistration + " has called close() multiple times.");
       return;
     }
     meterSharedState.removeCallback(callbackRegistration);
+  }
+
+  @Override
+  public String toString() {
+    return "SdkObservableInstrument{callback=" + callbackRegistration + "}";
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentBuilderTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
+import io.opentelemetry.sdk.metrics.internal.state.MeterProviderSharedState;
+import io.opentelemetry.sdk.metrics.internal.state.MeterSharedState;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.testing.time.TestClock;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class AbstractInstrumentBuilderTest {
+
+  @Test
+  void stringRepresentation() {
+    InstrumentationScopeInfo scope = InstrumentationScopeInfo.create("scope-name");
+    TestInstrumentBuilder builder =
+        new TestInstrumentBuilder(
+            MeterProviderSharedState.create(
+                TestClock.create(), Resource.getDefault(), ExemplarFilter.alwaysOff(), 0),
+            MeterSharedState.create(scope, Collections.emptyList()),
+            InstrumentType.COUNTER,
+            InstrumentValueType.LONG,
+            "instrument-name",
+            "instrument-description",
+            "instrument-unit");
+    assertThat(builder.toString())
+        .isEqualTo(
+            "TestInstrumentBuilder{"
+                + "descriptor="
+                + "InstrumentDescriptor{"
+                + "name=instrument-name, "
+                + "description=instrument-description, "
+                + "unit=instrument-unit, "
+                + "type=COUNTER, "
+                + "valueType=LONG"
+                + "}}");
+  }
+
+  private static class TestInstrumentBuilder
+      extends AbstractInstrumentBuilder<TestInstrumentBuilder> {
+
+    TestInstrumentBuilder(
+        MeterProviderSharedState meterProviderSharedState,
+        MeterSharedState meterSharedState,
+        InstrumentType type,
+        InstrumentValueType valueType,
+        String name,
+        String description,
+        String unit) {
+      super(meterProviderSharedState, meterSharedState, type, valueType, name, description, unit);
+    }
+
+    @Override
+    protected TestInstrumentBuilder getThis() {
+      return this;
+    }
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AbstractInstrumentTest.java
@@ -23,7 +23,7 @@ class AbstractInstrumentTest {
   }
 
   @Test
-  void testToString() {
+  void stringRepresentation() {
     TestInstrument testInstrument = new TestInstrument(INSTRUMENT_DESCRIPTOR);
     assertThat(testInstrument)
         .hasToString("TestInstrument{descriptor=" + INSTRUMENT_DESCRIPTOR + "}");

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterTest.java
@@ -453,4 +453,17 @@ class SdkMeterTest {
     sdkMeter.gaugeBuilder("doubleValueObserver").buildWithCallback(x -> {});
     logs.assertContains("Found duplicate metric definition");
   }
+
+  @Test
+  void stringRepresentation() {
+    assertThat(sdkMeter.toString())
+        .isEqualTo(
+            "SdkMeter{"
+                + "instrumentationScopeInfo=InstrumentationScopeInfo{"
+                + "name=io.opentelemetry.sdk.metrics.SdkMeterTest, "
+                + "version=null, "
+                + "schemaUrl=null, "
+                + "attributes={}"
+                + "}}");
+  }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/CallbackRegistrationTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/CallbackRegistrationTest.java
@@ -86,16 +86,43 @@ class CallbackRegistrationTest {
   }
 
   @Test
-  void callbackDescription() {
-    assertThatThrownBy(() -> CallbackRegistration.callbackDescription(Collections.emptyList()))
+  void stringRepresentation() {
+    Runnable callback = () -> {};
+    assertThatThrownBy(() -> CallbackRegistration.create(Collections.emptyList(), callback))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Callback with no instruments is not allowed");
-    assertThat(CallbackRegistration.callbackDescription(Collections.singletonList(LONG_INSTRUMENT)))
-        .isEqualTo("Instrument long-counter");
     assertThat(
-            CallbackRegistration.callbackDescription(
-                Arrays.asList(LONG_INSTRUMENT, DOUBLE_INSTRUMENT)))
-        .isEqualTo("BatchCallback([long-counter,double-counter])");
+            CallbackRegistration.create(Collections.singletonList(measurement1), callback)
+                .toString())
+        .isEqualTo(
+            "CallbackRegistration{"
+                + "instrumentDescriptors=["
+                + "InstrumentDescriptor{"
+                + "name=double-counter, "
+                + "description=description, "
+                + "unit=unit, "
+                + "type=OBSERVABLE_COUNTER, "
+                + "valueType=LONG"
+                + "}]}");
+    assertThat(
+            CallbackRegistration.create(Arrays.asList(measurement1, measurement2), callback)
+                .toString())
+        .isEqualTo(
+            "CallbackRegistration{"
+                + "instrumentDescriptors=["
+                + "InstrumentDescriptor{"
+                + "name=double-counter, "
+                + "description=description, "
+                + "unit=unit, "
+                + "type=OBSERVABLE_COUNTER, "
+                + "valueType=LONG}, "
+                + "InstrumentDescriptor{"
+                + "name=long-counter, "
+                + "description=description, "
+                + "unit=unit, "
+                + "type=OBSERVABLE_COUNTER, "
+                + "valueType=LONG"
+                + "}]}");
   }
 
   @Test
@@ -189,8 +216,7 @@ class CallbackRegistrationTest {
     verify(storage1, never()).recordDouble(anyDouble(), any());
     verify(storage2, never()).recordDouble(anyDouble(), any());
     verify(storage3, never()).recordDouble(anyDouble(), any());
-    logs.assertContains(
-        "An exception occurred invoking callback for BatchCallback([double-counter,long-counter])");
+    logs.assertContains("An exception occurred invoking callback");
   }
 
   @Test
@@ -208,6 +234,6 @@ class CallbackRegistrationTest {
     verify(storage2, never()).recordDouble(anyDouble(), any());
     verify(storage3, never()).recordDouble(anyDouble(), any());
 
-    logs.assertContains("An exception occurred invoking callback for Instrument long-counter");
+    logs.assertContains("An exception occurred invoking callback");
   }
 }


### PR DESCRIPTION
Resolves #5013.

The sample code I posted [here](https://github.com/open-telemetry/opentelemetry-java/issues/5013#issuecomment-1339733154) now prints:
```
io.opentelemetry.sdk.metrics.SdkMeterProvider: SdkMeterProvider{clock=SystemClock{}, resource=Resource{schemaUrl=null, attributes={service.name="unknown_service:java", telemetry.sdk.language="java", telemetry.sdk.name="opentelemetry", telemetry.sdk.version="1.22.0-SNAPSHOT"}}, metricReaders=[InMemoryMetricReader{aggregationTemporality=CUMULATIVE}], views=[]}
io.opentelemetry.sdk.metrics.SdkMeter: SdkMeter{instrumentationScopeInfo=InstrumentationScopeInfo{name=meter, version=null, schemaUrl=null, attributes={}}}
io.opentelemetry.sdk.metrics.SdkLongCounter$SdkLongCounterBuilder: SdkLongCounterBuilder{instrumentDescriptor=InstrumentDescriptor{name=counter, description=, unit=, type=COUNTER, valueType=LONG}}
io.opentelemetry.sdk.metrics.SdkLongCounter: SdkLongCounter{descriptor=InstrumentDescriptor{name=counter, description=, unit=, type=COUNTER, valueType=LONG}}
io.opentelemetry.sdk.metrics.SdkObservableInstrument: SdkObservableInstrument{callback=CallbackRegistration{instrumentDescriptors=[InstrumentDescriptor{name=counter, description=, unit=, type=OBSERVABLE_COUNTER, valueType=LONG}]}}
io.opentelemetry.sdk.metrics.SdkDoubleCounter$SdkDoubleCounterBuilder: SdkDoubleCounterBuilder{instrumentDescriptor=InstrumentDescriptor{name=counter, description=, unit=, type=COUNTER, valueType=DOUBLE}}
io.opentelemetry.sdk.metrics.SdkDoubleCounter: SdkDoubleCounter{descriptor=InstrumentDescriptor{name=counter, description=, unit=, type=COUNTER, valueType=DOUBLE}}
io.opentelemetry.sdk.metrics.SdkObservableInstrument: SdkObservableInstrument{callback=CallbackRegistration{instrumentDescriptors=[InstrumentDescriptor{name=counter, description=, unit=, type=OBSERVABLE_COUNTER, valueType=DOUBLE}]}}
io.opentelemetry.sdk.metrics.SdkLongUpDownCounter$SdkLongUpDownCounterBuilder: SdkLongUpDownCounterBuilder{instrumentDescriptor=InstrumentDescriptor{name=updowncounter, description=, unit=, type=UP_DOWN_COUNTER, valueType=LONG}}
io.opentelemetry.sdk.metrics.SdkLongUpDownCounter: SdkLongUpDownCounter{descriptor=InstrumentDescriptor{name=updowncounter, description=, unit=, type=UP_DOWN_COUNTER, valueType=LONG}}
io.opentelemetry.sdk.metrics.SdkObservableInstrument: SdkObservableInstrument{callback=CallbackRegistration{instrumentDescriptors=[InstrumentDescriptor{name=updowncounter, description=, unit=, type=OBSERVABLE_UP_DOWN_COUNTER, valueType=LONG}]}}
io.opentelemetry.sdk.metrics.SdkDoubleUpDownCounter$SdkDoubleUpDownCounterBuilder: SdkDoubleUpDownCounterBuilder{instrumentDescriptor=InstrumentDescriptor{name=updowncounter, description=, unit=, type=UP_DOWN_COUNTER, valueType=DOUBLE}}
io.opentelemetry.sdk.metrics.SdkDoubleUpDownCounter: SdkDoubleUpDownCounter{descriptor=InstrumentDescriptor{name=updowncounter, description=, unit=, type=UP_DOWN_COUNTER, valueType=DOUBLE}}
io.opentelemetry.sdk.metrics.SdkObservableInstrument: SdkObservableInstrument{callback=CallbackRegistration{instrumentDescriptors=[InstrumentDescriptor{name=updowncounter, description=, unit=, type=OBSERVABLE_UP_DOWN_COUNTER, valueType=LONG}]}}
io.opentelemetry.sdk.metrics.SdkDoubleHistogram$SdkDoubleHistogramBuilder: SdkDoubleHistogramBuilder{instrumentDescriptor=InstrumentDescriptor{name=histogram, description=, unit=, type=HISTOGRAM, valueType=DOUBLE}}
io.opentelemetry.sdk.metrics.SdkDoubleHistogram: SdkDoubleHistogram{descriptor=InstrumentDescriptor{name=histogram, description=, unit=, type=HISTOGRAM, valueType=DOUBLE}}
io.opentelemetry.sdk.metrics.SdkLongHistogram$SdkLongHistogramBuilder: SdkLongHistogramBuilder{instrumentDescriptor=InstrumentDescriptor{name=histogram, description=, unit=, type=HISTOGRAM, valueType=LONG}}
io.opentelemetry.sdk.metrics.SdkLongHistogram: SdkLongHistogram{descriptor=InstrumentDescriptor{name=histogram, description=, unit=, type=HISTOGRAM, valueType=LONG}}
io.opentelemetry.sdk.metrics.SdkObservableInstrument: SdkObservableInstrument{callback=CallbackRegistration{instrumentDescriptors=[InstrumentDescriptor{name=gauge, description=, unit=, type=OBSERVABLE_GAUGE, valueType=DOUBLE}]}}
io.opentelemetry.sdk.metrics.SdkObservableInstrument: SdkObservableInstrument{callback=CallbackRegistration{instrumentDescriptors=[InstrumentDescriptor{name=gauge, description=, unit=, type=OBSERVABLE_GAUGE, valueType=LONG}]}}
io.opentelemetry.sdk.metrics.SdkObservableInstrument: SdkObservableInstrument{callback=CallbackRegistration{instrumentDescriptors=[InstrumentDescriptor{name=gauge, description=, unit=, type=OBSERVABLE_GAUGE, valueType=LONG}]}}
```