### PR TITLE
Support parentbased samplers loaded by name

### DIFF
--- a/sdk-extensions/autoconfigure/build.gradle.kts
+++ b/sdk-extensions/autoconfigure/build.gradle.kts
@@ -71,6 +71,7 @@ testing {
         implementation(project(":exporters:zipkin"))
         implementation(project(":sdk:testing"))
         implementation(project(":sdk:trace-shaded-deps"))
+        implementation(project(":sdk-extensions:jaeger-remote-sampler"))
         implementation(project(":semconv"))
 
         implementation("com.google.guava:guava")

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
@@ -172,12 +172,14 @@ final class TracerProviderConfiguration {
           return Sampler.parentBased(Sampler.traceIdRatioBased(ratio));
         }
       default:
-        Sampler spiSampler = spiSamplersManager.getByName(sampler);
+        boolean parentBased = sampler.startsWith("parentbased_");
+        Sampler spiSampler =
+            spiSamplersManager.getByName(sampler.replaceFirst("^parentbased_", ""));
         if (spiSampler == null) {
           throw new ConfigurationException(
               "Unrecognized value for otel.traces.sampler: " + sampler);
         }
-        return spiSampler;
+        return parentBased ? Sampler.parentBased(spiSampler) : spiSampler;
     }
   }
 

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
@@ -246,5 +246,13 @@ class TracerProviderConfigurationTest {
                     "catsampler", EMPTY, TracerProviderConfiguration.class.getClassLoader()))
         .isInstanceOf(ConfigurationException.class)
         .hasMessage("Unrecognized value for otel.traces.sampler: catsampler");
+    assertThatThrownBy(
+            () ->
+                TracerProviderConfiguration.configureSampler(
+                    "parentbased_catsampler",
+                    EMPTY,
+                    TracerProviderConfiguration.class.getClassLoader()))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessage("Unrecognized value for otel.traces.sampler: parentbased_catsampler");
   }
 }

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
@@ -13,13 +13,14 @@ import io.opentelemetry.sdk.autoconfigure.provider.TestConfigurableSamplerProvid
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import io.opentelemetry.sdk.extension.trace.jaeger.sampler.JaegerRemoteSampler;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
-public class ConfigurableSamplerTest {
+public class TracerProviderConfigurationTest {
 
   @Test
   void configuration() {
@@ -57,5 +58,31 @@ public class ConfigurableSamplerTest {
                     TracerProviderConfiguration.class.getClassLoader()))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("catSampler");
+  }
+
+  @Test
+  void configureSampler_JaegerRemoteSampler() {
+    assertThat(
+            TracerProviderConfiguration.configureSampler(
+                "parentbased_jaeger_remote",
+                DefaultConfigProperties.createForTest(Collections.emptyMap()),
+                TracerProviderConfigurationTest.class.getClassLoader()))
+        .satisfies(
+            sampler -> {
+              assertThat(sampler.getClass().getSimpleName()).isEqualTo("ParentBasedSampler");
+              assertThat(sampler).extracting("root").isInstanceOf(JaegerRemoteSampler.class);
+            });
+  }
+
+  @Test
+  void parentBasedSamplerNotFound() {
+    assertThatThrownBy(
+            () ->
+                TracerProviderConfiguration.configureSampler(
+                    "parentbased_catSampler",
+                    DefaultConfigProperties.createForTest(Collections.emptyMap()),
+                    TracerProviderConfigurationTest.class.getClassLoader()))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("parentbased_catSampler");
   }
 }


### PR DESCRIPTION
This PR enable support for `parentbased_` samplers that are loaded by name from `NamedSpiManager<Sampler>`.  
For example it enables `parentbased_jaeger_remote` that is defined in the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration) but cannot be instantiated.