### PR TITLE
Add LongHistogramAdviceConfigurer to improve api surface types

### DIFF
--- a/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/metrics/DoubleHistogramAdviceConfigurer.java
+++ b/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/metrics/DoubleHistogramAdviceConfigurer.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.extension.incubator.metrics;
+
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.LongHistogram;
+import java.util.List;
+
+/** Configure advice for implementations of {@link DoubleHistogram}. */
+public interface DoubleHistogramAdviceConfigurer {
+
+  /** Specify recommended set of explicit bucket boundaries for this histogram. */
+  DoubleHistogramAdviceConfigurer setExplicitBucketBoundaries(List<Double> bucketBoundaries);
+}

--- a/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/metrics/DoubleHistogramAdviceConfigurer.java
+++ b/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/metrics/DoubleHistogramAdviceConfigurer.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.extension.incubator.metrics;
 
 import io.opentelemetry.api.metrics.DoubleHistogram;
-import io.opentelemetry.api.metrics.LongHistogram;
 import java.util.List;
 
 /** Configure advice for implementations of {@link DoubleHistogram}. */

--- a/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/metrics/ExtendedDoubleHistogramBuilder.java
+++ b/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/metrics/ExtendedDoubleHistogramBuilder.java
@@ -12,7 +12,8 @@ import java.util.function.Consumer;
 public interface ExtendedDoubleHistogramBuilder extends DoubleHistogramBuilder {
 
   /** Specify advice for histogram implementations. */
-  default DoubleHistogramBuilder setAdvice(Consumer<HistogramAdviceConfigurer> adviceConsumer) {
+  default DoubleHistogramBuilder setAdvice(
+      Consumer<DoubleHistogramAdviceConfigurer> adviceConsumer) {
     return this;
   }
 }

--- a/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/metrics/ExtendedLongHistogramBuilder.java
+++ b/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/metrics/ExtendedLongHistogramBuilder.java
@@ -12,7 +12,7 @@ import java.util.function.Consumer;
 public interface ExtendedLongHistogramBuilder extends LongHistogramBuilder {
 
   /** Specify advice for histogram implementations. */
-  default LongHistogramBuilder setAdvice(Consumer<HistogramAdviceConfigurer> adviceConsumer) {
+  default LongHistogramBuilder setAdvice(Consumer<LongHistogramAdviceConfigurer> adviceConsumer) {
     return this;
   }
 }

--- a/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/metrics/LongHistogramAdviceConfigurer.java
+++ b/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/metrics/LongHistogramAdviceConfigurer.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.extension.incubator.metrics;
 
-import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.LongHistogram;
 import java.util.List;
 

--- a/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/metrics/LongHistogramAdviceConfigurer.java
+++ b/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/metrics/LongHistogramAdviceConfigurer.java
@@ -9,9 +9,9 @@ import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.LongHistogram;
 import java.util.List;
 
-/** Configure advice for implementations of {@link LongHistogram} and {@link DoubleHistogram}. */
-public interface HistogramAdviceConfigurer {
+/** Configure advice for implementations of {@link LongHistogram}. */
+public interface LongHistogramAdviceConfigurer {
 
   /** Specify recommended set of explicit bucket boundaries for this histogram. */
-  HistogramAdviceConfigurer setExplicitBucketBoundaries(List<Double> bucketBoundaries);
+  LongHistogramAdviceConfigurer setExplicitBucketBoundaries(List<Long> bucketBoundaries);
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleHistogram.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleHistogram.java
@@ -9,8 +9,8 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.LongHistogramBuilder;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.extension.incubator.metrics.DoubleHistogramAdviceConfigurer;
 import io.opentelemetry.extension.incubator.metrics.ExtendedDoubleHistogramBuilder;
-import io.opentelemetry.extension.incubator.metrics.HistogramAdviceConfigurer;
 import io.opentelemetry.sdk.internal.ThrottlingLogger;
 import io.opentelemetry.sdk.metrics.internal.descriptor.Advice;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
@@ -58,7 +58,7 @@ final class SdkDoubleHistogram extends AbstractInstrument implements DoubleHisto
 
   static final class SdkDoubleHistogramBuilder
       extends AbstractInstrumentBuilder<SdkDoubleHistogramBuilder>
-      implements ExtendedDoubleHistogramBuilder, HistogramAdviceConfigurer {
+      implements ExtendedDoubleHistogramBuilder, DoubleHistogramAdviceConfigurer {
 
     SdkDoubleHistogramBuilder(
         MeterProviderSharedState meterProviderSharedState,
@@ -80,7 +80,8 @@ final class SdkDoubleHistogram extends AbstractInstrument implements DoubleHisto
     }
 
     @Override
-    public SdkDoubleHistogramBuilder setAdvice(Consumer<HistogramAdviceConfigurer> adviceConsumer) {
+    public SdkDoubleHistogramBuilder setAdvice(
+        Consumer<DoubleHistogramAdviceConfigurer> adviceConsumer) {
       adviceConsumer.accept(this);
       return this;
     }
@@ -96,7 +97,8 @@ final class SdkDoubleHistogram extends AbstractInstrument implements DoubleHisto
     }
 
     @Override
-    public HistogramAdviceConfigurer setExplicitBucketBoundaries(List<Double> bucketBoundaries) {
+    public DoubleHistogramAdviceConfigurer setExplicitBucketBoundaries(
+        List<Double> bucketBoundaries) {
       setAdvice(Advice.create(bucketBoundaries));
       return this;
     }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongHistogram.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongHistogram.java
@@ -9,7 +9,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.extension.incubator.metrics.ExtendedLongHistogramBuilder;
-import io.opentelemetry.extension.incubator.metrics.HistogramAdviceConfigurer;
+import io.opentelemetry.extension.incubator.metrics.LongHistogramAdviceConfigurer;
 import io.opentelemetry.sdk.internal.ThrottlingLogger;
 import io.opentelemetry.sdk.metrics.internal.descriptor.Advice;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 final class SdkLongHistogram extends AbstractInstrument implements LongHistogram {
   private static final Logger logger = Logger.getLogger(SdkLongHistogram.class.getName());
@@ -57,7 +58,7 @@ final class SdkLongHistogram extends AbstractInstrument implements LongHistogram
 
   static final class SdkLongHistogramBuilder
       extends AbstractInstrumentBuilder<SdkLongHistogramBuilder>
-      implements ExtendedLongHistogramBuilder, HistogramAdviceConfigurer {
+      implements ExtendedLongHistogramBuilder, LongHistogramAdviceConfigurer {
 
     SdkLongHistogramBuilder(
         MeterProviderSharedState meterProviderSharedState,
@@ -83,7 +84,8 @@ final class SdkLongHistogram extends AbstractInstrument implements LongHistogram
     }
 
     @Override
-    public SdkLongHistogramBuilder setAdvice(Consumer<HistogramAdviceConfigurer> adviceConsumer) {
+    public SdkLongHistogramBuilder setAdvice(
+        Consumer<LongHistogramAdviceConfigurer> adviceConsumer) {
       adviceConsumer.accept(this);
       return this;
     }
@@ -94,8 +96,10 @@ final class SdkLongHistogram extends AbstractInstrument implements LongHistogram
     }
 
     @Override
-    public HistogramAdviceConfigurer setExplicitBucketBoundaries(List<Double> bucketBoundaries) {
-      setAdvice(Advice.create(bucketBoundaries));
+    public LongHistogramAdviceConfigurer setExplicitBucketBoundaries(List<Long> bucketBoundaries) {
+      List<Double> doubleBoundaries =
+          bucketBoundaries.stream().map(Long::doubleValue).collect(Collectors.toList());
+      setAdvice(Advice.create(doubleBoundaries));
       return this;
     }
   }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AdviceTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/AdviceTest.java
@@ -194,8 +194,7 @@ class AdviceTest {
                               meterProvider.get("meter").histogramBuilder("histogram").ofLongs())
                           .setAdvice(
                               advice ->
-                                  advice.setExplicitBucketBoundaries(
-                                      Arrays.asList(10.0, 20.0, 30.0)))
+                                  advice.setExplicitBucketBoundaries(Arrays.asList(10L, 20L, 30L)))
                           .build();
                   return build::record;
                 }));


### PR DESCRIPTION
It struck me as a little bit of an ergonomics problem to have to pass a collection of doubles when setting explicit bucket boundaries for a LongHistogram builder/advice.

See how the `AdviceTest` changes in this PR for an example of how this should feel a slight bit better.