### PR TITLE
Add close method to MetricReader

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-metrics.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-metrics.txt
@@ -1,2 +1,11 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.metrics.export.MetricReader  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW INTERFACE: java.io.Closeable
+	+++  NEW INTERFACE: java.lang.AutoCloseable
+	+++  NEW METHOD: PUBLIC(+) void close()
+		+++  NEW EXCEPTION: java.io.IOException
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.metrics.export.PeriodicMetricReader  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW INTERFACE: java.io.Closeable
+	+++  NEW INTERFACE: java.lang.AutoCloseable

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServer.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServer.java
@@ -23,7 +23,6 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.CollectionRegistration;
 import io.opentelemetry.sdk.metrics.export.MetricReader;
 import io.opentelemetry.sdk.metrics.internal.export.MetricProducer;
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
@@ -53,7 +52,7 @@ import javax.annotation.Nullable;
  */
 // Very similar to
 // https://github.com/prometheus/client_java/blob/master/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java
-public final class PrometheusHttpServer implements Closeable, MetricReader {
+public final class PrometheusHttpServer implements MetricReader {
 
   private static final DaemonThreadFactory THREAD_FACTORY =
       new DaemonThreadFactory("prometheus-http");

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/MetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/MetricReader.java
@@ -9,6 +9,9 @@ import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A metric reader reads metrics from an {@link SdkMeterProvider}.
@@ -18,7 +21,8 @@ import io.opentelemetry.sdk.metrics.SdkMeterProvider;
  *
  * @since 1.14.0
  */
-public interface MetricReader extends AggregationTemporalitySelector, DefaultAggregationSelector {
+public interface MetricReader
+    extends AggregationTemporalitySelector, DefaultAggregationSelector, Closeable {
 
   /**
    * Called by {@link SdkMeterProvider} and supplies the {@link MetricReader} with a handle to
@@ -63,4 +67,10 @@ public interface MetricReader extends AggregationTemporalitySelector, DefaultAgg
    * @return the result of the shutdown.
    */
   CompletableResultCode shutdown();
+
+  /** Close this {@link MetricReader}, releasing any resources. */
+  @Override
+  default void close() throws IOException {
+    shutdown().join(10, TimeUnit.SECONDS);
+  }
 }


### PR DESCRIPTION
Working #5090 and noticed that `MetricReader` didn't implement `Closeable`. 

Adjusted `MetricReader` to extend `Closeable`, and added a default implementation so the change is backwards compatible. Ran into some issues where japicmp was flagging a false positive that the change was breaking. Ended up needing to dive deeper into the japicmp gradle plugin than I wanted to to discover the source of the bug, but along the way found some better ways to organize our config which make it easier to comprehend.