### PR TITLE
Reset exponential aggregator scale after collection

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleBase2ExponentialHistogramAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleBase2ExponentialHistogramAggregator.java
@@ -78,6 +78,7 @@ public final class DoubleBase2ExponentialHistogramAggregator
   static final class Handle
       extends AggregatorHandle<ExponentialHistogramPointData, DoubleExemplarData> {
     private final int maxBuckets;
+    private final int maxScale;
     @Nullable private DoubleBase2ExponentialHistogramBuckets positiveBuckets;
     @Nullable private DoubleBase2ExponentialHistogramBuckets negativeBuckets;
     private long zeroCount;
@@ -85,17 +86,18 @@ public final class DoubleBase2ExponentialHistogramAggregator
     private double min;
     private double max;
     private long count;
-    private int scale;
+    private int currentScale;
 
     Handle(ExemplarReservoir<DoubleExemplarData> reservoir, int maxBuckets, int maxScale) {
       super(reservoir);
       this.maxBuckets = maxBuckets;
+      this.maxScale = maxScale;
       this.sum = 0;
       this.zeroCount = 0;
       this.min = Double.MAX_VALUE;
       this.max = -1;
       this.count = 0;
-      this.scale = maxScale;
+      this.currentScale = maxScale;
     }
 
     @Override
@@ -107,15 +109,15 @@ public final class DoubleBase2ExponentialHistogramAggregator
         boolean reset) {
       ExponentialHistogramPointData point =
           ImmutableExponentialHistogramPointData.create(
-              scale,
+              currentScale,
               sum,
               zeroCount,
               this.count > 0,
               this.min,
               this.count > 0,
               this.max,
-              resolveBuckets(this.positiveBuckets, scale, reset),
-              resolveBuckets(this.negativeBuckets, scale, reset),
+              resolveBuckets(this.positiveBuckets, currentScale, reset),
+              resolveBuckets(this.negativeBuckets, currentScale, reset),
               startEpochNanos,
               epochNanos,
               attributes,
@@ -126,18 +128,19 @@ public final class DoubleBase2ExponentialHistogramAggregator
         this.min = Double.MAX_VALUE;
         this.max = -1;
         this.count = 0;
+        this.currentScale = maxScale;
       }
       return point;
     }
 
-    private static ExponentialHistogramBuckets resolveBuckets(
+    private ExponentialHistogramBuckets resolveBuckets(
         @Nullable DoubleBase2ExponentialHistogramBuckets buckets, int scale, boolean reset) {
       if (buckets == null) {
         return EmptyExponentialHistogramBuckets.get(scale);
       }
       ExponentialHistogramBuckets copy = buckets.copy();
       if (reset) {
-        buckets.clear();
+        buckets.clear(maxScale);
       }
       return copy;
     }
@@ -163,13 +166,13 @@ public final class DoubleBase2ExponentialHistogramAggregator
       } else if (c > 0) {
         // Initialize positive buckets at current scale, if needed
         if (positiveBuckets == null) {
-          positiveBuckets = new DoubleBase2ExponentialHistogramBuckets(scale, maxBuckets);
+          positiveBuckets = new DoubleBase2ExponentialHistogramBuckets(currentScale, maxBuckets);
         }
         buckets = positiveBuckets;
       } else {
         // Initialize negative buckets at current scale, if needed
         if (negativeBuckets == null) {
-          negativeBuckets = new DoubleBase2ExponentialHistogramBuckets(scale, maxBuckets);
+          negativeBuckets = new DoubleBase2ExponentialHistogramBuckets(currentScale, maxBuckets);
         }
         buckets = negativeBuckets;
       }
@@ -195,11 +198,11 @@ public final class DoubleBase2ExponentialHistogramAggregator
     void downScale(int by) {
       if (positiveBuckets != null) {
         positiveBuckets.downscale(by);
-        scale = positiveBuckets.getScale();
+        currentScale = positiveBuckets.getScale();
       }
       if (negativeBuckets != null) {
         negativeBuckets.downscale(by);
-        scale = negativeBuckets.getScale();
+        currentScale = negativeBuckets.getScale();
       }
     }
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleBase2ExponentialHistogramBuckets.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleBase2ExponentialHistogramBuckets.java
@@ -45,9 +45,11 @@ final class DoubleBase2ExponentialHistogramBuckets implements ExponentialHistogr
     return new DoubleBase2ExponentialHistogramBuckets(this);
   }
 
-  /** Resets all counters in this bucket set to zero, but preserves scale. */
-  void clear() {
+  /** Resets all counters in this bucket set to zero and resets the scale to {@code scale}. */
+  void clear(int scale) {
     this.totalCount = 0;
+    this.scale = scale;
+    this.base2ExponentialHistogramIndexer = Base2ExponentialHistogramIndexer.get(this.scale);
     this.counts.clear();
   }
 

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkLongHistogramTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkLongHistogramTest.java
@@ -34,12 +34,12 @@ class SdkLongHistogramTest {
   private static final InstrumentationScopeInfo INSTRUMENTATION_SCOPE_INFO =
       InstrumentationScopeInfo.create(SdkLongHistogramTest.class.getName());
   private final TestClock testClock = TestClock.create();
-  private final InMemoryMetricReader sdkMeterReader = InMemoryMetricReader.create();
+  private final InMemoryMetricReader reader = InMemoryMetricReader.create();
   private final SdkMeterProvider sdkMeterProvider =
       SdkMeterProvider.builder()
           .setClock(testClock)
           .setResource(RESOURCE)
-          .registerMetricReader(sdkMeterReader)
+          .registerMetricReader(reader)
           .build();
   private final Meter sdkMeter = sdkMeterProvider.get(getClass().getName());
 
@@ -56,7 +56,7 @@ class SdkLongHistogramTest {
   @Test
   void collectMetrics_NoRecords() {
     sdkMeter.histogramBuilder("testHistogram").ofLongs().build();
-    assertThat(sdkMeterReader.collectAllMetrics()).isEmpty();
+    assertThat(reader.collectAllMetrics()).isEmpty();
   }
 
   @Test
@@ -71,7 +71,7 @@ class SdkLongHistogramTest {
     testClock.advance(Duration.ofNanos(SECOND_NANOS));
     longHistogram.record(12, Attributes.empty());
     longHistogram.record(12);
-    assertThat(sdkMeterReader.collectAllMetrics())
+    assertThat(reader.collectAllMetrics())
         .satisfiesExactly(
             metric ->
                 assertThat(metric)
@@ -110,7 +110,7 @@ class SdkLongHistogramTest {
     testClock.advance(Duration.ofNanos(SECOND_NANOS));
     longHistogram.record(321, Attributes.builder().put("K", "V").build());
     longHistogram.record(1, Attributes.builder().put("K", "V").build());
-    assertThat(sdkMeterReader.collectAllMetrics())
+    assertThat(reader.collectAllMetrics())
         .satisfiesExactly(
             metric ->
                 assertThat(metric)
@@ -143,7 +143,7 @@ class SdkLongHistogramTest {
     testClock.advance(Duration.ofNanos(SECOND_NANOS));
     longHistogram.record(222, Attributes.builder().put("K", "V").build());
     longHistogram.record(17, Attributes.empty());
-    assertThat(sdkMeterReader.collectAllMetrics())
+    assertThat(reader.collectAllMetrics())
         .satisfiesExactly(
             metric ->
                 assertThat(metric)
@@ -173,13 +173,180 @@ class SdkLongHistogramTest {
                                         .hasAttributes(Attributes.empty()))));
   }
 
+  /**
+   * Verify that the exponential histogram scale behaves properly after collection with delta and
+   * cumulative readers.
+   */
+  @Test
+  void collectMetrics_ExponentialHistogramScaleResets() {
+    InMemoryMetricReader deltaReader = InMemoryMetricReader.createDelta();
+    InMemoryMetricReader cumulativeReader = InMemoryMetricReader.create();
+
+    SdkMeterProvider sdkMeterProvider =
+        SdkMeterProvider.builder()
+            .registerMetricReader(cumulativeReader)
+            .registerMetricReader(deltaReader)
+            .registerView(
+                InstrumentSelector.builder().setType(InstrumentType.HISTOGRAM).build(),
+                View.builder()
+                    .setAggregation(Aggregation.base2ExponentialBucketHistogram(5, 20))
+                    .build())
+            .build();
+
+    Meter meter = sdkMeterProvider.get(getClass().getName());
+
+    LongHistogram histogram = meter.histogramBuilder("histogram").ofLongs().build();
+    Attributes attributes1 = Attributes.builder().put("key", "value1").build();
+    Attributes attributes2 = Attributes.builder().put("key", "value2").build();
+
+    // Record 2 measurement to attributes1 such that scale changes, 1 measurement to attributes2
+    // such that scale doesn't change.
+    histogram.record(1, attributes1);
+    histogram.record(10, attributes1);
+    histogram.record(1, attributes2);
+
+    // Both deltaReader and cumulativeReader should read out the same values, with the attributes1
+    // point having a scale that accommodates the range of measurements.
+    assertThat(deltaReader.collectAllMetrics())
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasName("histogram")
+                    .hasExponentialHistogramSatisfying(
+                        expHistogram ->
+                            expHistogram
+                                .isDelta()
+                                .hasPointsSatisfying(
+                                    point ->
+                                        point
+                                            .hasAttributes(attributes1)
+                                            .hasScale(0)
+                                            .hasPositiveBucketsSatisfying(
+                                                buckets ->
+                                                    buckets
+                                                        .hasOffset(-1)
+                                                        .hasCounts(
+                                                            Arrays.asList(1L, 0L, 0L, 0L, 1L))),
+                                    point ->
+                                        point
+                                            .hasAttributes(attributes2)
+                                            .hasScale(20)
+                                            .hasPositiveBucketsSatisfying(
+                                                buckets ->
+                                                    buckets
+                                                        .hasOffset(-1)
+                                                        .hasCounts(
+                                                            Collections.singletonList(1L))))));
+    assertThat(cumulativeReader.collectAllMetrics())
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasName("histogram")
+                    .hasExponentialHistogramSatisfying(
+                        expHistogram ->
+                            expHistogram
+                                .isCumulative()
+                                .hasPointsSatisfying(
+                                    point ->
+                                        point
+                                            .hasAttributes(attributes1)
+                                            .hasScale(0)
+                                            .hasPositiveBucketsSatisfying(
+                                                buckets ->
+                                                    buckets
+                                                        .hasOffset(-1)
+                                                        .hasCounts(
+                                                            Arrays.asList(1L, 0L, 0L, 0L, 1L))),
+                                    point ->
+                                        point
+                                            .hasAttributes(attributes2)
+                                            .hasScale(20)
+                                            .hasPositiveBucketsSatisfying(
+                                                buckets ->
+                                                    buckets
+                                                        .hasOffset(-1)
+                                                        .hasCounts(
+                                                            Collections.singletonList(1L))))));
+
+    // Record 1 measurement to attributes1 such that scale doesn't change, 2 measurement to
+    // attributes2 such that scale changes.
+    histogram.record(1, attributes1);
+    histogram.record(1, attributes2);
+    histogram.record(10, attributes2);
+
+    // The deltaReader should have points reflecting a reset to the maxScale. The attributes1 point
+    // now has scale 20, the attributes2 point now has scale 0 to accommodate the range of
+    // measurements.
+    assertThat(deltaReader.collectAllMetrics())
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasName("histogram")
+                    .hasExponentialHistogramSatisfying(
+                        expHistogram ->
+                            expHistogram
+                                .isDelta()
+                                .hasPointsSatisfying(
+                                    point ->
+                                        point
+                                            .hasAttributes(attributes1)
+                                            .hasScale(20)
+                                            .hasPositiveBucketsSatisfying(
+                                                buckets ->
+                                                    buckets
+                                                        .hasOffset(-1)
+                                                        .hasCounts(Collections.singletonList(1L))),
+                                    point ->
+                                        point
+                                            .hasAttributes(attributes2)
+                                            .hasScale(0)
+                                            .hasPositiveBucketsSatisfying(
+                                                buckets ->
+                                                    buckets
+                                                        .hasOffset(-1)
+                                                        .hasCounts(
+                                                            Arrays.asList(1L, 0L, 0L, 0L, 1L))))));
+    // The cumulativeReader does not reset after collection, so both attributes1 and attributes2
+    // points should now have scale 0.
+    assertThat(cumulativeReader.collectAllMetrics())
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasName("histogram")
+                    .hasExponentialHistogramSatisfying(
+                        expHistogram ->
+                            expHistogram
+                                .isCumulative()
+                                .hasPointsSatisfying(
+                                    point ->
+                                        point
+                                            .hasAttributes(attributes1)
+                                            .hasScale(0)
+                                            .hasPositiveBucketsSatisfying(
+                                                buckets ->
+                                                    buckets
+                                                        .hasOffset(-1)
+                                                        .hasCounts(
+                                                            Arrays.asList(2L, 0L, 0L, 0L, 1L))),
+                                    point ->
+                                        point
+                                            .hasAttributes(attributes2)
+                                            .hasScale(0)
+                                            .hasPositiveBucketsSatisfying(
+                                                buckets ->
+                                                    buckets
+                                                        .hasOffset(-1)
+                                                        .hasCounts(
+                                                            Arrays.asList(2L, 0L, 0L, 0L, 1L))))));
+  }
+
   @Test
   void collectMetrics_ExponentialHistogramAggregation() {
     SdkMeterProvider sdkMeterProvider =
         SdkMeterProvider.builder()
             .setResource(RESOURCE)
             .setClock(testClock)
-            .registerMetricReader(sdkMeterReader)
+            .registerMetricReader(reader)
             .registerView(
                 InstrumentSelector.builder().setType(InstrumentType.HISTOGRAM).build(),
                 View.builder()
@@ -198,7 +365,7 @@ class SdkLongHistogramTest {
     longHistogram.record(12L, Attributes.builder().put("key", "value").build());
     longHistogram.record(12L);
     longHistogram.record(13L);
-    assertThat(sdkMeterReader.collectAllMetrics())
+    assertThat(reader.collectAllMetrics())
         .satisfiesExactly(
             metric ->
                 assertThat(metric)
@@ -263,7 +430,7 @@ class SdkLongHistogramTest {
   void longHistogramRecord_NonNegativeCheck() {
     LongHistogram histogram = sdkMeter.histogramBuilder("testHistogram").ofLongs().build();
     histogram.record(-45);
-    assertThat(sdkMeterReader.collectAllMetrics()).hasSize(0);
+    assertThat(reader.collectAllMetrics()).hasSize(0);
     logs.assertContains(
         "Histograms can only record non-negative values. Instrument testHistogram has recorded a negative value.");
   }
@@ -284,7 +451,7 @@ class SdkLongHistogramTest {
     }
 
     stressTestBuilder.build().run();
-    assertThat(sdkMeterReader.collectAllMetrics())
+    assertThat(reader.collectAllMetrics())
         .satisfiesExactly(
             metric ->
                 assertThat(metric)
@@ -324,7 +491,7 @@ class SdkLongHistogramTest {
                                 10, Attributes.builder().put(keys[i], values[i]).build()))));
 
     stressTestBuilder.build().run();
-    assertThat(sdkMeterReader.collectAllMetrics())
+    assertThat(reader.collectAllMetrics())
         .satisfiesExactly(
             metric ->
                 assertThat(metric)


### PR DESCRIPTION
@alanwest asked me whether or not the java exponential histogram aggregation resets the scale after collection when aggregation temporality is delta. I didn't know, and looking at the code realized that the current behavior in the java sdk has a bug. We do not reset the scale after collection when aggregation temporality is delta. This is a problem because we reuse the `DoubleBase2ExponentialHistogramAggregator` instances to reduce allocations. So an aggregator used for series `key=value1` could receive measurements that cause it be rescaled, then a collection moves that aggregator to the shared object pool. In the next collection window, that aggregator is unlikely to be assigned to to the same series `key=value1`, and thus might have a suboptimal scale assigned. By suboptimal, I mean that a higher scale (i.e. more granular buckets) could accommodate the range of measurements. 

This PR fixes that by resetting the scale of the pooled aggregator instances after collection when aggregation temporality is delta.