### PR TITLE
Add skaffolding for low level exporter SSL API

### DIFF
--- a/exporters/common/build.gradle.kts
+++ b/exporters/common/build.gradle.kts
@@ -22,9 +22,6 @@ dependencies {
   // dependency on all of our consumers.
   compileOnly("com.fasterxml.jackson.core:jackson-core")
   compileOnly("com.squareup.okhttp3:okhttp")
-  compileOnly("io.grpc:grpc-netty")
-  compileOnly("io.grpc:grpc-netty-shaded")
-  compileOnly("io.grpc:grpc-okhttp")
   compileOnly("io.grpc:grpc-stub")
 
   testImplementation(project(":sdk:common"))

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/TlsConfigHelper.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/TlsConfigHelper.java
@@ -18,10 +18,10 @@ import javax.net.ssl.X509TrustManager;
 /**
  * Utility class to help with management of TLS related components. TLS config consists {@link
  * #keyManager}, {@link #trustManager}, which combine to form {@link #sslContext}. These components
- * can be configured via higher level APIs ({@link #createTrustManager(byte[])} and {@link
- * #createKeyManager(byte[], byte[])}) which parse keys in PEM format, or the lower level API {@link
- * #setSslContext(SSLContext, X509TrustManager)} in which the components are directly set, but NOT
- * both. Attempts to reconfigure components which have already been configured throw {@link
+ * can be configured via higher level APIs ({@link #setTrustManagerFromCerts(byte[])} and {@link
+ * #setKeyManagerFromCerts(byte[], byte[])}) which parse keys in PEM format, or the lower level API
+ * {@link #setSslContext(SSLContext, X509TrustManager)} in which the components are directly set,
+ * but NOT both. Attempts to reconfigure components which have already been configured throw {@link
  * IllegalStateException}. Consumers access components via any combination of {@link
  * #getKeyManager()}, {@link #getTrustManager()}, and {@link #getSslContext()}.
  *
@@ -44,7 +44,7 @@ public class TlsConfigHelper {
    *
    * @param trustedCertsPem Certificate in PEM format.
    */
-  public void createTrustManager(byte[] trustedCertsPem) {
+  public void setTrustManagerFromCerts(byte[] trustedCertsPem) {
     if (trustManager != null) {
       throw new IllegalStateException("trustManager has been previously configured");
     }
@@ -68,7 +68,7 @@ public class TlsConfigHelper {
    * @param privateKeyPem Private key content in PEM format.
    * @param certificatePem Certificate content in PEM format.
    */
-  public void createKeyManager(byte[] privateKeyPem, byte[] certificatePem) {
+  public void setKeyManagerFromCerts(byte[] privateKeyPem, byte[] certificatePem) {
     if (keyManager != null) {
       throw new IllegalStateException("keyManager has been previously configured");
     }
@@ -85,8 +85,8 @@ public class TlsConfigHelper {
   /**
    * Configure the {@link SSLContext} and {@link X509TrustManager}.
    *
-   * <p>Must not be called multiple times, or if {@link #createTrustManager(byte[])} or {@link
-   * #createKeyManager(byte[], byte[])} has been previously called.
+   * <p>Must not be called multiple times, or if {@link #setTrustManagerFromCerts(byte[])} or {@link
+   * #setKeyManagerFromCerts(byte[], byte[])} has been previously called.
    *
    * @param sslContext the SSL context.
    * @param trustManager the trust manager.
@@ -119,8 +119,7 @@ public class TlsConfigHelper {
     }
 
     try {
-      SSLContext sslContext;
-      sslContext = SSLContext.getInstance("TLS");
+      SSLContext sslContext = SSLContext.getInstance("TLS");
       sslContext.init(
           keyManager == null ? null : new KeyManager[] {keyManager},
           trustManager == null ? null : new TrustManager[] {trustManager},

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/TlsConfigHelper.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/TlsConfigHelper.java
@@ -5,79 +5,76 @@
 
 package io.opentelemetry.exporter.internal;
 
-import com.google.common.annotations.VisibleForTesting;
-import java.util.logging.Logger;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 import javax.annotation.Nullable;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 
 /**
- * Utility class to help with management of TLS related components. This class is ultimately
- * responsible for enabling TLS via callbacks passed to the configure[...]() methods. This class is
- * only intended for internal OpenTelemetry exporter usage and should not be used by end-users.
+ * Utility class to help with management of TLS related components. TLS config consists {@link
+ * #keyManager}, {@link #trustManager}, which combine to form {@link #sslContext}. These components
+ * can be configured via higher level APIs ({@link #createTrustManager(byte[])} and {@link
+ * #createKeyManager(byte[], byte[])}) which parse keys in PEM format, or the lower level API {@link
+ * #setSslContext(SSLContext, X509TrustManager)} in which the components are directly set, but NOT
+ * both. Attempts to reconfigure components which have already been configured throw {@link
+ * IllegalStateException}. Consumers access components via any combination of {@link
+ * #getKeyManager()}, {@link #getTrustManager()}, and {@link #getSslContext()}.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
 public class TlsConfigHelper {
 
-  private static final Logger logger = Logger.getLogger(TlsConfigHelper.class.getName());
-
-  private final TlsUtility tlsUtil;
-
   @Nullable private X509KeyManager keyManager;
   @Nullable private X509TrustManager trustManager;
-  @Nullable private SSLSocketFactory sslSocketFactory;
+  @Nullable private SSLContext sslContext;
 
-  public TlsConfigHelper() {
-    this(new TlsUtility() {});
-  }
-
-  @VisibleForTesting
-  TlsConfigHelper(TlsUtility tlsUtil) {
-    this.tlsUtil = tlsUtil;
-  }
-
-  /** Sets the X509TrustManager. */
-  public TlsConfigHelper setTrustManager(X509TrustManager trustManager) {
-    this.trustManager = trustManager;
-    return this;
-  }
+  public TlsConfigHelper() {}
 
   /**
-   * Creates a new X509TrustManager from the given cert content.
+   * Configure the {@link X509TrustManager} from the given cert content.
+   *
+   * <p>Must not be called multiple times, or if {@link #setSslContext(SSLContext,
+   * X509TrustManager)} has been previously called.
    *
    * @param trustedCertsPem Certificate in PEM format.
-   * @return this
    */
-  public TlsConfigHelper createTrustManager(byte[] trustedCertsPem) {
+  public void createTrustManager(byte[] trustedCertsPem) {
+    if (trustManager != null) {
+      throw new IllegalStateException("trustManager has been previously configured");
+    }
+
     try {
-      this.trustManager = tlsUtil.trustManager(trustedCertsPem);
+      this.trustManager = TlsUtil.trustManager(trustedCertsPem);
     } catch (SSLException e) {
       throw new IllegalStateException(
           "Error creating X509TrustManager with provided certs. Are they valid X.509 in PEM format?",
           e);
     }
-    return this;
   }
 
   /**
-   * Creates a new X509KeyManager from the given private key and certificate, both in PEM format.
+   * Configure the {@link X509KeyManager} from the given private key and certificate, both in PEM
+   * format.
+   *
+   * <p>Must not be called multiple times, or if {@link #setSslContext(SSLContext,
+   * X509TrustManager)} has been previously called.
    *
    * @param privateKeyPem Private key content in PEM format.
    * @param certificatePem Certificate content in PEM format.
-   * @return this
    */
-  public TlsConfigHelper createKeyManager(byte[] privateKeyPem, byte[] certificatePem) {
+  public void createKeyManager(byte[] privateKeyPem, byte[] certificatePem) {
+    if (keyManager != null) {
+      throw new IllegalStateException("keyManager has been previously configured");
+    }
+
     try {
-      if (keyManager != null) {
-        logger.warning(
-            "Previous X509 Key manager is being replaced. This is probably an error and should only be set once.");
-      }
-      keyManager = tlsUtil.keyManager(privateKeyPem, certificatePem);
-      return this;
+      keyManager = TlsUtil.keyManager(privateKeyPem, certificatePem);
     } catch (SSLException e) {
       throw new IllegalStateException(
           "Error creating X509KeyManager with provided certs. Are they valid X.509 in PEM format?",
@@ -86,112 +83,51 @@ public class TlsConfigHelper {
   }
 
   /**
-   * Assigns the X509KeyManager.
+   * Configure the {@link SSLContext} and {@link X509TrustManager}.
    *
-   * @return this
+   * <p>Must not be called multiple times, or if {@link #createTrustManager(byte[])} or {@link
+   * #createKeyManager(byte[], byte[])} has been previously called.
+   *
+   * @param sslContext the SSL context.
+   * @param trustManager the trust manager.
    */
-  public TlsConfigHelper setKeyManager(X509KeyManager keyManager) {
-    if (this.keyManager != null) {
-      logger.warning(
-          "Previous X509 Key manager is being replaced. This is probably an error and should only be set once.");
+  public void setSslContext(SSLContext sslContext, X509TrustManager trustManager) {
+    if (this.sslContext != null || this.trustManager != null) {
+      throw new IllegalStateException("sslContext or trustManager has been previously configured");
     }
-    this.keyManager = keyManager;
-    return this;
+    this.trustManager = trustManager;
+    this.sslContext = sslContext;
   }
 
-  /**
-   * Sets the SSLSocketFactory, which is passed into the callback within
-   * configureWithSocketFactory().
-   */
-  public TlsConfigHelper setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
-    this.sslSocketFactory = sslSocketFactory;
-    return this;
+  /** Get the {@link X509KeyManager}. */
+  @Nullable
+  public X509KeyManager getKeyManager() {
+    return keyManager;
   }
 
-  /**
-   * Functional wrapper type used in configure methods. Exists primarily to declare checked
-   * SSLException.
-   */
-  public interface SslSocketFactoryConfigurer {
-    void configure(SSLSocketFactory sslSocketFactory, X509TrustManager trustManager)
-        throws SSLException;
+  /** Get the {@link X509TrustManager}. */
+  @Nullable
+  public X509TrustManager getTrustManager() {
+    return trustManager;
   }
 
-  /**
-   * Functional wrapper type used in configure methods. Exists primarily to declare checked
-   * SSLException.
-   */
-  public interface KeyManagerConfigurer {
-    void configure(X509TrustManager trustManager, @Nullable X509KeyManager keyManager)
-        throws SSLException;
-  }
-
-  /**
-   * Configures TLS by invoking the given callback with the X509TrustManager and X509KeyManager. If
-   * the trust manager or key manager have not yet been configured, this method does nothing.
-   */
-  public void configureWithKeyManager(KeyManagerConfigurer configurer) {
-    if (trustManager == null) {
-      return;
-    }
-    try {
-      configurer.configure(trustManager, keyManager);
-    } catch (SSLException e) {
-      wrapException(e);
-    }
-  }
-
-  /**
-   * Configures TLS by invoking the provided consumer with a new SSLSocketFactory and the
-   * preconfigured X509TrustManager. If the trust manager has not been configured, this method does
-   * nothing.
-   */
-  public void configureWithSocketFactory(SslSocketFactoryConfigurer configurer) {
-    if (trustManager == null) {
-      warnIfOtherComponentsConfigured();
-      return;
+  /** Get the {@link SSLContext}. */
+  @Nullable
+  public SSLContext getSslContext() {
+    if (sslContext != null) {
+      return sslContext;
     }
 
     try {
-      SSLSocketFactory sslSocketFactory = this.sslSocketFactory;
-      if (sslSocketFactory == null) {
-        sslSocketFactory = tlsUtil.sslSocketFactory(keyManager, trustManager);
-      }
-      configurer.configure(sslSocketFactory, trustManager);
-    } catch (SSLException e) {
-      wrapException(e);
-    }
-  }
-
-  private static void wrapException(SSLException e) {
-    throw new IllegalStateException(
-        "Could not configure TLS connection, are certs in valid X.509 in PEM format?", e);
-  }
-
-  private void warnIfOtherComponentsConfigured() {
-    if (sslSocketFactory != null) {
-      logger.warning("sslSocketFactory has been configured without an X509TrustManager.");
-      return;
-    }
-    if (keyManager != null) {
-      logger.warning("An X509KeyManager has been configured without an X509TrustManager.");
-    }
-  }
-
-  // Exists for testing
-  interface TlsUtility {
-    default SSLSocketFactory sslSocketFactory(
-        @Nullable X509KeyManager keyManager, X509TrustManager trustManager) throws SSLException {
-      return TlsUtil.sslSocketFactory(keyManager, trustManager);
-    }
-
-    default X509TrustManager trustManager(byte[] trustedCertificatesPem) throws SSLException {
-      return TlsUtil.trustManager(trustedCertificatesPem);
-    }
-
-    default X509KeyManager keyManager(byte[] privateKeyPem, byte[] certificatePem)
-        throws SSLException {
-      return TlsUtil.keyManager(privateKeyPem, certificatePem);
+      SSLContext sslContext;
+      sslContext = SSLContext.getInstance("TLS");
+      sslContext.init(
+          keyManager == null ? null : new KeyManager[] {keyManager},
+          trustManager == null ? null : new TrustManager[] {trustManager},
+          null);
+      return sslContext;
+    } catch (NoSuchAlgorithmException | KeyManagementException e) {
+      throw new IllegalArgumentException(e);
     }
   }
 }

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/TlsUtil.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/TlsUtil.java
@@ -12,7 +12,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
-import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -27,12 +26,9 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
-import javax.annotation.Nullable;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509KeyManager;
@@ -66,27 +62,6 @@ public final class TlsUtil {
   }
 
   private TlsUtil() {}
-
-  /** Returns a {@link SSLSocketFactory} configured to use the given key and trust manager. */
-  public static SSLSocketFactory sslSocketFactory(
-      @Nullable KeyManager keyManager, TrustManager trustManager) throws SSLException {
-
-    SSLContext sslContext;
-    try {
-      sslContext = SSLContext.getInstance("TLS");
-      if (keyManager == null) {
-        sslContext.init(null, new TrustManager[] {trustManager}, null);
-      } else {
-        sslContext.init(new KeyManager[] {keyManager}, new TrustManager[] {trustManager}, null);
-      }
-    } catch (NoSuchAlgorithmException | KeyManagementException e) {
-      throw new SSLException(
-          "Could not set trusted certificates for TLS connection, are they valid "
-              + "X.509 in PEM format?",
-          e);
-    }
-    return sslContext.getSocketFactory();
-  }
 
   /**
    * Creates {@link KeyManager} initiated by keystore containing single private key with matching

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
@@ -29,6 +29,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
 import okhttp3.Headers;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
@@ -133,7 +135,11 @@ public class GrpcExporterBuilder<T extends Marshaler> {
 
     clientBuilder.callTimeout(Duration.ofNanos(timeoutNanos));
 
-    tlsConfigHelper.configureWithSocketFactory(clientBuilder::sslSocketFactory);
+    SSLContext sslContext = tlsConfigHelper.getSslContext();
+    X509TrustManager trustManager = tlsConfigHelper.getTrustManager();
+    if (sslContext != null && trustManager != null) {
+      clientBuilder.sslSocketFactory(sslContext.getSocketFactory(), trustManager);
+    }
 
     String endpoint = this.endpoint.resolve(grpcEndpointPath).toString();
     if (endpoint.startsWith("http://")) {

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
@@ -100,13 +100,14 @@ public class GrpcExporterBuilder<T extends Marshaler> {
     return this;
   }
 
-  public GrpcExporterBuilder<T> configureTrustManager(byte[] trustedCertificatesPem) {
-    tlsConfigHelper.createTrustManager(trustedCertificatesPem);
+  public GrpcExporterBuilder<T> setTrustManagerFromCerts(byte[] trustedCertificatesPem) {
+    tlsConfigHelper.setTrustManagerFromCerts(trustedCertificatesPem);
     return this;
   }
 
-  public GrpcExporterBuilder<T> configureKeyManager(byte[] privateKeyPem, byte[] certificatePem) {
-    tlsConfigHelper.createKeyManager(privateKeyPem, certificatePem);
+  public GrpcExporterBuilder<T> setKeyManagerFromCerts(
+      byte[] privateKeyPem, byte[] certificatePem) {
+    tlsConfigHelper.setKeyManagerFromCerts(privateKeyPem, certificatePem);
     return this;
   }
 

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/ManagedChannelUtil.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/ManagedChannelUtil.java
@@ -5,15 +5,10 @@
 
 package io.opentelemetry.exporter.internal.grpc;
 
-import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.grpc.netty.GrpcSslContexts;
-import io.grpc.netty.NettyChannelBuilder;
-import io.netty.handler.ssl.SslContext;
-import io.opentelemetry.exporter.internal.TlsUtil;
 import io.opentelemetry.exporter.internal.retry.RetryPolicy;
 import io.opentelemetry.exporter.internal.retry.RetryUtil;
 import io.opentelemetry.sdk.common.CompletableResultCode;
@@ -24,10 +19,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nullable;
-import javax.net.ssl.SSLException;
-import javax.net.ssl.X509KeyManager;
-import javax.net.ssl.X509TrustManager;
 
 /**
  * Utilities for working with gRPC channels.
@@ -38,56 +29,6 @@ import javax.net.ssl.X509TrustManager;
 public final class ManagedChannelUtil {
 
   private static final Logger logger = Logger.getLogger(ManagedChannelUtil.class.getName());
-
-  /**
-   * Configure the channel builder to trust the certificates. The {@code byte[]} should contain an
-   * X.509 certificate collection in PEM format.
-   *
-   * @throws SSLException if error occur processing the certificates
-   */
-  public static void setClientKeysAndTrustedCertificatesPem(
-      ManagedChannelBuilder<?> managedChannelBuilder,
-      X509TrustManager tmf,
-      @Nullable X509KeyManager kmf)
-      throws SSLException {
-    requireNonNull(managedChannelBuilder, "managedChannelBuilder");
-    requireNonNull(tmf, "X509TrustManager");
-
-    // gRPC does not abstract TLS configuration so we need to check the implementation and act
-    // accordingly.
-    String channelBuilderClassName = managedChannelBuilder.getClass().getName();
-    switch (channelBuilderClassName) {
-      case "io.grpc.netty.NettyChannelBuilder":
-        {
-          NettyChannelBuilder nettyBuilder = (NettyChannelBuilder) managedChannelBuilder;
-          SslContext sslContext =
-              GrpcSslContexts.forClient().keyManager(kmf).trustManager(tmf).build();
-          nettyBuilder.sslContext(sslContext);
-          break;
-        }
-      case "io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder":
-        {
-          io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder nettyBuilder =
-              (io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder) managedChannelBuilder;
-          io.grpc.netty.shaded.io.netty.handler.ssl.SslContext sslContext =
-              io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts.forClient()
-                  .trustManager(tmf)
-                  .keyManager(kmf)
-                  .build();
-          nettyBuilder.sslContext(sslContext);
-          break;
-        }
-      case "io.grpc.okhttp.OkHttpChannelBuilder":
-        io.grpc.okhttp.OkHttpChannelBuilder okHttpBuilder =
-            (io.grpc.okhttp.OkHttpChannelBuilder) managedChannelBuilder;
-        okHttpBuilder.sslSocketFactory(TlsUtil.sslSocketFactory(kmf, tmf));
-        break;
-      default:
-        throw new SSLException(
-            "TLS certificate configuration not supported for unrecognized ManagedChannelBuilder "
-                + channelBuilderClassName);
-    }
-  }
 
   /**
    * Convert the {@link RetryPolicy} into a gRPC service config for the {@code serviceName}. The

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/OkHttpExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/okhttp/OkHttpExporterBuilder.java
@@ -89,13 +89,14 @@ public final class OkHttpExporterBuilder<T extends Marshaler> {
     return this;
   }
 
-  public OkHttpExporterBuilder<T> configureTrustManager(byte[] trustedCertificatesPem) {
-    tlsConfigHelper.createTrustManager(trustedCertificatesPem);
+  public OkHttpExporterBuilder<T> setTrustManagerFromCerts(byte[] trustedCertificatesPem) {
+    tlsConfigHelper.setTrustManagerFromCerts(trustedCertificatesPem);
     return this;
   }
 
-  public OkHttpExporterBuilder<T> configureKeyManager(byte[] privateKeyPem, byte[] certificatePem) {
-    tlsConfigHelper.createKeyManager(privateKeyPem, certificatePem);
+  public OkHttpExporterBuilder<T> setKeyManagerFromCerts(
+      byte[] privateKeyPem, byte[] certificatePem) {
+    tlsConfigHelper.setKeyManagerFromCerts(privateKeyPem, certificatePem);
     return this;
   }
 

--- a/exporters/common/src/test/java/io/opentelemetry/exporter/internal/TlsConfigHelperTest.java
+++ b/exporters/common/src/test/java/io/opentelemetry/exporter/internal/TlsConfigHelperTest.java
@@ -6,26 +6,16 @@
 package io.opentelemetry.exporter.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
-import io.github.netmikey.logunit.api.LogCapturer;
 import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
-import java.util.concurrent.atomic.AtomicReference;
-import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.X509KeyManager;
+import java.security.cert.CertificateEncodingException;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,170 +24,74 @@ class TlsConfigHelperTest {
   @RegisterExtension
   static final SelfSignedCertificateExtension serverTls = new SelfSignedCertificateExtension();
 
-  @RegisterExtension
-  LogCapturer logs = LogCapturer.create().captureForLogger(TlsConfigHelper.class.getName());
-
-  @Mock TlsConfigHelper.TlsUtility tlsUtil;
+  private TlsConfigHelper helper = new TlsConfigHelper();
 
   @Test
-  void createTrustManager_exceptionMapped() throws Exception {
-    when(tlsUtil.trustManager(any())).thenThrow(new SSLException("boom"));
-    TlsConfigHelper helper = new TlsConfigHelper(tlsUtil);
-    assertThrows(
-        IllegalStateException.class,
-        () -> {
-          helper.createTrustManager(serverTls.certificate().getEncoded());
-        });
+  void createTrustManager() throws CertificateEncodingException {
+    helper.createTrustManager(serverTls.certificate().getEncoded());
+
+    assertThat(helper.getTrustManager()).isNotNull();
   }
 
   @Test
-  void createKeymanager_exceptionMapped() throws Exception {
-    when(tlsUtil.keyManager(any(), any())).thenThrow(new SSLException("boom"));
-    TlsConfigHelper helper = new TlsConfigHelper(tlsUtil);
-    assertThrows(
-        IllegalStateException.class,
-        () -> {
-          helper.createKeyManager(
-              serverTls.privateKey().getEncoded(), serverTls.certificate().getEncoded());
-        });
+  void createTrustManager_AlreadyExists_Throws() throws Exception {
+    helper.createTrustManager(serverTls.certificate().getEncoded());
+    assertThatThrownBy(() -> helper.createTrustManager(serverTls.certificate().getEncoded()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("trustManager has been previously configured");
+
+    helper = new TlsConfigHelper();
+    helper.setSslContext(
+        SSLContext.getInstance("TLS"), TlsUtil.trustManager(serverTls.certificate().getEncoded()));
+    assertThatThrownBy(() -> helper.createTrustManager(serverTls.certificate().getEncoded()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("trustManager has been previously configured");
   }
 
   @Test
-  void socketFactory_happyPathWithBytes() throws Exception {
+  void createKeyManager() throws CertificateEncodingException {
+    helper.createKeyManager(
+        serverTls.privateKey().getEncoded(), serverTls.certificate().getEncoded());
 
-    byte[] cert = serverTls.certificate().getEncoded();
-    byte[] key = serverTls.privateKey().getEncoded();
-    AtomicReference<X509TrustManager> seenTrustManager = new AtomicReference<>();
-    AtomicReference<SSLSocketFactory> seenSocketFactory = new AtomicReference<>();
-
-    X509TrustManager trustManager = mock(X509TrustManager.class);
-    X509KeyManager keyManager = mock(X509KeyManager.class);
-    SSLSocketFactory sslSocketFactory = mock(SSLSocketFactory.class);
-
-    when(tlsUtil.trustManager(cert)).thenReturn(trustManager);
-    when(tlsUtil.keyManager(key, cert)).thenReturn(keyManager);
-    when(tlsUtil.sslSocketFactory(keyManager, trustManager)).thenReturn(sslSocketFactory);
-
-    TlsConfigHelper helper = new TlsConfigHelper(tlsUtil);
-
-    helper.createKeyManager(key, cert);
-    helper.createTrustManager(cert);
-    helper.configureWithSocketFactory(
-        (sf, tm) -> {
-          seenTrustManager.set(tm);
-          seenSocketFactory.set(sf);
-        });
-    assertSame(trustManager, seenTrustManager.get());
-    assertSame(sslSocketFactory, seenSocketFactory.get());
+    assertThat(helper.getKeyManager()).isNotNull();
   }
 
   @Test
-  void socketFactory_noTrustManager() {
-    TlsConfigHelper helper = new TlsConfigHelper(tlsUtil);
-    helper.configureWithSocketFactory(
-        (sf, tm) -> {
-          fail("Should not have called due to missing trust manager");
-        });
-    verifyNoInteractions(tlsUtil);
+  void createKeyManager_AlreadyExists_Throws() throws Exception {
+    helper.createKeyManager(
+        serverTls.privateKey().getEncoded(), serverTls.certificate().getEncoded());
+    assertThatThrownBy(
+            () ->
+                helper.createKeyManager(
+                    serverTls.privateKey().getEncoded(), serverTls.certificate().getEncoded()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("keyManager has been previously configured");
   }
 
   @Test
-  void socketFactoryCallbackExceptionHandled() {
-    X509TrustManager trustManager = mock(X509TrustManager.class);
+  void setSslContext() throws Exception {
+    SSLContext sslContext = SSLContext.getInstance("TLS");
+    X509TrustManager trustManager = TlsUtil.trustManager(serverTls.certificate().getEncoded());
+    helper.setSslContext(sslContext, trustManager);
 
-    TlsConfigHelper helper = new TlsConfigHelper(tlsUtil);
-
-    helper.setTrustManager(trustManager);
-    assertThrows(
-        IllegalStateException.class,
-        () -> {
-          helper.configureWithSocketFactory(
-              (sf, tm) -> {
-                throw new SSLException("bad times");
-              });
-        });
+    assertThat(helper.getSslContext()).isEqualTo(sslContext);
+    assertThat(helper.getTrustManager()).isEqualTo(trustManager);
   }
 
   @Test
-  void configureWithKeyManagerHappyPath() {
-    AtomicReference<X509TrustManager> seenTrustManager = new AtomicReference<>();
-    AtomicReference<X509KeyManager> seenKeyManager = new AtomicReference<>();
+  void setSslContext_AlreadyExists_Throws() throws Exception {
+    SSLContext sslContext = SSLContext.getInstance("TLS");
+    X509TrustManager trustManager = TlsUtil.trustManager(serverTls.certificate().getEncoded());
 
-    X509TrustManager trustManager = mock(X509TrustManager.class);
-    X509KeyManager keyManager = mock(X509KeyManager.class);
+    helper.setSslContext(sslContext, trustManager);
+    assertThatThrownBy(() -> helper.setSslContext(sslContext, trustManager))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("sslContext or trustManager has been previously configured");
 
-    TlsConfigHelper helper = new TlsConfigHelper(tlsUtil);
-
-    helper.setTrustManager(trustManager);
-    helper.setKeyManager(keyManager);
-    helper.configureWithKeyManager(
-        (tm, km) -> {
-          seenTrustManager.set(tm);
-          seenKeyManager.set(km);
-        });
-    assertThat(seenTrustManager.get()).isSameAs(trustManager);
-    assertThat(seenKeyManager.get()).isSameAs(keyManager);
-  }
-
-  @Test
-  void configureWithKeyManagerExceptionHandled() {
-    X509TrustManager trustManager = mock(X509TrustManager.class);
-    X509KeyManager keyManager = mock(X509KeyManager.class);
-
-    TlsConfigHelper helper = new TlsConfigHelper(tlsUtil);
-
-    helper.setTrustManager(trustManager);
-    helper.setKeyManager(keyManager);
-    assertThrows(
-        IllegalStateException.class,
-        () ->
-            helper.configureWithKeyManager(
-                (trustManager1, keyManager1) -> {
-                  throw new SSLException("ouchey");
-                }));
-  }
-
-  @Test
-  void configureWithKeyManagerNoTrustManager() {
-    TlsConfigHelper helper = new TlsConfigHelper(tlsUtil);
-    helper.configureWithKeyManager(
-        (tm, km) -> {
-          fail();
-        });
-    verifyNoInteractions(tlsUtil);
-  }
-
-  @Test
-  void setKeyManagerReplacesAndWarns() {
-    X509KeyManager keyManager1 = mock(X509KeyManager.class);
-    X509KeyManager keyManager2 = mock(X509KeyManager.class);
-
-    TlsConfigHelper helper = new TlsConfigHelper(tlsUtil);
-
-    helper.setTrustManager(mock(X509TrustManager.class));
-    helper.setKeyManager(keyManager1);
-    helper.setKeyManager(keyManager2);
-
-    helper.configureWithKeyManager((tm, km) -> assertSame(km, keyManager2));
-    logs.assertContains("Previous X509 Key manager is being replaced");
-  }
-
-  @Test
-  void createKeyManagerReplacesAndWarns() throws Exception {
-    X509KeyManager keyManager1 = mock(X509KeyManager.class);
-    X509KeyManager keyManager2 = mock(X509KeyManager.class);
-
-    byte[] cert = serverTls.certificate().getEncoded();
-    byte[] key = serverTls.privateKey().getEncoded();
-
-    when(tlsUtil.keyManager(key, cert)).thenReturn(keyManager2);
-    TlsConfigHelper helper = new TlsConfigHelper(tlsUtil);
-
-    helper.setTrustManager(mock(X509TrustManager.class));
-    helper.setKeyManager(keyManager1);
-    helper.createKeyManager(key, cert);
-
-    helper.configureWithKeyManager((tm, km) -> assertSame(km, keyManager2));
-    logs.assertContains("Previous X509 Key manager is being replaced");
+    helper = new TlsConfigHelper();
+    helper.createTrustManager(serverTls.certificate().getEncoded());
+    assertThatThrownBy(() -> helper.setSslContext(sslContext, trustManager))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("sslContext or trustManager has been previously configured");
   }
 }

--- a/exporters/common/src/test/java/io/opentelemetry/exporter/internal/TlsConfigHelperTest.java
+++ b/exporters/common/src/test/java/io/opentelemetry/exporter/internal/TlsConfigHelperTest.java
@@ -28,29 +28,29 @@ class TlsConfigHelperTest {
 
   @Test
   void createTrustManager() throws CertificateEncodingException {
-    helper.createTrustManager(serverTls.certificate().getEncoded());
+    helper.setTrustManagerFromCerts(serverTls.certificate().getEncoded());
 
     assertThat(helper.getTrustManager()).isNotNull();
   }
 
   @Test
   void createTrustManager_AlreadyExists_Throws() throws Exception {
-    helper.createTrustManager(serverTls.certificate().getEncoded());
-    assertThatThrownBy(() -> helper.createTrustManager(serverTls.certificate().getEncoded()))
+    helper.setTrustManagerFromCerts(serverTls.certificate().getEncoded());
+    assertThatThrownBy(() -> helper.setTrustManagerFromCerts(serverTls.certificate().getEncoded()))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("trustManager has been previously configured");
 
     helper = new TlsConfigHelper();
     helper.setSslContext(
         SSLContext.getInstance("TLS"), TlsUtil.trustManager(serverTls.certificate().getEncoded()));
-    assertThatThrownBy(() -> helper.createTrustManager(serverTls.certificate().getEncoded()))
+    assertThatThrownBy(() -> helper.setTrustManagerFromCerts(serverTls.certificate().getEncoded()))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("trustManager has been previously configured");
   }
 
   @Test
   void createKeyManager() throws CertificateEncodingException {
-    helper.createKeyManager(
+    helper.setKeyManagerFromCerts(
         serverTls.privateKey().getEncoded(), serverTls.certificate().getEncoded());
 
     assertThat(helper.getKeyManager()).isNotNull();
@@ -58,11 +58,11 @@ class TlsConfigHelperTest {
 
   @Test
   void createKeyManager_AlreadyExists_Throws() throws Exception {
-    helper.createKeyManager(
+    helper.setKeyManagerFromCerts(
         serverTls.privateKey().getEncoded(), serverTls.certificate().getEncoded());
     assertThatThrownBy(
             () ->
-                helper.createKeyManager(
+                helper.setKeyManagerFromCerts(
                     serverTls.privateKey().getEncoded(), serverTls.certificate().getEncoded()))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("keyManager has been previously configured");
@@ -89,7 +89,7 @@ class TlsConfigHelperTest {
         .hasMessageContaining("sslContext or trustManager has been previously configured");
 
     helper = new TlsConfigHelper();
-    helper.createTrustManager(serverTls.certificate().getEncoded());
+    helper.setTrustManagerFromCerts(serverTls.certificate().getEncoded());
     assertThatThrownBy(() -> helper.setSslContext(sslContext, trustManager))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("sslContext or trustManager has been previously configured");

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterBuilder.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterBuilder.java
@@ -109,13 +109,13 @@ public final class JaegerGrpcSpanExporterBuilder {
    * use the system default trusted certificates.
    */
   public JaegerGrpcSpanExporterBuilder setTrustedCertificates(byte[] trustedCertificatesPem) {
-    delegate.configureTrustManager(trustedCertificatesPem);
+    delegate.setTrustManagerFromCerts(trustedCertificatesPem);
     return this;
   }
 
   /** Sets the client key and chain to use for verifying servers when mTLS is enabled. */
   public JaegerGrpcSpanExporterBuilder setClientTls(byte[] privateKeyPem, byte[] certificatePem) {
-    delegate.configureKeyManager(privateKeyPem, certificatePem);
+    delegate.setKeyManagerFromCerts(privateKeyPem, certificatePem);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -99,7 +99,7 @@ public final class OtlpHttpMetricExporterBuilder {
    * use the system default trusted certificates.
    */
   public OtlpHttpMetricExporterBuilder setTrustedCertificates(byte[] trustedCertificatesPem) {
-    delegate.configureTrustManager(trustedCertificatesPem);
+    delegate.setTrustManagerFromCerts(trustedCertificatesPem);
     return this;
   }
 
@@ -108,7 +108,7 @@ public final class OtlpHttpMetricExporterBuilder {
    * The key must be PKCS8, and both must be in PEM format.
    */
   public OtlpHttpMetricExporterBuilder setClientTls(byte[] privateKeyPem, byte[] certificatePem) {
-    delegate.configureKeyManager(privateKeyPem, certificatePem);
+    delegate.setKeyManagerFromCerts(privateKeyPem, certificatePem);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -87,7 +87,7 @@ public final class OtlpHttpSpanExporterBuilder {
    * use the system default trusted certificates.
    */
   public OtlpHttpSpanExporterBuilder setTrustedCertificates(byte[] trustedCertificatesPem) {
-    delegate.configureTrustManager(trustedCertificatesPem);
+    delegate.setTrustManagerFromCerts(trustedCertificatesPem);
     return this;
   }
 
@@ -96,7 +96,7 @@ public final class OtlpHttpSpanExporterBuilder {
    * The key must be PKCS8, and both must be in PEM format.
    */
   public OtlpHttpSpanExporterBuilder setClientTls(byte[] privateKeyPem, byte[] certificatePem) {
-    delegate.configureKeyManager(privateKeyPem, certificatePem);
+    delegate.setKeyManagerFromCerts(privateKeyPem, certificatePem);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
@@ -131,7 +131,7 @@ public final class OtlpGrpcMetricExporterBuilder {
    * use the system default trusted certificates.
    */
   public OtlpGrpcMetricExporterBuilder setTrustedCertificates(byte[] trustedCertificatesPem) {
-    delegate.configureTrustManager(trustedCertificatesPem);
+    delegate.setTrustManagerFromCerts(trustedCertificatesPem);
     return this;
   }
 
@@ -140,7 +140,7 @@ public final class OtlpGrpcMetricExporterBuilder {
    * The key must be PKCS8, and both must be in PEM format.
    */
   public OtlpGrpcMetricExporterBuilder setClientTls(byte[] privateKeyPem, byte[] certificatePem) {
-    delegate.configureKeyManager(privateKeyPem, certificatePem);
+    delegate.setKeyManagerFromCerts(privateKeyPem, certificatePem);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
@@ -115,7 +115,7 @@ public final class OtlpGrpcSpanExporterBuilder {
    * use the system default trusted certificates.
    */
   public OtlpGrpcSpanExporterBuilder setTrustedCertificates(byte[] trustedCertificatesPem) {
-    delegate.configureTrustManager(trustedCertificatesPem);
+    delegate.setTrustManagerFromCerts(trustedCertificatesPem);
     return this;
   }
 
@@ -124,7 +124,7 @@ public final class OtlpGrpcSpanExporterBuilder {
    * The key must be PKCS8, and both must be in PEM format.
    */
   public OtlpGrpcSpanExporterBuilder setClientTls(byte[] privateKeyPem, byte[] certificatePem) {
-    delegate.configureKeyManager(privateKeyPem, certificatePem);
+    delegate.setKeyManagerFromCerts(privateKeyPem, certificatePem);
     return this;
   }
 

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -83,7 +83,7 @@ public final class OtlpHttpLogRecordExporterBuilder {
    * use the system default trusted certificates.
    */
   public OtlpHttpLogRecordExporterBuilder setTrustedCertificates(byte[] trustedCertificatesPem) {
-    delegate.configureTrustManager(trustedCertificatesPem);
+    delegate.setTrustManagerFromCerts(trustedCertificatesPem);
     return this;
   }
 
@@ -93,7 +93,7 @@ public final class OtlpHttpLogRecordExporterBuilder {
    */
   public OtlpHttpLogRecordExporterBuilder setClientTls(
       byte[] privateKeyPem, byte[] certificatePem) {
-    delegate.configureKeyManager(privateKeyPem, certificatePem);
+    delegate.setKeyManagerFromCerts(privateKeyPem, certificatePem);
     return this;
   }
 

--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
@@ -115,7 +115,7 @@ public final class OtlpGrpcLogRecordExporterBuilder {
    * use the system default trusted certificates.
    */
   public OtlpGrpcLogRecordExporterBuilder setTrustedCertificates(byte[] trustedCertificatesPem) {
-    delegate.configureTrustManager(trustedCertificatesPem);
+    delegate.setTrustManagerFromCerts(trustedCertificatesPem);
     return this;
   }
 
@@ -125,7 +125,7 @@ public final class OtlpGrpcLogRecordExporterBuilder {
    */
   public OtlpGrpcLogRecordExporterBuilder setClientTls(
       byte[] privateKeyPem, byte[] certificatePem) {
-    delegate.configureKeyManager(privateKeyPem, certificatePem);
+    delegate.setKeyManagerFromCerts(privateKeyPem, certificatePem);
     return this;
   }
 

--- a/exporters/otlp/testing-internal/build.gradle.kts
+++ b/exporters/otlp/testing-internal/build.gradle.kts
@@ -18,6 +18,9 @@ dependencies {
 
   // Must be compileOnly so gRPC isn't on the classpath for non-gRPC tests.
   compileOnly("io.grpc:grpc-stub")
+  compileOnly("io.grpc:grpc-netty")
+  compileOnly("io.grpc:grpc-netty-shaded")
+  compileOnly("io.grpc:grpc-okhttp")
 
   implementation(project(":testing-internal"))
 

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/ManagedChannelTelemetryExporterBuilder.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/ManagedChannelTelemetryExporterBuilder.java
@@ -93,13 +93,13 @@ public final class ManagedChannelTelemetryExporterBuilder<T>
 
   @Override
   public TelemetryExporterBuilder<T> setTrustedCertificates(byte[] certificates) {
-    tlsConfigHelper.createTrustManager(certificates);
+    tlsConfigHelper.setTrustManagerFromCerts(certificates);
     return this;
   }
 
   @Override
   public TelemetryExporterBuilder<T> setClientTls(byte[] privateKeyPem, byte[] certificatePem) {
-    tlsConfigHelper.createKeyManager(privateKeyPem, certificatePem);
+    tlsConfigHelper.setKeyManagerFromCerts(privateKeyPem, certificatePem);
     return this;
   }
 
@@ -167,7 +167,6 @@ public final class ManagedChannelTelemetryExporterBuilder<T>
   private static void setSslContext(
       ManagedChannelBuilder<?> managedChannelBuilder, TlsConfigHelper tlsConfigHelper)
       throws SSLException {
-    requireNonNull(managedChannelBuilder, "managedChannelBuilder");
     X509TrustManager trustManager = tlsConfigHelper.getTrustManager();
     if (trustManager == null) {
       return;

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/ManagedChannelTelemetryExporterBuilder.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/ManagedChannelTelemetryExporterBuilder.java
@@ -9,6 +9,9 @@ import static java.util.Objects.requireNonNull;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.NettyChannelBuilder;
+import io.netty.handler.ssl.SslContext;
 import io.opentelemetry.exporter.internal.TlsConfigHelper;
 import io.opentelemetry.exporter.internal.grpc.ManagedChannelUtil;
 import io.opentelemetry.exporter.internal.otlp.OtlpUserAgent;
@@ -19,6 +22,9 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.X509TrustManager;
 
 /**
  * Wraps a {@link TelemetryExporterBuilder}, delegating methods to upstream gRPC's {@link
@@ -124,11 +130,11 @@ public final class ManagedChannelTelemetryExporterBuilder<T>
   public TelemetryExporter<T> build() {
     requireNonNull(channelBuilder, "channel");
 
-    tlsConfigHelper.configureWithKeyManager(
-        (tm, km) -> {
-          requireNonNull(channelBuilder, "channel");
-          ManagedChannelUtil.setClientKeysAndTrustedCertificatesPem(channelBuilder, tm, km);
-        });
+    try {
+      setSslContext(channelBuilder, tlsConfigHelper);
+    } catch (SSLException e) {
+      throw new IllegalStateException(e);
+    }
 
     ManagedChannel channel = channelBuilder.build();
     delegate.setChannel(channel);
@@ -150,5 +156,63 @@ public final class ManagedChannelTelemetryExporterBuilder<T>
         return delegateExporter.shutdown();
       }
     };
+  }
+
+  /**
+   * Configure the channel builder to trust the certificates. The {@code byte[]} should contain an
+   * X.509 certificate collection in PEM format.
+   *
+   * @throws SSLException if error occur processing the certificates
+   */
+  private static void setSslContext(
+      ManagedChannelBuilder<?> managedChannelBuilder, TlsConfigHelper tlsConfigHelper)
+      throws SSLException {
+    requireNonNull(managedChannelBuilder, "managedChannelBuilder");
+    X509TrustManager trustManager = tlsConfigHelper.getTrustManager();
+    if (trustManager == null) {
+      return;
+    }
+
+    // gRPC does not abstract TLS configuration so we need to check the implementation and act
+    // accordingly.
+    String channelBuilderClassName = managedChannelBuilder.getClass().getName();
+    switch (channelBuilderClassName) {
+      case "io.grpc.netty.NettyChannelBuilder":
+        {
+          NettyChannelBuilder nettyBuilder = (NettyChannelBuilder) managedChannelBuilder;
+          SslContext sslContext =
+              GrpcSslContexts.forClient()
+                  .keyManager(tlsConfigHelper.getKeyManager())
+                  .trustManager(trustManager)
+                  .build();
+          nettyBuilder.sslContext(sslContext);
+          break;
+        }
+      case "io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder":
+        {
+          io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder nettyBuilder =
+              (io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder) managedChannelBuilder;
+          io.grpc.netty.shaded.io.netty.handler.ssl.SslContext sslContext =
+              io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts.forClient()
+                  .trustManager(trustManager)
+                  .keyManager(tlsConfigHelper.getKeyManager())
+                  .build();
+          nettyBuilder.sslContext(sslContext);
+          break;
+        }
+      case "io.grpc.okhttp.OkHttpChannelBuilder":
+        SSLContext sslContext = tlsConfigHelper.getSslContext();
+        if (sslContext == null) {
+          return;
+        }
+        io.grpc.okhttp.OkHttpChannelBuilder okHttpBuilder =
+            (io.grpc.okhttp.OkHttpChannelBuilder) managedChannelBuilder;
+        okHttpBuilder.sslSocketFactory(sslContext.getSocketFactory());
+        break;
+      default:
+        throw new SSLException(
+            "TLS certificate configuration not supported for unrecognized ManagedChannelBuilder "
+                + channelBuilderClassName);
+    }
   }
 }

--- a/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerBuilder.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerBuilder.java
@@ -19,6 +19,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
 import okhttp3.Headers;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
@@ -153,7 +155,11 @@ public final class JaegerRemoteSamplerBuilder {
 
     clientBuilder.callTimeout(Duration.ofNanos(TimeUnit.SECONDS.toNanos(DEFAULT_TIMEOUT_SECS)));
 
-    tlsConfigHelper.configureWithSocketFactory(clientBuilder::sslSocketFactory);
+    SSLContext sslContext = tlsConfigHelper.getSslContext();
+    X509TrustManager trustManager = tlsConfigHelper.getTrustManager();
+    if (sslContext != null && trustManager != null) {
+      clientBuilder.sslSocketFactory(sslContext.getSocketFactory(), trustManager);
+    }
 
     String endpoint = this.endpoint.resolve(GRPC_ENDPOINT_PATH).toString();
     if (endpoint.startsWith("http://")) {

--- a/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerBuilder.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerBuilder.java
@@ -75,7 +75,7 @@ public final class JaegerRemoteSamplerBuilder {
   /** Sets trusted certificate. */
   public JaegerRemoteSamplerBuilder setTrustedCertificates(byte[] trustedCertificatesPem) {
     requireNonNull(trustedCertificatesPem, "trustedCertificatesPem");
-    tlsConfigHelper.createTrustManager(trustedCertificatesPem);
+    tlsConfigHelper.setTrustManagerFromCerts(trustedCertificatesPem);
     return this;
   }
 
@@ -88,7 +88,7 @@ public final class JaegerRemoteSamplerBuilder {
   public JaegerRemoteSamplerBuilder setClientTls(byte[] privateKeyPem, byte[] certificatePem) {
     requireNonNull(privateKeyPem, "privateKeyPem");
     requireNonNull(certificatePem, "certificatePem");
-    tlsConfigHelper.createKeyManager(privateKeyPem, certificatePem);
+    tlsConfigHelper.setKeyManagerFromCerts(privateKeyPem, certificatePem);
     return this;
   }
 


### PR DESCRIPTION
Related to #5280 and this [comment](https://github.com/open-telemetry/opentelemetry-java/pull/5280#discussion_r1146352645).

The overall goal is to provide a low level API for configuring SSL on the exporters for when configuring a static certificate or static mTLS isn't good enough. This should be the last API we add, acting as a catch all for other TLS scenarios. 

Ideally we'd be able to just expose a `setSslContext(SSLContext)` method. SSLContext is initialized using `KeyManager`(s) and `TrustManager`(s), and produces a `SSLSocketFactory` via `SSLContext#getSocketFactory()`.

However, our dependence on okhttp complicates this, since okhttp requires TLS to be configured via `OkHttpClient.Builder#sslSocketFactory(SSLSocketFactory, X509TrustManager)`. You'd think that because a `SSLContext` is comprised of `X509TrustManager` and produces a `SSLSocketFactory`, that `SSLContext` would be enough, but its unfortunately not possible to access the `X509TrustManager` from `SSLContext`.

This means that our low level API has to instead be `setSslContext(SSLContext, X509TrustManager)`. Including the `X509TrustManager` will feel repetitive to users, since they have likely already included it while initializing `SSLContext`, but its the best we can do with okhttp.

Note, other http libraries like jdk httpclient and apache httpclient accept `SSLContext` for configuration, so okhttp's API is really rather strange. There's a [stackoverflow](https://stackoverflow.com/questions/31920719/getting-the-trusted-x509certificate-for-a-java-sslsocket) post that hints at the okhttp maintainers working through the API contract. 