### PR TITLE
Add new TLS related APIs on OTLP exporter builders.

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
@@ -1,11 +1,7 @@
 Comparing source compatibility of  against 
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder setKeyManager(javax.net.ssl.X509KeyManager)
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder setSslSocketFactory(javax.net.ssl.SSLSocketFactory)
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder setTrustManager(javax.net.ssl.X509TrustManager)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder setSslSocketFactory(javax.net.ssl.SSLSocketFactory, javax.net.ssl.X509TrustManager)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder setKeyManager(javax.net.ssl.X509KeyManager)
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder setSslSocketFactory(javax.net.ssl.SSLSocketFactory)
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder setTrustManager(javax.net.ssl.X509TrustManager)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder setSslSocketFactory(javax.net.ssl.SSLSocketFactory, javax.net.ssl.X509TrustManager)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
@@ -1,13 +1,13 @@
 Comparing source compatibility of  against 
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder setSslSocketFactory(javax.net.ssl.SSLSocketFactory, javax.net.ssl.X509TrustManager)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder setSslContext(javax.net.ssl.SSLContext, javax.net.ssl.X509TrustManager)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder setSslSocketFactory(javax.net.ssl.SSLSocketFactory, javax.net.ssl.X509TrustManager)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder setSslContext(javax.net.ssl.SSLContext, javax.net.ssl.X509TrustManager)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder setSslSocketFactory(javax.net.ssl.SSLSocketFactory, javax.net.ssl.X509TrustManager)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder setSslContext(javax.net.ssl.SSLContext, javax.net.ssl.X509TrustManager)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder setSslSocketFactory(javax.net.ssl.SSLSocketFactory, javax.net.ssl.X509TrustManager)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder setSslContext(javax.net.ssl.SSLContext, javax.net.ssl.X509TrustManager)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
@@ -5,3 +5,9 @@ Comparing source compatibility of  against
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder setSslSocketFactory(javax.net.ssl.SSLSocketFactory, javax.net.ssl.X509TrustManager)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder setSslSocketFactory(javax.net.ssl.SSLSocketFactory, javax.net.ssl.X509TrustManager)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder setSslSocketFactory(javax.net.ssl.SSLSocketFactory, javax.net.ssl.X509TrustManager)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
@@ -1,2 +1,11 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder setKeyManager(javax.net.ssl.X509KeyManager)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder setSslSocketFactory(javax.net.ssl.SSLSocketFactory)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder setTrustManager(javax.net.ssl.X509TrustManager)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder setKeyManager(javax.net.ssl.X509KeyManager)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder setSslSocketFactory(javax.net.ssl.SSLSocketFactory)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder setTrustManager(javax.net.ssl.X509TrustManager)

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 import okhttp3.Headers;
 import okhttp3.OkHttpClient;
@@ -111,17 +111,9 @@ public class GrpcExporterBuilder<T extends Marshaler> {
     return this;
   }
 
-  public GrpcExporterBuilder<T> setSslSocketFactory(
-      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
-    tlsConfigHelper.setSslSocketFactory(sslSocketFactory);
-    tlsConfigHelper.setTrustManager(trustManager);
-    return this;
-  }
-
-  public GrpcExporterBuilder<T> setSslSocketFactory(
-      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
-    tlsConfigHelper.setSslSocketFactory(sslSocketFactory);
-    tlsConfigHelper.setTrustManager(trustManager);
+  public GrpcExporterBuilder<T> setSslContext(
+      SSLContext sslContext, X509TrustManager trustManager) {
+    tlsConfigHelper.setSslContext(sslContext, trustManager);
     return this;
   }
 

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
@@ -29,7 +29,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509TrustManager;
 import okhttp3.Headers;
@@ -109,6 +108,13 @@ public class GrpcExporterBuilder<T extends Marshaler> {
   public GrpcExporterBuilder<T> setKeyManagerFromCerts(
       byte[] privateKeyPem, byte[] certificatePem) {
     tlsConfigHelper.setKeyManagerFromCerts(privateKeyPem, certificatePem);
+    return this;
+  }
+
+  public GrpcExporterBuilder<T> setSslSocketFactory(
+      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
+    tlsConfigHelper.setSslSocketFactory(sslSocketFactory);
+    tlsConfigHelper.setTrustManager(trustManager);
     return this;
   }
 

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
@@ -30,6 +30,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509TrustManager;
 import okhttp3.Headers;
 import okhttp3.OkHttpClient;
@@ -108,6 +109,13 @@ public class GrpcExporterBuilder<T extends Marshaler> {
   public GrpcExporterBuilder<T> setKeyManagerFromCerts(
       byte[] privateKeyPem, byte[] certificatePem) {
     tlsConfigHelper.setKeyManagerFromCerts(privateKeyPem, certificatePem);
+    return this;
+  }
+
+  public GrpcExporterBuilder<T> setSslSocketFactory(
+      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
+    tlsConfigHelper.setSslSocketFactory(sslSocketFactory);
+    tlsConfigHelper.setTrustManager(trustManager);
     return this;
   }
 

--- a/exporters/common/src/test/java/io/opentelemetry/exporter/internal/TlsConfigHelperTest.java
+++ b/exporters/common/src/test/java/io/opentelemetry/exporter/internal/TlsConfigHelperTest.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.exporter.internal;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;

--- a/exporters/common/src/test/java/io/opentelemetry/exporter/internal/TlsConfigHelperTest.java
+++ b/exporters/common/src/test/java/io/opentelemetry/exporter/internal/TlsConfigHelperTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.exporter.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -16,6 +16,9 @@ import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
 import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLSocketFactory;
@@ -106,6 +109,14 @@ public final class OtlpHttpMetricExporterBuilder {
   }
 
   /**
+   * Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled.
+   */
+  public OtlpHttpMetricExporterBuilder setTrustManager(X509TrustManager trustManager){
+    delegate.setTrustManager(trustManager);
+    return this;
+  }
+
+  /**
    * Sets ths client key and the certificate chain to use for verifying client when TLS is enabled.
    * The key must be PKCS8, and both must be in PEM format.
    */
@@ -121,6 +132,24 @@ public final class OtlpHttpMetricExporterBuilder {
   public OtlpHttpMetricExporterBuilder setSslSocketFactory(
       SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
     delegate.setSslSocketFactory(sslSocketFactory, trustManager);
+    return this;
+  }
+
+  /**
+   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing
+   * key manager that has been configured with this method, or with setClientTls().
+   */
+  public OtlpHttpMetricExporterBuilder setKeyManager(X509KeyManager x509KeyManager){
+    delegate.setKeyManager(x509KeyManager);
+    return this;
+  }
+
+  /**
+   * Sets the SSLSocketFactory to use when TLS is enabled. If a preconfigured SSLSocketFactory is
+   * provided, a trust manager must also be provided via setTrustManager() or setTrustedCertificates().
+   */
+  public OtlpHttpMetricExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory){
+    delegate.setSslSocketFactory(sslSocketFactory);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -19,7 +19,6 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -110,12 +109,6 @@ public final class OtlpHttpMetricExporterBuilder {
     return this;
   }
 
-  /** Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled. */
-  public OtlpHttpMetricExporterBuilder setTrustManager(X509TrustManager trustManager) {
-    delegate.setTrustManager(trustManager);
-    return this;
-  }
-
   /**
    * Sets ths client key and the certificate chain to use for verifying client when TLS is enabled.
    * The key must be PKCS8, and both must be in PEM format.
@@ -136,21 +129,13 @@ public final class OtlpHttpMetricExporterBuilder {
   }
 
   /**
-   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing key manager
-   * that has been configured with this method, or with setClientTls().
+   * Sets the SSLSocketFactory to use when TLS is enabled. When providing a preconfigured
+   * SSLSocketFactory, a trust manager must also be provided.
    */
-  public OtlpHttpMetricExporterBuilder setKeyManager(X509KeyManager x509KeyManager) {
-    delegate.setKeyManager(x509KeyManager);
-    return this;
-  }
-
-  /**
-   * Sets the SSLSocketFactory to use when TLS is enabled. If a preconfigured SSLSocketFactory is
-   * provided, a trust manager must also be provided via setTrustManager() or
-   * setTrustedCertificates().
-   */
-  public OtlpHttpMetricExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
+  public OtlpHttpMetricExporterBuilder setSslSocketFactory(
+      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
     delegate.setSslSocketFactory(sslSocketFactory);
+    delegate.setTrustManager(trustManager);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -19,7 +19,6 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 
 /**
@@ -106,12 +105,6 @@ public final class OtlpHttpMetricExporterBuilder {
     return this;
   }
 
-  /** Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled. */
-  public OtlpHttpMetricExporterBuilder setTrustManager(X509TrustManager trustManager) {
-    delegate.setTrustManager(trustManager);
-    return this;
-  }
-
   /**
    * Sets ths client key and the certificate chain to use for verifying client when TLS is enabled.
    * The key must be PKCS8, and both must be in PEM format.
@@ -122,21 +115,13 @@ public final class OtlpHttpMetricExporterBuilder {
   }
 
   /**
-   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing key manager
-   * that has been configured with this method, or with setClientTls().
+   * Sets the SSLSocketFactory to use when TLS is enabled. When providing a preconfigured
+   * SSLSocketFactory, a trust manager must also be provided.
    */
-  public OtlpHttpMetricExporterBuilder setKeyManager(X509KeyManager x509KeyManager) {
-    delegate.setKeyManager(x509KeyManager);
-    return this;
-  }
-
-  /**
-   * Sets the SSLSocketFactory to use when TLS is enabled. If a preconfigured SSLSocketFactory is
-   * provided, a trust manager must also be provided via setTrustManager() or
-   * setTrustedCertificates().
-   */
-  public OtlpHttpMetricExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
+  public OtlpHttpMetricExporterBuilder setSslSocketFactory(
+      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
     delegate.setSslSocketFactory(sslSocketFactory);
+    delegate.setTrustManager(trustManager);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -134,8 +134,7 @@ public final class OtlpHttpMetricExporterBuilder {
    */
   public OtlpHttpMetricExporterBuilder setSslSocketFactory(
       SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
-    delegate.setSslSocketFactory(sslSocketFactory);
-    delegate.setTrustManager(trustManager);
+    delegate.setSslSocketFactory(sslSocketFactory, trustManager);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -18,11 +18,7 @@ import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.X509TrustManager;
-import java.time.Duration;
-import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
 /**
@@ -119,22 +115,12 @@ public final class OtlpHttpMetricExporterBuilder {
   }
 
   /**
-   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
-   * call this _or_ set raw certificate bytes, but not both.
+   * Sets the "bring-your-own" SSLContext for use with TLS. Users should call this _or_ set raw
+   * certificate bytes, but not both.
    */
-  public OtlpHttpMetricExporterBuilder setSslSocketFactory(
-      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
-    delegate.setSslSocketFactory(sslSocketFactory, trustManager);
-    return this;
-  }
-
-  /**
-   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
-   * call this _or_ set raw certificate bytes, but not both.
-   */
-  public OtlpHttpMetricExporterBuilder setSslSocketFactory(
-      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
-    delegate.setSslSocketFactory(sslSocketFactory, trustManager);
+  public OtlpHttpMetricExporterBuilder setSslContext(
+      SSLContext sslContext, X509TrustManager trustManager) {
+    delegate.setSslContext(sslContext, trustManager);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -115,8 +115,8 @@ public final class OtlpHttpMetricExporterBuilder {
   }
 
   /**
-   * Sets the SSLSocketFactory to use when TLS is enabled. When providing a preconfigured
-   * SSLSocketFactory, a trust manager must also be provided.
+   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
+   * call this _or_ set raw certificate bytes, but not both.
    */
   public OtlpHttpMetricExporterBuilder setSslSocketFactory(
       SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -120,8 +120,7 @@ public final class OtlpHttpMetricExporterBuilder {
    */
   public OtlpHttpMetricExporterBuilder setSslSocketFactory(
       SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
-    delegate.setSslSocketFactory(sslSocketFactory);
-    delegate.setTrustManager(trustManager);
+    delegate.setSslSocketFactory(sslSocketFactory, trustManager);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -16,6 +16,8 @@ import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
 import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
@@ -108,10 +110,8 @@ public final class OtlpHttpMetricExporterBuilder {
     return this;
   }
 
-  /**
-   * Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled.
-   */
-  public OtlpHttpMetricExporterBuilder setTrustManager(X509TrustManager trustManager){
+  /** Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled. */
+  public OtlpHttpMetricExporterBuilder setTrustManager(X509TrustManager trustManager) {
     delegate.setTrustManager(trustManager);
     return this;
   }
@@ -136,19 +136,20 @@ public final class OtlpHttpMetricExporterBuilder {
   }
 
   /**
-   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing
-   * key manager that has been configured with this method, or with setClientTls().
+   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing key manager
+   * that has been configured with this method, or with setClientTls().
    */
-  public OtlpHttpMetricExporterBuilder setKeyManager(X509KeyManager x509KeyManager){
+  public OtlpHttpMetricExporterBuilder setKeyManager(X509KeyManager x509KeyManager) {
     delegate.setKeyManager(x509KeyManager);
     return this;
   }
 
   /**
    * Sets the SSLSocketFactory to use when TLS is enabled. If a preconfigured SSLSocketFactory is
-   * provided, a trust manager must also be provided via setTrustManager() or setTrustedCertificates().
+   * provided, a trust manager must also be provided via setTrustManager() or
+   * setTrustedCertificates().
    */
-  public OtlpHttpMetricExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory){
+  public OtlpHttpMetricExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
     delegate.setSslSocketFactory(sslSocketFactory);
     return this;
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -16,6 +16,9 @@ import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
 import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
@@ -104,11 +107,37 @@ public final class OtlpHttpMetricExporterBuilder {
   }
 
   /**
+   * Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled.
+   */
+  public OtlpHttpMetricExporterBuilder setTrustManager(X509TrustManager trustManager){
+    delegate.setTrustManager(trustManager);
+    return this;
+  }
+
+  /**
    * Sets ths client key and the certificate chain to use for verifying client when TLS is enabled.
    * The key must be PKCS8, and both must be in PEM format.
    */
   public OtlpHttpMetricExporterBuilder setClientTls(byte[] privateKeyPem, byte[] certificatePem) {
     delegate.setKeyManagerFromCerts(privateKeyPem, certificatePem);
+    return this;
+  }
+
+  /**
+   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing
+   * key manager that has been configured with this method, or with setClientTls().
+   */
+  public OtlpHttpMetricExporterBuilder setKeyManager(X509KeyManager x509KeyManager){
+    delegate.setKeyManager(x509KeyManager);
+    return this;
+  }
+
+  /**
+   * Sets the SSLSocketFactory to use when TLS is enabled. If a preconfigured SSLSocketFactory is
+   * provided, a trust manager must also be provided via setTrustManager() or setTrustedCertificates().
+   */
+  public OtlpHttpMetricExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory){
+    delegate.setSslSocketFactory(sslSocketFactory);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -16,11 +16,11 @@ import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
 import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
-import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Builder utility for {@link OtlpHttpMetricExporter}.
@@ -106,10 +106,8 @@ public final class OtlpHttpMetricExporterBuilder {
     return this;
   }
 
-  /**
-   * Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled.
-   */
-  public OtlpHttpMetricExporterBuilder setTrustManager(X509TrustManager trustManager){
+  /** Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled. */
+  public OtlpHttpMetricExporterBuilder setTrustManager(X509TrustManager trustManager) {
     delegate.setTrustManager(trustManager);
     return this;
   }
@@ -124,19 +122,20 @@ public final class OtlpHttpMetricExporterBuilder {
   }
 
   /**
-   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing
-   * key manager that has been configured with this method, or with setClientTls().
+   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing key manager
+   * that has been configured with this method, or with setClientTls().
    */
-  public OtlpHttpMetricExporterBuilder setKeyManager(X509KeyManager x509KeyManager){
+  public OtlpHttpMetricExporterBuilder setKeyManager(X509KeyManager x509KeyManager) {
     delegate.setKeyManager(x509KeyManager);
     return this;
   }
 
   /**
    * Sets the SSLSocketFactory to use when TLS is enabled. If a preconfigured SSLSocketFactory is
-   * provided, a trust manager must also be provided via setTrustManager() or setTrustedCertificates().
+   * provided, a trust manager must also be provided via setTrustManager() or
+   * setTrustedCertificates().
    */
-  public OtlpHttpMetricExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory){
+  public OtlpHttpMetricExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
     delegate.setSslSocketFactory(sslSocketFactory);
     return this;
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -129,8 +129,8 @@ public final class OtlpHttpMetricExporterBuilder {
   }
 
   /**
-   * Sets the SSLSocketFactory to use when TLS is enabled. When providing a preconfigured
-   * SSLSocketFactory, a trust manager must also be provided.
+   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
+   * call this _or_ set raw certificate bytes, but not both.
    */
   public OtlpHttpMetricExporterBuilder setSslSocketFactory(
       SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -13,6 +13,9 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
 import io.opentelemetry.exporter.internal.otlp.OtlpUserAgent;
 import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLSocketFactory;
@@ -94,8 +97,17 @@ public final class OtlpHttpSpanExporterBuilder {
   }
 
   /**
+   * Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled.
+   */
+  public OtlpHttpSpanExporterBuilder setTrustManager(X509TrustManager trustManager) {
+    delegate.setTrustManager(trustManager);
+    return this;
+  }
+
+  /**
    * Sets ths client key and the certificate chain to use for verifying client when TLS is enabled.
-   * The key must be PKCS8, and both must be in PEM format.
+   * The key must be PKCS8, and both must be in PEM format. This will replace any other key manager
+   * that has been configured with this method or with setKeyManager().
    */
   public OtlpHttpSpanExporterBuilder setClientTls(byte[] privateKeyPem, byte[] certificatePem) {
     delegate.setKeyManagerFromCerts(privateKeyPem, certificatePem);
@@ -109,6 +121,25 @@ public final class OtlpHttpSpanExporterBuilder {
   public OtlpHttpSpanExporterBuilder setSslSocketFactory(
       SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
     delegate.setSslSocketFactory(sslSocketFactory, trustManager);
+    return this;
+  }
+
+  /**
+   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing
+   * key manager that has been configured with this method, or with setClientTls().
+   */
+  public OtlpHttpSpanExporterBuilder setKeyManager(X509KeyManager keyManager){
+    delegate.setKeyManager(keyManager);
+    return this;
+  }
+
+
+  /**
+   * Sets the SSLSocketFactory to use when TLS is enabled. If a preconfigured SSLSocketFactory is
+   * provided, a trust manager must also be provided via setTrustManager() or setTrustedCertificates().
+   */
+  public OtlpHttpSpanExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory){
+    delegate.setSslSocketFactory(sslSocketFactory);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -13,6 +13,8 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
 import io.opentelemetry.exporter.internal.otlp.OtlpUserAgent;
 import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
@@ -96,9 +98,7 @@ public final class OtlpHttpSpanExporterBuilder {
     return this;
   }
 
-  /**
-   * Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled.
-   */
+  /** Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled. */
   public OtlpHttpSpanExporterBuilder setTrustManager(X509TrustManager trustManager) {
     delegate.setTrustManager(trustManager);
     return this;
@@ -125,20 +125,20 @@ public final class OtlpHttpSpanExporterBuilder {
   }
 
   /**
-   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing
-   * key manager that has been configured with this method, or with setClientTls().
+   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing key manager
+   * that has been configured with this method, or with setClientTls().
    */
-  public OtlpHttpSpanExporterBuilder setKeyManager(X509KeyManager keyManager){
+  public OtlpHttpSpanExporterBuilder setKeyManager(X509KeyManager keyManager) {
     delegate.setKeyManager(keyManager);
     return this;
   }
 
-
   /**
    * Sets the SSLSocketFactory to use when TLS is enabled. If a preconfigured SSLSocketFactory is
-   * provided, a trust manager must also be provided via setTrustManager() or setTrustedCertificates().
+   * provided, a trust manager must also be provided via setTrustManager() or
+   * setTrustedCertificates().
    */
-  public OtlpHttpSpanExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory){
+  public OtlpHttpSpanExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
     delegate.setSslSocketFactory(sslSocketFactory);
     return this;
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -16,7 +16,6 @@ import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 
 /**
@@ -94,12 +93,6 @@ public final class OtlpHttpSpanExporterBuilder {
     return this;
   }
 
-  /** Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled. */
-  public OtlpHttpSpanExporterBuilder setTrustManager(X509TrustManager trustManager) {
-    delegate.setTrustManager(trustManager);
-    return this;
-  }
-
   /**
    * Sets ths client key and the certificate chain to use for verifying client when TLS is enabled.
    * The key must be PKCS8, and both must be in PEM format. This will replace any other key manager
@@ -111,21 +104,13 @@ public final class OtlpHttpSpanExporterBuilder {
   }
 
   /**
-   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing key manager
-   * that has been configured with this method, or with setClientTls().
+   * Sets the SSLSocketFactory to use when TLS is enabled. When providing a preconfigured
+   * SSLSocketFactory, a trust manager must also be provided.
    */
-  public OtlpHttpSpanExporterBuilder setKeyManager(X509KeyManager keyManager) {
-    delegate.setKeyManager(keyManager);
-    return this;
-  }
-
-  /**
-   * Sets the SSLSocketFactory to use when TLS is enabled. If a preconfigured SSLSocketFactory is
-   * provided, a trust manager must also be provided via setTrustManager() or
-   * setTrustedCertificates().
-   */
-  public OtlpHttpSpanExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
+  public OtlpHttpSpanExporterBuilder setSslSocketFactory(
+      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
     delegate.setSslSocketFactory(sslSocketFactory);
+    delegate.setTrustManager(trustManager);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -13,11 +13,11 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
 import io.opentelemetry.exporter.internal.otlp.OtlpUserAgent;
 import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
-import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Builder utility for {@link OtlpHttpSpanExporter}.
@@ -94,9 +94,7 @@ public final class OtlpHttpSpanExporterBuilder {
     return this;
   }
 
-  /**
-   * Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled.
-   */
+  /** Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled. */
   public OtlpHttpSpanExporterBuilder setTrustManager(X509TrustManager trustManager) {
     delegate.setTrustManager(trustManager);
     return this;
@@ -113,20 +111,20 @@ public final class OtlpHttpSpanExporterBuilder {
   }
 
   /**
-   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing
-   * key manager that has been configured with this method, or with setClientTls().
+   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing key manager
+   * that has been configured with this method, or with setClientTls().
    */
-  public OtlpHttpSpanExporterBuilder setKeyManager(X509KeyManager keyManager){
+  public OtlpHttpSpanExporterBuilder setKeyManager(X509KeyManager keyManager) {
     delegate.setKeyManager(keyManager);
     return this;
   }
 
-
   /**
    * Sets the SSLSocketFactory to use when TLS is enabled. If a preconfigured SSLSocketFactory is
-   * provided, a trust manager must also be provided via setTrustManager() or setTrustedCertificates().
+   * provided, a trust manager must also be provided via setTrustManager() or
+   * setTrustedCertificates().
    */
-  public OtlpHttpSpanExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory){
+  public OtlpHttpSpanExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
     delegate.setSslSocketFactory(sslSocketFactory);
     return this;
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -103,8 +103,8 @@ public final class OtlpHttpSpanExporterBuilder {
   }
 
   /**
-   * Sets the SSLSocketFactory to use when TLS is enabled. When providing a preconfigured
-   * SSLSocketFactory, a trust manager must also be provided.
+   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
+   * call this _or_ set raw certificate bytes, but not both.
    */
   public OtlpHttpSpanExporterBuilder setSslSocketFactory(
       SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -15,11 +15,7 @@ import io.opentelemetry.exporter.internal.otlp.OtlpUserAgent;
 import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.X509TrustManager;
-import java.time.Duration;
-import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
 /**
@@ -107,22 +103,12 @@ public final class OtlpHttpSpanExporterBuilder {
   }
 
   /**
-   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
-   * call this _or_ set raw certificate bytes, but not both.
+   * Sets the "bring-your-own" SSLContext for use with TLS. Users should call this _or_ set raw
+   * certificate bytes, but not both.
    */
-  public OtlpHttpSpanExporterBuilder setSslSocketFactory(
-      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
-    delegate.setSslSocketFactory(sslSocketFactory, trustManager);
-    return this;
-  }
-
-  /**
-   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
-   * call this _or_ set raw certificate bytes, but not both.
-   */
-  public OtlpHttpSpanExporterBuilder setSslSocketFactory(
-      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
-    delegate.setSslSocketFactory(sslSocketFactory, trustManager);
+  public OtlpHttpSpanExporterBuilder setSslContext(
+      SSLContext sslContext, X509TrustManager trustManager) {
+    delegate.setSslContext(sslContext, trustManager);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -16,7 +16,6 @@ import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -98,12 +97,6 @@ public final class OtlpHttpSpanExporterBuilder {
     return this;
   }
 
-  /** Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled. */
-  public OtlpHttpSpanExporterBuilder setTrustManager(X509TrustManager trustManager) {
-    delegate.setTrustManager(trustManager);
-    return this;
-  }
-
   /**
    * Sets ths client key and the certificate chain to use for verifying client when TLS is enabled.
    * The key must be PKCS8, and both must be in PEM format. This will replace any other key manager
@@ -125,21 +118,13 @@ public final class OtlpHttpSpanExporterBuilder {
   }
 
   /**
-   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing key manager
-   * that has been configured with this method, or with setClientTls().
+   * Sets the SSLSocketFactory to use when TLS is enabled. When providing a preconfigured
+   * SSLSocketFactory, a trust manager must also be provided.
    */
-  public OtlpHttpSpanExporterBuilder setKeyManager(X509KeyManager keyManager) {
-    delegate.setKeyManager(keyManager);
-    return this;
-  }
-
-  /**
-   * Sets the SSLSocketFactory to use when TLS is enabled. If a preconfigured SSLSocketFactory is
-   * provided, a trust manager must also be provided via setTrustManager() or
-   * setTrustedCertificates().
-   */
-  public OtlpHttpSpanExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
+  public OtlpHttpSpanExporterBuilder setSslSocketFactory(
+      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
     delegate.setSslSocketFactory(sslSocketFactory);
+    delegate.setTrustManager(trustManager);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -117,8 +117,8 @@ public final class OtlpHttpSpanExporterBuilder {
   }
 
   /**
-   * Sets the SSLSocketFactory to use when TLS is enabled. When providing a preconfigured
-   * SSLSocketFactory, a trust manager must also be provided.
+   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
+   * call this _or_ set raw certificate bytes, but not both.
    */
   public OtlpHttpSpanExporterBuilder setSslSocketFactory(
       SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -13,6 +13,9 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
 import io.opentelemetry.exporter.internal.otlp.OtlpUserAgent;
 import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
@@ -92,11 +95,39 @@ public final class OtlpHttpSpanExporterBuilder {
   }
 
   /**
+   * Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled.
+   */
+  public OtlpHttpSpanExporterBuilder setTrustManager(X509TrustManager trustManager) {
+    delegate.setTrustManager(trustManager);
+    return this;
+  }
+
+  /**
    * Sets ths client key and the certificate chain to use for verifying client when TLS is enabled.
-   * The key must be PKCS8, and both must be in PEM format.
+   * The key must be PKCS8, and both must be in PEM format. This will replace any other key manager
+   * that has been configured with this method or with setKeyManager().
    */
   public OtlpHttpSpanExporterBuilder setClientTls(byte[] privateKeyPem, byte[] certificatePem) {
     delegate.setKeyManagerFromCerts(privateKeyPem, certificatePem);
+    return this;
+  }
+
+  /**
+   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing
+   * key manager that has been configured with this method, or with setClientTls().
+   */
+  public OtlpHttpSpanExporterBuilder setKeyManager(X509KeyManager keyManager){
+    delegate.setKeyManager(keyManager);
+    return this;
+  }
+
+
+  /**
+   * Sets the SSLSocketFactory to use when TLS is enabled. If a preconfigured SSLSocketFactory is
+   * provided, a trust manager must also be provided via setTrustManager() or setTrustedCertificates().
+   */
+  public OtlpHttpSpanExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory){
+    delegate.setSslSocketFactory(sslSocketFactory);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -99,8 +99,7 @@ public final class OtlpHttpSpanExporterBuilder {
 
   /**
    * Sets ths client key and the certificate chain to use for verifying client when TLS is enabled.
-   * The key must be PKCS8, and both must be in PEM format. This will replace any other key manager
-   * that has been configured with this method or with setKeyManager().
+   * The key must be PKCS8, and both must be in PEM format.
    */
   public OtlpHttpSpanExporterBuilder setClientTls(byte[] privateKeyPem, byte[] certificatePem) {
     delegate.setKeyManagerFromCerts(privateKeyPem, certificatePem);
@@ -123,8 +122,7 @@ public final class OtlpHttpSpanExporterBuilder {
    */
   public OtlpHttpSpanExporterBuilder setSslSocketFactory(
       SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
-    delegate.setSslSocketFactory(sslSocketFactory);
-    delegate.setTrustManager(trustManager);
+    delegate.setSslSocketFactory(sslSocketFactory, trustManager);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -95,8 +95,7 @@ public final class OtlpHttpSpanExporterBuilder {
 
   /**
    * Sets ths client key and the certificate chain to use for verifying client when TLS is enabled.
-   * The key must be PKCS8, and both must be in PEM format. This will replace any other key manager
-   * that has been configured with this method or with setKeyManager().
+   * The key must be PKCS8, and both must be in PEM format.
    */
   public OtlpHttpSpanExporterBuilder setClientTls(byte[] privateKeyPem, byte[] certificatePem) {
     delegate.setKeyManagerFromCerts(privateKeyPem, certificatePem);
@@ -109,8 +108,7 @@ public final class OtlpHttpSpanExporterBuilder {
    */
   public OtlpHttpSpanExporterBuilder setSslSocketFactory(
       SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
-    delegate.setSslSocketFactory(sslSocketFactory);
-    delegate.setTrustManager(trustManager);
+    delegate.setSslSocketFactory(sslSocketFactory, trustManager);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
@@ -147,8 +147,8 @@ public final class OtlpGrpcMetricExporterBuilder {
   }
 
   /**
-   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager. Users should call this _or_
-   * set raw certificate bytes, but not both.
+   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
+   * call this _or_ set raw certificate bytes, but not both.
    */
   public OtlpGrpcMetricExporterBuilder setSslSocketFactory(
       SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
@@ -157,6 +157,16 @@ public final class OtlpGrpcMetricExporterBuilder {
   }
 
   /**
+   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager. Users should call this _or_
+   * set raw certificate bytes, but not both.
+   */
+  public OtlpGrpcMetricExporterBuilder setSslSocketFactory(
+      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
+    delegate.setSslSocketFactory(sslSocketFactory, trustManager);
+    return this;
+  }
+
+  /**
    * Add header to request. Optional. Applicable only if {@link
    * OtlpGrpcMetricExporterBuilder#setChannel(ManagedChannel)} is not used to set channel.
    *

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
@@ -21,6 +21,8 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
 
 /**
  * Builder utility for this exporter.
@@ -141,6 +143,16 @@ public final class OtlpGrpcMetricExporterBuilder {
    */
   public OtlpGrpcMetricExporterBuilder setClientTls(byte[] privateKeyPem, byte[] certificatePem) {
     delegate.setKeyManagerFromCerts(privateKeyPem, certificatePem);
+    return this;
+  }
+
+  /**
+   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager. Users should call this _or_
+   * set raw certificate bytes, but not both.
+   */
+  public OtlpGrpcMetricExporterBuilder setSslSocketFactory(
+      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
+    delegate.setSslSocketFactory(sslSocketFactory, trustManager);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
@@ -21,7 +21,7 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
 /**
@@ -147,22 +147,12 @@ public final class OtlpGrpcMetricExporterBuilder {
   }
 
   /**
-   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
-   * call this _or_ set raw certificate bytes, but not both.
+   * Sets the "bring-your-own" SSLContext for use with TLS. Users should call this _or_ set raw
+   * certificate bytes, but not both.
    */
-  public OtlpGrpcMetricExporterBuilder setSslSocketFactory(
-      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
-    delegate.setSslSocketFactory(sslSocketFactory, trustManager);
-    return this;
-  }
-
-  /**
-   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
-   * call this _or_ set raw certificate bytes, but not both.
-   */
-  public OtlpGrpcMetricExporterBuilder setSslSocketFactory(
-      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
-    delegate.setSslSocketFactory(sslSocketFactory, trustManager);
+  public OtlpGrpcMetricExporterBuilder setSslContext(
+      SSLContext sslContext, X509TrustManager trustManager) {
+    delegate.setSslContext(sslContext, trustManager);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
@@ -157,8 +157,8 @@ public final class OtlpGrpcMetricExporterBuilder {
   }
 
   /**
-   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager. Users should call this _or_
-   * set raw certificate bytes, but not both.
+   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
+   * call this _or_ set raw certificate bytes, but not both.
    */
   public OtlpGrpcMetricExporterBuilder setSslSocketFactory(
       SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
@@ -18,6 +18,8 @@ import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
 import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
 
 /** Builder utility for this exporter. */
 public final class OtlpGrpcSpanExporterBuilder {
@@ -125,6 +127,16 @@ public final class OtlpGrpcSpanExporterBuilder {
    */
   public OtlpGrpcSpanExporterBuilder setClientTls(byte[] privateKeyPem, byte[] certificatePem) {
     delegate.setKeyManagerFromCerts(privateKeyPem, certificatePem);
+    return this;
+  }
+
+  /**
+   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager. Users should call this _or_
+   * set raw certificate bytes, but not both.
+   */
+  public OtlpGrpcSpanExporterBuilder setSslSocketFactory(
+      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
+    delegate.setSslSocketFactory(sslSocketFactory, trustManager);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
@@ -141,6 +141,16 @@ public final class OtlpGrpcSpanExporterBuilder {
   }
 
   /**
+   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager. Users should call this _or_
+   * set raw certificate bytes, but not both.
+   */
+  public OtlpGrpcSpanExporterBuilder setSslSocketFactory(
+      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
+    delegate.setSslSocketFactory(sslSocketFactory, trustManager);
+    return this;
+  }
+
+  /**
    * Add header to request. Optional. Applicable only if {@link
    * OtlpGrpcSpanExporterBuilder#setChannel(ManagedChannel)} is not called.
    *

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
@@ -131,8 +131,8 @@ public final class OtlpGrpcSpanExporterBuilder {
   }
 
   /**
-   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager. Users should call this _or_
-   * set raw certificate bytes, but not both.
+   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
+   * call this _or_ set raw certificate bytes, but not both.
    */
   public OtlpGrpcSpanExporterBuilder setSslSocketFactory(
       SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
@@ -18,7 +18,7 @@ import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
 import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
 /** Builder utility for this exporter. */
@@ -131,22 +131,12 @@ public final class OtlpGrpcSpanExporterBuilder {
   }
 
   /**
-   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
-   * call this _or_ set raw certificate bytes, but not both.
+   * Sets the "bring-your-own" SSLContext for use with TLS. Users should call this _or_ set raw
+   * certificate bytes, but not both.
    */
-  public OtlpGrpcSpanExporterBuilder setSslSocketFactory(
-      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
-    delegate.setSslSocketFactory(sslSocketFactory, trustManager);
-    return this;
-  }
-
-  /**
-   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
-   * call this _or_ set raw certificate bytes, but not both.
-   */
-  public OtlpGrpcSpanExporterBuilder setSslSocketFactory(
-      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
-    delegate.setSslSocketFactory(sslSocketFactory, trustManager);
+  public OtlpGrpcSpanExporterBuilder setSslContext(
+      SSLContext sslContext, X509TrustManager trustManager) {
+    delegate.setSslContext(sslContext, trustManager);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
@@ -141,8 +141,8 @@ public final class OtlpGrpcSpanExporterBuilder {
   }
 
   /**
-   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager. Users should call this _or_
-   * set raw certificate bytes, but not both.
+   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
+   * call this _or_ set raw certificate bytes, but not both.
    */
   public OtlpGrpcSpanExporterBuilder setSslSocketFactory(
       SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterTest.java
@@ -27,6 +27,8 @@ import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
 import org.junit.jupiter.api.Test;
 
 class OtlpHttpMetricExporterTest
@@ -117,6 +119,13 @@ class OtlpHttpMetricExporterTest
       @Override
       public TelemetryExporterBuilder<MetricData> setTrustedCertificates(byte[] certificates) {
         builder.setTrustedCertificates(certificates);
+        return this;
+      }
+
+      @Override
+      public TelemetryExporterBuilder<MetricData> setSslSocketFactory(
+          SSLSocketFactory socketFactory, X509TrustManager trustManager) {
+        builder.setSslSocketFactory(socketFactory, trustManager);
         return this;
       }
 

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterTest.java
@@ -27,7 +27,7 @@ import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 import org.junit.jupiter.api.Test;
 
@@ -123,9 +123,9 @@ class OtlpHttpMetricExporterTest
       }
 
       @Override
-      public TelemetryExporterBuilder<MetricData> setSslSocketFactory(
-          SSLSocketFactory socketFactory, X509TrustManager trustManager) {
-        builder.setSslSocketFactory(socketFactory, trustManager);
+      public TelemetryExporterBuilder<MetricData> setSslContext(
+          SSLContext sslContext, X509TrustManager trustManager) {
+        builder.setSslContext(sslContext, trustManager);
         return this;
       }
 

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterTest.java
@@ -18,7 +18,7 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
 class OtlpHttpSpanExporterTest extends AbstractHttpTelemetryExporterTest<SpanData, ResourceSpans> {
@@ -68,9 +68,9 @@ class OtlpHttpSpanExporterTest extends AbstractHttpTelemetryExporterTest<SpanDat
       }
 
       @Override
-      public TelemetryExporterBuilder<SpanData> setSslSocketFactory(
-          SSLSocketFactory socketFactory, X509TrustManager trustManager) {
-        builder.setSslSocketFactory(socketFactory, trustManager);
+      public TelemetryExporterBuilder<SpanData> setSslContext(
+          SSLContext sslContext, X509TrustManager trustManager) {
+        builder.setSslContext(sslContext, trustManager);
         return this;
       }
 

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterTest.java
@@ -18,6 +18,8 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
 
 class OtlpHttpSpanExporterTest extends AbstractHttpTelemetryExporterTest<SpanData, ResourceSpans> {
 
@@ -62,6 +64,13 @@ class OtlpHttpSpanExporterTest extends AbstractHttpTelemetryExporterTest<SpanDat
       @Override
       public TelemetryExporterBuilder<SpanData> setTrustedCertificates(byte[] certificates) {
         builder.setTrustedCertificates(certificates);
+        return this;
+      }
+
+      @Override
+      public TelemetryExporterBuilder<SpanData> setSslSocketFactory(
+          SSLSocketFactory socketFactory, X509TrustManager trustManager) {
+        builder.setSslSocketFactory(socketFactory, trustManager);
         return this;
       }
 

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -13,11 +13,11 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
 import io.opentelemetry.exporter.internal.otlp.OtlpUserAgent;
 import io.opentelemetry.exporter.internal.otlp.logs.LogsRequestMarshaler;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
-import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
 /** Builder utility for {@link OtlpHttpLogRecordExporter}. */
 public final class OtlpHttpLogRecordExporterBuilder {
@@ -90,10 +90,8 @@ public final class OtlpHttpLogRecordExporterBuilder {
     return this;
   }
 
-  /**
-   * Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled.
-   */
-  public OtlpHttpLogRecordExporterBuilder setTrustManager(X509TrustManager trustManager){
+  /** Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled. */
+  public OtlpHttpLogRecordExporterBuilder setTrustManager(X509TrustManager trustManager) {
     delegate.setTrustManager(trustManager);
     return this;
   }
@@ -109,19 +107,20 @@ public final class OtlpHttpLogRecordExporterBuilder {
   }
 
   /**
-   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing
-   * key manager that has been configured with this method, or with setClientTls().
+   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing key manager
+   * that has been configured with this method, or with setClientTls().
    */
-  public OtlpHttpLogRecordExporterBuilder setKeyManager(X509KeyManager keyManager){
+  public OtlpHttpLogRecordExporterBuilder setKeyManager(X509KeyManager keyManager) {
     delegate.setKeyManager(keyManager);
     return this;
   }
 
   /**
    * Sets the SSLSocketFactory to use when TLS is enabled. If a preconfigured SSLSocketFactory is
-   * provided, a trust manager must also be provided via setTrustManager() or setTrustedCertificates().
+   * provided, a trust manager must also be provided via setTrustManager() or
+   * setTrustedCertificates().
    */
-  public OtlpHttpLogRecordExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory){
+  public OtlpHttpLogRecordExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
     delegate.setSslSocketFactory(sslSocketFactory);
     return this;
   }

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -13,6 +13,8 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
 import io.opentelemetry.exporter.internal.otlp.OtlpUserAgent;
 import io.opentelemetry.exporter.internal.otlp.logs.LogsRequestMarshaler;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
@@ -92,10 +94,8 @@ public final class OtlpHttpLogRecordExporterBuilder {
     return this;
   }
 
-  /**
-   * Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled.
-   */
-  public OtlpHttpLogRecordExporterBuilder setTrustManager(X509TrustManager trustManager){
+  /** Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled. */
+  public OtlpHttpLogRecordExporterBuilder setTrustManager(X509TrustManager trustManager) {
     delegate.setTrustManager(trustManager);
     return this;
   }
@@ -121,19 +121,20 @@ public final class OtlpHttpLogRecordExporterBuilder {
   }
 
   /**
-   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing
-   * key manager that has been configured with this method, or with setClientTls().
+   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing key manager
+   * that has been configured with this method, or with setClientTls().
    */
-  public OtlpHttpLogRecordExporterBuilder setKeyManager(X509KeyManager keyManager){
+  public OtlpHttpLogRecordExporterBuilder setKeyManager(X509KeyManager keyManager) {
     delegate.setKeyManager(keyManager);
     return this;
   }
 
   /**
    * Sets the SSLSocketFactory to use when TLS is enabled. If a preconfigured SSLSocketFactory is
-   * provided, a trust manager must also be provided via setTrustManager() or setTrustedCertificates().
+   * provided, a trust manager must also be provided via setTrustManager() or
+   * setTrustedCertificates().
    */
-  public OtlpHttpLogRecordExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory){
+  public OtlpHttpLogRecordExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
     delegate.setSslSocketFactory(sslSocketFactory);
     return this;
   }

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -13,6 +13,9 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
 import io.opentelemetry.exporter.internal.otlp.OtlpUserAgent;
 import io.opentelemetry.exporter.internal.otlp.logs.LogsRequestMarshaler;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
@@ -88,12 +91,38 @@ public final class OtlpHttpLogRecordExporterBuilder {
   }
 
   /**
+   * Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled.
+   */
+  public OtlpHttpLogRecordExporterBuilder setTrustManager(X509TrustManager trustManager){
+    delegate.setTrustManager(trustManager);
+    return this;
+  }
+
+  /**
    * Sets ths client key and the certificate chain to use for verifying client when TLS is enabled.
    * The key must be PKCS8, and both must be in PEM format.
    */
   public OtlpHttpLogRecordExporterBuilder setClientTls(
       byte[] privateKeyPem, byte[] certificatePem) {
     delegate.setKeyManagerFromCerts(privateKeyPem, certificatePem);
+    return this;
+  }
+
+  /**
+   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing
+   * key manager that has been configured with this method, or with setClientTls().
+   */
+  public OtlpHttpLogRecordExporterBuilder setKeyManager(X509KeyManager keyManager){
+    delegate.setKeyManager(keyManager);
+    return this;
+  }
+
+  /**
+   * Sets the SSLSocketFactory to use when TLS is enabled. If a preconfigured SSLSocketFactory is
+   * provided, a trust manager must also be provided via setTrustManager() or setTrustedCertificates().
+   */
+  public OtlpHttpLogRecordExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory){
+    delegate.setSslSocketFactory(sslSocketFactory);
     return this;
   }
 

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -16,7 +16,6 @@ import io.opentelemetry.exporter.internal.otlp.logs.LogsRequestMarshaler;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 
 /** Builder utility for {@link OtlpHttpLogRecordExporter}. */
@@ -90,12 +89,6 @@ public final class OtlpHttpLogRecordExporterBuilder {
     return this;
   }
 
-  /** Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled. */
-  public OtlpHttpLogRecordExporterBuilder setTrustManager(X509TrustManager trustManager) {
-    delegate.setTrustManager(trustManager);
-    return this;
-  }
-
   /**
    * Sets ths client key and the certificate chain to use for verifying client when TLS is enabled.
    * The key must be PKCS8, and both must be in PEM format.
@@ -107,21 +100,13 @@ public final class OtlpHttpLogRecordExporterBuilder {
   }
 
   /**
-   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing key manager
-   * that has been configured with this method, or with setClientTls().
+   * Sets the SSLSocketFactory to use when TLS is enabled. When providing a preconfigured
+   * SSLSocketFactory, a trust manager must also be provided.
    */
-  public OtlpHttpLogRecordExporterBuilder setKeyManager(X509KeyManager keyManager) {
-    delegate.setKeyManager(keyManager);
-    return this;
-  }
-
-  /**
-   * Sets the SSLSocketFactory to use when TLS is enabled. If a preconfigured SSLSocketFactory is
-   * provided, a trust manager must also be provided via setTrustManager() or
-   * setTrustedCertificates().
-   */
-  public OtlpHttpLogRecordExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
+  public OtlpHttpLogRecordExporterBuilder setSslSocketFactory(
+      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
     delegate.setSslSocketFactory(sslSocketFactory);
+    delegate.setTrustManager(trustManager);
     return this;
   }
 

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -16,7 +16,6 @@ import io.opentelemetry.exporter.internal.otlp.logs.LogsRequestMarshaler;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -94,12 +93,6 @@ public final class OtlpHttpLogRecordExporterBuilder {
     return this;
   }
 
-  /** Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled. */
-  public OtlpHttpLogRecordExporterBuilder setTrustManager(X509TrustManager trustManager) {
-    delegate.setTrustManager(trustManager);
-    return this;
-  }
-
   /**
    * Sets ths client key and the certificate chain to use for verifying client when TLS is enabled.
    * The key must be PKCS8, and both must be in PEM format.
@@ -121,21 +114,13 @@ public final class OtlpHttpLogRecordExporterBuilder {
   }
 
   /**
-   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing key manager
-   * that has been configured with this method, or with setClientTls().
+   * Sets the SSLSocketFactory to use when TLS is enabled. When providing a preconfigured
+   * SSLSocketFactory, a trust manager must also be provided.
    */
-  public OtlpHttpLogRecordExporterBuilder setKeyManager(X509KeyManager keyManager) {
-    delegate.setKeyManager(keyManager);
-    return this;
-  }
-
-  /**
-   * Sets the SSLSocketFactory to use when TLS is enabled. If a preconfigured SSLSocketFactory is
-   * provided, a trust manager must also be provided via setTrustManager() or
-   * setTrustedCertificates().
-   */
-  public OtlpHttpLogRecordExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
+  public OtlpHttpLogRecordExporterBuilder setSslSocketFactory(
+      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
     delegate.setSslSocketFactory(sslSocketFactory);
+    delegate.setTrustManager(trustManager);
     return this;
   }
 

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -15,11 +15,7 @@ import io.opentelemetry.exporter.internal.otlp.OtlpUserAgent;
 import io.opentelemetry.exporter.internal.otlp.logs.LogsRequestMarshaler;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.X509TrustManager;
-import java.time.Duration;
-import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
 /** Builder utility for {@link OtlpHttpLogRecordExporter}. */
@@ -104,22 +100,12 @@ public final class OtlpHttpLogRecordExporterBuilder {
   }
 
   /**
-   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
-   * call this _or_ set raw certificate bytes, but not both.
+   * Sets the "bring-your-own" SSLContext. Users should call this _or_ set raw certificate bytes,
+   * but not both.
    */
   public OtlpHttpLogRecordExporterBuilder setSslSocketFactory(
-      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
-    delegate.setSslSocketFactory(sslSocketFactory, trustManager);
-    return this;
-  }
-
-  /**
-   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
-   * call this _or_ set raw certificate bytes, but not both.
-   */
-  public OtlpHttpLogRecordExporterBuilder setSslSocketFactory(
-      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
-    delegate.setSslSocketFactory(sslSocketFactory, trustManager);
+      SSLContext sslContext, X509TrustManager trustManager) {
+    delegate.setSslContext(sslContext, trustManager);
     return this;
   }
 

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -119,8 +119,7 @@ public final class OtlpHttpLogRecordExporterBuilder {
    */
   public OtlpHttpLogRecordExporterBuilder setSslSocketFactory(
       SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
-    delegate.setSslSocketFactory(sslSocketFactory);
-    delegate.setTrustManager(trustManager);
+    delegate.setSslSocketFactory(sslSocketFactory, trustManager);
     return this;
   }
 

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -13,6 +13,9 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.internal.okhttp.OkHttpExporterBuilder;
 import io.opentelemetry.exporter.internal.otlp.OtlpUserAgent;
 import io.opentelemetry.exporter.internal.otlp.logs.LogsRequestMarshaler;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLSocketFactory;
@@ -90,6 +93,14 @@ public final class OtlpHttpLogRecordExporterBuilder {
   }
 
   /**
+   * Sets the preconfigured X509TrustManager to be used to verify servers when TLS is enabled.
+   */
+  public OtlpHttpLogRecordExporterBuilder setTrustManager(X509TrustManager trustManager){
+    delegate.setTrustManager(trustManager);
+    return this;
+  }
+
+  /**
    * Sets ths client key and the certificate chain to use for verifying client when TLS is enabled.
    * The key must be PKCS8, and both must be in PEM format.
    */
@@ -106,6 +117,24 @@ public final class OtlpHttpLogRecordExporterBuilder {
   public OtlpHttpLogRecordExporterBuilder setSslSocketFactory(
       SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
     delegate.setSslSocketFactory(sslSocketFactory, trustManager);
+    return this;
+  }
+
+  /**
+   * Sets the X509KeyManager to use when TLS is enabled. This will replace any existing
+   * key manager that has been configured with this method, or with setClientTls().
+   */
+  public OtlpHttpLogRecordExporterBuilder setKeyManager(X509KeyManager keyManager){
+    delegate.setKeyManager(keyManager);
+    return this;
+  }
+
+  /**
+   * Sets the SSLSocketFactory to use when TLS is enabled. If a preconfigured SSLSocketFactory is
+   * provided, a trust manager must also be provided via setTrustManager() or setTrustedCertificates().
+   */
+  public OtlpHttpLogRecordExporterBuilder setSslSocketFactory(SSLSocketFactory sslSocketFactory){
+    delegate.setSslSocketFactory(sslSocketFactory);
     return this;
   }
 

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -100,8 +100,8 @@ public final class OtlpHttpLogRecordExporterBuilder {
   }
 
   /**
-   * Sets the SSLSocketFactory to use when TLS is enabled. When providing a preconfigured
-   * SSLSocketFactory, a trust manager must also be provided.
+   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
+   * call this _or_ set raw certificate bytes, but not both.
    */
   public OtlpHttpLogRecordExporterBuilder setSslSocketFactory(
       SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -114,8 +114,8 @@ public final class OtlpHttpLogRecordExporterBuilder {
   }
 
   /**
-   * Sets the SSLSocketFactory to use when TLS is enabled. When providing a preconfigured
-   * SSLSocketFactory, a trust manager must also be provided.
+   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
+   * call this _or_ set raw certificate bytes, but not both.
    */
   public OtlpHttpLogRecordExporterBuilder setSslSocketFactory(
       SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -105,8 +105,7 @@ public final class OtlpHttpLogRecordExporterBuilder {
    */
   public OtlpHttpLogRecordExporterBuilder setSslSocketFactory(
       SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
-    delegate.setSslSocketFactory(sslSocketFactory);
-    delegate.setTrustManager(trustManager);
+    delegate.setSslSocketFactory(sslSocketFactory, trustManager);
     return this;
   }
 

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
@@ -142,6 +142,16 @@ public final class OtlpGrpcLogRecordExporterBuilder {
   }
 
   /**
+   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager. Users should call this _or_
+   * set raw certificate bytes, but not both.
+   */
+  public OtlpGrpcLogRecordExporterBuilder setSslSocketFactory(
+      SSLSocketFactory socketFactory, X509TrustManager trustManager) {
+    delegate.setSslSocketFactory(socketFactory, trustManager);
+    return this;
+  }
+
+  /**
    * Add header to request. Optional. Applicable only if {@link
    * OtlpGrpcLogRecordExporterBuilder#setChannel(ManagedChannel)} is not used to set channel.
    *

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
@@ -18,6 +18,8 @@ import io.opentelemetry.exporter.internal.otlp.logs.LogsRequestMarshaler;
 import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
 
 /** Builder for {@link OtlpGrpcLogRecordExporter}. */
 public final class OtlpGrpcLogRecordExporterBuilder {
@@ -126,6 +128,16 @@ public final class OtlpGrpcLogRecordExporterBuilder {
   public OtlpGrpcLogRecordExporterBuilder setClientTls(
       byte[] privateKeyPem, byte[] certificatePem) {
     delegate.setKeyManagerFromCerts(privateKeyPem, certificatePem);
+    return this;
+  }
+
+  /**
+   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager. Users should call this _or_
+   * set raw certificate bytes, but not both.
+   */
+  public OtlpGrpcLogRecordExporterBuilder setSslSocketFactory(
+      SSLSocketFactory socketFactory, X509TrustManager trustManager) {
+    delegate.setSslSocketFactory(socketFactory, trustManager);
     return this;
   }
 

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
@@ -132,8 +132,8 @@ public final class OtlpGrpcLogRecordExporterBuilder {
   }
 
   /**
-   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager. Users should call this _or_
-   * set raw certificate bytes, but not both.
+   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
+   * call this _or_ set raw certificate bytes, but not both.
    */
   public OtlpGrpcLogRecordExporterBuilder setSslSocketFactory(
       SSLSocketFactory socketFactory, X509TrustManager trustManager) {

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
@@ -18,7 +18,7 @@ import io.opentelemetry.exporter.internal.otlp.logs.LogsRequestMarshaler;
 import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
 /** Builder for {@link OtlpGrpcLogRecordExporter}. */
@@ -132,22 +132,12 @@ public final class OtlpGrpcLogRecordExporterBuilder {
   }
 
   /**
-   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
-   * call this _or_ set raw certificate bytes, but not both.
+   * Sets the "bring-your-own" SSLContext for use with TLS. Users should call this _or_ set raw
+   * certificate bytes, but not both.
    */
-  public OtlpGrpcLogRecordExporterBuilder setSslSocketFactory(
-      SSLSocketFactory socketFactory, X509TrustManager trustManager) {
-    delegate.setSslSocketFactory(socketFactory, trustManager);
-    return this;
-  }
-
-  /**
-   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
-   * call this _or_ set raw certificate bytes, but not both.
-   */
-  public OtlpGrpcLogRecordExporterBuilder setSslSocketFactory(
-      SSLSocketFactory socketFactory, X509TrustManager trustManager) {
-    delegate.setSslSocketFactory(socketFactory, trustManager);
+  public OtlpGrpcLogRecordExporterBuilder setSslContext(
+      SSLContext sslContext, X509TrustManager trustManager) {
+    delegate.setSslContext(sslContext, trustManager);
     return this;
   }
 

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
@@ -142,8 +142,8 @@ public final class OtlpGrpcLogRecordExporterBuilder {
   }
 
   /**
-   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager. Users should call this _or_
-   * set raw certificate bytes, but not both.
+   * Sets the "bring-your-own" SSLSocketFactory and X509TrustManager for use with TLS. Users should
+   * call this _or_ set raw certificate bytes, but not both.
    */
   public OtlpGrpcLogRecordExporterBuilder setSslSocketFactory(
       SSLSocketFactory socketFactory, X509TrustManager trustManager) {

--- a/exporters/otlp/logs/src/test/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterTest.java
+++ b/exporters/otlp/logs/src/test/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterTest.java
@@ -18,6 +18,8 @@ import io.opentelemetry.sdk.logs.data.LogRecordData;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
 
 class OtlpHttpLogRecordExporterTest
     extends AbstractHttpTelemetryExporterTest<LogRecordData, ResourceLogs> {
@@ -63,6 +65,13 @@ class OtlpHttpLogRecordExporterTest
       @Override
       public TelemetryExporterBuilder<LogRecordData> setTrustedCertificates(byte[] certificates) {
         builder.setTrustedCertificates(certificates);
+        return this;
+      }
+
+      @Override
+      public TelemetryExporterBuilder<LogRecordData> setSslSocketFactory(
+          SSLSocketFactory socketFactory, X509TrustManager trustManager) {
+        builder.setSslSocketFactory(socketFactory, trustManager);
         return this;
       }
 

--- a/exporters/otlp/logs/src/test/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterTest.java
+++ b/exporters/otlp/logs/src/test/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterTest.java
@@ -18,7 +18,7 @@ import io.opentelemetry.sdk.logs.data.LogRecordData;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
 class OtlpHttpLogRecordExporterTest
@@ -69,9 +69,9 @@ class OtlpHttpLogRecordExporterTest
       }
 
       @Override
-      public TelemetryExporterBuilder<LogRecordData> setSslSocketFactory(
-          SSLSocketFactory socketFactory, X509TrustManager trustManager) {
-        builder.setSslSocketFactory(socketFactory, trustManager);
+      public TelemetryExporterBuilder<LogRecordData> setSslContext(
+          SSLContext ssLContext, X509TrustManager trustManager) {
+        builder.setSslSocketFactory(ssLContext, trustManager);
         return this;
       }
 

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
@@ -55,7 +55,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 import org.assertj.core.api.iterable.ThrowingExtractor;
@@ -323,18 +325,19 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
   }
 
   @Test
-  void tlsViaSslSocketFactory() throws Exception {
+  void tlsViaSslContext() throws Exception {
     X509TrustManager trustManager = TlsUtil.trustManager(certificate.certificate().getEncoded());
 
     X509KeyManager keyManager =
         TlsUtil.keyManager(
             certificate.privateKey().getEncoded(), certificate.certificate().getEncoded());
 
-    SSLSocketFactory sslSocketFactory = TlsUtil.sslSocketFactory(keyManager, trustManager);
+    SSLContext sslContext = SSLContext.getInstance("TLS");
+    sslContext.init(new KeyManager[] {keyManager}, new TrustManager[] {trustManager}, null);
 
     TelemetryExporter<T> exporter =
         exporterBuilder()
-            .setSslSocketFactory(sslSocketFactory, trustManager)
+            .setSslContext(sslContext, trustManager)
             .setEndpoint(server.httpsUri().toString())
             .build();
     try {

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
@@ -23,6 +23,7 @@ import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 import io.github.netmikey.logunit.api.LogCapturer;
+import io.opentelemetry.exporter.internal.TlsUtil;
 import io.opentelemetry.exporter.internal.grpc.OkHttpGrpcExporter;
 import io.opentelemetry.exporter.internal.grpc.UpstreamGrpcExporter;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
@@ -54,6 +55,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
 import org.assertj.core.api.iterable.ThrowingExtractor;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -307,6 +311,30 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
             .setTrustedCertificates(Files.readAllBytes(certificate.certificateFile().toPath()))
             .setClientTls(
                 certificate.privateKey().getEncoded(), certificate.certificate().getEncoded())
+            .setEndpoint(server.httpsUri().toString())
+            .build();
+    try {
+      CompletableResultCode result =
+          exporter.export(Collections.singletonList(generateFakeTelemetry()));
+      assertThat(result.join(10, TimeUnit.SECONDS).isSuccess()).isTrue();
+    } finally {
+      exporter.shutdown();
+    }
+  }
+
+  @Test
+  void tlsViaSslSocketFactory() throws Exception {
+    X509TrustManager trustManager = TlsUtil.trustManager(certificate.certificate().getEncoded());
+
+    X509KeyManager keyManager =
+        TlsUtil.keyManager(
+            certificate.privateKey().getEncoded(), certificate.certificate().getEncoded());
+
+    SSLSocketFactory sslSocketFactory = TlsUtil.sslSocketFactory(keyManager, trustManager);
+
+    TelemetryExporter<T> exporter =
+        exporterBuilder()
+            .setSslSocketFactory(sslSocketFactory, trustManager)
             .setEndpoint(server.httpsUri().toString())
             .build();
     try {

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcLogRecordExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcLogRecordExporterBuilderWrapper.java
@@ -12,6 +12,8 @@ import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporterBuilder;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
 
 final class GrpcLogRecordExporterBuilderWrapper implements TelemetryExporterBuilder<LogRecordData> {
   private final OtlpGrpcLogRecordExporterBuilder builder;
@@ -60,6 +62,13 @@ final class GrpcLogRecordExporterBuilderWrapper implements TelemetryExporterBuil
   public TelemetryExporterBuilder<LogRecordData> setClientTls(
       byte[] privateKeyPem, byte[] certificatePem) {
     builder.setClientTls(privateKeyPem, certificatePem);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<LogRecordData> setSslSocketFactory(
+      SSLSocketFactory socketFactory, X509TrustManager trustManager) {
+    builder.setSslSocketFactory(socketFactory, trustManager);
     return this;
   }
 

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcLogRecordExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcLogRecordExporterBuilderWrapper.java
@@ -12,7 +12,7 @@ import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporterBuilder;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
 final class GrpcLogRecordExporterBuilderWrapper implements TelemetryExporterBuilder<LogRecordData> {
@@ -66,9 +66,9 @@ final class GrpcLogRecordExporterBuilderWrapper implements TelemetryExporterBuil
   }
 
   @Override
-  public TelemetryExporterBuilder<LogRecordData> setSslSocketFactory(
-      SSLSocketFactory socketFactory, X509TrustManager trustManager) {
-    builder.setSslSocketFactory(socketFactory, trustManager);
+  public TelemetryExporterBuilder<LogRecordData> setSslContext(
+      SSLContext sslContext, X509TrustManager trustManager) {
+    builder.setSslContext(sslContext, trustManager);
     return this;
   }
 

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcMetricExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcMetricExporterBuilderWrapper.java
@@ -12,7 +12,7 @@ import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
 final class GrpcMetricExporterBuilderWrapper implements TelemetryExporterBuilder<MetricData> {
@@ -66,9 +66,9 @@ final class GrpcMetricExporterBuilderWrapper implements TelemetryExporterBuilder
   }
 
   @Override
-  public TelemetryExporterBuilder<MetricData> setSslSocketFactory(
-      SSLSocketFactory socketFactory, X509TrustManager trustManager) {
-    builder.setSslSocketFactory(socketFactory, trustManager);
+  public TelemetryExporterBuilder<MetricData> setSslContext(
+      SSLContext sslContext, X509TrustManager trustManager) {
+    builder.setSslContext(sslContext, trustManager);
     return this;
   }
 

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcMetricExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcMetricExporterBuilderWrapper.java
@@ -12,6 +12,8 @@ import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
 
 final class GrpcMetricExporterBuilderWrapper implements TelemetryExporterBuilder<MetricData> {
   private final OtlpGrpcMetricExporterBuilder builder;
@@ -60,6 +62,13 @@ final class GrpcMetricExporterBuilderWrapper implements TelemetryExporterBuilder
   public TelemetryExporterBuilder<MetricData> setClientTls(
       byte[] privateKeyPem, byte[] certificatePem) {
     builder.setClientTls(privateKeyPem, certificatePem);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<MetricData> setSslSocketFactory(
+      SSLSocketFactory socketFactory, X509TrustManager trustManager) {
+    builder.setSslSocketFactory(socketFactory, trustManager);
     return this;
   }
 

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcSpanExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcSpanExporterBuilderWrapper.java
@@ -12,6 +12,8 @@ import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
 
 /** Wrapper of {@link OtlpGrpcSpanExporterBuilder} for use in integration tests. */
 final class GrpcSpanExporterBuilderWrapper implements TelemetryExporterBuilder<SpanData> {
@@ -61,6 +63,13 @@ final class GrpcSpanExporterBuilderWrapper implements TelemetryExporterBuilder<S
   public TelemetryExporterBuilder<SpanData> setClientTls(
       byte[] privateKeyPem, byte[] certificatePem) {
     builder.setClientTls(privateKeyPem, certificatePem);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<SpanData> setSslSocketFactory(
+      SSLSocketFactory socketFactory, X509TrustManager trustManager) {
+    builder.setSslSocketFactory(socketFactory, trustManager);
     return this;
   }
 

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcSpanExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcSpanExporterBuilderWrapper.java
@@ -12,7 +12,7 @@ import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
 /** Wrapper of {@link OtlpGrpcSpanExporterBuilder} for use in integration tests. */
@@ -67,9 +67,9 @@ final class GrpcSpanExporterBuilderWrapper implements TelemetryExporterBuilder<S
   }
 
   @Override
-  public TelemetryExporterBuilder<SpanData> setSslSocketFactory(
-      SSLSocketFactory socketFactory, X509TrustManager trustManager) {
-    builder.setSslSocketFactory(socketFactory, trustManager);
+  public TelemetryExporterBuilder<SpanData> setSslContext(
+      SSLContext sslContext, X509TrustManager trustManager) {
+    builder.setSslContext(sslContext, trustManager);
     return this;
   }
 

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/ManagedChannelTelemetryExporterBuilder.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/ManagedChannelTelemetryExporterBuilder.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509TrustManager;
 
 /**
@@ -100,6 +101,14 @@ public final class ManagedChannelTelemetryExporterBuilder<T>
   @Override
   public TelemetryExporterBuilder<T> setClientTls(byte[] privateKeyPem, byte[] certificatePem) {
     tlsConfigHelper.setKeyManagerFromCerts(privateKeyPem, certificatePem);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<T> setSslSocketFactory(
+      SSLSocketFactory socketFactory, X509TrustManager trustManager) {
+    tlsConfigHelper.setSslSocketFactory(socketFactory);
+    tlsConfigHelper.setTrustManager(trustManager);
     return this;
   }
 

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/ManagedChannelTelemetryExporterBuilder.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/ManagedChannelTelemetryExporterBuilder.java
@@ -22,8 +22,6 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509TrustManager;
 
@@ -101,6 +99,14 @@ public final class ManagedChannelTelemetryExporterBuilder<T>
   @Override
   public TelemetryExporterBuilder<T> setClientTls(byte[] privateKeyPem, byte[] certificatePem) {
     tlsConfigHelper.setKeyManagerFromCerts(privateKeyPem, certificatePem);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<T> setSslSocketFactory(
+      SSLSocketFactory socketFactory, X509TrustManager trustManager) {
+    tlsConfigHelper.setSslSocketFactory(socketFactory);
+    tlsConfigHelper.setTrustManager(trustManager);
     return this;
   }
 

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/ManagedChannelTelemetryExporterBuilder.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/ManagedChannelTelemetryExporterBuilder.java
@@ -22,7 +22,8 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
 import javax.net.ssl.X509TrustManager;
 
 /**
@@ -103,22 +104,6 @@ public final class ManagedChannelTelemetryExporterBuilder<T>
   }
 
   @Override
-  public TelemetryExporterBuilder<T> setSslSocketFactory(
-      SSLSocketFactory socketFactory, X509TrustManager trustManager) {
-    tlsConfigHelper.setSslSocketFactory(socketFactory);
-    tlsConfigHelper.setTrustManager(trustManager);
-    return this;
-  }
-
-  @Override
-  public TelemetryExporterBuilder<T> setSslSocketFactory(
-      SSLSocketFactory socketFactory, X509TrustManager trustManager) {
-    tlsConfigHelper.setSslSocketFactory(socketFactory);
-    tlsConfigHelper.setTrustManager(trustManager);
-    return this;
-  }
-
-  @Override
   public TelemetryExporterBuilder<T> setRetryPolicy(RetryPolicy retryPolicy) {
     String grpcServiceName;
     if (delegate instanceof GrpcLogRecordExporterBuilderWrapper) {
@@ -171,6 +156,13 @@ public final class ManagedChannelTelemetryExporterBuilder<T>
         return delegateExporter.shutdown();
       }
     };
+  }
+
+  @Override
+  public TelemetryExporterBuilder<T> setSslContext(
+      SSLContext sslContext, X509TrustManager trustManager) {
+    tlsConfigHelper.setSslContext(sslContext, trustManager);
+    return this;
   }
 
   /**

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/TelemetryExporterBuilder.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/TelemetryExporterBuilder.java
@@ -15,7 +15,7 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
 public interface TelemetryExporterBuilder<T> {
@@ -46,8 +46,7 @@ public interface TelemetryExporterBuilder<T> {
 
   TelemetryExporterBuilder<T> setClientTls(byte[] privateKeyPem, byte[] certificatePem);
 
-  TelemetryExporterBuilder<T> setSslSocketFactory(
-      SSLSocketFactory socketFactory, X509TrustManager trustManager);
+  TelemetryExporterBuilder<T> setSslContext(SSLContext sslContext, X509TrustManager trustManager);
 
   TelemetryExporterBuilder<T> setRetryPolicy(RetryPolicy retryPolicy);
 

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/TelemetryExporterBuilder.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/TelemetryExporterBuilder.java
@@ -15,6 +15,8 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
 
 public interface TelemetryExporterBuilder<T> {
 
@@ -43,6 +45,9 @@ public interface TelemetryExporterBuilder<T> {
   TelemetryExporterBuilder<T> setTrustedCertificates(byte[] certificates);
 
   TelemetryExporterBuilder<T> setClientTls(byte[] privateKeyPem, byte[] certificatePem);
+
+  TelemetryExporterBuilder<T> setSslSocketFactory(
+      SSLSocketFactory socketFactory, X509TrustManager trustManager);
 
   TelemetryExporterBuilder<T> setRetryPolicy(RetryPolicy retryPolicy);
 


### PR DESCRIPTION
Relates to #5211.

This is a follow-up from #5246 and provides new methods for configuring TLS on the OTLP exporters in a more DIY or BYO fashion. This allows users to preconfigure their own existing `X509TrustManager`, `X509KeyManager`, and/or `SSLSocketFactory` without necessarily having to manually deal with certificate bytes (existing APIs).