### PR TITLE
Add proper shutdown implementations for all exporters

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/UpstreamGrpcExporter.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/UpstreamGrpcExporter.java
@@ -36,6 +36,7 @@ public final class UpstreamGrpcExporter<T extends Marshaler> implements GrpcExpo
 
   // We only log unavailable once since it's a configuration issue that won't be recovered.
   private final AtomicBoolean loggedUnimplemented = new AtomicBoolean();
+  private final AtomicBoolean isShutdown = new AtomicBoolean();
 
   private final String type;
   private final ExporterMetrics exporterMetrics;
@@ -57,6 +58,10 @@ public final class UpstreamGrpcExporter<T extends Marshaler> implements GrpcExpo
 
   @Override
   public CompletableResultCode export(T exportRequest, int numItems) {
+    if (isShutdown.get()) {
+      return CompletableResultCode.ofFailure();
+    }
+
     exporterMetrics.addSeen(numItems);
 
     CompletableResultCode result = new CompletableResultCode();
@@ -118,6 +123,9 @@ public final class UpstreamGrpcExporter<T extends Marshaler> implements GrpcExpo
 
   @Override
   public CompletableResultCode shutdown() {
+    if (!isShutdown.compareAndSet(false, true)) {
+      logger.log(Level.WARNING, "Calling shutdown() multiple times.");
+    }
     return CompletableResultCode.ofSuccess();
   }
 }

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/OkHttpExporter.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/OkHttpExporter.java
@@ -13,6 +13,7 @@ import io.opentelemetry.exporter.internal.retry.RetryUtil;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.internal.ThrottlingLogger;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -44,6 +45,7 @@ public final class OkHttpExporter<T extends Marshaler> {
   private static final Logger internalLogger = Logger.getLogger(OkHttpExporter.class.getName());
 
   private final ThrottlingLogger logger = new ThrottlingLogger(internalLogger);
+  private final AtomicBoolean isShutdown = new AtomicBoolean();
 
   private final String type;
   private final OkHttpClient client;
@@ -76,6 +78,10 @@ public final class OkHttpExporter<T extends Marshaler> {
   }
 
   public CompletableResultCode export(T exportRequest, int numItems) {
+    if (isShutdown.get()) {
+      return CompletableResultCode.ofFailure();
+    }
+
     exporterMetrics.addSeen(numItems);
 
     Request.Builder requestBuilder = new Request.Builder().url(url);
@@ -139,11 +145,14 @@ public final class OkHttpExporter<T extends Marshaler> {
   }
 
   public CompletableResultCode shutdown() {
-    CompletableResultCode result = CompletableResultCode.ofSuccess();
+    if (!isShutdown.compareAndSet(false, true)) {
+      logger.log(Level.WARNING, "Calling shutdown() multiple times.");
+      return CompletableResultCode.ofSuccess();
+    }
     client.dispatcher().cancelAll();
     client.dispatcher().executorService().shutdownNow();
     client.connectionPool().evictAll();
-    return result;
+    return CompletableResultCode.ofSuccess();
   }
 
   static boolean isRetryable(Response response) {

--- a/exporters/jaeger-thrift/src/main/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftSpanExporter.java
+++ b/exporters/jaeger-thrift/src/main/java/io/opentelemetry/exporter/jaeger/thrift/JaegerThriftSpanExporter.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -43,6 +44,7 @@ public final class JaegerThriftSpanExporter implements SpanExporter {
 
   private final ThrottlingLogger logger =
       new ThrottlingLogger(Logger.getLogger(JaegerThriftSpanExporter.class.getName()));
+  private final AtomicBoolean isShutdown = new AtomicBoolean();
   private final ThriftSender thriftSender;
   private final Process process;
 
@@ -82,13 +84,16 @@ public final class JaegerThriftSpanExporter implements SpanExporter {
    */
   @Override
   public CompletableResultCode export(Collection<SpanData> spans) {
+    if (isShutdown.get()) {
+      return CompletableResultCode.ofFailure();
+    }
+
     Map<Process, List<Span>> batches =
         spans.stream().collect(Collectors.groupingBy(SpanData::getResource)).entrySet().stream()
             .collect(
                 Collectors.toMap(
                     entry -> createProcess(entry.getKey()),
                     entry -> Adapter.toJaeger(entry.getValue())));
-
     List<CompletableResultCode> batchResults = new ArrayList<>(batches.size());
     batches.forEach(
         (process, jaegerSpans) -> {
@@ -148,13 +153,9 @@ public final class JaegerThriftSpanExporter implements SpanExporter {
    */
   @Override
   public CompletableResultCode shutdown() {
-    CompletableResultCode result = new CompletableResultCode();
-    // todo
-    return result.succeed();
-  }
-
-  // Visible for testing
-  Process getProcess() {
-    return process;
+    if (!isShutdown.compareAndSet(false, true)) {
+      logger.log(Level.WARNING, "Calling shutdown() multiple times.");
+    }
+    return CompletableResultCode.ofSuccess();
   }
 }

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporter.java
@@ -17,6 +17,7 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -28,6 +29,8 @@ public final class OtlpJsonLoggingMetricExporter implements MetricExporter {
 
   private static final Logger logger =
       Logger.getLogger(OtlpJsonLoggingMetricExporter.class.getName());
+
+  private final AtomicBoolean isShutdown = new AtomicBoolean();
 
   private final AggregationTemporality aggregationTemporality;
 
@@ -68,6 +71,10 @@ public final class OtlpJsonLoggingMetricExporter implements MetricExporter {
 
   @Override
   public CompletableResultCode export(Collection<MetricData> metrics) {
+    if (isShutdown.get()) {
+      return CompletableResultCode.ofFailure();
+    }
+
     ResourceMetricsMarshaler[] allResourceMetrics = ResourceMetricsMarshaler.create(metrics);
     for (ResourceMetricsMarshaler resourceMetrics : allResourceMetrics) {
       SegmentedStringWriter sw = new SegmentedStringWriter(JSON_FACTORY._getBufferRecycler());
@@ -89,6 +96,9 @@ public final class OtlpJsonLoggingMetricExporter implements MetricExporter {
 
   @Override
   public CompletableResultCode shutdown() {
+    if (!isShutdown.compareAndSet(false, true)) {
+      logger.log(Level.WARNING, "Calling shutdown() multiple times.");
+    }
     return CompletableResultCode.ofSuccess();
   }
 }

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporter.java
@@ -13,6 +13,7 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -25,6 +26,8 @@ public final class OtlpJsonLoggingSpanExporter implements SpanExporter {
   private static final Logger logger =
       Logger.getLogger(OtlpJsonLoggingSpanExporter.class.getName());
 
+  private final AtomicBoolean isShutdown = new AtomicBoolean();
+
   /** Returns a new {@link OtlpJsonLoggingSpanExporter}. */
   public static SpanExporter create() {
     return new OtlpJsonLoggingSpanExporter();
@@ -34,6 +37,10 @@ public final class OtlpJsonLoggingSpanExporter implements SpanExporter {
 
   @Override
   public CompletableResultCode export(Collection<SpanData> spans) {
+    if (isShutdown.get()) {
+      return CompletableResultCode.ofFailure();
+    }
+
     ResourceSpansMarshaler[] allResourceSpans = ResourceSpansMarshaler.create(spans);
     for (ResourceSpansMarshaler resourceSpans : allResourceSpans) {
       SegmentedStringWriter sw =
@@ -56,6 +63,9 @@ public final class OtlpJsonLoggingSpanExporter implements SpanExporter {
 
   @Override
   public CompletableResultCode shutdown() {
+    if (!isShutdown.compareAndSet(false, true)) {
+      logger.log(Level.WARNING, "Calling shutdown() multiple times.");
+    }
     return CompletableResultCode.ofSuccess();
   }
 }

--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingLogRecordExporterTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingLogRecordExporterTest.java
@@ -23,6 +23,7 @@ import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.logs.TestLogRecordData;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -166,5 +167,11 @@ class OtlpJsonLoggingLogRecordExporterTest {
   @Test
   void shutdown() {
     assertThat(exporter.shutdown().isSuccess()).isTrue();
+    assertThat(
+            exporter.export(Collections.singletonList(LOG1)).join(10, TimeUnit.SECONDS).isSuccess())
+        .isFalse();
+    assertThat(logs.getEvents()).isEmpty();
+    assertThat(exporter.shutdown().isSuccess()).isTrue();
+    logs.assertContains("Calling shutdown() multiple times.");
   }
 }

--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporterTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporterTest.java
@@ -21,6 +21,8 @@ import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableSumData;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -170,5 +172,14 @@ class OtlpJsonLoggingMetricExporterTest {
   @Test
   void shutdown() {
     assertThat(exporter.shutdown().isSuccess()).isTrue();
+    assertThat(
+            exporter
+                .export(Collections.singletonList(METRIC1))
+                .join(10, TimeUnit.SECONDS)
+                .isSuccess())
+        .isFalse();
+    assertThat(logs.getEvents()).isEmpty();
+    assertThat(exporter.shutdown().isSuccess()).isTrue();
+    logs.assertContains("Calling shutdown() multiple times.");
   }
 }

--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporterTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporterTest.java
@@ -26,6 +26,7 @@ import io.opentelemetry.sdk.trace.data.StatusData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -191,5 +192,14 @@ class OtlpJsonLoggingSpanExporterTest {
   @Test
   void shutdown() {
     assertThat(exporter.shutdown().isSuccess()).isTrue();
+    assertThat(
+            exporter
+                .export(Collections.singletonList(SPAN1))
+                .join(10, TimeUnit.SECONDS)
+                .isSuccess())
+        .isFalse();
+    assertThat(logs.getEvents()).isEmpty();
+    assertThat(exporter.shutdown().isSuccess()).isTrue();
+    logs.assertContains("Calling shutdown() multiple times.");
   }
 }

--- a/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/LoggingMetricExporter.java
+++ b/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/LoggingMetricExporter.java
@@ -11,6 +11,7 @@ import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.util.Collection;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -18,6 +19,7 @@ import java.util.logging.Logger;
 public final class LoggingMetricExporter implements MetricExporter {
   private static final Logger logger = Logger.getLogger(LoggingMetricExporter.class.getName());
 
+  private final AtomicBoolean isShutdown = new AtomicBoolean();
   private final AggregationTemporality aggregationTemporality;
 
   /**
@@ -64,6 +66,10 @@ public final class LoggingMetricExporter implements MetricExporter {
 
   @Override
   public CompletableResultCode export(Collection<MetricData> metrics) {
+    if (isShutdown.get()) {
+      return CompletableResultCode.ofFailure();
+    }
+
     logger.info("Received a collection of " + metrics.size() + " metrics for export.");
     for (MetricData metricData : metrics) {
       logger.log(Level.INFO, "metric: {0}", metricData);
@@ -91,8 +97,10 @@ public final class LoggingMetricExporter implements MetricExporter {
 
   @Override
   public CompletableResultCode shutdown() {
-    // no-op
-    this.flush();
-    return CompletableResultCode.ofSuccess();
+    if (!isShutdown.compareAndSet(false, true)) {
+      logger.log(Level.WARNING, "Calling shutdown() multiple times.");
+      return CompletableResultCode.ofSuccess();
+    }
+    return flush();
   }
 }

--- a/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/LoggingSpanExporter.java
+++ b/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/LoggingSpanExporter.java
@@ -10,6 +10,7 @@ import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Collection;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -17,6 +18,8 @@ import java.util.logging.Logger;
 /** A Span Exporter that logs every span at INFO level using java.util.logging. */
 public final class LoggingSpanExporter implements SpanExporter {
   private static final Logger logger = Logger.getLogger(LoggingSpanExporter.class.getName());
+
+  private final AtomicBoolean isShutdown = new AtomicBoolean();
 
   /** Returns a new {@link LoggingSpanExporter}. */
   public static LoggingSpanExporter create() {
@@ -33,6 +36,10 @@ public final class LoggingSpanExporter implements SpanExporter {
 
   @Override
   public CompletableResultCode export(Collection<SpanData> spans) {
+    if (isShutdown.get()) {
+      return CompletableResultCode.ofFailure();
+    }
+
     // We always have 32 + 16 + name + several whitespace, 60 seems like an OK initial guess.
     StringBuilder sb = new StringBuilder(60);
     for (SpanData span : spans) {
@@ -80,6 +87,10 @@ public final class LoggingSpanExporter implements SpanExporter {
 
   @Override
   public CompletableResultCode shutdown() {
+    if (!isShutdown.compareAndSet(false, true)) {
+      logger.log(Level.WARNING, "Calling shutdown() multiple times.");
+      return CompletableResultCode.ofSuccess();
+    }
     return flush();
   }
 }

--- a/exporters/logging/src/test/java/io/opentelemetry/exporter/logging/LoggingMetricExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporter/logging/LoggingMetricExporterTest.java
@@ -8,44 +8,58 @@ package io.opentelemetry.exporter.logging;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.github.netmikey.logunit.api.LogCapturer;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
-import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoublePointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableLongPointData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableSumData;
-import io.opentelemetry.sdk.metrics.internal.data.ImmutableSummaryData;
-import io.opentelemetry.sdk.metrics.internal.data.ImmutableSummaryPointData;
-import io.opentelemetry.sdk.metrics.internal.data.ImmutableValueAtQuantile;
 import io.opentelemetry.sdk.resources.Resource;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.util.Arrays;
+import java.time.Instant;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
 import java.util.logging.StreamHandler;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 @SuppressLogger(LoggingMetricExporter.class)
 class LoggingMetricExporterTest {
 
-  LoggingMetricExporter exporter;
+  private static final MetricData METRIC_DATA =
+      ImmutableMetricData.createLongSum(
+          Resource.create(Attributes.of(stringKey("host"), "localhost")),
+          InstrumentationScopeInfo.builder("manualInstrumentation").setVersion("1.0").build(),
+          "counterOne",
+          "A simple counter",
+          "one",
+          ImmutableSumData.create(
+              true,
+              AggregationTemporality.CUMULATIVE,
+              Collections.singletonList(
+                  ImmutableLongPointData.create(
+                      TimeUnit.MILLISECONDS.toNanos(Instant.now().toEpochMilli()),
+                      TimeUnit.MILLISECONDS.toNanos(Instant.now().plusMillis(245).toEpochMilli()),
+                      Attributes.of(stringKey("z"), "y", stringKey("x"), "w"),
+                      1010))));
+
+  @RegisterExtension
+  LogCapturer logs = LogCapturer.create().captureForType(LoggingMetricExporter.class);
+
+  private LoggingMetricExporter exporter;
 
   @BeforeEach
   void setUp() {
     exporter = LoggingMetricExporter.create();
-  }
-
-  @AfterEach
-  void tearDown() {
-    exporter.shutdown();
   }
 
   @Test
@@ -59,64 +73,21 @@ class LoggingMetricExporterTest {
   }
 
   @Test
-  void testExport() {
-    long nowEpochNanos = System.currentTimeMillis() * 1000 * 1000;
-    Resource resource = Resource.create(Attributes.of(stringKey("host"), "localhost"));
-    InstrumentationScopeInfo instrumentationScopeInfo =
-        InstrumentationScopeInfo.builder("manualInstrumentation").setVersion("1.0").build();
-    exporter.export(
-        Arrays.asList(
-            ImmutableMetricData.createDoubleSummary(
-                resource,
-                instrumentationScopeInfo,
-                "measureOne",
-                "A summarized test measure",
-                "ms",
-                ImmutableSummaryData.create(
-                    Collections.singletonList(
-                        ImmutableSummaryPointData.create(
-                            nowEpochNanos,
-                            nowEpochNanos + 245,
-                            Attributes.of(stringKey("a"), "b", stringKey("c"), "d"),
-                            1010,
-                            50000,
-                            Arrays.asList(
-                                ImmutableValueAtQuantile.create(0.0, 25),
-                                ImmutableValueAtQuantile.create(1.0, 433)))))),
-            ImmutableMetricData.createLongSum(
-                resource,
-                instrumentationScopeInfo,
-                "counterOne",
-                "A simple counter",
-                "one",
-                ImmutableSumData.create(
-                    true,
-                    AggregationTemporality.CUMULATIVE,
-                    Collections.singletonList(
-                        ImmutableLongPointData.create(
-                            nowEpochNanos,
-                            nowEpochNanos + 245,
-                            Attributes.of(stringKey("z"), "y", stringKey("x"), "w"),
-                            1010)))),
-            ImmutableMetricData.createDoubleSum(
-                resource,
-                instrumentationScopeInfo,
-                "observedValue",
-                "an observer gauge",
-                "kb",
-                ImmutableSumData.create(
-                    true,
-                    AggregationTemporality.CUMULATIVE,
-                    Collections.singletonList(
-                        ImmutableDoublePointData.create(
-                            nowEpochNanos,
-                            nowEpochNanos + 245,
-                            Attributes.of(stringKey("1"), "2", stringKey("3"), "4"),
-                            33.7767))))));
+  void export() {
+    assertThat(exporter.export(Collections.singletonList(METRIC_DATA)).isSuccess()).isTrue();
+    assertThat(logs.getEvents())
+        .satisfiesExactly(
+            loggingEvent ->
+                assertThat(loggingEvent.getMessage())
+                    .isEqualTo("Received a collection of 1 metrics for export."),
+            loggingEvent -> {
+              assertThat(loggingEvent.getMessage()).isEqualTo("metric: {0}");
+              assertThat(loggingEvent.getArgumentArray()).isEqualTo(new MetricData[] {METRIC_DATA});
+            });
   }
 
   @Test
-  void testFlush() {
+  void flush() {
     AtomicBoolean flushed = new AtomicBoolean(false);
     Logger.getLogger(LoggingMetricExporter.class.getName())
         .addHandler(
@@ -128,5 +99,19 @@ class LoggingMetricExporterTest {
             });
     exporter.flush();
     assertThat(flushed.get()).isTrue();
+  }
+
+  @Test
+  void shutdown() {
+    assertThat(exporter.shutdown().isSuccess()).isTrue();
+    assertThat(
+            exporter
+                .export(Collections.singletonList(METRIC_DATA))
+                .join(10, TimeUnit.SECONDS)
+                .isSuccess())
+        .isFalse();
+    assertThat(logs.getEvents()).isEmpty();
+    assertThat(exporter.shutdown().isSuccess()).isTrue();
+    logs.assertContains("Calling shutdown() multiple times.");
   }
 }

--- a/exporters/logging/src/test/java/io/opentelemetry/exporter/logging/SystemOutLogRecordExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporter/logging/SystemOutLogRecordExporterTest.java
@@ -15,7 +15,6 @@ import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
-import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.resources.Resource;
@@ -23,18 +22,17 @@ import io.opentelemetry.sdk.testing.logs.TestLogRecordData;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.ZoneOffset;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 class SystemOutLogRecordExporterTest {
 
   @Test
-  void returnCodes() {
+  void export() {
     SystemOutLogRecordExporter exporter = SystemOutLogRecordExporter.create();
-    CompletableResultCode resultCode =
-        exporter.export(singletonList(sampleLog(System.currentTimeMillis())));
-    assertThat(resultCode).isSameAs(CompletableResultCode.ofSuccess());
-    assertThat(exporter.shutdown()).isSameAs(CompletableResultCode.ofSuccess());
+    assertThat(exporter.export(singletonList(sampleLog(System.currentTimeMillis()))).isSuccess())
+        .isTrue();
   }
 
   @Test
@@ -48,6 +46,19 @@ class SystemOutLogRecordExporterTest {
         .isEqualTo(
             "1970-08-07T10:00:00Z ERROR3 'message' : 00000000000000010000000000000002 0000000000000003 "
                 + "[scopeInfo: logTest:1.0] {amount=1, cheese=\"cheddar\"}");
+  }
+
+  @Test
+  void shutdown() {
+    SystemOutLogRecordExporter exporter = SystemOutLogRecordExporter.create();
+    assertThat(exporter.shutdown().isSuccess()).isTrue();
+    assertThat(
+            exporter
+                .export(Collections.singletonList(sampleLog(System.currentTimeMillis())))
+                .join(10, TimeUnit.SECONDS)
+                .isSuccess())
+        .isFalse();
+    assertThat(exporter.shutdown().isSuccess()).isTrue();
   }
 
   private static LogRecordData sampleLog(long timestamp) {

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
@@ -394,14 +394,19 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
                 .join(10, TimeUnit.SECONDS)
                 .isSuccess())
         .isFalse();
+    assertThat(httpRequests).isEmpty();
   }
 
   @Test
+  @SuppressLogger(OkHttpGrpcExporter.class)
+  @SuppressLogger(UpstreamGrpcExporter.class)
   void doubleShutdown() {
     TelemetryExporter<T> exporter =
         exporterBuilder().setEndpoint(server.httpUri().toString()).build();
     assertThat(exporter.shutdown().join(10, TimeUnit.SECONDS).isSuccess()).isTrue();
+    assertThat(logs.getEvents()).isEmpty();
     assertThat(exporter.shutdown().join(10, TimeUnit.SECONDS).isSuccess()).isTrue();
+    logs.assertContains("Calling shutdown() multiple times.");
   }
 
   @Test

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
@@ -431,13 +431,17 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
                 .join(10, TimeUnit.SECONDS)
                 .isSuccess())
         .isFalse();
+    assertThat(httpRequests).isEmpty();
   }
 
   @Test
+  @SuppressLogger(OkHttpExporter.class)
   void doubleShutdown() {
     TelemetryExporter<T> exporter = exporterBuilder().setEndpoint(server.httpUri() + path).build();
     assertThat(exporter.shutdown().join(10, TimeUnit.SECONDS).isSuccess()).isTrue();
+    assertThat(logs.getEvents()).isEmpty();
     assertThat(exporter.shutdown().join(10, TimeUnit.SECONDS).isSuccess()).isTrue();
+    logs.assertContains("Calling shutdown() multiple times.");
   }
 
   @Test

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -36,6 +37,7 @@ public final class ZipkinSpanExporter implements SpanExporter {
   public static final String DEFAULT_ENDPOINT = "http://localhost:9411/api/v2/spans";
 
   private final ThrottlingLogger logger = new ThrottlingLogger(baseLogger);
+  private final AtomicBoolean isShutdown = new AtomicBoolean();
   private final BytesEncoder<Span> encoder;
   private final Sender sender;
   private final ExporterMetrics exporterMetrics;
@@ -58,6 +60,10 @@ public final class ZipkinSpanExporter implements SpanExporter {
 
   @Override
   public CompletableResultCode export(Collection<SpanData> spanDataList) {
+    if (isShutdown.get()) {
+      return CompletableResultCode.ofFailure();
+    }
+
     int numItems = spanDataList.size();
     exporterMetrics.addSeen(numItems);
 
@@ -96,6 +102,10 @@ public final class ZipkinSpanExporter implements SpanExporter {
 
   @Override
   public CompletableResultCode shutdown() {
+    if (!isShutdown.compareAndSet(false, true)) {
+      logger.log(Level.WARNING, "Calling shutdown() multiple times.");
+      return CompletableResultCode.ofSuccess();
+    }
     try {
       sender.close();
     } catch (IOException e) {


### PR DESCRIPTION
Add proper shutdown implementation to all the exporters:

- Shutting down multiple times logs a warning
- Calling export after shutdown returns `CompletableResultCode.ofFailure()` and skips export