### PR TITLE
Skip build and publish step to finish release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
           java-version: 17
 
       - name: Build and publish artifacts
+        # Skip publish artifacts step to finish partial release
+        if: false
         uses: gradle/gradle-build-action@v2
         with:
           arguments: assemble publishToSonatype closeAndReleaseSonatypeStagingRepository


### PR DESCRIPTION
The release [partially completed](https://github.com/open-telemetry/opentelemetry-java/actions/runs/4386207903/jobs/7679942522). Artifacts were published but the following steps were not completed.

In order to allow re-running the release job, this disables the "Build and publish artifacts" step. 