### PR TITLE
Prepare to point to new semantic convention repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ with a few exceptions / comments:
   the API / SDK to function in key areas of the Java ecosystem. Inclusion is subject to maintainers'
   discretion.
 * The [semconv](./semconv) module contains generated classes representing
-  the [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/semantic_conventions).
+  the [semantic conventions](https://github.com/open-telemetry/semantic-conventions).
 * As a general rule, components which implement semantic conventions belong elsewhere.
 
 Other repositories in the OpenTelemetry Java ecosystem include:

--- a/buildscripts/semantic-convention/.gitignore
+++ b/buildscripts/semantic-convention/.gitignore
@@ -1,1 +1,1 @@
-opentelemetry-specification/
+semantic-conventions/

--- a/buildscripts/semantic-convention/generate.sh
+++ b/buildscripts/semantic-convention/generate.sh
@@ -4,25 +4,26 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../../"
 
 # freeze the spec & generator tools versions to make SemanticAttributes generation reproducible
-SEMCONV_VERSION=1.19.0
+# TODO: replace with tag after first release
+SEMCONV_VERSION=c5f7a17b341a92055e7518067f6ed97426f5d0fe
 SPEC_VERSION=v$SEMCONV_VERSION
 SCHEMA_URL=https://opentelemetry.io/schemas/$SEMCONV_VERSION
 GENERATOR_VERSION=0.18.0
 
 cd ${SCRIPT_DIR}
 
-rm -rf opentelemetry-specification || true
-mkdir opentelemetry-specification
-cd opentelemetry-specification
+rm -rf semantic-conventions || true
+mkdir semantic-conventions
+cd semantic-conventions
 
 git init
-git remote add origin https://github.com/open-telemetry/opentelemetry-specification.git
-git fetch origin "$SPEC_VERSION"
+git remote add origin https://github.com/open-telemetry/semantic-conventions.git
+git fetch origin "$SEMCONV_VERSION"
 git reset --hard FETCH_HEAD
 cd ${SCRIPT_DIR}
 
 docker run --rm \
-  -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions:/source \
+  -v ${SCRIPT_DIR}/semantic-conventions/semantic_conventions:/source \
   -v ${SCRIPT_DIR}/templates:/templates \
   -v ${ROOT_DIR}/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/:/output \
   otel/semconvgen:$GENERATOR_VERSION \
@@ -36,7 +37,7 @@ docker run --rm \
   -Dpkg=io.opentelemetry.semconv.trace.attributes
 
 docker run --rm \
-  -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions:/source \
+  -v ${SCRIPT_DIR}/semantic-conventions/semantic_conventions:/source \
   -v ${SCRIPT_DIR}/templates:/templates \
   -v ${ROOT_DIR}/semconv/src/main/java/io/opentelemetry/semconv/resource/attributes/:/output \
   otel/semconvgen:$GENERATOR_VERSION \

--- a/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/SemanticAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/trace/attributes/SemanticAttributes.java
@@ -19,7 +19,217 @@ import java.util.List;
 @SuppressWarnings("unused")
 public final class SemanticAttributes {
   /** The URL of the OpenTelemetry schema for these keys and values. */
-  public static final String SCHEMA_URL = "https://opentelemetry.io/schemas/1.19.0";
+  public static final String SCHEMA_URL =
+      "https://opentelemetry.io/schemas/c5f7a17b341a92055e7518067f6ed97426f5d0fe";
+
+  /**
+   * Client address - unix domain socket name, IPv4 or IPv6 address.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>When observed from the server side, and when communicating through an intermediary,
+   *       {@code client.address} SHOULD represent client address behind any intermediaries (e.g.
+   *       proxies) if it's available.
+   * </ul>
+   */
+  public static final AttributeKey<String> CLIENT_ADDRESS = stringKey("client.address");
+
+  /**
+   * Client port number
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>When observed from the server side, and when communicating through an intermediary,
+   *       {@code client.port} SHOULD represent client port behind any intermediaries (e.g. proxies)
+   *       if it's available.
+   * </ul>
+   */
+  public static final AttributeKey<Long> CLIENT_PORT = longKey("client.port");
+
+  /** Immediate client peer address - unix domain socket name, IPv4 or IPv6 address. */
+  public static final AttributeKey<String> CLIENT_SOCKET_ADDRESS =
+      stringKey("client.socket.address");
+
+  /** Immediate client peer port number */
+  public static final AttributeKey<Long> CLIENT_SOCKET_PORT = longKey("client.socket.port");
+
+  /**
+   * Deprecated, use {@code http.request.method} instead.
+   *
+   * @deprecated Deprecated, use `http.request.method` instead.
+   */
+  @Deprecated public static final AttributeKey<String> HTTP_METHOD = stringKey("http.method");
+
+  /**
+   * Deprecated, use {@code http.response.status_code} instead.
+   *
+   * @deprecated Deprecated, use `http.response.status_code` instead.
+   */
+  @Deprecated public static final AttributeKey<Long> HTTP_STATUS_CODE = longKey("http.status_code");
+
+  /**
+   * Deprecated, use {@code url.scheme} instead.
+   *
+   * @deprecated Deprecated, use `url.scheme` instead.
+   */
+  @Deprecated public static final AttributeKey<String> HTTP_SCHEME = stringKey("http.scheme");
+
+  /**
+   * Deprecated, use {@code url.full} instead.
+   *
+   * @deprecated Deprecated, use `url.full` instead.
+   */
+  @Deprecated public static final AttributeKey<String> HTTP_URL = stringKey("http.url");
+
+  /**
+   * Deprecated, use {@code url.path} and {@code url.query} instead.
+   *
+   * @deprecated Deprecated, use `url.path` and `url.query` instead.
+   */
+  @Deprecated public static final AttributeKey<String> HTTP_TARGET = stringKey("http.target");
+
+  /**
+   * Deprecated, use {@code http.request.body.size} instead.
+   *
+   * @deprecated Deprecated, use `http.request.body.size` instead.
+   */
+  @Deprecated
+  public static final AttributeKey<Long> HTTP_REQUEST_CONTENT_LENGTH =
+      longKey("http.request_content_length");
+
+  /**
+   * Deprecated, use {@code http.response.body.size} instead.
+   *
+   * @deprecated Deprecated, use `http.response.body.size` instead.
+   */
+  @Deprecated
+  public static final AttributeKey<Long> HTTP_RESPONSE_CONTENT_LENGTH =
+      longKey("http.response_content_length");
+
+  /**
+   * Deprecated, use {@code server.socket.domain} on client spans.
+   *
+   * @deprecated Deprecated, use `server.socket.domain` on client spans.
+   */
+  @Deprecated
+  public static final AttributeKey<String> NET_SOCK_PEER_NAME = stringKey("net.sock.peer.name");
+
+  /**
+   * Deprecated, use {@code server.socket.address} on client spans and {@code client.socket.address}
+   * on server spans.
+   *
+   * @deprecated Deprecated, use `server.socket.address` on client spans and `client.socket.address`
+   *     on server spans.
+   */
+  @Deprecated
+  public static final AttributeKey<String> NET_SOCK_PEER_ADDR = stringKey("net.sock.peer.addr");
+
+  /**
+   * Deprecated, use {@code server.socket.port} on client spans and {@code client.socket.port} on
+   * server spans.
+   *
+   * @deprecated Deprecated, use `server.socket.port` on client spans and `client.socket.port` on
+   *     server spans.
+   */
+  @Deprecated
+  public static final AttributeKey<Long> NET_SOCK_PEER_PORT = longKey("net.sock.peer.port");
+
+  /**
+   * Deprecated, use {@code server.address} on client spans and {@code client.address} on server
+   * spans.
+   *
+   * @deprecated Deprecated, use `server.address` on client spans and `client.address` on server
+   *     spans.
+   */
+  @Deprecated public static final AttributeKey<String> NET_PEER_NAME = stringKey("net.peer.name");
+
+  /**
+   * Deprecated, use {@code server.port} on client spans and {@code client.port} on server spans.
+   *
+   * @deprecated Deprecated, use `server.port` on client spans and `client.port` on server spans.
+   */
+  @Deprecated public static final AttributeKey<Long> NET_PEER_PORT = longKey("net.peer.port");
+
+  /**
+   * Deprecated, use {@code server.address}.
+   *
+   * @deprecated Deprecated, use `server.address`.
+   */
+  @Deprecated public static final AttributeKey<String> NET_HOST_NAME = stringKey("net.host.name");
+
+  /**
+   * Deprecated, use {@code server.port}.
+   *
+   * @deprecated Deprecated, use `server.port`.
+   */
+  @Deprecated public static final AttributeKey<Long> NET_HOST_PORT = longKey("net.host.port");
+
+  /**
+   * Deprecated, use {@code server.socket.address}.
+   *
+   * @deprecated Deprecated, use `server.socket.address`.
+   */
+  @Deprecated
+  public static final AttributeKey<String> NET_SOCK_HOST_ADDR = stringKey("net.sock.host.addr");
+
+  /**
+   * Deprecated, use {@code server.socket.port}.
+   *
+   * @deprecated Deprecated, use `server.socket.port`.
+   */
+  @Deprecated
+  public static final AttributeKey<Long> NET_SOCK_HOST_PORT = longKey("net.sock.host.port");
+
+  /**
+   * Deprecated, use {@code network.transport}.
+   *
+   * @deprecated Deprecated, use `network.transport`.
+   */
+  @Deprecated public static final AttributeKey<String> NET_TRANSPORT = stringKey("net.transport");
+
+  /**
+   * Deprecated, use {@code network.protocol.name}.
+   *
+   * @deprecated Deprecated, use `network.protocol.name`.
+   */
+  @Deprecated
+  public static final AttributeKey<String> NET_PROTOCOL_NAME = stringKey("net.protocol.name");
+
+  /**
+   * Deprecated, use {@code network.protocol.version}.
+   *
+   * @deprecated Deprecated, use `network.protocol.version`.
+   */
+  @Deprecated
+  public static final AttributeKey<String> NET_PROTOCOL_VERSION = stringKey("net.protocol.version");
+
+  /**
+   * Deprecated, use {@code network.transport} and {@code network.type}.
+   *
+   * @deprecated Deprecated, use `network.transport` and `network.type`.
+   */
+  @Deprecated
+  public static final AttributeKey<String> NET_SOCK_FAMILY = stringKey("net.sock.family");
+
+  /**
+   * The domain name of the destination system.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>This value may be a host name, a fully qualified domain name, or another host naming
+   *       format.
+   * </ul>
+   */
+  public static final AttributeKey<String> DESTINATION_DOMAIN = stringKey("destination.domain");
+
+  /** Peer address, for example IP address or UNIX socket name. */
+  public static final AttributeKey<String> DESTINATION_ADDRESS = stringKey("destination.address");
+
+  /** Peer port number */
+  public static final AttributeKey<Long> DESTINATION_PORT = longKey("destination.port");
 
   /**
    * The type of the exception (its fully-qualified class name, if applicable). The dynamic type of
@@ -37,16 +247,11 @@ public final class SemanticAttributes {
   public static final AttributeKey<String> EXCEPTION_STACKTRACE = stringKey("exception.stacktrace");
 
   /** HTTP request method. */
-  public static final AttributeKey<String> HTTP_METHOD = stringKey("http.method");
+  public static final AttributeKey<String> HTTP_REQUEST_METHOD = stringKey("http.request.method");
 
   /** <a href="https://tools.ietf.org/html/rfc7231#section-6">HTTP response status code</a>. */
-  public static final AttributeKey<Long> HTTP_STATUS_CODE = longKey("http.status_code");
-
-  /** Kind of HTTP protocol used. */
-  public static final AttributeKey<String> HTTP_FLAVOR = stringKey("http.flavor");
-
-  /** The URI scheme identifying the used protocol. */
-  public static final AttributeKey<String> HTTP_SCHEME = stringKey("http.scheme");
+  public static final AttributeKey<Long> HTTP_RESPONSE_STATUS_CODE =
+      longKey("http.response.status_code");
 
   /**
    * The matched route (path template in the format used by the respective server framework). See
@@ -78,6 +283,82 @@ public final class SemanticAttributes {
    * </ul>
    */
   public static final AttributeKey<String> EVENT_DOMAIN = stringKey("event.domain");
+
+  /**
+   * A unique identifier for the Log Record.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>If an id is provided, other log records with the same id will be considered duplicates
+   *       and can be removed safely. This means, that two distinguishable log records MUST have
+   *       different values. The id MAY be an <a href="https://github.com/ulid/spec">Universally
+   *       Unique Lexicographically Sortable Identifier (ULID)</a>, but other identifiers (e.g.
+   *       UUID) may be used as needed.
+   * </ul>
+   */
+  public static final AttributeKey<String> LOG_RECORD_UID = stringKey("log.record.uid");
+
+  /** The type of memory. */
+  public static final AttributeKey<String> TYPE = stringKey("type");
+
+  /**
+   * Name of the memory pool.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Pool names are generally obtained via <a
+   *       href="https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName()">MemoryPoolMXBean#getName()</a>.
+   * </ul>
+   */
+  public static final AttributeKey<String> POOL = stringKey("pool");
+
+  /**
+   * Logical server hostname, matches server FQDN if available, and IP or socket address if FQDN is
+   * not known.
+   */
+  public static final AttributeKey<String> SERVER_ADDRESS = stringKey("server.address");
+
+  /** Logical server port number */
+  public static final AttributeKey<Long> SERVER_PORT = longKey("server.port");
+
+  /**
+   * The domain name of an immediate peer.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Typically observed from the client side, and represents a proxy or other intermediary
+   *       domain name.
+   * </ul>
+   */
+  public static final AttributeKey<String> SERVER_SOCKET_DOMAIN = stringKey("server.socket.domain");
+
+  /** Physical server IP address or Unix socket address. */
+  public static final AttributeKey<String> SERVER_SOCKET_ADDRESS =
+      stringKey("server.socket.address");
+
+  /** Physical server port. */
+  public static final AttributeKey<Long> SERVER_SOCKET_PORT = longKey("server.socket.port");
+
+  /**
+   * The domain name of the source system.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>This value may be a host name, a fully qualified domain name, or another host naming
+   *       format.
+   * </ul>
+   */
+  public static final AttributeKey<String> SOURCE_DOMAIN = stringKey("source.domain");
+
+  /** Source address, for example IP address or Unix socket name. */
+  public static final AttributeKey<String> SOURCE_ADDRESS = stringKey("source.address");
+
+  /** Source port number */
+  public static final AttributeKey<Long> SOURCE_PORT = longKey("source.port");
 
   /**
    * The full invoked ARN as provided on the {@code Context} passed to the function ({@code
@@ -181,15 +462,7 @@ public final class SemanticAttributes {
    */
   public static final AttributeKey<String> DB_NAME = stringKey("db.name");
 
-  /**
-   * The database statement being executed.
-   *
-   * <p>Notes:
-   *
-   * <ul>
-   *   <li>The value may be sanitized to exclude sensitive information.
-   * </ul>
-   */
+  /** The database statement being executed. */
   public static final AttributeKey<String> DB_STATEMENT = stringKey("db.statement");
 
   /**
@@ -216,7 +489,7 @@ public final class SemanticAttributes {
    * <p>Notes:
    *
    * <ul>
-   *   <li>If setting a {@code db.mssql.instance_name}, {@code net.peer.port} is no longer required
+   *   <li>If setting a {@code db.mssql.instance_name}, {@code server.port} is no longer required
    *       (but still recommended if non-standard).
    * </ul>
    */
@@ -294,6 +567,38 @@ public final class SemanticAttributes {
    * </ul>
    */
   public static final AttributeKey<String> DB_SQL_TABLE = stringKey("db.sql.table");
+
+  /** Unique Cosmos client instance id. */
+  public static final AttributeKey<String> DB_COSMOSDB_CLIENT_ID =
+      stringKey("db.cosmosdb.client_id");
+
+  /** CosmosDB Operation Type. */
+  public static final AttributeKey<String> DB_COSMOSDB_OPERATION_TYPE =
+      stringKey("db.cosmosdb.operation_type");
+
+  /** Cosmos client connection mode. */
+  public static final AttributeKey<String> DB_COSMOSDB_CONNECTION_MODE =
+      stringKey("db.cosmosdb.connection_mode");
+
+  /** Cosmos DB container name. */
+  public static final AttributeKey<String> DB_COSMOSDB_CONTAINER =
+      stringKey("db.cosmosdb.container");
+
+  /** Request payload size in bytes */
+  public static final AttributeKey<Long> DB_COSMOSDB_REQUEST_CONTENT_LENGTH =
+      longKey("db.cosmosdb.request_content_length");
+
+  /** Cosmos DB status code. */
+  public static final AttributeKey<Long> DB_COSMOSDB_STATUS_CODE =
+      longKey("db.cosmosdb.status_code");
+
+  /** Cosmos DB sub status code. */
+  public static final AttributeKey<Long> DB_COSMOSDB_SUB_STATUS_CODE =
+      longKey("db.cosmosdb.sub_status_code");
+
+  /** RU consumed for that operation */
+  public static final AttributeKey<Double> DB_COSMOSDB_REQUEST_CHARGE =
+      doubleKey("db.cosmosdb.request_charge");
 
   /**
    * Name of the code, either &quot;OK&quot; or &quot;ERROR&quot;. MUST NOT be set if the status
@@ -427,12 +732,25 @@ public final class SemanticAttributes {
    */
   public static final AttributeKey<String> FEATURE_FLAG_VARIANT = stringKey("feature_flag.variant");
 
-  /** Transport protocol used. See note below. */
-  public static final AttributeKey<String> NET_TRANSPORT = stringKey("net.transport");
+  /**
+   * <a href="https://osi-model.com/transport-layer/">OSI Transport Layer</a> or <a
+   * href="https://en.wikipedia.org/wiki/Inter-process_communication">Inter-process Communication
+   * method</a>. The value SHOULD be normalized to lowercase.
+   */
+  public static final AttributeKey<String> NETWORK_TRANSPORT = stringKey("network.transport");
 
-  /** Application layer protocol used. The value SHOULD be normalized to lowercase. */
-  public static final AttributeKey<String> NET_APP_PROTOCOL_NAME =
-      stringKey("net.app.protocol.name");
+  /**
+   * <a href="https://osi-model.com/network-layer/">OSI Network Layer</a> or non-OSI equivalent. The
+   * value SHOULD be normalized to lowercase.
+   */
+  public static final AttributeKey<String> NETWORK_TYPE = stringKey("network.type");
+
+  /**
+   * <a href="https://osi-model.com/application-layer/">OSI Application Layer</a> or non-OSI
+   * equivalent. The value SHOULD be normalized to lowercase.
+   */
+  public static final AttributeKey<String> NETWORK_PROTOCOL_NAME =
+      stringKey("network.protocol.name");
 
   /**
    * Version of the application layer protocol used. See note below.
@@ -440,83 +758,37 @@ public final class SemanticAttributes {
    * <p>Notes:
    *
    * <ul>
-   *   <li>{@code net.app.protocol.version} refers to the version of the protocol used and might be
+   *   <li>{@code network.protocol.version} refers to the version of the protocol used and might be
    *       different from the protocol client's version. If the HTTP client used has a version of
    *       {@code 0.27.2}, but sends HTTP version {@code 1.1}, this attribute should be set to
    *       {@code 1.1}.
    * </ul>
    */
-  public static final AttributeKey<String> NET_APP_PROTOCOL_VERSION =
-      stringKey("net.app.protocol.version");
+  public static final AttributeKey<String> NETWORK_PROTOCOL_VERSION =
+      stringKey("network.protocol.version");
 
-  /** Remote socket peer name. */
-  public static final AttributeKey<String> NET_SOCK_PEER_NAME = stringKey("net.sock.peer.name");
-
-  /**
-   * Remote socket peer address: IPv4 or IPv6 for internet protocols, path for local communication,
-   * <a href="https://man7.org/linux/man-pages/man7/address_families.7.html">etc</a>.
-   */
-  public static final AttributeKey<String> NET_SOCK_PEER_ADDR = stringKey("net.sock.peer.addr");
-
-  /** Remote socket peer port. */
-  public static final AttributeKey<Long> NET_SOCK_PEER_PORT = longKey("net.sock.peer.port");
-
-  /**
-   * Protocol <a href="https://man7.org/linux/man-pages/man7/address_families.7.html">address
-   * family</a> which is used for communication.
-   */
-  public static final AttributeKey<String> NET_SOCK_FAMILY = stringKey("net.sock.family");
-
-  /**
-   * Logical remote hostname, see note below.
-   *
-   * <p>Notes:
-   *
-   * <ul>
-   *   <li>{@code net.peer.name} SHOULD NOT be set if capturing it would require an extra DNS
-   *       lookup.
-   * </ul>
-   */
-  public static final AttributeKey<String> NET_PEER_NAME = stringKey("net.peer.name");
-
-  /** Logical remote port number */
-  public static final AttributeKey<Long> NET_PEER_PORT = longKey("net.peer.port");
-
-  /** Logical local hostname or similar, see note below. */
-  public static final AttributeKey<String> NET_HOST_NAME = stringKey("net.host.name");
-
-  /** Logical local port number, preferably the one that the peer used to connect */
-  public static final AttributeKey<Long> NET_HOST_PORT = longKey("net.host.port");
-
-  /** Local socket address. Useful in case of a multi-IP host. */
-  public static final AttributeKey<String> NET_SOCK_HOST_ADDR = stringKey("net.sock.host.addr");
-
-  /** Local socket port number. */
-  public static final AttributeKey<Long> NET_SOCK_HOST_PORT = longKey("net.sock.host.port");
-
-  /** The internet connection type currently being used by the host. */
-  public static final AttributeKey<String> NET_HOST_CONNECTION_TYPE =
-      stringKey("net.host.connection.type");
+  /** The internet connection type. */
+  public static final AttributeKey<String> NETWORK_CONNECTION_TYPE =
+      stringKey("network.connection.type");
 
   /**
    * This describes more details regarding the connection.type. It may be the type of cell
    * technology connection, but it could be used for describing details about a wifi connection.
    */
-  public static final AttributeKey<String> NET_HOST_CONNECTION_SUBTYPE =
-      stringKey("net.host.connection.subtype");
+  public static final AttributeKey<String> NETWORK_CONNECTION_SUBTYPE =
+      stringKey("network.connection.subtype");
 
   /** The name of the mobile carrier. */
-  public static final AttributeKey<String> NET_HOST_CARRIER_NAME =
-      stringKey("net.host.carrier.name");
+  public static final AttributeKey<String> NETWORK_CARRIER_NAME = stringKey("network.carrier.name");
 
   /** The mobile carrier country code. */
-  public static final AttributeKey<String> NET_HOST_CARRIER_MCC = stringKey("net.host.carrier.mcc");
+  public static final AttributeKey<String> NETWORK_CARRIER_MCC = stringKey("network.carrier.mcc");
 
   /** The mobile carrier network code. */
-  public static final AttributeKey<String> NET_HOST_CARRIER_MNC = stringKey("net.host.carrier.mnc");
+  public static final AttributeKey<String> NETWORK_CARRIER_MNC = stringKey("network.carrier.mnc");
 
   /** The ISO 3166-1 alpha-2 2-character country code associated with the mobile carrier network. */
-  public static final AttributeKey<String> NET_HOST_CARRIER_ICC = stringKey("net.host.carrier.icc");
+  public static final AttributeKey<String> NETWORK_CARRIER_ICC = stringKey("network.carrier.icc");
 
   /**
    * The <a href="../../resource/semantic_conventions/README.md#service">{@code service.name}</a> of
@@ -590,8 +862,7 @@ public final class SemanticAttributes {
    * href="https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length">Content-Length</a>
    * header. For requests using transport encoding, this should be the compressed size.
    */
-  public static final AttributeKey<Long> HTTP_REQUEST_CONTENT_LENGTH =
-      longKey("http.request_content_length");
+  public static final AttributeKey<Long> HTTP_REQUEST_BODY_SIZE = longKey("http.request.body.size");
 
   /**
    * The size of the response payload body in bytes. This is the number of bytes transferred
@@ -599,23 +870,8 @@ public final class SemanticAttributes {
    * href="https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length">Content-Length</a>
    * header. For requests using transport encoding, this should be the compressed size.
    */
-  public static final AttributeKey<Long> HTTP_RESPONSE_CONTENT_LENGTH =
-      longKey("http.response_content_length");
-
-  /**
-   * Full HTTP request URL in the form {@code scheme://host[:port]/path?query[#fragment]}. Usually
-   * the fragment is not transmitted over HTTP, but if it is known, it should be included
-   * nevertheless.
-   *
-   * <p>Notes:
-   *
-   * <ul>
-   *   <li>{@code http.url} MUST NOT contain credentials passed via URL in form of {@code
-   *       https://username:password@www.example.com/}. In such case the attribute's value should be
-   *       {@code https://www.example.com/}.
-   * </ul>
-   */
-  public static final AttributeKey<String> HTTP_URL = stringKey("http.url");
+  public static final AttributeKey<Long> HTTP_RESPONSE_BODY_SIZE =
+      longKey("http.response.body.size");
 
   /**
    * The ordinal number of request resending attempt (for any reason, including redirects).
@@ -630,28 +886,11 @@ public final class SemanticAttributes {
    */
   public static final AttributeKey<Long> HTTP_RESEND_COUNT = longKey("http.resend_count");
 
-  /** The full request target as passed in a HTTP request line or equivalent. */
-  public static final AttributeKey<String> HTTP_TARGET = stringKey("http.target");
-
   /**
-   * The IP address of the original client behind all proxies, if known (e.g. from <a
-   * href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For">X-Forwarded-For</a>).
-   *
-   * <p>Notes:
-   *
-   * <ul>
-   *   <li>This is not necessarily the same as {@code net.sock.peer.addr}, which would identify the
-   *       network-level peer, which may be a proxy.
-   *   <li>This attribute should be set when a source of information different from the one used for
-   *       {@code net.sock.peer.addr}, is available even if that other source just confirms the same
-   *       value as {@code net.sock.peer.addr}. Rationale: For {@code net.sock.peer.addr}, one
-   *       typically does not know if it comes from a proxy, reverse proxy, or the actual client.
-   *       Setting {@code http.client_ip} when it's the same as {@code net.sock.peer.addr} means
-   *       that one is at least somewhat confident that the address is not that of the closest
-   *       proxy.
-   * </ul>
+   * The AWS request ID as returned in the response headers {@code x-amz-request-id} or {@code
+   * x-amz-requestid}.
    */
-  public static final AttributeKey<String> HTTP_CLIENT_IP = stringKey("http.client_ip");
+  public static final AttributeKey<String> AWS_REQUEST_ID = stringKey("aws.request_id");
 
   /** The keys in the {@code RequestItems} object field. */
   public static final AttributeKey<List<String>> AWS_DYNAMODB_TABLE_NAMES =
@@ -740,6 +979,138 @@ public final class SemanticAttributes {
   public static final AttributeKey<List<String>> AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES =
       stringArrayKey("aws.dynamodb.global_secondary_index_updates");
 
+  /**
+   * The S3 bucket name the request refers to. Corresponds to the {@code --bucket} parameter of the
+   * <a href="https://docs.aws.amazon.com/cli/latest/reference/s3api/index.html">S3 API</a>
+   * operations.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The {@code bucket} attribute is applicable to all S3 operations that reference a bucket,
+   *       i.e. that require the bucket name as a mandatory parameter. This applies to almost all S3
+   *       operations except {@code list-buckets}.
+   * </ul>
+   */
+  public static final AttributeKey<String> AWS_S3_BUCKET = stringKey("aws.s3.bucket");
+
+  /**
+   * The S3 object key the request refers to. Corresponds to the {@code --key} parameter of the <a
+   * href="https://docs.aws.amazon.com/cli/latest/reference/s3api/index.html">S3 API</a> operations.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The {@code key} attribute is applicable to all object-related S3 operations, i.e. that
+   *       require the object key as a mandatory parameter. This applies in particular to the
+   *       following operations:
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html">copy-object</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-object.html">delete-object</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/get-object.html">get-object</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/head-object.html">head-object</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/put-object.html">put-object</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/restore-object.html">restore-object</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/select-object-content.html">select-object-content</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/abort-multipart-upload.html">abort-multipart-upload</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/complete-multipart-upload.html">complete-multipart-upload</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/create-multipart-upload.html">create-multipart-upload</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/list-parts.html">list-parts</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html">upload-part</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html">upload-part-copy</a>
+   * </ul>
+   */
+  public static final AttributeKey<String> AWS_S3_KEY = stringKey("aws.s3.key");
+
+  /**
+   * The source object (in the form {@code bucket}/{@code key}) for the copy operation.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The {@code copy_source} attribute applies to S3 copy operations and corresponds to the
+   *       {@code --copy-source} parameter of the <a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html">copy-object
+   *       operation within the S3 API</a>. This applies in particular to the following operations:
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html">copy-object</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html">upload-part-copy</a>
+   * </ul>
+   */
+  public static final AttributeKey<String> AWS_S3_COPY_SOURCE = stringKey("aws.s3.copy_source");
+
+  /**
+   * Upload ID that identifies the multipart upload.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The {@code upload_id} attribute applies to S3 multipart-upload operations and corresponds
+   *       to the {@code --upload-id} parameter of the <a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/index.html">S3 API</a>
+   *       multipart operations. This applies in particular to the following operations:
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/abort-multipart-upload.html">abort-multipart-upload</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/complete-multipart-upload.html">complete-multipart-upload</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/list-parts.html">list-parts</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html">upload-part</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html">upload-part-copy</a>
+   * </ul>
+   */
+  public static final AttributeKey<String> AWS_S3_UPLOAD_ID = stringKey("aws.s3.upload_id");
+
+  /**
+   * The delete request container that specifies the objects to be deleted.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The {@code delete} attribute is only applicable to the <a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-object.html">delete-object</a>
+   *       operation. The {@code delete} attribute corresponds to the {@code --delete} parameter of
+   *       the <a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-objects.html">delete-objects
+   *       operation within the S3 API</a>.
+   * </ul>
+   */
+  public static final AttributeKey<String> AWS_S3_DELETE = stringKey("aws.s3.delete");
+
+  /**
+   * The part number of the part being uploaded in a multipart-upload operation. This is a positive
+   * integer between 1 and 10,000.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The {@code part_number} attribute is only applicable to the <a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html">upload-part</a>
+   *       and <a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html">upload-part-copy</a>
+   *       operations. The {@code part_number} attribute corresponds to the {@code --part-number}
+   *       parameter of the <a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html">upload-part
+   *       operation within the S3 API</a>.
+   * </ul>
+   */
+  public static final AttributeKey<Long> AWS_S3_PART_NUMBER = longKey("aws.s3.part_number");
+
   /** The name of the operation being executed. */
   public static final AttributeKey<String> GRAPHQL_OPERATION_NAME =
       stringKey("graphql.operation.name");
@@ -796,10 +1167,6 @@ public final class SemanticAttributes {
   public static final AttributeKey<String> MESSAGING_DESTINATION_NAME =
       stringKey("messaging.destination.name");
 
-  /** The kind of message destination */
-  public static final AttributeKey<String> MESSAGING_DESTINATION_KIND =
-      stringKey("messaging.destination.kind");
-
   /**
    * Low cardinality representation of the messaging destination name
    *
@@ -842,10 +1209,6 @@ public final class SemanticAttributes {
    */
   public static final AttributeKey<String> MESSAGING_SOURCE_NAME =
       stringKey("messaging.source.name");
-
-  /** The kind of message source */
-  public static final AttributeKey<String> MESSAGING_SOURCE_KIND =
-      stringKey("messaging.source.kind");
 
   /**
    * Low cardinality representation of the messaging source name
@@ -907,14 +1270,8 @@ public final class SemanticAttributes {
   public static final AttributeKey<Long> MESSAGING_BATCH_MESSAGE_COUNT =
       longKey("messaging.batch.message_count");
 
-  /**
-   * The identifier for the consumer receiving a message. For Kafka, set it to {@code
-   * {messaging.kafka.consumer.group} - {messaging.kafka.client_id}}, if both are present, or only
-   * {@code messaging.kafka.consumer.group}. For brokers, such as RabbitMQ and Artemis, set it to
-   * the {@code client_id} of the client consuming the message.
-   */
-  public static final AttributeKey<String> MESSAGING_CONSUMER_ID =
-      stringKey("messaging.consumer.id");
+  /** A unique identifier for the client that consumes or produces a message. */
+  public static final AttributeKey<String> MESSAGING_CLIENT_ID = stringKey("messaging.client_id");
 
   /** RabbitMQ message routing key. */
   public static final AttributeKey<String> MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY =
@@ -942,10 +1299,6 @@ public final class SemanticAttributes {
   public static final AttributeKey<String> MESSAGING_KAFKA_CONSUMER_GROUP =
       stringKey("messaging.kafka.consumer.group");
 
-  /** Client Id for the Consumer or Producer that is handling the message. */
-  public static final AttributeKey<String> MESSAGING_KAFKA_CLIENT_ID =
-      stringKey("messaging.kafka.client_id");
-
   /** Partition the message is sent to. */
   public static final AttributeKey<Long> MESSAGING_KAFKA_DESTINATION_PARTITION =
       longKey("messaging.kafka.destination.partition");
@@ -972,10 +1325,6 @@ public final class SemanticAttributes {
    */
   public static final AttributeKey<String> MESSAGING_ROCKETMQ_CLIENT_GROUP =
       stringKey("messaging.rocketmq.client_group");
-
-  /** The unique identifier for each client. */
-  public static final AttributeKey<String> MESSAGING_ROCKETMQ_CLIENT_ID =
-      stringKey("messaging.rocketmq.client_id");
 
   /**
    * The timestamp in milliseconds that the delay message is expected to be delivered to consumer.
@@ -1125,27 +1474,95 @@ public final class SemanticAttributes {
   public static final AttributeKey<Boolean> EXCEPTION_ESCAPED = booleanKey("exception.escaped");
 
   /**
+   * The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.1">URI scheme</a> component
+   * identifying the used protocol.
+   */
+  public static final AttributeKey<String> URL_SCHEME = stringKey("url.scheme");
+
+  /**
+   * Absolute URL describing a network resource according to <a
+   * href="https://www.rfc-editor.org/rfc/rfc3986">RFC3986</a>
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>For network calls, URL usually has {@code scheme://host[:port][path][?query][#fragment]}
+   *       format, where the fragment is not transmitted over HTTP, but if it is known, it should be
+   *       included nevertheless. {@code url.full} MUST NOT contain credentials passed via URL in
+   *       form of {@code https://username:password@www.example.com/}. In such case username and
+   *       password should be redacted and attribute's value should be {@code
+   *       https://REDACTED:REDACTED@www.example.com/}. {@code url.full} SHOULD capture the absolute
+   *       URL when it is available (or can be reconstructed) and SHOULD NOT be validated or
+   *       modified except for sanitizing purposes.
+   * </ul>
+   */
+  public static final AttributeKey<String> URL_FULL = stringKey("url.full");
+
+  /**
+   * The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.3">URI path</a> component
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>When missing, the value is assumed to be {@code /}
+   * </ul>
+   */
+  public static final AttributeKey<String> URL_PATH = stringKey("url.path");
+
+  /**
+   * The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.4">URI query</a> component
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Sensitive content provided in query string SHOULD be scrubbed when instrumentations can
+   *       identify it.
+   * </ul>
+   */
+  public static final AttributeKey<String> URL_QUERY = stringKey("url.query");
+
+  /** The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.5">URI fragment</a> component */
+  public static final AttributeKey<String> URL_FRAGMENT = stringKey("url.fragment");
+
+  /**
    * Value of the <a href="https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent">HTTP
    * User-Agent</a> header sent by the client.
    */
   public static final AttributeKey<String> USER_AGENT_ORIGINAL = stringKey("user_agent.original");
 
   // Enum definitions
-  public static final class HttpFlavorValues {
-    /** HTTP/1.0. */
-    public static final String HTTP_1_0 = "1.0";
-    /** HTTP/1.1. */
-    public static final String HTTP_1_1 = "1.1";
-    /** HTTP/2. */
-    public static final String HTTP_2_0 = "2.0";
-    /** HTTP/3. */
-    public static final String HTTP_3_0 = "3.0";
-    /** SPDY protocol. */
-    public static final String SPDY = "SPDY";
-    /** QUIC protocol. */
-    public static final String QUIC = "QUIC";
+  public static final class NetTransportValues {
+    /** ip_tcp. */
+    public static final String IP_TCP = "ip_tcp";
+    /** ip_udp. */
+    public static final String IP_UDP = "ip_udp";
+    /** Named or anonymous pipe. */
+    public static final String PIPE = "pipe";
+    /** In-process communication. */
+    public static final String INPROC = "inproc";
+    /** Something else (non IP-based). */
+    public static final String OTHER = "other";
+    /**
+     * @deprecated This item has been removed as of 1.13.0 of the semantic conventions.
+     */
+    @Deprecated public static final String IP = "ip";
+    /**
+     * @deprecated This item has been removed as of 1.13.0 of the semantic conventions.
+     */
+    @Deprecated public static final String UNIX = "unix";
 
-    private HttpFlavorValues() {}
+    private NetTransportValues() {}
+  }
+
+  public static final class NetSockFamilyValues {
+    /** IPv4 address. */
+    public static final String INET = "inet";
+    /** IPv6 address. */
+    public static final String INET6 = "inet6";
+    /** Unix domain socket path. */
+    public static final String UNIX = "unix";
+
+    private NetSockFamilyValues() {}
   }
 
   public static final class EventDomainValues {
@@ -1157,6 +1574,15 @@ public final class SemanticAttributes {
     public static final String K8S = "k8s";
 
     private EventDomainValues() {}
+  }
+
+  public static final class TypeValues {
+    /** Heap memory. */
+    public static final String HEAP = "heap";
+    /** Non-heap memory. */
+    public static final String NON_HEAP = "non_heap";
+
+    private TypeValues() {}
   }
 
   public static final class OpentracingRefTypeValues {
@@ -1271,6 +1697,8 @@ public final class SemanticAttributes {
     public static final String CLICKHOUSE = "clickhouse";
     /** Cloud Spanner. */
     public static final String SPANNER = "spanner";
+    /** Trino. */
+    public static final String TRINO = "trino";
 
     private DbSystemValues() {}
   }
@@ -1300,6 +1728,50 @@ public final class SemanticAttributes {
     public static final String LOCAL_SERIAL = "local_serial";
 
     private DbCassandraConsistencyLevelValues() {}
+  }
+
+  public static final class DbCosmosdbOperationTypeValues {
+    /** invalid. */
+    public static final String INVALID = "Invalid";
+    /** create. */
+    public static final String CREATE = "Create";
+    /** patch. */
+    public static final String PATCH = "Patch";
+    /** read. */
+    public static final String READ = "Read";
+    /** read_feed. */
+    public static final String READ_FEED = "ReadFeed";
+    /** delete. */
+    public static final String DELETE = "Delete";
+    /** replace. */
+    public static final String REPLACE = "Replace";
+    /** execute. */
+    public static final String EXECUTE = "Execute";
+    /** query. */
+    public static final String QUERY = "Query";
+    /** head. */
+    public static final String HEAD = "Head";
+    /** head_feed. */
+    public static final String HEAD_FEED = "HeadFeed";
+    /** upsert. */
+    public static final String UPSERT = "Upsert";
+    /** batch. */
+    public static final String BATCH = "Batch";
+    /** query_plan. */
+    public static final String QUERY_PLAN = "QueryPlan";
+    /** execute_javascript. */
+    public static final String EXECUTE_JAVASCRIPT = "ExecuteJavaScript";
+
+    private DbCosmosdbOperationTypeValues() {}
+  }
+
+  public static final class DbCosmosdbConnectionModeValues {
+    /** Gateway (HTTP) connections mode. */
+    public static final String GATEWAY = "gateway";
+    /** Direct connection. */
+    public static final String DIRECT = "direct";
+
+    private DbCosmosdbConnectionModeValues() {}
   }
 
   public static final class OtelStatusCodeValues {
@@ -1355,41 +1827,29 @@ public final class SemanticAttributes {
     private FaasInvokedProviderValues() {}
   }
 
-  public static final class NetTransportValues {
-    /** ip_tcp. */
-    public static final String IP_TCP = "ip_tcp";
-    /** ip_udp. */
-    public static final String IP_UDP = "ip_udp";
+  public static final class NetworkTransportValues {
+    /** TCP. */
+    public static final String TCP = "tcp";
+    /** UDP. */
+    public static final String UDP = "udp";
     /** Named or anonymous pipe. See note below. */
     public static final String PIPE = "pipe";
-    /** In-process communication. */
-    public static final String INPROC = "inproc";
-    /** Something else (non IP-based). */
-    public static final String OTHER = "other";
-    /**
-     * @deprecated This item has been removed as of 1.13.0 of the semantic conventions.
-     */
-    @Deprecated public static final String IP = "ip";
-    /**
-     * @deprecated This item has been removed as of 1.13.0 of the semantic conventions.
-     */
-    @Deprecated public static final String UNIX = "unix";
-
-    private NetTransportValues() {}
-  }
-
-  public static final class NetSockFamilyValues {
-    /** IPv4 address. */
-    public static final String INET = "inet";
-    /** IPv6 address. */
-    public static final String INET6 = "inet6";
-    /** Unix domain socket path. */
+    /** Unix domain socket. */
     public static final String UNIX = "unix";
 
-    private NetSockFamilyValues() {}
+    private NetworkTransportValues() {}
   }
 
-  public static final class NetHostConnectionTypeValues {
+  public static final class NetworkTypeValues {
+    /** IPv4. */
+    public static final String IPV4 = "ipv4";
+    /** IPv6. */
+    public static final String IPV6 = "ipv6";
+
+    private NetworkTypeValues() {}
+  }
+
+  public static final class NetworkConnectionTypeValues {
     /** wifi. */
     public static final String WIFI = "wifi";
     /** wired. */
@@ -1401,10 +1861,10 @@ public final class SemanticAttributes {
     /** unknown. */
     public static final String UNKNOWN = "unknown";
 
-    private NetHostConnectionTypeValues() {}
+    private NetworkConnectionTypeValues() {}
   }
 
-  public static final class NetHostConnectionSubtypeValues {
+  public static final class NetworkConnectionSubtypeValues {
     /** GPRS. */
     public static final String GPRS = "gprs";
     /** EDGE. */
@@ -1448,7 +1908,7 @@ public final class SemanticAttributes {
     /** LTE CA. */
     public static final String LTE_CA = "lte_ca";
 
-    private NetHostConnectionSubtypeValues() {}
+    private NetworkConnectionSubtypeValues() {}
   }
 
   public static final class GraphqlOperationTypeValues {
@@ -1460,24 +1920,6 @@ public final class SemanticAttributes {
     public static final String SUBSCRIPTION = "subscription";
 
     private GraphqlOperationTypeValues() {}
-  }
-
-  public static final class MessagingDestinationKindValues {
-    /** A message sent to a queue. */
-    public static final String QUEUE = "queue";
-    /** A message sent to a topic. */
-    public static final String TOPIC = "topic";
-
-    private MessagingDestinationKindValues() {}
-  }
-
-  public static final class MessagingSourceKindValues {
-    /** A message received from a queue. */
-    public static final String QUEUE = "queue";
-    /** A message received from a topic. */
-    public static final String TOPIC = "topic";
-
-    private MessagingSourceKindValues() {}
   }
 
   public static final class MessagingOperationValues {


### PR DESCRIPTION
Semantic conventions moved to [open-telemetry/semantic-conventions](https://github.com/open-telemetry/semantic-conventions).

Should keep this as a draft until the first release from the new repo.