### PR TITLE
Fix a typo in autoconfigure-spi module.

### DIFF
--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizer.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizer.java
@@ -146,7 +146,7 @@ public interface AutoConfigurationCustomizer {
    */
   default AutoConfigurationCustomizer addLoggerProviderCustomizer(
       BiFunction<SdkLoggerProviderBuilder, ConfigProperties, SdkLoggerProviderBuilder>
-          meterProviderCustomizer) {
+          loggerProviderCustomizer) {
     return this;
   }
 


### PR DESCRIPTION
The parameter name `meterProviderCustomizer` looks like a typo. Renaming it to `loggerProviderCustomizer`.