### PR TITLE
Ignore updates to mockito 5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,6 @@ updates:
     ignore:
       - dependency-name: "edu.berkeley.cs.jqf:jqf-fuzz"
       - dependency-name: "org.jetbrains.kotlinx:kotlinx-coroutines-core"
+      # Ignore updates to next mockito major version 5.x.x, which requires Java 11
+      - dependency-name: "org.mockito:mockito-core"
+        update-types: ["version-update:semver-major"]

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -28,6 +28,7 @@ val DEPENDENCY_BOMS = listOf(
 val autoValueVersion = "1.10.1"
 val errorProneVersion = "2.15.0"
 val jmhVersion = "1.36"
+// Mockito 5.x.x requires Java 11 https://github.com/mockito/mockito/releases/tag/v5.0.0
 val mockitoVersion = "4.11.0"
 val slf4jVersion = "2.0.6"
 val opencensusVersion = "0.31.1"


### PR DESCRIPTION
#5128 build is failing because mockito 5 requires java 11 support. If we want to include it in our build, we could require java 11+ to run tests, but the simplest approach is to pin the version to mockito 4.x.x. 