### PR TITLE
chore(GHA): Update the usage of set-output command in GH actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
                             --discussion-category announcements \
                             v$VERSION
 
-          echo "::set-output name=version::$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
   merge-change-log-to-main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR updates the usage of set-output command in GH actions.

Reference : https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

ChangeLog entry is not required