### PR TITLE
Increase metric name maximum length from 63 to 255 characters

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/metrics/Meter.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/Meter.java
@@ -64,7 +64,7 @@ public interface Meter {
    * <p>This is used to build both synchronous instruments and asynchronous instruments (i.e.
    * callbacks).
    *
-   * @param name the name of the Counter. Instrument names must consist of 63 or fewer characters
+   * @param name the name of the Counter. Instrument names must consist of 255 or fewer characters
    *     including alphanumeric, _, ., -, and start with a letter.
    * @return a builder for configuring a Counter instrument. Defaults to recording long values, but
    *     may be changed.
@@ -80,7 +80,7 @@ public interface Meter {
    * <p>This is used to build both synchronous instruments and asynchronous instruments (i.e.
    * callbacks).
    *
-   * @param name the name of the UpDownCounter. Instrument names must consist of 63 or fewer
+   * @param name the name of the UpDownCounter. Instrument names must consist of 255 or fewer
    *     characters including alphanumeric, _, ., -, and start with a letter.
    * @return a builder for configuring an UpDownCounter instrument. Defaults to recording long
    *     values, but may be changed.
@@ -93,7 +93,7 @@ public interface Meter {
   /**
    * Constructs a Histogram instrument.
    *
-   * @param name the name of the Histogram. Instrument names must consist of 63 or fewer characters
+   * @param name the name of the Histogram. Instrument names must consist of 255 or fewer characters
    *     including alphanumeric, _, ., -, and start with a letter.
    * @return a builder for configuring a Histogram synchronous instrument. Defaults to recording
    *     double values, but may be changed.
@@ -106,7 +106,7 @@ public interface Meter {
   /**
    * Constructs an Asynchronous Gauge instrument.
    *
-   * @param name the name of the Gauge. Instrument names must consist of 63 or fewer characters
+   * @param name the name of the Gauge. Instrument names must consist of 255 or fewer characters
    *     including alphanumeric, _, ., -, and start with a letter.
    * @return a builder used for configuring a Gauge instrument. Defaults to recording double values,
    *     but may be changed.

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java
@@ -43,11 +43,11 @@ final class SdkMeter implements Meter {
    *   <li>They are case-insensitive, ASCII strings.
    *   <li>The first character must be an alphabetic character.
    *   <li>Subsequent characters must belong to the alphanumeric characters, '_', '.', and '-'.
-   *   <li>They can have a maximum length of 63 characters.
+   *   <li>They can have a maximum length of 255 characters.
    * </ul>
    */
   private static final Pattern VALID_INSTRUMENT_NAME_PATTERN =
-      Pattern.compile("([A-Za-z]){1}([A-Za-z0-9\\_\\-\\.]){0,62}");
+      Pattern.compile("([A-Za-z]){1}([A-Za-z0-9\\_\\-\\.]){0,254}");
 
   private static final Meter NOOP_METER = MeterProvider.noop().get("noop");
   private static final String NOOP_INSTRUMENT_NAME = "noop";
@@ -162,7 +162,7 @@ final class SdkMeter implements Meter {
           Level.WARNING,
           "Instrument name \""
               + name
-              + "\" is invalid, returning noop instrument. Instrument names must consist of 63 or fewer characters including alphanumeric, _, ., -, and start with a letter.",
+              + "\" is invalid, returning noop instrument. Instrument names must consist of 255 or fewer characters including alphanumeric, _, ., -, and start with a letter.",
           new AssertionError());
     }
 

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterTest.java
@@ -94,7 +94,7 @@ class SdkMeterTest {
   void checkValidInstrumentName_InvalidNameLogs() {
     assertThat(checkValidInstrumentName("1")).isFalse();
     sdkMeterLogs.assertContains(
-        "Instrument name \"1\" is invalid, returning noop instrument. Instrument names must consist of 63 or fewer characters including alphanumeric, _, ., -, and start with a letter.");
+        "Instrument name \"1\" is invalid, returning noop instrument. Instrument names must consist of 255 or fewer characters including alphanumeric, _, ., -, and start with a letter.");
   }
 
   @Test
@@ -109,7 +109,7 @@ class SdkMeterTest {
     assertThat(checkValidInstrumentName("ABCDEFGHIJKLMNOPQRSTUVWXYZ")).isTrue();
     assertThat(checkValidInstrumentName("a1234567890")).isTrue();
     assertThat(checkValidInstrumentName("a_-.")).isTrue();
-    assertThat(checkValidInstrumentName(new String(new char[63]).replace('\0', 'a'))).isTrue();
+    assertThat(checkValidInstrumentName(new String(new char[255]).replace('\0', 'a'))).isTrue();
 
     // Empty and null not allowed
     assertThat(checkValidInstrumentName(null)).isFalse();
@@ -140,8 +140,8 @@ class SdkMeterTest {
     assertThat(checkValidInstrumentName("a<")).isFalse();
     assertThat(checkValidInstrumentName("a>")).isFalse();
     assertThat(checkValidInstrumentName("a?")).isFalse();
-    // Must be 63 characters or fewer
-    assertThat(checkValidInstrumentName(new String(new char[64]).replace('\0', 'a'))).isFalse();
+    // Must be 255 characters or fewer
+    assertThat(checkValidInstrumentName(new String(new char[256]).replace('\0', 'a'))).isFalse();
   }
 
   @Test


### PR DESCRIPTION
~Pending spec PR https://github.com/open-telemetry/opentelemetry-specification/pull/3648~ Spec update is merged!