### PR TITLE
add additional attributes to metric

### DIFF
--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/metrics/ConfigurableMetricAttributesProvider.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/metrics/ConfigurableMetricAttributesProvider.java
@@ -9,14 +9,11 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 
 /**
- * A service provider interface (SPI) for providing additional attributes that can be used with the View AttributeProcessor.
- *
+ * A service provider interface (SPI) for providing additional attributes that can be used with the
+ * View AttributeProcessor.
  */
 public interface ConfigurableMetricAttributesProvider {
 
-  /**
-   * Returns a {@link Attributes} that can be added to OpenTelemetry view AttributeProcessor
-   */
+  /** Returns a {@link Attributes} that can be added to OpenTelemetry view AttributeProcessor */
   Attributes addCustomAttributes(ConfigProperties config);
-
 }

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/metrics/ConfigurableMetricAttributesProvider.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/metrics/ConfigurableMetricAttributesProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure.spi.metrics;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+
+/**
+ * A service provider interface (SPI) for providing additional attributes that can be used with the View AttributeProcessor.
+ *
+ */
+public interface ConfigurableMetricAttributesProvider {
+
+  /**
+   * Returns a {@link Attributes} that can be added to OpenTelemetry view AttributeProcessor
+   */
+  Attributes addCustomAttributes(ConfigProperties config);
+
+}

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/metric/viewconfig/ViewConfigCustomizer.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/metric/viewconfig/ViewConfigCustomizer.java
@@ -29,6 +29,7 @@ public final class ViewConfigCustomizer implements AutoConfigurationCustomizerPr
       SdkMeterProviderBuilder meterProviderBuilder, ConfigProperties configProperties) {
     List<String> configFileLocations =
         configProperties.getList("otel.experimental.metrics.view.config");
+    boolean additionAttrsEnable = configProperties.getBoolean("otel.experimental.metrics.view.additional.enable",true);
     for (String configFileLocation : configFileLocations) {
       if (configFileLocation.startsWith("classpath:")) {
         String classpathLocation = configFileLocation.substring("classpath:".length());
@@ -41,7 +42,12 @@ public final class ViewConfigCustomizer implements AutoConfigurationCustomizerPr
                     + " not found on classpath of classloader "
                     + ViewConfigCustomizer.class.getClassLoader().getClass().getName());
           }
-          ViewConfig.registerViews(meterProviderBuilder, inputStream);
+          if (additionAttrsEnable) {
+            ViewConfig.registerViews(meterProviderBuilder,inputStream,configProperties);
+          } else {
+            ViewConfig.registerViews(meterProviderBuilder, inputStream);
+          }
+
         } catch (IOException e) {
           throw new ConfigurationException(
               "An error occurred reading view config resource on classpath: " + classpathLocation,
@@ -49,7 +55,11 @@ public final class ViewConfigCustomizer implements AutoConfigurationCustomizerPr
         }
       } else {
         try (FileInputStream fileInputStream = new FileInputStream(configFileLocation)) {
-          ViewConfig.registerViews(meterProviderBuilder, fileInputStream);
+          if (additionAttrsEnable) {
+            ViewConfig.registerViews(meterProviderBuilder,fileInputStream,configProperties);
+          } else {
+            ViewConfig.registerViews(meterProviderBuilder, fileInputStream);
+          }
         } catch (FileNotFoundException e) {
           throw new ConfigurationException("View config file not found: " + configFileLocation, e);
         } catch (IOException e) {

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/metric/viewconfig/CustomConfigurableAttributesProvider.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/metric/viewconfig/CustomConfigurableAttributesProvider.java
@@ -1,0 +1,14 @@
+package io.opentelemetry.sdk.extension.incubator.metric.viewconfig;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricAttributesProvider;
+
+
+public class CustomConfigurableAttributesProvider implements ConfigurableMetricAttributesProvider {
+  @Override
+  public Attributes addCustomAttributes(ConfigProperties config) {
+    return Attributes.of(AttributeKey.stringKey("foo"),"val");
+  }
+}

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/metric/viewconfig/ViewConfigAdditionalTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/metric/viewconfig/ViewConfigAdditionalTest.java
@@ -1,0 +1,59 @@
+package io.opentelemetry.sdk.extension.incubator.metric.viewconfig;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.attributeEntry;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import org.junit.jupiter.api.Test;
+
+public class ViewConfigAdditionalTest {
+
+  @Test
+  public void testViewConfigAdditionAttrs() {
+    InMemoryMetricReader reader = InMemoryMetricReader.create();
+    AutoConfiguredOpenTelemetrySdk.builder()
+        .setResultAsGlobal(false)
+        .addPropertiesSupplier(
+            () ->
+                ImmutableMap.of(
+                    "otel.traces.exporter",
+                    "none",
+                    "otel.metrics.exporter",
+                    "none",
+                    "otel.experimental.metrics.view.config",
+                    "classpath:/view-config-customizer-test.yaml"))
+        .addMeterProviderCustomizer(
+            (meterProviderBuilder, configProperties) ->
+                meterProviderBuilder.registerMetricReader(reader))
+        .build()
+        .getOpenTelemetrySdk()
+        .getSdkMeterProvider()
+        .get("test-meter")
+        .counterBuilder("counter")
+        .buildWithCallback(
+            callback -> {
+              // Attributes with keys baz and qux should be filtered out
+              callback.record(
+                  1,
+                  Attributes.builder()
+                      .build());
+            });
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactly(
+            metricData ->
+                OpenTelemetryAssertions.assertThat(metricData)
+                    .hasLongSumSatisfying(
+                        sum ->
+                            sum.hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(1)
+                                        .hasAttributes(
+                                            attributeEntry("foo", "val")))));
+  }
+}

--- a/sdk-extensions/incubator/src/test/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricAttributesProvider
+++ b/sdk-extensions/incubator/src/test/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricAttributesProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.sdk.extension.incubator.metric.viewconfig.CustomConfigurableAttributesProvider

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/SdkMeterProviderUtil.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/SdkMeterProviderUtil.java
@@ -69,6 +69,10 @@ public final class SdkMeterProviderUtil {
     appendFilteredBaggageAttributes(viewBuilder, StringPredicates.ALL);
   }
 
+  public static void appendAdditionalAttributes(ViewBuilder viewBuilder,AttributesProcessor attributesProcessor) {
+    addAttributesProcessor(viewBuilder,attributesProcessor);
+  }
+
   private static void addAttributesProcessor(
       ViewBuilder viewBuilder, AttributesProcessor attributesProcessor) {
     try {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/SdkMeterProviderUtil.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/SdkMeterProviderUtil.java
@@ -69,8 +69,9 @@ public final class SdkMeterProviderUtil {
     appendFilteredBaggageAttributes(viewBuilder, StringPredicates.ALL);
   }
 
-  public static void appendAdditionalAttributes(ViewBuilder viewBuilder,AttributesProcessor attributesProcessor) {
-    addAttributesProcessor(viewBuilder,attributesProcessor);
+  public static void appendAdditionalAttributes(
+      ViewBuilder viewBuilder, AttributesProcessor attributesProcessor) {
+    addAttributesProcessor(viewBuilder, attributesProcessor);
   }
 
   private static void addAttributesProcessor(


### PR DESCRIPTION
Sometimes, we need to add extra properties to the metrics, but I can't add it via auto Instrumentation,so I define a SPI ```ConfigurableMetricAttributesProvider```, it returns ```Attributes```, you can implement it yourself, When registering the view, we call the SPI interface to get the extra attributes and then add it to the ```AttributeProcessor```