### PR TITLE
Publish build scans to ge.opentelemetry.io

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,8 @@ jobs:
             ${{ matrix.coverage && 'jacocoTestReport' || '' }}
             -PtestJavaVersion=${{ matrix.test-java-version }}
             -Porg.gradle.java.installations.paths=${{ steps.setup-java-test.outputs.path }},${{ steps.setup-java.outputs.path }}
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
       - name: Check for diff
         # The jApiCmp diff compares current to latest, which isn't appropriate for release branches

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -62,15 +62,42 @@ include(":sdk-extensions:incubator")
 include(":sdk-extensions:jaeger-remote-sampler")
 include(":testing-internal")
 
+val gradleEnterpriseServer = "https://ge.opentelemetry.io"
 val isCI = System.getenv("CI") != null
-gradleEnterprise {
-  buildScan {
-    termsOfServiceUrl = "https://gradle.com/terms-of-service"
-    termsOfServiceAgree = "yes"
+val geAccessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY") ?: ""
 
-    if (isCI) {
+// if GE access key is not given and we are in CI, then we publish to scans.gradle.com
+val useScansGradleCom = isCI && geAccessKey.isEmpty()
+
+if (useScansGradleCom) {
+  gradleEnterprise {
+    buildScan {
+      termsOfServiceUrl = "https://gradle.com/terms-of-service"
+      termsOfServiceAgree = "yes"
+      isUploadInBackground = !isCI
       publishAlways()
-      tag("CI")
+
+      capture {
+        isTaskInputFiles = true
+      }
+    }
+  }
+} else {
+  gradleEnterprise {
+    server = gradleEnterpriseServer
+    buildScan {
+      isUploadInBackground = !isCI
+
+      this as com.gradle.enterprise.gradleplugin.internal.extension.BuildScanExtensionWithHiddenFeatures
+      publishIfAuthenticated()
+      publishAlways()
+
+      capture {
+        isTaskInputFiles = true
+      }
+
+      gradle.startParameter.projectProperties["testJavaVersion"]?.let { tag(it) }
+      gradle.startParameter.projectProperties["testJavaVM"]?.let { tag(it) }
     }
   }
 }


### PR DESCRIPTION
I worked with @iNikem to obtain a set of credentials on https://ge.opentelemetry.io. One logged in, I could create an access token, which I've added as a secret for github actions under `GRADLE_ENTERPRISE_ACCESS_KEY`. 