### PR TITLE
Add include_trace_context property to logger builder

### DIFF
--- a/api/logs/src/main/java/io/opentelemetry/api/logs/DefaultLoggerProvider.java
+++ b/api/logs/src/main/java/io/opentelemetry/api/logs/DefaultLoggerProvider.java
@@ -34,6 +34,11 @@ class DefaultLoggerProvider implements LoggerProvider {
     }
 
     @Override
+    public LoggerBuilder excludeTraceContext() {
+      return this;
+    }
+
+    @Override
     public Logger build() {
       return DefaultLogger.getInstance();
     }

--- a/api/logs/src/main/java/io/opentelemetry/api/logs/LoggerBuilder.java
+++ b/api/logs/src/main/java/io/opentelemetry/api/logs/LoggerBuilder.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.api.logs;
 
+import io.opentelemetry.context.Context;
+
 /**
  * Builder class for creating {@link Logger} instances.
  *
@@ -31,6 +33,14 @@ public interface LoggerBuilder {
    * @return this
    */
   LoggerBuilder setInstrumentationVersion(String instrumentationScopeVersion);
+
+  /**
+   * Specify that emitted log records SHOULD NOT automatically include trace context from the {@link
+   * Context#current()}.
+   *
+   * @return this
+   */
+  LoggerBuilder excludeTraceContext();
 
   /**
    * Gets or creates a {@link Logger} instance.

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogger.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogger.java
@@ -14,16 +14,28 @@ final class SdkLogger implements Logger {
 
   private final LoggerSharedState loggerSharedState;
   private final InstrumentationScopeInfo instrumentationScopeInfo;
+  private final boolean includeTraceContext;
 
   SdkLogger(
-      LoggerSharedState loggerSharedState, InstrumentationScopeInfo instrumentationScopeInfo) {
+      LoggerSharedState loggerSharedState,
+      InstrumentationScopeInfo instrumentationScopeInfo,
+      boolean includeTraceContext) {
     this.loggerSharedState = loggerSharedState;
     this.instrumentationScopeInfo = instrumentationScopeInfo;
+    this.includeTraceContext = includeTraceContext;
+  }
+
+  SdkLogger withIncludeTraceContext(boolean includeTraceContext) {
+    if (this.includeTraceContext != includeTraceContext) {
+      return new SdkLogger(loggerSharedState, instrumentationScopeInfo, includeTraceContext);
+    }
+    return this;
   }
 
   @Override
   public LogRecordBuilder logRecordBuilder() {
-    return new SdkLogRecordBuilder(loggerSharedState, instrumentationScopeInfo);
+    return new SdkLogRecordBuilder(
+        loggerSharedState, instrumentationScopeInfo, includeTraceContext);
   }
 
   // VisibleForTesting

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerBuilder.java
@@ -16,6 +16,7 @@ final class SdkLoggerBuilder implements LoggerBuilder {
   private final String instrumentationScopeName;
   @Nullable private String instrumentationScopeVersion;
   @Nullable private String schemaUrl;
+  private boolean includeTraceContext = true;
 
   SdkLoggerBuilder(ComponentRegistry<SdkLogger> registry, String instrumentationScopeName) {
     this.registry = registry;
@@ -35,8 +36,15 @@ final class SdkLoggerBuilder implements LoggerBuilder {
   }
 
   @Override
+  public LoggerBuilder excludeTraceContext() {
+    this.includeTraceContext = false;
+    return this;
+  }
+
+  @Override
   public SdkLogger build() {
-    return registry.get(
-        instrumentationScopeName, instrumentationScopeVersion, schemaUrl, Attributes.empty());
+    return registry
+        .get(instrumentationScopeName, instrumentationScopeVersion, schemaUrl, Attributes.empty())
+        .withIncludeTraceContext(includeTraceContext);
   }
 }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerProvider.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerProvider.java
@@ -50,7 +50,9 @@ public final class SdkLoggerProvider implements LoggerProvider, Closeable {
         new LoggerSharedState(resource, logLimitsSupplier, logRecordProcessor, clock);
     this.loggerComponentRegistry =
         new ComponentRegistry<>(
-            instrumentationScopeInfo -> new SdkLogger(sharedState, instrumentationScopeInfo));
+            instrumentationScopeInfo ->
+                new SdkLogger(
+                    sharedState, instrumentationScopeInfo, /* includeTraceContext= */ true));
     this.isNoopLogRecordProcessor = logRecordProcessor instanceof NoopLogRecordProcessor;
   }
 

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerTest.java
@@ -46,7 +46,7 @@ class SdkLoggerTest {
     when(state.getLogRecordProcessor()).thenReturn(logRecordProcessor);
     when(state.getClock()).thenReturn(clock);
 
-    SdkLogger logger = new SdkLogger(state, info);
+    SdkLogger logger = new SdkLogger(state, info, true);
     LogRecordBuilder logRecordBuilder = logger.logRecordBuilder();
     logRecordBuilder.setBody("foo");
 


### PR DESCRIPTION
The spec for LoggerProvider's "Get a Logger" operation includes a `include_trace_context` parameter, which defaults to true. If `include_trace_context=true`, then the SpanContext field of emitted LogRecords should be extracted from the current context. If false, then the SpanContext field of emitted LogRecords should be extracted from the explicitly set context, or otherwise invalid.

I've haven't included this so far because the use case is rather esoteric and we haven't seen users ask for it. Its used in situations where the emitted log records are coming from threads which may have active spans, but which are not related to the emitted log records. Its probably more useful in event scenarios. But you can also imagine valid logging scenarios, where a log framework has its own holder for span context and deriving SpanContext from current span context is invalid.

Anyway, that's the backstory. 

I've opened this PR because the spec says the "API MUST accept the following parameter". However, we could add it in a backwards compatible way after an initial stable release. Additionally, there are other cases where our implementation doesn't include all the "MUST" elements of the specification. Our [ReadWriteLogRecord](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/sdk.md#readwritelogrecord) has [placeholders](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java#L22-L28) for reading / writing fields.