### PR TITLE
Add resource assertion methods to SpanDataAssert and MetricAssert

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
@@ -29,6 +29,23 @@ Comparing source compatibility of  against
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.MetricAssert  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricAssert hasExponentialHistogramSatisfying(java.util.function.Consumer)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.MetricAssert hasResourceSatisfying(java.util.function.Consumer)
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.ResourceAssert  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.ResourceAssert hasAttribute(io.opentelemetry.api.common.AttributeKey, java.lang.Object)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.ResourceAssert hasAttribute(io.opentelemetry.sdk.testing.assertj.AttributeAssertion)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.ResourceAssert hasAttributes(io.opentelemetry.api.common.Attributes)
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.ResourceAssert hasAttributes(java.util.Map$Entry[])
+		+++  NEW ANNOTATION: java.lang.SafeVarargs
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.ResourceAssert hasAttributesSatisfying(java.util.function.Consumer)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.ResourceAssert hasAttributesSatisfying(io.opentelemetry.sdk.testing.assertj.AttributeAssertion[])
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.ResourceAssert hasAttributesSatisfying(java.lang.Iterable)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.ResourceAssert hasAttributesSatisfyingExactly(io.opentelemetry.sdk.testing.assertj.AttributeAssertion[])
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.ResourceAssert hasAttributesSatisfyingExactly(java.lang.Iterable)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.ResourceAssert hasSchemaUrl(java.lang.String)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.SpanDataAssert  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.SpanDataAssert hasResourceSatisfying(java.util.function.Consumer)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.TracesAssert  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.assertj.TracesAssert assertThat(java.util.List)

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/AttributeAssertion.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/AttributeAssertion.java
@@ -43,7 +43,7 @@ public abstract class AttributeAssertion {
   }
 
   private static AbstractAssert<? extends AbstractAssert<?, ?>, ?> makeAssertion(
-      AttributeKey<?> key, Object value) {
+      AttributeKey<?> key, @Nullable Object value) {
     switch (key.getType()) {
       case STRING:
         return assertThat((String) value);

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/MetricAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/MetricAssert.java
@@ -37,6 +37,18 @@ public final class MetricAssert extends AbstractAssert<MetricAssert, MetricData>
     return this;
   }
 
+  /**
+   * Asserts the metric has a resource satisfying the given condition.
+   *
+   * @since 1.23.0
+   */
+  public MetricAssert hasResourceSatisfying(Consumer<ResourceAssert> resource) {
+    isNotNull();
+    resource.accept(
+        new ResourceAssert(actual.getResource(), String.format("metric [%s]", actual.getName())));
+    return this;
+  }
+
   /** Asserts the metric has the given the {@link InstrumentationScopeInfo}. */
   public MetricAssert hasInstrumentationScope(InstrumentationScopeInfo instrumentationScopeInfo) {
     isNotNull();

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/ResourceAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/ResourceAssert.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.testing.assertj;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import javax.annotation.Nullable;
+import org.assertj.core.api.AbstractAssert;
+
+/**
+ * Assertions for {@link Resource}.
+ *
+ * @since 1.23.0
+ */
+public final class ResourceAssert extends AbstractAssert<ResourceAssert, Resource> {
+
+  private final String label;
+
+  ResourceAssert(Resource resource, String label) {
+    super(resource, ResourceAssert.class);
+    this.label = label;
+  }
+
+  /** Asserts the resource has a schemaUrl satisfying the given condition. */
+  // Workaround "passing @Nullable parameter 'schemaUrl' where @NonNull is required", Nullaway
+  // seems to think assertThat is supposed to be passed NonNull even though we know that can't be
+  // true for assertions.
+  @SuppressWarnings("NullAway")
+  public ResourceAssert hasSchemaUrl(@Nullable String schemaUrl) {
+    isNotNull();
+    assertThat(actual.getSchemaUrl()).as("resource schema URL of %s", label).isEqualTo(schemaUrl);
+    return this;
+  }
+
+  /** Asserts the resource has the given attribute. */
+  public <T> ResourceAssert hasAttribute(AttributeKey<T> key, T value) {
+    return hasAttribute(OpenTelemetryAssertions.equalTo(key, value));
+  }
+
+  /** Asserts the resource has an attribute matching the {@code attributeAssertion}. */
+  public ResourceAssert hasAttribute(AttributeAssertion attributeAssertion) {
+    isNotNull();
+
+    Set<AttributeKey<?>> actualKeys = actual.getAttributes().asMap().keySet();
+    AttributeKey<?> key = attributeAssertion.getKey();
+
+    assertThat(actualKeys).as("resource attribute keys of %s", label).contains(key);
+
+    Object value = actual.getAttributes().get(key);
+    AbstractAssert<?, ?> assertion = AttributeAssertion.attributeValueAssertion(key, value);
+    attributeAssertion.getAssertion().accept(assertion);
+
+    return this;
+  }
+
+  /** Asserts the resource has the given attributes. */
+  public ResourceAssert hasAttributes(Attributes attributes) {
+    isNotNull();
+    if (!AssertUtil.attributesAreEqual(actual.getAttributes(), attributes)) {
+      failWithActualExpectedAndMessage(
+          actual.getAttributes(),
+          attributes,
+          "Expected resource of <%s> to have attributes <%s> but was <%s>",
+          label,
+          attributes,
+          actual.getAttributes());
+    }
+    return this;
+  }
+
+  /** Asserts the resource has the given attributes. */
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  @SafeVarargs
+  public final ResourceAssert hasAttributes(Map.Entry<? extends AttributeKey<?>, ?>... entries) {
+    AttributesBuilder attributesBuilder = Attributes.builder();
+    for (Map.Entry<? extends AttributeKey<?>, ?> attr : entries) {
+      attributesBuilder.put((AttributeKey) attr.getKey(), attr.getValue());
+    }
+    Attributes attributes = attributesBuilder.build();
+    return hasAttributes(attributes);
+  }
+
+  /** Asserts the resource has attributes satisfying the given condition. */
+  public ResourceAssert hasAttributesSatisfying(Consumer<Attributes> attributes) {
+    isNotNull();
+    OpenTelemetryAssertions.assertThat(actual.getAttributes())
+        .as("resource attributes of %s", label)
+        .satisfies(attributes);
+    return this;
+  }
+
+  /**
+   * Asserts the event has attributes matching all {@code assertions}. Assertions can be created
+   * using methods like {@link OpenTelemetryAssertions#satisfies(AttributeKey,
+   * OpenTelemetryAssertions.LongAssertConsumer)}.
+   */
+  public ResourceAssert hasAttributesSatisfying(AttributeAssertion... assertions) {
+    return hasAttributesSatisfying(Arrays.asList(assertions));
+  }
+
+  /**
+   * Asserts the event has attributes matching all {@code assertions}. Assertions can be created
+   * using methods like {@link OpenTelemetryAssertions#satisfies(AttributeKey,
+   * OpenTelemetryAssertions.LongAssertConsumer)}.
+   */
+  public ResourceAssert hasAttributesSatisfying(Iterable<AttributeAssertion> assertions) {
+    AssertUtil.assertAttributes(
+        actual.getAttributes(), assertions, String.format("resource of %s attribute keys", label));
+    return this;
+  }
+
+  /**
+   * Asserts the resource has attributes matching all {@code assertions} and no more. Assertions can
+   * be created using methods like {@link OpenTelemetryAssertions#satisfies(AttributeKey,
+   * OpenTelemetryAssertions.LongAssertConsumer)}.
+   */
+  public ResourceAssert hasAttributesSatisfyingExactly(AttributeAssertion... assertions) {
+    return hasAttributesSatisfyingExactly(Arrays.asList(assertions));
+  }
+
+  /**
+   * Asserts the resource has attributes matching all {@code assertions} and no more. Assertions can
+   * be created using methods like {@link OpenTelemetryAssertions#satisfies(AttributeKey,
+   * OpenTelemetryAssertions.LongAssertConsumer)}.
+   */
+  public ResourceAssert hasAttributesSatisfyingExactly(Iterable<AttributeAssertion> assertions) {
+    AssertUtil.assertAttributesExactly(
+        actual.getAttributes(), assertions, String.format("resource of %s attribute keys", label));
+    return this;
+  }
+}

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SpanDataAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SpanDataAssert.java
@@ -160,6 +160,18 @@ public final class SpanDataAssert extends AbstractAssert<SpanDataAssert, SpanDat
   }
 
   /**
+   * Asserts the span has a resource satisfying the given condition.
+   *
+   * @since 1.23.0
+   */
+  public SpanDataAssert hasResourceSatisfying(Consumer<ResourceAssert> resource) {
+    isNotNull();
+    resource.accept(
+        new ResourceAssert(actual.getResource(), String.format("span [%s]", actual.getName())));
+    return this;
+  }
+
+  /**
    * Asserts the span has the given {@link io.opentelemetry.sdk.common.InstrumentationLibraryInfo}.
    *
    * @deprecated Use {@link #hasInstrumentationScopeInfo(InstrumentationScopeInfo)}.

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/MetricAssertionsTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/MetricAssertionsTest.java
@@ -1052,6 +1052,12 @@ class MetricAssertionsTest {
         .isInstanceOf(AssertionError.class);
     assertThatThrownBy(
             () ->
+                assertThat(DOUBLE_GAUGE_METRIC)
+                    .hasSummarySatisfying(
+                        summary -> summary.hasPointsSatisfying(point -> {}, point -> {})))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
                 assertThat(SUMMARY_METRIC)
                     .hasSummarySatisfying(
                         summary -> summary.hasPointsSatisfying(point -> {}, point -> {})))

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/MetricAssertionsTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/MetricAssertionsTest.java
@@ -221,7 +221,7 @@ class MetricAssertionsTest {
           ImmutableHistogramData.create(
               AggregationTemporality.CUMULATIVE,
               // Points
-              Arrays.asList(HISTOGRAM_POINT_DATA)));
+              Collections.singletonList(HISTOGRAM_POINT_DATA)));
 
   private static final MetricData HISTOGRAM_METRIC_DELTA =
       ImmutableMetricData.createDoubleHistogram(
@@ -233,7 +233,7 @@ class MetricAssertionsTest {
           ImmutableHistogramData.create(
               AggregationTemporality.DELTA,
               // Points
-              Arrays.asList(HISTOGRAM_POINT_DATA)));
+              Collections.singletonList(HISTOGRAM_POINT_DATA)));
 
   private static final ExponentialHistogramPointData EXPONENTIAL_HISTOGRAM_POINT_DATA =
       ImmutableExponentialHistogramPointData.create(
@@ -291,9 +291,10 @@ class MetricAssertionsTest {
           /* unit= */ "1",
           ImmutableSummaryData.create(
               // Points
-              Arrays.asList(SUMMARY_POINT_DATA)));
+              Collections.singletonList(SUMMARY_POINT_DATA)));
 
   @Test
+  @SuppressWarnings("Convert2MethodRef")
   void doubleGauge() {
     assertThat(DOUBLE_GAUGE_METRIC)
         .hasResource(RESOURCE)
@@ -421,6 +422,7 @@ class MetricAssertionsTest {
   }
 
   @Test
+  @SuppressWarnings("Convert2MethodRef")
   void doubleGaugeFailure() {
     assertThatThrownBy(() -> assertThat(DOUBLE_GAUGE_METRIC).hasResource(Resource.empty()))
         .isInstanceOf(AssertionError.class);
@@ -784,6 +786,7 @@ class MetricAssertionsTest {
   }
 
   @Test
+  @SuppressWarnings("Convert2MethodRef")
   void doubleSumFailure() {
     assertThatThrownBy(() -> assertThat(DOUBLE_SUM_METRIC).hasLongSumSatisfying(sum -> {}))
         .isInstanceOf(AssertionError.class);
@@ -825,6 +828,7 @@ class MetricAssertionsTest {
   }
 
   @Test
+  @SuppressWarnings("Convert2MethodRef")
   void longSumFailure() {
     assertThatThrownBy(() -> assertThat(LONG_SUM_METRIC).hasDoubleSumSatisfying(sum -> {}))
         .isInstanceOf(AssertionError.class);

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/MetricAssertionsTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/MetricAssertionsTest.java
@@ -55,10 +55,11 @@ class MetricAssertionsTest {
   private static final String SPAN_ID2 = "0000000000000004";
 
   private static final Resource RESOURCE =
-      Resource.create(Attributes.builder().put("dog", "bark").build());
+      Resource.create(Attributes.builder().put("dog", "bark").put("dog is cute", true).build());
   private static final InstrumentationScopeInfo INSTRUMENTATION_SCOPE_INFO =
       InstrumentationScopeInfo.builder("opentelemetry").setVersion("1.0").build();
 
+  private static final AttributeKey<String> DOG = AttributeKey.stringKey("dog");
   private static final AttributeKey<String> BEAR = AttributeKey.stringKey("bear");
   private static final AttributeKey<String> CAT = AttributeKey.stringKey("cat");
   private static final AttributeKey<Boolean> WARM = AttributeKey.booleanKey("warm");
@@ -298,6 +299,36 @@ class MetricAssertionsTest {
   void doubleGauge() {
     assertThat(DOUBLE_GAUGE_METRIC)
         .hasResource(RESOURCE)
+        .hasResourceSatisfying(
+            resource ->
+                resource
+                    .hasSchemaUrl(null)
+                    .hasAttribute(DOG, "bark")
+                    .hasAttributes(
+                        Attributes.of(DOG, "bark", AttributeKey.booleanKey("dog is cute"), true))
+                    .hasAttributes(
+                        attributeEntry("dog", "bark"), attributeEntry("dog is cute", true))
+                    .hasAttributesSatisfying(
+                        attributes ->
+                            assertThat(attributes)
+                                .hasSize(2)
+                                .containsEntry(AttributeKey.stringKey("dog"), "bark")
+                                .hasEntrySatisfying(DOG, value -> assertThat(value).hasSize(4))
+                                .hasEntrySatisfying(
+                                    AttributeKey.booleanKey("dog is cute"),
+                                    value -> assertThat(value).isTrue())))
+        .hasResourceSatisfying(
+            resource ->
+                resource.hasAttributesSatisfying(satisfies(DOG, val -> val.isEqualTo("bark"))))
+        .hasResourceSatisfying(
+            resource ->
+                resource.hasAttributesSatisfyingExactly(
+                    equalTo(DOG, "bark"), equalTo(AttributeKey.booleanKey("dog is cute"), true)))
+        .hasResourceSatisfying(
+            resource ->
+                resource.hasAttributesSatisfyingExactly(
+                    satisfies(DOG, val -> val.startsWith("bar")),
+                    satisfies(AttributeKey.booleanKey("dog is cute"), val -> val.isTrue())))
         .hasInstrumentationScope(INSTRUMENTATION_SCOPE_INFO)
         .hasName("gauge")
         .hasDescription("a gauge")
@@ -425,6 +456,79 @@ class MetricAssertionsTest {
   @SuppressWarnings("Convert2MethodRef")
   void doubleGaugeFailure() {
     assertThatThrownBy(() -> assertThat(DOUBLE_GAUGE_METRIC).hasResource(Resource.empty()))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(DOUBLE_GAUGE_METRIC)
+                    .hasResourceSatisfying(resource -> resource.hasSchemaUrl("http://example.com")))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(DOUBLE_GAUGE_METRIC)
+                    .hasResourceSatisfying(resource -> resource.hasAttribute(DOG, "meow")))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(DOUBLE_GAUGE_METRIC)
+                    .hasResourceSatisfying(
+                        resource -> resource.hasAttributes(Attributes.of(DOG, "bark"))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(DOUBLE_GAUGE_METRIC)
+                    .hasResourceSatisfying(
+                        resource -> resource.hasAttributes(attributeEntry("dog is cute", true))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(DOUBLE_GAUGE_METRIC)
+                    .hasResourceSatisfying(
+                        resource ->
+                            resource.hasAttributesSatisfying(
+                                attributes -> assertThat(attributes).hasSize(1))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(DOUBLE_GAUGE_METRIC)
+                    .hasResourceSatisfying(
+                        resource ->
+                            resource.hasAttributesSatisfying(
+                                attributes ->
+                                    assertThat(attributes)
+                                        .containsEntry(AttributeKey.stringKey("dog"), "meow"))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(DOUBLE_GAUGE_METRIC)
+                    .hasResourceSatisfying(
+                        resource ->
+                            resource.hasAttributesSatisfying(
+                                attributes ->
+                                    assertThat(attributes)
+                                        .containsEntry(
+                                            AttributeKey.booleanKey("dog is cute"), false))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(DOUBLE_GAUGE_METRIC)
+                    .hasResourceSatisfying(
+                        resource ->
+                            resource.hasAttributesSatisfying(
+                                satisfies(DOG, val -> val.isEqualTo("meow")))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(DOUBLE_GAUGE_METRIC)
+                    .hasResourceSatisfying(
+                        resource -> resource.hasAttributesSatisfyingExactly(equalTo(DOG, "bark"))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(DOUBLE_GAUGE_METRIC)
+                    .hasResourceSatisfying(
+                        resource ->
+                            resource.hasAttributesSatisfyingExactly(
+                                satisfies(DOG, val -> val.isEqualTo("bark")))))
         .isInstanceOf(AssertionError.class);
     assertThatThrownBy(
             () ->

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/TraceAssertionsTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/TraceAssertionsTest.java
@@ -132,6 +132,7 @@ class TraceAssertionsTest {
   }
 
   @Test
+  @SuppressWarnings("Convert2MethodRef")
   void passing() {
     assertThat(SPAN1)
         .hasTraceId(TRACE_ID)
@@ -274,6 +275,7 @@ class TraceAssertionsTest {
   }
 
   @Test
+  @SuppressWarnings("Convert2MethodRef")
   void failure() {
     assertThatThrownBy(() -> assertThat(SPAN1).hasTraceId("foo"))
         .isInstanceOf(AssertionError.class);
@@ -513,6 +515,7 @@ class TraceAssertionsTest {
   }
 
   @Test
+  @SuppressWarnings("Convert2MethodRef")
   void optionalAttributes() {
     assertThat(SPAN1)
         .hasAttributesSatisfyingExactly(

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/TraceAssertionsTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/TraceAssertionsTest.java
@@ -44,10 +44,11 @@ class TraceAssertionsTest {
   private static final String SPAN_ID2 = "0000000000000004";
   private static final TraceState TRACE_STATE = TraceState.builder().put("cat", "meow").build();
   private static final Resource RESOURCE =
-      Resource.create(Attributes.builder().put("dog", "bark").build());
+      Resource.create(Attributes.builder().put("dog", "bark").put("dog is cute", true).build());
   private static final InstrumentationScopeInfo INSTRUMENTATION_SCOPE_INFO =
       InstrumentationScopeInfo.builder("opentelemetry").setVersion("1.0").build();
 
+  private static final AttributeKey<String> DOG = AttributeKey.stringKey("dog");
   private static final AttributeKey<String> BEAR = AttributeKey.stringKey("bear");
   private static final AttributeKey<String> CAT = AttributeKey.stringKey("cat");
   private static final AttributeKey<Boolean> WARM = AttributeKey.booleanKey("warm");
@@ -141,6 +142,36 @@ class TraceAssertionsTest {
         .hasTraceState(TRACE_STATE)
         .hasParentSpanId(SPAN_ID2)
         .hasResource(RESOURCE)
+        .hasResourceSatisfying(
+            resource ->
+                resource
+                    .hasSchemaUrl(null)
+                    .hasAttribute(DOG, "bark")
+                    .hasAttributes(
+                        Attributes.of(DOG, "bark", AttributeKey.booleanKey("dog is cute"), true))
+                    .hasAttributes(
+                        attributeEntry("dog", "bark"), attributeEntry("dog is cute", true))
+                    .hasAttributesSatisfying(
+                        attributes ->
+                            assertThat(attributes)
+                                .hasSize(2)
+                                .containsEntry(AttributeKey.stringKey("dog"), "bark")
+                                .hasEntrySatisfying(DOG, value -> assertThat(value).hasSize(4))
+                                .hasEntrySatisfying(
+                                    AttributeKey.booleanKey("dog is cute"),
+                                    value -> assertThat(value).isTrue())))
+        .hasResourceSatisfying(
+            resource ->
+                resource.hasAttributesSatisfying(satisfies(DOG, val -> val.isEqualTo("bark"))))
+        .hasResourceSatisfying(
+            resource ->
+                resource.hasAttributesSatisfyingExactly(
+                    equalTo(DOG, "bark"), equalTo(AttributeKey.booleanKey("dog is cute"), true)))
+        .hasResourceSatisfying(
+            resource ->
+                resource.hasAttributesSatisfyingExactly(
+                    satisfies(DOG, val -> val.startsWith("bar")),
+                    satisfies(AttributeKey.booleanKey("dog is cute"), val -> val.isTrue())))
         .hasInstrumentationScopeInfo(INSTRUMENTATION_SCOPE_INFO)
         .hasName("span")
         .hasKind(SpanKind.CLIENT)
@@ -271,7 +302,8 @@ class TraceAssertionsTest {
         .hasTotalRecordedLinks(400)
         .hasTotalAttributeCount(500);
 
-    assertThat(RESOURCE.getAttributes()).containsOnly(entry(AttributeKey.stringKey("dog"), "bark"));
+    assertThat(RESOURCE.getAttributes())
+        .containsOnly(entry(DOG, "bark"), entry(AttributeKey.booleanKey("dog is cute"), true));
   }
 
   @Test
@@ -287,6 +319,79 @@ class TraceAssertionsTest {
     assertThatThrownBy(() -> assertThat(SPAN1).hasParentSpanId("foo"))
         .isInstanceOf(AssertionError.class);
     assertThatThrownBy(() -> assertThat(SPAN1).hasResource(Resource.empty()))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(SPAN1)
+                    .hasResourceSatisfying(resource -> resource.hasSchemaUrl("http://example.com")))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(SPAN1)
+                    .hasResourceSatisfying(resource -> resource.hasAttribute(DOG, "meow")))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(SPAN1)
+                    .hasResourceSatisfying(
+                        resource -> resource.hasAttributes(Attributes.of(DOG, "bark"))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(SPAN1)
+                    .hasResourceSatisfying(
+                        resource -> resource.hasAttributes(attributeEntry("dog is cute", true))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(SPAN1)
+                    .hasResourceSatisfying(
+                        resource ->
+                            resource.hasAttributesSatisfying(
+                                attributes -> assertThat(attributes).hasSize(1))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(SPAN1)
+                    .hasResourceSatisfying(
+                        resource ->
+                            resource.hasAttributesSatisfying(
+                                attributes ->
+                                    assertThat(attributes)
+                                        .containsEntry(AttributeKey.stringKey("dog"), "meow"))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(SPAN1)
+                    .hasResourceSatisfying(
+                        resource ->
+                            resource.hasAttributesSatisfying(
+                                attributes ->
+                                    assertThat(attributes)
+                                        .containsEntry(
+                                            AttributeKey.booleanKey("dog is cute"), false))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(SPAN1)
+                    .hasResourceSatisfying(
+                        resource ->
+                            resource.hasAttributesSatisfying(
+                                satisfies(DOG, val -> val.isEqualTo("meow")))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(SPAN1)
+                    .hasResourceSatisfying(
+                        resource -> resource.hasAttributesSatisfyingExactly(equalTo(DOG, "bark"))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(SPAN1)
+                    .hasResourceSatisfying(
+                        resource ->
+                            resource.hasAttributesSatisfyingExactly(
+                                satisfies(DOG, val -> val.isEqualTo("bark")))))
         .isInstanceOf(AssertionError.class);
     assertThatThrownBy(
             () -> assertThat(SPAN1).hasInstrumentationScopeInfo(InstrumentationScopeInfo.empty()))


### PR DESCRIPTION
The `SpanDataAssert` and `MetricAssert` classes are missing convenient methods to assert resource attributes. The provided `hasResource()` quickly reaches its limits when the captured `Resource` is populated with (system dependent) autoconfigured values (e.g. host resources).

This PR adds a `ResourceAssert` class with methods to assert the resource schema URL and the resource attributes, copying the already established assertion methods from the span attributes.

See also https://cloud-native.slack.com/archives/C014L2KCTE3/p1675083869242799