### PR TITLE
Replace OTLP User-Agent spaces with dashes

### DIFF
--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/OtlpUserAgent.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/OtlpUserAgent.java
@@ -14,7 +14,7 @@ import java.util.function.BiConsumer;
  */
 public final class OtlpUserAgent {
 
-  private static final String userAgent = "OTel OTLP Exporter Java/" + readVersion();
+  private static final String userAgent = "OTel-OTLP-Exporter-Java/" + readVersion();
 
   private static String readVersion() {
     Properties properties = new Properties();

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/OtlpUserAgentTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/OtlpUserAgentTest.java
@@ -14,7 +14,7 @@ class OtlpUserAgentTest {
 
   @Test
   void getUserAgent() {
-    assertThat(OtlpUserAgent.getUserAgent()).matches("OTel OTLP Exporter Java/1\\..*");
+    assertThat(OtlpUserAgent.getUserAgent()).matches("OTel-OTLP-Exporter-Java/1\\..*");
   }
 
   @Test
@@ -27,6 +27,6 @@ class OtlpUserAgentTest {
           valueRef.set(value);
         });
     assertThat(keyRef.get()).isEqualTo("User-Agent");
-    assertThat(valueRef.get()).matches("OTel OTLP Exporter Java/1\\..*");
+    assertThat(valueRef.get()).matches("OTel-OTLP-Exporter-Java/1\\..*");
   }
 }

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
@@ -224,7 +224,7 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
         .satisfies(
             req ->
                 assertThat(req.headers().get("User-Agent"))
-                    .matches("OTel OTLP Exporter Java/1\\..*"));
+                    .matches("OTel-OTLP-Exporter-Java/1\\..*"));
   }
 
   @Test

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
@@ -248,9 +248,9 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
     assertThat(httpRequests)
         .singleElement()
         .satisfies(
-            req -> {
-              assertThat(req.headers().get("User-Agent")).matches("OTel OTLP Exporter Java/1\\..*");
-            });
+            req ->
+                assertThat(req.headers().get("User-Agent"))
+                    .matches("OTel-OTLP-Exporter-Java/1\\..*"));
   }
 
   @Test


### PR DESCRIPTION
Apparently spaces aren't allowable characters in the `<product>` portion of the `User-Agent`. See [opentelemetry-specification#3052](https://github.com/open-telemetry/opentelemetry-specification/pull/3052). 