### PR TITLE
Skip OWASP dependencyCheck on test modules

### DIFF
--- a/exporters/otlp/testing-internal/build.gradle.kts
+++ b/exporters/otlp/testing-internal/build.gradle.kts
@@ -34,3 +34,8 @@ dependencies {
   implementation("io.github.netmikey.logunit:logunit-jul")
   implementation("org.assertj:assertj-core")
 }
+
+// Skip OWASP dependencyCheck task on test module
+dependencyCheck {
+  skip = true
+}

--- a/integration-tests/otlp/build.gradle.kts
+++ b/integration-tests/otlp/build.gradle.kts
@@ -43,3 +43,8 @@ tasks {
     dependsOn(testing.suites)
   }
 }
+
+// Skip OWASP dependencyCheck task on test module
+dependencyCheck {
+  skip = true
+}

--- a/integration-tests/tracecontext/build.gradle.kts
+++ b/integration-tests/tracecontext/build.gradle.kts
@@ -33,3 +33,8 @@ tasks {
     jvmArgs("-Dio.opentelemetry.testArchive=${shadowJar.get().archiveFile.get().asFile.absolutePath}")
   }
 }
+
+// Skip OWASP dependencyCheck task on test module
+dependencyCheck {
+  skip = true
+}


### PR DESCRIPTION
The [default configuration](http://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration.html) skips test dependency groups, but we have a number of testing modules which look like regular published modules. Skipping owasp dependencyCheck on these to avoid [false positives](https://github.com/open-telemetry/opentelemetry-java/actions/workflows/owasp-dependency-check-daily.yml). 