### PR TITLE
Reuse MetricData

### DIFF
--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/PrimitiveLongList.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/PrimitiveLongList.java
@@ -30,6 +30,13 @@ public final class PrimitiveLongList {
     return new LongListImpl(values);
   }
 
+  /** Set the size. */
+  public static void setSize(List<Long> list, int size) {
+    if (list instanceof LongListImpl) {
+      ((LongListImpl) list).setSize(size);
+    }
+  }
+
   /**
    * Returns a primitive array with the values of the list. The list should generally have been
    * created with {@link PrimitiveLongList#wrap(long[])}.
@@ -49,13 +56,22 @@ public final class PrimitiveLongList {
   private static class LongListImpl extends AbstractList<Long> {
 
     private final long[] values;
+    private int size;
 
     LongListImpl(long[] values) {
       this.values = values;
+      this.size = values.length;
+    }
+
+    private void setSize(int size) {
+      this.size = size;
     }
 
     @Override
     public Long get(int index) {
+      if (index >= size) {
+        throw new IndexOutOfBoundsException();
+      }
       // If out of bounds, the array access will produce a perfectly fine IndexOutOfBoundsException.
       return values[index];
     }
@@ -75,7 +91,7 @@ public final class PrimitiveLongList {
 
     @Override
     public int size() {
-      return values.length;
+      return size;
     }
   }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/AdaptingCircularBufferCounter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/AdaptingCircularBufferCounter.java
@@ -14,7 +14,7 @@ package io.opentelemetry.sdk.metrics.internal.aggregator;
  *
  * <p>This class is NOT thread-safe. It is expected to be behind a synchronized incrementer.
  */
-final class AdaptingCircularBufferCounter {
+public final class AdaptingCircularBufferCounter {
   private static final int NULL_INDEX = Integer.MIN_VALUE;
   private int endIndex = NULL_INDEX;
   private int startIndex = NULL_INDEX;
@@ -41,7 +41,7 @@ final class AdaptingCircularBufferCounter {
    *
    * @return the first index with a recording.
    */
-  int getIndexStart() {
+  public int getIndexStart() {
     return startIndex;
   }
 
@@ -52,7 +52,7 @@ final class AdaptingCircularBufferCounter {
    *
    * @return The last index with a recording.
    */
-  int getIndexEnd() {
+  public int getIndexEnd() {
     return endIndex;
   }
 
@@ -95,7 +95,7 @@ final class AdaptingCircularBufferCounter {
    *
    * @return the number of recordings for the index, or 0 if the index is out of bounds.
    */
-  long get(int index) {
+  public long get(int index) {
     if (index < startIndex || index > endIndex) {
       return 0;
     }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramBuckets.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExponentialHistogramBuckets.java
@@ -18,7 +18,7 @@ import javax.annotation.Nullable;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-final class DoubleExponentialHistogramBuckets implements ExponentialHistogramBuckets {
+public final class DoubleExponentialHistogramBuckets implements ExponentialHistogramBuckets {
 
   private AdaptingCircularBufferCounter counts;
   private int scale;
@@ -73,6 +73,10 @@ final class DoubleExponentialHistogramBuckets implements ExponentialHistogramBuc
       return 0;
     }
     return counts.getIndexStart();
+  }
+
+  public AdaptingCircularBufferCounter getCounts() {
+    return counts;
   }
 
   @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/MutableExponentialHistogramBuckets.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/MutableExponentialHistogramBuckets.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.internal.data;
+
+import io.opentelemetry.sdk.internal.PrimitiveLongList;
+import io.opentelemetry.sdk.metrics.data.ExponentialHistogramBuckets;
+import io.opentelemetry.sdk.metrics.internal.aggregator.AdaptingCircularBufferCounter;
+import io.opentelemetry.sdk.metrics.internal.aggregator.DoubleExponentialHistogramBuckets;
+import java.util.List;
+
+public class MutableExponentialHistogramBuckets implements ExponentialHistogramBuckets {
+
+  private int scale;
+  private int offset;
+  private final long[] bucketCounts;
+  private final List<Long> bucketCountsList;
+  private long totalCount;
+
+  public MutableExponentialHistogramBuckets(int maxBuckets) {
+    this.bucketCounts = new long[maxBuckets];
+    this.bucketCountsList = PrimitiveLongList.wrap(bucketCounts);
+  }
+
+  @Override
+  public int getScale() {
+    return scale;
+  }
+
+  @Override
+  public int getOffset() {
+    return offset;
+  }
+
+  @Override
+  public List<Long> getBucketCounts() {
+    return bucketCountsList;
+  }
+
+  @Override
+  public long getTotalCount() {
+    return totalCount;
+  }
+
+  /** Set the values. */
+  public void set(DoubleExponentialHistogramBuckets exponentialHistogramBuckets) {
+    this.scale = exponentialHistogramBuckets.getScale();
+    this.offset = exponentialHistogramBuckets.getOffset();
+    AdaptingCircularBufferCounter counts = exponentialHistogramBuckets.getCounts();
+    for (int i = 0; i < bucketCounts.length; i++) {
+      this.bucketCounts[i] = counts.get(i + counts.getIndexStart());
+    }
+    PrimitiveLongList.setSize(
+        this.bucketCountsList, counts.getIndexEnd() - counts.getIndexStart() + 1);
+    this.totalCount = exponentialHistogramBuckets.getTotalCount();
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/MutableExponentialHistogramData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/MutableExponentialHistogramData.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.internal.data;
+
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.ExponentialHistogramData;
+import io.opentelemetry.sdk.metrics.data.ExponentialHistogramPointData;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Auto value implementation of {@link ExponentialHistogramData}.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public class MutableExponentialHistogramData implements ExponentialHistogramData {
+
+  private AggregationTemporality temporality = AggregationTemporality.CUMULATIVE;
+  private Collection<ExponentialHistogramPointData> pointData = Collections.emptyList();
+
+  public MutableExponentialHistogramData() {}
+
+  @Override
+  public AggregationTemporality getAggregationTemporality() {
+    return temporality;
+  }
+
+  @Override
+  public Collection<ExponentialHistogramPointData> getPoints() {
+    return pointData;
+  }
+
+  /** Set the values. */
+  public void set(
+      AggregationTemporality temporality, Collection<ExponentialHistogramPointData> pointData) {
+    this.temporality = temporality;
+    this.pointData = pointData;
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/MutableExponentialHistogramPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/MutableExponentialHistogramPointData.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.internal.data;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
+import io.opentelemetry.sdk.metrics.data.ExponentialHistogramBuckets;
+import io.opentelemetry.sdk.metrics.data.ExponentialHistogramPointData;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * Auto value implementation of {@link ExponentialHistogramPointData}.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public class MutableExponentialHistogramPointData implements ExponentialHistogramPointData {
+
+  private int scale;
+  private double sum;
+  private long zeroCount;
+  private boolean hasMin;
+  private double min;
+  private boolean hasMax;
+  private double max;
+  @Nullable private ExponentialHistogramBuckets positiveBuckets;
+  @Nullable private ExponentialHistogramBuckets negativeBuckets;
+  private long startEpochNanos;
+  private long epochNanos;
+  private Attributes attributes = Attributes.empty();
+  private List<DoubleExemplarData> exemplars = Collections.emptyList();
+
+  public MutableExponentialHistogramPointData() {}
+
+  @Override
+  public int getScale() {
+    return scale;
+  }
+
+  @Override
+  public double getSum() {
+    return sum;
+  }
+
+  @Override
+  public long getCount() {
+    if (positiveBuckets == null || negativeBuckets == null) {
+      throw new IllegalStateException("Set not called");
+    }
+    return zeroCount + positiveBuckets.getTotalCount() + negativeBuckets.getTotalCount();
+  }
+
+  @Override
+  public long getZeroCount() {
+    return zeroCount;
+  }
+
+  @Override
+  public boolean hasMin() {
+    return hasMin;
+  }
+
+  @Override
+  public double getMin() {
+    return min;
+  }
+
+  @Override
+  public boolean hasMax() {
+    return hasMax;
+  }
+
+  @Override
+  public double getMax() {
+    return max;
+  }
+
+  @Override
+  public ExponentialHistogramBuckets getPositiveBuckets() {
+    if (positiveBuckets == null) {
+      throw new IllegalStateException("Set not called");
+    }
+    return positiveBuckets;
+  }
+
+  @Override
+  public ExponentialHistogramBuckets getNegativeBuckets() {
+    if (negativeBuckets == null) {
+      throw new IllegalStateException("Set not called");
+    }
+    return negativeBuckets;
+  }
+
+  @Override
+  public long getStartEpochNanos() {
+    return startEpochNanos;
+  }
+
+  @Override
+  public long getEpochNanos() {
+    return epochNanos;
+  }
+
+  @Override
+  public Attributes getAttributes() {
+    return attributes;
+  }
+
+  @Override
+  public List<DoubleExemplarData> getExemplars() {
+    return exemplars;
+  }
+
+  /** Set the values. */
+  @SuppressWarnings("TooManyParameters")
+  public void set(
+      int scale,
+      double sum,
+      long zeroCount,
+      boolean hasMin,
+      double min,
+      boolean hasMax,
+      double max,
+      ExponentialHistogramBuckets positiveBuckets,
+      ExponentialHistogramBuckets negativeBuckets,
+      long startEpochNanos,
+      long epochNanos,
+      Attributes attributes,
+      List<DoubleExemplarData> exemplars) {
+    this.scale = scale;
+    this.sum = sum;
+    this.zeroCount = zeroCount;
+    this.hasMin = hasMin;
+    this.min = min;
+    this.hasMax = hasMax;
+    this.max = max;
+    this.positiveBuckets = positiveBuckets;
+    this.negativeBuckets = negativeBuckets;
+    this.startEpochNanos = startEpochNanos;
+    this.epochNanos = epochNanos;
+    this.attributes = attributes;
+    this.exemplars = exemplars;
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/MutableMetricData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/MutableMetricData.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.internal.data;
+
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.metrics.data.Data;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.MetricDataType;
+import io.opentelemetry.sdk.metrics.data.PointData;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.Collections;
+
+/**
+ * A mutable container of metrics.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public class MutableMetricData implements MetricData {
+
+  private final MetricDataType metricDataType;
+
+  private Resource resource = Resource.getDefault();
+  private InstrumentationScopeInfo scope = InstrumentationScopeInfo.empty();
+  private String name = "";
+  private String description = "";
+  private String unit = "";
+  private Data<?> data = (Data<PointData>) Collections::emptyList;
+
+  public MutableMetricData(MetricDataType metricDataType) {
+    this.metricDataType = metricDataType;
+  }
+
+  @Override
+  public Resource getResource() {
+    return resource;
+  }
+
+  @Override
+  public InstrumentationScopeInfo getInstrumentationScopeInfo() {
+    return scope;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public String getUnit() {
+    return unit;
+  }
+
+  @Override
+  public MetricDataType getType() {
+    return metricDataType;
+  }
+
+  @Override
+  public Data<?> getData() {
+    return data;
+  }
+
+  /** Set the values. */
+  public void set(
+      Resource resource,
+      InstrumentationScopeInfo scope,
+      String name,
+      String description,
+      String unit,
+      Data<?> data) {
+    this.resource = resource;
+    this.scope = scope;
+    this.name = name;
+    this.description = description;
+    this.unit = unit;
+    this.data = data;
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java
@@ -53,6 +53,7 @@ public final class DefaultSynchronousMetricStorage<T extends PointData, U extend
   private final AttributesProcessor attributesProcessor;
   private final ConcurrentLinkedQueue<AggregatorHandle<T, U>> aggregatorHandlePool =
       new ConcurrentLinkedQueue<>();
+  private final List<T> points = new ArrayList<>();
 
   DefaultSynchronousMetricStorage(
       RegisteredReader registeredReader,
@@ -130,7 +131,7 @@ public final class DefaultSynchronousMetricStorage<T extends PointData, U extend
             : startEpochNanos;
 
     // Grab aggregated points.
-    List<T> points = new ArrayList<>(aggregatorHandles.size());
+    points.clear();
     for (Map.Entry<Attributes, AggregatorHandle<T, U>> entry : aggregatorHandles.entrySet()) {
       T point = entry.getValue().aggregateThenMaybeReset(start, epochNanos, entry.getKey(), reset);
       if (reset) {


### PR DESCRIPTION
This is POC that pushes the effort to reduce memory allocation to its limit by reusing all data carrier classes on repeated collections (i.e. `MetricData`, `PointData`, supporting arrays etc). I've prototyped this on the exponential histogram aggregation, which is the most complicated.

We can arguably do this safely because readers aren't allowed to perform concurrent reads, so if they synchronously consume all the data during collection and export, there's no risk of the data being updated out from under them. Could also make this explicit by adding a method to `MetricReader` / `MetricExporter` that indicated the desired memory behavior, where the default is to make immutable data carriers as we do today, while allowing for opting in to this improved alternative.

The memory allocation pretty close to as low as possible with this change. The only remaining allocations I see when profiling are allocations for iterators like [this](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java#L134), which would be hard to get rid of.

Performance results before:
```
Benchmark                                                                            (aggregationGenerator)  (aggregationTemporality)  Mode  Cnt           Score           Error   Units
HistogramCollectBenchmark.recordAndCollect                                        EXPLICIT_BUCKET_HISTOGRAM                     DELTA    ss    5  3390255558.400 ±  29491981.021   ns/op
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate                         EXPLICIT_BUCKET_HISTOGRAM                     DELTA    ss    5           3.007 ±         0.020  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate.norm                    EXPLICIT_BUCKET_HISTOGRAM                     DELTA    ss    5    10689731.200 ±     36579.743    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.count                              EXPLICIT_BUCKET_HISTOGRAM                     DELTA    ss    5           1.000                  counts
HistogramCollectBenchmark.recordAndCollect:·gc.time                               EXPLICIT_BUCKET_HISTOGRAM                     DELTA    ss    5           2.000                      ms
HistogramCollectBenchmark.recordAndCollect                                        EXPLICIT_BUCKET_HISTOGRAM                CUMULATIVE    ss    5  3436534566.600 ± 102736943.608   ns/op
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate                         EXPLICIT_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           3.202 ±         0.199  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate.norm                    EXPLICIT_BUCKET_HISTOGRAM                CUMULATIVE    ss    5    11536620.800 ±    526953.810    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.count                              EXPLICIT_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           1.000                  counts
HistogramCollectBenchmark.recordAndCollect:·gc.time                               EXPLICIT_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           3.000                      ms
HistogramCollectBenchmark.recordAndCollect                             DEFAULT_EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5  9538995141.800 ±  95720490.562   ns/op
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate              DEFAULT_EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5           0.636 ±         0.030  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate.norm         DEFAULT_EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5     6363548.800 ±    305261.174    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.count                   DEFAULT_EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5             ≈ 0                  counts
HistogramCollectBenchmark.recordAndCollect                             DEFAULT_EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5  9042829725.000 ± 169838553.573   ns/op
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate              DEFAULT_EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           0.933 ±         0.068  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate.norm         DEFAULT_EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5     8849014.400 ±    654075.369    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.count                   DEFAULT_EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           1.000                  counts
HistogramCollectBenchmark.recordAndCollect:·gc.time                    DEFAULT_EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           1.000                      ms
HistogramCollectBenchmark.recordAndCollect                      ZERO_MAX_SCALE_EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5  2616061300.000 ±  67260283.355   ns/op
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate       ZERO_MAX_SCALE_EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5           2.391 ±         0.104  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate.norm  ZERO_MAX_SCALE_EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5     6559592.000 ±    284720.892    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.count            ZERO_MAX_SCALE_EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5             ≈ 0                  counts
HistogramCollectBenchmark.recordAndCollect                      ZERO_MAX_SCALE_EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5  2624043408.200 ±  48730935.089   ns/op
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate       ZERO_MAX_SCALE_EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           3.420 ±         0.167  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate.norm  ZERO_MAX_SCALE_EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5     9411476.800 ±    308800.163    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.count            ZERO_MAX_SCALE_EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           1.000                  counts
HistogramCollectBenchmark.recordAndCollect:·gc.time             ZERO_MAX_SCALE_EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           1.000                      ms

```

And after:
```
Benchmark                                                                            (aggregationGenerator)  (aggregationTemporality)  Mode  Cnt           Score           Error   Units
HistogramCollectBenchmark.recordAndCollect                                        EXPLICIT_BUCKET_HISTOGRAM                     DELTA    ss    5  3419985283.400 ± 151582884.704   ns/op
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate                         EXPLICIT_BUCKET_HISTOGRAM                     DELTA    ss    5           2.751 ±         0.123  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate.norm                    EXPLICIT_BUCKET_HISTOGRAM                     DELTA    ss    5     9866568.000 ±     37649.913    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.count                              EXPLICIT_BUCKET_HISTOGRAM                     DELTA    ss    5           1.000                  counts
HistogramCollectBenchmark.recordAndCollect:·gc.time                               EXPLICIT_BUCKET_HISTOGRAM                     DELTA    ss    5           2.000                      ms
HistogramCollectBenchmark.recordAndCollect                                        EXPLICIT_BUCKET_HISTOGRAM                CUMULATIVE    ss    5  3388788383.400 ±  60495964.200   ns/op
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate                         EXPLICIT_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           3.135 ±         0.145  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate.norm                    EXPLICIT_BUCKET_HISTOGRAM                CUMULATIVE    ss    5    11139739.200 ±    524543.367    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.count                              EXPLICIT_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           1.000                  counts
HistogramCollectBenchmark.recordAndCollect:·gc.time                               EXPLICIT_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           2.000                      ms
HistogramCollectBenchmark.recordAndCollect                             DEFAULT_EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5  9395388091.800 ± 153378190.486   ns/op
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate              DEFAULT_EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5           0.091 ±         0.004  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate.norm         DEFAULT_EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5      897084.800 ±     37461.645    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.count                   DEFAULT_EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5             ≈ 0                  counts
HistogramCollectBenchmark.recordAndCollect                             DEFAULT_EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5  9112423758.200 ± 236433256.733   ns/op
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate              DEFAULT_EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           0.037 ±         0.011  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate.norm         DEFAULT_EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5      354672.000 ±    106694.842    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.count                   DEFAULT_EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5             ≈ 0                  counts
HistogramCollectBenchmark.recordAndCollect                      ZERO_MAX_SCALE_EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5  2718587791.800 ± 101656015.007   ns/op
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate       ZERO_MAX_SCALE_EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5           0.308 ±         0.005  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate.norm  ZERO_MAX_SCALE_EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5      877884.800 ±     37461.645    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.count            ZERO_MAX_SCALE_EXPONENTIAL_BUCKET_HISTOGRAM                     DELTA    ss    5             ≈ 0                  counts
HistogramCollectBenchmark.recordAndCollect                      ZERO_MAX_SCALE_EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5  2500148341.400 ±  52782025.526   ns/op
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate       ZERO_MAX_SCALE_EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5           0.130 ±         0.011  MB/sec
HistogramCollectBenchmark.recordAndCollect:·gc.alloc.rate.norm  ZERO_MAX_SCALE_EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5      342076.800 ±     25754.927    B/op
HistogramCollectBenchmark.recordAndCollect:·gc.count            ZERO_MAX_SCALE_EXPONENTIAL_BUCKET_HISTOGRAM                CUMULATIVE    ss    5             ≈ 0                  counts
```

The aggregate reduction of memory between this and the other changes is quite impressive. The default exp histogram aggregation with delta temporality has reduced from an [original](https://github.com/open-telemetry/opentelemetry-java/pull/4912) bytes / op of `37_862_288` to `897_084` with this PR. A **98%** reduction, and 50x improvement!

Immutability is great, but it's hard to ignore these performance gains!