### PR TITLE
Align BatchLogRecordProcessor defaults with specification

### DIFF
--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/LoggerProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/LoggerProviderConfigurationTest.java
@@ -63,7 +63,7 @@ class LoggerProviderConfigurationTest {
                           worker -> {
                             assertThat(worker)
                                 .extracting("scheduleDelayNanos")
-                                .isEqualTo(TimeUnit.MILLISECONDS.toNanos(200));
+                                .isEqualTo(TimeUnit.SECONDS.toNanos(1));
                             assertThat(worker)
                                 .extracting("exporterTimeoutNanos")
                                 .isEqualTo(TimeUnit.MILLISECONDS.toNanos(30000));

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessorBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessorBuilder.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
 public final class BatchLogRecordProcessorBuilder {
 
   // Visible for testing
-  static final long DEFAULT_SCHEDULE_DELAY_MILLIS = 200;
+  static final long DEFAULT_SCHEDULE_DELAY_MILLIS = 1000;
   // Visible for testing
   static final int DEFAULT_MAX_QUEUE_SIZE = 2048;
   // Visible for testing

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessorTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessorTest.java
@@ -425,7 +425,12 @@ class BatchLogRecordProcessorTest {
     when(mockLogRecordExporter.toString()).thenReturn("MockLogRecordExporter");
     assertThat(BatchLogRecordProcessor.builder(mockLogRecordExporter).build().toString())
         .isEqualTo(
-            "BatchLogRecordProcessor{logRecordExporter=MockLogRecordExporter, scheduleDelayNanos=200000000, maxExportBatchSize=512, exporterTimeoutNanos=30000000000}");
+            "BatchLogRecordProcessor{"
+                + "logRecordExporter=MockLogRecordExporter"
+                + ", scheduleDelayNanos=1000000000"
+                + ", maxExportBatchSize=512"
+                + ", exporterTimeoutNanos=30000000000"
+                + "}");
   }
 
   private static final class BlockingLogRecordExporter implements LogRecordExporter {


### PR DESCRIPTION
See defaults [here](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/sdk.md#batching-processor). 