### PR TITLE
Add hasResourceSatisfying to LogRecordDataAssert

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.LogRecordDataAssert  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LogRecordDataAssert hasResourceSatisfying(java.util.function.Consumer<io.opentelemetry.sdk.testing.assertj.ResourceAssert>)

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LogRecordDataAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LogRecordDataAssert.java
@@ -47,6 +47,19 @@ public final class LogRecordDataAssert extends AbstractAssert<LogRecordDataAsser
   }
 
   /**
+   * Asserts the log has a resource satisfying the given condition.
+   *
+   * @since 1.29.0
+   */
+  public LogRecordDataAssert hasResourceSatisfying(Consumer<ResourceAssert> resource) {
+    isNotNull();
+    resource.accept(
+        new ResourceAssert(
+            actual.getResource(), String.format("log [%s]", actual.getBody().asString())));
+    return this;
+  }
+
+  /**
    * Asserts the {@link InstrumentationScopeInfo} associated with a log matches the expected value.
    */
   public LogRecordDataAssert hasInstrumentationScope(


### PR DESCRIPTION
This brings log asserts into parity with metric and span asserts. Been meaning to do this for a while.