### PR TITLE
Add OtlpHttp{Signal}Exporter#toBuilder() methods

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
@@ -1,2 +1,10 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder toBuilder()
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder toBuilder()
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder toBuilder()

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-common.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-common.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+**** MODIFIED CLASS: PUBLIC ABSTRACT io.opentelemetry.sdk.common.export.RetryPolicy  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++* NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.common.export.RetryPolicy$RetryPolicyBuilder toBuilder()

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/TlsConfigHelper.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/TlsConfigHelper.java
@@ -129,4 +129,13 @@ public class TlsConfigHelper {
       throw new IllegalArgumentException(e);
     }
   }
+
+  /** Return a shallow copy of this instance. */
+  public TlsConfigHelper copy() {
+    TlsConfigHelper copy = new TlsConfigHelper();
+    copy.keyManager = keyManager;
+    copy.trustManager = trustManager;
+    copy.sslContext = sslContext;
+    return copy;
+  }
 }

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpExporterBuilder.java
@@ -49,7 +49,7 @@ public final class HttpExporterBuilder<T extends Marshaler> {
   private boolean exportAsJson = false;
   @Nullable private Map<String, String> headers;
 
-  private final TlsConfigHelper tlsConfigHelper = new TlsConfigHelper();
+  private TlsConfigHelper tlsConfigHelper = new TlsConfigHelper();
   @Nullable private RetryPolicy retryPolicy;
   private Supplier<MeterProvider> meterProviderSupplier = GlobalOpenTelemetry::getMeterProvider;
   @Nullable private Authenticator authenticator;
@@ -124,6 +124,25 @@ public final class HttpExporterBuilder<T extends Marshaler> {
   public HttpExporterBuilder<T> exportAsJson() {
     this.exportAsJson = true;
     return this;
+  }
+
+  @SuppressWarnings("BuilderReturnThis")
+  public HttpExporterBuilder<T> copy() {
+    HttpExporterBuilder<T> copy = new HttpExporterBuilder<>(exporterName, type, endpoint);
+    copy.endpoint = endpoint;
+    copy.timeoutNanos = timeoutNanos;
+    copy.exportAsJson = exportAsJson;
+    copy.compressionEnabled = compressionEnabled;
+    if (headers != null) {
+      copy.headers = new HashMap<>(headers);
+    }
+    copy.tlsConfigHelper = tlsConfigHelper.copy();
+    if (retryPolicy != null) {
+      copy.retryPolicy = retryPolicy.toBuilder().build();
+    }
+    copy.meterProviderSupplier = meterProviderSupplier;
+    copy.authenticator = authenticator;
+    return copy;
   }
 
   public HttpExporter<T> build() {

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.exporter.otlp.http.logs;
 
 import io.opentelemetry.exporter.internal.http.HttpExporter;
+import io.opentelemetry.exporter.internal.http.HttpExporterBuilder;
 import io.opentelemetry.exporter.internal.otlp.logs.LogsRequestMarshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
@@ -21,9 +22,13 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class OtlpHttpLogRecordExporter implements LogRecordExporter {
 
+  private final HttpExporterBuilder<LogsRequestMarshaler> builder;
   private final HttpExporter<LogsRequestMarshaler> delegate;
 
-  OtlpHttpLogRecordExporter(HttpExporter<LogsRequestMarshaler> delegate) {
+  OtlpHttpLogRecordExporter(
+      HttpExporterBuilder<LogsRequestMarshaler> builder,
+      HttpExporter<LogsRequestMarshaler> delegate) {
+    this.builder = builder;
     this.delegate = delegate;
   }
 
@@ -46,6 +51,15 @@ public final class OtlpHttpLogRecordExporter implements LogRecordExporter {
    */
   public static OtlpHttpLogRecordExporterBuilder builder() {
     return new OtlpHttpLogRecordExporterBuilder();
+  }
+
+  /**
+   * Returns a builder with configuration values equal to those for this exporter.
+   *
+   * <p>IMPORTANT: Be sure to {@link #shutdown()} this instance if it will no longer be used.
+   */
+  public OtlpHttpLogRecordExporterBuilder toBuilder() {
+    return new OtlpHttpLogRecordExporterBuilder(builder.copy());
   }
 
   /**

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -30,9 +30,13 @@ public final class OtlpHttpLogRecordExporterBuilder {
 
   private final HttpExporterBuilder<LogsRequestMarshaler> delegate;
 
-  OtlpHttpLogRecordExporterBuilder() {
-    delegate = new HttpExporterBuilder<>("otlp", "log", DEFAULT_ENDPOINT);
+  OtlpHttpLogRecordExporterBuilder(HttpExporterBuilder<LogsRequestMarshaler> delegate) {
+    this.delegate = delegate;
     OtlpUserAgent.addUserAgentHeader(delegate::addHeader);
+  }
+
+  OtlpHttpLogRecordExporterBuilder() {
+    this(new HttpExporterBuilder<>("otlp", "log", DEFAULT_ENDPOINT));
   }
 
   /**
@@ -141,6 +145,6 @@ public final class OtlpHttpLogRecordExporterBuilder {
    * @return a new exporter's instance
    */
   public OtlpHttpLogRecordExporter build() {
-    return new OtlpHttpLogRecordExporter(delegate.build());
+    return new OtlpHttpLogRecordExporter(delegate, delegate.build());
   }
 }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.exporter.otlp.http.metrics;
 
 import io.opentelemetry.exporter.internal.http.HttpExporter;
+import io.opentelemetry.exporter.internal.http.HttpExporterBuilder;
 import io.opentelemetry.exporter.internal.otlp.metrics.MetricsRequestMarshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.Aggregation;
@@ -26,14 +27,17 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class OtlpHttpMetricExporter implements MetricExporter {
 
+  private final HttpExporterBuilder<MetricsRequestMarshaler> builder;
   private final HttpExporter<MetricsRequestMarshaler> delegate;
   private final AggregationTemporalitySelector aggregationTemporalitySelector;
   private final DefaultAggregationSelector defaultAggregationSelector;
 
   OtlpHttpMetricExporter(
+      HttpExporterBuilder<MetricsRequestMarshaler> builder,
       HttpExporter<MetricsRequestMarshaler> delegate,
       AggregationTemporalitySelector aggregationTemporalitySelector,
       DefaultAggregationSelector defaultAggregationSelector) {
+    this.builder = builder;
     this.delegate = delegate;
     this.aggregationTemporalitySelector = aggregationTemporalitySelector;
     this.defaultAggregationSelector = defaultAggregationSelector;
@@ -58,6 +62,15 @@ public final class OtlpHttpMetricExporter implements MetricExporter {
    */
   public static OtlpHttpMetricExporterBuilder builder() {
     return new OtlpHttpMetricExporterBuilder();
+  }
+
+  /**
+   * Returns a builder with configuration values equal to those for this exporter.
+   *
+   * <p>IMPORTANT: Be sure to {@link #shutdown()} this instance if it will no longer be used.
+   */
+  public OtlpHttpMetricExporterBuilder toBuilder() {
+    return new OtlpHttpMetricExporterBuilder(builder.copy());
   }
 
   @Override

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -41,10 +41,14 @@ public final class OtlpHttpMetricExporterBuilder {
   private DefaultAggregationSelector defaultAggregationSelector =
       DefaultAggregationSelector.getDefault();
 
-  OtlpHttpMetricExporterBuilder() {
-    delegate = new HttpExporterBuilder<>("otlp", "metric", DEFAULT_ENDPOINT);
+  OtlpHttpMetricExporterBuilder(HttpExporterBuilder<MetricsRequestMarshaler> delegate) {
+    this.delegate = delegate;
     delegate.setMeterProvider(MeterProvider.noop());
     OtlpUserAgent.addUserAgentHeader(delegate::addHeader);
+  }
+
+  OtlpHttpMetricExporterBuilder() {
+    this(new HttpExporterBuilder<>("otlp", "metric", DEFAULT_ENDPOINT));
   }
 
   /**
@@ -181,6 +185,6 @@ public final class OtlpHttpMetricExporterBuilder {
    */
   public OtlpHttpMetricExporter build() {
     return new OtlpHttpMetricExporter(
-        delegate.build(), aggregationTemporalitySelector, defaultAggregationSelector);
+        delegate, delegate.build(), aggregationTemporalitySelector, defaultAggregationSelector);
   }
 }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.exporter.otlp.http.trace;
 
 import io.opentelemetry.exporter.internal.http.HttpExporter;
+import io.opentelemetry.exporter.internal.http.HttpExporterBuilder;
 import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -21,9 +22,13 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class OtlpHttpSpanExporter implements SpanExporter {
 
+  private final HttpExporterBuilder<TraceRequestMarshaler> builder;
   private final HttpExporter<TraceRequestMarshaler> delegate;
 
-  OtlpHttpSpanExporter(HttpExporter<TraceRequestMarshaler> delegate) {
+  OtlpHttpSpanExporter(
+      HttpExporterBuilder<TraceRequestMarshaler> builder,
+      HttpExporter<TraceRequestMarshaler> delegate) {
+    this.builder = builder;
     this.delegate = delegate;
   }
 
@@ -49,6 +54,15 @@ public final class OtlpHttpSpanExporter implements SpanExporter {
   }
 
   /**
+   * Returns a builder with configuration values equal to those for this exporter.
+   *
+   * <p>IMPORTANT: Be sure to {@link #shutdown()} this instance if it will no longer be used.
+   */
+  public OtlpHttpSpanExporterBuilder toBuilder() {
+    return new OtlpHttpSpanExporterBuilder(builder.copy());
+  }
+
+  /**
    * Submits all the given spans in a single batch to the OpenTelemetry collector.
    *
    * @param spans the list of sampled Spans to be exported.
@@ -70,7 +84,7 @@ public final class OtlpHttpSpanExporter implements SpanExporter {
     return CompletableResultCode.ofSuccess();
   }
 
-  /** Shutdown the exporter. */
+  /** Shutdown the exporter, releasing any resources and preventing subsequent exports. */
   @Override
   public CompletableResultCode shutdown() {
     return delegate.shutdown();

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -30,9 +30,13 @@ public final class OtlpHttpSpanExporterBuilder {
 
   private final HttpExporterBuilder<TraceRequestMarshaler> delegate;
 
-  OtlpHttpSpanExporterBuilder() {
-    delegate = new HttpExporterBuilder<>("otlp", "span", DEFAULT_ENDPOINT);
+  OtlpHttpSpanExporterBuilder(HttpExporterBuilder<TraceRequestMarshaler> delegate) {
+    this.delegate = delegate;
     OtlpUserAgent.addUserAgentHeader(delegate::addHeader);
+  }
+
+  OtlpHttpSpanExporterBuilder() {
+    this(new HttpExporterBuilder<>("otlp", "span", DEFAULT_ENDPOINT));
   }
 
   /**
@@ -142,6 +146,6 @@ public final class OtlpHttpSpanExporterBuilder {
    * @return a new exporter's instance
    */
   public OtlpHttpSpanExporter build() {
-    return new OtlpHttpSpanExporter(delegate.build());
+    return new OtlpHttpSpanExporter(delegate, delegate.build());
   }
 }

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterOkHttpSenderTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterOkHttpSenderTest.java
@@ -5,21 +5,16 @@
 
 package io.opentelemetry.exporter.otlp.http.logs;
 
-import io.opentelemetry.exporter.internal.auth.Authenticator;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.exporter.internal.otlp.logs.ResourceLogsMarshaler;
 import io.opentelemetry.exporter.otlp.testing.internal.AbstractHttpTelemetryExporterTest;
 import io.opentelemetry.exporter.otlp.testing.internal.FakeTelemetryUtil;
+import io.opentelemetry.exporter.otlp.testing.internal.HttpLogRecordExporterBuilderWrapper;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporter;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporterBuilder;
 import io.opentelemetry.proto.logs.v1.ResourceLogs;
-import io.opentelemetry.sdk.common.export.RetryPolicy;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
-import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.X509TrustManager;
 
 class OtlpHttpLogRecordExporterOkHttpSenderTest
     extends AbstractHttpTelemetryExporterTest<LogRecordData, ResourceLogs> {
@@ -30,80 +25,14 @@ class OtlpHttpLogRecordExporterOkHttpSenderTest
 
   @Override
   protected TelemetryExporterBuilder<LogRecordData> exporterBuilder() {
-    OtlpHttpLogRecordExporterBuilder builder = OtlpHttpLogRecordExporter.builder();
-    return new TelemetryExporterBuilder<LogRecordData>() {
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> setEndpoint(String endpoint) {
-        builder.setEndpoint(endpoint);
-        return this;
-      }
+    return new HttpLogRecordExporterBuilderWrapper(OtlpHttpLogRecordExporter.builder());
+  }
 
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> setTimeout(long timeout, TimeUnit unit) {
-        builder.setTimeout(timeout, unit);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> setTimeout(Duration timeout) {
-        builder.setTimeout(timeout);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> setCompression(String compression) {
-        builder.setCompression(compression);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> addHeader(String key, String value) {
-        builder.addHeader(key, value);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> setAuthenticator(Authenticator authenticator) {
-        Authenticator.setAuthenticatorOnDelegate(builder, authenticator);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> setTrustedCertificates(byte[] certificates) {
-        builder.setTrustedCertificates(certificates);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> setSslContext(
-          SSLContext ssLContext, X509TrustManager trustManager) {
-        builder.setSslContext(ssLContext, trustManager);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> setClientTls(
-          byte[] privateKeyPem, byte[] certificatePem) {
-        builder.setClientTls(privateKeyPem, certificatePem);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> setRetryPolicy(RetryPolicy retryPolicy) {
-        builder.setRetryPolicy(retryPolicy);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> setChannel(io.grpc.ManagedChannel channel) {
-        throw new UnsupportedOperationException("Not implemented");
-      }
-
-      @Override
-      public TelemetryExporter<LogRecordData> build() {
-        return TelemetryExporter.wrap(builder.build());
-      }
-    };
+  @Override
+  protected TelemetryExporterBuilder<LogRecordData> toBuilder(
+      TelemetryExporter<LogRecordData> exporter) {
+    return new HttpLogRecordExporterBuilderWrapper(
+        ((OtlpHttpLogRecordExporter) exporter.unwrap()).toBuilder());
   }
 
   @Override

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterOkHttpSenderTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterOkHttpSenderTest.java
@@ -9,26 +9,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.opentelemetry.exporter.internal.auth.Authenticator;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.exporter.internal.otlp.metrics.ResourceMetricsMarshaler;
 import io.opentelemetry.exporter.otlp.testing.internal.AbstractHttpTelemetryExporterTest;
 import io.opentelemetry.exporter.otlp.testing.internal.FakeTelemetryUtil;
+import io.opentelemetry.exporter.otlp.testing.internal.HttpMetricExporterBuilderWrapper;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporter;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporterBuilder;
 import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
-import io.opentelemetry.sdk.common.export.RetryPolicy;
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
 import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
-import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.X509TrustManager;
 import org.junit.jupiter.api.Test;
 
 class OtlpHttpMetricExporterOkHttpSenderTest
@@ -84,80 +79,13 @@ class OtlpHttpMetricExporterOkHttpSenderTest
 
   @Override
   protected TelemetryExporterBuilder<MetricData> exporterBuilder() {
-    OtlpHttpMetricExporterBuilder builder = OtlpHttpMetricExporter.builder();
-    return new TelemetryExporterBuilder<MetricData>() {
-      @Override
-      public TelemetryExporterBuilder<MetricData> setEndpoint(String endpoint) {
-        builder.setEndpoint(endpoint);
-        return this;
-      }
+    return new HttpMetricExporterBuilderWrapper(OtlpHttpMetricExporter.builder());
+  }
 
-      @Override
-      public TelemetryExporterBuilder<MetricData> setTimeout(long timeout, TimeUnit unit) {
-        builder.setTimeout(timeout, unit);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<MetricData> setTimeout(Duration timeout) {
-        builder.setTimeout(timeout);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<MetricData> setCompression(String compression) {
-        builder.setCompression(compression);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<MetricData> addHeader(String key, String value) {
-        builder.addHeader(key, value);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<MetricData> setAuthenticator(Authenticator authenticator) {
-        Authenticator.setAuthenticatorOnDelegate(builder, authenticator);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<MetricData> setTrustedCertificates(byte[] certificates) {
-        builder.setTrustedCertificates(certificates);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<MetricData> setSslContext(
-          SSLContext sslContext, X509TrustManager trustManager) {
-        builder.setSslContext(sslContext, trustManager);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<MetricData> setClientTls(
-          byte[] privateKeyPem, byte[] certificatePem) {
-        builder.setClientTls(privateKeyPem, certificatePem);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<MetricData> setRetryPolicy(RetryPolicy retryPolicy) {
-        builder.setRetryPolicy(retryPolicy);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<MetricData> setChannel(io.grpc.ManagedChannel channel) {
-        throw new UnsupportedOperationException("Not implemented");
-      }
-
-      @Override
-      public TelemetryExporter<MetricData> build() {
-        return TelemetryExporter.wrap(builder.build());
-      }
-    };
+  @Override
+  protected TelemetryExporterBuilder<MetricData> toBuilder(TelemetryExporter<MetricData> exporter) {
+    return new HttpMetricExporterBuilderWrapper(
+        ((OtlpHttpMetricExporter) exporter.unwrap()).toBuilder());
   }
 
   @Override

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterOkHttpSenderTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterOkHttpSenderTest.java
@@ -5,21 +5,16 @@
 
 package io.opentelemetry.exporter.otlp.http.trace;
 
-import io.opentelemetry.exporter.internal.auth.Authenticator;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.exporter.internal.otlp.traces.ResourceSpansMarshaler;
 import io.opentelemetry.exporter.otlp.testing.internal.AbstractHttpTelemetryExporterTest;
 import io.opentelemetry.exporter.otlp.testing.internal.FakeTelemetryUtil;
+import io.opentelemetry.exporter.otlp.testing.internal.HttpSpanExporterBuilderWrapper;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporter;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporterBuilder;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
-import io.opentelemetry.sdk.common.export.RetryPolicy;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.X509TrustManager;
 
 class OtlpHttpSpanExporterOkHttpSenderTest
     extends AbstractHttpTelemetryExporterTest<SpanData, ResourceSpans> {
@@ -30,80 +25,13 @@ class OtlpHttpSpanExporterOkHttpSenderTest
 
   @Override
   protected TelemetryExporterBuilder<SpanData> exporterBuilder() {
-    OtlpHttpSpanExporterBuilder builder = OtlpHttpSpanExporter.builder();
-    return new TelemetryExporterBuilder<SpanData>() {
-      @Override
-      public TelemetryExporterBuilder<SpanData> setEndpoint(String endpoint) {
-        builder.setEndpoint(endpoint);
-        return this;
-      }
+    return new HttpSpanExporterBuilderWrapper(OtlpHttpSpanExporter.builder());
+  }
 
-      @Override
-      public TelemetryExporterBuilder<SpanData> setTimeout(long timeout, TimeUnit unit) {
-        builder.setTimeout(timeout, unit);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<SpanData> setTimeout(Duration timeout) {
-        builder.setTimeout(timeout);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<SpanData> setCompression(String compression) {
-        builder.setCompression(compression);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<SpanData> addHeader(String key, String value) {
-        builder.addHeader(key, value);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<SpanData> setAuthenticator(Authenticator authenticator) {
-        Authenticator.setAuthenticatorOnDelegate(builder, authenticator);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<SpanData> setTrustedCertificates(byte[] certificates) {
-        builder.setTrustedCertificates(certificates);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<SpanData> setSslContext(
-          SSLContext sslContext, X509TrustManager trustManager) {
-        builder.setSslContext(sslContext, trustManager);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<SpanData> setClientTls(
-          byte[] privateKeyPem, byte[] certificatePem) {
-        builder.setClientTls(privateKeyPem, certificatePem);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<SpanData> setRetryPolicy(RetryPolicy retryPolicy) {
-        builder.setRetryPolicy(retryPolicy);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<SpanData> setChannel(io.grpc.ManagedChannel channel) {
-        throw new UnsupportedOperationException("Not implemented");
-      }
-
-      @Override
-      public TelemetryExporter<SpanData> build() {
-        return TelemetryExporter.wrap(builder.build());
-      }
-    };
+  @Override
+  protected TelemetryExporterBuilder<SpanData> toBuilder(TelemetryExporter<SpanData> exporter) {
+    return new HttpSpanExporterBuilderWrapper(
+        ((OtlpHttpSpanExporter) exporter.unwrap()).toBuilder());
   }
 
   @Override

--- a/exporters/otlp/all/src/testJdkHttpSender/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterJdkSenderTest.java
+++ b/exporters/otlp/all/src/testJdkHttpSender/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterJdkSenderTest.java
@@ -5,21 +5,16 @@
 
 package io.opentelemetry.exporter.otlp.http.logs;
 
-import io.opentelemetry.exporter.internal.auth.Authenticator;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.exporter.internal.otlp.logs.ResourceLogsMarshaler;
 import io.opentelemetry.exporter.otlp.testing.internal.AbstractHttpTelemetryExporterTest;
 import io.opentelemetry.exporter.otlp.testing.internal.FakeTelemetryUtil;
+import io.opentelemetry.exporter.otlp.testing.internal.HttpLogRecordExporterBuilderWrapper;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporter;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporterBuilder;
 import io.opentelemetry.proto.logs.v1.ResourceLogs;
-import io.opentelemetry.sdk.common.export.RetryPolicy;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
-import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.X509TrustManager;
 
 class OtlpHttpLogRecordExporterJdkSenderTest
     extends AbstractHttpTelemetryExporterTest<LogRecordData, ResourceLogs> {
@@ -35,80 +30,14 @@ class OtlpHttpLogRecordExporterJdkSenderTest
 
   @Override
   protected TelemetryExporterBuilder<LogRecordData> exporterBuilder() {
-    OtlpHttpLogRecordExporterBuilder builder = OtlpHttpLogRecordExporter.builder();
-    return new TelemetryExporterBuilder<>() {
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> setEndpoint(String endpoint) {
-        builder.setEndpoint(endpoint);
-        return this;
-      }
+    return new HttpLogRecordExporterBuilderWrapper(OtlpHttpLogRecordExporter.builder());
+  }
 
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> setTimeout(long timeout, TimeUnit unit) {
-        builder.setTimeout(timeout, unit);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> setTimeout(Duration timeout) {
-        builder.setTimeout(timeout);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> setCompression(String compression) {
-        builder.setCompression(compression);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> addHeader(String key, String value) {
-        builder.addHeader(key, value);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> setAuthenticator(Authenticator authenticator) {
-        Authenticator.setAuthenticatorOnDelegate(builder, authenticator);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> setTrustedCertificates(byte[] certificates) {
-        builder.setTrustedCertificates(certificates);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> setSslContext(
-          SSLContext ssLContext, X509TrustManager trustManager) {
-        builder.setSslContext(ssLContext, trustManager);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> setClientTls(
-          byte[] privateKeyPem, byte[] certificatePem) {
-        builder.setClientTls(privateKeyPem, certificatePem);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> setRetryPolicy(RetryPolicy retryPolicy) {
-        builder.setRetryPolicy(retryPolicy);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<LogRecordData> setChannel(io.grpc.ManagedChannel channel) {
-        throw new UnsupportedOperationException("Not implemented");
-      }
-
-      @Override
-      public TelemetryExporter<LogRecordData> build() {
-        return TelemetryExporter.wrap(builder.build());
-      }
-    };
+  @Override
+  protected TelemetryExporterBuilder<LogRecordData> toBuilder(
+      TelemetryExporter<LogRecordData> exporter) {
+    return new HttpLogRecordExporterBuilderWrapper(
+        ((OtlpHttpLogRecordExporter) exporter.unwrap()).toBuilder());
   }
 
   @Override

--- a/exporters/otlp/all/src/testJdkHttpSender/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterJdkSenderTest.java
+++ b/exporters/otlp/all/src/testJdkHttpSender/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterJdkSenderTest.java
@@ -7,22 +7,18 @@ package io.opentelemetry.exporter.otlp.http.trace;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.exporter.internal.auth.Authenticator;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.exporter.internal.otlp.traces.ResourceSpansMarshaler;
 import io.opentelemetry.exporter.otlp.testing.internal.AbstractHttpTelemetryExporterTest;
 import io.opentelemetry.exporter.otlp.testing.internal.FakeTelemetryUtil;
+import io.opentelemetry.exporter.otlp.testing.internal.HttpSpanExporterBuilderWrapper;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporter;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporterBuilder;
 import io.opentelemetry.exporter.sender.jdk.internal.JdkHttpSender;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
-import io.opentelemetry.sdk.common.export.RetryPolicy;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.X509TrustManager;
+import org.junit.jupiter.api.Test;
 
 class OtlpHttpSpanExporterJdkSenderTest
     extends AbstractHttpTelemetryExporterTest<SpanData, ResourceSpans> {
@@ -38,85 +34,27 @@ class OtlpHttpSpanExporterJdkSenderTest
 
   @Override
   protected TelemetryExporterBuilder<SpanData> exporterBuilder() {
-    OtlpHttpSpanExporterBuilder builder = OtlpHttpSpanExporter.builder();
-    return new TelemetryExporterBuilder<>() {
-      @Override
-      public TelemetryExporterBuilder<SpanData> setEndpoint(String endpoint) {
-        builder.setEndpoint(endpoint);
-        return this;
-      }
+    return new HttpSpanExporterBuilderWrapper(OtlpHttpSpanExporter.builder());
+  }
 
-      @Override
-      public TelemetryExporterBuilder<SpanData> setTimeout(long timeout, TimeUnit unit) {
-        builder.setTimeout(timeout, unit);
-        return this;
-      }
+  @Override
+  protected TelemetryExporterBuilder<SpanData> toBuilder(TelemetryExporter<SpanData> exporter) {
+    return new HttpSpanExporterBuilderWrapper(
+        ((OtlpHttpSpanExporter) exporter.unwrap()).toBuilder());
+  }
 
-      @Override
-      public TelemetryExporterBuilder<SpanData> setTimeout(Duration timeout) {
-        builder.setTimeout(timeout);
-        return this;
-      }
+  @Test
+  void isJdkHttpSender() {
+    TelemetryExporter<SpanData> exporter = exporterBuilder().build();
 
-      @Override
-      public TelemetryExporterBuilder<SpanData> setCompression(String compression) {
-        builder.setCompression(compression);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<SpanData> addHeader(String key, String value) {
-        builder.addHeader(key, value);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<SpanData> setAuthenticator(Authenticator authenticator) {
-        Authenticator.setAuthenticatorOnDelegate(builder, authenticator);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<SpanData> setTrustedCertificates(byte[] certificates) {
-        builder.setTrustedCertificates(certificates);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<SpanData> setSslContext(
-          SSLContext sslContext, X509TrustManager trustManager) {
-        builder.setSslContext(sslContext, trustManager);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<SpanData> setClientTls(
-          byte[] privateKeyPem, byte[] certificatePem) {
-        builder.setClientTls(privateKeyPem, certificatePem);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<SpanData> setRetryPolicy(RetryPolicy retryPolicy) {
-        builder.setRetryPolicy(retryPolicy);
-        return this;
-      }
-
-      @Override
-      public TelemetryExporterBuilder<SpanData> setChannel(io.grpc.ManagedChannel channel) {
-        throw new UnsupportedOperationException("Not implemented");
-      }
-
-      @Override
-      public TelemetryExporter<SpanData> build() {
-        OtlpHttpSpanExporter exporter = builder.build();
-        assertThat(exporter)
-            .extracting("delegate")
-            .extracting("httpSender")
-            .isInstanceOf(JdkHttpSender.class);
-        return TelemetryExporter.wrap(exporter);
-      }
-    };
+    try {
+      assertThat(exporter.unwrap())
+          .extracting("delegate")
+          .extracting("httpSender")
+          .isInstanceOf(JdkHttpSender.class);
+    } finally {
+      exporter.shutdown();
+    }
   }
 
   @Override

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/HttpLogRecordExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/HttpLogRecordExporterBuilderWrapper.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.testing.internal;
+
+import io.opentelemetry.exporter.internal.auth.Authenticator;
+import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder;
+import io.opentelemetry.sdk.common.export.RetryPolicy;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
+
+/** Wrapper of {@link OtlpHttpLogRecordExporterBuilder} for use in integration tests. */
+public class HttpLogRecordExporterBuilderWrapper
+    implements TelemetryExporterBuilder<LogRecordData> {
+  private final OtlpHttpLogRecordExporterBuilder builder;
+
+  public HttpLogRecordExporterBuilderWrapper(OtlpHttpLogRecordExporterBuilder builder) {
+    this.builder = builder;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<LogRecordData> setEndpoint(String endpoint) {
+    builder.setEndpoint(endpoint);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<LogRecordData> setTimeout(long timeout, TimeUnit unit) {
+    builder.setTimeout(timeout, unit);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<LogRecordData> setTimeout(Duration timeout) {
+    builder.setTimeout(timeout);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<LogRecordData> setCompression(String compression) {
+    builder.setCompression(compression);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<LogRecordData> addHeader(String key, String value) {
+    builder.addHeader(key, value);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<LogRecordData> setAuthenticator(Authenticator authenticator) {
+    Authenticator.setAuthenticatorOnDelegate(builder, authenticator);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<LogRecordData> setTrustedCertificates(byte[] certificates) {
+    builder.setTrustedCertificates(certificates);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<LogRecordData> setSslContext(
+      SSLContext sslContext, X509TrustManager trustManager) {
+    builder.setSslContext(sslContext, trustManager);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<LogRecordData> setClientTls(
+      byte[] privateKeyPem, byte[] certificatePem) {
+    builder.setClientTls(privateKeyPem, certificatePem);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<LogRecordData> setRetryPolicy(RetryPolicy retryPolicy) {
+    builder.setRetryPolicy(retryPolicy);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<LogRecordData> setChannel(io.grpc.ManagedChannel channel) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public TelemetryExporter<LogRecordData> build() {
+    return TelemetryExporter.wrap(builder.build());
+  }
+}

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/HttpMetricExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/HttpMetricExporterBuilderWrapper.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.testing.internal;
+
+import io.opentelemetry.exporter.internal.auth.Authenticator;
+import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder;
+import io.opentelemetry.sdk.common.export.RetryPolicy;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
+
+/** Wrapper of {@link OtlpHttpMetricExporterBuilder} for use in integration tests. */
+public class HttpMetricExporterBuilderWrapper implements TelemetryExporterBuilder<MetricData> {
+  private final OtlpHttpMetricExporterBuilder builder;
+
+  public HttpMetricExporterBuilderWrapper(OtlpHttpMetricExporterBuilder builder) {
+    this.builder = builder;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<MetricData> setEndpoint(String endpoint) {
+    builder.setEndpoint(endpoint);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<MetricData> setTimeout(long timeout, TimeUnit unit) {
+    builder.setTimeout(timeout, unit);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<MetricData> setTimeout(Duration timeout) {
+    builder.setTimeout(timeout);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<MetricData> setCompression(String compression) {
+    builder.setCompression(compression);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<MetricData> addHeader(String key, String value) {
+    builder.addHeader(key, value);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<MetricData> setAuthenticator(Authenticator authenticator) {
+    Authenticator.setAuthenticatorOnDelegate(builder, authenticator);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<MetricData> setTrustedCertificates(byte[] certificates) {
+    builder.setTrustedCertificates(certificates);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<MetricData> setSslContext(
+      SSLContext sslContext, X509TrustManager trustManager) {
+    builder.setSslContext(sslContext, trustManager);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<MetricData> setClientTls(
+      byte[] privateKeyPem, byte[] certificatePem) {
+    builder.setClientTls(privateKeyPem, certificatePem);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<MetricData> setRetryPolicy(RetryPolicy retryPolicy) {
+    builder.setRetryPolicy(retryPolicy);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<MetricData> setChannel(io.grpc.ManagedChannel channel) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public TelemetryExporter<MetricData> build() {
+    return TelemetryExporter.wrap(builder.build());
+  }
+}

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/HttpSpanExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/HttpSpanExporterBuilderWrapper.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.testing.internal;
+
+import io.opentelemetry.exporter.internal.auth.Authenticator;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder;
+import io.opentelemetry.sdk.common.export.RetryPolicy;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
+
+/** Wrapper of {@link OtlpHttpSpanExporterBuilder} for use in integration tests. */
+public class HttpSpanExporterBuilderWrapper implements TelemetryExporterBuilder<SpanData> {
+  private final OtlpHttpSpanExporterBuilder builder;
+
+  public HttpSpanExporterBuilderWrapper(OtlpHttpSpanExporterBuilder builder) {
+    this.builder = builder;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<SpanData> setEndpoint(String endpoint) {
+    builder.setEndpoint(endpoint);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<SpanData> setTimeout(long timeout, TimeUnit unit) {
+    builder.setTimeout(timeout, unit);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<SpanData> setTimeout(Duration timeout) {
+    builder.setTimeout(timeout);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<SpanData> setCompression(String compression) {
+    builder.setCompression(compression);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<SpanData> addHeader(String key, String value) {
+    builder.addHeader(key, value);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<SpanData> setAuthenticator(Authenticator authenticator) {
+    Authenticator.setAuthenticatorOnDelegate(builder, authenticator);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<SpanData> setTrustedCertificates(byte[] certificates) {
+    builder.setTrustedCertificates(certificates);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<SpanData> setSslContext(
+      SSLContext sslContext, X509TrustManager trustManager) {
+    builder.setSslContext(sslContext, trustManager);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<SpanData> setClientTls(
+      byte[] privateKeyPem, byte[] certificatePem) {
+    builder.setClientTls(privateKeyPem, certificatePem);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<SpanData> setRetryPolicy(RetryPolicy retryPolicy) {
+    builder.setRetryPolicy(retryPolicy);
+    return this;
+  }
+
+  @Override
+  public TelemetryExporterBuilder<SpanData> setChannel(io.grpc.ManagedChannel channel) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public TelemetryExporter<SpanData> build() {
+    return TelemetryExporter.wrap(builder.build());
+  }
+}

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/export/RetryPolicy.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/export/RetryPolicy.java
@@ -46,6 +46,12 @@ public abstract class RetryPolicy {
         .setBackoffMultiplier(DEFAULT_BACKOFF_MULTIPLIER);
   }
 
+  /**
+   * Returns a {@link RetryPolicyBuilder} reflecting configuration values for this {@link
+   * RetryPolicy}.
+   */
+  public abstract RetryPolicyBuilder toBuilder();
+
   /** Returns the max number of attempts, including the original request. */
   public abstract int getMaxAttempts();
 


### PR DESCRIPTION
Related to #5642. If merged, I'll follow up with a PR to add the same to the OtlpGrpc{Signal}Exporters.