### PR TITLE
Add meaningful `.toString` to `NoopLogRecordProcessor` and `DefaultOpenTelemetry`

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/DefaultOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/DefaultOpenTelemetry.java
@@ -46,4 +46,9 @@ final class DefaultOpenTelemetry implements OpenTelemetry {
   public ContextPropagators getPropagators() {
     return propagators;
   }
+
+  @Override
+  public String toString() {
+    return "DefaultOpenTelemetry{" + "propagators=" + propagators + "}";
+  }
 }

--- a/api/all/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
@@ -85,6 +85,15 @@ class OpenTelemetryTest {
         .hasStackTraceContaining("getOpenTelemetry");
   }
 
+  @Test
+  void toString_noop_Valid() {
+    assertThat(OpenTelemetry.noop().toString())
+        .isEqualTo(
+            "DefaultOpenTelemetry{"
+                + "propagators=DefaultContextPropagators{textMapPropagator=NoopTextMapPropagator}"
+                + "}");
+  }
+
   private static void setOpenTelemetry() {
     GlobalOpenTelemetry.set(OpenTelemetry.noop());
   }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/NoopLogRecordProcessor.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/NoopLogRecordProcessor.java
@@ -18,4 +18,9 @@ final class NoopLogRecordProcessor implements LogRecordProcessor {
 
   @Override
   public void onEmit(Context context, ReadWriteLogRecord logRecord) {}
+
+  @Override
+  public String toString() {
+    return "NoopLogRecordProcessor";
+  }
 }

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/NoopLogRecordProcessorTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/NoopLogRecordProcessorTest.java
@@ -25,4 +25,9 @@ class NoopLogRecordProcessorTest {
     assertThat(logRecordProcessor.forceFlush().isSuccess()).isEqualTo(true);
     assertThat(logRecordProcessor.shutdown().isSuccess()).isEqualTo(true);
   }
+
+  @Test
+  void toString_Valid() {
+    assertThat(NoopLogRecordProcessor.getInstance().toString()).isEqualTo("NoopLogRecordProcessor");
+  }
 }


### PR DESCRIPTION
A small improvement. The behavior is similar to https://github.com/open-telemetry/opentelemetry-java/blob/93bcdf28706c1b6830394dc3a6d4dae1844e1c90/context/src/main/java/io/opentelemetry/context/propagation/NoopTextMapPropagator.java#L36-L39