### PR TITLE
Change processedSpans&processedLogs labels

### DIFF
--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/AttributeValueConstants.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/AttributeValueConstants.java
@@ -7,8 +7,7 @@ package io.opentelemetry.sdk.internal;
 
 public final class AttributeValueConstants {
 
-  private AttributeValueConstants() {
-  }
+  private AttributeValueConstants() {}
 
   public static final String PROCESS_STATUS_DROPPED = "dropped";
   public static final String PROCESS_STATUS_PROCESSED = "processed";

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/AttributeValueConstants.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/AttributeValueConstants.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.internal;
+
+public final class AttributeValueConstants {
+
+  private AttributeValueConstants() {
+  }
+
+  public static final String PROCESS_STATUS_DROPPED = "dropped";
+  public static final String PROCESS_STATUS_PROCESSED = "processed";
+  public static final String PROCESS_STATUS_EXPORTED = "exported";
+}

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessor.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessor.java
@@ -5,6 +5,10 @@
 
 package io.opentelemetry.sdk.logs.export;
 
+import static io.opentelemetry.sdk.internal.AttributeValueConstants.PROCESS_STATUS_DROPPED;
+import static io.opentelemetry.sdk.internal.AttributeValueConstants.PROCESS_STATUS_EXPORTED;
+import static io.opentelemetry.sdk.internal.AttributeValueConstants.PROCESS_STATUS_PROCESSED;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
@@ -28,10 +32,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static io.opentelemetry.sdk.internal.AttributeValueConstants.PROCESS_STATUS_DROPPED;
-import static io.opentelemetry.sdk.internal.AttributeValueConstants.PROCESS_STATUS_EXPORTED;
-import static io.opentelemetry.sdk.internal.AttributeValueConstants.PROCESS_STATUS_PROCESSED;
-
 /**
  * Implementation of the {@link LogRecordProcessor} that batches logs exported by the SDK then
  * pushes them to the exporter pipeline.
@@ -49,9 +49,8 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
       BatchLogRecordProcessor.class.getSimpleName() + "_WorkerThread";
   private static final AttributeKey<String> LOG_RECORD_PROCESSOR_TYPE_LABEL =
       AttributeKey.stringKey("logRecordProcessorType");
-  private static final AttributeKey<String> LOG_RECORD_PROCESSOR_STATUS_LABEL =
+  private static final AttributeKey<String> LOG_RECORD_PROCESS_STATUS_LABEL =
       AttributeKey.stringKey("status");
-
   private static final String LOG_RECORD_PROCESSOR_TYPE_VALUE =
       BatchLogRecordProcessor.class.getSimpleName();
 
@@ -197,19 +196,19 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
           Attributes.of(
               LOG_RECORD_PROCESSOR_TYPE_LABEL,
               LOG_RECORD_PROCESSOR_TYPE_VALUE,
-              LOG_RECORD_PROCESSOR_STATUS_LABEL,
+              LOG_RECORD_PROCESS_STATUS_LABEL,
               PROCESS_STATUS_DROPPED);
       exportedAttrs =
           Attributes.of(
               LOG_RECORD_PROCESSOR_TYPE_LABEL,
               LOG_RECORD_PROCESSOR_TYPE_VALUE,
-              LOG_RECORD_PROCESSOR_STATUS_LABEL,
+              LOG_RECORD_PROCESS_STATUS_LABEL,
               PROCESS_STATUS_EXPORTED);
       processedAttrs =
           Attributes.of(
               LOG_RECORD_PROCESSOR_TYPE_LABEL,
               LOG_RECORD_PROCESSOR_TYPE_VALUE,
-              LOG_RECORD_PROCESSOR_STATUS_LABEL,
+              LOG_RECORD_PROCESS_STATUS_LABEL,
               PROCESS_STATUS_PROCESSED);
 
       this.batch = new ArrayList<>(this.maxExportBatchSize);

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -5,6 +5,10 @@
 
 package io.opentelemetry.sdk.trace.export;
 
+import static io.opentelemetry.sdk.internal.AttributeValueConstants.PROCESS_STATUS_DROPPED;
+import static io.opentelemetry.sdk.internal.AttributeValueConstants.PROCESS_STATUS_EXPORTED;
+import static io.opentelemetry.sdk.internal.AttributeValueConstants.PROCESS_STATUS_PROCESSED;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
@@ -31,10 +35,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static io.opentelemetry.sdk.internal.AttributeValueConstants.PROCESS_STATUS_DROPPED;
-import static io.opentelemetry.sdk.internal.AttributeValueConstants.PROCESS_STATUS_EXPORTED;
-import static io.opentelemetry.sdk.internal.AttributeValueConstants.PROCESS_STATUS_PROCESSED;
-
 /**
  * Implementation of the {@link SpanProcessor} that batches spans exported by the SDK then pushes
  * them to the exporter pipeline.
@@ -52,10 +52,8 @@ public final class BatchSpanProcessor implements SpanProcessor {
       BatchSpanProcessor.class.getSimpleName() + "_WorkerThread";
   private static final AttributeKey<String> SPAN_PROCESSOR_TYPE_LABEL =
       AttributeKey.stringKey("spanProcessorType");
-  private static final AttributeKey<String> SPAN_PROCESSOR_STATUS_LABEL =
+  private static final AttributeKey<String> SPAN_PROCESS_STATUS_LABEL =
       AttributeKey.stringKey("status");
-
-
   private static final String SPAN_PROCESSOR_TYPE_VALUE = BatchSpanProcessor.class.getSimpleName();
 
   private final Worker worker;
@@ -214,19 +212,19 @@ public final class BatchSpanProcessor implements SpanProcessor {
           Attributes.of(
               SPAN_PROCESSOR_TYPE_LABEL,
               SPAN_PROCESSOR_TYPE_VALUE,
-              SPAN_PROCESSOR_STATUS_LABEL,
+              SPAN_PROCESS_STATUS_LABEL,
               PROCESS_STATUS_DROPPED);
       exportedAttrs =
           Attributes.of(
               SPAN_PROCESSOR_TYPE_LABEL,
               SPAN_PROCESSOR_TYPE_VALUE,
-              SPAN_PROCESSOR_STATUS_LABEL,
+              SPAN_PROCESS_STATUS_LABEL,
               PROCESS_STATUS_EXPORTED);
       processedAttrs =
           Attributes.of(
               SPAN_PROCESSOR_TYPE_LABEL,
               SPAN_PROCESSOR_TYPE_VALUE,
-              SPAN_PROCESSOR_STATUS_LABEL,
+              SPAN_PROCESS_STATUS_LABEL,
               PROCESS_STATUS_PROCESSED);
 
       this.batch = new ArrayList<>(this.maxExportBatchSize);


### PR DESCRIPTION
when i use BatchLogRecordProcessor/BatchSpanProcessor. 
i want to know  dropped ratio and  exported success ratio and  exported fail ratio  and etc. but exist metrics can not compute those.

i want achieve this goal by updating processedSpans&processedLogs labels  .

dropped ratio:                                `dropped/processed`
exported success ratio:                `exported/(processed - dropped)`
exported fail ratio:                         `1 - exported/(processed - dropped)`