### PR TITLE
AutoConfiguredOpenTelemetrySdkBuilder does not set GlobalOpenTelemetry by default

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdk.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdk.java
@@ -28,7 +28,7 @@ public abstract class AutoConfiguredOpenTelemetrySdk {
    * <p>This will automatically set the resulting SDK as the {@link GlobalOpenTelemetry} instance.
    */
   public static AutoConfiguredOpenTelemetrySdk initialize() {
-    return builder().build();
+    return builder().setResultAsGlobal().build();
   }
 
   /**

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -89,7 +89,7 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
 
   private boolean registerShutdownHook = true;
 
-  private boolean setResultAsGlobal = true;
+  private boolean setResultAsGlobal = false;
 
   private boolean customized;
 
@@ -300,9 +300,11 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
   /**
    * Sets whether the configured {@link OpenTelemetrySdk} should be set as the application's
    * {@linkplain io.opentelemetry.api.GlobalOpenTelemetry global} instance.
+   *
+   * <p>By default, {@link GlobalOpenTelemetry} is not set.
    */
-  public AutoConfiguredOpenTelemetrySdkBuilder setResultAsGlobal(boolean setResultAsGlobal) {
-    this.setResultAsGlobal = setResultAsGlobal;
+  public AutoConfiguredOpenTelemetrySdkBuilder setResultAsGlobal() {
+    this.setResultAsGlobal = true;
     return this;
   }
 

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkTest.java
@@ -147,7 +147,6 @@ class AutoConfiguredOpenTelemetrySdkTest {
     GlobalEventEmitterProvider.resetForTest();
     builder =
         AutoConfiguredOpenTelemetrySdk.builder()
-            .setResultAsGlobal(false)
             .addPropertiesSupplier(disableExportPropertySupplier());
   }
 
@@ -355,7 +354,7 @@ class AutoConfiguredOpenTelemetrySdkTest {
   void builder_setResultAsGlobalFalse() {
     GlobalOpenTelemetry.set(OpenTelemetry.noop());
 
-    OpenTelemetrySdk openTelemetry = builder.setResultAsGlobal(false).build().getOpenTelemetrySdk();
+    OpenTelemetrySdk openTelemetry = builder.build().getOpenTelemetrySdk();
 
     assertThat(GlobalOpenTelemetry.get()).extracting("delegate").isNotSameAs(openTelemetry);
     assertThat(GlobalEventEmitterProvider.get()).isNotSameAs(openTelemetry.getSdkLoggerProvider());
@@ -363,7 +362,7 @@ class AutoConfiguredOpenTelemetrySdkTest {
 
   @Test
   void builder_setResultAsGlobalTrue() {
-    OpenTelemetrySdk openTelemetry = builder.setResultAsGlobal(true).build().getOpenTelemetrySdk();
+    OpenTelemetrySdk openTelemetry = builder.setResultAsGlobal().build().getOpenTelemetrySdk();
 
     assertThat(GlobalOpenTelemetry.get()).extracting("delegate").isSameAs(openTelemetry);
     assertThat(GlobalEventEmitterProvider.get())
@@ -378,7 +377,7 @@ class AutoConfiguredOpenTelemetrySdkTest {
     Thread thread = new Thread();
     doReturn(thread).when(builder).shutdownHook(any());
 
-    OpenTelemetrySdk sdk = builder.setResultAsGlobal(false).build().getOpenTelemetrySdk();
+    OpenTelemetrySdk sdk = builder.build().getOpenTelemetrySdk();
 
     verify(builder, times(1)).shutdownHook(sdk);
     assertThat(Runtime.getRuntime().removeShutdownHook(thread)).isTrue();
@@ -443,8 +442,7 @@ class AutoConfiguredOpenTelemetrySdkTest {
                 (resource, config) -> resource.merge(Resource.builder().put("cow", "moo").build()))
             .addPropertiesSupplier(() -> singletonMap("otel.metrics.exporter", "none"))
             .addPropertiesSupplier(() -> singletonMap("otel.traces.exporter", "none"))
-            .addPropertiesSupplier(() -> singletonMap("otel.logs.exporter", "none"))
-            .setResultAsGlobal(false);
+            .addPropertiesSupplier(() -> singletonMap("otel.logs.exporter", "none"));
 
     AutoConfiguredOpenTelemetrySdk autoConfigured = autoConfiguration.build();
     assertThat(autoConfigured.getResource().getAttribute(stringKey("cow"))).isEqualTo("moo");
@@ -515,7 +513,6 @@ class AutoConfiguredOpenTelemetrySdkTest {
                     .addPropertiesSupplier(() -> singletonMap("otel.traces.exporter", "none"))
                     .addPropertiesSupplier(() -> singletonMap("otel.logs.exporter", "none"))
                     .addPropertiesSupplier(() -> singletonMap("otel.propagators", "foo"))
-                    .setResultAsGlobal(false)
                     .build())
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("Unrecognized value for otel.propagators");

--- a/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/OrderedSpiTest.java
+++ b/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/OrderedSpiTest.java
@@ -16,10 +16,7 @@ class OrderedSpiTest {
   @Test
   void shouldLoadSpiImplementationsInOrder() {
     AutoConfiguredOpenTelemetrySdk sdk =
-        AutoConfiguredOpenTelemetrySdk.builder()
-            .setResultAsGlobal(false)
-            .registerShutdownHook(false)
-            .build();
+        AutoConfiguredOpenTelemetrySdk.builder().registerShutdownHook(false).build();
 
     assertThat(sdk.getResource().getAttributes().asMap())
         .contains(

--- a/sdk-extensions/autoconfigure/src/testConditionalResourceProvider/java/io/opentelemetry/sdk/autoconfigure/ConditionalResourceProviderTest.java
+++ b/sdk-extensions/autoconfigure/src/testConditionalResourceProvider/java/io/opentelemetry/sdk/autoconfigure/ConditionalResourceProviderTest.java
@@ -17,10 +17,7 @@ class ConditionalResourceProviderTest {
   @Test
   void shouldConditionallyProvideResourceAttributes_skipBasedOnPreviousResource() {
     AutoConfiguredOpenTelemetrySdk sdk =
-        AutoConfiguredOpenTelemetrySdk.builder()
-            .setResultAsGlobal(false)
-            .registerShutdownHook(false)
-            .build();
+        AutoConfiguredOpenTelemetrySdk.builder().registerShutdownHook(false).build();
 
     assertThat(sdk.getResource().getAttributes().asMap())
         .contains(entry(ResourceAttributes.SERVICE_NAME, "test-service"));
@@ -30,7 +27,6 @@ class ConditionalResourceProviderTest {
   void shouldConditionallyProvideResourceAttributes_skipBasedOnConfig() {
     AutoConfiguredOpenTelemetrySdk sdk =
         AutoConfiguredOpenTelemetrySdk.builder()
-            .setResultAsGlobal(false)
             .registerShutdownHook(false)
             .addPropertiesSupplier(() -> singletonMap("skip-first-resource-provider", "true"))
             .build();

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkTest.java
@@ -44,10 +44,7 @@ class AutoConfiguredOpenTelemetrySdkTest {
   @Test
   void initializeAndGet_noGlobal() {
     try (OpenTelemetrySdk sdk =
-        AutoConfiguredOpenTelemetrySdk.builder()
-            .setResultAsGlobal(false)
-            .build()
-            .getOpenTelemetrySdk()) {
+        AutoConfiguredOpenTelemetrySdk.builder().build().getOpenTelemetrySdk()) {
       assertThat(GlobalOpenTelemetry.get()).isNotSameAs(sdk);
     }
   }

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfigurationTest.java
@@ -72,7 +72,6 @@ class MetricExporterConfigurationTest {
 
     try (OpenTelemetrySdk sdk =
         AutoConfiguredOpenTelemetrySdk.builder()
-            .setResultAsGlobal(false)
             .setConfig(DefaultConfigProperties.createForTest(config))
             .build()
             .getOpenTelemetrySdk()) {

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/metric/viewconfig/ViewConfigCustomizerTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/metric/viewconfig/ViewConfigCustomizerTest.java
@@ -28,7 +28,6 @@ class ViewConfigCustomizerTest {
   void customizeMeterProvider_Spi() {
     InMemoryMetricReader reader = InMemoryMetricReader.create();
     AutoConfiguredOpenTelemetrySdk.builder()
-        .setResultAsGlobal(false)
         .addPropertiesSupplier(
             () ->
                 ImmutableMap.of(


### PR DESCRIPTION
GlobalOpenTelemetry makes you opt into initializing with autoconfigure by setting a environment variable / system property.

In contrast, AutoConfiguredOpenTelemetrySdk will set GlobalOpenTelemetry by default. This PR aligns AutoConfiguredOpenTelemetrySdk with the opt-in behavior of GlobalOpenTelemetry, and also with our general advice discouraging use of GlobalOpenTelemetry.

Also, this PR changes AutoConfiguredOpenTelemetrySdkBuilder#setResultAsGlobal(boolean) to simply be AutoConfiguredOpenTelemetrySdkBuilder#setResultAsGlobal(). This means there is no option to undo a decision to `setResultAsGlobal` after its previously been invoked. 

This aligns with our builders elsewhere.