### PR TITLE
add metrics about metric export

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
@@ -1,2 +1,5 @@
 Comparing source compatibility of  against 
-No changes.
+***! MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	---! REMOVED METHOD: PUBLIC(-) ABSTRACT(-) io.opentelemetry.sdk.metrics.export.MetricExporter createExporter(io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties)
+	+++* NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.metrics.export.MetricExporter createExporter(io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties, java.util.function.Supplier)

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
@@ -129,6 +129,12 @@ public class GrpcExporterBuilder<T extends Marshaler> {
     return this;
   }
 
+  public GrpcExporterBuilder<T> setMeterProviderSupplier(
+      Supplier<MeterProvider> meterProviderSupplier) {
+    this.meterProviderSupplier = meterProviderSupplier;
+    return this;
+  }
+
   public GrpcExporter<T> build() {
     if (grpcChannel != null) {
       return new UpstreamGrpcExporterFactory().buildWithChannel((Channel) grpcChannel);

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/OkHttpExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/OkHttpExporterBuilder.java
@@ -107,6 +107,12 @@ public final class OkHttpExporterBuilder<T extends Marshaler> {
     return this;
   }
 
+  public OkHttpExporterBuilder<T> setMeterProviderSupplier(
+      Supplier<MeterProvider> meterProviderSupplier) {
+    this.meterProviderSupplier = meterProviderSupplier;
+    return this;
+  }
+
   public OkHttpExporterBuilder<T> setRetryPolicy(RetryPolicy retryPolicy) {
     this.retryPolicy = retryPolicy;
     return this;

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/internal/LoggingMetricExporterProvider.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/internal/LoggingMetricExporterProvider.java
@@ -5,10 +5,12 @@
 
 package io.opentelemetry.exporter.logging.otlp.internal;
 
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingMetricExporter;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.function.Supplier;
 
 /**
  * {@link MetricExporter} SPI implementation for {@link OtlpJsonLoggingMetricExporter}.
@@ -18,7 +20,8 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
  */
 public class LoggingMetricExporterProvider implements ConfigurableMetricExporterProvider {
   @Override
-  public MetricExporter createExporter(ConfigProperties config) {
+  public MetricExporter createExporter(
+      ConfigProperties config, Supplier<MeterProvider> meterProviderSupplier) {
     return OtlpJsonLoggingMetricExporter.create();
   }
 

--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/internal/LoggingExporterProviderTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/internal/LoggingExporterProviderTest.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.sdk.testing.assertj.LogAssertions.assertThat;
 import io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingLogRecordExporter;
 import io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingMetricExporter;
 import io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingSpanExporter;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -29,8 +30,8 @@ class LoggingExporterProviderTest {
   void metricExporterProvider() {
     LoggingMetricExporterProvider provider = new LoggingMetricExporterProvider();
     assertThat(provider.getName()).isEqualTo("logging-otlp");
-    assertThat(
-            provider.createExporter(DefaultConfigProperties.createForTest(Collections.emptyMap())))
+    ConfigProperties config = DefaultConfigProperties.createForTest(Collections.emptyMap());
+    assertThat(provider.createExporter(config, () -> null))
         .isInstanceOf(OtlpJsonLoggingMetricExporter.class);
   }
 

--- a/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/internal/LoggingMetricExporterProvider.java
+++ b/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/internal/LoggingMetricExporterProvider.java
@@ -5,10 +5,12 @@
 
 package io.opentelemetry.exporter.logging.internal;
 
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.logging.LoggingMetricExporter;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.function.Supplier;
 
 /**
  * {@link MetricExporter} SPI implementation for {@link LoggingMetricExporter}.
@@ -18,7 +20,8 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
  */
 public class LoggingMetricExporterProvider implements ConfigurableMetricExporterProvider {
   @Override
-  public MetricExporter createExporter(ConfigProperties config) {
+  public MetricExporter createExporter(
+      ConfigProperties config, Supplier<MeterProvider> meterProviderSupplier) {
     return LoggingMetricExporter.create();
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -18,6 +18,7 @@ import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /**
  * Builder utility for {@link OtlpHttpMetricExporter}.
@@ -71,6 +72,12 @@ public final class OtlpHttpMetricExporterBuilder {
   public OtlpHttpMetricExporterBuilder setEndpoint(String endpoint) {
     requireNonNull(endpoint, "endpoint");
     delegate.setEndpoint(endpoint);
+    return this;
+  }
+
+  public OtlpHttpMetricExporterBuilder setMeterProviderSupplier(
+      Supplier<MeterProvider> meterProviderSupplier) {
+    delegate.setMeterProviderSupplier(meterProviderSupplier);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpMetricExporterProvider.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpMetricExporterProvider.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.exporter.internal.otlp.OtlpConfigUtil.DATA_TYPE_M
 import static io.opentelemetry.exporter.internal.otlp.OtlpConfigUtil.PROTOCOL_GRPC;
 import static io.opentelemetry.exporter.internal.otlp.OtlpConfigUtil.PROTOCOL_HTTP_PROTOBUF;
 
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.internal.otlp.OtlpConfigUtil;
 import io.opentelemetry.exporter.internal.retry.RetryUtil;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
@@ -19,6 +20,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.function.Supplier;
 
 /**
  * {@link MetricExporter} SPI implementation for {@link OtlpGrpcMetricExporter} and {@link
@@ -29,11 +31,13 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
  */
 public class OtlpMetricExporterProvider implements ConfigurableMetricExporterProvider {
   @Override
-  public MetricExporter createExporter(ConfigProperties config) {
+  public MetricExporter createExporter(
+      ConfigProperties config, Supplier<MeterProvider> meterProviderSupplier) {
     String protocol = OtlpConfigUtil.getOtlpProtocol(DATA_TYPE_METRICS, config);
 
     if (protocol.equals(PROTOCOL_HTTP_PROTOBUF)) {
-      OtlpHttpMetricExporterBuilder builder = httpBuilder();
+      OtlpHttpMetricExporterBuilder builder =
+          httpBuilder().setMeterProviderSupplier(meterProviderSupplier);
 
       OtlpConfigUtil.configureOtlpExporterBuilder(
           DATA_TYPE_METRICS,
@@ -52,7 +56,8 @@ public class OtlpMetricExporterProvider implements ConfigurableMetricExporterPro
 
       return builder.build();
     } else if (protocol.equals(PROTOCOL_GRPC)) {
-      OtlpGrpcMetricExporterBuilder builder = grpcBuilder();
+      OtlpGrpcMetricExporterBuilder builder =
+          grpcBuilder().setMeterProviderSupplier(meterProviderSupplier);
 
       OtlpConfigUtil.configureOtlpExporterBuilder(
           DATA_TYPE_METRICS,

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
@@ -21,6 +21,7 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /**
  * Builder utility for this exporter.
@@ -60,6 +61,12 @@ public final class OtlpGrpcMetricExporterBuilder {
             GRPC_ENDPOINT_PATH);
     delegate.setMeterProvider(MeterProvider.noop());
     OtlpUserAgent.addUserAgentHeader(delegate::addHeader);
+  }
+
+  public OtlpGrpcMetricExporterBuilder setMeterProviderSupplier(
+      Supplier<MeterProvider> meterProviderSupplier) {
+    delegate.setMeterProviderSupplier(meterProviderSupplier);
+    return this;
   }
 
   /**

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpMetricExporterProviderTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpMetricExporterProviderTest.java
@@ -93,7 +93,8 @@ class OtlpMetricExporterProviderTest {
             () ->
                 provider.createExporter(
                     DefaultConfigProperties.createForTest(
-                        Collections.singletonMap("otel.exporter.otlp.protocol", "foo"))))
+                        Collections.singletonMap("otel.exporter.otlp.protocol", "foo")),
+                    () -> null))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("Unsupported OTLP metrics protocol: foo");
   }
@@ -103,13 +104,15 @@ class OtlpMetricExporterProviderTest {
     // Verifies createExporter after resetting the spy overrides
     Mockito.reset(provider);
     try (MetricExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(Collections.emptyMap()))) {
+        provider.createExporter(
+            DefaultConfigProperties.createForTest(Collections.emptyMap()), () -> null)) {
       assertThat(exporter).isInstanceOf(OtlpGrpcMetricExporter.class);
     }
     try (MetricExporter exporter =
         provider.createExporter(
             DefaultConfigProperties.createForTest(
-                Collections.singletonMap("otel.exporter.otlp.protocol", "http/protobuf")))) {
+                Collections.singletonMap("otel.exporter.otlp.protocol", "http/protobuf")),
+            () -> null)) {
       assertThat(exporter).isInstanceOf(OtlpHttpMetricExporter.class);
     }
   }
@@ -117,7 +120,8 @@ class OtlpMetricExporterProviderTest {
   @Test
   void createExporter_GrpcDefaults() {
     try (MetricExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(Collections.emptyMap()))) {
+        provider.createExporter(
+            DefaultConfigProperties.createForTest(Collections.emptyMap()), () -> null)) {
       assertThat(exporter).isInstanceOf(OtlpGrpcMetricExporter.class);
       verify(grpcBuilder, times(1)).build();
       verify(grpcBuilder, never()).setEndpoint(any());
@@ -144,7 +148,7 @@ class OtlpMetricExporterProviderTest {
     config.put("otel.experimental.exporter.otlp.retry.enabled", "true");
 
     try (MetricExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(config))) {
+        provider.createExporter(DefaultConfigProperties.createForTest(config), () -> null)) {
       assertThat(exporter).isInstanceOf(OtlpGrpcMetricExporter.class);
       verify(grpcBuilder, times(1)).build();
       verify(grpcBuilder).setEndpoint("https://localhost:443/");
@@ -178,7 +182,7 @@ class OtlpMetricExporterProviderTest {
     config.put("otel.exporter.otlp.metrics.timeout", "15s");
 
     try (MetricExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(config))) {
+        provider.createExporter(DefaultConfigProperties.createForTest(config), () -> null)) {
       assertThat(exporter).isInstanceOf(OtlpGrpcMetricExporter.class);
       verify(grpcBuilder, times(1)).build();
       verify(grpcBuilder).setEndpoint("https://localhost:443/");
@@ -197,8 +201,8 @@ class OtlpMetricExporterProviderTest {
     try (MetricExporter exporter =
         provider.createExporter(
             DefaultConfigProperties.createForTest(
-                Collections.singletonMap(
-                    "otel.exporter.otlp.metrics.protocol", "http/protobuf")))) {
+                Collections.singletonMap("otel.exporter.otlp.metrics.protocol", "http/protobuf")),
+            () -> null)) {
       assertThat(exporter).isInstanceOf(OtlpHttpMetricExporter.class);
       verify(httpBuilder, times(1)).build();
       verify(httpBuilder, never()).setEndpoint(any());
@@ -226,7 +230,7 @@ class OtlpMetricExporterProviderTest {
     config.put("otel.experimental.exporter.otlp.retry.enabled", "true");
 
     try (MetricExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(config))) {
+        provider.createExporter(DefaultConfigProperties.createForTest(config), () -> null)) {
       assertThat(exporter).isInstanceOf(OtlpHttpMetricExporter.class);
       verify(httpBuilder, times(1)).build();
       verify(httpBuilder).setEndpoint("https://localhost:443/v1/metrics");
@@ -262,7 +266,7 @@ class OtlpMetricExporterProviderTest {
     config.put("otel.exporter.otlp.metrics.timeout", "15s");
 
     try (MetricExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(config))) {
+        provider.createExporter(DefaultConfigProperties.createForTest(config), () -> null)) {
       assertThat(exporter).isInstanceOf(OtlpHttpMetricExporter.class);
       verify(httpBuilder, times(1)).build();
       verify(httpBuilder).setEndpoint("https://localhost:443/v1/metrics");

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/metrics/ConfigurableMetricExporterProvider.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/metrics/ConfigurableMetricExporterProvider.java
@@ -5,14 +5,16 @@
 
 package io.opentelemetry.sdk.autoconfigure.spi.metrics;
 
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.function.Supplier;
 
 /**
  * A service provider interface (SPI) for providing additional exporters that can be used with the
  * autoconfigured SDK. If the {@code otel.metrics.exporter} property contains a value equal to what
  * is returned by {@link #getName()}, the exporter returned by {@link
- * #createExporter(ConfigProperties)} will be enabled and added to the SDK.
+ * #createExporter(ConfigProperties, Supplier)} will be enabled and added to the SDK.
  *
  * @since 1.15.0
  */
@@ -22,7 +24,8 @@ public interface ConfigurableMetricExporterProvider {
    * Returns a {@link MetricExporter} that can be registered to OpenTelemetry by providing the
    * property value specified by {@link #getName()}.
    */
-  MetricExporter createExporter(ConfigProperties config);
+  MetricExporter createExporter(
+      ConfigProperties config, Supplier<MeterProvider> meterProviderSupplier);
 
   /**
    * Returns the name of this exporter, which can be specified with the {@code

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -9,6 +9,7 @@ import static java.util.Objects.requireNonNull;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.logs.GlobalLoggerProvider;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -337,10 +338,16 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
     if (sdkEnabled) {
       SdkMeterProviderBuilder meterProviderBuilder = SdkMeterProvider.builder();
       meterProviderBuilder.setResource(resource);
+      MutableSupplier<MeterProvider> meterProviderSupplier = new MutableSupplier<>();
       MeterProviderConfiguration.configureMeterProvider(
-          meterProviderBuilder, config, serviceClassLoader, metricExporterCustomizer);
+          meterProviderBuilder,
+          config,
+          serviceClassLoader,
+          metricExporterCustomizer,
+          meterProviderSupplier);
       meterProviderBuilder = meterProviderCustomizer.apply(meterProviderBuilder, config);
       SdkMeterProvider meterProvider = meterProviderBuilder.build();
+      meterProviderSupplier.setValue(meterProvider);
 
       SdkTracerProviderBuilder tracerProviderBuilder = SdkTracerProvider.builder();
       tracerProviderBuilder.setResource(resource);

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MutableSupplier.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MutableSupplier.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure;
+
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+
+class MutableSupplier<T> implements Supplier<T> {
+  @Nullable private T value;
+
+  @Nullable
+  @Override
+  public T get() {
+    return value;
+  }
+
+  public void setValue(T value) {
+    this.value = value;
+  }
+}

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/MeterProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/MeterProviderConfigurationTest.java
@@ -51,7 +51,8 @@ class MeterProviderConfigurationTest {
         builder,
         DefaultConfigProperties.createForTest(configWithDefault),
         MeterProviderConfigurationTest.class.getClassLoader(),
-        (a, b) -> a);
+        (a, b) -> a,
+        () -> null);
     return assertThat(builder)
         .extracting("exemplarFilter", as(InstanceOfAssertFactories.type(ExemplarFilter.class)));
   }

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfigurationTest.java
@@ -29,7 +29,8 @@ class MetricExporterConfigurationTest {
                     "prometheus",
                     EMPTY,
                     MetricExporterConfiguration.class.getClassLoader(),
-                    (a, b) -> a))
+                    (a, b) -> a,
+                    () -> null))
         .isInstanceOf(ConfigurationException.class)
         .hasMessage(
             "otel.metrics.exporter set to \"prometheus\" but opentelemetry-exporter-prometheus"
@@ -40,7 +41,7 @@ class MetricExporterConfigurationTest {
   void configureExporter_KnownSpiExportersNotOnClasspath() {
     NamedSpiManager<MetricExporter> spiExportersManager =
         MetricExporterConfiguration.metricExporterSpiManager(
-            EMPTY, MetricExporterConfigurationTest.class.getClassLoader());
+            EMPTY, MetricExporterConfigurationTest.class.getClassLoader(), () -> null);
 
     assertThatThrownBy(() -> configureExporter("logging", spiExportersManager))
         .isInstanceOf(ConfigurationException.class)

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableMetricExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableMetricExporterTest.java
@@ -32,7 +32,7 @@ public class ConfigurableMetricExporterTest {
         MetricExporterConfiguration.configureExporter(
             "testExporter",
             MetricExporterConfiguration.metricExporterSpiManager(
-                config, ConfigurableMetricExporterTest.class.getClassLoader()));
+                config, ConfigurableMetricExporterTest.class.getClassLoader(), () -> null));
 
     assertThat(metricExporter)
         .isInstanceOf(TestConfigurableMetricExporterProvider.TestMetricExporter.class)
@@ -48,7 +48,8 @@ public class ConfigurableMetricExporterTest {
                     "testExporter",
                     MetricExporterConfiguration.metricExporterSpiManager(
                         DefaultConfigProperties.createForTest(Collections.emptyMap()),
-                        new URLClassLoader(new URL[] {}, null))))
+                        new URLClassLoader(new URL[] {}, null),
+                        () -> null)))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("testExporter");
   }
@@ -61,7 +62,8 @@ public class ConfigurableMetricExporterTest {
                     "catExporter",
                     MetricExporterConfiguration.metricExporterSpiManager(
                         DefaultConfigProperties.createForTest(Collections.emptyMap()),
-                        ConfigurableMetricExporterTest.class.getClassLoader())))
+                        ConfigurableMetricExporterTest.class.getClassLoader(),
+                        () -> null)))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("catExporter");
   }
@@ -77,7 +79,8 @@ public class ConfigurableMetricExporterTest {
                 MeterProviderConfiguration.configureMetricReaders(
                     config,
                     ConfigurableMetricExporterTest.class.getClassLoader(),
-                    (a, unused) -> a))
+                    (a, unused) -> a,
+                    () -> null))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("otel.metrics.exporter contains none along with other exporters");
   }
@@ -90,7 +93,8 @@ public class ConfigurableMetricExporterTest {
             MeterProviderConfiguration.configureMetricReaders(
                 config,
                 MeterProviderConfiguration.class.getClassLoader(),
-                (metricExporter, unused) -> metricExporter))
+                (metricExporter, unused) -> metricExporter,
+                () -> null))
         .hasSize(1)
         .first()
         .isInstanceOf(PeriodicMetricReader.class)
@@ -111,7 +115,8 @@ public class ConfigurableMetricExporterTest {
             MeterProviderConfiguration.configureMetricReaders(
                 config,
                 MeterProviderConfiguration.class.getClassLoader(),
-                (metricExporter, unused) -> metricExporter))
+                (metricExporter, unused) -> metricExporter,
+                () -> null))
         .hasSize(2)
         .hasAtLeastOneElementOfType(PeriodicMetricReader.class)
         .hasAtLeastOneElementOfType(PeriodicMetricReader.class)

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfigurationTest.java
@@ -41,7 +41,8 @@ class MetricExporterConfigurationTest {
                 "prometheus",
                 EMPTY,
                 MetricExporterConfigurationTest.class.getClassLoader(),
-                (a, b) -> a))
+                (a, b) -> a,
+                () -> null))
         .isNull();
   }
 
@@ -79,7 +80,7 @@ class MetricExporterConfigurationTest {
   void configureExporter_KnownSpiExportersOnClasspath() {
     NamedSpiManager<MetricExporter> spiExportersManager =
         MetricExporterConfiguration.metricExporterSpiManager(
-            EMPTY, ConfigurableMetricExporterTest.class.getClassLoader());
+            EMPTY, ConfigurableMetricExporterTest.class.getClassLoader(), () -> null);
 
     assertThat(MetricExporterConfiguration.configureExporter("logging", spiExportersManager))
         .isInstanceOf(LoggingMetricExporter.class);
@@ -98,7 +99,8 @@ class MetricExporterConfigurationTest {
                     MetricExporterConfiguration.metricExporterSpiManager(
                         DefaultConfigProperties.createForTest(
                             ImmutableMap.of("otel.exporter.otlp.protocol", "foo")),
-                        MetricExporterConfigurationTest.class.getClassLoader())))
+                        MetricExporterConfigurationTest.class.getClassLoader(),
+                        () -> null)))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("Unsupported OTLP metrics protocol: foo");
   }

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestConfigurableMetricExporterProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestConfigurableMetricExporterProvider.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.autoconfigure.provider;
 
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider;
 import io.opentelemetry.sdk.common.CompletableResultCode;
@@ -13,11 +14,13 @@ import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.util.Collection;
+import java.util.function.Supplier;
 
 public class TestConfigurableMetricExporterProvider implements ConfigurableMetricExporterProvider {
 
   @Override
-  public MetricExporter createExporter(ConfigProperties config) {
+  public MetricExporter createExporter(
+      ConfigProperties config, Supplier<MeterProvider> meterProviderSupplier) {
     return new TestMetricExporter(config);
   }
 

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/ThrowingConfigurableMetricExporterProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/ThrowingConfigurableMetricExporterProvider.java
@@ -5,14 +5,17 @@
 
 package io.opentelemetry.sdk.autoconfigure.provider;
 
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.function.Supplier;
 
 public class ThrowingConfigurableMetricExporterProvider
     implements ConfigurableMetricExporterProvider {
   @Override
-  public MetricExporter createExporter(ConfigProperties config) {
+  public MetricExporter createExporter(
+      ConfigProperties config, Supplier<MeterProvider> meterProviderSupplier) {
     throw new IllegalStateException("always throws");
   }
 


### PR DESCRIPTION
Span data export already provides [export metrics](https://github.com/open-telemetry/opentelemetry-java/blob/main/exporters/common/src/main/java/io/opentelemetry/exporter/internal/ExporterMetrics.java).

This PR adds the same export metrics for metrics itself.
The metrics exporting is basically referring to itself for providing the metrics, so if metrics export is completely failing, you also don't get any metrics about it. 
In cases where there are some errors, however, this metric is very useful.

Implementation note: Since we cannot pass the ready-made MeterProvider to the MetricExporter, we pass in a mutable supplier, which is ready before it's needed, since the supplier is used lazily.

Testing: There is no test yet - please advise how to best test this feature.