### PR TITLE
Cache ImmutableKeyValuePairs#hashCode

### DIFF
--- a/api/all/src/jmh/java/io/opentelemetry/api/common/AttributesBenchmark.java
+++ b/api/all/src/jmh/java/io/opentelemetry/api/common/AttributesBenchmark.java
@@ -25,11 +25,30 @@ public class AttributesBenchmark {
   // pre-allocate the keys & values to remove one possible confounding factor
   private static final List<AttributeKey<String>> keys = new ArrayList<>(10);
   private static final List<String> values = new ArrayList<>(10);
+  private static final List<Attributes> attributes = new ArrayList<>();
 
   static {
     for (int i = 0; i < 10; i++) {
       keys.add(AttributeKey.stringKey("key" + i));
       values.add("value" + i);
+      AttributesBuilder builder = Attributes.builder();
+      for (int j = 0; j <= i; j++) {
+        builder.put(keys.get(j), values.get(j));
+      }
+      attributes.add(builder.build());
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @Fork(1)
+  @Measurement(iterations = 15, time = 1)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  @Warmup(iterations = 5, time = 1)
+  @SuppressWarnings("ReturnValueIgnored")
+  public void computeHashCode() {
+    for (Attributes attributes : attributes) {
+      attributes.hashCode();
     }
   }
 

--- a/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/ImmutableKeyValuePairs.java
@@ -32,6 +32,7 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public abstract class ImmutableKeyValuePairs<K, V> {
   private final Object[] data;
+  private int hashcode;
 
   /**
    * Stores the raw object data directly. Does not do any de-duping or sorting. If you use this
@@ -247,9 +248,13 @@ public abstract class ImmutableKeyValuePairs<K, V> {
 
   @Override
   public int hashCode() {
-    int result = 1;
-    result *= 1000003;
-    result ^= Arrays.hashCode(data);
+    int result = hashcode;
+    if (result == 0) {
+      result = 1;
+      result *= 1000003;
+      result ^= Arrays.hashCode(data);
+      hashcode = result;
+    }
     return result;
   }
 


### PR DESCRIPTION
The metrics hot path involves finding the relevant `AggregationHandle` in a `ConcurrentHashmap` for a given measurement based on its `Attributes`. We recommend that callers save references to common `Attributes` to prevent extra allocations on each measurement. In this case, callers can benefit from caching `Attributes#hashCode` so that it doesn't need to be recomputed each time we record a measurement and do a lookup in the `ConcurrentHashmap`. 

I've added benchmarks to `AttributesBenchmark`, which shows a ~15x improvement in time to compute `hashCode` (not surprising). But its more interesting to see the performance improvement in an actual metrics scenario. I've extended `MetricsBenchmark` to include a case where there's enough cardinality to make the map lookup not completely trivial (the other benchmarks only have a single attributes entry). The performance gains are modest since there's a lot more going on when performing a measurement besides computing a hashcode, but non-zero. Check out the [before](https://gist.github.com/jack-berg/f297ae32a28c139eb9fda614cf36df37) and [after](https://gist.github.com/jack-berg/10f298f5ab86f96bc933b54f028eaf9e) for more details.