### PR TITLE
Add public API to access environment resource

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/internal/EnvironmentResourceProvider.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/internal/EnvironmentResourceProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure.internal;
+
+import io.opentelemetry.sdk.autoconfigure.ResourceConfiguration;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.sdk.resources.Resource;
+
+/**
+ * {@link ResourceProvider} for automatically configuring {@link
+ * ResourceConfiguration#createEnvironmentResource(ConfigProperties)}.
+ */
+public final class EnvironmentResourceProvider implements ResourceProvider {
+  @Override
+  public Resource createResource(ConfigProperties config) {
+    return ResourceConfiguration.createEnvironmentResource(config);
+  }
+
+  @Override
+  public int order() {
+    // Environment resource takes precedent over all other ResourceProviders
+    return Integer.MAX_VALUE;
+  }
+}

--- a/sdk-extensions/autoconfigure/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
+++ b/sdk-extensions/autoconfigure/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.sdk.autoconfigure.internal.EnvironmentResourceProvider

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationFuzzTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationFuzzTest.java
@@ -30,11 +30,12 @@ class ResourceConfigurationFuzzTest {
     @Fuzz
     public void getAttributesWithRandomValues(String value1, String value2) {
       Attributes attributes =
-          ResourceConfiguration.getAttributes(
-              DefaultConfigProperties.createForTest(
-                  singletonMap(
-                      ResourceConfiguration.ATTRIBUTE_PROPERTY,
-                      "key1=" + escaper.escape(value1) + ",key2=" + escaper.escape(value2))));
+          ResourceConfiguration.createEnvironmentResource(
+                  DefaultConfigProperties.createForTest(
+                      singletonMap(
+                          ResourceConfiguration.ATTRIBUTE_PROPERTY,
+                          "key1=" + escaper.escape(value1) + ",key2=" + escaper.escape(value2))))
+              .getAttributes();
 
       assertThat(attributes).hasSize(2).containsEntry("key1", value1).containsEntry("key2", value2);
     }

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
@@ -7,7 +7,6 @@ package io.opentelemetry.sdk.autoconfigure;
 
 import static io.opentelemetry.sdk.autoconfigure.ResourceConfiguration.DISABLED_ATTRIBUTE_KEYS;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 
 import com.google.common.collect.ImmutableMap;
@@ -47,21 +46,21 @@ class ResourceConfigurationTest {
   }
 
   @Test
-  void resourceFromConfig_empty() {
-    Attributes attributes =
-        ResourceConfiguration.getAttributes(DefaultConfigProperties.createForTest(emptyMap()));
+  void createEnvironmentResource_Empty() {
+    Attributes attributes = ResourceConfiguration.createEnvironmentResource().getAttributes();
 
     assertThat(attributes).isEmpty();
   }
 
   @Test
-  void resourceFromConfig() {
+  void createEnvironmentResource_WithResourceAttributes() {
     Attributes attributes =
-        ResourceConfiguration.getAttributes(
-            DefaultConfigProperties.createForTest(
-                singletonMap(
-                    ResourceConfiguration.ATTRIBUTE_PROPERTY,
-                    "service.name=myService,appName=MyApp")));
+        ResourceConfiguration.createEnvironmentResource(
+                DefaultConfigProperties.createForTest(
+                    singletonMap(
+                        ResourceConfiguration.ATTRIBUTE_PROPERTY,
+                        "service.name=myService,appName=MyApp")))
+            .getAttributes();
 
     assertThat(attributes)
         .hasSize(2)
@@ -70,25 +69,27 @@ class ResourceConfigurationTest {
   }
 
   @Test
-  void serviceName() {
+  void createEnvironmentResource_WithServiceName() {
     Attributes attributes =
-        ResourceConfiguration.getAttributes(
-            DefaultConfigProperties.createForTest(
-                singletonMap(ResourceConfiguration.SERVICE_NAME_PROPERTY, "myService")));
+        ResourceConfiguration.createEnvironmentResource(
+                DefaultConfigProperties.createForTest(
+                    singletonMap(ResourceConfiguration.SERVICE_NAME_PROPERTY, "myService")))
+            .getAttributes();
 
     assertThat(attributes).hasSize(1).containsEntry(ResourceAttributes.SERVICE_NAME, "myService");
   }
 
   @Test
-  void resourceFromConfig_overrideServiceName() {
+  void createEnvironmentResource_ServiceNamePriority() {
     Attributes attributes =
-        ResourceConfiguration.getAttributes(
-            DefaultConfigProperties.createForTest(
-                ImmutableMap.of(
-                    ResourceConfiguration.ATTRIBUTE_PROPERTY,
-                    "service.name=myService,appName=MyApp",
-                    ResourceConfiguration.SERVICE_NAME_PROPERTY,
-                    "ReallyMyService")));
+        ResourceConfiguration.createEnvironmentResource(
+                DefaultConfigProperties.createForTest(
+                    ImmutableMap.of(
+                        ResourceConfiguration.ATTRIBUTE_PROPERTY,
+                        "service.name=myService,appName=MyApp",
+                        ResourceConfiguration.SERVICE_NAME_PROPERTY,
+                        "ReallyMyService")))
+            .getAttributes();
 
     assertThat(attributes)
         .hasSize(2)
@@ -97,11 +98,12 @@ class ResourceConfigurationTest {
   }
 
   @Test
-  void resourceFromConfig_emptyEnvVar() {
+  void createEnvironmentResource_EmptyResourceAttributes() {
     Attributes attributes =
-        ResourceConfiguration.getAttributes(
-            DefaultConfigProperties.createForTest(
-                singletonMap(ResourceConfiguration.ATTRIBUTE_PROPERTY, "")));
+        ResourceConfiguration.createEnvironmentResource(
+                DefaultConfigProperties.createForTest(
+                    singletonMap(ResourceConfiguration.ATTRIBUTE_PROPERTY, "")))
+            .getAttributes();
 
     assertThat(attributes).isEmpty();
   }


### PR DESCRIPTION
Related to #5464.

Implementation of my preferred solution to provide public access to resource configured from the environment, as discussed [here](https://github.com/open-telemetry/opentelemetry-java/pull/5544#issuecomment-1595302453).

Adds new public method `ResourceConfiguration#createEnvironmentResource()` to autoconfigure.

