### PR TITLE
Add AttributesProcessor toString, add attribute filter helper

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-metrics.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-metrics.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.metrics.ViewBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.metrics.ViewBuilder setAttributeFilter(java.util.Set<java.lang.String>)

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/ViewBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/ViewBuilder.java
@@ -5,11 +5,14 @@
 
 package io.opentelemetry.sdk.metrics;
 
+import static io.opentelemetry.sdk.metrics.internal.view.AttributesProcessor.setIncludes;
+
 import io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil;
 import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.internal.state.MetricStorage;
 import io.opentelemetry.sdk.metrics.internal.view.AttributesProcessor;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
@@ -64,6 +67,12 @@ public final class ViewBuilder {
     return this;
   }
 
+  /** Sets a filter which retains attribute keys included in {@code keysToRetain}. */
+  public ViewBuilder setAttributeFilter(Set<String> keysToRetain) {
+    Objects.requireNonNull(keysToRetain, "keysToRetain");
+    return setAttributeFilter(setIncludes(keysToRetain));
+  }
+
   /**
    * Sets a filter for attributes keys.
    *
@@ -73,7 +82,8 @@ public final class ViewBuilder {
    */
   public ViewBuilder setAttributeFilter(Predicate<String> keyFilter) {
     Objects.requireNonNull(keyFilter, "keyFilter");
-    return addAttributesProcessor(AttributesProcessor.filterByKeyName(keyFilter));
+    this.processor = AttributesProcessor.filterByKeyName(keyFilter);
+    return this;
   }
 
   /**

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/ViewTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/ViewTest.java
@@ -7,6 +7,8 @@ package io.opentelemetry.sdk.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import org.junit.jupiter.api.Test;
 
 class ViewTest {
@@ -26,6 +28,7 @@ class ViewTest {
                 .setDescription("description")
                 .setAggregation(Aggregation.sum())
                 .setCardinalityLimit(10)
+                .setAttributeFilter(new HashSet<>(Arrays.asList("key1", "key2")))
                 .build()
                 .toString())
         .isEqualTo(
@@ -33,7 +36,7 @@ class ViewTest {
                 + "name=name, "
                 + "description=description, "
                 + "aggregation=SumAggregation, "
-                + "attributesProcessor=NoopAttributesProcessor{}, "
+                + "attributesProcessor=AttributeKeyFilteringProcessor{nameFilter=SetIncludesPredicate{set=[key1, key2]}}, "
                 + "cardinalityLimit=10"
                 + "}");
   }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/view/AttributesProcessorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/view/AttributesProcessorTest.java
@@ -18,8 +18,21 @@ import org.junit.jupiter.api.Test;
 /** Tests for the {@link AttributesProcessor} DSL-ish library. */
 class AttributesProcessorTest {
   @Test
-  void filterKeyName_removesKeys() {
+  void filterKeyName_Predicate() {
     AttributesProcessor processor = AttributesProcessor.filterByKeyName("test"::equals);
+
+    assertThat(
+            processor.process(
+                Attributes.builder().put("remove", "me").put("test", "keep").build(),
+                Context.root()))
+        .hasSize(1)
+        .containsEntry("test", "keep");
+  }
+
+  @Test
+  void filterKeyName_SetIncludes() {
+    AttributesProcessor processor =
+        AttributesProcessor.filterByKeyName(setIncludes(Collections.singleton("test")));
 
     assertThat(
             processor.process(


### PR DESCRIPTION
Adds a helper function for specifying that a view should retain only a specific set of attribute keys:
Previous:
```
Set<String> keysToRetain = new HashSet<>(Arrays.asList("key1", "key2"));
View view = View.builder().setAttributesFilter(keysToRetain::contains);
```
After:
```
View view = View.builder().setAttributesFilter(new HashSet<>(Arrays.asList("key1", "key2")));
```
As an added benefit, we can have ensure a proper `toString()` implementation when the helper function is used:
```
Set<String> keysToRetain = new HashSet<>(Arrays.asList("key1", "key2"));
View view = View.builder().setAttributesFilter(keysToRetain::contains);
view.toString(); // View{aggregation=DefaultAggregation, attributesProcessor=AttributeKeyFilteringProcessor{nameFilter=io.opentelemetry.sdk.metrics.ViewTest$$Lambda$405/0x0000000800263508@1dcca8d3}, cardinalityLimit=2000}

View view = View.builder().setAttributesFilter(new HashSet<>(Arrays.asList("key1", "key2")));
view.toString(); // View{aggregation=DefaultAggregation, attributesProcessor=AttributeKeyFilteringProcessor{nameFilter=SetIncludesPredicate{set=[key1, key2]}}, cardinalityLimit=2000}
```