### PR TITLE
Add toString to OTLP exporters

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
@@ -2,18 +2,24 @@ Comparing source compatibility of  against
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder toBuilder()
+	+++  NEW METHOD: PUBLIC(+) java.lang.String toString()
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder toBuilder()
+	+++  NEW METHOD: PUBLIC(+) java.lang.String toString()
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder toBuilder()
+	+++  NEW METHOD: PUBLIC(+) java.lang.String toString()
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporter  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporterBuilder toBuilder()
+	+++  NEW METHOD: PUBLIC(+) java.lang.String toString()
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder toBuilder()
+	+++  NEW METHOD: PUBLIC(+) java.lang.String toString()
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder toBuilder()
+	+++  NEW METHOD: PUBLIC(+) java.lang.String toString()

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
@@ -203,9 +203,11 @@ public class GrpcExporterBuilder<T extends Marshaler> {
         compressionEnabled);
   }
 
-  @Override
-  public String toString() {
-    StringJoiner joiner = new StringJoiner(", ", "GrpcExporterBuilder{", "}");
+  public String toString(boolean includePrefixAndSuffix) {
+    StringJoiner joiner =
+        includePrefixAndSuffix
+            ? new StringJoiner(", ", "GrpcExporterBuilder{", "}")
+            : new StringJoiner(", ");
     joiner.add("exporterName=" + exporterName);
     joiner.add("type=" + type);
     joiner.add("endpoint=" + endpoint.toString());
@@ -224,6 +226,11 @@ public class GrpcExporterBuilder<T extends Marshaler> {
     // Note: omit tlsConfigHelper because we can't log the configuration in any readable way
     // Note: omit meterProviderSupplier because we can't log the configuration in any readable way
     return joiner.toString();
+  }
+
+  @Override
+  public String toString() {
+    return toString(true);
   }
 
   // Use an inner class to ensure GrpcExporterBuilder does not have classloading dependencies on

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -200,6 +201,29 @@ public class GrpcExporterBuilder<T extends Marshaler> {
         endpoint,
         headers.build(),
         compressionEnabled);
+  }
+
+  @Override
+  public String toString() {
+    StringJoiner joiner = new StringJoiner(", ", "GrpcExporterBuilder{", "}");
+    joiner.add("exporterName=" + exporterName);
+    joiner.add("type=" + type);
+    joiner.add("endpoint=" + endpoint.toString());
+    joiner.add("endpointPath=" + grpcEndpointPath);
+    joiner.add("timeoutNanos=" + timeoutNanos);
+    joiner.add("compressionEnabled=" + compressionEnabled);
+    StringJoiner headersJoiner = new StringJoiner(", ", "Headers{", "}");
+    headers.forEach((key, value) -> headersJoiner.add(key + "=OBFUSCATED"));
+    joiner.add("headers=" + headersJoiner);
+    if (retryPolicy != null) {
+      joiner.add("retryPolicy=" + retryPolicy);
+    }
+    if (grpcChannel != null) {
+      joiner.add("grpcChannel=" + grpcChannel);
+    }
+    // Note: omit tlsConfigHelper because we can't log the configuration in any readable way
+    // Note: omit meterProviderSupplier because we can't log the configuration in any readable way
+    return joiner.toString();
   }
 
   // Use an inner class to ensure GrpcExporterBuilder does not have classloading dependencies on

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpExporterBuilder.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -164,6 +165,29 @@ public final class HttpExporterBuilder<T extends Marshaler> {
     LOGGER.log(Level.FINE, "Using HttpSender: " + httpSender.getClass().getName());
 
     return new HttpExporter<>(exporterName, type, httpSender, meterProviderSupplier, exportAsJson);
+  }
+
+  @Override
+  public String toString() {
+    StringJoiner joiner = new StringJoiner(", ", "HttpExporterBuilder{", "}");
+    joiner.add("exporterName=" + exporterName);
+    joiner.add("type=" + type);
+    joiner.add("endpoint=" + endpoint);
+    joiner.add("timeoutNanos=" + timeoutNanos);
+    joiner.add("compressionEnabled=" + compressionEnabled);
+    joiner.add("exportAsJson=" + exportAsJson);
+    if (headers != null) {
+      StringJoiner headersJoiner = new StringJoiner(", ", "Headers{", "}");
+      headers.forEach((key, value) -> headersJoiner.add(key + "=OBFUSCATED"));
+      joiner.add("headers=" + headersJoiner);
+    }
+    if (retryPolicy != null) {
+      joiner.add("retryPolicy=" + retryPolicy);
+    }
+    // Note: omit tlsConfigHelper because we can't log the configuration in any readable way
+    // Note: omit meterProviderSupplier because we can't log the configuration in any readable way
+    // Note: omit authenticator because we can't log the configuration in any readable way
+    return joiner.toString();
   }
 
   /**

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpExporterBuilder.java
@@ -167,9 +167,11 @@ public final class HttpExporterBuilder<T extends Marshaler> {
     return new HttpExporter<>(exporterName, type, httpSender, meterProviderSupplier, exportAsJson);
   }
 
-  @Override
-  public String toString() {
-    StringJoiner joiner = new StringJoiner(", ", "HttpExporterBuilder{", "}");
+  public String toString(boolean includePrefixAndSuffix) {
+    StringJoiner joiner =
+        includePrefixAndSuffix
+            ? new StringJoiner(", ", "GrpcExporterBuilder{", "}")
+            : new StringJoiner(", ");
     joiner.add("exporterName=" + exporterName);
     joiner.add("type=" + type);
     joiner.add("endpoint=" + endpoint);
@@ -188,6 +190,11 @@ public final class HttpExporterBuilder<T extends Marshaler> {
     // Note: omit meterProviderSupplier because we can't log the configuration in any readable way
     // Note: omit authenticator because we can't log the configuration in any readable way
     return joiner.toString();
+  }
+
+  @Override
+  public String toString() {
+    return toString(true);
   }
 
   /**

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpExporterBuilder.java
@@ -170,7 +170,7 @@ public final class HttpExporterBuilder<T extends Marshaler> {
   public String toString(boolean includePrefixAndSuffix) {
     StringJoiner joiner =
         includePrefixAndSuffix
-            ? new StringJoiner(", ", "GrpcExporterBuilder{", "}")
+            ? new StringJoiner(", ", "HttpExporterBuilder{", "}")
             : new StringJoiner(", ");
     joiner.add("exporterName=" + exporterName);
     joiner.add("type=" + type);

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporter.java
@@ -84,4 +84,9 @@ public final class OtlpHttpLogRecordExporter implements LogRecordExporter {
   public CompletableResultCode shutdown() {
     return delegate.shutdown();
   }
+
+  @Override
+  public String toString() {
+    return "OtlpHttpLogRecordExporter{builder=" + builder + "}";
+  }
 }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporter.java
@@ -87,6 +87,6 @@ public final class OtlpHttpLogRecordExporter implements LogRecordExporter {
 
   @Override
   public String toString() {
-    return "OtlpHttpLogRecordExporter{builder=" + builder + "}";
+    return "OtlpHttpLogRecordExporter{" + builder.toString(false) + "}";
   }
 }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporter.java
@@ -113,6 +113,6 @@ public final class OtlpHttpMetricExporter implements MetricExporter {
 
   @Override
   public String toString() {
-    return "OtlpHttpMetricExporter{builder=" + builder + "}";
+    return "OtlpHttpMetricExporter{" + builder.toString(false) + "}";
   }
 }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporter.java
@@ -110,4 +110,9 @@ public final class OtlpHttpMetricExporter implements MetricExporter {
   public CompletableResultCode shutdown() {
     return delegate.shutdown();
   }
+
+  @Override
+  public String toString() {
+    return "OtlpHttpMetricExporter{builder=" + builder + "}";
+  }
 }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporter.java
@@ -92,6 +92,6 @@ public final class OtlpHttpSpanExporter implements SpanExporter {
 
   @Override
   public String toString() {
-    return "OtlpHttpSpanExporter{builder=" + builder + "}";
+    return "OtlpHttpSpanExporter{" + builder.toString(false) + "}";
   }
 }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporter.java
@@ -89,4 +89,9 @@ public final class OtlpHttpSpanExporter implements SpanExporter {
   public CompletableResultCode shutdown() {
     return delegate.shutdown();
   }
+
+  @Override
+  public String toString() {
+    return "OtlpHttpSpanExporter{builder=" + builder + "}";
+  }
 }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporter.java
@@ -90,6 +90,6 @@ public final class OtlpGrpcLogRecordExporter implements LogRecordExporter {
 
   @Override
   public String toString() {
-    return "OtlpGrpcLogRecordExporter{builder=" + builder + "}";
+    return "OtlpGrpcLogRecordExporter{" + builder.toString(false) + "}";
   }
 }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporter.java
@@ -87,4 +87,9 @@ public final class OtlpGrpcLogRecordExporter implements LogRecordExporter {
   public CompletableResultCode shutdown() {
     return delegate.shutdown();
   }
+
+  @Override
+  public String toString() {
+    return "OtlpGrpcLogRecordExporter{builder=" + builder + "}";
+  }
 }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporter.java
@@ -117,6 +117,6 @@ public final class OtlpGrpcMetricExporter implements MetricExporter {
 
   @Override
   public String toString() {
-    return "OtlpGrpcMetricExporter{builder=" + builder + "}";
+    return "OtlpGrpcMetricExporter{" + builder.toString(false) + "}";
   }
 }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporter.java
@@ -114,4 +114,9 @@ public final class OtlpGrpcMetricExporter implements MetricExporter {
   public CompletableResultCode shutdown() {
     return delegate.shutdown();
   }
+
+  @Override
+  public String toString() {
+    return "OtlpGrpcMetricExporter{builder=" + builder + "}";
+  }
 }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporter.java
@@ -92,6 +92,6 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
 
   @Override
   public String toString() {
-    return "OtlpGrpcSpanExporter{builder=" + builder + "}";
+    return "OtlpGrpcSpanExporter{" + builder.toString(false) + "}";
   }
 }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporter.java
@@ -89,4 +89,9 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
   public CompletableResultCode shutdown() {
     return delegate.shutdown();
   }
+
+  @Override
+  public String toString() {
+    return "OtlpGrpcSpanExporter{builder=" + builder + "}";
+  }
 }

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
@@ -790,7 +790,7 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
     try {
       assertThat(telemetryExporter.unwrap().toString())
           .matches(
-              "OtlpGrpc[a-zA-Z]*Exporter\\{builder=GrpcExporterBuilder\\{"
+              "OtlpGrpc[a-zA-Z]*Exporter\\{"
                   + "exporterName=otlp, "
                   + "type=[a-zA_Z]*, "
                   + "endpoint=http://localhost:4317, "
@@ -801,7 +801,7 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
                   + "compressionEnabled=false, "
                   + "headers=Headers\\{User-Agent=OBFUSCATED\\}"
                   + ".*" // Maybe additional grpcChannel field
-                  + "\\}\\}");
+                  + "\\}");
     } finally {
       telemetryExporter.shutdown();
     }
@@ -827,7 +827,7 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
     try {
       assertThat(telemetryExporter.unwrap().toString())
           .matches(
-              "OtlpGrpc[a-zA-Z]*Exporter\\{builder=GrpcExporterBuilder\\{"
+              "OtlpGrpc[a-zA-Z]*Exporter\\{"
                   + "exporterName=otlp, "
                   + "type=[a-zA_Z]*, "
                   + "endpoint=http://example:4317, "
@@ -839,7 +839,7 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
                   + "headers=Headers\\{.*foo=OBFUSCATED.*\\}, "
                   + "retryPolicy=RetryPolicy\\{maxAttempts=2, initialBackoff=PT0\\.05S, maxBackoff=PT3S, backoffMultiplier=1\\.3\\}"
                   + ".*" // Maybe additional grpcChannel field
-                  + "\\}\\}");
+                  + "\\}");
     } finally {
       telemetryExporter.shutdown();
     }

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
@@ -783,6 +783,68 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
     }
   }
 
+  @Test
+  void stringRepresentation() throws IOException, CertificateEncodingException {
+    TelemetryExporter<T> telemetryExporter =
+        exporterBuilder().setEndpoint("http://localhost:4317").build();
+    try {
+      assertThat(telemetryExporter.unwrap().toString())
+          .matches(
+              "OtlpGrpc[a-zA-Z]*Exporter\\{builder=GrpcExporterBuilder\\{"
+                  + "exporterName=otlp, "
+                  + "type=[a-zA_Z]*, "
+                  + "endpoint=http://localhost:4317, "
+                  + "endpointPath=.*, "
+                  + "timeoutNanos="
+                  + TimeUnit.SECONDS.toNanos(10)
+                  + ", "
+                  + "compressionEnabled=false, "
+                  + "headers=Headers\\{User-Agent=OBFUSCATED\\}"
+                  + ".*" // Maybe additional grpcChannel field
+                  + "\\}\\}");
+    } finally {
+      telemetryExporter.shutdown();
+    }
+
+    telemetryExporter =
+        exporterBuilder()
+            .setTimeout(Duration.ofSeconds(5))
+            .setEndpoint("http://example:4317")
+            .setCompression("gzip")
+            .addHeader("foo", "bar")
+            .setTrustedCertificates(certificate.certificate().getEncoded())
+            .setClientTls(
+                Files.readAllBytes(clientCertificate.privateKeyFile().toPath()),
+                Files.readAllBytes(clientCertificate.certificateFile().toPath()))
+            .setRetryPolicy(
+                RetryPolicy.builder()
+                    .setMaxAttempts(2)
+                    .setMaxBackoff(Duration.ofSeconds(3))
+                    .setInitialBackoff(Duration.ofMillis(50))
+                    .setBackoffMultiplier(1.3)
+                    .build())
+            .build();
+    try {
+      assertThat(telemetryExporter.unwrap().toString())
+          .matches(
+              "OtlpGrpc[a-zA-Z]*Exporter\\{builder=GrpcExporterBuilder\\{"
+                  + "exporterName=otlp, "
+                  + "type=[a-zA_Z]*, "
+                  + "endpoint=http://example:4317, "
+                  + "endpointPath=.*, "
+                  + "timeoutNanos="
+                  + TimeUnit.SECONDS.toNanos(5)
+                  + ", "
+                  + "compressionEnabled=true, "
+                  + "headers=Headers\\{.*foo=OBFUSCATED.*\\}, "
+                  + "retryPolicy=RetryPolicy\\{maxAttempts=2, initialBackoff=PT0\\.05S, maxBackoff=PT3S, backoffMultiplier=1\\.3\\}"
+                  + ".*" // Maybe additional grpcChannel field
+                  + "\\}\\}");
+    } finally {
+      telemetryExporter.shutdown();
+    }
+  }
+
   protected abstract TelemetryExporterBuilder<T> exporterBuilder();
 
   protected abstract TelemetryExporterBuilder<T> toBuilder(TelemetryExporter<T> exporter);

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
@@ -721,7 +721,7 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
     try {
       assertThat(telemetryExporter.unwrap().toString())
           .matches(
-              "OtlpHttp[a-zA-Z]*Exporter\\{builder=HttpExporterBuilder\\{"
+              "OtlpHttp[a-zA-Z]*Exporter\\{"
                   + "exporterName=otlp, "
                   + "type=[a-zA_Z]*, "
                   + "endpoint=http://localhost:4318/v1/[a-zA-Z]*, "
@@ -731,7 +731,7 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
                   + "compressionEnabled=false, "
                   + "exportAsJson=false, "
                   + "headers=Headers\\{User-Agent=OBFUSCATED\\}"
-                  + "\\}\\}");
+                  + "\\}");
     } finally {
       telemetryExporter.shutdown();
     }
@@ -757,7 +757,7 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
     try {
       assertThat(telemetryExporter.unwrap().toString())
           .matches(
-              "OtlpHttp[a-zA-Z]*Exporter\\{builder=HttpExporterBuilder\\{"
+              "OtlpHttp[a-zA-Z]*Exporter\\{"
                   + "exporterName=otlp, "
                   + "type=[a-zA_Z]*, "
                   + "endpoint=http://example:4318/v1/[a-zA-Z]*, "
@@ -768,7 +768,7 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
                   + "exportAsJson=false, "
                   + "headers=Headers\\{.*foo=OBFUSCATED.*\\}, "
                   + "retryPolicy=RetryPolicy\\{maxAttempts=2, initialBackoff=PT0\\.05S, maxBackoff=PT3S, backoffMultiplier=1\\.3\\}"
-                  + "\\}\\}");
+                  + "\\}");
     } finally {
       telemetryExporter.shutdown();
     }

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/ManagedChannelTelemetryExporterBuilder.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/ManagedChannelTelemetryExporterBuilder.java
@@ -90,6 +90,7 @@ public final class ManagedChannelTelemetryExporterBuilder<T>
 
   @Override
   public TelemetryExporterBuilder<T> setAuthenticator(Authenticator authenticator) {
+    delegate.setAuthenticator(authenticator);
     return this;
   }
 
@@ -99,18 +100,21 @@ public final class ManagedChannelTelemetryExporterBuilder<T>
 
   @Override
   public TelemetryExporterBuilder<T> setTrustedCertificates(byte[] certificates) {
+    delegate.setTrustedCertificates(certificates);
     tlsConfigHelper.setTrustManagerFromCerts(certificates);
     return this;
   }
 
   @Override
   public TelemetryExporterBuilder<T> setClientTls(byte[] privateKeyPem, byte[] certificatePem) {
+    delegate.setClientTls(privateKeyPem, certificatePem);
     tlsConfigHelper.setKeyManagerFromCerts(privateKeyPem, certificatePem);
     return this;
   }
 
   @Override
   public TelemetryExporterBuilder<T> setRetryPolicy(RetryPolicy retryPolicy) {
+    delegate.setRetryPolicy(retryPolicy);
     String grpcServiceName;
     if (delegate instanceof GrpcLogRecordExporterBuilderWrapper) {
       grpcServiceName = "opentelemetry.proto.collector.logs.v1.LogsService";
@@ -167,6 +171,7 @@ public final class ManagedChannelTelemetryExporterBuilder<T>
   @Override
   public TelemetryExporterBuilder<T> setSslContext(
       SSLContext sslContext, X509TrustManager trustManager) {
+    delegate.setSslContext(sslContext, trustManager);
     tlsConfigHelper.setSslContext(sslContext, trustManager);
     return this;
   }


### PR DESCRIPTION
#5680  and #5652 opened the door to an easy toString implementation on OTLP exporters. This continues down the path of making it easier to diagnose the configuration of OpenTelemetrySdk, since the otel java agent or any other application can log `OpenTelemetrySdk#toString()`.

Another nice side affect of this is that it makes it easier to compare configured instances of the OTLP exporters (i.e. from file configuration) without a bunch of reflective introspection to examine internal fields.

Note, in order to avoid printing secrets, I print all headers as `{header-name}=OBFUSCATED`. Better to be overly restrictive about what we print than accidentally print some secret because we misidentify a header as safe to print.