### PR TITLE
Try to improve build scan reliability

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,11 @@ org.gradle.priority=low
 
 # Gradle default is 256m which causes issues with our build - https://docs.gradle.org/current/userguide/build_environment.html#sec:configuring_jvm_memory
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
+
+# Try to reduce CI failures due to maven central flakiness
+# in particular this has been a problem for maven-metadata.xml files, which are TTL'd quickly out of
+# the gradle cache since they contain the latest versions available in maven central
+systemProp.org.gradle.internal.http.connectionTimeout=120000
+systemProp.org.gradle.internal.http.socketTimeout=120000
+systemProp.org.gradle.internal.repository.max.retries=10
+systemProp.org.gradle.internal.repository.initial.backoff=500


### PR DESCRIPTION
Publishing build scans to ge.opentelemetry.io is very flaky right now. For example, on this [build](https://github.com/open-telemetry/opentelemetry-java/actions/runs/5260154929/jobs/9506673424), only 3 out of the 8 succeeded. The rest fail with messages like:
```
BUILD SUCCESSFUL in 1m 9s
756 actionable tasks: 209 executed, 429 from cache, 118 up-to-date

Publishing build scan...
Publishing build scan failed due to 'An unexpected error occurred creating your build scan.
Please report this problem at https://ge.opentelemetry.io/help, quoting the following reference code:
ywz4mtu7755ai' (2 retries remaining)...
Publishing build scan failed due to 'An unexpected error occurred creating your build scan.
Please report this problem at https://ge.opentelemetry.io/help, quoting the following reference code:
sydjdcozsej2c' (1 retry remaining)...

An unexpected error occurred creating your build scan.
Please report this problem at https://ge.opentelemetry.io/help, quoting the following reference code:
zrx4envzqyfj4
```

I noticed some settings in the opentelemetry-java-instrumentation `gradle.properties` file which I suspect help improve the reliability of these uploads.