### PR TITLE
Introduce SpanBuilder.startSpanImmediately() and CloseableSpan

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/trace/CloseableSpan.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/CloseableSpan.java
@@ -1,0 +1,156 @@
+package io.opentelemetry.api.trace;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+public interface CloseableSpan extends Span, AutoCloseable {
+
+  static CloseableSpan noop(Span span) {
+    return new CloseableSpan() {
+      @Override
+      public Span getSpan() {
+        return span;
+      }
+
+      @Override
+      public Scope getScope() {
+        return Scope.noop();
+      }
+    };
+  }
+
+  Span getSpan();
+
+  Scope getScope();
+
+  @Override
+  default void close() {
+    getScope().close();
+    getSpan().end();
+  }
+
+  @Override
+  default <T> Span setAttribute(AttributeKey<T> key, T value) {
+    return getSpan().setAttribute(key, value);
+  }
+
+  @Override
+  default Span setAttribute(String key, String value) {
+    return getSpan().setAttribute(key, value);
+  }
+
+  @Override
+  default Span setAttribute(String key, long value) {
+    return getSpan().setAttribute(key, value);
+  }
+
+  @Override
+  default Span setAttribute(String key, double value) {
+    return getSpan().setAttribute(key, value);
+
+  }
+
+  @Override
+  default Span setAttribute(String key, boolean value) {
+    return getSpan().setAttribute(key, value);
+  }
+
+  @Override
+  default Span setAttribute(AttributeKey<Long> key, int value) {
+    return getSpan().setAttribute(key, value);
+  }
+
+  @Override
+  default Span setAllAttributes(Attributes attributes) {
+    return getSpan().setAllAttributes(attributes);
+  }
+
+  @Override
+  default Span addEvent(String name, Attributes attributes) {
+    return getSpan().addEvent(name, attributes);
+  }
+
+  @Override
+  default Span addEvent(String name, Attributes attributes, long timestamp, TimeUnit unit) {
+    return getSpan().addEvent(name, attributes, timestamp, unit);
+  }
+
+  @Override
+  default Span addEvent(String name) {
+    return getSpan().addEvent(name);
+  }
+
+  @Override
+  default Span addEvent(String name, long timestamp, TimeUnit unit) {
+    return getSpan().addEvent(name, timestamp, unit);
+  }
+
+  @Override
+  default Span addEvent(String name, Instant timestamp) {
+    return getSpan().addEvent(name, timestamp);
+  }
+
+  @Override
+  default Span addEvent(String name, Attributes attributes, Instant timestamp) {
+    return getSpan().addEvent(name, attributes, timestamp);
+  }
+
+  @Override
+  default Span setStatus(StatusCode statusCode, String description) {
+    return getSpan().setStatus(statusCode, description);
+  }
+
+  @Override
+  default Span setStatus(StatusCode statusCode) {
+    return getSpan().setStatus(statusCode);
+  }
+
+  @Override
+  default Span recordException(Throwable exception) {
+    return getSpan().recordException(exception);
+  }
+
+  @Override
+  default Span recordException(Throwable exception, Attributes additionalAttributes) {
+    return getSpan().recordException(exception, additionalAttributes);
+  }
+
+  @Override
+  default Span updateName(String name) {
+    return getSpan().updateName(name);
+  }
+
+  @Override
+  default void end() {
+    getSpan().end();
+  }
+
+  @Override
+  default void end(Instant timestamp) {
+    getSpan().end(timestamp);
+  }
+
+  @Override
+  default Context storeInContext(Context context) {
+    return getSpan().storeInContext(context);
+  }
+
+  @Override
+  default void end(long timestamp, TimeUnit unit) {
+    getSpan().end(timestamp, unit);
+  }
+
+  @Override
+  default SpanContext getSpanContext() {
+    return getSpan().getSpanContext();
+  }
+
+  @Override
+  default boolean isRecording() {
+    return getSpan().isRecording();
+  }
+}

--- a/api/all/src/main/java/io/opentelemetry/api/trace/DefaultTracer.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/DefaultTracer.java
@@ -48,6 +48,11 @@ final class DefaultTracer implements Tracer {
     }
 
     @Override
+    public CloseableSpan startSpanImmediately() {
+      return CloseableSpan.noop(startSpan());
+    }
+
+    @Override
     public NoopSpanBuilder setParent(Context context) {
       if (context == null) {
         ApiUsageLogger.log("context is null");

--- a/api/all/src/main/java/io/opentelemetry/api/trace/SpanBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/SpanBuilder.java
@@ -339,4 +339,6 @@ public interface SpanBuilder {
    * @return the newly created {@code Span}.
    */
   Span startSpan();
+
+  CloseableSpan startSpanImmediately();
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkCloseableSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkCloseableSpan.java
@@ -1,0 +1,30 @@
+package io.opentelemetry.sdk.trace;
+
+import io.opentelemetry.api.trace.CloseableSpan;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
+
+public final class SdkCloseableSpan implements CloseableSpan {
+  private final Span span;
+  private final Scope scope;
+
+  private SdkCloseableSpan(Span span, Scope scope) {
+    this.span = span;
+    this.scope = scope;
+  }
+
+  public static CloseableSpan create(Span span) {
+    Scope scope = span.makeCurrent();
+    return new SdkCloseableSpan(span, scope);
+  }
+
+  @Override
+  public Span getSpan() {
+    return span;
+  }
+
+  @Override
+  public Scope getScope() {
+    return scope;
+  }
+}

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java
@@ -13,6 +13,7 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.internal.ImmutableSpanContext;
+import io.opentelemetry.api.trace.CloseableSpan;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanContext;
@@ -20,6 +21,7 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.internal.AttributeUtil;
 import io.opentelemetry.sdk.internal.AttributesMap;
@@ -161,6 +163,12 @@ final class SdkSpanBuilder implements SpanBuilder {
     }
     startEpochNanos = unit.toNanos(startTimestamp);
     return this;
+  }
+
+  @Override
+  public CloseableSpan startSpanImmediately() {
+    Span span = startSpan();
+    return SdkCloseableSpan.create(span);
   }
 
   @Override


### PR DESCRIPTION
This is primarily offered to provoke discussion.

One of my colleagues is building instrumentation for some custom internal code and was a bit surprised by the fact that the main user-facing span API requires two steps essentially back-to-back: start a span and then make it current (in-scope).

I couldn't remember the exact history, and I couldn't come up with a contrived reason why these would _need_ to be separate things. If you have a good use case, please let me know. 

Anyway, I thought I'd see if it's possible to do this in a non-breaking way. Names are subject to scrutiny and change, of course, but here's where this ended up:

* new method `spanBuilder.startSpanImmediately()`. Returns a new type called `CloseableSpan` (see below). The implementation in the `SdkSpanBuilder` starts the span and then calls `SdkCloseableSpan.create(span)`.
* `CloseableSpan` is an interface that extends `Span` in order to delegate but is also itself `Autocloseable`. In the `close()` default implementation, the scope is closed and then the span is ended.

See the test in `SdkSpanBuilderTest` for an example usage.

No idea if this has legs. At best, it provides two ways to do the same thing and might muddy the API a bit as a result.  Curious what folks think.

Thanks for the feedback/input!