### PR TITLE
Add method to get all property names from `ConfigProperties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### SDK
+
+#### SDK Extensions
+
+* Add method to get all property names from `ConfigProperties`
+  ([#5655](https://github.com/open-telemetry/opentelemetry-java/pull/5655))
+
 ## Version 1.28.0 (2023-07-07)
 
 [opentelemetry-sdk-extension-autoconfigure](./sdk-extensions/autoconfigure) is now stable! See "SDK

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
@@ -1,4 +1,8 @@
 Comparing source compatibility of  against 
-**** MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties  (not serializable)
-	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++* NEW METHOD: PUBLIC(+) ABSTRACT(+) java.util.Set getNormalizedPropertyNames()
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.autoconfigure.spi.IterableConfigProperties  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties
+	+++  NEW INTERFACE: java.lang.Iterable
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) java.util.Set getNormalizedPropertyNames()
+	+++  NEW METHOD: PUBLIC(+) java.util.Iterator iterator()

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+**** MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++* NEW METHOD: PUBLIC(+) ABSTRACT(+) java.util.Set getNormalizedPropertyNames()

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java
@@ -7,11 +7,9 @@ package io.opentelemetry.sdk.autoconfigure.spi;
 
 import static io.opentelemetry.api.internal.ConfigUtil.defaultIfNull;
 
-import io.opentelemetry.api.internal.ConfigUtil;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import javax.annotation.Nullable;
 
 /** Properties used for auto-configuration of the OpenTelemetry SDK components. */
@@ -206,13 +204,4 @@ public interface ConfigProperties {
     Map<String, String> value = getMap(name);
     return value.isEmpty() ? defaultValue : value;
   }
-
-  /**
-   * Returns all property names in the normalized form. System properties are normalized using
-   * {@link ConfigUtil#normalizePropertyKey(String)}. Environment variables are normalized using
-   * {@link ConfigUtil#normalizeEnvironmentVariableKey(String)}.
-   *
-   * @return all property names in the normalized form.
-   */
-  Set<String> getNormalizedPropertyNames();
 }

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java
@@ -7,9 +7,11 @@ package io.opentelemetry.sdk.autoconfigure.spi;
 
 import static io.opentelemetry.api.internal.ConfigUtil.defaultIfNull;
 
+import io.opentelemetry.api.internal.ConfigUtil;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /** Properties used for auto-configuration of the OpenTelemetry SDK components. */
@@ -204,4 +206,13 @@ public interface ConfigProperties {
     Map<String, String> value = getMap(name);
     return value.isEmpty() ? defaultValue : value;
   }
+
+  /**
+   * Returns all property names in the normalized form. System properties are normalized using
+   * {@link ConfigUtil#normalizePropertyKey(String)}. Environment variables are normalized using
+   * {@link ConfigUtil#normalizeEnvironmentVariableKey(String)}.
+   *
+   * @return all property names in the normalized form.
+   */
+  Set<String> getNormalizedPropertyNames();
 }

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/IterableConfigProperties.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/IterableConfigProperties.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure.spi;
+
+import io.opentelemetry.api.internal.ConfigUtil;
+import java.util.Iterator;
+import java.util.Set;
+
+/** Config properties that allow access to the property names. */
+public interface IterableConfigProperties extends ConfigProperties, Iterable<String> {
+
+  /**
+   * Returns all property names in the normalized form. System properties are normalized using
+   * {@link ConfigUtil#normalizePropertyKey(String)}. Environment variables are normalized using
+   * {@link ConfigUtil#normalizeEnvironmentVariableKey(String)}.
+   *
+   * @return all property names in the normalized form.
+   */
+  Set<String> getNormalizedPropertyNames();
+
+  @Override
+  default Iterator<String> iterator() {
+    return getNormalizedPropertyNames().iterator();
+  }
+}

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/DefaultConfigProperties.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/DefaultConfigProperties.java
@@ -283,4 +283,9 @@ public final class DefaultConfigProperties implements ConfigProperties {
     // Pull everything after the last digit.
     return rawValue.substring(lastDigitIndex + 1);
   }
+
+  @Override
+  public Set<String> getNormalizedPropertyNames() {
+    return config.keySet();
+  }
 }

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/DefaultConfigProperties.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/DefaultConfigProperties.java
@@ -11,6 +11,7 @@ import static java.util.stream.Collectors.joining;
 import io.opentelemetry.api.internal.ConfigUtil;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
+import io.opentelemetry.sdk.autoconfigure.spi.IterableConfigProperties;
 import java.time.Duration;
 import java.util.AbstractMap;
 import java.util.Arrays;
@@ -34,7 +35,7 @@ import javax.annotation.Nullable;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public final class DefaultConfigProperties implements ConfigProperties {
+public final class DefaultConfigProperties implements IterableConfigProperties {
 
   private final Map<String, String> config;
 

--- a/sdk-extensions/autoconfigure-spi/src/test/java/io/opentelemetry/sdk/autoconfigure/spi/internal/ConfigPropertiesTest.java
+++ b/sdk-extensions/autoconfigure-spi/src/test/java/io/opentelemetry/sdk/autoconfigure/spi/internal/ConfigPropertiesTest.java
@@ -23,6 +23,21 @@ import org.junit.jupiter.api.Test;
 class ConfigPropertiesTest {
 
   @Test
+  void getPropertyNames() {
+    ConfigProperties config = DefaultConfigProperties.createForTest(makeTestProps());
+    assertThat(config.getNormalizedPropertyNames())
+        .containsExactlyInAnyOrder(
+            "test.string",
+            "test.int",
+            "test.long",
+            "test.double",
+            "test.boolean",
+            "test.list",
+            "test.map",
+            "test.duration");
+  }
+
+  @Test
   void allValid() {
     Map<String, String> properties = makeTestProps();
 

--- a/sdk-extensions/autoconfigure-spi/src/test/java/io/opentelemetry/sdk/autoconfigure/spi/internal/ConfigPropertiesTest.java
+++ b/sdk-extensions/autoconfigure-spi/src/test/java/io/opentelemetry/sdk/autoconfigure/spi/internal/ConfigPropertiesTest.java
@@ -13,10 +13,12 @@ import static org.assertj.core.api.Assertions.entry;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
+import io.opentelemetry.sdk.autoconfigure.spi.IterableConfigProperties;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -24,9 +26,9 @@ class ConfigPropertiesTest {
 
   @Test
   void getPropertyNames() {
-    ConfigProperties config = DefaultConfigProperties.createForTest(makeTestProps());
-    assertThat(config.getNormalizedPropertyNames())
-        .containsExactlyInAnyOrder(
+    IterableConfigProperties config = DefaultConfigProperties.createForTest(makeTestProps());
+    List<String> expected =
+        Arrays.asList(
             "test.string",
             "test.int",
             "test.long",
@@ -35,6 +37,8 @@ class ConfigPropertiesTest {
             "test.list",
             "test.map",
             "test.duration");
+    assertThat(config.getNormalizedPropertyNames()).containsExactlyInAnyOrderElementsOf(expected);
+    assertThat(config).containsExactlyInAnyOrderElementsOf(expected);
   }
 
   @Test


### PR DESCRIPTION
Use case: In an extension, I want to check which modules the user has disabled or enabled.