### PR TITLE
Use OtelVersionClassPlugin instead of reading version from resource

### DIFF
--- a/opencensus-shim/build.gradle.kts
+++ b/opencensus-shim/build.gradle.kts
@@ -1,7 +1,10 @@
+import io.opentelemetry.gradle.OtelVersionClassPlugin
+
 plugins {
   id("otel.java-conventions")
   id("otel.publish-conventions")
 }
+apply<OtelVersionClassPlugin>()
 
 description = "OpenTelemetry OpenCensus Shim"
 otelJava.moduleName.set("io.opentelemetry.opencensusshim")

--- a/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/OpenTelemetrySpanBuilderImpl.java
+++ b/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/OpenTelemetrySpanBuilderImpl.java
@@ -41,18 +41,17 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.internal.OtelVersion;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
 import java.util.Random;
 import javax.annotation.Nullable;
 
 class OpenTelemetrySpanBuilderImpl extends SpanBuilder {
 
-  private static final String OPENCENSUSSHIM_VERSION = readVersion();
   private static final Tracer OTEL_TRACER =
-      GlobalOpenTelemetry.getTracer("io.opentelemetry.opencensusshim", OPENCENSUSSHIM_VERSION);
+      GlobalOpenTelemetry.getTracer("io.opentelemetry.opencensusshim", OtelVersion.VERSION);
   private static final Tracestate OC_TRACESTATE_DEFAULT = Tracestate.builder().build();
   private static final TraceOptions OC_SAMPLED_TRACE_OPTIONS =
       TraceOptions.builder().setIsSampled(true).build();
@@ -210,20 +209,6 @@ class OpenTelemetrySpanBuilderImpl extends SpanBuilder {
       }
     }
     return false;
-  }
-
-  private static String readVersion() {
-    Properties properties = new Properties();
-    String version;
-    try {
-      properties.load(
-          OpenTelemetrySpanBuilderImpl.class.getResourceAsStream(
-              "/io/opentelemetry/opencensusshim/version.properties"));
-      version = properties.getProperty("sdk.version", "unknown");
-    } catch (Exception e) {
-      version = "unknown";
-    }
-    return version;
   }
 
   static final class Options {

--- a/opentracing-shim/build.gradle.kts
+++ b/opentracing-shim/build.gradle.kts
@@ -1,7 +1,10 @@
+import io.opentelemetry.gradle.OtelVersionClassPlugin
+
 plugins {
   id("otel.java-conventions")
   id("otel.publish-conventions")
 }
+apply<OtelVersionClassPlugin>()
 
 description = "OpenTelemetry OpenTracing Bridge"
 otelJava.moduleName.set("io.opentelemetry.opentracingshim")

--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/TracerShim.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/TracerShim.java
@@ -7,6 +7,7 @@ package io.opentelemetry.opentracingshim;
 
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.opentracing.shim.internal.OtelVersion;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
@@ -18,7 +19,6 @@ import io.opentracing.propagation.TextMapInject;
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -26,8 +26,6 @@ import javax.annotation.Nullable;
 
 final class TracerShim implements Tracer {
   private static final Logger logger = Logger.getLogger(TracerShim.class.getName());
-
-  static final String OPENTRACINGSHIM_VERSION = readVersion();
 
   private final io.opentelemetry.api.trace.TracerProvider provider;
   private final io.opentelemetry.api.trace.Tracer tracer;
@@ -40,7 +38,7 @@ final class TracerShim implements Tracer {
       TextMapPropagator textMapPropagator,
       TextMapPropagator httpPropagator) {
     this.provider = provider;
-    this.tracer = provider.get("opentracing-shim", OPENTRACINGSHIM_VERSION);
+    this.tracer = provider.get("opentracing-shim", OtelVersion.VERSION);
     this.propagation = new Propagation(textMapPropagator, httpPropagator);
     this.scopeManagerShim = new ScopeManagerShim();
   }
@@ -149,19 +147,5 @@ final class TracerShim implements Tracer {
       logger.log(Level.INFO, "Error trying to unobfuscate SdkTracerProvider", e);
     }
     return tracerProvider;
-  }
-
-  private static String readVersion() {
-    Properties properties = new Properties();
-    String version;
-    try {
-      properties.load(
-          TracerShim.class.getResourceAsStream(
-              "/io/opentelemetry/opentracingshim/version.properties"));
-      version = properties.getProperty("sdk.version", "unknown");
-    } catch (Exception e) {
-      version = "unknown";
-    }
-    return version;
   }
 }

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/OpenTracingShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/OpenTracingShimTest.java
@@ -14,6 +14,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.sdk.common.internal.OtelVersion;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentracing.propagation.Format;
 import org.junit.jupiter.api.AfterEach;
@@ -41,8 +42,7 @@ class OpenTracingShimTest {
         .isSameAs(textMapPropagator);
     assertThat(tracerShim.propagation().getPropagator(Format.Builtin.HTTP_HEADERS))
         .isSameAs(textMapPropagator);
-    assertThat(tracerShim.tracer())
-        .isEqualTo(sdk.get("opentracing-shim", TracerShim.OPENTRACINGSHIM_VERSION));
+    assertThat(tracerShim.tracer()).isEqualTo(sdk.get("opentracing-shim", OtelVersion.VERSION));
   }
 
   @Test
@@ -76,7 +76,6 @@ class OpenTracingShimTest {
         .isSameAs(textMapPropagator);
     assertThat(tracerShim.propagation().getPropagator(Format.Builtin.HTTP_HEADERS))
         .isSameAs(httpHeadersPropagator);
-    assertThat(tracerShim.tracer())
-        .isSameAs(sdk.get("opentracing-shim", TracerShim.OPENTRACINGSHIM_VERSION));
+    assertThat(tracerShim.tracer()).isSameAs(sdk.get("opentracing-shim", OtelVersion.VERSION));
   }
 }


### PR DESCRIPTION
Resolves #5369.

Converts remaining code that reads version from `version.properties` to instead obtain it from a generated class.