### PR TITLE
Add reminder to shutdown exporter instances if replacing

### DIFF
--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizer.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizer.java
@@ -56,6 +56,9 @@ public interface AutoConfigurationCustomizer {
    * allow customization. The return value of the {@link BiFunction} will replace the passed-in
    * argument.
    *
+   * <p>NOTE: If returning a different exporter instance, be sure to call {@link
+   * SpanExporter#shutdown()} on the instance passed as an argument to release resources.
+   *
    * <p>Multiple calls will execute the customizers in order.
    */
   AutoConfigurationCustomizer addSpanExporterCustomizer(
@@ -128,6 +131,9 @@ public interface AutoConfigurationCustomizer {
    * allow customization. The return value of the {@link BiFunction} will replace the passed-in
    * argument.
    *
+   * <p>NOTE: If returning a different exporter instance, be sure to call {@link
+   * SpanExporter#shutdown()} on the instance passed as an argument to release resources.
+   *
    * <p>Multiple calls will execute the customizers in order.
    */
   default AutoConfigurationCustomizer addMetricExporterCustomizer(
@@ -154,6 +160,9 @@ public interface AutoConfigurationCustomizer {
    * Adds a {@link BiFunction} to invoke with the default autoconfigured {@link LogRecordExporter}
    * to allow customization. The return value of the {@link BiFunction} will replace the passed-in
    * argument.
+   *
+   * <p>NOTE: If returning a different exporter instance, be sure to call {@link
+   * SpanExporter#shutdown()} on the instance passed as an argument to release resources.
    *
    * <p>Multiple calls will execute the customizers in order.
    *


### PR DESCRIPTION
Improving docs now that #5680 and #5652 allow you to easily replace exporters with additional customizations not available via environment variables.