### PR TITLE
Add missing links to deprecated constants in SemanticAttributes

### DIFF
--- a/buildscripts/semantic-convention/templates/SemanticAttributes.java.j2
+++ b/buildscripts/semantic-convention/templates/SemanticAttributes.java.j2
@@ -204,14 +204,14 @@ public final class {{class}} {
 
  /**
   * The name of the transport protocol.
-  * @deprecated This item has been removed as of 1.17.0 of the semantic conventions. There is no replacement.
+  * @deprecated This item has been removed as of 1.17.0 of the semantic conventions. Use {@link SemanticAttributes#NET_APP_PROTOCOL_NAME} instead.
   */
   @Deprecated
   public static final AttributeKey<String> MESSAGING_PROTOCOL = stringKey("messaging.protocol");
 
   /**
   * The version of the transport protocol.
-  * @deprecated This item has been removed as of 1.17.0 of the semantic conventions. There is no replacement.
+  * @deprecated This item has been removed as of 1.17.0 of the semantic conventions. Use {@link SemanticAttributes#NET_APP_PROTOCOL_VERSION} instead.
   */
   @Deprecated
   public static final AttributeKey<String> MESSAGING_PROTOCOL_VERSION =

--- a/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/SemanticAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/SemanticAttributes.java
@@ -1716,8 +1716,8 @@ public final class SemanticAttributes {
   /**
    * The name of the transport protocol.
    *
-   * @deprecated This item has been removed as of 1.17.0 of the semantic conventions. There is no
-   *     replacement.
+   * @deprecated This item has been removed as of 1.17.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#NET_APP_PROTOCOL_NAME} instead.
    */
   @Deprecated
   public static final AttributeKey<String> MESSAGING_PROTOCOL = stringKey("messaging.protocol");
@@ -1725,8 +1725,8 @@ public final class SemanticAttributes {
   /**
    * The version of the transport protocol.
    *
-   * @deprecated This item has been removed as of 1.17.0 of the semantic conventions. There is no
-   *     replacement.
+   * @deprecated This item has been removed as of 1.17.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#NET_APP_PROTOCOL_VERSION} instead.
    */
   @Deprecated
   public static final AttributeKey<String> MESSAGING_PROTOCOL_VERSION =


### PR DESCRIPTION
The deprecated semantic convention keys `MESSAGING_PROTOCOL` and `MESSAGING_PROTOCOL_VERSION` are missing a link to their according replacements. See https://github.com/open-telemetry/opentelemetry-specification/pull/2957

If you don't know where to look, it's quite cumbersome to find the spec change PR. In the worst case developers remove their attributes instead of updating correctly.