### PR TITLE
Switch from snakeyaml to snakeyaml engine

### DIFF
--- a/sdk-extensions/incubator/build.gradle.kts
+++ b/sdk-extensions/incubator/build.gradle.kts
@@ -27,7 +27,6 @@ dependencies {
   // io.opentelemetry.sdk.extension.incubator.fileconfig
   implementation("com.fasterxml.jackson.core:jackson-databind")
   implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
-  implementation("org.yaml:snakeyaml:2.1")
 
   testImplementation(project(":sdk:testing"))
   testImplementation(project(":sdk-extensions:autoconfigure"))

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ConfigurationReader.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ConfigurationReader.java
@@ -8,18 +8,20 @@ package io.opentelemetry.sdk.extension.incubator.fileconfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfiguration;
 import java.io.InputStream;
-import org.yaml.snakeyaml.Yaml;
+import org.snakeyaml.engine.v2.api.Load;
+import org.snakeyaml.engine.v2.api.LoadSettings;
 
 class ConfigurationReader {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
-  private static final Yaml YAML = new Yaml();
 
   private ConfigurationReader() {}
 
   /** Parse the {@code configuration} YAML and return the {@link OpenTelemetryConfiguration}. */
   static OpenTelemetryConfiguration parse(InputStream configuration) {
-    Object yamlObj = YAML.load(configuration);
+    LoadSettings settings = LoadSettings.builder().build();
+    Load yaml = new Load(settings);
+    Object yamlObj = yaml.loadFromInputStream(configuration);
     return MAPPER.convertValue(yamlObj, OpenTelemetryConfiguration.class);
   }
 }


### PR DESCRIPTION
We switched from snakeyaml to snakeyaml-engine in #5138.

One of the motivations for this was because of https://nvd.nist.gov/vuln/detail/CVE-2022-1471.

Since then, snakeyaml agreed to release 2.0 to address/quiet scanners: https://bitbucket.org/snakeyaml/snakeyaml/issues/561/cve-2022-1471-vulnerability-in#comment-64876314 (which is great).

Still probably a good idea to consolidate on snakeyaml-engine.

Btw, this doesn't remove `snakeyaml` from the classpath, since `jackson-dataformat-yaml` still uses `snakeyaml`. They have updated to `snakeyaml-engine` in `master`, but won't be released until 3.0 (https://github.com/FasterXML/jackson-dataformats-text/tree/master/yaml).