### PR TITLE
Downgrade kotlin to 1.8.0

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,7 @@ pluginManagement {
     id("com.github.johnrengelman.shadow") version "8.1.0"
     id("com.gradle.enterprise") version "3.12.3"
     id("io.github.gradle-nexus.publish-plugin") version "1.2.0"
-    id("org.jetbrains.kotlin.jvm") version "1.8.10"
+    id("org.jetbrains.kotlin.jvm") version "1.8.0"
     id("org.graalvm.buildtools.native") version "0.9.20"
   }
 }


### PR DESCRIPTION
Address failing [CodeQL](https://github.com/open-telemetry/opentelemetry-java/actions/runs/4299298665) workflow, which [doesn't support kotlin 1.8.10](https://github.com/github/codeql/pull/11637#issuecomment-1418657970) yet.

`opentelemetry-java-instrumentation` dealt with something [similar](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7788). 