### PR TITLE
Rename setEpoch to setTimestamp

### DIFF
--- a/api/logs/src/main/java/io/opentelemetry/api/logs/DefaultLogger.java
+++ b/api/logs/src/main/java/io/opentelemetry/api/logs/DefaultLogger.java
@@ -31,12 +31,12 @@ class DefaultLogger implements Logger {
     private NoopLogRecordBuilder() {}
 
     @Override
-    public LogRecordBuilder setEpoch(long timestamp, TimeUnit unit) {
+    public LogRecordBuilder setTimestamp(long timestamp, TimeUnit unit) {
       return this;
     }
 
     @Override
-    public LogRecordBuilder setEpoch(Instant instant) {
+    public LogRecordBuilder setTimestamp(Instant instant) {
       return this;
     }
 

--- a/api/logs/src/main/java/io/opentelemetry/api/logs/LogRecordBuilder.java
+++ b/api/logs/src/main/java/io/opentelemetry/api/logs/LogRecordBuilder.java
@@ -19,11 +19,21 @@ import java.util.concurrent.TimeUnit;
  */
 public interface LogRecordBuilder {
 
-  /** Set the epoch timestamp using the timestamp and unit. */
-  LogRecordBuilder setEpoch(long timestamp, TimeUnit unit);
+  /**
+   * Set the epoch {@code timestamp}, using the timestamp and unit.
+   *
+   * <p>The {@code timestamp} is the time at which the log record occurred. If unset, it will be set
+   * to the current time when {@link #emit()} is called.
+   */
+  LogRecordBuilder setTimestamp(long timestamp, TimeUnit unit);
 
-  /** Set the epoch timestamp using the instant. */
-  LogRecordBuilder setEpoch(Instant instant);
+  /**
+   * Set the epoch {@code timestamp}, using the instant.
+   *
+   * <p>The {@code timestamp} is the time at which the log record occurred. If unset, it will be set
+   * to the current time when {@link #emit()} is called.
+   */
+  LogRecordBuilder setTimestamp(Instant instant);
 
   /** Set the context. */
   LogRecordBuilder setContext(Context context);

--- a/api/logs/src/test/java/io/opentelemetry/api/logs/DefaultLoggerTest.java
+++ b/api/logs/src/test/java/io/opentelemetry/api/logs/DefaultLoggerTest.java
@@ -22,8 +22,8 @@ class DefaultLoggerTest {
             () ->
                 DefaultLogger.getInstance()
                     .logRecordBuilder()
-                    .setEpoch(100, TimeUnit.SECONDS)
-                    .setEpoch(Instant.now())
+                    .setTimestamp(100, TimeUnit.SECONDS)
+                    .setTimestamp(Instant.now())
                     .setContext(Context.root())
                     .setSeverity(Severity.DEBUG)
                     .setSeverityText("debug")

--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingLogRecordExporterTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingLogRecordExporterTest.java
@@ -48,7 +48,7 @@ class OtlpJsonLoggingLogRecordExporterTest {
           .setBody("body1")
           .setSeverity(Severity.INFO)
           .setSeverityText("INFO")
-          .setEpoch(1631533710L, TimeUnit.MILLISECONDS)
+          .setTimestamp(1631533710L, TimeUnit.MILLISECONDS)
           .setAttributes(Attributes.of(stringKey("animal"), "cat", longKey("lives"), 9L))
           .setSpanContext(
               SpanContext.create(
@@ -66,7 +66,7 @@ class OtlpJsonLoggingLogRecordExporterTest {
           .setBody("body2")
           .setSeverity(Severity.INFO)
           .setSeverityText("INFO")
-          .setEpoch(1631533710L, TimeUnit.MILLISECONDS)
+          .setTimestamp(1631533710L, TimeUnit.MILLISECONDS)
           .setAttributes(Attributes.of(booleanKey("important"), true))
           .setSpanContext(
               SpanContext.create(

--- a/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/SystemOutLogRecordExporter.java
+++ b/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/SystemOutLogRecordExporter.java
@@ -66,7 +66,7 @@ public class SystemOutLogRecordExporter implements LogRecordExporter {
     stringBuilder
         .append(
             ISO_FORMAT.format(
-                Instant.ofEpochMilli(NANOSECONDS.toMillis(log.getEpochNanos()))
+                Instant.ofEpochMilli(NANOSECONDS.toMillis(log.getTimestampEpochNanos()))
                     .atZone(ZoneOffset.UTC)))
         .append(" ")
         .append(log.getSeverity())

--- a/exporters/logging/src/test/java/io/opentelemetry/exporter/logging/SystemOutLogRecordExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporter/logging/SystemOutLogRecordExporterTest.java
@@ -69,7 +69,7 @@ class SystemOutLogRecordExporterTest {
         .setAttributes(Attributes.of(stringKey("cheese"), "cheddar", longKey("amount"), 1L))
         .setBody("message")
         .setSeverity(Severity.ERROR3)
-        .setEpoch(timestamp, TimeUnit.MILLISECONDS)
+        .setTimestamp(timestamp, TimeUnit.MILLISECONDS)
         .setSpanContext(
             SpanContext.create(
                 "00000000000000010000000000000002",

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/logs/LogMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/logs/LogMarshaler.java
@@ -46,7 +46,7 @@ final class LogMarshaler extends MarshalerWithSize {
 
     SpanContext spanContext = logRecordData.getSpanContext();
     return new LogMarshaler(
-        logRecordData.getEpochNanos(),
+        logRecordData.getTimestampEpochNanos(),
         toProtoSeverityNumber(logRecordData.getSeverity()),
         MarshalerUtil.toBytes(logRecordData.getSeverityText()),
         anyValueMarshaler,

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/logs/LogsRequestMarshalerTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/logs/LogsRequestMarshalerTest.java
@@ -70,7 +70,7 @@ class LogsRequestMarshalerTest {
                             TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()))
                     .setAttributes(Attributes.of(AttributeKey.booleanKey("key"), true))
                     .setTotalAttributeCount(2)
-                    .setEpoch(12345, TimeUnit.NANOSECONDS)
+                    .setTimestamp(12345, TimeUnit.NANOSECONDS)
                     .build()));
 
     assertThat(resourceLogsMarshalers).hasSize(1);
@@ -113,7 +113,7 @@ class LogsRequestMarshalerTest {
                             TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()))
                     .setAttributes(Attributes.of(AttributeKey.booleanKey("key"), true))
                     .setTotalAttributeCount(2)
-                    .setEpoch(12345, TimeUnit.NANOSECONDS)
+                    .setTimestamp(12345, TimeUnit.NANOSECONDS)
                     .build()));
 
     assertThat(logRecord.getTraceId().toByteArray()).isEqualTo(TRACE_ID_BYTES);
@@ -141,7 +141,7 @@ class LogsRequestMarshalerTest {
                         Resource.create(Attributes.builder().put("testKey", "testValue").build()))
                     .setInstrumentationScopeInfo(
                         InstrumentationScopeInfo.builder("instrumentation").setVersion("1").build())
-                    .setEpoch(12345, TimeUnit.NANOSECONDS)
+                    .setTimestamp(12345, TimeUnit.NANOSECONDS)
                     .build()));
 
     assertThat(logRecord.getTraceId()).isEmpty();

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/FakeTelemetryUtil.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/FakeTelemetryUtil.java
@@ -90,7 +90,7 @@ public class FakeTelemetryUtil {
         .setAttributes(Attributes.builder().put("key", "value").build())
         .setSeverity(Severity.INFO)
         .setSeverityText(Severity.INFO.name())
-        .setEpoch(Instant.now())
+        .setTimestamp(Instant.now())
         .build();
   }
 

--- a/integration-tests/otlp/src/main/java/io/opentelemetry/integrationtest/OtlpExporterIntegrationTest.java
+++ b/integration-tests/otlp/src/main/java/io/opentelemetry/integrationtest/OtlpExporterIntegrationTest.java
@@ -534,7 +534,7 @@ abstract class OtlpExporterIntegrationTest {
           .setAllAttributes(Attributes.builder().put("key", "value").build())
           .setSeverity(Severity.DEBUG)
           .setSeverityText("DEBUG")
-          .setEpoch(Instant.now())
+          .setTimestamp(Instant.now())
           .setContext(Context.current())
           .emit();
       eventEmitter.emit("event-name", Attributes.builder().put("key", "value").build());

--- a/sdk/logs-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LogRecordDataAssert.java
+++ b/sdk/logs-testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LogRecordDataAssert.java
@@ -57,16 +57,16 @@ public class LogRecordDataAssert extends AbstractAssert<LogRecordDataAssert, Log
     return this;
   }
 
-  /** Asserts the log has the given epoch timestamp. */
-  public LogRecordDataAssert hasEpochNanos(long epochNanos) {
+  /** Asserts the log has the given epoch {@code timestamp}. */
+  public LogRecordDataAssert hasTimestamp(long timestampEpochNanos) {
     isNotNull();
-    if (actual.getEpochNanos() != epochNanos) {
+    if (actual.getTimestampEpochNanos() != timestampEpochNanos) {
       failWithActualExpectedAndMessage(
-          actual.getEpochNanos(),
-          epochNanos,
-          "Expected log to have epoch <%s> nanos but was <%s>",
-          epochNanos,
-          actual.getEpochNanos());
+          actual.getTimestampEpochNanos(),
+          timestampEpochNanos,
+          "Expected log to have timestamp <%s> nanos but was <%s>",
+          timestampEpochNanos,
+          actual.getTimestampEpochNanos());
     }
     return this;
   }

--- a/sdk/logs-testing/src/main/java/io/opentelemetry/sdk/testing/logs/TestLogRecordData.java
+++ b/sdk/logs-testing/src/main/java/io/opentelemetry/sdk/testing/logs/TestLogRecordData.java
@@ -27,7 +27,7 @@ public abstract class TestLogRecordData implements LogRecordData {
     return new AutoValue_TestLogRecordData.Builder()
         .setResource(Resource.empty())
         .setInstrumentationScopeInfo(InstrumentationScopeInfo.empty())
-        .setEpoch(0, TimeUnit.NANOSECONDS)
+        .setTimestamp(0, TimeUnit.NANOSECONDS)
         .setSpanContext(SpanContext.getInvalid())
         .setSeverity(Severity.UNDEFINED_SEVERITY_NUMBER)
         .setBody("")
@@ -55,18 +55,31 @@ public abstract class TestLogRecordData implements LogRecordData {
     public abstract Builder setInstrumentationScopeInfo(
         InstrumentationScopeInfo instrumentationScopeInfo);
 
-    /** Set the epoch timestamp to the {@code instant}. */
-    public Builder setEpoch(Instant instant) {
-      return setEpochNanos(TimeUnit.SECONDS.toNanos(instant.getEpochSecond()) + instant.getNano());
+    /**
+     * Set the epoch {@code timestamp}, using the instant.
+     *
+     * <p>The {@code timestamp} is the time at which the log record occurred.
+     */
+    public Builder setTimestamp(Instant instant) {
+      return setTimestampEpochNanos(
+          TimeUnit.SECONDS.toNanos(instant.getEpochSecond()) + instant.getNano());
     }
 
-    /** Set the epoch timestamp. */
-    public Builder setEpoch(long timestamp, TimeUnit unit) {
-      return setEpochNanos(unit.toNanos(timestamp));
+    /**
+     * Set the epoch {@code timestamp}, using the timestamp and unit.
+     *
+     * <p>The {@code timestamp} is the time at which the log record occurred.
+     */
+    public Builder setTimestamp(long timestamp, TimeUnit unit) {
+      return setTimestampEpochNanos(unit.toNanos(timestamp));
     }
 
-    /** Set the epoch timestamp in nanos. */
-    abstract Builder setEpochNanos(long epochNanos);
+    /**
+     * Set the epoch {@code timestamp}.
+     *
+     * <p>The {@code timestamp} is the time at which the log record occurred.
+     */
+    abstract Builder setTimestampEpochNanos(long epochNanos);
 
     /** Set the span context. */
     public abstract Builder setSpanContext(SpanContext spanContext);

--- a/sdk/logs-testing/src/test/java/io/opentelemetry/sdk/testing/assertj/LogAssertionsTest.java
+++ b/sdk/logs-testing/src/test/java/io/opentelemetry/sdk/testing/assertj/LogAssertionsTest.java
@@ -48,7 +48,7 @@ public class LogAssertionsTest {
       TestLogRecordData.builder()
           .setResource(RESOURCE)
           .setInstrumentationScopeInfo(INSTRUMENTATION_SCOPE_INFO)
-          .setEpoch(100, TimeUnit.NANOSECONDS)
+          .setTimestamp(100, TimeUnit.NANOSECONDS)
           .setSpanContext(
               SpanContext.create(
                   TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()))
@@ -64,7 +64,7 @@ public class LogAssertionsTest {
     assertThat(LOG_DATA)
         .hasResource(RESOURCE)
         .hasInstrumentationScope(INSTRUMENTATION_SCOPE_INFO)
-        .hasEpochNanos(100)
+        .hasTimestamp(100)
         .hasSpanContext(
             SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()))
         .hasSeverity(Severity.INFO)
@@ -132,7 +132,7 @@ public class LogAssertionsTest {
     assertThatThrownBy(() -> assertThat(LOG_DATA).hasResource(Resource.empty()));
     assertThatThrownBy(
         () -> assertThat(LOG_DATA).hasInstrumentationScope(InstrumentationScopeInfo.empty()));
-    assertThatThrownBy(() -> assertThat(LOG_DATA).hasEpochNanos(200));
+    assertThatThrownBy(() -> assertThat(LOG_DATA).hasTimestamp(200));
     assertThatThrownBy(
         () ->
             assertThat(LOG_DATA)

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogRecordBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogRecordBuilder.java
@@ -24,7 +24,7 @@ final class SdkLogRecordBuilder implements LogRecordBuilder {
   private final LogLimits logLimits;
 
   private final InstrumentationScopeInfo instrumentationScopeInfo;
-  private long epochNanos;
+  private long timestampEpochNanos;
   @Nullable private Context context;
   private Severity severity = Severity.UNDEFINED_SEVERITY_NUMBER;
   @Nullable private String severityText;
@@ -39,14 +39,15 @@ final class SdkLogRecordBuilder implements LogRecordBuilder {
   }
 
   @Override
-  public SdkLogRecordBuilder setEpoch(long timestamp, TimeUnit unit) {
-    this.epochNanos = unit.toNanos(timestamp);
+  public SdkLogRecordBuilder setTimestamp(long timestamp, TimeUnit unit) {
+    this.timestampEpochNanos = unit.toNanos(timestamp);
     return this;
   }
 
   @Override
-  public SdkLogRecordBuilder setEpoch(Instant instant) {
-    this.epochNanos = TimeUnit.SECONDS.toNanos(instant.getEpochSecond()) + instant.getNano();
+  public SdkLogRecordBuilder setTimestamp(Instant instant) {
+    this.timestampEpochNanos =
+        TimeUnit.SECONDS.toNanos(instant.getEpochSecond()) + instant.getNano();
     return this;
   }
 
@@ -102,7 +103,9 @@ final class SdkLogRecordBuilder implements LogRecordBuilder {
                 loggerSharedState.getLogLimits(),
                 loggerSharedState.getResource(),
                 instrumentationScopeInfo,
-                this.epochNanos == 0 ? this.loggerSharedState.getClock().now() : this.epochNanos,
+                this.timestampEpochNanos == 0
+                    ? this.loggerSharedState.getClock().now()
+                    : this.timestampEpochNanos,
                 Span.fromContext(context).getSpanContext(),
                 severity,
                 severityText,

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/data/LogRecordData.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/data/LogRecordData.java
@@ -28,8 +28,8 @@ public interface LogRecordData {
   /** Returns the instrumentation scope that generated this log. */
   InstrumentationScopeInfo getInstrumentationScopeInfo();
 
-  /** Returns the epoch timestamp in nanos when the log was recorded. */
-  long getEpochNanos();
+  /** Returns the timestamp at which the log record occurred, in epoch nanos. */
+  long getTimestampEpochNanos();
 
   /** Return the span context for this log, or {@link SpanContext#getInvalid()} if unset. */
   SpanContext getSpanContext();

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLogRecordBuilderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLogRecordBuilderTest.java
@@ -57,7 +57,8 @@ class SdkLogRecordBuilderTest {
 
   @Test
   void emit_AllFields() {
-    Instant now = Instant.now();
+    Instant timestamp = Instant.now();
+
     String bodyStr = "body";
     String sevText = "sevText";
     Severity severity = Severity.DEBUG3;
@@ -69,8 +70,8 @@ class SdkLogRecordBuilderTest {
             TraceState.getDefault());
 
     builder.setBody(bodyStr);
-    builder.setEpoch(123, TimeUnit.SECONDS);
-    builder.setEpoch(now);
+    builder.setTimestamp(123, TimeUnit.SECONDS);
+    builder.setTimestamp(timestamp);
     builder.setAttribute(null, null);
     builder.setAttribute(AttributeKey.stringKey("k1"), "v1");
     builder.setAllAttributes(Attributes.builder().put("k2", "v2").put("k3", "v3").build());
@@ -82,7 +83,7 @@ class SdkLogRecordBuilderTest {
         .hasResource(RESOURCE)
         .hasInstrumentationScope(SCOPE_INFO)
         .hasBody(bodyStr)
-        .hasEpochNanos(TimeUnit.SECONDS.toNanos(now.getEpochSecond()) + now.getNano())
+        .hasTimestamp(TimeUnit.SECONDS.toNanos(timestamp.getEpochSecond()) + timestamp.getNano())
         .hasAttributes(Attributes.builder().put("k1", "v1").put("k2", "v2").put("k3", "v3").build())
         .hasSpanContext(spanContext)
         .hasSeverity(severity)
@@ -101,7 +102,7 @@ class SdkLogRecordBuilderTest {
         .hasResource(RESOURCE)
         .hasInstrumentationScope(SCOPE_INFO)
         .hasBody(Body.empty().asString())
-        .hasEpochNanos(10L)
+        .hasTimestamp(10L)
         .hasAttributes(Attributes.empty())
         .hasSpanContext(SpanContext.getInvalid())
         .hasSeverity(Severity.UNDEFINED_SEVERITY_NUMBER);

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerProviderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerProviderTest.java
@@ -248,7 +248,7 @@ class SdkLoggerProviderTest {
     sdkLoggerProvider
         .get("test")
         .logRecordBuilder()
-        .setEpoch(100, TimeUnit.NANOSECONDS)
+        .setTimestamp(100, TimeUnit.NANOSECONDS)
         .setContext(Span.wrap(spanContext).storeInContext(Context.root()))
         .setSeverity(Severity.DEBUG)
         .setSeverityText("debug")
@@ -260,7 +260,7 @@ class SdkLoggerProviderTest {
     assertThat(logRecordData.get())
         .hasResource(resource)
         .hasInstrumentationScope(InstrumentationScopeInfo.create("test"))
-        .hasEpochNanos(100)
+        .hasTimestamp(100)
         .hasSpanContext(spanContext)
         .hasSeverity(Severity.DEBUG)
         .hasSeverityText("debug")
@@ -347,7 +347,7 @@ class SdkLoggerProviderTest {
             .build();
     sdkLoggerProvider.loggerBuilder(null).build().logRecordBuilder().emit();
     assertThat(seenLogs.size()).isEqualTo(1);
-    assertThat(seenLogs.get(0).toLogRecordData().getEpochNanos()).isEqualTo(now);
+    assertThat(seenLogs.get(0).toLogRecordData().getTimestampEpochNanos()).isEqualTo(now);
   }
 
   @Test

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerTest.java
@@ -52,7 +52,7 @@ class SdkLoggerTest {
 
     // Have to test through the builder
     logRecordBuilder.emit();
-    assertThat(seenLog.get().toLogRecordData()).hasBody("foo").hasEpochNanos(5);
+    assertThat(seenLog.get().toLogRecordData()).hasBody("foo").hasTimestamp(5);
   }
 
   @Test


### PR DESCRIPTION
Was adding support [observed timestamp](https://github.com/open-telemetry/opentelemetry-java/pull/5367) and I noticed `LogRecordBuilder#setEpoch` is poorly named. The log record data model has two timestamp fields (timestamp and observed timstamp), and `setEpoch` is ambiguous about which is being set.

Let's get this resolved before stabilizing. I propose we rename to `setTimestamp`, which is more clear. 