### PR TITLE
Fix flakey JaegerRemoteSamplerGrpcNettyTest

### DIFF
--- a/sdk-extensions/jaeger-remote-sampler/src/testGrpcNetty/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerGrpcNettyTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/testGrpcNetty/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerGrpcNettyTest.java
@@ -247,7 +247,8 @@ class JaegerRemoteSamplerGrpcNettyTest {
         JaegerRemoteSampler.builder()
             .setChannel(managedChannel())
             .setServiceName(SERVICE_NAME)
-            .setPollingInterval(50, TimeUnit.MILLISECONDS)
+            // Make sure only polls once.
+            .setPollingInterval(500, TimeUnit.SECONDS)
             .build()) {
       assertThat(sampler).extracting("delegate").isInstanceOf(UpstreamGrpcService.class);
 
@@ -272,7 +273,8 @@ class JaegerRemoteSamplerGrpcNettyTest {
         JaegerRemoteSampler.builder()
             .setChannel(managedChannel())
             .setServiceName(SERVICE_NAME)
-            .setPollingInterval(50, TimeUnit.MILLISECONDS)
+            // Make sure only polls once.
+            .setPollingInterval(500, TimeUnit.SECONDS)
             .build()) {
       assertThat(sampler).extracting("delegate").isInstanceOf(UpstreamGrpcService.class);
 
@@ -296,7 +298,8 @@ class JaegerRemoteSamplerGrpcNettyTest {
         JaegerRemoteSampler.builder()
             .setChannel(managedChannel())
             .setServiceName(SERVICE_NAME)
-            .setPollingInterval(50, TimeUnit.MILLISECONDS)
+            // Make sure only polls once.
+            .setPollingInterval(500, TimeUnit.SECONDS)
             .build()) {
       assertThat(sampler).extracting("delegate").isInstanceOf(UpstreamGrpcService.class);
 


### PR DESCRIPTION
This test flakes fairly frequently ([example](https://github.com/open-telemetry/opentelemetry-java/actions/runs/4708069727/jobs/8350293854)). The tests validate the behavior when the server returns various errors, and assert that the default configuration is not updated, and that there are warnings of the errors in the logs. I think the test flakes because the polling interval is low at just 50ms, allowing the sampler to perform a second successful request and update its configuration before the assertions take place. Recreated locally by adding manual `Thread.sleep`, and verified this should fix the issue.