### PR TITLE
OpenTracing Shim: Update Tracer.close()

### DIFF
--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/OpenTracingShim.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/OpenTracingShim.java
@@ -44,6 +44,6 @@ public final class OpenTracingShim {
       TracerProvider provider,
       TextMapPropagator textMapPropagator,
       TextMapPropagator httpPropagator) {
-    return new TracerShim(provider.get("opentracing-shim"), textMapPropagator, httpPropagator);
+    return new TracerShim(provider, textMapPropagator, httpPropagator);
   }
 }


### PR DESCRIPTION
Fixes #5081 

As per the 1.17 Specification, the OpenTracing Tracer [Close](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/opentracing.md#close) operation was added.

I feel tempted to deprecate the `OpenTracingShim.createTracerShim(OpenTelemetry)` method overload, as it wraps the actually `TracerProvider` with `ObfuscatedTracerProvider`, which prevents checking whether the actual instance implements `Closeable` or not.