### PR TITLE
Fix owasp dependency check

### DIFF
--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -46,7 +46,7 @@ dependencyCheck {
     "checkstyle",
     "annotationProcessor",
     "animalsniffer",
-    "spotless-1972451482", // spotless-1972451482 is a weird configuration that's only added in jaeger-proto
+    "spotless865457264", // spotless865457264 is a weird configuration that's only added in jaeger-proto, jaeger-remote-sampler
     "js2p",
     "jmhAnnotationProcessor",
     "jmhCompileClasspath",


### PR DESCRIPTION
The OWASP check has been [failing](https://github.com/open-telemetry/opentelemetry-java/actions/runs/5816003940) with a false positive.

There's a configuration which is added by any module which includes `otel.protobuf-conventions`. The name of the config seems to have some sort of randomness / hash encoded in it, which we'll probably need to occasionally keep updating. Unfortunately, there's no way to exclude configurations based on patterns.