### PR TITLE
Remove log record timestamp default

### DIFF
--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -424,7 +424,6 @@ class OpenTelemetrySdkTest {
                 + "views=[RegisteredView{instrumentSelector=InstrumentSelector{instrumentName=instrument}, view=View{name=new-instrument, aggregation=DefaultAggregation, attributesProcessor=NoopAttributesProcessor{}}}]"
                 + "}, "
                 + "loggerProvider=SdkLoggerProvider{"
-                + "clock=SystemClock{}, "
                 + "resource=Resource{schemaUrl=null, attributes={service.name=\"otel-test\"}}, "
                 + "logLimits=LogLimits{maxNumberOfAttributes=128, maxAttributeValueLength=2147483647}, "
                 + "logRecordProcessor=SimpleLogRecordProcessor{logRecordExporter=MultiLogRecordExporter{logRecordExporters=[MockLogRecordExporter{}, MockLogRecordExporter{}]}}"

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/LoggerSharedState.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/LoggerSharedState.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.sdk.logs;
 
-import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.function.Supplier;
@@ -20,18 +19,15 @@ final class LoggerSharedState {
   private final Resource resource;
   private final Supplier<LogLimits> logLimitsSupplier;
   private final LogRecordProcessor logRecordProcessor;
-  private final Clock clock;
   @Nullable private volatile CompletableResultCode shutdownResult = null;
 
   LoggerSharedState(
       Resource resource,
       Supplier<LogLimits> logLimitsSupplier,
-      LogRecordProcessor logRecordProcessor,
-      Clock clock) {
+      LogRecordProcessor logRecordProcessor) {
     this.resource = resource;
     this.logLimitsSupplier = logLimitsSupplier;
     this.logRecordProcessor = logRecordProcessor;
-    this.clock = clock;
   }
 
   Resource getResource() {
@@ -44,10 +40,6 @@ final class LoggerSharedState {
 
   LogRecordProcessor getLogRecordProcessor() {
     return logRecordProcessor;
-  }
-
-  Clock getClock() {
-    return clock;
   }
 
   boolean hasBeenShutdown() {

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogRecordBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogRecordBuilder.java
@@ -103,9 +103,7 @@ final class SdkLogRecordBuilder implements LogRecordBuilder {
                 loggerSharedState.getLogLimits(),
                 loggerSharedState.getResource(),
                 instrumentationScopeInfo,
-                this.timestampEpochNanos == 0
-                    ? this.loggerSharedState.getClock().now()
-                    : this.timestampEpochNanos,
+                this.timestampEpochNanos,
                 Span.fromContext(context).getSpanContext(),
                 severity,
                 severityText,

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerProvider.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerProvider.java
@@ -9,7 +9,6 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.api.logs.LoggerBuilder;
 import io.opentelemetry.api.logs.LoggerProvider;
-import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.internal.ComponentRegistry;
 import io.opentelemetry.sdk.resources.Resource;
@@ -43,11 +42,9 @@ public final class SdkLoggerProvider implements LoggerProvider, Closeable {
   SdkLoggerProvider(
       Resource resource,
       Supplier<LogLimits> logLimitsSupplier,
-      List<LogRecordProcessor> processors,
-      Clock clock) {
+      List<LogRecordProcessor> processors) {
     LogRecordProcessor logRecordProcessor = LogRecordProcessor.composite(processors);
-    this.sharedState =
-        new LoggerSharedState(resource, logLimitsSupplier, logRecordProcessor, clock);
+    this.sharedState = new LoggerSharedState(resource, logLimitsSupplier, logRecordProcessor);
     this.loggerComponentRegistry =
         new ComponentRegistry<>(
             instrumentationScopeInfo -> new SdkLogger(sharedState, instrumentationScopeInfo));
@@ -108,9 +105,7 @@ public final class SdkLoggerProvider implements LoggerProvider, Closeable {
   @Override
   public String toString() {
     return "SdkLoggerProvider{"
-        + "clock="
-        + sharedState.getClock()
-        + ", resource="
+        + "resource="
         + sharedState.getResource()
         + ", logLimits="
         + sharedState.getLogLimits()

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerProviderBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerProviderBuilder.java
@@ -10,7 +10,6 @@ import static java.util.Objects.requireNonNull;
 import io.opentelemetry.api.logs.LogRecordBuilder;
 import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.ArrayList;
@@ -23,7 +22,6 @@ public final class SdkLoggerProviderBuilder {
   private final List<LogRecordProcessor> logRecordProcessors = new ArrayList<>();
   private Resource resource = Resource.getDefault();
   private Supplier<LogLimits> logLimitsSupplier = LogLimits::getDefault;
-  private Clock clock = Clock.getDefault();
 
   SdkLoggerProviderBuilder() {}
 
@@ -72,27 +70,11 @@ public final class SdkLoggerProviderBuilder {
   }
 
   /**
-   * Assign a {@link Clock}. The {@link Clock} may be used to determine "now" in the event that the
-   * epoch millis are not set directly.
-   *
-   * <p>The {@code clock} must be thread-safe and return immediately (no remote calls, as contention
-   * free as possible).
-   *
-   * @param clock The clock to use for all temporal needs.
-   * @return this
-   */
-  public SdkLoggerProviderBuilder setClock(Clock clock) {
-    requireNonNull(clock, "clock");
-    this.clock = clock;
-    return this;
-  }
-
-  /**
    * Create a {@link SdkLoggerProvider} instance.
    *
    * @return an instance configured with the provided options
    */
   public SdkLoggerProvider build() {
-    return new SdkLoggerProvider(resource, logLimitsSupplier, logRecordProcessors, clock);
+    return new SdkLoggerProvider(resource, logLimitsSupplier, logRecordProcessors);
   }
 }

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/LoggerSharedStateTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/LoggerSharedStateTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.resources.Resource;
 import org.junit.jupiter.api.Test;
@@ -23,8 +22,7 @@ class LoggerSharedStateTest {
     CompletableResultCode code = new CompletableResultCode();
     when(logRecordProcessor.shutdown()).thenReturn(code);
     LoggerSharedState state =
-        new LoggerSharedState(
-            Resource.empty(), LogLimits::getDefault, logRecordProcessor, Clock.getDefault());
+        new LoggerSharedState(Resource.empty(), LogLimits::getDefault, logRecordProcessor);
     state.shutdown();
     state.shutdown();
     verify(logRecordProcessor, times(1)).shutdown();

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLogRecordBuilderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLogRecordBuilderTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.sdk.logs;
 
 import static io.opentelemetry.sdk.testing.assertj.LogAssertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -17,7 +16,6 @@ import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.logs.data.Body;
 import io.opentelemetry.sdk.resources.Resource;
@@ -50,7 +48,6 @@ class SdkLogRecordBuilderTest {
     when(loggerSharedState.getLogRecordProcessor())
         .thenReturn((context, logRecord) -> emittedLog.set(logRecord));
     when(loggerSharedState.getResource()).thenReturn(RESOURCE);
-    when(loggerSharedState.getClock()).thenReturn(Clock.getDefault());
 
     builder = new SdkLogRecordBuilder(loggerSharedState, SCOPE_INFO);
   }
@@ -92,17 +89,13 @@ class SdkLogRecordBuilderTest {
 
   @Test
   void emit_NoFields() {
-    Clock clock = mock(Clock.class);
-    when(clock.now()).thenReturn(10L);
-    when(loggerSharedState.getClock()).thenReturn(clock);
-
     builder.emit();
 
     assertThat(emittedLog.get().toLogRecordData())
         .hasResource(RESOURCE)
         .hasInstrumentationScope(SCOPE_INFO)
         .hasBody(Body.empty().asString())
-        .hasTimestamp(10L)
+        .hasTimestamp(0L)
         .hasAttributes(Attributes.empty())
         .hasSpanContext(SpanContext.getInvalid())
         .hasSeverity(Severity.UNDEFINED_SEVERITY_NUMBER);

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerProviderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerProviderTest.java
@@ -8,7 +8,6 @@ package io.opentelemetry.sdk.logs;
 import static io.opentelemetry.sdk.testing.assertj.LogAssertions.assertThat;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.entry;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,13 +24,10 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
-import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.resources.Resource;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -105,23 +101,6 @@ class SdkLoggerProviderTest {
         .extracting("sharedState", as(InstanceOfAssertFactories.type(LoggerSharedState.class)))
         .extracting(LoggerSharedState::getLogLimits)
         .isSameAs(logLimits);
-  }
-
-  @Test
-  void builder_defaultClock() {
-    assertThat(SdkLoggerProvider.builder().build())
-        .extracting("sharedState", as(InstanceOfAssertFactories.type(LoggerSharedState.class)))
-        .extracting(LoggerSharedState::getClock)
-        .isSameAs(Clock.getDefault());
-  }
-
-  @Test
-  void builder_clockProvided() {
-    Clock clock = mock(Clock.class);
-    assertThat(SdkLoggerProvider.builder().setClock(clock).build())
-        .extracting("sharedState", as(InstanceOfAssertFactories.type(LoggerSharedState.class)))
-        .extracting(LoggerSharedState::getClock)
-        .isSameAs(clock);
   }
 
   @Test
@@ -334,29 +313,11 @@ class SdkLoggerProviderTest {
   }
 
   @Test
-  void canSetClock() {
-    long now = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
-    Clock clock = mock(Clock.class);
-    when(clock.now()).thenReturn(now);
-    List<ReadWriteLogRecord> seenLogs = new ArrayList<>();
-    logRecordProcessor = (context, logRecord) -> seenLogs.add(logRecord);
-    sdkLoggerProvider =
-        SdkLoggerProvider.builder()
-            .setClock(clock)
-            .addLogRecordProcessor(logRecordProcessor)
-            .build();
-    sdkLoggerProvider.loggerBuilder(null).build().logRecordBuilder().emit();
-    assertThat(seenLogs.size()).isEqualTo(1);
-    assertThat(seenLogs.get(0).toLogRecordData().getTimestampEpochNanos()).isEqualTo(now);
-  }
-
-  @Test
   void toString_Valid() {
     when(logRecordProcessor.toString()).thenReturn("MockLogRecordProcessor");
     assertThat(sdkLoggerProvider.toString())
         .isEqualTo(
             "SdkLoggerProvider{"
-                + "clock=SystemClock{}, "
                 + "resource=Resource{schemaUrl=null, attributes={key=\"value\"}}, "
                 + "logLimits=LogLimits{maxNumberOfAttributes=128, maxAttributeValueLength=2147483647}, "
                 + "logRecordProcessor=MockLogRecordProcessor"

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerTest.java
@@ -22,7 +22,6 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.internal.StringUtils;
 import io.opentelemetry.api.logs.LogRecordBuilder;
-import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.resources.Resource;
@@ -39,12 +38,9 @@ class SdkLoggerTest {
     InstrumentationScopeInfo info = InstrumentationScopeInfo.create("foo");
     AtomicReference<ReadWriteLogRecord> seenLog = new AtomicReference<>();
     LogRecordProcessor logRecordProcessor = (context, logRecord) -> seenLog.set(logRecord);
-    Clock clock = mock(Clock.class);
-    when(clock.now()).thenReturn(5L);
 
     when(state.getResource()).thenReturn(Resource.getDefault());
     when(state.getLogRecordProcessor()).thenReturn(logRecordProcessor);
-    when(state.getClock()).thenReturn(clock);
 
     SdkLogger logger = new SdkLogger(state, info);
     LogRecordBuilder logRecordBuilder = logger.logRecordBuilder();
@@ -52,7 +48,7 @@ class SdkLoggerTest {
 
     // Have to test through the builder
     logRecordBuilder.emit();
-    assertThat(seenLog.get().toLogRecordData()).hasBody("foo").hasTimestamp(5);
+    assertThat(seenLog.get().toLogRecordData()).hasBody("foo").hasTimestamp(0);
   }
 
   @Test


### PR DESCRIPTION
Reflects spec issue [#3386](https://github.com/open-telemetry/opentelemetry-specification/issues/3386).

As mentioned [here](https://github.com/open-telemetry/opentelemetry-specification/issues/3386#issuecomment-1505757443), this further demonstrates that the Bridge API is not for end users. It's trivial for a appender component to map the timestamp from the log record. It will be inconvenient and awkward for an end user to specify the timestamp on each log if they try to misuse the log bridge API. 

Without this default behavior, there's no need for SdkLoggerProvider to have a reference to a `Clock`, so the code simplifies somewhat.