### PR TITLE
Change OpenCensus shim default sampling to defer to OpenTelemetry

### DIFF
--- a/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/OpenTelemetryTraceComponentImpl.java
+++ b/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/OpenTelemetryTraceComponentImpl.java
@@ -12,8 +12,10 @@ import io.opencensus.implcore.trace.internal.RandomHandler;
 import io.opencensus.trace.TraceComponent;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.config.TraceConfig;
+import io.opencensus.trace.config.TraceParams;
 import io.opencensus.trace.export.ExportComponent;
 import io.opencensus.trace.propagation.PropagationComponent;
+import io.opencensus.trace.samplers.Samplers;
 
 /**
  * Implementation of the {@link TraceComponent} for OpenTelemetry migration, which uses the
@@ -25,7 +27,7 @@ public final class OpenTelemetryTraceComponentImpl extends TraceComponent {
       new OpenTelemetryPropagationComponentImpl();
   private final ExportComponent noopExportComponent = ExportComponent.newNoopExportComponent();
   private final Clock clock;
-  private final TraceConfig traceConfig = new TraceConfigImpl();
+  private final TraceConfig traceConfig = makeTraceConfig();
   private final Tracer tracer;
 
   /** Public constructor to be used with reflection loading. */
@@ -58,6 +60,15 @@ public final class OpenTelemetryTraceComponentImpl extends TraceComponent {
 
   @Override
   public TraceConfig getTraceConfig() {
+    return traceConfig;
+  }
+
+  private static TraceConfig makeTraceConfig() {
+    // Use the default TraceParams except use an always-on sampler. This defers the
+    // sampling decision to OpenTelemetry
+    TraceConfig traceConfig = new TraceConfigImpl();
+    traceConfig.updateActiveTraceParams(
+        TraceParams.DEFAULT.toBuilder().setSampler(Samplers.alwaysSample()).build());
     return traceConfig;
   }
 }

--- a/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/InteroperabilityTest.java
+++ b/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/InteroperabilityTest.java
@@ -322,7 +322,14 @@ class InteroperabilityTest {
   }
 
   @Test
-  public void testNoRecordDoesNotExport() {
+  public void testOpenCensusSamplerIsAlwaysOn() {
+    // OpenTelemetryTraceComponentImpl provides this behavior
+    assertThat(Tracing.getTraceConfig().getActiveTraceParams().getSampler())
+        .isEqualTo(Samplers.alwaysSample());
+  }
+
+  @Test
+  public void testByDefaultDoesExport() {
     io.opencensus.trace.Tracer tracer = Tracing.getTracer();
     try (io.opencensus.common.Scope scope =
         tracer.spanBuilder("OpenCensusSpan").setRecordEvents(false).startScopedSpan()) {
@@ -333,7 +340,7 @@ class InteroperabilityTest {
       span.putAttribute("testKey", AttributeValue.stringAttributeValue("testValue"));
     }
     Tracing.getExportComponent().shutdown();
-    verify(spanExporter, never()).export(anyCollection());
+    verify(spanExporter, times(1)).export(anyCollection());
   }
 
   private static void createOpenCensusScopedSpanWithChildSpan(


### PR DESCRIPTION
Previously, the default OpenCensus sampler would run *before* the shim calls the OpenTelemetry API. This causes both the OpenCensus and OpenTelemetry samplers to be evaluated, and they must both pass to be sampled.

This PR changes the default OpenCensus sampler for the shim to be `Samplers.alwaysSample()`.  That way, users can just configure Sampling in OpenTelemetry.