### PR TITLE
Move environment resource to :sdk:all

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk.txt
@@ -1,2 +1,6 @@
 Comparing source compatibility of  against 
-No changes.
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.resources.EnvironmentResource  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.resources.Resource create(io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties)
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.resources.Resource get()

--- a/sdk-extensions/autoconfigure-spi/build.gradle.kts
+++ b/sdk-extensions/autoconfigure-spi/build.gradle.kts
@@ -7,12 +7,8 @@ description = "OpenTelemetry SDK Auto-configuration SPI"
 otelJava.moduleName.set("io.opentelemetry.sdk.autoconfigure.spi")
 
 dependencies {
-  api(project(":sdk:all"))
-
-  // implementation dependency to require users to add the artifact directly to their build to use
-  // SdkMeterProviderBuilder.
-  implementation(project(":sdk:metrics"))
-  // implementation dependency to require users to add the artifact directly to their build to use
-  // SdkLoggerProviderBuilder.
-  implementation(project(":sdk:logs"))
+  api(project(":sdk:common"))
+  api(project(":sdk:trace"))
+  api(project(":sdk:metrics"))
+  api(project(":sdk:logs"))
 }

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
@@ -7,12 +7,9 @@ package io.opentelemetry.sdk.autoconfigure;
 
 import static io.opentelemetry.sdk.autoconfigure.ResourceConfiguration.DISABLED_ATTRIBUTE_KEYS;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonMap;
 
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
@@ -44,66 +41,6 @@ class ResourceConfigurationTest {
                 .put("food", "cheesecake")
                 .setSchemaUrl(ResourceAttributes.SCHEMA_URL)
                 .build());
-  }
-
-  @Test
-  void resourceFromConfig_empty() {
-    Attributes attributes =
-        ResourceConfiguration.getAttributes(DefaultConfigProperties.createForTest(emptyMap()));
-
-    assertThat(attributes).isEmpty();
-  }
-
-  @Test
-  void resourceFromConfig() {
-    Attributes attributes =
-        ResourceConfiguration.getAttributes(
-            DefaultConfigProperties.createForTest(
-                singletonMap(
-                    ResourceConfiguration.ATTRIBUTE_PROPERTY,
-                    "service.name=myService,appName=MyApp")));
-
-    assertThat(attributes)
-        .hasSize(2)
-        .containsEntry(ResourceAttributes.SERVICE_NAME, "myService")
-        .containsEntry("appName", "MyApp");
-  }
-
-  @Test
-  void serviceName() {
-    Attributes attributes =
-        ResourceConfiguration.getAttributes(
-            DefaultConfigProperties.createForTest(
-                singletonMap(ResourceConfiguration.SERVICE_NAME_PROPERTY, "myService")));
-
-    assertThat(attributes).hasSize(1).containsEntry(ResourceAttributes.SERVICE_NAME, "myService");
-  }
-
-  @Test
-  void resourceFromConfig_overrideServiceName() {
-    Attributes attributes =
-        ResourceConfiguration.getAttributes(
-            DefaultConfigProperties.createForTest(
-                ImmutableMap.of(
-                    ResourceConfiguration.ATTRIBUTE_PROPERTY,
-                    "service.name=myService,appName=MyApp",
-                    ResourceConfiguration.SERVICE_NAME_PROPERTY,
-                    "ReallyMyService")));
-
-    assertThat(attributes)
-        .hasSize(2)
-        .containsEntry(ResourceAttributes.SERVICE_NAME, "ReallyMyService")
-        .containsEntry("appName", "MyApp");
-  }
-
-  @Test
-  void resourceFromConfig_emptyEnvVar() {
-    Attributes attributes =
-        ResourceConfiguration.getAttributes(
-            DefaultConfigProperties.createForTest(
-                singletonMap(ResourceConfiguration.ATTRIBUTE_PROPERTY, "")));
-
-    assertThat(attributes).isEmpty();
   }
 
   @Test

--- a/sdk/all/build.gradle.kts
+++ b/sdk/all/build.gradle.kts
@@ -16,10 +16,16 @@ dependencies {
   api(project(":sdk:trace"))
   api(project(":sdk:metrics"))
   api(project(":sdk:logs"))
+  api(project(":sdk-extensions:autoconfigure-spi"))
+
+  implementation(project(":semconv"))
 
   annotationProcessor("com.google.auto.value:auto-value")
 
   testAnnotationProcessor("com.google.auto.value:auto-value")
 
   testImplementation(project(":sdk:testing"))
+
+  testImplementation("com.google.guava:guava")
+  testImplementation("edu.berkeley.cs.jqf:jqf-fuzz")
 }

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/resources/EnvironmentResource.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/resources/EnvironmentResource.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.resources;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+
+/** Access resource derived from environment variables. */
+public final class EnvironmentResource {
+
+  // Visible for testing
+  static final String ATTRIBUTE_PROPERTY = "otel.resource.attributes";
+  static final String SERVICE_NAME_PROPERTY = "otel.service.name";
+
+  private static final Resource INSTANCE =
+      create(DefaultConfigProperties.create(Collections.emptyMap()));
+
+  /**
+   * Returns a new {@link Resource} from the environment. The resource contains attributes parsed
+   * from environment variables and system property keys {@code otel.resource.attributes} and {@code
+   * otel.service.name}.
+   *
+   * @return the resource
+   */
+  public static Resource get() {
+    return INSTANCE;
+  }
+
+  /**
+   * Create a new {@link Resource} from the environment by parsing the {@code config}. The resource
+   * contains attributes parsed from keys {@code otel.resource.attributes} and {@code
+   * otel.service.name}.
+   *
+   * @return the resource
+   */
+  public static Resource create(ConfigProperties configProperties) {
+    return Resource.create(getAttributes(configProperties), ResourceAttributes.SCHEMA_URL);
+  }
+
+  // visible for testing
+  static Attributes getAttributes(ConfigProperties configProperties) {
+    AttributesBuilder resourceAttributes = Attributes.builder();
+    try {
+      for (Map.Entry<String, String> entry :
+          configProperties.getMap(ATTRIBUTE_PROPERTY).entrySet()) {
+        resourceAttributes.put(
+            entry.getKey(),
+            // Attributes specified via otel.resource.attributes follow the W3C Baggage spec and
+            // characters outside the baggage-octet range are percent encoded
+            // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable
+            URLDecoder.decode(entry.getValue(), StandardCharsets.UTF_8.displayName()));
+      }
+    } catch (UnsupportedEncodingException e) {
+      // Should not happen since always using standard charset
+      throw new ConfigurationException("Unable to decode resource attributes.", e);
+    }
+    String serviceName = configProperties.getString(SERVICE_NAME_PROPERTY);
+    if (serviceName != null) {
+      resourceAttributes.put(ResourceAttributes.SERVICE_NAME, serviceName);
+    }
+    return resourceAttributes.build();
+  }
+
+  private EnvironmentResource() {}
+}

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/resources/internal/EnvironmentResourceProvider.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/resources/internal/EnvironmentResourceProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.resources.internal;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.sdk.resources.EnvironmentResource;
+import io.opentelemetry.sdk.resources.Resource;
+
+/** {@link ResourceProvider} for automatically configuring {@link EnvironmentResource}. */
+public final class EnvironmentResourceProvider implements ResourceProvider {
+  @Override
+  public Resource createResource(ConfigProperties config) {
+    return EnvironmentResource.create(config);
+  }
+
+  @Override
+  public int order() {
+    // A high order ensures that the environment resource takes precedent over the resources from
+    // other ResourceProviders
+    return 10;
+  }
+}

--- a/sdk/all/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
+++ b/sdk/all/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.sdk.resources.internal.EnvironmentResourceProvider

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/resources/EnvironmentResourceFuzzTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/resources/EnvironmentResourceFuzzTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.sdk.autoconfigure;
+package io.opentelemetry.sdk.resources;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static java.util.Collections.singletonMap;
@@ -15,12 +15,13 @@ import edu.berkeley.cs.jqf.fuzz.random.NoGuidance;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.internal.PercentEscaper;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.Result;
 import org.junit.runner.RunWith;
 
 @SuppressWarnings("SystemOut")
-class ResourceConfigurationFuzzTest {
+class EnvironmentResourceFuzzTest {
 
   @RunWith(JQF.class)
   public static class TestCases {
@@ -30,10 +31,10 @@ class ResourceConfigurationFuzzTest {
     @Fuzz
     public void getAttributesWithRandomValues(String value1, String value2) {
       Attributes attributes =
-          ResourceConfiguration.getAttributes(
+          EnvironmentResource.getAttributes(
               DefaultConfigProperties.createForTest(
                   singletonMap(
-                      ResourceConfiguration.ATTRIBUTE_PROPERTY,
+                      EnvironmentResource.ATTRIBUTE_PROPERTY,
                       "key1=" + escaper.escape(value1) + ",key2=" + escaper.escape(value2))));
 
       assertThat(attributes).hasSize(2).containsEntry("key1", value1).containsEntry("key2", value2);
@@ -51,6 +52,6 @@ class ResourceConfigurationFuzzTest {
             "getAttributesWithRandomValues",
             new NoGuidance(10000, System.out),
             System.out);
-    assertThat(result.wasSuccessful()).isTrue();
+    Assertions.assertThat(result.wasSuccessful()).isTrue();
   }
 }

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/resources/EnvironmentResourceTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/resources/EnvironmentResourceTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.resources;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+
+import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class EnvironmentResourceTest {
+
+  @Test
+  void customConfigResource() {
+    Map<String, String> props = new HashMap<>();
+    props.put("otel.service.name", "test-service");
+    props.put("otel.resource.attributes", "food=cheesecake,drink=juice");
+
+    assertThat(EnvironmentResource.create(DefaultConfigProperties.create(props)))
+        .isEqualTo(
+            Resource.empty().toBuilder()
+                .put(ResourceAttributes.SERVICE_NAME, "test-service")
+                .put("food", "cheesecake")
+                .put("drink", "juice")
+                .setSchemaUrl(ResourceAttributes.SCHEMA_URL)
+                .build());
+  }
+
+  @Test
+  void resourceFromConfig_empty() {
+    Attributes attributes =
+        EnvironmentResource.getAttributes(DefaultConfigProperties.createForTest(emptyMap()));
+
+    assertThat(attributes).isEmpty();
+  }
+
+  @Test
+  void resourceFromConfig() {
+    Attributes attributes =
+        EnvironmentResource.getAttributes(
+            DefaultConfigProperties.createForTest(
+                singletonMap(
+                    EnvironmentResource.ATTRIBUTE_PROPERTY,
+                    "service.name=myService,appName=MyApp")));
+
+    assertThat(attributes)
+        .hasSize(2)
+        .containsEntry(ResourceAttributes.SERVICE_NAME, "myService")
+        .containsEntry("appName", "MyApp");
+  }
+
+  @Test
+  void serviceName() {
+    Attributes attributes =
+        EnvironmentResource.getAttributes(
+            DefaultConfigProperties.createForTest(
+                singletonMap(EnvironmentResource.SERVICE_NAME_PROPERTY, "myService")));
+
+    assertThat(attributes).hasSize(1).containsEntry(ResourceAttributes.SERVICE_NAME, "myService");
+  }
+
+  @Test
+  void resourceFromConfig_overrideServiceName() {
+    Attributes attributes =
+        EnvironmentResource.getAttributes(
+            DefaultConfigProperties.createForTest(
+                ImmutableMap.of(
+                    EnvironmentResource.ATTRIBUTE_PROPERTY,
+                    "service.name=myService,appName=MyApp",
+                    EnvironmentResource.SERVICE_NAME_PROPERTY,
+                    "ReallyMyService")));
+
+    assertThat(attributes)
+        .hasSize(2)
+        .containsEntry(ResourceAttributes.SERVICE_NAME, "ReallyMyService")
+        .containsEntry("appName", "MyApp");
+  }
+
+  @Test
+  void resourceFromConfig_emptyEnvVar() {
+    Attributes attributes =
+        EnvironmentResource.getAttributes(
+            DefaultConfigProperties.createForTest(
+                singletonMap(EnvironmentResource.ATTRIBUTE_PROPERTY, "")));
+
+    assertThat(attributes).isEmpty();
+  }
+}


### PR DESCRIPTION
Another attempt to find the right home for environment resource logic. Related to #5464.

Summary of options:

- (option A) [opentelemetry-java-instrumentation#8604](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8604): Move to instrumentation.
  - Pros: All resource providers are in same place. No [awkward](#5500) move of ConfigProperties.
  - Cons: not aligned with spec which implies environment resource logic should live in core.
- (option B) [opentelemetry-java#5500](#5500): Move ConfigProperties, environment resource to `:sdk:common`.
  - Pros: Environment resource lives alongside core resource logic.
  - Cons: Moving ConfigProperties is awkward and will be hard to explain to users.
- (option c) [opentelemetry-java#5467](#5467): Keep environment resource in autoconfigure. Can adjust to add dedicated EnvironmentResource accessor class and corresponding ResourceProvider.
  - Pros: Simple. No [awkward](#5500) move of ConfigProperties.
  - Cons: autoconfigure doesn't contain any other SPI implementations. Feels weird to take autoconfigure dependency if only accessing EnvironmentResource programatically. Does living in autoconfigure meet the spirit of the specification?
- (option d) This PR: Move environment resource to `:sdk:all`.
  - Pros: Environment resource logic stays in java core repo, and doesn't require dependency on autoconfigure. No need for [awkward](#5500) move of ConfigProperties
  - Cons: Feels awkward to have this logic in `:sdk:all`. No other similar code lives there.

This seems like a pretty exhaustive set of options. Should try to pick our preferred solution so we can unblock stabilization of autoconfigure  (this is really the only thorny issue).

