### PR TITLE
OWASP dependencyCheck skips jmh configurations

### DIFF
--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -41,8 +41,16 @@ checkstyle {
 }
 
 dependencyCheck {
-  // spotless-1972451482 is a weird configuration that's only added in jaeger-proto
-  skipConfigurations = listOf("errorprone", "checkstyle", "annotationProcessor", "animalsniffer", "spotless-1972451482")
+  skipConfigurations = listOf(
+    "errorprone",
+    "checkstyle",
+    "annotationProcessor",
+    "animalsniffer",
+    "spotless-1972451482", // spotless-1972451482 is a weird configuration that's only added in jaeger-proto
+    "jmhAnnotationProcessor",
+    "jmhCompileClasspath",
+    "jmhRuntimeClasspath",
+    "jmhRuntimeOnly")
   failBuildOnCVSS = 7.0f // fail on high or critical CVE
   analyzers.assemblyEnabled = false // not sure why its trying to analyze .NET assemblies
 }


### PR DESCRIPTION
Need to skip one more set of configurations to get the owasp check to pass without false positives.