### PR TITLE
Fix test flake in FullConfigTest

### DIFF
--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FullConfigTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FullConfigTest.java
@@ -156,7 +156,8 @@ class FullConfigTest {
     String endpoint = "http://localhost:" + server.httpPort();
     System.setProperty("otel.exporter.otlp.endpoint", endpoint);
     System.setProperty("otel.exporter.otlp.timeout", "10000");
-    // Set log exporter interval to a high value and rely on flushing to produce reliable export batches
+    // Set log exporter interval to a high value and rely on flushing to produce reliable export
+    // batches
     System.setProperty("otel.blrp.schedule.delay", "60000");
 
     // Initialize here so we can shutdown when done

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FullConfigTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FullConfigTest.java
@@ -156,6 +156,8 @@ class FullConfigTest {
     String endpoint = "http://localhost:" + server.httpPort();
     System.setProperty("otel.exporter.otlp.endpoint", endpoint);
     System.setProperty("otel.exporter.otlp.timeout", "10000");
+    // Set log exporter interval to a high value and rely on flushing to produce reliable export batches
+    System.setProperty("otel.blrp.schedule.delay", "60000");
 
     // Initialize here so we can shutdown when done
     GlobalOpenTelemetry.resetForTest();


### PR DESCRIPTION
I've seen this test flake occur a number of times ([example](https://github.com/open-telemetry/opentelemetry-java/actions/runs/4163981695/jobs/7205028081#step:5:1280)) where FullConfigTest fails because the test expects the emitted log records from the log api and event api to be in one batch, but occasionally they're split across two. 

I was able to reliably recreate this by placing a `Thread.sleep(1000)` in between the calls to the log and event API. 

Fixing it by lengthening the export interval and relying on `forceFlush()`. 