### PR TITLE
Instruments with names which are case-insensitive equal contribute to…

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/descriptor/InstrumentDescriptor.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/descriptor/InstrumentDescriptor.java
@@ -23,6 +23,7 @@ import javax.annotation.concurrent.Immutable;
 public abstract class InstrumentDescriptor {
 
   private final SourceInfo sourceInfo = SourceInfo.fromCurrentStack();
+  private int hashcode;
 
   public static InstrumentDescriptor create(
       String name,
@@ -65,19 +66,22 @@ public abstract class InstrumentDescriptor {
    */
   @Override
   public final int hashCode() {
-    // TODO: memoize
-    int h = 1;
-    h *= 1000003;
-    h ^= getName().toLowerCase(Locale.ROOT).hashCode();
-    h *= 1000003;
-    h ^= getDescription().hashCode();
-    h *= 1000003;
-    h ^= getUnit().hashCode();
-    h *= 1000003;
-    h ^= getType().hashCode();
-    h *= 1000003;
-    h ^= getValueType().hashCode();
-    return h;
+    int result = hashcode;
+    if (result == 0) {
+      result = 1;
+      result *= 1000003;
+      result ^= getName().toLowerCase(Locale.ROOT).hashCode();
+      result *= 1000003;
+      result ^= getDescription().hashCode();
+      result *= 1000003;
+      result ^= getUnit().hashCode();
+      result *= 1000003;
+      result ^= getType().hashCode();
+      result *= 1000003;
+      result ^= getValueType().hashCode();
+      hashcode = result;
+    }
+    return result;
   }
 
   /**

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/descriptor/InstrumentDescriptor.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/descriptor/InstrumentDescriptor.java
@@ -6,10 +6,10 @@
 package io.opentelemetry.sdk.metrics.internal.descriptor;
 
 import com.google.auto.value.AutoValue;
-import com.google.auto.value.extension.memoized.Memoized;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.internal.debug.SourceInfo;
+import java.util.Locale;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -46,6 +46,9 @@ public abstract class InstrumentDescriptor {
 
   public abstract InstrumentValueType getValueType();
 
+  /**
+   * Not part of instrument identity. Ignored from {@link #hashCode()} and {@link #equals(Object)}.
+   */
   public abstract Advice getAdvice();
 
   /**
@@ -56,7 +59,44 @@ public abstract class InstrumentDescriptor {
     return sourceInfo;
   }
 
-  @Memoized
+  /**
+   * Uses case-insensitive version of {@link #getName()}, ignores {@link #getAdvice()} (not part of
+   * instrument identity}, ignores {@link #getSourceInfo()}.
+   */
   @Override
-  public abstract int hashCode();
+  public final int hashCode() {
+    // TODO: memoize
+    int h = 1;
+    h *= 1000003;
+    h ^= getName().toLowerCase(Locale.ROOT).hashCode();
+    h *= 1000003;
+    h ^= getDescription().hashCode();
+    h *= 1000003;
+    h ^= getUnit().hashCode();
+    h *= 1000003;
+    h ^= getType().hashCode();
+    h *= 1000003;
+    h ^= getValueType().hashCode();
+    return h;
+  }
+
+  /**
+   * Uses case-insensitive version of {@link #getName()}, ignores {@link #getAdvice()} (not part of
+   * instrument identity}, ignores {@link #getSourceInfo()}.
+   */
+  @Override
+  public final boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof InstrumentDescriptor) {
+      InstrumentDescriptor that = (InstrumentDescriptor) o;
+      return this.getName().equalsIgnoreCase(that.getName())
+          && this.getDescription().equals(that.getDescription())
+          && this.getUnit().equals(that.getUnit())
+          && this.getType().equals(that.getType())
+          && this.getValueType().equals(that.getValueType());
+    }
+    return false;
+  }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/descriptor/MetricDescriptor.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/descriptor/MetricDescriptor.java
@@ -6,13 +6,13 @@
 package io.opentelemetry.sdk.metrics.internal.descriptor;
 
 import com.google.auto.value.AutoValue;
-import com.google.auto.value.extension.memoized.Memoized;
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.View;
 import io.opentelemetry.sdk.metrics.internal.aggregator.AggregationUtil;
 import io.opentelemetry.sdk.metrics.internal.debug.SourceInfo;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.concurrent.Immutable;
 
@@ -94,36 +94,35 @@ public abstract class MetricDescriptor {
     return AggregationUtil.aggregationName(getView().getAggregation());
   }
 
-  @Memoized
+  /** Uses case-insensitive version of {@link #getName()}. */
   @Override
-  public abstract int hashCode();
+  public final int hashCode() {
+    // TODO: memoize
+    int h = 1;
+    h *= 1000003;
+    h ^= getName().toLowerCase(Locale.ROOT).hashCode();
+    h *= 1000003;
+    h ^= getDescription().hashCode();
+    h *= 1000003;
+    h ^= getView().hashCode();
+    h *= 1000003;
+    h ^= getSourceInstrument().hashCode();
+    return h;
+  }
 
-  /**
-   * Returns true if another metric descriptor is compatible with this one.
-   *
-   * <p>A metric descriptor is compatible with another if the following are true:
-   *
-   * <ul>
-   *   <li>{@link #getName()} is equal
-   *   <li>{@link #getDescription()} is equal
-   *   <li>{@link #getAggregationName()} is equal
-   *   <li>{@link InstrumentDescriptor#getName()} is equal
-   *   <li>{@link InstrumentDescriptor#getDescription()} is equal
-   *   <li>{@link InstrumentDescriptor#getUnit()} is equal
-   *   <li>{@link InstrumentDescriptor#getType()} is equal
-   *   <li>{@link InstrumentDescriptor#getValueType()} is equal
-   * </ul>
-   */
-  public boolean isCompatibleWith(MetricDescriptor other) {
-    return getName().equals(other.getName())
-        && getDescription().equals(other.getDescription())
-        && getAggregationName().equals(other.getAggregationName())
-        && getSourceInstrument().getName().equals(other.getSourceInstrument().getName())
-        && getSourceInstrument()
-            .getDescription()
-            .equals(other.getSourceInstrument().getDescription())
-        && getSourceInstrument().getUnit().equals(other.getSourceInstrument().getUnit())
-        && getSourceInstrument().getType().equals(other.getSourceInstrument().getType())
-        && getSourceInstrument().getValueType().equals(other.getSourceInstrument().getValueType());
+  /** Uses case-insensitive version of {@link #getName()}. */
+  @Override
+  public final boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof MetricDescriptor) {
+      MetricDescriptor that = (MetricDescriptor) o;
+      return this.getName().equalsIgnoreCase(that.getName())
+          && this.getDescription().equals(that.getDescription())
+          && this.getView().equals(that.getView())
+          && this.getSourceInstrument().equals(that.getSourceInstrument());
+    }
+    return false;
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/descriptor/MetricDescriptor.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/descriptor/MetricDescriptor.java
@@ -29,6 +29,7 @@ import javax.annotation.concurrent.Immutable;
 public abstract class MetricDescriptor {
 
   private final AtomicReference<SourceInfo> viewSourceInfo = new AtomicReference<>();
+  private int hashcode;
 
   /**
    * Constructs a metric descriptor with no instrument and default view.
@@ -97,17 +98,20 @@ public abstract class MetricDescriptor {
   /** Uses case-insensitive version of {@link #getName()}. */
   @Override
   public final int hashCode() {
-    // TODO: memoize
-    int h = 1;
-    h *= 1000003;
-    h ^= getName().toLowerCase(Locale.ROOT).hashCode();
-    h *= 1000003;
-    h ^= getDescription().hashCode();
-    h *= 1000003;
-    h ^= getView().hashCode();
-    h *= 1000003;
-    h ^= getSourceInstrument().hashCode();
-    return h;
+    int result = hashcode;
+    if (result == 0) {
+      result = 1;
+      result *= 1000003;
+      result ^= getName().toLowerCase(Locale.ROOT).hashCode();
+      result *= 1000003;
+      result ^= getDescription().hashCode();
+      result *= 1000003;
+      result ^= getView().hashCode();
+      result *= 1000003;
+      result ^= getSourceInstrument().hashCode();
+      hashcode = result;
+    }
+    return result;
   }
 
   /** Uses case-insensitive version of {@link #getName()}. */

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DebugUtils.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DebugUtils.java
@@ -22,7 +22,7 @@ public final class DebugUtils {
    * Creates a detailed error message comparing two {@link MetricDescriptor}s.
    *
    * <p>Called when the metrics with the descriptors have the same name, but {@link
-   * MetricDescriptor#isCompatibleWith(MetricDescriptor)} is {@code false}.
+   * MetricDescriptor#equals(Object)} is {@code false}.
    *
    * <p>This should identify all issues between the descriptor and log information on where they are
    * defined. Users should be able to find/fix issues based on this error.

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageRegistry.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageRegistry.java
@@ -22,9 +22,10 @@ import java.util.logging.Logger;
  *
  * <p>Each descriptor in the registry results in an exported metric stream. Under normal
  * circumstances each descriptor shares a unique {@link MetricDescriptor#getName()}. When multiple
- * descriptors share the same name, an identity conflict has occurred. The registry detects identity
- * conflicts on {@link #register(MetricStorage)} and logs diagnostic information when they occur.
- * See {@link MetricDescriptor#isCompatibleWith(MetricDescriptor)} for definition of compatibility.
+ * descriptors share the same name, but have some difference in identifying fields, an identity
+ * conflict has occurred. The registry detects identity conflicts on {@link
+ * #register(MetricStorage)} and logs diagnostic information when they occur. See {@link
+ * MetricDescriptor#equals(Object)} for definition of identity equality.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
@@ -75,9 +76,9 @@ public class MetricStorageRegistry {
         continue;
       }
       MetricDescriptor existing = storage.getMetricDescriptor();
+      // TODO: consider this alternative
       // Check compatibility of metrics which share the same case-insensitive name
-      if (existing.getName().equalsIgnoreCase(descriptor.getName())
-          && !existing.isCompatibleWith(descriptor)) {
+      if (existing.getName().equalsIgnoreCase(descriptor.getName())) {
         logger.log(Level.WARNING, DebugUtils.duplicateMetricErrorMessage(existing, descriptor));
         break; // Only log information about the first conflict found to reduce noise
       }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/descriptor/MetricDescriptorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/descriptor/MetricDescriptorTest.java
@@ -12,6 +12,7 @@ import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.InstrumentValueType;
 import io.opentelemetry.sdk.metrics.View;
 import io.opentelemetry.sdk.metrics.internal.debug.SourceInfo;
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 class MetricDescriptorTest {
@@ -57,7 +58,7 @@ class MetricDescriptorTest {
   }
 
   @Test
-  void metricDescriptor_isCompatible() {
+  void metricDescriptor_equals() {
     View view = View.builder().build();
     InstrumentDescriptor instrument =
         InstrumentDescriptor.create(
@@ -67,116 +68,106 @@ class MetricDescriptorTest {
             InstrumentType.COUNTER,
             InstrumentValueType.DOUBLE,
             Advice.empty());
-    MetricDescriptor descriptor =
+    MetricDescriptor descriptor1 =
         MetricDescriptor.create(view, SourceInfo.fromCurrentStack(), instrument);
-    // Same name, description, source name, source description, source unit, source type, and source
-    // value type is compatible
-    assertThat(
-            descriptor.isCompatibleWith(
-                MetricDescriptor.create(
-                    View.builder().build(),
-                    SourceInfo.fromCurrentStack(),
-                    InstrumentDescriptor.create(
-                        "name",
-                        "description",
-                        "unit",
-                        InstrumentType.COUNTER,
-                        InstrumentValueType.DOUBLE,
-                        Advice.empty()))))
-        .isTrue();
-    // Different name overridden by view is not compatible
-    assertThat(
-            descriptor.isCompatibleWith(
-                MetricDescriptor.create(
-                    View.builder().setName("bar").build(),
-                    SourceInfo.fromCurrentStack(),
-                    instrument)))
-        .isFalse();
-    // Different description overridden by view is not compatible
-    assertThat(
-            descriptor.isCompatibleWith(
-                MetricDescriptor.create(
-                    View.builder().setDescription("foo").build(),
-                    SourceInfo.fromCurrentStack(),
-                    instrument)))
-        .isFalse();
-    // Different aggregation overridden by view is not compatible
-    assertThat(
-            descriptor.isCompatibleWith(
-                MetricDescriptor.create(
-                    View.builder().setAggregation(Aggregation.lastValue()).build(),
-                    SourceInfo.fromCurrentStack(),
-                    instrument)))
-        .isFalse();
-    // Different instrument source name is not compatible
-    assertThat(
-            descriptor.isCompatibleWith(
-                MetricDescriptor.create(
-                    view,
-                    SourceInfo.fromCurrentStack(),
-                    InstrumentDescriptor.create(
-                        "foo",
-                        "description",
-                        "unit",
-                        InstrumentType.COUNTER,
-                        InstrumentValueType.DOUBLE,
-                        Advice.empty()))))
-        .isFalse();
-    // Different instrument source description is not compatible
-    assertThat(
-            descriptor.isCompatibleWith(
-                MetricDescriptor.create(
-                    view,
-                    SourceInfo.fromCurrentStack(),
-                    InstrumentDescriptor.create(
-                        "name",
-                        "foo",
-                        "unit",
-                        InstrumentType.COUNTER,
-                        InstrumentValueType.DOUBLE,
-                        Advice.empty()))))
-        .isFalse();
-    // Different instrument source unit is not compatible
-    assertThat(
-            descriptor.isCompatibleWith(
-                MetricDescriptor.create(
-                    view,
-                    SourceInfo.fromCurrentStack(),
-                    InstrumentDescriptor.create(
-                        "name",
-                        "description",
-                        "foo",
-                        InstrumentType.COUNTER,
-                        InstrumentValueType.DOUBLE,
-                        Advice.empty()))))
-        .isFalse();
-    // Different instrument source type is not compatible
-    assertThat(
-            descriptor.isCompatibleWith(
-                MetricDescriptor.create(
-                    view,
-                    SourceInfo.fromCurrentStack(),
-                    InstrumentDescriptor.create(
-                        "name",
-                        "description",
-                        "unit",
-                        InstrumentType.HISTOGRAM,
-                        InstrumentValueType.DOUBLE,
-                        Advice.empty()))))
-        .isFalse();
-    // Different instrument source value type is not compatible
-    assertThat(
-            descriptor.isCompatibleWith(
-                MetricDescriptor.create(
-                    view,
-                    SourceInfo.fromCurrentStack(),
-                    InstrumentDescriptor.create(
-                        "name",
-                        "description",
-                        "unit",
-                        InstrumentType.COUNTER,
-                        InstrumentValueType.LONG,
-                        Advice.empty()))))
-        .isFalse();
+    // Same name (case-insensitive), description, view, source name (case-insensitive), source unit,
+    // source description, source type, and source value type is equal. Advice is not part of
+    // equals.
+    MetricDescriptor descriptor2 =
+        MetricDescriptor.create(
+            View.builder().build(),
+            SourceInfo.fromCurrentStack(),
+            InstrumentDescriptor.create(
+                "Name",
+                "description",
+                "unit",
+                InstrumentType.COUNTER,
+                InstrumentValueType.DOUBLE,
+                Advice.create(Arrays.asList(1.0, 2.0))));
+    assertThat(descriptor1).isEqualTo(descriptor2).hasSameHashCodeAs(descriptor2);
+    // Different name overridden by view is not equal
+    descriptor2 =
+        MetricDescriptor.create(
+            View.builder().setName("bar").build(), SourceInfo.fromCurrentStack(), instrument);
+    assertThat(descriptor1).isNotEqualTo(descriptor2).doesNotHaveSameHashCodeAs(descriptor2);
+    // Different description overridden by view is not equal
+    descriptor2 =
+        MetricDescriptor.create(
+            View.builder().setDescription("foo").build(),
+            SourceInfo.fromCurrentStack(),
+            instrument);
+    assertThat(descriptor1).isNotEqualTo(descriptor2).doesNotHaveSameHashCodeAs(descriptor2);
+    // Different aggregation overridden by view is not equal
+    descriptor2 =
+        MetricDescriptor.create(
+            View.builder().setAggregation(Aggregation.lastValue()).build(),
+            SourceInfo.fromCurrentStack(),
+            instrument);
+    assertThat(descriptor1).isNotEqualTo(descriptor2).doesNotHaveSameHashCodeAs(descriptor2);
+    // Different instrument source name is not equal
+    descriptor2 =
+        MetricDescriptor.create(
+            view,
+            SourceInfo.fromCurrentStack(),
+            InstrumentDescriptor.create(
+                "foo",
+                "description",
+                "unit",
+                InstrumentType.COUNTER,
+                InstrumentValueType.DOUBLE,
+                Advice.empty()));
+    assertThat(descriptor1).isNotEqualTo(descriptor2).doesNotHaveSameHashCodeAs(descriptor2);
+    // Different instrument source description is not equal
+    descriptor2 =
+        MetricDescriptor.create(
+            view,
+            SourceInfo.fromCurrentStack(),
+            InstrumentDescriptor.create(
+                "name",
+                "foo",
+                "unit",
+                InstrumentType.COUNTER,
+                InstrumentValueType.DOUBLE,
+                Advice.empty()));
+    assertThat(descriptor1).isNotEqualTo(descriptor2).doesNotHaveSameHashCodeAs(descriptor2);
+    // Different instrument source unit is not equal
+    descriptor2 =
+        MetricDescriptor.create(
+            view,
+            SourceInfo.fromCurrentStack(),
+            InstrumentDescriptor.create(
+                "name",
+                "description",
+                "foo",
+                InstrumentType.COUNTER,
+                InstrumentValueType.DOUBLE,
+                Advice.empty()));
+    assertThat(descriptor1).isNotEqualTo(descriptor2).doesNotHaveSameHashCodeAs(descriptor2);
+    // Different instrument source type is not equal
+    descriptor2 =
+        MetricDescriptor.create(
+            view,
+            SourceInfo.fromCurrentStack(),
+            InstrumentDescriptor.create(
+                "name",
+                "description",
+                "unit",
+                InstrumentType.HISTOGRAM,
+                InstrumentValueType.DOUBLE,
+                Advice.empty()));
+    assertThat(descriptor1).isNotEqualTo(descriptor2).doesNotHaveSameHashCodeAs(descriptor2);
+    // Different instrument source value type is not equal
+    descriptor2 =
+        MetricDescriptor.create(
+            view,
+            SourceInfo.fromCurrentStack(),
+            InstrumentDescriptor.create(
+                "name",
+                "description",
+                "unit",
+                InstrumentType.COUNTER,
+                InstrumentValueType.LONG,
+                Advice.empty()));
+    assertThat(descriptor1).isNotEqualTo(descriptor2).doesNotHaveSameHashCodeAs(descriptor2);
   }
 }


### PR DESCRIPTION
Resolves #5683.

Instruments with names which are case-insensitive equal contribute to same metric, advice is not part of instrument identity. 

Embodies the [comment here](https://github.com/open-telemetry/opentelemetry-specification/issues/3622#issuecomment-1671853516).