### PR TITLE
Update semconv to 1.19.0 and related build tool changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@
 ### Semantic Conventions
 
 * Update semconv to 1.19.0
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-java/pull/TODO))
+  ([#5311](https://github.com/open-telemetry/opentelemetry-java/pull/5311))
 
 ## Version 1.23.1 (2023-02-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@
 * Fix case of bug label in open issue workflow
   ([#5268](https://github.com/open-telemetry/opentelemetry-java/pull/5268))
 
+### Semantic Conventions
+
+* Update semconv to 1.19.0
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-java/pull/TODO))
+
 ## Version 1.23.1 (2023-02-15)
 
 * Fix bug that broke `AutoConfiguredOpenTelemetrySdk`'s shutdown hook.

--- a/buildscripts/semantic-convention/generate.sh
+++ b/buildscripts/semantic-convention/generate.sh
@@ -4,10 +4,10 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../../"
 
 # freeze the spec & generator tools versions to make SemanticAttributes generation reproducible
-SEMCONV_VERSION=1.18.0
+SEMCONV_VERSION=1.19.0
 SPEC_VERSION=v$SEMCONV_VERSION
 SCHEMA_URL=https://opentelemetry.io/schemas/$SEMCONV_VERSION
-GENERATOR_VERSION=0.14.0
+GENERATOR_VERSION=0.18.0
 
 cd ${SCRIPT_DIR}
 
@@ -26,7 +26,7 @@ docker run --rm \
   -v ${SCRIPT_DIR}/templates:/templates \
   -v ${ROOT_DIR}/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/:/output \
   otel/semconvgen:$GENERATOR_VERSION \
-  --exclude resource/** \
+  --only span,event,attribute_group,scope \
   -f /source code \
   --template /templates/SemanticAttributes.java.j2 \
   --output /output/SemanticAttributes.java \
@@ -36,10 +36,11 @@ docker run --rm \
   -Dpkg=io.opentelemetry.semconv.trace.attributes
 
 docker run --rm \
-  -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions/resource:/source \
+  -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions:/source \
   -v ${SCRIPT_DIR}/templates:/templates \
   -v ${ROOT_DIR}/semconv/src/main/java/io/opentelemetry/semconv/resource/attributes/:/output \
   otel/semconvgen:$GENERATOR_VERSION \
+  --only resource \
   -f /source code \
   --template /templates/SemanticAttributes.java.j2 \
   --output /output/ResourceAttributes.java \

--- a/buildscripts/semantic-convention/templates/SemanticAttributes.java.j2
+++ b/buildscripts/semantic-convention/templates/SemanticAttributes.java.j2
@@ -303,6 +303,22 @@ public final class {{class}} {
   @Deprecated
   public static final AttributeKey<String> HTTP_USER_AGENT = stringKey("http.user_agent");
 
+  /**
+   * Deprecated, use the {@link SemanticAttributes#OTEL_SCOPE_NAME} attribute.
+   *
+   * @deprecated Deprecated, use the `{@link SemanticAttributes#OTEL_SCOPE_NAME} attribute.
+   */
+  @Deprecated
+  public static final AttributeKey<String> OTEL_LIBRARY_NAME = stringKey("otel.library.name");
+
+  /**
+   * Deprecated, use the {@link SemanticAttributes#OTEL_SCOPE_VERSION} attribute.
+   *
+   * @deprecated Deprecated, use the {@link SemanticAttributes#OTEL_SCOPE_VERSION} attribute.
+   */
+  @Deprecated
+  public static final AttributeKey<String> OTEL_LIBRARY_VERSION = stringKey("otel.library.version");  
+
   {% endif %}
 
   {%- if class == "ResourceAttributes" %}

--- a/buildscripts/semantic-convention/templates/SemanticAttributes.java.j2
+++ b/buildscripts/semantic-convention/templates/SemanticAttributes.java.j2
@@ -276,21 +276,22 @@ public final class {{class}} {
 
   /** 
    * The name of the instrumentation scope - ({@code InstrumentationScope.Name} in OTLP).
-   * @deprecated This item has been moved, use {@link ResourceAttributes#OTEL_SCOPE_NAME} instead.
+   * @deprecated This item has been moved, use {@link io.opentelemetry.semconv.resource.attributes.ResourceAttributes#OTEL_SCOPE_NAME} instead.
    */
   @Deprecated
-  public static final AttributeKey<String> OTEL_SCOPE_NAME = ResourceAttributes.OTEL_SCOPE_NAME;
+  public static final AttributeKey<String> OTEL_SCOPE_NAME = stringKey("otel.scope.name");
 
   /** 
    * The version of the instrumentation scope - ({@code InstrumentationScope.Version} in OTLP).
-   * @deprecated This item has been moved, use {@link ResourceAttributes#OTEL_SCOPE_VERSION} instead.
+   * @deprecated This item has been moved, use {@link io.opentelemetry.semconv.resource.attributes.ResourceAttributes#OTEL_SCOPE_VERSION} instead.
    */
   @Deprecated
-  public static final AttributeKey<String> OTEL_SCOPE_VERSION = ResourceAttributes.OTEL_SCOPE_VERSION;
+  public static final AttributeKey<String> OTEL_SCOPE_VERSION = stringKey("otel.scope.version");;
 
   /**
    * The execution ID of the current function execution.
-   * @deprecated This item has been renamed in 1.19.0 version of the semantic conventions. Use {@link SemanticAttributes#FAAS_INVOCATION_ID} instead.
+   * @deprecated This item has been renamed in 1.19.0 version of the semantic conventions. 
+   * Use {@link SemanticAttributes#FAAS_INVOCATION_ID} instead.
    */
   @Deprecated
   public static final AttributeKey<String> FAAS_EXECUTION = stringKey("faas.execution");
@@ -298,23 +299,24 @@ public final class {{class}} {
   /**
    * Value of the <a href="https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent">HTTP
    * User-Agent</a> header sent by the client.
-   * @deprecated This item has been renamed in 1.19.0 version of the semantic conventions. Use {@link SemanticAttributes#USER_AGENT_ORIGINAL} instead.
+   * @deprecated This item has been renamed in 1.19.0 version of the semantic conventions. 
+   * Use {@link SemanticAttributes#USER_AGENT_ORIGINAL} instead.
    */
   @Deprecated
   public static final AttributeKey<String> HTTP_USER_AGENT = stringKey("http.user_agent");
 
   /**
-   * Deprecated, use the {@link SemanticAttributes#OTEL_SCOPE_NAME} attribute.
+   * Deprecated.
    *
-   * @deprecated Deprecated, use the `{@link SemanticAttributes#OTEL_SCOPE_NAME} attribute.
+   * @deprecated Deprecated, use the {@link io.opentelemetry.semconv.resource.attributes.ResourceAttributes#OTEL_SCOPE_NAME} attribute.
    */
   @Deprecated
   public static final AttributeKey<String> OTEL_LIBRARY_NAME = stringKey("otel.library.name");
 
   /**
-   * Deprecated, use the {@link SemanticAttributes#OTEL_SCOPE_VERSION} attribute.
+   * Deprecated.
    *
-   * @deprecated Deprecated, use the {@link SemanticAttributes#OTEL_SCOPE_VERSION} attribute.
+   * @deprecated Deprecated, use the {@link io.opentelemetry.semconv.resource.attributes.ResourceAttributes#OTEL_SCOPE_VERSION} attribute.
    */
   @Deprecated
   public static final AttributeKey<String> OTEL_LIBRARY_VERSION = stringKey("otel.library.version");  
@@ -340,7 +342,7 @@ public final class {{class}} {
    *       to retrieve brands and platform individually from the User-Agent Client Hints API. To
    *       retrieve the value, the legacy {@code navigator.userAgent} API can be used.
    * </ul>
-   * @deprecated This item has been renamed in 1.19.0 version of the semantic conventions. Use {@link SemanticAttributes#USER_AGENT_ORIGINAL} instead.
+   * @deprecated This item has been renamed in 1.19.0 version of the semantic conventions. Use {@link io.opentelemetry.semconv.trace.attributes.SemanticAttributes#USER_AGENT_ORIGINAL} instead.
    */
   @Deprecated
   public static final AttributeKey<String> BROWSER_USER_AGENT = stringKey("browser.user_agent");

--- a/buildscripts/semantic-convention/templates/SemanticAttributes.java.j2
+++ b/buildscripts/semantic-convention/templates/SemanticAttributes.java.j2
@@ -274,6 +274,35 @@ public final class {{class}} {
   public static final AttributeKey<Long> MESSAGING_ROCKETMQ_DELAY_TIME_LEVEL =
       longKey("messaging.rocketmq.delay_time_level");
 
+  /** 
+   * The name of the instrumentation scope - ({@code InstrumentationScope.Name} in OTLP).
+   * @deprecated This item has been moved, use {@link ResourceAttributes#OTEL_SCOPE_NAME} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> OTEL_SCOPE_NAME = ResourceAttributes.OTEL_SCOPE_NAME;
+
+  /** 
+   * The version of the instrumentation scope - ({@code InstrumentationScope.Version} in OTLP).
+   * @deprecated This item has been moved, use {@link ResourceAttributes#OTEL_SCOPE_VERSION} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> OTEL_SCOPE_VERSION = ResourceAttributes.OTEL_SCOPE_VERSION;
+
+  /**
+   * The execution ID of the current function execution.
+   * @deprecated This item has been renamed in 1.19.0 version of the semantic conventions. Use {@link SemanticAttributes#FAAS_INVOCATION_ID} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> FAAS_EXECUTION = stringKey("faas.execution");
+
+  /**
+   * Value of the <a href="https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent">HTTP
+   * User-Agent</a> header sent by the client.
+   * @deprecated This item has been renamed in 1.19.0 version of the semantic conventions. Use {@link SemanticAttributes#USER_AGENT_ORIGINAL} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> HTTP_USER_AGENT = stringKey("http.user_agent");
+
   {% endif %}
 
   {%- if class == "ResourceAttributes" %}
@@ -284,6 +313,51 @@ public final class {{class}} {
    */
   @Deprecated
   public static final String GCP_OPENSHIFT = "gcp_openshift";
+
+  /**
+   * Full user-agent string provided by the browser
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The user-agent value SHOULD be provided only from browsers that do not have a mechanism
+   *       to retrieve brands and platform individually from the User-Agent Client Hints API. To
+   *       retrieve the value, the legacy {@code navigator.userAgent} API can be used.
+   * </ul>
+   * @deprecated This item has been renamed in 1.19.0 version of the semantic conventions. Use {@link SemanticAttributes#USER_AGENT_ORIGINAL} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> BROWSER_USER_AGENT = stringKey("browser.user_agent");
+
+  /**
+   * The unique ID of the single function that this runtime instance executes.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>On some cloud providers, it may not be possible to determine the full ID at startup, so
+   *       consider setting {@code faas.id} as a span attribute instead.
+   *   <li>The exact value to use for {@code faas.id} depends on the cloud provider:
+   *   <li><strong>AWS Lambda:</strong> The function <a
+   *       href="https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">ARN</a>.
+   *       Take care not to use the &quot;invoked ARN&quot; directly but replace any <a
+   *       href="https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html">alias
+   *       suffix</a> with the resolved function version, as the same runtime instance may be
+   *       invokable with multiple different aliases.
+   *   <li><strong>GCP:</strong> The <a
+   *       href="https://cloud.google.com/iam/docs/full-resource-names">URI of the resource</a>
+   *   <li><strong>Azure:</strong> The <a
+   *       href="https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id">Fully
+   *       Qualified Resource ID</a> of the invoked function, <em>not</em> the function app, having
+   *       the form {@code
+   *       /subscriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>}.
+   *       This means that a span attribute MUST be used, as an Azure function app can host multiple
+   *       functions that would usually share a TracerProvider.
+   * </ul>
+   * @deprecated This item has been removed in 1.19.0 version of the semantic conventions. Use {@link ResourceAttributes#CLOUD_RESOURCE_ID} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> FAAS_ID = stringKey("faas.id");
 
   {% endif %}
 

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/DelegatingSpanData.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/DelegatingSpanData.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
  * //   SpanDataWithClientType(SpanData delegate) {
  * //     super(delegate);
  * //     String clientType = ClientConfig.parseUserAgent(
- * //       delegate.getAttributes().get(SemanticAttributes.HTTP_USER_AGENT).getStringValue());
+ * //       delegate.getAttributes().get(SemanticAttributes.USER_AGENT_ORIGINAL).getStringValue());
  * //     Attributes.Builder newAttributes = Attributes.builder(delegate.getAttributes());
  * //     newAttributes.setAttribute("client_type", clientType);
  * //     attributes = newAttributes.build();

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/data/DelegatingSpanDataTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/data/DelegatingSpanDataTest.java
@@ -35,7 +35,7 @@ class DelegatingSpanDataTest {
     private SpanDataWithClientType(SpanData delegate) {
       super(delegate);
       String clientType;
-      String userAgent = delegate.getAttributes().get(SemanticAttributes.HTTP_USER_AGENT);
+      String userAgent = delegate.getAttributes().get(SemanticAttributes.USER_AGENT_ORIGINAL);
       if (userAgent != null) {
         clientType = parseUserAgent(userAgent);
       } else {

--- a/semconv/src/main/java/io/opentelemetry/semconv/resource/attributes/ResourceAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/resource/attributes/ResourceAttributes.java
@@ -862,5 +862,53 @@ public final class ResourceAttributes {
    */
   @Deprecated public static final String GCP_OPENSHIFT = "gcp_openshift";
 
+  /**
+   * Full user-agent string provided by the browser
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The user-agent value SHOULD be provided only from browsers that do not have a mechanism
+   *       to retrieve brands and platform individually from the User-Agent Client Hints API. To
+   *       retrieve the value, the legacy {@code navigator.userAgent} API can be used.
+   * </ul>
+   *
+   * @deprecated This item has been renamed in 1.19.0 version of the semantic conventions. Use
+   *     {@link SemanticAttributes#USER_AGENT_ORIGINAL} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> BROWSER_USER_AGENT = stringKey("browser.user_agent");
+
+  /**
+   * The unique ID of the single function that this runtime instance executes.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>On some cloud providers, it may not be possible to determine the full ID at startup, so
+   *       consider setting {@code faas.id} as a span attribute instead.
+   *   <li>The exact value to use for {@code faas.id} depends on the cloud provider:
+   *   <li><strong>AWS Lambda:</strong> The function <a
+   *       href="https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">ARN</a>.
+   *       Take care not to use the &quot;invoked ARN&quot; directly but replace any <a
+   *       href="https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html">alias
+   *       suffix</a> with the resolved function version, as the same runtime instance may be
+   *       invokable with multiple different aliases.
+   *   <li><strong>GCP:</strong> The <a
+   *       href="https://cloud.google.com/iam/docs/full-resource-names">URI of the resource</a>
+   *   <li><strong>Azure:</strong> The <a
+   *       href="https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id">Fully
+   *       Qualified Resource ID</a> of the invoked function, <em>not</em> the function app, having
+   *       the form {@code
+   *       /subscriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>}.
+   *       This means that a span attribute MUST be used, as an Azure function app can host multiple
+   *       functions that would usually share a TracerProvider.
+   * </ul>
+   *
+   * @deprecated This item has been removed in 1.19.0 version of the semantic conventions. Use
+   *     {@link ResourceAttributes#CLOUD_RESOURCE_ID} instead.
+   */
+  @Deprecated public static final AttributeKey<String> FAAS_ID = stringKey("faas.id");
+
   private ResourceAttributes() {}
 }

--- a/semconv/src/main/java/io/opentelemetry/semconv/resource/attributes/ResourceAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/resource/attributes/ResourceAttributes.java
@@ -18,7 +18,7 @@ import java.util.List;
 @SuppressWarnings("unused")
 public final class ResourceAttributes {
   /** The URL of the OpenTelemetry schema for these keys and values. */
-  public static final String SCHEMA_URL = "https://opentelemetry.io/schemas/1.18.0";
+  public static final String SCHEMA_URL = "https://opentelemetry.io/schemas/1.19.0";
 
   /**
    * Array of brand name and version separated by a space
@@ -67,19 +67,6 @@ public final class ResourceAttributes {
   public static final AttributeKey<Boolean> BROWSER_MOBILE = booleanKey("browser.mobile");
 
   /**
-   * Full user-agent string provided by the browser
-   *
-   * <p>Notes:
-   *
-   * <ul>
-   *   <li>The user-agent value SHOULD be provided only from browsers that do not have a mechanism
-   *       to retrieve brands and platform individually from the User-Agent Client Hints API. To
-   *       retrieve the value, the legacy {@code navigator.userAgent} API can be used.
-   * </ul>
-   */
-  public static final AttributeKey<String> BROWSER_USER_AGENT = stringKey("browser.user_agent");
-
-  /**
    * Preferred language of the user using the browser
    *
    * <p>Notes:
@@ -108,11 +95,45 @@ public final class ResourceAttributes {
    *       regions</a>, <a
    *       href="https://azure.microsoft.com/en-us/global-infrastructure/geographies/">Azure
    *       regions</a>, <a href="https://cloud.google.com/about/locations">Google Cloud regions</a>,
-   *       or <a href="https://intl.cloud.tencent.com/document/product/213/6091">Tencent Cloud
+   *       or <a href="https://www.tencentcloud.com/document/product/213/6091">Tencent Cloud
    *       regions</a>.
    * </ul>
    */
   public static final AttributeKey<String> CLOUD_REGION = stringKey("cloud.region");
+
+  /**
+   * Cloud provider-specific native identifier of the monitored cloud resource (e.g. an <a
+   * href="https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">ARN</a> on
+   * AWS, a <a href="https://learn.microsoft.com/en-us/rest/api/resources/resources/get-by-id">fully
+   * qualified resource ID</a> on Azure, a <a
+   * href="https://cloud.google.com/apis/design/resource_names#full_resource_name">full resource
+   * name</a> on GCP)
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>On some cloud providers, it may not be possible to determine the full ID at startup, so
+   *       it may be necessary to set {@code cloud.resource_id} as a span attribute instead.
+   *   <li>The exact value to use for {@code cloud.resource_id} depends on the cloud provider. The
+   *       following well-known definitions MUST be used if you set this attribute and they apply:
+   *   <li><strong>AWS Lambda:</strong> The function <a
+   *       href="https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">ARN</a>.
+   *       Take care not to use the &quot;invoked ARN&quot; directly but replace any <a
+   *       href="https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html">alias
+   *       suffix</a> with the resolved function version, as the same runtime instance may be
+   *       invokable with multiple different aliases.
+   *   <li><strong>GCP:</strong> The <a
+   *       href="https://cloud.google.com/iam/docs/full-resource-names">URI of the resource</a>
+   *   <li><strong>Azure:</strong> The <a
+   *       href="https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id">Fully
+   *       Qualified Resource ID</a> of the invoked function, <em>not</em> the function app, having
+   *       the form {@code
+   *       /subscriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>}.
+   *       This means that a span attribute MUST be used, as an Azure function app can host multiple
+   *       functions that would usually share a TracerProvider.
+   * </ul>
+   */
+  public static final AttributeKey<String> CLOUD_RESOURCE_ID = stringKey("cloud.resource_id");
 
   /**
    * Cloud regions often have multiple, isolated locations known as zones to increase availability.
@@ -223,6 +244,17 @@ public final class ResourceAttributes {
   public static final AttributeKey<List<String>> AWS_LOG_STREAM_ARNS =
       stringArrayKey("aws.log.stream.arns");
 
+  /** Time and date the release was created */
+  public static final AttributeKey<String> HEROKU_RELEASE_CREATION_TIMESTAMP =
+      stringKey("heroku.release.creation_timestamp");
+
+  /** Commit hash for the current release */
+  public static final AttributeKey<String> HEROKU_RELEASE_COMMIT =
+      stringKey("heroku.release.commit");
+
+  /** Unique identifier for the application */
+  public static final AttributeKey<String> HEROKU_APP_ID = stringKey("heroku.app.id");
+
   /** Container name used by container runtime. */
   public static final AttributeKey<String> CONTAINER_NAME = stringKey("container.name");
 
@@ -325,38 +357,10 @@ public final class ResourceAttributes {
    *       followed by a forward slash followed by the function name (this form can also be seen in
    *       the resource JSON for the function). This means that a span attribute MUST be used, as an
    *       Azure function app can host multiple functions that would usually share a TracerProvider
-   *       (see also the {@code faas.id} attribute).
+   *       (see also the {@code cloud.resource_id} attribute).
    * </ul>
    */
   public static final AttributeKey<String> FAAS_NAME = stringKey("faas.name");
-
-  /**
-   * The unique ID of the single function that this runtime instance executes.
-   *
-   * <p>Notes:
-   *
-   * <ul>
-   *   <li>On some cloud providers, it may not be possible to determine the full ID at startup, so
-   *       consider setting {@code faas.id} as a span attribute instead.
-   *   <li>The exact value to use for {@code faas.id} depends on the cloud provider:
-   *   <li><strong>AWS Lambda:</strong> The function <a
-   *       href="https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">ARN</a>.
-   *       Take care not to use the &quot;invoked ARN&quot; directly but replace any <a
-   *       href="https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html">alias
-   *       suffix</a> with the resolved function version, as the same runtime instance may be
-   *       invokable with multiple different aliases.
-   *   <li><strong>GCP:</strong> The <a
-   *       href="https://cloud.google.com/iam/docs/full-resource-names">URI of the resource</a>
-   *   <li><strong>Azure:</strong> The <a
-   *       href="https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id">Fully
-   *       Qualified Resource ID</a> of the invoked function, <em>not</em> the function app, having
-   *       the form {@code
-   *       /subscriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>}.
-   *       This means that a span attribute MUST be used, as an Azure function app can host multiple
-   *       functions that would usually share a TracerProvider.
-   * </ul>
-   */
-  public static final AttributeKey<String> FAAS_ID = stringKey("faas.id");
 
   /**
    * The immutable version of the function being executed.
@@ -392,22 +396,23 @@ public final class ResourceAttributes {
   public static final AttributeKey<String> FAAS_INSTANCE = stringKey("faas.instance");
 
   /**
-   * The amount of memory available to the serverless function in MiB.
+   * The amount of memory available to the serverless function converted to Bytes.
    *
    * <p>Notes:
    *
    * <ul>
    *   <li>It's recommended to set this attribute since e.g. too little memory can easily stop a
    *       Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable
-   *       {@code AWS_LAMBDA_FUNCTION_MEMORY_SIZE} provides this information.
+   *       {@code AWS_LAMBDA_FUNCTION_MEMORY_SIZE} provides this information (which must be
+   *       multiplied by 1,048,576).
    * </ul>
    */
   public static final AttributeKey<Long> FAAS_MAX_MEMORY = longKey("faas.max_memory");
 
   /**
    * Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For
-   * non-containerized Linux systems, the {@code machine-id} located in {@code /etc/machine-id} or
-   * {@code /var/lib/dbus/machine-id} may be used.
+   * non-containerized systems, this should be the {@code machine-id}. See the table below for the
+   * sources to use to determine the {@code machine-id} based on operating system.
    */
   public static final AttributeKey<String> HOST_ID = stringKey("host.id");
 
@@ -666,6 +671,28 @@ public final class ResourceAttributes {
   public static final AttributeKey<String> WEBENGINE_DESCRIPTION =
       stringKey("webengine.description");
 
+  /** The name of the instrumentation scope - ({@code InstrumentationScope.Name} in OTLP). */
+  public static final AttributeKey<String> OTEL_SCOPE_NAME = stringKey("otel.scope.name");
+
+  /** The version of the instrumentation scope - ({@code InstrumentationScope.Version} in OTLP). */
+  public static final AttributeKey<String> OTEL_SCOPE_VERSION = stringKey("otel.scope.version");
+
+  /**
+   * Deprecated, use the {@code otel.scope.name} attribute.
+   *
+   * @deprecated Deprecated, use the `otel.scope.name` attribute.
+   */
+  @Deprecated
+  public static final AttributeKey<String> OTEL_LIBRARY_NAME = stringKey("otel.library.name");
+
+  /**
+   * Deprecated, use the {@code otel.scope.version} attribute.
+   *
+   * @deprecated Deprecated, use the `otel.scope.version` attribute.
+   */
+  @Deprecated
+  public static final AttributeKey<String> OTEL_LIBRARY_VERSION = stringKey("otel.library.version");
+
   // Enum definitions
   public static final class CloudProviderValues {
     /** Alibaba Cloud. */
@@ -676,6 +703,8 @@ public final class ResourceAttributes {
     public static final String AZURE = "azure";
     /** Google Cloud Platform. */
     public static final String GCP = "gcp";
+    /** Heroku Platform as a Service. */
+    public static final String HEROKU = "heroku";
     /** IBM Cloud. */
     public static final String IBM_CLOUD = "ibm_cloud";
     /** Tencent Cloud. */

--- a/semconv/src/main/java/io/opentelemetry/semconv/resource/attributes/ResourceAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/resource/attributes/ResourceAttributes.java
@@ -874,7 +874,8 @@ public final class ResourceAttributes {
    * </ul>
    *
    * @deprecated This item has been renamed in 1.19.0 version of the semantic conventions. Use
-   *     {@link SemanticAttributes#USER_AGENT_ORIGINAL} instead.
+   *     {@link io.opentelemetry.semconv.trace.attributes.SemanticAttributes#USER_AGENT_ORIGINAL}
+   *     instead.
    */
   @Deprecated
   public static final AttributeKey<String> BROWSER_USER_AGENT = stringKey("browser.user_agent");

--- a/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/SemanticAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/SemanticAttributes.java
@@ -1837,5 +1837,21 @@ public final class SemanticAttributes {
   @Deprecated
   public static final AttributeKey<String> HTTP_USER_AGENT = stringKey("http.user_agent");
 
+  /**
+   * Deprecated, use the {@link SemanticAttributes#OTEL_SCOPE_NAME} attribute.
+   *
+   * @deprecated Deprecated, use the `{@link SemanticAttributes#OTEL_SCOPE_NAME} attribute.
+   */
+  @Deprecated
+  public static final AttributeKey<String> OTEL_LIBRARY_NAME = stringKey("otel.library.name");
+
+  /**
+   * Deprecated, use the {@link SemanticAttributes#OTEL_SCOPE_VERSION} attribute.
+   *
+   * @deprecated Deprecated, use the {@link SemanticAttributes#OTEL_SCOPE_VERSION} attribute.
+   */
+  @Deprecated
+  public static final AttributeKey<String> OTEL_LIBRARY_VERSION = stringKey("otel.library.version");
+
   private SemanticAttributes() {}
 }

--- a/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/SemanticAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/SemanticAttributes.java
@@ -1801,5 +1801,41 @@ public final class SemanticAttributes {
   public static final AttributeKey<Long> MESSAGING_ROCKETMQ_DELAY_TIME_LEVEL =
       longKey("messaging.rocketmq.delay_time_level");
 
+  /**
+   * The name of the instrumentation scope - ({@code InstrumentationScope.Name} in OTLP).
+   *
+   * @deprecated This item has been moved, use {@link ResourceAttributes#OTEL_SCOPE_NAME} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> OTEL_SCOPE_NAME = ResourceAttributes.OTEL_SCOPE_NAME;
+
+  /**
+   * The version of the instrumentation scope - ({@code InstrumentationScope.Version} in OTLP).
+   *
+   * @deprecated This item has been moved, use {@link ResourceAttributes#OTEL_SCOPE_VERSION}
+   *     instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> OTEL_SCOPE_VERSION =
+      ResourceAttributes.OTEL_SCOPE_VERSION;
+
+  /**
+   * The execution ID of the current function execution.
+   *
+   * @deprecated This item has been renamed in 1.19.0 version of the semantic conventions. Use
+   *     {@link SemanticAttributes#FAAS_INVOCATION_ID} instead.
+   */
+  @Deprecated public static final AttributeKey<String> FAAS_EXECUTION = stringKey("faas.execution");
+
+  /**
+   * Value of the <a href="https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent">HTTP
+   * User-Agent</a> header sent by the client.
+   *
+   * @deprecated This item has been renamed in 1.19.0 version of the semantic conventions. Use
+   *     {@link SemanticAttributes#USER_AGENT_ORIGINAL} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> HTTP_USER_AGENT = stringKey("http.user_agent");
+
   private SemanticAttributes() {}
 }

--- a/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/SemanticAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/SemanticAttributes.java
@@ -19,7 +19,7 @@ import java.util.List;
 @SuppressWarnings("unused")
 public final class SemanticAttributes {
   /** The URL of the OpenTelemetry schema for these keys and values. */
-  public static final String SCHEMA_URL = "https://opentelemetry.io/schemas/1.17.0";
+  public static final String SCHEMA_URL = "https://opentelemetry.io/schemas/1.19.0";
 
   /**
    * The type of the exception (its fully-qualified class name, if applicable). The dynamic type of
@@ -36,6 +36,34 @@ public final class SemanticAttributes {
    */
   public static final AttributeKey<String> EXCEPTION_STACKTRACE = stringKey("exception.stacktrace");
 
+  /** HTTP request method. */
+  public static final AttributeKey<String> HTTP_METHOD = stringKey("http.method");
+
+  /** <a href="https://tools.ietf.org/html/rfc7231#section-6">HTTP response status code</a>. */
+  public static final AttributeKey<Long> HTTP_STATUS_CODE = longKey("http.status_code");
+
+  /** Kind of HTTP protocol used. */
+  public static final AttributeKey<String> HTTP_FLAVOR = stringKey("http.flavor");
+
+  /** The URI scheme identifying the used protocol. */
+  public static final AttributeKey<String> HTTP_SCHEME = stringKey("http.scheme");
+
+  /**
+   * The matched route (path template in the format used by the respective server framework). See
+   * note below
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>MUST NOT be populated when this is not supported by the HTTP server framework as the
+   *       route attribute should have low-cardinality and the URI path can NOT substitute it.
+   *       SHOULD include the <a
+   *       href="/specification/trace/semantic_conventions/http.md#http-server-definitions">application
+   *       root</a> if there is one.
+   * </ul>
+   */
+  public static final AttributeKey<String> HTTP_ROUTE = stringKey("http.route");
+
   /** The name identifies the event. */
   public static final AttributeKey<String> EVENT_NAME = stringKey("event.name");
 
@@ -51,28 +79,6 @@ public final class SemanticAttributes {
    */
   public static final AttributeKey<String> EVENT_DOMAIN = stringKey("event.domain");
 
-  /** The name of the instrumentation scope - ({@code InstrumentationScope.Name} in OTLP). */
-  public static final AttributeKey<String> OTEL_SCOPE_NAME = stringKey("otel.scope.name");
-
-  /** The version of the instrumentation scope - ({@code InstrumentationScope.Version} in OTLP). */
-  public static final AttributeKey<String> OTEL_SCOPE_VERSION = stringKey("otel.scope.version");
-
-  /**
-   * Deprecated, use the {@code otel.scope.name} attribute.
-   *
-   * @deprecated Deprecated, use the `otel.scope.name` attribute.
-   */
-  @Deprecated
-  public static final AttributeKey<String> OTEL_LIBRARY_NAME = stringKey("otel.library.name");
-
-  /**
-   * Deprecated, use the {@code otel.scope.version} attribute.
-   *
-   * @deprecated Deprecated, use the `otel.scope.version` attribute.
-   */
-  @Deprecated
-  public static final AttributeKey<String> OTEL_LIBRARY_VERSION = stringKey("otel.library.version");
-
   /**
    * The full invoked ARN as provided on the {@code Context} passed to the function ({@code
    * Lambda-Runtime-Invoked-Function-Arn} header on the {@code /runtime/invocation/next}
@@ -81,7 +87,7 @@ public final class SemanticAttributes {
    * <p>Notes:
    *
    * <ul>
-   *   <li>This may be different from {@code faas.id} if an alias is involved.
+   *   <li>This may be different from {@code cloud.resource_id} if an alias is involved.
    * </ul>
    */
   public static final AttributeKey<String> AWS_LAMBDA_INVOKED_ARN =
@@ -300,7 +306,7 @@ public final class SemanticAttributes {
       stringKey("otel.status_description");
 
   /**
-   * Type of the trigger which caused this function execution.
+   * Type of the trigger which caused this function invocation.
    *
    * <p>Notes:
    *
@@ -315,8 +321,8 @@ public final class SemanticAttributes {
    */
   public static final AttributeKey<String> FAAS_TRIGGER = stringKey("faas.trigger");
 
-  /** The execution ID of the current function execution. */
-  public static final AttributeKey<String> FAAS_EXECUTION = stringKey("faas.execution");
+  /** The invocation ID of the current function invocation. */
+  public static final AttributeKey<String> FAAS_INVOCATION_ID = stringKey("faas.invocation_id");
 
   /**
    * The name of the source on which the triggering operation was performed. For example, in Cloud
@@ -578,30 +584,6 @@ public final class SemanticAttributes {
    */
   public static final AttributeKey<Long> CODE_COLUMN = longKey("code.column");
 
-  /** HTTP request method. */
-  public static final AttributeKey<String> HTTP_METHOD = stringKey("http.method");
-
-  /** <a href="https://tools.ietf.org/html/rfc7231#section-6">HTTP response status code</a>. */
-  public static final AttributeKey<Long> HTTP_STATUS_CODE = longKey("http.status_code");
-
-  /**
-   * Kind of HTTP protocol used.
-   *
-   * <p>Notes:
-   *
-   * <ul>
-   *   <li>If {@code net.transport} is not specified, it can be assumed to be {@code IP.TCP} except
-   *       if {@code http.flavor} is {@code QUIC}, in which case {@code IP.UDP} is assumed.
-   * </ul>
-   */
-  public static final AttributeKey<String> HTTP_FLAVOR = stringKey("http.flavor");
-
-  /**
-   * Value of the <a href="https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent">HTTP
-   * User-Agent</a> header sent by the client.
-   */
-  public static final AttributeKey<String> HTTP_USER_AGENT = stringKey("http.user_agent");
-
   /**
    * The size of the request payload body in bytes. This is the number of bytes transferred
    * excluding headers and is often, but not always, present as the <a
@@ -648,25 +630,8 @@ public final class SemanticAttributes {
    */
   public static final AttributeKey<Long> HTTP_RESEND_COUNT = longKey("http.resend_count");
 
-  /** The URI scheme identifying the used protocol. */
-  public static final AttributeKey<String> HTTP_SCHEME = stringKey("http.scheme");
-
   /** The full request target as passed in a HTTP request line or equivalent. */
   public static final AttributeKey<String> HTTP_TARGET = stringKey("http.target");
-
-  /**
-   * The matched route (path template in the format used by the respective server framework). See
-   * note below
-   *
-   * <p>Notes:
-   *
-   * <ul>
-   *   <li>'http.route' MUST NOT be populated when this is not supported by the HTTP server
-   *       framework as the route attribute should have low-cardinality and the URI path can NOT
-   *       substitute it.
-   * </ul>
-   */
-  public static final AttributeKey<String> HTTP_ROUTE = stringKey("http.route");
 
   /**
    * The IP address of the original client behind all proxies, if known (e.g. from <a
@@ -1130,6 +1095,13 @@ public final class SemanticAttributes {
       longKey("message.uncompressed_size");
 
   /**
+   * The <a href="https://connect.build/docs/protocol/#error-codes">error codes</a> of the Connect
+   * request. Error codes are always string values.
+   */
+  public static final AttributeKey<String> RPC_CONNECT_RPC_ERROR_CODE =
+      stringKey("rpc.connect_rpc.error_code");
+
+  /**
    * SHOULD be set to true if the exception event is recorded at a point where it is known that the
    * exception is escaping the scope of the span.
    *
@@ -1152,7 +1124,30 @@ public final class SemanticAttributes {
    */
   public static final AttributeKey<Boolean> EXCEPTION_ESCAPED = booleanKey("exception.escaped");
 
+  /**
+   * Value of the <a href="https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent">HTTP
+   * User-Agent</a> header sent by the client.
+   */
+  public static final AttributeKey<String> USER_AGENT_ORIGINAL = stringKey("user_agent.original");
+
   // Enum definitions
+  public static final class HttpFlavorValues {
+    /** HTTP/1.0. */
+    public static final String HTTP_1_0 = "1.0";
+    /** HTTP/1.1. */
+    public static final String HTTP_1_1 = "1.1";
+    /** HTTP/2. */
+    public static final String HTTP_2_0 = "2.0";
+    /** HTTP/3. */
+    public static final String HTTP_3_0 = "3.0";
+    /** SPDY protocol. */
+    public static final String SPDY = "SPDY";
+    /** QUIC protocol. */
+    public static final String QUIC = "QUIC";
+
+    private HttpFlavorValues() {}
+  }
+
   public static final class EventDomainValues {
     /** Events from browser apps. */
     public static final String BROWSER = "browser";
@@ -1178,6 +1173,8 @@ public final class SemanticAttributes {
     public static final String OTHER_SQL = "other_sql";
     /** Microsoft SQL Server. */
     public static final String MSSQL = "mssql";
+    /** Microsoft SQL Server Compact. */
+    public static final String MSSQLCOMPACT = "mssqlcompact";
     /** MySQL. */
     public static final String MYSQL = "mysql";
     /** Oracle Database. */
@@ -1272,6 +1269,8 @@ public final class SemanticAttributes {
     public static final String OPENSEARCH = "opensearch";
     /** ClickHouse. */
     public static final String CLICKHOUSE = "clickhouse";
+    /** Cloud Spanner. */
+    public static final String SPANNER = "spanner";
 
     private DbSystemValues() {}
   }
@@ -1452,23 +1451,6 @@ public final class SemanticAttributes {
     private NetHostConnectionSubtypeValues() {}
   }
 
-  public static final class HttpFlavorValues {
-    /** HTTP/1.0. */
-    public static final String HTTP_1_0 = "1.0";
-    /** HTTP/1.1. */
-    public static final String HTTP_1_1 = "1.1";
-    /** HTTP/2. */
-    public static final String HTTP_2_0 = "2.0";
-    /** HTTP/3. */
-    public static final String HTTP_3_0 = "3.0";
-    /** SPDY protocol. */
-    public static final String SPDY = "SPDY";
-    /** QUIC protocol. */
-    public static final String QUIC = "QUIC";
-
-    private HttpFlavorValues() {}
-  }
-
   public static final class GraphqlOperationTypeValues {
     /** GraphQL query. */
     public static final String QUERY = "query";
@@ -1540,6 +1522,8 @@ public final class SemanticAttributes {
     public static final String DOTNET_WCF = "dotnet_wcf";
     /** Apache Dubbo. */
     public static final String APACHE_DUBBO = "apache_dubbo";
+    /** Connect RPC. */
+    public static final String CONNECT_RPC = "connect_rpc";
 
     private RpcSystemValues() {}
   }
@@ -1590,6 +1574,43 @@ public final class SemanticAttributes {
     public static final String RECEIVED = "RECEIVED";
 
     private MessageTypeValues() {}
+  }
+
+  public static final class RpcConnectRpcErrorCodeValues {
+    /** cancelled. */
+    public static final String CANCELLED = "cancelled";
+    /** unknown. */
+    public static final String UNKNOWN = "unknown";
+    /** invalid_argument. */
+    public static final String INVALID_ARGUMENT = "invalid_argument";
+    /** deadline_exceeded. */
+    public static final String DEADLINE_EXCEEDED = "deadline_exceeded";
+    /** not_found. */
+    public static final String NOT_FOUND = "not_found";
+    /** already_exists. */
+    public static final String ALREADY_EXISTS = "already_exists";
+    /** permission_denied. */
+    public static final String PERMISSION_DENIED = "permission_denied";
+    /** resource_exhausted. */
+    public static final String RESOURCE_EXHAUSTED = "resource_exhausted";
+    /** failed_precondition. */
+    public static final String FAILED_PRECONDITION = "failed_precondition";
+    /** aborted. */
+    public static final String ABORTED = "aborted";
+    /** out_of_range. */
+    public static final String OUT_OF_RANGE = "out_of_range";
+    /** unimplemented. */
+    public static final String UNIMPLEMENTED = "unimplemented";
+    /** internal. */
+    public static final String INTERNAL = "internal";
+    /** unavailable. */
+    public static final String UNAVAILABLE = "unavailable";
+    /** data_loss. */
+    public static final String DATA_LOSS = "data_loss";
+    /** unauthenticated. */
+    public static final String UNAUTHENTICATED = "unauthenticated";
+
+    private RpcConnectRpcErrorCodeValues() {}
   }
 
   // Manually defined and not YET in the YAML

--- a/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/SemanticAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/SemanticAttributes.java
@@ -1804,20 +1804,23 @@ public final class SemanticAttributes {
   /**
    * The name of the instrumentation scope - ({@code InstrumentationScope.Name} in OTLP).
    *
-   * @deprecated This item has been moved, use {@link ResourceAttributes#OTEL_SCOPE_NAME} instead.
+   * @deprecated This item has been moved, use {@link
+   *     io.opentelemetry.semconv.resource.attributes.ResourceAttributes#OTEL_SCOPE_NAME} instead.
    */
   @Deprecated
-  public static final AttributeKey<String> OTEL_SCOPE_NAME = ResourceAttributes.OTEL_SCOPE_NAME;
+  public static final AttributeKey<String> OTEL_SCOPE_NAME = stringKey("otel.scope.name");
 
   /**
    * The version of the instrumentation scope - ({@code InstrumentationScope.Version} in OTLP).
    *
-   * @deprecated This item has been moved, use {@link ResourceAttributes#OTEL_SCOPE_VERSION}
+   * @deprecated This item has been moved, use {@link
+   *     io.opentelemetry.semconv.resource.attributes.ResourceAttributes#OTEL_SCOPE_VERSION}
    *     instead.
    */
   @Deprecated
-  public static final AttributeKey<String> OTEL_SCOPE_VERSION =
-      ResourceAttributes.OTEL_SCOPE_VERSION;
+  public static final AttributeKey<String> OTEL_SCOPE_VERSION = stringKey("otel.scope.version");
+
+  ;
 
   /**
    * The execution ID of the current function execution.
@@ -1838,17 +1841,20 @@ public final class SemanticAttributes {
   public static final AttributeKey<String> HTTP_USER_AGENT = stringKey("http.user_agent");
 
   /**
-   * Deprecated, use the {@link SemanticAttributes#OTEL_SCOPE_NAME} attribute.
+   * Deprecated.
    *
-   * @deprecated Deprecated, use the `{@link SemanticAttributes#OTEL_SCOPE_NAME} attribute.
+   * @deprecated Deprecated, use the {@link
+   *     io.opentelemetry.semconv.resource.attributes.ResourceAttributes#OTEL_SCOPE_NAME} attribute.
    */
   @Deprecated
   public static final AttributeKey<String> OTEL_LIBRARY_NAME = stringKey("otel.library.name");
 
   /**
-   * Deprecated, use the {@link SemanticAttributes#OTEL_SCOPE_VERSION} attribute.
+   * Deprecated.
    *
-   * @deprecated Deprecated, use the {@link SemanticAttributes#OTEL_SCOPE_VERSION} attribute.
+   * @deprecated Deprecated, use the {@link
+   *     io.opentelemetry.semconv.resource.attributes.ResourceAttributes#OTEL_SCOPE_VERSION}
+   *     attribute.
    */
   @Deprecated
   public static final AttributeKey<String> OTEL_LIBRARY_VERSION = stringKey("otel.library.version");


### PR DESCRIPTION
There were a bunch of [breaking changes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/schemas/1.19.0) in the spec in 1.19.0 along with changes in internal yaml structure and signal types.

Spec changes caused build-tool to break (https://github.com/open-telemetry/opentelemetry-specification/issues/3299) and fix requires semconv generation script changes implemented in this PR and shown in https://github.com/open-telemetry/build-tools/pull/157

