### PR TITLE
Add a `hasBucketBoundaries()` variant that allows specifying precision

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
@@ -1,4 +1,7 @@
 Comparing source compatibility of  against 
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.HistogramPointAssert  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.HistogramPointAssert hasBucketBoundaries(double[], org.assertj.core.data.Offset)
 +++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.LogRecordDataAssert  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LogRecordDataAssert hasAttributes(io.opentelemetry.api.common.Attributes)

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/HistogramPointAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/HistogramPointAssert.java
@@ -12,6 +12,7 @@ import io.opentelemetry.sdk.metrics.data.HistogramPointData;
 import java.util.Arrays;
 import java.util.function.Consumer;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.data.Offset;
 
 /**
  * Test assertions for {@link HistogramPointData}.
@@ -71,6 +72,20 @@ public final class HistogramPointAssert
     isNotNull();
     Double[] bigBoundaries = Arrays.stream(boundaries).boxed().toArray(Double[]::new);
     Assertions.assertThat(actual.getBoundaries()).as("boundaries").containsExactly(bigBoundaries);
+    return this;
+  }
+
+  /**
+   * Asserts the {@code boundaries} field matches the expected value. The boundaries are may vary
+   * with a specified precision.
+   *
+   * @param boundaries The set of bucket boundaries in the same order as the expected collection.
+   * @param precision The precision under which boundaries may vary.
+   */
+  public HistogramPointAssert hasBucketBoundaries(double[] boundaries, Offset<Double> precision) {
+    isNotNull();
+    double[] actualBoundaries = actual.getBoundaries().stream().mapToDouble(d -> d).toArray();
+    Assertions.assertThat(actualBoundaries).as("boundaries").containsExactly(boundaries, precision);
     return this;
   }
 

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/HistogramPointAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/HistogramPointAssert.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.testing.assertj;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.HistogramPointData;
@@ -69,10 +70,7 @@ public final class HistogramPointAssert
    * @param boundaries The set of bucket boundaries in the same order as the expected collection.
    */
   public HistogramPointAssert hasBucketBoundaries(double... boundaries) {
-    isNotNull();
-    Double[] bigBoundaries = Arrays.stream(boundaries).boxed().toArray(Double[]::new);
-    Assertions.assertThat(actual.getBoundaries()).as("boundaries").containsExactly(bigBoundaries);
-    return this;
+    return hasBucketBoundaries(boundaries, within(0.000_001));
   }
 
   /**

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/MetricAssertionsTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/MetricAssertionsTest.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equal
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.offset;
+import static org.assertj.core.api.Assertions.within;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -981,7 +982,8 @@ class MetricAssertionsTest {
                                 .hasMax(7.0)
                                 .hasMin(4.0)
                                 .hasCount(3)
-                                .hasBucketBoundaries(10.0)));
+                                .hasBucketBoundaries(10.0)
+                                .hasBucketBoundaries(new double[] {10.1}, within(0.1))));
     assertThat(HISTOGRAM_METRIC_DELTA).hasHistogramSatisfying(histogram -> histogram.isDelta());
   }
 
@@ -1043,6 +1045,15 @@ class MetricAssertionsTest {
                         histogram ->
                             histogram.hasPointsSatisfying(
                                 point -> point.hasBucketBoundaries(11.0))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(HISTOGRAM_METRIC)
+                    .hasHistogramSatisfying(
+                        histogram ->
+                            histogram.hasPointsSatisfying(
+                                point ->
+                                    point.hasBucketBoundaries(new double[] {11.0}, within(0.1)))))
         .isInstanceOf(AssertionError.class);
   }
 


### PR DESCRIPTION
I ran into some issues with double metrics precision in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8490#discussion_r1193622265, figured we might as well add a method varian that allows passing `Offset`