### PR TITLE
Rename misnamed setSslContext method

### DIFF
--- a/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/logs/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -100,10 +100,10 @@ public final class OtlpHttpLogRecordExporterBuilder {
   }
 
   /**
-   * Sets the "bring-your-own" SSLContext. Users should call this _or_ set raw certificate bytes,
-   * but not both.
+   * Sets the "bring-your-own" SSLContext for use with TLS. Users should call this _or_ set raw
+   * certificate bytes, but not both.
    */
-  public OtlpHttpLogRecordExporterBuilder setSslSocketFactory(
+  public OtlpHttpLogRecordExporterBuilder setSslContext(
       SSLContext sslContext, X509TrustManager trustManager) {
     delegate.setSslContext(sslContext, trustManager);
     return this;

--- a/exporters/otlp/logs/src/test/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterTest.java
+++ b/exporters/otlp/logs/src/test/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterTest.java
@@ -78,7 +78,7 @@ class OtlpHttpLogRecordExporterTest
       @Override
       public TelemetryExporterBuilder<LogRecordData> setSslContext(
           SSLContext ssLContext, X509TrustManager trustManager) {
-        builder.setSslSocketFactory(ssLContext, trustManager);
+        builder.setSslContext(ssLContext, trustManager);
         return this;
       }
 


### PR DESCRIPTION
Looks like there was a typo in one of the method names @breedx-splk. 