### PR TITLE
Fix gradle java version requirement warning

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,15 +7,6 @@ plugins {
   id("otel.spotless-conventions")
 }
 
-if (!JavaVersion.current().isJava11Compatible()) {
-  throw GradleException(
-    "JDK 11 or higher is required to build. " +
-      "One option is to download it from https://adoptopenjdk.net/. If you believe you already " +
-      "have it, please check that the JAVA_HOME environment variable is pointing at the " +
-      "JDK 11 installation.",
-  )
-}
-
 apply(from = "version.gradle.kts")
 
 nexusPublishing {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,6 +5,15 @@ plugins {
   id("com.diffplug.spotless") version "6.19.0"
 }
 
+if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+  throw GradleException(
+    "JDK 17 or higher is required to build. " +
+      "One option is to download it from https://adoptopenjdk.net/. If you believe you already " +
+      "have it, please check that the JAVA_HOME environment variable is pointing at the " +
+      "JDK 17 installation.",
+  )
+}
+
 spotless {
   kotlinGradle {
     ktlint().editorConfigOverride(mapOf(


### PR DESCRIPTION
The existing warning is wrong (says java 11 is required to build instead of java 17) and is in the wrong place (gradle fails with compatibility exception when building `buildSrc` before the `build.gradle.kts` has a chance to run). 