### PR TITLE
Remove unused com.github.ben-manes.versions plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 import java.time.Duration
 
 plugins {
-  id("com.github.ben-manes.versions")
   id("io.github.gradle-nexus.publish-plugin")
 
   id("otel.spotless-conventions")

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -96,11 +96,3 @@ dependencies {
     }
   }
 }
-
-fun isNonStable(version: String): Boolean {
-  val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.uppercase().contains(it) }
-  val regex = "^[0-9,.v-]+(-r)?$".toRegex()
-  val isGuava = version.endsWith("-jre")
-  val isStable = stableKeyword || regex.matches(version) || isGuava
-  return isStable.not()
-}

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
-
 plugins {
   `java-platform`
 }

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -2,8 +2,6 @@ import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
 plugins {
   `java-platform`
-
-  id("com.github.ben-manes.versions")
 }
 
 data class DependencySet(val group: String, val version: String, val modules: List<String>)
@@ -107,15 +105,4 @@ fun isNonStable(version: String): Boolean {
   val isGuava = version.endsWith("-jre")
   val isStable = stableKeyword || regex.matches(version) || isGuava
   return isStable.not()
-}
-
-tasks {
-  named<DependencyUpdatesTask>("dependencyUpdates") {
-    revision = "release"
-    checkConstraints = true
-
-    rejectVersionIf {
-      isNonStable(candidate.version)
-    }
-  }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/descriptor/MetricDescriptorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/descriptor/MetricDescriptorTest.java
@@ -83,7 +83,7 @@ class MetricDescriptorTest {
                 "unit",
                 InstrumentType.COUNTER,
                 InstrumentValueType.DOUBLE,
-                Advice.create(Arrays.asList(1.0, 2.0))));
+                Advice.builder().explicitBucketBoundaries(Arrays.asList(1.0, 2.0)).build()));
     assertThat(descriptor1).isEqualTo(descriptor2).hasSameHashCodeAs(descriptor2);
     // Different name overridden by view is not equal
     descriptor2 =

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,5 @@
 pluginManagement {
   plugins {
-    id("com.github.ben-manes.versions") version "0.47.0"
     id("com.github.johnrengelman.shadow") version "8.1.1"
     id("com.gradle.enterprise") version "3.14.1"
     id("de.undercouch.download") version "5.4.0"


### PR DESCRIPTION
This plugin was used to manually detect dependency updates prior to us using dependabot / renovate.