### PR TITLE
Move kotlin plugin dependency to buildsrc

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -45,8 +45,9 @@ dependencies {
   implementation("me.champeau.jmh:jmh-gradle-plugin:0.7.0")
   implementation("net.ltgt.gradle:gradle-errorprone-plugin:3.0.1")
   implementation("net.ltgt.gradle:gradle-nullaway-plugin:1.5.0")
-  implementation("ru.vyarus:gradle-animalsniffer-plugin:1.7.0")
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.20")
   implementation("org.owasp:dependency-check-gradle:8.2.1")
+  implementation("ru.vyarus:gradle-animalsniffer-plugin:1.7.0")
 }
 
 // We can't apply conventions to this build so include important ones such as the Java compilation

--- a/docs/apidiffs/current_vs_latest/opentelemetry-extension-kotlin.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-extension-kotlin.txt
@@ -1,2 +1,9 @@
 Comparing source compatibility of  against 
-No changes.
+===  UNCHANGED CLASS: PUBLIC FINAL io.opentelemetry.extension.kotlin.ContextExtensionsKt  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	***  MODIFIED ANNOTATION: kotlin.Metadata
+		===  UNCHANGED ELEMENT: xi=48
+		***  MODIFIED ELEMENT: mv=1,8,0 (<- 1,6,0)
+		===  UNCHANGED ELEMENT: k=2
+		===  UNCHANGED ELEMENT: d1=��&#xA;�&#xA;���&#xA;���&#xA;���&#xA;����&#xA;����0�*�0��&#xA;����0�*�0��&#xA;����0�*�0�¨��
+		===  UNCHANGED ELEMENT: d2=asContextElement,Lkotlin/coroutines/CoroutineContext;,Lio/opentelemetry/context/Context;,Lio/opentelemetry/context/ImplicitContextKeyed;,getOpenTelemetryContext,opentelemetry-extension-kotlin

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,6 @@ pluginManagement {
     id("com.github.johnrengelman.shadow") version "8.1.1"
     id("com.gradle.enterprise") version "3.12.6"
     id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
-    id("org.jetbrains.kotlin.jvm") version "1.8.20"
     id("org.graalvm.buildtools.native") version "0.9.20"
   }
 }


### PR DESCRIPTION
Investigated why [upgrading wire-gradle-plugin](https://github.com/open-telemetry/opentelemetry-java/pull/5323#discussion_r1152572032) impacts kotlin extension. Determined that `wire-gradle-plugin` has a transitive dependency on the gradle kotlin plugin, which itself has a dependency on the kotlin plugin which resolves in a weird way.

Moving our kotlin plugin dependency from `settings.gradle.kts` to `buildSrc/build.gradle.kts` seems to resolve the conflict consistently.