### PR TITLE
Prometheus exporter: handle colliding metric attribute keys

### DIFF
--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Serializer.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Serializer.java
@@ -57,7 +57,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
@@ -471,18 +470,15 @@ abstract class Serializer {
   private static Map<String, String> sanitizeAttributePairs(Attributes attributes) {
     Map<String, String> sanitizedAttributes = new HashMap<String, String>();
     attributes.forEach(
-        new BiConsumer<AttributeKey<?>, Object>() {
-          @Override
-          public void accept(AttributeKey<?> key, Object value) {
-            String sanitizedKey = NameSanitizer.INSTANCE.apply(key.getKey());
-            String val = "";
-            if (sanitizedAttributes.containsKey(sanitizedKey)) {
-              val = sanitizedAttributes.get(sanitizedKey) + ";" + value.toString();
-            } else {
-              val = value.toString();
-            }
-            sanitizedAttributes.put(sanitizedKey, val);
+        (AttributeKey<?> key, Object value) -> {
+          String sanitizedKey = NameSanitizer.INSTANCE.apply(key.getKey());
+          String val = "";
+          if (sanitizedAttributes.containsKey(sanitizedKey)) {
+            val = sanitizedAttributes.get(sanitizedKey) + ";" + value.toString();
+          } else {
+            val = value.toString();
           }
+          sanitizedAttributes.put(sanitizedKey, val);
         });
     return sanitizedAttributes;
   }

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Serializer.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Serializer.java
@@ -445,6 +445,9 @@ abstract class Serializer {
   private static void writeAttributePairs(
       Writer writer, boolean initialComma, Attributes attributes) throws IOException {
     try {
+      // This logic handles colliding attribute keys by joining the values,
+      // separated by a semicolon. It relies on the attributes being sorted, so that
+      // colliding attribute keys are in subsequent iterations of the for loop.
       attributes.forEach(
           new BiConsumer<AttributeKey<?>, Object>() {
             boolean initialAttribute = true;

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Serializer.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Serializer.java
@@ -470,18 +470,18 @@ abstract class Serializer {
                   // This key collides with the previous one. Append the value
                   // to the previous value instead of writing the key again.
                   writer.write(';');
-                } else if (compare < 0) {
-                  THROTTLING_LOGGER.log(
-                      Level.WARNING,
-                      "Dropping out-of-order attribute "
-                          + sanitizedKey
-                          + "="
-                          + value
-                          + ", which occurred after "
-                          + previousKey
-                          + ". This can occur when an alternative Attribute implementation is used.");
-                  return;
                 } else {
+                  if (compare < 0) {
+                    THROTTLING_LOGGER.log(
+                        Level.WARNING,
+                        "Dropping out-of-order attribute "
+                            + sanitizedKey
+                            + "="
+                            + value
+                            + ", which occurred after "
+                            + previousKey
+                            + ". This can occur when an alternative Attribute implementation is used.");
+                  }
                   if (!initialAttribute) {
                     writer.write('"');
                   }

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/SerializerTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/SerializerTest.java
@@ -215,10 +215,7 @@ class SerializerTest {
   void outOfOrderedAttributes() {
     // Alternative attributes implementation which sorts entries by the order they were added rather
     // than lexicographically
-    // a_key should be dropped since the Serializer expects / asserts lexicographical ordering in
-    // order to merge duplicate keys
-    // b.key should be merged with b_key since after a_key is dropped, it is equal to the previously
-    // processed b_key
+    // all attributes are retained, we log a warning, and b_key and b.key are not be merged
     LinkedHashMap<AttributeKey<?>, Object> attributesMap = new LinkedHashMap<>();
     attributesMap.put(AttributeKey.stringKey("b_key"), "val1");
     attributesMap.put(AttributeKey.stringKey("a_key"), "val2");
@@ -249,7 +246,7 @@ class SerializerTest {
                 + "otel_scope_info{otel_scope_name=\"scope\",otel_scope_version=\"1.0.0\"} 1\n"
                 + "# TYPE sum_seconds_total counter\n"
                 + "# HELP sum_seconds_total description\n"
-                + "sum_seconds_total{otel_scope_name=\"scope\",otel_scope_version=\"1.0.0\",b_key=\"val1;val3\"} 5.0 1633950672000\n");
+                + "sum_seconds_total{otel_scope_name=\"scope\",otel_scope_version=\"1.0.0\",b_key=\"val1\",a_key=\"val2\",b_key=\"val3\"} 5.0 1633950672000\n");
     logCapturer.assertContains(
         "Dropping out-of-order attribute a_key=val2, which occurred after b_key. This can occur when an alternative Attribute implementation is used.");
   }

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/SerializerTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/SerializerTest.java
@@ -103,12 +103,12 @@ class SerializerTest {
                 + "# TYPE double_gauge_no_attributes_seconds gauge\n"
                 + "# HELP double_gauge_no_attributes_seconds unused\n"
                 + "double_gauge_no_attributes_seconds{otel_scope_name=\"full\",otel_scope_version=\"version\"} 7.0 1633950672000\n"
-                + "# TYPE double_gauge_multiple_attributes gauge\n"
-                + "# HELP double_gauge_multiple_attributes unused\n"
-                + "double_gauge_multiple_attributes_ratio{otel_scope_name=\"full\",otel_scope_version=\"version\",animal=\"bear\",type=\"dgma\"} 8.0 1633950672000\n"
                 + "# TYPE double_gauge_multiple_attributes_seconds gauge\n"
                 + "# HELP double_gauge_multiple_attributes_seconds unused\n"
-                + "double_gauge_multiple_attributes_seconds{otel_scope_name=\"full\",otel_scope_version=\"version\",animal=\"bear\",type=\"dgma\"} 8.0 1633950672000\n");
+                + "double_gauge_multiple_attributes_seconds{otel_scope_name=\"full\",otel_scope_version=\"version\",animal=\"bear\",type=\"dgma\"} 8.0 1633950672000\n"
+                + "# TYPE double_gauge_colliding_attributes_seconds gauge\n"
+                + "# HELP double_gauge_colliding_attributes_seconds unused\n"
+                + "double_gauge_colliding_attributes_seconds{otel_scope_name=\"full\",otel_scope_version=\"version\",foo_bar=\"a;b\",type=\"dgma\"} 8.0 1633950672000\n");
   }
 
   @Test
@@ -178,12 +178,12 @@ class SerializerTest {
                 + "# TYPE double_gauge_no_attributes_seconds gauge\n"
                 + "# HELP double_gauge_no_attributes_seconds unused\n"
                 + "double_gauge_no_attributes_seconds{otel_scope_name=\"full\",otel_scope_version=\"version\"} 7.0 1633950672.000\n"
-                + "# TYPE double_gauge_multiple_attributes gauge\n"
-                + "# HELP double_gauge_multiple_attributes unused\n"
-                + "double_gauge_multiple_attributes_ratio{otel_scope_name=\"full\",otel_scope_version=\"version\",animal=\"bear\",type=\"dgma\"} 8.0 1633950672.000\n"
                 + "# TYPE double_gauge_multiple_attributes_seconds gauge\n"
                 + "# HELP double_gauge_multiple_attributes_seconds unused\n"
                 + "double_gauge_multiple_attributes_seconds{otel_scope_name=\"full\",otel_scope_version=\"version\",animal=\"bear\",type=\"dgma\"} 8.0 1633950672.000\n"
+                + "# TYPE double_gauge_colliding_attributes_seconds gauge\n"
+                + "# HELP double_gauge_colliding_attributes_seconds unused\n"
+                + "double_gauge_colliding_attributes_seconds{otel_scope_name=\"full\",otel_scope_version=\"version\",foo_bar=\"a;b\",type=\"dgma\"} 8.0 1633950672.000\n"
                 + "# EOF\n");
   }
 

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/SerializerTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/SerializerTest.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.exporter.prometheus.TestConstants.DELTA_DOUBLE_SU
 import static io.opentelemetry.exporter.prometheus.TestConstants.DELTA_HISTOGRAM;
 import static io.opentelemetry.exporter.prometheus.TestConstants.DELTA_LONG_SUM;
 import static io.opentelemetry.exporter.prometheus.TestConstants.DOUBLE_GAUGE;
+import static io.opentelemetry.exporter.prometheus.TestConstants.DOUBLE_GAUGE_COLLIDING_ATTRIBUTES;
 import static io.opentelemetry.exporter.prometheus.TestConstants.DOUBLE_GAUGE_MULTIPLE_ATTRIBUTES;
 import static io.opentelemetry.exporter.prometheus.TestConstants.DOUBLE_GAUGE_NO_ATTRIBUTES;
 import static io.opentelemetry.exporter.prometheus.TestConstants.LONG_GAUGE;
@@ -53,7 +54,8 @@ class SerializerTest {
                 CUMULATIVE_HISTOGRAM_NO_ATTRIBUTES,
                 CUMULATIVE_HISTOGRAM_SINGLE_ATTRIBUTE,
                 DOUBLE_GAUGE_NO_ATTRIBUTES,
-                DOUBLE_GAUGE_MULTIPLE_ATTRIBUTES))
+                DOUBLE_GAUGE_MULTIPLE_ATTRIBUTES,
+                DOUBLE_GAUGE_COLLIDING_ATTRIBUTES))
         .isEqualTo(
             "# TYPE target info\n"
                 + "# HELP target Target metadata\n"
@@ -101,6 +103,9 @@ class SerializerTest {
                 + "# TYPE double_gauge_no_attributes_seconds gauge\n"
                 + "# HELP double_gauge_no_attributes_seconds unused\n"
                 + "double_gauge_no_attributes_seconds{otel_scope_name=\"full\",otel_scope_version=\"version\"} 7.0 1633950672000\n"
+                + "# TYPE double_gauge_multiple_attributes gauge\n"
+                + "# HELP double_gauge_multiple_attributes unused\n"
+                + "double_gauge_multiple_attributes_ratio{otel_scope_name=\"full\",otel_scope_version=\"version\",animal=\"bear\",type=\"dgma\"} 8.0 1633950672000\n"
                 + "# TYPE double_gauge_multiple_attributes_seconds gauge\n"
                 + "# HELP double_gauge_multiple_attributes_seconds unused\n"
                 + "double_gauge_multiple_attributes_seconds{otel_scope_name=\"full\",otel_scope_version=\"version\",animal=\"bear\",type=\"dgma\"} 8.0 1633950672000\n");
@@ -124,7 +129,8 @@ class SerializerTest {
                 CUMULATIVE_HISTOGRAM_NO_ATTRIBUTES,
                 CUMULATIVE_HISTOGRAM_SINGLE_ATTRIBUTE,
                 DOUBLE_GAUGE_NO_ATTRIBUTES,
-                DOUBLE_GAUGE_MULTIPLE_ATTRIBUTES))
+                DOUBLE_GAUGE_MULTIPLE_ATTRIBUTES,
+                DOUBLE_GAUGE_COLLIDING_ATTRIBUTES))
         .isEqualTo(
             "# TYPE target info\n"
                 + "# HELP target Target metadata\n"
@@ -172,6 +178,9 @@ class SerializerTest {
                 + "# TYPE double_gauge_no_attributes_seconds gauge\n"
                 + "# HELP double_gauge_no_attributes_seconds unused\n"
                 + "double_gauge_no_attributes_seconds{otel_scope_name=\"full\",otel_scope_version=\"version\"} 7.0 1633950672.000\n"
+                + "# TYPE double_gauge_multiple_attributes gauge\n"
+                + "# HELP double_gauge_multiple_attributes unused\n"
+                + "double_gauge_multiple_attributes_ratio{otel_scope_name=\"full\",otel_scope_version=\"version\",animal=\"bear\",type=\"dgma\"} 8.0 1633950672.000\n"
                 + "# TYPE double_gauge_multiple_attributes_seconds gauge\n"
                 + "# HELP double_gauge_multiple_attributes_seconds unused\n"
                 + "double_gauge_multiple_attributes_seconds{otel_scope_name=\"full\",otel_scope_version=\"version\",animal=\"bear\",type=\"dgma\"} 8.0 1633950672.000\n"

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/TestConstants.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/TestConstants.java
@@ -366,7 +366,7 @@ class TestConstants {
               .build(),
           "double.gauge.colliding.attributes",
           "unused",
-          "1",
+          "s",
           ImmutableGaugeData.create(
               Collections.singletonList(
                   ImmutableDoublePointData.create(

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/TestConstants.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/TestConstants.java
@@ -357,4 +357,22 @@ class TestConstants {
                       1633950672000000000L,
                       Attributes.of(TYPE, "dgma", stringKey("animal"), "bear"),
                       8))));
+  static final MetricData DOUBLE_GAUGE_COLLIDING_ATTRIBUTES =
+      ImmutableMetricData.createDoubleGauge(
+          Resource.create(Attributes.of(stringKey("kr"), "vr")),
+          InstrumentationScopeInfo.builder("full")
+              .setVersion("version")
+              .setAttributes(Attributes.of(stringKey("ks"), "vs"))
+              .build(),
+          "double.gauge.colliding.attributes",
+          "unused",
+          "1",
+          ImmutableGaugeData.create(
+              Collections.singletonList(
+                  ImmutableDoublePointData.create(
+                      1633947011000000000L,
+                      1633950672000000000L,
+                      Attributes.of(
+                          TYPE, "dgma", stringKey("foo.bar"), "a", stringKey("foo_bar"), "b"),
+                      8))));
 }


### PR DESCRIPTION
From https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/prometheus_and_openmetrics.md#metric-attributes

> OpenTelemetry Metric Attributes MUST be converted to [Prometheus labels](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels). String Attribute values are converted directly to Metric Attributes, and non-string Attribute values MUST be converted to string attributes following the [attribute specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute). Prometheus metric label keys are required to match the following regex: [a-zA-Z_]([a-zA-Z0-9_])*. Metrics from OpenTelemetry with unsupported Attribute names MUST replace invalid characters with the _ character. Multiple consecutive _ characters MUST be replaced with a single _ character. This may cause ambiguity in scenarios where multiple similar-named attributes share invalid characters at the same location. In such unlikely cases, if multiple key-value pairs are converted to have the same Prometheus key, the values MUST be concatenated together, separated by ;, and ordered by the lexicographical order of the original keys.

This implements the last part of the spec, where values for colliding attributes are concatenated.

Question: are attributes sorted before they are passed to the prometheus exporter?