### PR TITLE
Stop ignoring long measurements in HistogramExemplarReservoir

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/HistogramExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/HistogramExemplarReservoir.java
@@ -23,6 +23,11 @@ class HistogramExemplarReservoir extends FixedSizeExemplarReservoir<DoubleExempl
         ReservoirCell::getAndResetDouble);
   }
 
+  @Override
+  public void offerLongMeasurement(long value, Attributes attributes, Context context) {
+    super.offerDoubleMeasurement((double) value, attributes, context);
+  }
+
   static class HistogramCellSelector implements ReservoirCellSelector {
 
     private final double[] boundaries;


### PR DESCRIPTION
As noted by @dashpole [here](https://github.com/open-telemetry/opentelemetry-java-docs/pull/96#issuecomment-1428747455) there's a bug in the `HistogramExemplarReservoir` implementation. 

[HistogramPointData](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/HistogramPointData.java#L68) only supports double exemplars. Despite our API supporting both `LongHistogram` and `DoubleHistogram`, long values are simply converted to doubles in the aggregator. However, the `HistogramExemplarReservoir` didn't get the memo and reports a value of `0.0` when any long measurement is recorded as an exemplar. 

This fixes the issue by casting long measurements to double before storing in the reservoir. 