### PR TITLE
Logging OTLP sdk dependencies

### DIFF
--- a/exporters/logging-otlp/build.gradle.kts
+++ b/exporters/logging-otlp/build.gradle.kts
@@ -9,9 +9,9 @@ description = "OpenTelemetry Protocol JSON Logging Exporters"
 otelJava.moduleName.set("io.opentelemetry.exporter.logging.otlp")
 
 dependencies {
-  compileOnly(project(":sdk:trace"))
-  compileOnly(project(":sdk:metrics"))
-  compileOnly(project(":sdk:logs"))
+  implementation(project(":sdk:trace"))
+  implementation(project(":sdk:metrics"))
+  implementation(project(":sdk:logs"))
 
   implementation(project(":exporters:otlp:common"))
   implementation(project(":sdk-extensions:autoconfigure-spi"))
@@ -20,9 +20,6 @@ dependencies {
 
   testImplementation(project(":sdk:testing"))
   testImplementation(project(":sdk:logs-testing"))
-  testImplementation(project(":sdk:logs"))
-  testImplementation(project(":sdk:metrics"))
-  testImplementation(project(":sdk:trace"))
 
   testImplementation("org.skyscreamer:jsonassert")
 }


### PR DESCRIPTION
Resolves #4250. 

If someone fields strongly about having one SDK implementation and not the others, they can use gradle to include the unused transitive dependency. 

As for the question of whether its appropriate to have a transitive dependency on an alpha artifact, we decided that implementation dependencies are acceptable because users have to "opt-in" to use the alpha surface area by adding their own dependency. We have several examples of this behavior, including [:sdk:all](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/all/build.gradle.kts#L21). 