### PR TITLE
Fix broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ with a few exceptions / comments:
   the API / SDK to function in key areas of the Java ecosystem. Inclusion is subject to maintainers'
   discretion.
 * The [semconv](./semconv) module contains generated classes representing
-  the [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/semantic_conventions).
+  the [semantic conventions](https://github.com/open-telemetry/semantic-conventions).
 * As a general rule, components which implement semantic conventions belong elsewhere.
 
 Other repositories in the OpenTelemetry Java ecosystem include:


### PR DESCRIPTION
The build is [broken](https://github.com/open-telemetry/opentelemetry-java/actions/runs/4962968173/jobs/8881688794?pr=5443) after the recent move of the semantic convention repo to [open-telemetry/semantic-conventions](https://github.com/open-telemetry/semantic-conventions).