### PR TITLE
Revert kotlin upgrade; the newest version does not agree with CodeQL

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -57,7 +57,8 @@ dependencies {
   implementation("me.champeau.jmh:jmh-gradle-plugin:0.7.1")
   implementation("net.ltgt.gradle:gradle-errorprone-plugin:3.1.0")
   implementation("net.ltgt.gradle:gradle-nullaway-plugin:1.6.0")
-  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10")
+  // at the moment 1.9.0 is the latest version supported by codeql
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0")
   implementation("org.owasp:dependency-check-gradle:8.4.0")
   implementation("ru.vyarus:gradle-animalsniffer-plugin:1.7.1")
 }


### PR DESCRIPTION
Same as https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/9294

Resolves #5760

Related issue https://github.com/github/codeql/issues/14046
