### PR TITLE
Document github actions secrets

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -53,3 +53,14 @@ Same settings as above for `main`, except:
 * Allow deletions: CHECKED
 
   (So that bot PR branches can be deleted)
+
+## Secrets and variables > Actions
+
+* `GPG_PASSWORD` - stored in OpenTelemetry-Java 1Password
+* `GPG_PRIVATE_KEY` - stored in OpenTelemetry-Java 1Password
+* `GRADLE_ENTERPRISE_ACCESS_KEY` - owned by [@jack-berg](https://github.com/jack-berg)
+  * Generated at https://ge.opentelemetry.io > My settings > Access keys
+  * format of env var is `ge.opentelemetry.io=<access key>`,
+    see [docs](https://docs.gradle.com/enterprise/gradle-plugin/#via_environment_variable)
+* `SONATYPE_KEY` - owned by [@jack-berg](https://github.com/jack-berg)
+* `SONATYPE_USER` - owned by [@jack-berg](https://github.com/jack-berg)

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           NUMBER: ${{ github.event.inputs.number }}
           # not using secrets.GITHUB_TOKEN since pull requests from that token do not run workflows
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
         run: |
           commit=$(gh pr view $NUMBER --json mergeCommit --jq .mergeCommit.oid)
           title=$(gh pr view $NUMBER --json title --jq .title)

--- a/.github/workflows/prepare-patch-release.yml
+++ b/.github/workflows/prepare-patch-release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Create pull request
         env:
           # not using secrets.GITHUB_TOKEN since pull requests from that token do not run workflows
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
         run: |
           message="Prepare release $VERSION"
           branch="opentelemetrybot/prepare-release-${VERSION}"

--- a/.github/workflows/prepare-release-branch.yml
+++ b/.github/workflows/prepare-release-branch.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Create pull request against the release branch
         env:
           # not using secrets.GITHUB_TOKEN since pull requests from that token do not run workflows
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
         run: |
           message="Prepare release $VERSION"
           branch="opentelemetrybot/prepare-release-${VERSION}"
@@ -105,7 +105,7 @@ jobs:
       - name: Create pull request against main
         env:
           # not using secrets.GITHUB_TOKEN since pull requests from that token do not run workflows
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
         run: |
           message="Update version to $NEXT_VERSION"
           body="Update version to \`$NEXT_VERSION\`."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
         env:
           VERSION: ${{ needs.release.outputs.version }}
           # not using secrets.GITHUB_TOKEN since pull requests from that token do not run workflows
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
         run: |
           if git diff --quiet; then
             if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.0 ]]; then


### PR DESCRIPTION
TODO: delete unused `BOT_TOKEN` and `DOC_UPDATE_TOKEN` secrets.

Following the [good example](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/.github/repository-settings.md#secrets-and-variables--actions) from `opentelemetry-java-instrumentation`. 