### PR TITLE
Shutdown ManagedChannel resources in tests

### DIFF
--- a/exporters/otlp/all/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcNettyMetricExporterTest.java
+++ b/exporters/otlp/all/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcNettyMetricExporterTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.exporter.otlp.metrics;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import io.grpc.ManagedChannel;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.opentelemetry.exporter.internal.grpc.UpstreamGrpcExporter;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
@@ -43,11 +44,11 @@ class OtlpGrpcNettyMetricExporterTest
   @Test
   @SuppressWarnings("deprecation") // testing deprecated feature
   void usingGrpc() throws Exception {
-    try (Closeable exporter =
-        OtlpGrpcMetricExporter.builder()
-            .setChannel(InProcessChannelBuilder.forName("test").build())
-            .build()) {
+    ManagedChannel channel = InProcessChannelBuilder.forName("test").build();
+    try (Closeable exporter = OtlpGrpcMetricExporter.builder().setChannel(channel).build()) {
       assertThat(exporter).extracting("delegate").isInstanceOf(UpstreamGrpcExporter.class);
+    } finally {
+      channel.shutdownNow();
     }
   }
 

--- a/exporters/otlp/all/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcNettySpanExporterTest.java
+++ b/exporters/otlp/all/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcNettySpanExporterTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.exporter.otlp.trace;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import io.grpc.ManagedChannel;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.opentelemetry.exporter.internal.grpc.UpstreamGrpcExporter;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
@@ -43,11 +44,11 @@ class OtlpGrpcNettySpanExporterTest
   @Test
   @SuppressWarnings("deprecation") // testing deprecated feature
   void usingGrpc() throws Exception {
-    try (Closeable exporter =
-        OtlpGrpcSpanExporter.builder()
-            .setChannel(InProcessChannelBuilder.forName("test").build())
-            .build()) {
+    ManagedChannel channel = InProcessChannelBuilder.forName("test").build();
+    try (Closeable exporter = OtlpGrpcSpanExporter.builder().setChannel(channel).build()) {
       assertThat(exporter).extracting("delegate").isInstanceOf(UpstreamGrpcExporter.class);
+    } finally {
+      channel.shutdownNow();
     }
   }
 

--- a/exporters/otlp/all/src/testGrpcNettyShaded/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcNettyShadedMetricExporterTest.java
+++ b/exporters/otlp/all/src/testGrpcNettyShaded/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcNettyShadedMetricExporterTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.exporter.otlp.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.grpc.ManagedChannel;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.opentelemetry.exporter.internal.grpc.UpstreamGrpcExporter;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
@@ -31,11 +32,11 @@ class OtlpGrpcNettyShadedMetricExporterTest
   @Test
   @SuppressWarnings("deprecation") // testing deprecated feature
   void usingGrpc() throws Exception {
-    try (Closeable exporter =
-        OtlpGrpcMetricExporter.builder()
-            .setChannel(InProcessChannelBuilder.forName("test").build())
-            .build()) {
+    ManagedChannel channel = InProcessChannelBuilder.forName("test").build();
+    try (Closeable exporter = OtlpGrpcMetricExporter.builder().setChannel(channel).build()) {
       assertThat(exporter).extracting("delegate").isInstanceOf(UpstreamGrpcExporter.class);
+    } finally {
+      channel.shutdownNow();
     }
   }
 

--- a/exporters/otlp/all/src/testGrpcNettyShaded/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcNettyShadedSpanExporterTest.java
+++ b/exporters/otlp/all/src/testGrpcNettyShaded/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcNettyShadedSpanExporterTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.exporter.otlp.trace;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.grpc.ManagedChannel;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.opentelemetry.exporter.internal.grpc.UpstreamGrpcExporter;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
@@ -31,11 +32,11 @@ class OtlpGrpcNettyShadedSpanExporterTest
   @Test
   @SuppressWarnings("deprecation") // testing deprecated feature
   void usingGrpc() throws Exception {
-    try (Closeable exporter =
-        OtlpGrpcSpanExporter.builder()
-            .setChannel(InProcessChannelBuilder.forName("test").build())
-            .build()) {
+    ManagedChannel channel = InProcessChannelBuilder.forName("test").build();
+    try (Closeable exporter = OtlpGrpcSpanExporter.builder().setChannel(channel).build()) {
       assertThat(exporter).extracting("delegate").isInstanceOf(UpstreamGrpcExporter.class);
+    } finally {
+      channel.shutdownNow();
     }
   }
 

--- a/exporters/otlp/all/src/testGrpcOkhttp/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcOkHttpMetricExporterTest.java
+++ b/exporters/otlp/all/src/testGrpcOkhttp/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcOkHttpMetricExporterTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.exporter.otlp.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.grpc.ManagedChannel;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.opentelemetry.exporter.internal.grpc.UpstreamGrpcExporter;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
@@ -31,11 +32,11 @@ class OtlpGrpcOkHttpMetricExporterTest
   @Test
   @SuppressWarnings("deprecation") // testing deprecated featurea
   void usingGrpc() throws Exception {
-    try (Closeable exporter =
-        OtlpGrpcMetricExporter.builder()
-            .setChannel(InProcessChannelBuilder.forName("test").build())
-            .build()) {
+    ManagedChannel channel = InProcessChannelBuilder.forName("test").build();
+    try (Closeable exporter = OtlpGrpcMetricExporter.builder().setChannel(channel).build()) {
       assertThat(exporter).extracting("delegate").isInstanceOf(UpstreamGrpcExporter.class);
+    } finally {
+      channel.shutdownNow();
     }
   }
 

--- a/exporters/otlp/all/src/testGrpcOkhttp/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcOkHttpSpanExporterTest.java
+++ b/exporters/otlp/all/src/testGrpcOkhttp/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcOkHttpSpanExporterTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.exporter.otlp.trace;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.grpc.ManagedChannel;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.opentelemetry.exporter.internal.grpc.UpstreamGrpcExporter;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
@@ -31,11 +32,11 @@ class OtlpGrpcOkHttpSpanExporterTest
   @Test
   @SuppressWarnings("deprecation") // testing deprecated feature
   void usingGrpc() throws Exception {
-    try (Closeable exporter =
-        OtlpGrpcSpanExporter.builder()
-            .setChannel(InProcessChannelBuilder.forName("test").build())
-            .build()) {
+    ManagedChannel channel = InProcessChannelBuilder.forName("test").build();
+    try (Closeable exporter = OtlpGrpcSpanExporter.builder().setChannel(channel).build()) {
       assertThat(exporter).extracting("delegate").isInstanceOf(UpstreamGrpcExporter.class);
+    } finally {
+      channel.shutdownNow();
     }
   }
 

--- a/exporters/otlp/logs/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcNettyLogRecordExporterTest.java
+++ b/exporters/otlp/logs/src/testGrpcNetty/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcNettyLogRecordExporterTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.exporter.otlp.logs;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import io.grpc.ManagedChannel;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.opentelemetry.exporter.internal.grpc.UpstreamGrpcExporter;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
@@ -43,11 +44,11 @@ class OtlpGrpcNettyLogRecordExporterTest
   @Test
   @SuppressWarnings("deprecation") // testing deprecated feature
   void usingGrpc() throws Exception {
-    try (Closeable exporter =
-        OtlpGrpcLogRecordExporter.builder()
-            .setChannel(InProcessChannelBuilder.forName("test").build())
-            .build()) {
+    ManagedChannel channel = InProcessChannelBuilder.forName("test").build();
+    try (Closeable exporter = OtlpGrpcLogRecordExporter.builder().setChannel(channel).build()) {
       assertThat(exporter).extracting("delegate").isInstanceOf(UpstreamGrpcExporter.class);
+    } finally {
+      channel.shutdownNow();
     }
   }
 

--- a/exporters/otlp/logs/src/testGrpcNettyShaded/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcNettyShadedLogRecordExporterTest.java
+++ b/exporters/otlp/logs/src/testGrpcNettyShaded/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcNettyShadedLogRecordExporterTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.exporter.otlp.logs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.grpc.ManagedChannel;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.opentelemetry.exporter.internal.grpc.UpstreamGrpcExporter;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
@@ -31,11 +32,11 @@ class OtlpGrpcNettyShadedLogRecordExporterTest
   @Test
   @SuppressWarnings("deprecation") // testing deprecated feature
   void usingGrpc() throws Exception {
-    try (Closeable exporter =
-        OtlpGrpcLogRecordExporter.builder()
-            .setChannel(InProcessChannelBuilder.forName("test").build())
-            .build()) {
+    ManagedChannel channel = InProcessChannelBuilder.forName("test").build();
+    try (Closeable exporter = OtlpGrpcLogRecordExporter.builder().setChannel(channel).build()) {
       assertThat(exporter).extracting("delegate").isInstanceOf(UpstreamGrpcExporter.class);
+    } finally {
+      channel.shutdownNow();
     }
   }
 

--- a/exporters/otlp/logs/src/testGrpcOkhttp/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcNettyOkHttpLogRecordExporterTest.java
+++ b/exporters/otlp/logs/src/testGrpcOkhttp/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcNettyOkHttpLogRecordExporterTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.exporter.otlp.logs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.grpc.ManagedChannel;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.opentelemetry.exporter.internal.grpc.UpstreamGrpcExporter;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
@@ -31,11 +32,11 @@ class OtlpGrpcNettyOkHttpLogRecordExporterTest
   @Test
   @SuppressWarnings("deprecation") // testing deprecated feature
   void usingGrpc() throws Exception {
-    try (Closeable exporter =
-        OtlpGrpcLogRecordExporter.builder()
-            .setChannel(InProcessChannelBuilder.forName("test").build())
-            .build()) {
+    ManagedChannel channel = InProcessChannelBuilder.forName("test").build();
+    try (Closeable exporter = OtlpGrpcLogRecordExporter.builder().setChannel(channel).build()) {
       assertThat(exporter).extracting("delegate").isInstanceOf(UpstreamGrpcExporter.class);
+    } finally {
+      channel.shutdownNow();
     }
   }
 

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
@@ -242,22 +242,30 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
   void compressionWithNone() {
     TelemetryExporter<T> exporter =
         exporterBuilder().setEndpoint(server.httpUri().toString()).setCompression("none").build();
-    // UpstreamGrpcExporter doesn't support compression, so we skip the assertion
-    assumeThat(exporter.unwrap())
-        .extracting("delegate")
-        .isNotInstanceOf(UpstreamGrpcExporter.class);
-    assertThat(exporter.unwrap()).extracting("delegate.compressionEnabled").isEqualTo(false);
+    try {
+      // UpstreamGrpcExporter doesn't support compression, so we skip the assertion
+      assumeThat(exporter.unwrap())
+          .extracting("delegate")
+          .isNotInstanceOf(UpstreamGrpcExporter.class);
+      assertThat(exporter.unwrap()).extracting("delegate.compressionEnabled").isEqualTo(false);
+    } finally {
+      exporter.shutdown();
+    }
   }
 
   @Test
   void compressionWithGzip() {
     TelemetryExporter<T> exporter =
         exporterBuilder().setEndpoint(server.httpUri().toString()).setCompression("gzip").build();
-    // UpstreamGrpcExporter doesn't support compression, so we skip the assertion
-    assumeThat(exporter.unwrap())
-        .extracting("delegate")
-        .isNotInstanceOf(UpstreamGrpcExporter.class);
-    assertThat(exporter.unwrap()).extracting("delegate.compressionEnabled").isEqualTo(true);
+    try {
+      // UpstreamGrpcExporter doesn't support compression, so we skip the assertion
+      assumeThat(exporter.unwrap())
+          .extracting("delegate")
+          .isNotInstanceOf(UpstreamGrpcExporter.class);
+      assertThat(exporter.unwrap()).extracting("delegate.compressionEnabled").isEqualTo(true);
+    } finally {
+      exporter.shutdown();
+    }
   }
 
   @Test


### PR DESCRIPTION
The build output is full of ugly stack traces that start look like the following:
```
    [Test worker] ERROR io.grpc.internal.ManagedChannelOrphanWrapper - *~*~*~ Previous channel ManagedChannelImpl{logId=95, target=127.0.0.1:49651} was not shutdown properly!!! ~*~*~*
        Make sure to call shutdown()/shutdownNow() and wait until awaitTermination() returns true.
    java.lang.RuntimeException: ManagedChannel allocation site
    	at io.grpc.internal.ManagedChannelOrphanWrapper$ManagedChannelReference.<init>(ManagedChannelOrphanWrapper.java:100)
```
I've been ignoring this for a while thinking that it wasn't easily solved, but took a closer look today and noticed that the stack trace actually points to the site where a `ManagedChannel` was initialized and never shutdown. Went through offending tests and closed the resources and the build output is a lot cleaner. 