### PR TITLE
Support parentbased_jaeger_remote sampler.

### DIFF
--- a/sdk-extensions/autoconfigure/build.gradle.kts
+++ b/sdk-extensions/autoconfigure/build.gradle.kts
@@ -71,6 +71,7 @@ testing {
         implementation(project(":exporters:zipkin"))
         implementation(project(":sdk:testing"))
         implementation(project(":sdk:trace-shaded-deps"))
+        implementation(project(":sdk-extensions:jaeger-remote-sampler"))
         implementation(project(":semconv"))
 
         implementation("com.google.guava:guava")

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
@@ -171,6 +171,13 @@ final class TracerProviderConfiguration {
               config.getDouble("otel.traces.sampler.arg", DEFAULT_TRACEIDRATIO_SAMPLE_RATIO);
           return Sampler.parentBased(Sampler.traceIdRatioBased(ratio));
         }
+      case "parentbased_jaeger_remote":
+        Sampler jaegerRemote = spiSamplersManager.getByName("jaeger_remote");
+        if (jaegerRemote == null) {
+          throw new ConfigurationException(
+              "parentbased_jaeger_remote configured but opentelemetry-sdk-extension-jaeger-remote-sampler not on classpath");
+        }
+        return Sampler.parentBased(jaegerRemote);
       default:
         Sampler spiSampler = spiSamplersManager.getByName(sampler);
         if (spiSampler == null) {

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
@@ -246,5 +246,14 @@ class TracerProviderConfigurationTest {
                     "catsampler", EMPTY, TracerProviderConfiguration.class.getClassLoader()))
         .isInstanceOf(ConfigurationException.class)
         .hasMessage("Unrecognized value for otel.traces.sampler: catsampler");
+    assertThatThrownBy(
+            () ->
+                TracerProviderConfiguration.configureSampler(
+                    "parentbased_jaeger_remote",
+                    EMPTY,
+                    TracerProviderConfiguration.class.getClassLoader()))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessage(
+            "parentbased_jaeger_remote configured but opentelemetry-sdk-extension-jaeger-remote-sampler not on classpath");
   }
 }

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
@@ -13,13 +13,14 @@ import io.opentelemetry.sdk.autoconfigure.provider.TestConfigurableSamplerProvid
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import io.opentelemetry.sdk.extension.trace.jaeger.sampler.JaegerRemoteSampler;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
-public class ConfigurableSamplerTest {
+public class TracerProviderConfigurationTest {
 
   @Test
   void configuration() {
@@ -57,5 +58,19 @@ public class ConfigurableSamplerTest {
                     TracerProviderConfiguration.class.getClassLoader()))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("catSampler");
+  }
+
+  @Test
+  void configureSampler_JaegerRemoteSampler() {
+    assertThat(
+            TracerProviderConfiguration.configureSampler(
+                "parentbased_jaeger_remote",
+                DefaultConfigProperties.createForTest(Collections.emptyMap()),
+                TracerProviderConfigurationTest.class.getClassLoader()))
+        .satisfies(
+            sampler -> {
+              assertThat(sampler.getClass().getSimpleName()).isEqualTo("ParentBasedSampler");
+              assertThat(sampler).extracting("root").isInstanceOf(JaegerRemoteSampler.class);
+            });
   }
 }


### PR DESCRIPTION
This PR enables support for `parentbased_jaeger_remote` sampler that is documented in the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration) but cannot be instantiated.