### PR TITLE
Make implicit gradle dependencies explicit

### DIFF
--- a/exporters/jaeger/build.gradle.kts
+++ b/exporters/jaeger/build.gradle.kts
@@ -42,6 +42,9 @@ wire {
   }
 }
 
+// Declare sourcesJar dependency on proto generation so gradle doesn't complain about implicit dependency
+tasks.getByName("sourcesJar").dependsOn("generateMainProtos")
+
 sourceSets {
   main {
     java.srcDir("$buildDir/generated/source/wire")

--- a/exporters/otlp/common/build.gradle.kts
+++ b/exporters/otlp/common/build.gradle.kts
@@ -53,6 +53,9 @@ wire {
   }
 }
 
+// Declare sourcesJar dependency on proto generation so gradle doesn't complain about implicit dependency
+tasks.getByName("sourcesJar").dependsOn("generateMainProtos")
+
 sourceSets {
   main {
     java.srcDir("$buildDir/generated/source/wire")

--- a/sdk-extensions/jaeger-remote-sampler/build.gradle.kts
+++ b/sdk-extensions/jaeger-remote-sampler/build.gradle.kts
@@ -69,6 +69,9 @@ wire {
   }
 }
 
+// Declare sourcesJar dependency on proto generation so gradle doesn't complain about implicit dependency
+tasks.getByName("sourcesJar").dependsOn("generateMainProtos")
+
 sourceSets {
   main {
     java.srcDir("$buildDir/generated/source/wire")


### PR DESCRIPTION
Gets rid of gradle warnings about implicit dependencies:
> Task :exporters:jaeger:sourcesJar
Execution optimizations have been disabled for task ':exporters:jaeger:sourcesJar' to ensure correctness due to the following reasons:
Gradle detected a problem with the following location: '/Users/jberg/code/open-telemetry/opentelemetry-java/exporters/jaeger/build/generated/source/wire'. Reason: Task ':exporters:jaeger:sourcesJar' uses this output of task ':exporters:jaeger:generateMainProtos' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.6/userguide/validation_problems.html#implicit_dependency for more details about this problem.
Gradle detected a problem with the following location: '/Users/jberg/code/open-telemetry/opentelemetry-java/exporters/jaeger/build/generated/source/wire'. Reason: Task ':exporters:jaeger:sourcesJar' uses this output of task ':exporters:jaeger:generateMainProtos' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. Execution optimizations are disabled to ensure correctness. See https://docs.gradle.org/7.6/userguide/validation_problems.html#implicit_dependency for more details.