### PR TITLE
Remove redundant SPI dependencies

### DIFF
--- a/sdk-extensions/autoconfigure-spi/build.gradle.kts
+++ b/sdk-extensions/autoconfigure-spi/build.gradle.kts
@@ -8,11 +8,4 @@ otelJava.moduleName.set("io.opentelemetry.sdk.autoconfigure.spi")
 
 dependencies {
   api(project(":sdk:all"))
-
-  // implementation dependency to require users to add the artifact directly to their build to use
-  // SdkMeterProviderBuilder.
-  implementation(project(":sdk:metrics"))
-  // implementation dependency to require users to add the artifact directly to their build to use
-  // SdkLoggerProviderBuilder.
-  implementation(project(":sdk:logs"))
 }


### PR DESCRIPTION
These are already `api` dependencies of `:sdk:all`. 