### PR TITLE
General attribute limits configuration factory

### DIFF
--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogLimitsFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogLimitsFactory.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AttributeLimits;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordLimits;
 import io.opentelemetry.sdk.logs.LogLimits;
 import io.opentelemetry.sdk.logs.LogLimitsBuilder;
@@ -13,7 +14,7 @@ import java.io.Closeable;
 import java.util.List;
 import javax.annotation.Nullable;
 
-final class LogLimitsFactory implements Factory<LogRecordLimits, LogLimits> {
+final class LogLimitsFactory implements Factory<LogRecordLimitsAndAttributeLimits, LogLimits> {
 
   private static final LogLimitsFactory INSTANCE = new LogLimitsFactory();
 
@@ -25,18 +26,34 @@ final class LogLimitsFactory implements Factory<LogRecordLimits, LogLimits> {
 
   @Override
   public LogLimits create(
-      @Nullable LogRecordLimits model, SpiHelper spiHelper, List<Closeable> closeables) {
+      @Nullable LogRecordLimitsAndAttributeLimits model,
+      SpiHelper spiHelper,
+      List<Closeable> closeables) {
     if (model == null) {
       return LogLimits.getDefault();
     }
-
     LogLimitsBuilder builder = LogLimits.builder();
-    if (model.getAttributeCountLimit() != null) {
-      builder.setMaxNumberOfAttributes(model.getAttributeCountLimit());
+
+    AttributeLimits attributeLimitsModel = model.getAttributeLimits();
+    if (attributeLimitsModel != null) {
+      if (attributeLimitsModel.getAttributeCountLimit() != null) {
+        builder.setMaxNumberOfAttributes(attributeLimitsModel.getAttributeCountLimit());
+      }
+      if (attributeLimitsModel.getAttributeValueLengthLimit() != null) {
+        builder.setMaxAttributeValueLength(attributeLimitsModel.getAttributeValueLengthLimit());
+      }
     }
-    if (model.getAttributeValueLengthLimit() != null) {
-      builder.setMaxAttributeValueLength(model.getAttributeValueLengthLimit());
+
+    LogRecordLimits logRecordLimitsModel = model.getLogRecordLimits();
+    if (logRecordLimitsModel != null) {
+      if (logRecordLimitsModel.getAttributeCountLimit() != null) {
+        builder.setMaxNumberOfAttributes(logRecordLimitsModel.getAttributeCountLimit());
+      }
+      if (logRecordLimitsModel.getAttributeValueLengthLimit() != null) {
+        builder.setMaxAttributeValueLength(logRecordLimitsModel.getAttributeValueLengthLimit());
+      }
     }
+
     return builder.build();
   }
 }

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordLimitsAndAttributeLimits.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordLimitsAndAttributeLimits.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.extension.incubator.fileconfig;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AttributeLimits;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordLimits;
+import javax.annotation.Nullable;
+
+@AutoValue
+abstract class LogRecordLimitsAndAttributeLimits {
+
+  static LogRecordLimitsAndAttributeLimits create(
+      @Nullable AttributeLimits attributeLimits, @Nullable LogRecordLimits spanLimits) {
+    return new AutoValue_LogRecordLimitsAndAttributeLimits(attributeLimits, spanLimits);
+  }
+
+  @Nullable
+  abstract AttributeLimits getAttributeLimits();
+
+  @Nullable
+  abstract LogRecordLimits getLogRecordLimits();
+}

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LoggerProviderAndAttributeLimits.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LoggerProviderAndAttributeLimits.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.extension.incubator.fileconfig;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AttributeLimits;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LoggerProvider;
+import javax.annotation.Nullable;
+
+@AutoValue
+abstract class LoggerProviderAndAttributeLimits {
+
+  static LoggerProviderAndAttributeLimits create(
+      @Nullable AttributeLimits attributeLimits, @Nullable LoggerProvider loggerProvider) {
+    return new AutoValue_LoggerProviderAndAttributeLimits(attributeLimits, loggerProvider);
+  }
+
+  @Nullable
+  abstract AttributeLimits getAttributeLimits();
+
+  @Nullable
+  abstract LoggerProvider getLoggerProvider();
+}

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactory.java
@@ -31,15 +31,14 @@ final class OpenTelemetryConfigurationFactory
   @Override
   public OpenTelemetrySdk create(
       @Nullable OpenTelemetryConfiguration model, SpiHelper spiHelper, List<Closeable> closeables) {
+    OpenTelemetrySdkBuilder builder = OpenTelemetrySdk.builder();
     if (model == null) {
-      return FileConfigUtil.addAndReturn(closeables, OpenTelemetrySdk.builder().build());
+      return FileConfigUtil.addAndReturn(closeables, builder.build());
     }
 
     if (!"0.1".equals(model.getFileFormat())) {
       throw new ConfigurationException("Unsupported file format. Supported formats include: 0.1");
     }
-
-    OpenTelemetrySdkBuilder builder = OpenTelemetrySdk.builder();
 
     if (Objects.equals(Boolean.TRUE, model.getDisabled())) {
       return builder.build();
@@ -88,8 +87,6 @@ final class OpenTelemetryConfigurationFactory
                   .setResource(resource)
                   .build()));
     }
-
-    // TODO(jack-berg): add support for general attribute limits
 
     return FileConfigUtil.addAndReturn(closeables, builder.build());
   }

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactory.java
@@ -56,7 +56,11 @@ final class OpenTelemetryConfigurationFactory
           FileConfigUtil.addAndReturn(
               closeables,
               LoggerProviderFactory.getInstance()
-                  .create(model.getLoggerProvider(), spiHelper, closeables)
+                  .create(
+                      LoggerProviderAndAttributeLimits.create(
+                          model.getAttributeLimits(), model.getLoggerProvider()),
+                      spiHelper,
+                      closeables)
                   .setResource(resource)
                   .build()));
     }
@@ -66,7 +70,11 @@ final class OpenTelemetryConfigurationFactory
           FileConfigUtil.addAndReturn(
               closeables,
               TracerProviderFactory.getInstance()
-                  .create(model.getTracerProvider(), spiHelper, closeables)
+                  .create(
+                      TracerProviderAndAttributeLimits.create(
+                          model.getAttributeLimits(), model.getTracerProvider()),
+                      spiHelper,
+                      closeables)
                   .setResource(resource)
                   .build()));
     }

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanLimitsAndAttributeLimits.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanLimitsAndAttributeLimits.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.extension.incubator.fileconfig;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AttributeLimits;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanLimits;
+import javax.annotation.Nullable;
+
+@AutoValue
+abstract class SpanLimitsAndAttributeLimits {
+
+  static SpanLimitsAndAttributeLimits create(
+      @Nullable AttributeLimits attributeLimits, @Nullable SpanLimits spanLimits) {
+    return new AutoValue_SpanLimitsAndAttributeLimits(attributeLimits, spanLimits);
+  }
+
+  @Nullable
+  abstract AttributeLimits getAttributeLimits();
+
+  @Nullable
+  abstract SpanLimits getSpanLimits();
+}

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanLimitsFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanLimitsFactory.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AttributeLimits;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanLimits;
 import io.opentelemetry.sdk.trace.SpanLimitsBuilder;
 import java.io.Closeable;
@@ -13,7 +14,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 final class SpanLimitsFactory
-    implements Factory<SpanLimits, io.opentelemetry.sdk.trace.SpanLimits> {
+    implements Factory<SpanLimitsAndAttributeLimits, io.opentelemetry.sdk.trace.SpanLimits> {
 
   private static final SpanLimitsFactory INSTANCE = new SpanLimitsFactory();
 
@@ -25,29 +26,45 @@ final class SpanLimitsFactory
 
   @Override
   public io.opentelemetry.sdk.trace.SpanLimits create(
-      @Nullable SpanLimits model, SpiHelper spiHelper, List<Closeable> closeables) {
+      @Nullable SpanLimitsAndAttributeLimits model,
+      SpiHelper spiHelper,
+      List<Closeable> closeables) {
     if (model == null) {
       return io.opentelemetry.sdk.trace.SpanLimits.getDefault();
     }
 
     SpanLimitsBuilder builder = io.opentelemetry.sdk.trace.SpanLimits.builder();
-    if (model.getAttributeCountLimit() != null) {
-      builder.setMaxNumberOfAttributes(model.getAttributeCountLimit());
+
+    AttributeLimits attributeLimitsModel = model.getAttributeLimits();
+    if (attributeLimitsModel != null) {
+      if (attributeLimitsModel.getAttributeCountLimit() != null) {
+        builder.setMaxNumberOfAttributes(attributeLimitsModel.getAttributeCountLimit());
+      }
+      if (attributeLimitsModel.getAttributeValueLengthLimit() != null) {
+        builder.setMaxAttributeValueLength(attributeLimitsModel.getAttributeValueLengthLimit());
+      }
     }
-    if (model.getAttributeValueLengthLimit() != null) {
-      builder.setMaxAttributeValueLength(model.getAttributeValueLengthLimit());
-    }
-    if (model.getEventCountLimit() != null) {
-      builder.setMaxNumberOfEvents(model.getEventCountLimit());
-    }
-    if (model.getLinkCountLimit() != null) {
-      builder.setMaxNumberOfLinks(model.getLinkCountLimit());
-    }
-    if (model.getEventAttributeCountLimit() != null) {
-      builder.setMaxNumberOfAttributesPerEvent(model.getEventAttributeCountLimit());
-    }
-    if (model.getLinkAttributeCountLimit() != null) {
-      builder.setMaxNumberOfAttributesPerLink(model.getLinkAttributeCountLimit());
+
+    SpanLimits spanLimitsModel = model.getSpanLimits();
+    if (spanLimitsModel != null) {
+      if (spanLimitsModel.getAttributeCountLimit() != null) {
+        builder.setMaxNumberOfAttributes(spanLimitsModel.getAttributeCountLimit());
+      }
+      if (spanLimitsModel.getAttributeValueLengthLimit() != null) {
+        builder.setMaxAttributeValueLength(spanLimitsModel.getAttributeValueLengthLimit());
+      }
+      if (spanLimitsModel.getEventCountLimit() != null) {
+        builder.setMaxNumberOfEvents(spanLimitsModel.getEventCountLimit());
+      }
+      if (spanLimitsModel.getLinkCountLimit() != null) {
+        builder.setMaxNumberOfLinks(spanLimitsModel.getLinkCountLimit());
+      }
+      if (spanLimitsModel.getEventAttributeCountLimit() != null) {
+        builder.setMaxNumberOfAttributesPerEvent(spanLimitsModel.getEventAttributeCountLimit());
+      }
+      if (spanLimitsModel.getLinkAttributeCountLimit() != null) {
+        builder.setMaxNumberOfAttributesPerLink(spanLimitsModel.getLinkAttributeCountLimit());
+      }
     }
 
     return builder.build();

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/TracerProviderAndAttributeLimits.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/TracerProviderAndAttributeLimits.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.extension.incubator.fileconfig;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AttributeLimits;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.TracerProvider;
+import javax.annotation.Nullable;
+
+@AutoValue
+abstract class TracerProviderAndAttributeLimits {
+
+  static TracerProviderAndAttributeLimits create(
+      @Nullable AttributeLimits attributeLimits, @Nullable TracerProvider tracerProvider) {
+    return new AutoValue_TracerProviderAndAttributeLimits(attributeLimits, tracerProvider);
+  }
+
+  @Nullable
+  abstract AttributeLimits getAttributeLimits();
+
+  @Nullable
+  abstract TracerProvider getTracerProvider();
+}

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogLimitsFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogLimitsFactoryTest.java
@@ -33,6 +33,8 @@ class LogLimitsFactoryTest {
     return Stream.of(
         Arguments.of(null, LogLimits.builder().build()),
         Arguments.of(
+            LogRecordLimitsAndAttributeLimits.create(null, null), LogLimits.builder().build()),
+        Arguments.of(
             LogRecordLimitsAndAttributeLimits.create(new AttributeLimits(), new LogRecordLimits()),
             LogLimits.builder().build()),
         Arguments.of(

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogLimitsFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogLimitsFactoryTest.java
@@ -9,40 +9,41 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.asser
 import static org.mockito.Mockito.mock;
 
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AttributeLimits;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordLimits;
 import io.opentelemetry.sdk.logs.LogLimits;
 import java.util.Collections;
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class LogLimitsFactoryTest {
 
-  @Test
-  void create_Null() {
+  @ParameterizedTest
+  @MethodSource("createArguments")
+  void create(LogRecordLimitsAndAttributeLimits model, LogLimits expectedLogLimits) {
     assertThat(
             LogLimitsFactory.getInstance()
-                .create(null, mock(SpiHelper.class), Collections.emptyList()))
-        .isEqualTo(LogLimits.getDefault());
+                .create(model, mock(SpiHelper.class), Collections.emptyList()))
+        .isEqualTo(expectedLogLimits);
   }
 
-  @Test
-  void create_Defaults() {
-    assertThat(
-            LogLimitsFactory.getInstance()
-                .create(new LogRecordLimits(), mock(SpiHelper.class), Collections.emptyList()))
-        .isEqualTo(LogLimits.getDefault());
-  }
-
-  @Test
-  void create() {
-    assertThat(
-            LogLimitsFactory.getInstance()
-                .create(
-                    new LogRecordLimits()
-                        .withAttributeCountLimit(1)
-                        .withAttributeValueLengthLimit(2),
-                    mock(SpiHelper.class),
-                    Collections.emptyList()))
-        .isEqualTo(
-            LogLimits.builder().setMaxNumberOfAttributes(1).setMaxAttributeValueLength(2).build());
+  private static Stream<Arguments> createArguments() {
+    return Stream.of(
+        Arguments.of(null, LogLimits.builder().build()),
+        Arguments.of(
+            LogRecordLimitsAndAttributeLimits.create(new AttributeLimits(), new LogRecordLimits()),
+            LogLimits.builder().build()),
+        Arguments.of(
+            LogRecordLimitsAndAttributeLimits.create(
+                new AttributeLimits().withAttributeValueLengthLimit(1).withAttributeCountLimit(2),
+                new LogRecordLimits()),
+            LogLimits.builder().setMaxAttributeValueLength(1).setMaxNumberOfAttributes(2).build()),
+        Arguments.of(
+            LogRecordLimitsAndAttributeLimits.create(
+                new AttributeLimits().withAttributeValueLengthLimit(1).withAttributeCountLimit(2),
+                new LogRecordLimits().withAttributeValueLengthLimit(3).withAttributeCountLimit(4)),
+            LogLimits.builder().setMaxAttributeValueLength(3).setMaxNumberOfAttributes(4).build()));
   }
 }

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LoggerProviderFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LoggerProviderFactoryTest.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.asser
 import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporter;
 import io.opentelemetry.internal.testing.CleanupExtension;
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AttributeLimits;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.BatchLogRecordProcessor;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordExporter;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordLimits;
@@ -54,7 +55,11 @@ class LoggerProviderFactoryTest {
 
     SdkLoggerProvider provider =
         LoggerProviderFactory.getInstance()
-            .create(new LoggerProvider(), spiHelper, closeables)
+            .create(
+                LoggerProviderAndAttributeLimits.create(
+                    new AttributeLimits(), new LoggerProvider()),
+                spiHelper,
+                closeables)
             .build();
     cleanup.addCloseable(provider);
     cleanup.addCloseables(closeables);
@@ -83,18 +88,20 @@ class LoggerProviderFactoryTest {
     SdkLoggerProvider provider =
         LoggerProviderFactory.getInstance()
             .create(
-                new LoggerProvider()
-                    .withLimits(
-                        new LogRecordLimits()
-                            .withAttributeCountLimit(1)
-                            .withAttributeValueLengthLimit(2))
-                    .withProcessors(
-                        Collections.singletonList(
-                            new LogRecordProcessor()
-                                .withBatch(
-                                    new BatchLogRecordProcessor()
-                                        .withExporter(
-                                            new LogRecordExporter().withOtlp(new Otlp()))))),
+                LoggerProviderAndAttributeLimits.create(
+                    new AttributeLimits(),
+                    new LoggerProvider()
+                        .withLimits(
+                            new LogRecordLimits()
+                                .withAttributeCountLimit(1)
+                                .withAttributeValueLengthLimit(2))
+                        .withProcessors(
+                            Collections.singletonList(
+                                new LogRecordProcessor()
+                                    .withBatch(
+                                        new BatchLogRecordProcessor()
+                                            .withExporter(
+                                                new LogRecordExporter().withOtlp(new Otlp())))))),
                 spiHelper,
                 closeables)
             .build();

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanLimitsFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanLimitsFactoryTest.java
@@ -9,50 +9,58 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.asser
 import static org.mockito.Mockito.mock;
 
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AttributeLimits;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanLimits;
 import java.util.Collections;
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class SpanLimitsFactoryTest {
 
-  @Test
-  void create_Null() {
+  @ParameterizedTest
+  @MethodSource("createArguments")
+  void create(
+      SpanLimitsAndAttributeLimits model,
+      io.opentelemetry.sdk.trace.SpanLimits expectedSpanLimits) {
     assertThat(
             SpanLimitsFactory.getInstance()
-                .create(null, mock(SpiHelper.class), Collections.emptyList()))
-        .isEqualTo(io.opentelemetry.sdk.trace.SpanLimits.getDefault());
+                .create(model, mock(SpiHelper.class), Collections.emptyList()))
+        .isEqualTo(expectedSpanLimits);
   }
 
-  @Test
-  void create_Defaults() {
-    assertThat(
-            SpanLimitsFactory.getInstance()
-                .create(new SpanLimits(), mock(SpiHelper.class), Collections.emptyList()))
-        .isEqualTo(io.opentelemetry.sdk.trace.SpanLimits.getDefault());
-  }
-
-  @Test
-  void create() {
-    assertThat(
-            SpanLimitsFactory.getInstance()
-                .create(
-                    new SpanLimits()
-                        .withAttributeCountLimit(1)
-                        .withAttributeValueLengthLimit(2)
-                        .withEventCountLimit(3)
-                        .withLinkCountLimit(4)
-                        .withEventAttributeCountLimit(5)
-                        .withLinkAttributeCountLimit(6),
-                    mock(SpiHelper.class),
-                    Collections.emptyList()))
-        .isEqualTo(
+  private static Stream<Arguments> createArguments() {
+    return Stream.of(
+        Arguments.of(null, io.opentelemetry.sdk.trace.SpanLimits.getDefault()),
+        Arguments.of(
+            SpanLimitsAndAttributeLimits.create(new AttributeLimits(), new SpanLimits()),
+            io.opentelemetry.sdk.trace.SpanLimits.getDefault()),
+        Arguments.of(
+            SpanLimitsAndAttributeLimits.create(
+                new AttributeLimits().withAttributeCountLimit(1).withAttributeValueLengthLimit(2),
+                new SpanLimits()),
             io.opentelemetry.sdk.trace.SpanLimits.builder()
                 .setMaxNumberOfAttributes(1)
                 .setMaxAttributeValueLength(2)
-                .setMaxNumberOfEvents(3)
-                .setMaxNumberOfLinks(4)
-                .setMaxNumberOfAttributesPerEvent(5)
-                .setMaxNumberOfAttributesPerLink(6)
-                .build());
+                .build()),
+        Arguments.of(
+            SpanLimitsAndAttributeLimits.create(
+                new AttributeLimits().withAttributeCountLimit(1).withAttributeValueLengthLimit(2),
+                new SpanLimits()
+                    .withAttributeCountLimit(3)
+                    .withAttributeValueLengthLimit(4)
+                    .withEventCountLimit(5)
+                    .withLinkCountLimit(6)
+                    .withEventAttributeCountLimit(7)
+                    .withLinkAttributeCountLimit(8)),
+            io.opentelemetry.sdk.trace.SpanLimits.builder()
+                .setMaxNumberOfAttributes(3)
+                .setMaxAttributeValueLength(4)
+                .setMaxNumberOfEvents(5)
+                .setMaxNumberOfLinks(6)
+                .setMaxNumberOfAttributesPerEvent(7)
+                .setMaxNumberOfAttributesPerLink(8)
+                .build()));
   }
 }

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanLimitsFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanLimitsFactoryTest.java
@@ -34,6 +34,9 @@ class SpanLimitsFactoryTest {
     return Stream.of(
         Arguments.of(null, io.opentelemetry.sdk.trace.SpanLimits.getDefault()),
         Arguments.of(
+            SpanLimitsAndAttributeLimits.create(null, null),
+            io.opentelemetry.sdk.trace.SpanLimits.getDefault()),
+        Arguments.of(
             SpanLimitsAndAttributeLimits.create(new AttributeLimits(), new SpanLimits()),
             io.opentelemetry.sdk.trace.SpanLimits.getDefault()),
         Arguments.of(

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/TracerProviderFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/TracerProviderFactoryTest.java
@@ -12,6 +12,7 @@ import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.internal.testing.CleanupExtension;
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AlwaysOn;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AttributeLimits;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.BatchSpanProcessor;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Otlp;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Sampler;
@@ -56,7 +57,11 @@ class TracerProviderFactoryTest {
 
     SdkTracerProvider provider =
         TracerProviderFactory.getInstance()
-            .create(new TracerProvider(), spiHelper, closeables)
+            .create(
+                TracerProviderAndAttributeLimits.create(
+                    new AttributeLimits(), new TracerProvider()),
+                spiHelper,
+                closeables)
             .build();
     cleanup.addCloseable(provider);
     cleanup.addCloseables(closeables);
@@ -89,23 +94,26 @@ class TracerProviderFactoryTest {
     SdkTracerProvider provider =
         TracerProviderFactory.getInstance()
             .create(
-                new TracerProvider()
-                    .withLimits(
-                        new io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model
-                                .SpanLimits()
-                            .withAttributeCountLimit(1)
-                            .withAttributeValueLengthLimit(2)
-                            .withEventCountLimit(3)
-                            .withLinkCountLimit(4)
-                            .withEventAttributeCountLimit(5)
-                            .withLinkAttributeCountLimit(6))
-                    .withSampler(new Sampler().withAlwaysOn(new AlwaysOn()))
-                    .withProcessors(
-                        Collections.singletonList(
-                            new SpanProcessor()
-                                .withBatch(
-                                    new BatchSpanProcessor()
-                                        .withExporter(new SpanExporter().withOtlp(new Otlp()))))),
+                TracerProviderAndAttributeLimits.create(
+                    new AttributeLimits(),
+                    new TracerProvider()
+                        .withLimits(
+                            new io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model
+                                    .SpanLimits()
+                                .withAttributeCountLimit(1)
+                                .withAttributeValueLengthLimit(2)
+                                .withEventCountLimit(3)
+                                .withLinkCountLimit(4)
+                                .withEventAttributeCountLimit(5)
+                                .withLinkAttributeCountLimit(6))
+                        .withSampler(new Sampler().withAlwaysOn(new AlwaysOn()))
+                        .withProcessors(
+                            Collections.singletonList(
+                                new SpanProcessor()
+                                    .withBatch(
+                                        new BatchSpanProcessor()
+                                            .withExporter(
+                                                new SpanExporter().withOtlp(new Otlp())))))),
                 spiHelper,
                 closeables)
             .build();


### PR DESCRIPTION
Builds on #5751, #5687, #5399, #5757, #5758, #5763, #5771, #5773 by adding logic to interpret general attribute limits in addition to signal specific log and span limits.