### PR TITLE
Ensure correct compiled output and sources are included in multi version jar

### DIFF
--- a/sdk/common/build.gradle.kts
+++ b/sdk/common/build.gradle.kts
@@ -1,4 +1,5 @@
 import io.opentelemetry.gradle.OtelVersionClassPlugin
+import kotlin.script.experimental.jvm.JvmScriptEvaluationConfigurationBuilder.Companion.invoke
 
 plugins {
   id("otel.java-conventions")
@@ -63,9 +64,17 @@ for (version in mrJarVersions) {
 
 tasks {
   withType(Jar::class) {
+    val sourcePathProvider = if (name.equals("jar")) {
+      { ss: SourceSet? -> ss?.output }
+    } else if (name.equals("sourcesJar")) {
+      { ss: SourceSet? -> ss?.java }
+    } else {
+      { _: SourceSet -> project.objects.fileCollection() }
+    }
+
     for (version in mrJarVersions) {
       into("META-INF/versions/$version") {
-        from(sourceSets["java$version"].output)
+        from(sourcePathProvider(sourceSets["java$version"]))
       }
     }
     manifest.attributes(

--- a/sdk/common/build.gradle.kts
+++ b/sdk/common/build.gradle.kts
@@ -1,5 +1,4 @@
 import io.opentelemetry.gradle.OtelVersionClassPlugin
-import kotlin.script.experimental.jvm.JvmScriptEvaluationConfigurationBuilder.Companion.invoke
 
 plugins {
   id("otel.java-conventions")


### PR DESCRIPTION
Fixes #5474.

`opentelemetry-sdk-common` publishes is a multi-version jar. It looks like the sources and javadoc jars incorrectly include compiled class files. This fixes that, including the correct files in each the respective jars.