### PR TITLE
Refactor autoconfigure registerShutdownHook(boolean) to disableShutdownHook()

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -282,18 +282,15 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
   }
 
   /**
-   * Control the registration of a shutdown hook to shut down the SDK when appropriate. By default,
+   * Disable the registration of a shutdown hook to shut down the SDK when appropriate. By default,
    * the shutdown hook is registered.
    *
    * <p>Skipping the registration of the shutdown hook may cause unexpected behavior. This
    * configuration is for SDK consumers that require control over the SDK lifecycle. In this case,
    * alternatives must be provided by the SDK consumer to shut down the SDK.
-   *
-   * @param registerShutdownHook a boolean <code>true</code> will register the hook, otherwise
-   *     <code>false</code> will skip registration.
    */
-  public AutoConfiguredOpenTelemetrySdkBuilder registerShutdownHook(boolean registerShutdownHook) {
-    this.registerShutdownHook = registerShutdownHook;
+  public AutoConfiguredOpenTelemetrySdkBuilder disableShutdownHook() {
+    this.registerShutdownHook = false;
     return this;
   }
 

--- a/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/OrderedSpiTest.java
+++ b/sdk-extensions/autoconfigure/src/testAutoConfigureOrder/java/io/opentelemetry/sdk/autoconfigure/OrderedSpiTest.java
@@ -18,7 +18,7 @@ class OrderedSpiTest {
     AutoConfiguredOpenTelemetrySdk sdk =
         AutoConfiguredOpenTelemetrySdk.builder()
             .setResultAsGlobal(false)
-            .registerShutdownHook(false)
+            .disableShutdownHook()
             .build();
 
     assertThat(sdk.getResource().getAttributes().asMap())

--- a/sdk-extensions/autoconfigure/src/testConditionalResourceProvider/java/io/opentelemetry/sdk/autoconfigure/ConditionalResourceProviderTest.java
+++ b/sdk-extensions/autoconfigure/src/testConditionalResourceProvider/java/io/opentelemetry/sdk/autoconfigure/ConditionalResourceProviderTest.java
@@ -17,10 +17,7 @@ class ConditionalResourceProviderTest {
   @Test
   void shouldConditionallyProvideResourceAttributes_skipBasedOnPreviousResource() {
     AutoConfiguredOpenTelemetrySdk sdk =
-        AutoConfiguredOpenTelemetrySdk.builder()
-            .setResultAsGlobal(false)
-            .registerShutdownHook(false)
-            .build();
+        AutoConfiguredOpenTelemetrySdk.builder().setResultAsGlobal(false).build();
 
     assertThat(sdk.getResource().getAttributes().asMap())
         .contains(entry(ResourceAttributes.SERVICE_NAME, "test-service"));
@@ -31,7 +28,6 @@ class ConditionalResourceProviderTest {
     AutoConfiguredOpenTelemetrySdk sdk =
         AutoConfiguredOpenTelemetrySdk.builder()
             .setResultAsGlobal(false)
-            .registerShutdownHook(false)
             .addPropertiesSupplier(() -> singletonMap("skip-first-resource-provider", "true"))
             .build();
 


### PR DESCRIPTION
This aligns AutoConfiguredOpenTelemetrySdkBuilder with our other builders. 