### PR TITLE
Config properties from map

### DIFF
--- a/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/internal/JaegerGrpcSpanExporterProviderTest.java
+++ b/exporters/jaeger/src/test/java/io/opentelemetry/exporter/jaeger/internal/JaegerGrpcSpanExporterProviderTest.java
@@ -29,7 +29,7 @@ class JaegerGrpcSpanExporterProviderTest {
   @Test
   void createExporter_Default() {
     try (SpanExporter spanExporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(Collections.emptyMap()))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(Collections.emptyMap()))) {
       assertThat(spanExporter)
           .isInstanceOf(io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter.class);
       assertThat(spanExporter)
@@ -52,7 +52,7 @@ class JaegerGrpcSpanExporterProviderTest {
     config.put("otel.exporter.jaeger.timeout", "1s");
 
     try (SpanExporter spanExporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(config))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
       assertThat(spanExporter)
           .isInstanceOf(io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter.class);
       assertThat(spanExporter)

--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/internal/LoggingExporterProviderTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/internal/LoggingExporterProviderTest.java
@@ -21,7 +21,7 @@ class LoggingExporterProviderTest {
     LoggingLogRecordExporterProvider provider = new LoggingLogRecordExporterProvider();
     assertThat(provider.getName()).isEqualTo("logging-otlp");
     assertThat(
-            provider.createExporter(DefaultConfigProperties.createForTest(Collections.emptyMap())))
+            provider.createExporter(DefaultConfigProperties.createFromMap(Collections.emptyMap())))
         .isInstanceOf(OtlpJsonLoggingLogRecordExporter.class);
   }
 
@@ -30,7 +30,7 @@ class LoggingExporterProviderTest {
     LoggingMetricExporterProvider provider = new LoggingMetricExporterProvider();
     assertThat(provider.getName()).isEqualTo("logging-otlp");
     assertThat(
-            provider.createExporter(DefaultConfigProperties.createForTest(Collections.emptyMap())))
+            provider.createExporter(DefaultConfigProperties.createFromMap(Collections.emptyMap())))
         .isInstanceOf(OtlpJsonLoggingMetricExporter.class);
   }
 
@@ -39,7 +39,7 @@ class LoggingExporterProviderTest {
     LoggingSpanExporterProvider provider = new LoggingSpanExporterProvider();
     assertThat(provider.getName()).isEqualTo("logging-otlp");
     assertThat(
-            provider.createExporter(DefaultConfigProperties.createForTest(Collections.emptyMap())))
+            provider.createExporter(DefaultConfigProperties.createFromMap(Collections.emptyMap())))
         .isInstanceOf(OtlpJsonLoggingSpanExporter.class);
   }
 }

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtilTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtilTest.java
@@ -39,20 +39,20 @@ class OtlpConfigUtilTest {
   void getOtlpProtocolDefault() {
     assertThat(
             OtlpConfigUtil.getOtlpProtocol(
-                DATA_TYPE_TRACES, DefaultConfigProperties.createForTest(Collections.emptyMap())))
+                DATA_TYPE_TRACES, DefaultConfigProperties.createFromMap(Collections.emptyMap())))
         .isEqualTo(PROTOCOL_GRPC);
 
     assertThat(
             OtlpConfigUtil.getOtlpProtocol(
                 DATA_TYPE_TRACES,
-                DefaultConfigProperties.createForTest(
+                DefaultConfigProperties.createFromMap(
                     ImmutableMap.of("otel.exporter.otlp.protocol", "foo"))))
         .isEqualTo("foo");
 
     assertThat(
             OtlpConfigUtil.getOtlpProtocol(
                 DATA_TYPE_TRACES,
-                DefaultConfigProperties.createForTest(
+                DefaultConfigProperties.createFromMap(
                     ImmutableMap.of(
                         "otel.exporter.otlp.protocol", "foo",
                         "otel.exporter.otlp.traces.protocol", "bar"))))
@@ -318,7 +318,7 @@ class OtlpConfigUtilTest {
 
     OtlpConfigUtil.configureOtlpExporterBuilder(
         dataType,
-        DefaultConfigProperties.createForTest(properties),
+        DefaultConfigProperties.createFromMap(properties),
         endpoint::set,
         (value1, value2) -> {},
         value -> {},
@@ -362,7 +362,7 @@ class OtlpConfigUtilTest {
       Map<String, String> properties) {
     AtomicReference<AggregationTemporalitySelector> temporalityRef = new AtomicReference<>();
     OtlpConfigUtil.configureOtlpAggregationTemporality(
-        DefaultConfigProperties.createForTest(properties), temporalityRef::set);
+        DefaultConfigProperties.createFromMap(properties), temporalityRef::set);
     // We apply the temporality selector to a HISTOGRAM instrument to simplify assertions
     return temporalityRef.get().getAggregationTemporality(InstrumentType.HISTOGRAM);
   }
@@ -409,7 +409,7 @@ class OtlpConfigUtilTest {
       Map<String, String> properties) {
     AtomicReference<DefaultAggregationSelector> aggregationRef = new AtomicReference<>();
     OtlpConfigUtil.configureOtlpHistogramDefaultAggregation(
-        DefaultConfigProperties.createForTest(properties), aggregationRef::set);
+        DefaultConfigProperties.createFromMap(properties), aggregationRef::set);
     // We apply the temporality selector to a HISTOGRAM instrument to simplify assertions
     return aggregationRef.get();
   }

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpLogRecordExporterProviderTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpLogRecordExporterProviderTest.java
@@ -92,7 +92,7 @@ class OtlpLogRecordExporterProviderTest {
     assertThatThrownBy(
             () ->
                 provider.createExporter(
-                    DefaultConfigProperties.createForTest(
+                    DefaultConfigProperties.createFromMap(
                         Collections.singletonMap("otel.exporter.otlp.protocol", "foo"))))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("Unsupported OTLP logs protocol: foo");
@@ -103,12 +103,12 @@ class OtlpLogRecordExporterProviderTest {
     // Verifies createExporter after resetting the spy overrides
     Mockito.reset(provider);
     try (LogRecordExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(Collections.emptyMap()))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(Collections.emptyMap()))) {
       assertThat(exporter).isInstanceOf(OtlpGrpcLogRecordExporter.class);
     }
     try (LogRecordExporter exporter =
         provider.createExporter(
-            DefaultConfigProperties.createForTest(
+            DefaultConfigProperties.createFromMap(
                 Collections.singletonMap("otel.exporter.otlp.protocol", "http/protobuf")))) {
       assertThat(exporter).isInstanceOf(OtlpHttpLogRecordExporter.class);
     }
@@ -117,7 +117,7 @@ class OtlpLogRecordExporterProviderTest {
   @Test
   void createExporter_GrpcDefaults() {
     try (LogRecordExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(Collections.emptyMap()))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(Collections.emptyMap()))) {
       assertThat(exporter).isInstanceOf(OtlpGrpcLogRecordExporter.class);
       verify(grpcBuilder, times(1)).build();
       verify(grpcBuilder, never()).setEndpoint(any());
@@ -144,7 +144,7 @@ class OtlpLogRecordExporterProviderTest {
     config.put("otel.experimental.exporter.otlp.retry.enabled", "true");
 
     try (LogRecordExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(config))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
       assertThat(exporter).isInstanceOf(OtlpGrpcLogRecordExporter.class);
       verify(grpcBuilder, times(1)).build();
       verify(grpcBuilder).setEndpoint("https://localhost:443/");
@@ -178,7 +178,7 @@ class OtlpLogRecordExporterProviderTest {
     config.put("otel.exporter.otlp.logs.timeout", "15s");
 
     try (LogRecordExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(config))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
       assertThat(exporter).isInstanceOf(OtlpGrpcLogRecordExporter.class);
       verify(grpcBuilder, times(1)).build();
       verify(grpcBuilder).setEndpoint("https://localhost:443/");
@@ -196,7 +196,7 @@ class OtlpLogRecordExporterProviderTest {
   void createExporter_HttpDefaults() {
     try (LogRecordExporter exporter =
         provider.createExporter(
-            DefaultConfigProperties.createForTest(
+            DefaultConfigProperties.createFromMap(
                 Collections.singletonMap("otel.exporter.otlp.logs.protocol", "http/protobuf")))) {
       assertThat(exporter).isInstanceOf(OtlpHttpLogRecordExporter.class);
       verify(httpBuilder, times(1)).build();
@@ -225,7 +225,7 @@ class OtlpLogRecordExporterProviderTest {
     config.put("otel.experimental.exporter.otlp.retry.enabled", "true");
 
     try (LogRecordExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(config))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
       assertThat(exporter).isInstanceOf(OtlpHttpLogRecordExporter.class);
       verify(httpBuilder, times(1)).build();
       verify(httpBuilder).setEndpoint("https://localhost:443/v1/logs");
@@ -261,7 +261,7 @@ class OtlpLogRecordExporterProviderTest {
     config.put("otel.exporter.otlp.logs.timeout", "15s");
 
     try (LogRecordExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(config))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
       assertThat(exporter).isInstanceOf(OtlpHttpLogRecordExporter.class);
       verify(httpBuilder, times(1)).build();
       verify(httpBuilder).setEndpoint("https://localhost:443/v1/logs");

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpMetricExporterProviderTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpMetricExporterProviderTest.java
@@ -92,7 +92,7 @@ class OtlpMetricExporterProviderTest {
     assertThatThrownBy(
             () ->
                 provider.createExporter(
-                    DefaultConfigProperties.createForTest(
+                    DefaultConfigProperties.createFromMap(
                         Collections.singletonMap("otel.exporter.otlp.protocol", "foo"))))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("Unsupported OTLP metrics protocol: foo");
@@ -103,12 +103,12 @@ class OtlpMetricExporterProviderTest {
     // Verifies createExporter after resetting the spy overrides
     Mockito.reset(provider);
     try (MetricExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(Collections.emptyMap()))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(Collections.emptyMap()))) {
       assertThat(exporter).isInstanceOf(OtlpGrpcMetricExporter.class);
     }
     try (MetricExporter exporter =
         provider.createExporter(
-            DefaultConfigProperties.createForTest(
+            DefaultConfigProperties.createFromMap(
                 Collections.singletonMap("otel.exporter.otlp.protocol", "http/protobuf")))) {
       assertThat(exporter).isInstanceOf(OtlpHttpMetricExporter.class);
     }
@@ -117,7 +117,7 @@ class OtlpMetricExporterProviderTest {
   @Test
   void createExporter_GrpcDefaults() {
     try (MetricExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(Collections.emptyMap()))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(Collections.emptyMap()))) {
       assertThat(exporter).isInstanceOf(OtlpGrpcMetricExporter.class);
       verify(grpcBuilder, times(1)).build();
       verify(grpcBuilder, never()).setEndpoint(any());
@@ -144,7 +144,7 @@ class OtlpMetricExporterProviderTest {
     config.put("otel.experimental.exporter.otlp.retry.enabled", "true");
 
     try (MetricExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(config))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
       assertThat(exporter).isInstanceOf(OtlpGrpcMetricExporter.class);
       verify(grpcBuilder, times(1)).build();
       verify(grpcBuilder).setEndpoint("https://localhost:443/");
@@ -178,7 +178,7 @@ class OtlpMetricExporterProviderTest {
     config.put("otel.exporter.otlp.metrics.timeout", "15s");
 
     try (MetricExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(config))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
       assertThat(exporter).isInstanceOf(OtlpGrpcMetricExporter.class);
       verify(grpcBuilder, times(1)).build();
       verify(grpcBuilder).setEndpoint("https://localhost:443/");
@@ -196,7 +196,7 @@ class OtlpMetricExporterProviderTest {
   void createExporter_HttpDefaults() {
     try (MetricExporter exporter =
         provider.createExporter(
-            DefaultConfigProperties.createForTest(
+            DefaultConfigProperties.createFromMap(
                 Collections.singletonMap(
                     "otel.exporter.otlp.metrics.protocol", "http/protobuf")))) {
       assertThat(exporter).isInstanceOf(OtlpHttpMetricExporter.class);
@@ -226,7 +226,7 @@ class OtlpMetricExporterProviderTest {
     config.put("otel.experimental.exporter.otlp.retry.enabled", "true");
 
     try (MetricExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(config))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
       assertThat(exporter).isInstanceOf(OtlpHttpMetricExporter.class);
       verify(httpBuilder, times(1)).build();
       verify(httpBuilder).setEndpoint("https://localhost:443/v1/metrics");
@@ -262,7 +262,7 @@ class OtlpMetricExporterProviderTest {
     config.put("otel.exporter.otlp.metrics.timeout", "15s");
 
     try (MetricExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(config))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
       assertThat(exporter).isInstanceOf(OtlpHttpMetricExporter.class);
       verify(httpBuilder, times(1)).build();
       verify(httpBuilder).setEndpoint("https://localhost:443/v1/metrics");

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpSpanExporterProviderTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpSpanExporterProviderTest.java
@@ -92,7 +92,7 @@ class OtlpSpanExporterProviderTest {
     assertThatThrownBy(
             () ->
                 provider.createExporter(
-                    DefaultConfigProperties.createForTest(
+                    DefaultConfigProperties.createFromMap(
                         Collections.singletonMap("otel.exporter.otlp.protocol", "foo"))))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("Unsupported OTLP traces protocol: foo");
@@ -103,12 +103,12 @@ class OtlpSpanExporterProviderTest {
     // Verifies createExporter after resetting the spy overrides
     Mockito.reset(provider);
     try (SpanExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(Collections.emptyMap()))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(Collections.emptyMap()))) {
       assertThat(exporter).isInstanceOf(OtlpGrpcSpanExporter.class);
     }
     try (SpanExporter exporter =
         provider.createExporter(
-            DefaultConfigProperties.createForTest(
+            DefaultConfigProperties.createFromMap(
                 Collections.singletonMap("otel.exporter.otlp.protocol", "http/protobuf")))) {
       assertThat(exporter).isInstanceOf(OtlpHttpSpanExporter.class);
     }
@@ -117,7 +117,7 @@ class OtlpSpanExporterProviderTest {
   @Test
   void createExporter_GrpcDefaults() {
     try (SpanExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(Collections.emptyMap()))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(Collections.emptyMap()))) {
       assertThat(exporter).isInstanceOf(OtlpGrpcSpanExporter.class);
       verify(grpcBuilder, times(1)).build();
       verify(grpcBuilder, never()).setEndpoint(any());
@@ -144,7 +144,7 @@ class OtlpSpanExporterProviderTest {
     config.put("otel.experimental.exporter.otlp.retry.enabled", "true");
 
     try (SpanExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(config))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
       assertThat(exporter).isInstanceOf(OtlpGrpcSpanExporter.class);
       verify(grpcBuilder, times(1)).build();
       verify(grpcBuilder).setEndpoint("https://localhost:443/");
@@ -178,7 +178,7 @@ class OtlpSpanExporterProviderTest {
     config.put("otel.exporter.otlp.traces.timeout", "15s");
 
     try (SpanExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(config))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
       assertThat(exporter).isInstanceOf(OtlpGrpcSpanExporter.class);
       verify(grpcBuilder, times(1)).build();
       verify(grpcBuilder).setEndpoint("https://localhost:443/");
@@ -196,7 +196,7 @@ class OtlpSpanExporterProviderTest {
   void createExporter_HttpDefaults() {
     try (SpanExporter exporter =
         provider.createExporter(
-            DefaultConfigProperties.createForTest(
+            DefaultConfigProperties.createFromMap(
                 Collections.singletonMap("otel.exporter.otlp.traces.protocol", "http/protobuf")))) {
       assertThat(exporter).isInstanceOf(OtlpHttpSpanExporter.class);
       verify(httpBuilder, times(1)).build();
@@ -225,7 +225,7 @@ class OtlpSpanExporterProviderTest {
     config.put("otel.experimental.exporter.otlp.retry.enabled", "true");
 
     try (SpanExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(config))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
       assertThat(exporter).isInstanceOf(OtlpHttpSpanExporter.class);
       verify(httpBuilder, times(1)).build();
       verify(httpBuilder).setEndpoint("https://localhost:443/v1/traces");
@@ -261,7 +261,7 @@ class OtlpSpanExporterProviderTest {
     config.put("otel.exporter.otlp.traces.timeout", "15s");
 
     try (SpanExporter exporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(config))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
       assertThat(exporter).isInstanceOf(OtlpHttpSpanExporter.class);
       verify(httpBuilder, times(1)).build();
       verify(httpBuilder).setEndpoint("https://localhost:443/v1/traces");

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/internal/PrometheusMetricReaderProviderTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/internal/PrometheusMetricReaderProviderTest.java
@@ -76,7 +76,7 @@ class PrometheusMetricReaderProviderTest {
     when(configProperties.getString(any())).thenReturn(null);
 
     try (MetricReader metricReader =
-        provider.createMetricReader(DefaultConfigProperties.createForTest(config))) {
+        provider.createMetricReader(DefaultConfigProperties.createFromMap(config))) {
       assertThat(metricReader)
           .extracting("server", as(InstanceOfAssertFactories.type(HttpServer.class)))
           .satisfies(

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/internal/ZipkinSpanExporterProviderTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/internal/ZipkinSpanExporterProviderTest.java
@@ -28,7 +28,7 @@ class ZipkinSpanExporterProviderTest {
   @Test
   void createExporter_Default() {
     try (SpanExporter spanExporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(Collections.emptyMap()))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(Collections.emptyMap()))) {
       assertThat(spanExporter).isInstanceOf(ZipkinSpanExporter.class);
       assertThat(spanExporter)
           .extracting("sender")
@@ -49,7 +49,7 @@ class ZipkinSpanExporterProviderTest {
     config.put("otel.exporter.zipkin.timeout", "1s");
 
     try (SpanExporter spanExporter =
-        provider.createExporter(DefaultConfigProperties.createForTest(config))) {
+        provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
       assertThat(spanExporter).isInstanceOf(ZipkinSpanExporter.class);
       assertThat(spanExporter)
           .extracting("sender")

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/DefaultConfigProperties.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/DefaultConfigProperties.java
@@ -53,7 +53,7 @@ public final class DefaultConfigProperties implements ConfigProperties {
    * Create a {@link DefaultConfigProperties} from the {@code properties}, ignoring system
    * properties and environment variables.
    */
-  public static DefaultConfigProperties createForTest(Map<String, String> properties) {
+  public static DefaultConfigProperties createFromMap(Map<String, String> properties) {
     return new DefaultConfigProperties(properties, Collections.emptyMap(), Collections.emptyMap());
   }
 

--- a/sdk-extensions/autoconfigure-spi/src/test/java/io/opentelemetry/sdk/autoconfigure/spi/internal/ConfigPropertiesTest.java
+++ b/sdk-extensions/autoconfigure-spi/src/test/java/io/opentelemetry/sdk/autoconfigure/spi/internal/ConfigPropertiesTest.java
@@ -26,7 +26,7 @@ class ConfigPropertiesTest {
   void allValid() {
     Map<String, String> properties = makeTestProps();
 
-    ConfigProperties config = DefaultConfigProperties.createForTest(properties);
+    ConfigProperties config = DefaultConfigProperties.createFromMap(properties);
     assertThat(config.getString("test.string")).isEqualTo("str");
     assertThat(config.getInt("test.int")).isEqualTo(10);
     assertThat(config.getLong("test.long")).isEqualTo(20);
@@ -41,7 +41,7 @@ class ConfigPropertiesTest {
   void allValidUsingHyphens() {
     Map<String, String> properties = makeTestProps();
 
-    ConfigProperties config = DefaultConfigProperties.createForTest(properties);
+    ConfigProperties config = DefaultConfigProperties.createFromMap(properties);
     assertThat(config.getString("test-string")).isEqualTo("str");
     assertThat(config.getInt("test-int")).isEqualTo(10);
     assertThat(config.getLong("test-long")).isEqualTo(20);
@@ -54,7 +54,7 @@ class ConfigPropertiesTest {
 
   @Test
   void allMissing() {
-    ConfigProperties config = DefaultConfigProperties.createForTest(emptyMap());
+    ConfigProperties config = DefaultConfigProperties.createFromMap(emptyMap());
     assertThat(config.getString("test.string")).isNull();
     assertThat(config.getInt("test.int")).isNull();
     assertThat(config.getLong("test.long")).isNull();
@@ -75,7 +75,7 @@ class ConfigPropertiesTest {
     properties.put("test.map", "");
     properties.put("test.duration", "");
 
-    ConfigProperties config = DefaultConfigProperties.createForTest(properties);
+    ConfigProperties config = DefaultConfigProperties.createFromMap(properties);
     assertThat(config.getString("test.string")).isEmpty();
     assertThat(config.getInt("test.int")).isNull();
     assertThat(config.getLong("test.long")).isNull();
@@ -89,13 +89,13 @@ class ConfigPropertiesTest {
   void invalidInt() {
     assertThatThrownBy(
             () ->
-                DefaultConfigProperties.createForTest(Collections.singletonMap("int", "bar"))
+                DefaultConfigProperties.createFromMap(Collections.singletonMap("int", "bar"))
                     .getInt("int"))
         .isInstanceOf(ConfigurationException.class)
         .hasMessage("Invalid value for property int=bar. Must be a integer.");
     assertThatThrownBy(
             () ->
-                DefaultConfigProperties.createForTest(
+                DefaultConfigProperties.createFromMap(
                         Collections.singletonMap("int", "999999999999999"))
                     .getInt("int"))
         .isInstanceOf(ConfigurationException.class)
@@ -106,13 +106,13 @@ class ConfigPropertiesTest {
   void invalidLong() {
     assertThatThrownBy(
             () ->
-                DefaultConfigProperties.createForTest(Collections.singletonMap("long", "bar"))
+                DefaultConfigProperties.createFromMap(Collections.singletonMap("long", "bar"))
                     .getLong("long"))
         .isInstanceOf(ConfigurationException.class)
         .hasMessage("Invalid value for property long=bar. Must be a long.");
     assertThatThrownBy(
             () ->
-                DefaultConfigProperties.createForTest(
+                DefaultConfigProperties.createFromMap(
                         Collections.singletonMap("long", "99223372036854775807"))
                     .getLong("long"))
         .isInstanceOf(ConfigurationException.class)
@@ -123,13 +123,13 @@ class ConfigPropertiesTest {
   void invalidDouble() {
     assertThatThrownBy(
             () ->
-                DefaultConfigProperties.createForTest(Collections.singletonMap("double", "bar"))
+                DefaultConfigProperties.createFromMap(Collections.singletonMap("double", "bar"))
                     .getDouble("double"))
         .isInstanceOf(ConfigurationException.class)
         .hasMessage("Invalid value for property double=bar. Must be a double.");
     assertThatThrownBy(
             () ->
-                DefaultConfigProperties.createForTest(Collections.singletonMap("double", "1.0.1"))
+                DefaultConfigProperties.createFromMap(Collections.singletonMap("double", "1.0.1"))
                     .getDouble("double"))
         .isInstanceOf(ConfigurationException.class)
         .hasMessage("Invalid value for property double=1.0.1. Must be a double.");
@@ -138,7 +138,7 @@ class ConfigPropertiesTest {
   @Test
   void uncleanList() {
     assertThat(
-            DefaultConfigProperties.createForTest(
+            DefaultConfigProperties.createFromMap(
                     Collections.singletonMap("list", "  a  ,b,c  ,  d,,   ,"))
                 .getList("list"))
         .containsExactly("a", "b", "c", "d");
@@ -147,7 +147,7 @@ class ConfigPropertiesTest {
   @Test
   void uncleanMap() {
     assertThat(
-            DefaultConfigProperties.createForTest(
+            DefaultConfigProperties.createFromMap(
                     Collections.singletonMap("map", "  a=1  ,b=2,c = 3  ,  d=  4,,  ,"))
                 .getMap("map"))
         .containsExactly(entry("a", "1"), entry("b", "2"), entry("c", "3"), entry("d", "4"));
@@ -157,19 +157,19 @@ class ConfigPropertiesTest {
   void invalidMap() {
     assertThatThrownBy(
             () ->
-                DefaultConfigProperties.createForTest(Collections.singletonMap("map", "a=1,b="))
+                DefaultConfigProperties.createFromMap(Collections.singletonMap("map", "a=1,b="))
                     .getMap("map"))
         .isInstanceOf(ConfigurationException.class)
         .hasMessage("Invalid map property: map=a=1,b=");
     assertThatThrownBy(
             () ->
-                DefaultConfigProperties.createForTest(Collections.singletonMap("map", "a=1,b"))
+                DefaultConfigProperties.createFromMap(Collections.singletonMap("map", "a=1,b"))
                     .getMap("map"))
         .isInstanceOf(ConfigurationException.class)
         .hasMessage("Invalid map property: map=a=1,b");
     assertThatThrownBy(
             () ->
-                DefaultConfigProperties.createForTest(Collections.singletonMap("map", "a=1,=b"))
+                DefaultConfigProperties.createFromMap(Collections.singletonMap("map", "a=1,=b"))
                     .getMap("map"))
         .isInstanceOf(ConfigurationException.class)
         .hasMessage("Invalid map property: map=a=1,=b");
@@ -179,13 +179,13 @@ class ConfigPropertiesTest {
   void invalidDuration() {
     assertThatThrownBy(
             () ->
-                DefaultConfigProperties.createForTest(Collections.singletonMap("duration", "1a1ms"))
+                DefaultConfigProperties.createFromMap(Collections.singletonMap("duration", "1a1ms"))
                     .getDuration("duration"))
         .isInstanceOf(ConfigurationException.class)
         .hasMessage("Invalid duration property duration=1a1ms. Expected number, found: 1a1");
     assertThatThrownBy(
             () ->
-                DefaultConfigProperties.createForTest(Collections.singletonMap("duration", "9mm"))
+                DefaultConfigProperties.createFromMap(Collections.singletonMap("duration", "9mm"))
                     .getDuration("duration"))
         .isInstanceOf(ConfigurationException.class)
         .hasMessage("Invalid duration property duration=9mm. Invalid duration string, found: mm");
@@ -194,36 +194,36 @@ class ConfigPropertiesTest {
   @Test
   void durationUnitParsing() {
     assertThat(
-            DefaultConfigProperties.createForTest(Collections.singletonMap("duration", "1"))
+            DefaultConfigProperties.createFromMap(Collections.singletonMap("duration", "1"))
                 .getDuration("duration"))
         .isEqualTo(Duration.ofMillis(1));
     assertThat(
-            DefaultConfigProperties.createForTest(Collections.singletonMap("duration", "2ms"))
+            DefaultConfigProperties.createFromMap(Collections.singletonMap("duration", "2ms"))
                 .getDuration("duration"))
         .isEqualTo(Duration.ofMillis(2));
     assertThat(
-            DefaultConfigProperties.createForTest(Collections.singletonMap("duration", "3s"))
+            DefaultConfigProperties.createFromMap(Collections.singletonMap("duration", "3s"))
                 .getDuration("duration"))
         .isEqualTo(Duration.ofSeconds(3));
     assertThat(
-            DefaultConfigProperties.createForTest(Collections.singletonMap("duration", "4m"))
+            DefaultConfigProperties.createFromMap(Collections.singletonMap("duration", "4m"))
                 .getDuration("duration"))
         .isEqualTo(Duration.ofMinutes(4));
     assertThat(
-            DefaultConfigProperties.createForTest(Collections.singletonMap("duration", "5h"))
+            DefaultConfigProperties.createFromMap(Collections.singletonMap("duration", "5h"))
                 .getDuration("duration"))
         .isEqualTo(Duration.ofHours(5));
     assertThat(
-            DefaultConfigProperties.createForTest(Collections.singletonMap("duration", "6d"))
+            DefaultConfigProperties.createFromMap(Collections.singletonMap("duration", "6d"))
                 .getDuration("duration"))
         .isEqualTo(Duration.ofDays(6));
     // Check Space handling
     assertThat(
-            DefaultConfigProperties.createForTest(Collections.singletonMap("duration", "7 ms"))
+            DefaultConfigProperties.createFromMap(Collections.singletonMap("duration", "7 ms"))
                 .getDuration("duration"))
         .isEqualTo(Duration.ofMillis(7));
     assertThat(
-            DefaultConfigProperties.createForTest(Collections.singletonMap("duration", "8   ms"))
+            DefaultConfigProperties.createFromMap(Collections.singletonMap("duration", "8   ms"))
                 .getDuration("duration"))
         .isEqualTo(Duration.ofMillis(8));
   }

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/LogRecordExporterConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/LogRecordExporterConfigurationTest.java
@@ -34,7 +34,7 @@ class LogRecordExporterConfigurationTest {
   void configureExporter_KnownSpiExportersNotOnClasspath() {
     NamedSpiManager<LogRecordExporter> spiExportersManager =
         LogRecordExporterConfiguration.logRecordExporterSpiManager(
-            DefaultConfigProperties.createForTest(Collections.emptyMap()), spiHelper);
+            DefaultConfigProperties.createFromMap(Collections.emptyMap()), spiHelper);
 
     assertThatThrownBy(() -> configureExporter("logging", spiExportersManager))
         .isInstanceOf(ConfigurationException.class)
@@ -64,7 +64,7 @@ class LogRecordExporterConfigurationTest {
     assertThatThrownBy(
             () ->
                 LogRecordExporterConfiguration.configureLogRecordExporters(
-                    DefaultConfigProperties.createForTest(
+                    DefaultConfigProperties.createFromMap(
                         ImmutableMap.of("otel.logs.exporter", "otlp,otlp")),
                     spiHelper,
                     (a, unused) -> a,
@@ -82,7 +82,7 @@ class LogRecordExporterConfigurationTest {
     assertThatThrownBy(
             () ->
                 LogRecordExporterConfiguration.configureLogRecordExporters(
-                    DefaultConfigProperties.createForTest(
+                    DefaultConfigProperties.createFromMap(
                         ImmutableMap.of("otel.logs.exporter", "foo")),
                     spiHelper,
                     (a, unused) -> a,
@@ -100,7 +100,7 @@ class LogRecordExporterConfigurationTest {
     assertThatThrownBy(
             () ->
                 LogRecordExporterConfiguration.configureLogRecordExporters(
-                    DefaultConfigProperties.createForTest(
+                    DefaultConfigProperties.createFromMap(
                         ImmutableMap.of("otel.logs.exporter", "otlp,none")),
                     spiHelper,
                     (a, unused) -> a,

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/LoggerProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/LoggerProviderConfigurationTest.java
@@ -44,7 +44,7 @@ class LoggerProviderConfigurationTest {
     SdkLoggerProviderBuilder builder = SdkLoggerProvider.builder();
     LoggerProviderConfiguration.configureLoggerProvider(
         builder,
-        DefaultConfigProperties.createForTest(properties),
+        DefaultConfigProperties.createFromMap(properties),
         SpiHelper.create(LoggerProviderConfiguration.class.getClassLoader()),
         MeterProvider.noop(),
         (a, unused) -> a,
@@ -73,12 +73,12 @@ class LoggerProviderConfigurationTest {
   void configureLogLimits() {
     assertThat(
             LoggerProviderConfiguration.configureLogLimits(
-                DefaultConfigProperties.createForTest(Collections.emptyMap())))
+                DefaultConfigProperties.createFromMap(Collections.emptyMap())))
         .isEqualTo(LogLimits.getDefault());
 
     LogLimits config =
         LoggerProviderConfiguration.configureLogLimits(
-            DefaultConfigProperties.createForTest(
+            DefaultConfigProperties.createFromMap(
                 ImmutableMap.of(
                     "otel.attribute.value.length.limit", "100",
                     "otel.attribute.count.limit", "5")));

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/MeterProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/MeterProviderConfigurationTest.java
@@ -51,7 +51,7 @@ class MeterProviderConfigurationTest {
     SdkMeterProviderBuilder builder = SdkMeterProvider.builder();
     MeterProviderConfiguration.configureMeterProvider(
         builder,
-        DefaultConfigProperties.createForTest(configWithDefault),
+        DefaultConfigProperties.createFromMap(configWithDefault),
         SpiHelper.create(MeterProviderConfigurationTest.class.getClassLoader()),
         (a, b) -> a,
         new ArrayList<>());

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfigurationTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 class MetricExporterConfigurationTest {
 
   private static final ConfigProperties EMPTY =
-      DefaultConfigProperties.createForTest(Collections.emptyMap());
+      DefaultConfigProperties.createFromMap(Collections.emptyMap());
 
   private final SpiHelper spiHelper =
       SpiHelper.create(MetricExporterConfigurationTest.class.getClassLoader());

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/PropagatorConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/PropagatorConfigurationTest.java
@@ -24,7 +24,7 @@ class PropagatorConfigurationTest {
   void defaultPropagators() {
     ContextPropagators contextPropagators =
         PropagatorConfiguration.configurePropagators(
-            DefaultConfigProperties.createForTest(Collections.emptyMap()),
+            DefaultConfigProperties.createFromMap(Collections.emptyMap()),
             spiHelper,
             (a, unused) -> a);
 
@@ -36,7 +36,7 @@ class PropagatorConfigurationTest {
   void configurePropagators_none() {
     ContextPropagators contextPropagators =
         PropagatorConfiguration.configurePropagators(
-            DefaultConfigProperties.createForTest(
+            DefaultConfigProperties.createFromMap(
                 Collections.singletonMap("otel.propagators", "none")),
             spiHelper,
             (a, unused) -> a);
@@ -49,7 +49,7 @@ class PropagatorConfigurationTest {
     assertThatThrownBy(
             () ->
                 PropagatorConfiguration.configurePropagators(
-                    DefaultConfigProperties.createForTest(
+                    DefaultConfigProperties.createFromMap(
                         Collections.singletonMap("otel.propagators", "none,blather")),
                     spiHelper,
                     (a, unused) -> a))
@@ -62,7 +62,7 @@ class PropagatorConfigurationTest {
     assertThatThrownBy(
             () ->
                 PropagatorConfiguration.configurePropagators(
-                    DefaultConfigProperties.createForTest(
+                    DefaultConfigProperties.createFromMap(
                         Collections.singletonMap("otel.propagators", "b3")),
                     spiHelper,
                     (a, config) -> a))

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationFuzzTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationFuzzTest.java
@@ -31,7 +31,7 @@ class ResourceConfigurationFuzzTest {
     public void getAttributesWithRandomValues(String value1, String value2) {
       Attributes attributes =
           ResourceConfiguration.createEnvironmentResource(
-                  DefaultConfigProperties.createForTest(
+                  DefaultConfigProperties.createFromMap(
                       singletonMap(
                           ResourceConfiguration.ATTRIBUTE_PROPERTY,
                           "key1=" + escaper.escape(value1) + ",key2=" + escaper.escape(value2))))

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
@@ -57,7 +57,7 @@ class ResourceConfigurationTest {
   void createEnvironmentResource_WithResourceAttributes() {
     Attributes attributes =
         ResourceConfiguration.createEnvironmentResource(
-                DefaultConfigProperties.createForTest(
+                DefaultConfigProperties.createFromMap(
                     singletonMap(
                         ResourceConfiguration.ATTRIBUTE_PROPERTY,
                         "service.name=myService,appName=MyApp")))
@@ -73,7 +73,7 @@ class ResourceConfigurationTest {
   void createEnvironmentResource_WithServiceName() {
     Attributes attributes =
         ResourceConfiguration.createEnvironmentResource(
-                DefaultConfigProperties.createForTest(
+                DefaultConfigProperties.createFromMap(
                     singletonMap(ResourceConfiguration.SERVICE_NAME_PROPERTY, "myService")))
             .getAttributes();
 
@@ -84,7 +84,7 @@ class ResourceConfigurationTest {
   void createEnvironmentResource_ServiceNamePriority() {
     Attributes attributes =
         ResourceConfiguration.createEnvironmentResource(
-                DefaultConfigProperties.createForTest(
+                DefaultConfigProperties.createFromMap(
                     ImmutableMap.of(
                         ResourceConfiguration.ATTRIBUTE_PROPERTY,
                         "service.name=myService,appName=MyApp",
@@ -102,7 +102,7 @@ class ResourceConfigurationTest {
   void createEnvironmentResource_EmptyResourceAttributes() {
     Attributes attributes =
         ResourceConfiguration.createEnvironmentResource(
-                DefaultConfigProperties.createForTest(
+                DefaultConfigProperties.createFromMap(
                     singletonMap(ResourceConfiguration.ATTRIBUTE_PROPERTY, "")))
             .getAttributes();
 
@@ -112,7 +112,7 @@ class ResourceConfigurationTest {
   @Test
   void filterAttributes() {
     ConfigProperties configProperties =
-        DefaultConfigProperties.createForTest(ImmutableMap.of(DISABLED_ATTRIBUTE_KEYS, "foo,bar"));
+        DefaultConfigProperties.createFromMap(ImmutableMap.of(DISABLED_ATTRIBUTE_KEYS, "foo,bar"));
 
     Resource resourceNoSchema =
         Resource.builder().put("foo", "val").put("bar", "val").put("baz", "val").build();

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfigurationTest.java
@@ -22,7 +22,7 @@ class SpanExporterConfigurationTest {
   void configureExporter_KnownSpiExportersNotOnClasspath() {
     NamedSpiManager<SpanExporter> spiExportersManager =
         SpanExporterConfiguration.spanExporterSpiManager(
-            DefaultConfigProperties.createForTest(Collections.emptyMap()),
+            DefaultConfigProperties.createFromMap(Collections.emptyMap()),
             SpiHelper.create(SpanExporterConfigurationTest.class.getClassLoader()));
 
     assertThatThrownBy(() -> configureExporter("jaeger", spiExportersManager))

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
@@ -47,7 +47,7 @@ import org.mockito.quality.Strictness;
 class TracerProviderConfigurationTest {
 
   private static final ConfigProperties EMPTY =
-      DefaultConfigProperties.createForTest(Collections.emptyMap());
+      DefaultConfigProperties.createFromMap(Collections.emptyMap());
 
   @RegisterExtension CleanupExtension cleanup = new CleanupExtension();
 
@@ -74,7 +74,7 @@ class TracerProviderConfigurationTest {
     SdkTracerProviderBuilder tracerProviderBuilder = SdkTracerProvider.builder();
     TracerProviderConfiguration.configureTracerProvider(
         tracerProviderBuilder,
-        DefaultConfigProperties.createForTest(properties),
+        DefaultConfigProperties.createFromMap(properties),
         spiHelper,
         MeterProvider.noop(),
         (a, unused) -> a,
@@ -130,7 +130,7 @@ class TracerProviderConfigurationTest {
 
     try (BatchSpanProcessor processor =
         TracerProviderConfiguration.configureBatchSpanProcessor(
-            DefaultConfigProperties.createForTest(properties),
+            DefaultConfigProperties.createFromMap(properties),
             mockSpanExporter,
             MeterProvider.noop())) {
       assertThat(processor)
@@ -160,7 +160,7 @@ class TracerProviderConfigurationTest {
 
     SpanLimits config =
         TracerProviderConfiguration.configureSpanLimits(
-            DefaultConfigProperties.createForTest(
+            DefaultConfigProperties.createFromMap(
                 ImmutableMap.of(
                     "otel.attribute.value.length.limit", "100",
                     "otel.attribute.count.limit", "5")));
@@ -175,7 +175,7 @@ class TracerProviderConfigurationTest {
 
     config =
         TracerProviderConfiguration.configureSpanLimits(
-            DefaultConfigProperties.createForTest(
+            DefaultConfigProperties.createFromMap(
                 ImmutableMap.of(
                     "otel.attribute.value.length.limit", "100",
                     "otel.span.attribute.value.length.limit", "200",
@@ -200,7 +200,7 @@ class TracerProviderConfigurationTest {
     assertThat(
             TracerProviderConfiguration.configureSampler(
                 "traceidratio",
-                DefaultConfigProperties.createForTest(
+                DefaultConfigProperties.createFromMap(
                     Collections.singletonMap("otel.traces.sampler.arg", "0.5")),
                 spiHelper))
         .isEqualTo(Sampler.traceIdRatioBased(0.5));
@@ -216,7 +216,7 @@ class TracerProviderConfigurationTest {
     assertThat(
             TracerProviderConfiguration.configureSampler(
                 "parentbased_traceidratio",
-                DefaultConfigProperties.createForTest(
+                DefaultConfigProperties.createFromMap(
                     Collections.singletonMap("otel.traces.sampler.arg", "0.4")),
                 spiHelper))
         .isEqualTo(Sampler.parentBased(Sampler.traceIdRatioBased(0.4)));

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/internal/SpiHelperTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/internal/SpiHelperTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class SpiHelperTest {
 
   private static final ConfigProperties EMPTY =
-      DefaultConfigProperties.createForTest(Collections.emptyMap());
+      DefaultConfigProperties.createFromMap(Collections.emptyMap());
 
   @Test
   public void canRetrieveByName() {

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableLogRecordExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableLogRecordExporterTest.java
@@ -33,7 +33,7 @@ class ConfigurableLogRecordExporterTest {
   @Test
   void configureLogRecordExporters_spiExporter() {
     ConfigProperties config =
-        DefaultConfigProperties.createForTest(
+        DefaultConfigProperties.createFromMap(
             ImmutableMap.of("test.option", "true", "otel.logs.exporter", "testExporter"));
     List<Closeable> closeables = new ArrayList<>();
 
@@ -60,7 +60,7 @@ class ConfigurableLogRecordExporterTest {
   @Test
   void configureLogRecordExporters_emptyClassLoader() {
     ConfigProperties config =
-        DefaultConfigProperties.createForTest(
+        DefaultConfigProperties.createFromMap(
             ImmutableMap.of("test.option", "true", "otel.logs.exporter", "testExporter"));
     List<Closeable> closeables = new ArrayList<>();
 

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableMetricExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableMetricExporterTest.java
@@ -39,7 +39,7 @@ class ConfigurableMetricExporterTest {
   @Test
   void configureExporter_spiExporter() {
     ConfigProperties config =
-        DefaultConfigProperties.createForTest(ImmutableMap.of("test.option", "true"));
+        DefaultConfigProperties.createFromMap(ImmutableMap.of("test.option", "true"));
 
     try (MetricExporter metricExporter =
         MetricExporterConfiguration.configureExporter(
@@ -58,7 +58,7 @@ class ConfigurableMetricExporterTest {
             MetricExporterConfiguration.configureExporter(
                 "testExporter",
                 MetricExporterConfiguration.metricExporterSpiManager(
-                    DefaultConfigProperties.createForTest(Collections.emptyMap()),
+                    DefaultConfigProperties.createFromMap(Collections.emptyMap()),
                     SpiHelper.create(new URLClassLoader(new URL[] {}, null)))))
         .isNull();
   }
@@ -69,14 +69,14 @@ class ConfigurableMetricExporterTest {
             MetricExporterConfiguration.configureExporter(
                 "catExporter",
                 MetricExporterConfiguration.metricExporterSpiManager(
-                    DefaultConfigProperties.createForTest(Collections.emptyMap()), spiHelper)))
+                    DefaultConfigProperties.createFromMap(Collections.emptyMap()), spiHelper)))
         .isNull();
   }
 
   @Test
   void configureMetricReaders_multipleWithNone() {
     ConfigProperties config =
-        DefaultConfigProperties.createForTest(
+        DefaultConfigProperties.createFromMap(
             ImmutableMap.of("otel.metrics.exporter", "otlp,none"));
     List<Closeable> closeables = new ArrayList<>();
 
@@ -92,7 +92,7 @@ class ConfigurableMetricExporterTest {
 
   @Test
   void configureMetricReaders_defaultExporter() {
-    ConfigProperties config = DefaultConfigProperties.createForTest(Collections.emptyMap());
+    ConfigProperties config = DefaultConfigProperties.createFromMap(Collections.emptyMap());
     List<Closeable> closeables = new ArrayList<>();
 
     List<MetricReader> metricReaders =
@@ -114,7 +114,7 @@ class ConfigurableMetricExporterTest {
   @Test
   void configureMetricReaders_multipleExporters() {
     ConfigProperties config =
-        DefaultConfigProperties.createForTest(
+        DefaultConfigProperties.createFromMap(
             ImmutableMap.of("otel.metrics.exporter", "otlp,logging"));
     List<Closeable> closeables = new ArrayList<>();
 

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
@@ -45,7 +45,7 @@ class ConfigurableSpanExporterTest {
   @Test
   void configureSpanExporters_spiExporter() {
     ConfigProperties config =
-        DefaultConfigProperties.createForTest(
+        DefaultConfigProperties.createFromMap(
             ImmutableMap.of("test.option", "true", "otel.traces.exporter", "testExporter"));
     List<Closeable> closeables = new ArrayList<>();
 
@@ -68,7 +68,7 @@ class ConfigurableSpanExporterTest {
   @Test
   void configureSpanExporters_emptyClassLoader() {
     ConfigProperties config =
-        DefaultConfigProperties.createForTest(
+        DefaultConfigProperties.createFromMap(
             ImmutableMap.of("test.option", "true", "otel.traces.exporter", "testExporter"));
     List<Closeable> closeables = new ArrayList<>();
 
@@ -88,7 +88,7 @@ class ConfigurableSpanExporterTest {
   @Test
   void configureSpanExporters_duplicates() {
     ConfigProperties config =
-        DefaultConfigProperties.createForTest(
+        DefaultConfigProperties.createFromMap(
             ImmutableMap.of("otel.traces.exporter", "otlp,otlp,logging"));
     List<Closeable> closeables = new ArrayList<>();
 
@@ -105,7 +105,7 @@ class ConfigurableSpanExporterTest {
   @Test
   void configureSpanExporters_multipleWithNone() {
     ConfigProperties config =
-        DefaultConfigProperties.createForTest(ImmutableMap.of("otel.traces.exporter", "otlp,none"));
+        DefaultConfigProperties.createFromMap(ImmutableMap.of("otel.traces.exporter", "otlp,none"));
     List<Closeable> closeables = new ArrayList<>();
 
     assertThatThrownBy(
@@ -135,7 +135,7 @@ class ConfigurableSpanExporterTest {
 
     List<SpanProcessor> spanProcessors =
         TracerProviderConfiguration.configureSpanProcessors(
-            DefaultConfigProperties.createForTest(
+            DefaultConfigProperties.createFromMap(
                 Collections.singletonMap("otel.traces.exporter", exporterName)),
             ImmutableMap.of(exporterName, LoggingSpanExporter.create()),
             MeterProvider.noop(),
@@ -153,7 +153,7 @@ class ConfigurableSpanExporterTest {
 
     List<SpanProcessor> spanProcessors =
         TracerProviderConfiguration.configureSpanProcessors(
-            DefaultConfigProperties.createForTest(
+            DefaultConfigProperties.createFromMap(
                 Collections.singletonMap("otel.traces.exporter", exporterName)),
             ImmutableMap.of(exporterName, ZipkinSpanExporter.builder().build()),
             MeterProvider.noop(),
@@ -170,7 +170,7 @@ class ConfigurableSpanExporterTest {
 
     List<SpanProcessor> spanProcessors =
         TracerProviderConfiguration.configureSpanProcessors(
-            DefaultConfigProperties.createForTest(
+            DefaultConfigProperties.createFromMap(
                 Collections.singletonMap("otel.traces.exporter", "otlp,zipkin")),
             ImmutableMap.of(
                 "otlp",
@@ -212,7 +212,7 @@ class ConfigurableSpanExporterTest {
 
     List<SpanProcessor> spanProcessors =
         TracerProviderConfiguration.configureSpanProcessors(
-            DefaultConfigProperties.createForTest(
+            DefaultConfigProperties.createFromMap(
                 Collections.singletonMap("otel.traces.exporter", "logging,zipkin")),
             ImmutableMap.of(
                 "logging",

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/LogRecordExporterConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/LogRecordExporterConfigurationTest.java
@@ -29,7 +29,7 @@ class LogRecordExporterConfigurationTest {
   void configureExporter_KnownSpiExportersOnClasspath() {
     NamedSpiManager<LogRecordExporter> spiExportersManager =
         LogRecordExporterConfiguration.logRecordExporterSpiManager(
-            DefaultConfigProperties.createForTest(Collections.emptyMap()), spiHelper);
+            DefaultConfigProperties.createFromMap(Collections.emptyMap()), spiHelper);
 
     assertThat(LogRecordExporterConfiguration.configureExporter("logging", spiExportersManager))
         .isInstanceOf(SystemOutLogRecordExporter.class);
@@ -47,7 +47,7 @@ class LogRecordExporterConfigurationTest {
                 LogRecordExporterConfiguration.configureExporter(
                     "otlp",
                     LogRecordExporterConfiguration.logRecordExporterSpiManager(
-                        DefaultConfigProperties.createForTest(
+                        DefaultConfigProperties.createFromMap(
                             ImmutableMap.of("otel.exporter.otlp.protocol", "foo")),
                         spiHelper)))
         .isInstanceOf(ConfigurationException.class)

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/LoggerProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/LoggerProviderConfigurationTest.java
@@ -43,7 +43,7 @@ class LoggerProviderConfigurationTest {
     SdkLoggerProviderBuilder builder = SdkLoggerProvider.builder();
     LoggerProviderConfiguration.configureLoggerProvider(
         builder,
-        DefaultConfigProperties.createForTest(Collections.emptyMap()),
+        DefaultConfigProperties.createFromMap(Collections.emptyMap()),
         SpiHelper.create(LoggerProviderConfiguration.class.getClassLoader()),
         MeterProvider.noop(),
         (a, unused) -> a,
@@ -86,7 +86,7 @@ class LoggerProviderConfigurationTest {
 
     List<LogRecordProcessor> logRecordProcessors =
         LoggerProviderConfiguration.configureLogRecordProcessors(
-            DefaultConfigProperties.createForTest(Collections.emptyMap()),
+            DefaultConfigProperties.createFromMap(Collections.emptyMap()),
             ImmutableMap.of(
                 "logging",
                 SystemOutLogRecordExporter.create(),
@@ -116,7 +116,7 @@ class LoggerProviderConfigurationTest {
 
     try (BatchLogRecordProcessor processor =
         LoggerProviderConfiguration.configureBatchLogRecordProcessor(
-            DefaultConfigProperties.createForTest(properties),
+            DefaultConfigProperties.createFromMap(properties),
             SystemOutLogRecordExporter.create(),
             MeterProvider.noop())) {
       assertThat(processor)

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/MeterProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/MeterProviderConfigurationTest.java
@@ -42,7 +42,7 @@ class MeterProviderConfigurationTest {
             () -> {
               MeterProviderConfiguration.configureMeterProvider(
                   SdkMeterProvider.builder(),
-                  DefaultConfigProperties.createForTest(
+                  DefaultConfigProperties.createFromMap(
                       ImmutableMap.of(
                           "otel.metrics.exporter",
                           "logging",
@@ -65,7 +65,7 @@ class MeterProviderConfigurationTest {
     SdkMeterProviderBuilder builder = SdkMeterProvider.builder();
     MeterProviderConfiguration.configureMeterProvider(
         builder,
-        DefaultConfigProperties.createForTest(
+        DefaultConfigProperties.createFromMap(
             Collections.singletonMap("otel.metrics.exporter", "logging")),
         spiHelper,
         (a, b) -> a,
@@ -77,7 +77,7 @@ class MeterProviderConfigurationTest {
     builder = SdkMeterProvider.builder();
     MeterProviderConfiguration.configureMeterProvider(
         builder,
-        DefaultConfigProperties.createForTest(
+        DefaultConfigProperties.createFromMap(
             ImmutableMap.of(
                 "otel.metrics.exporter",
                 "logging",

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfigurationTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class MetricExporterConfigurationTest {
 
   private static final ConfigProperties EMPTY =
-      DefaultConfigProperties.createForTest(Collections.emptyMap());
+      DefaultConfigProperties.createFromMap(Collections.emptyMap());
 
   @RegisterExtension CleanupExtension cleanup = new CleanupExtension();
 
@@ -101,7 +101,7 @@ class MetricExporterConfigurationTest {
                 MetricExporterConfiguration.configureExporter(
                     "otlp",
                     MetricExporterConfiguration.metricExporterSpiManager(
-                        DefaultConfigProperties.createForTest(
+                        DefaultConfigProperties.createFromMap(
                             ImmutableMap.of("otel.exporter.otlp.protocol", "foo")),
                         spiHelper)))
         .isInstanceOf(ConfigurationException.class)

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/SpanExporterConfigurationTest.java
@@ -32,7 +32,7 @@ class SpanExporterConfigurationTest {
   void configureExporter_KnownSpiExportersOnClasspath() {
     NamedSpiManager<SpanExporter> spiExportersManager =
         SpanExporterConfiguration.spanExporterSpiManager(
-            DefaultConfigProperties.createForTest(Collections.emptyMap()), spiHelper);
+            DefaultConfigProperties.createFromMap(Collections.emptyMap()), spiHelper);
 
     assertThat(SpanExporterConfiguration.configureExporter("jaeger", spiExportersManager))
         .isInstanceOf(io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter.class);
@@ -49,7 +49,7 @@ class SpanExporterConfigurationTest {
   @Test
   void configureOtlpSpansUnsupportedProtocol() {
     ConfigProperties config =
-        DefaultConfigProperties.createForTest(
+        DefaultConfigProperties.createFromMap(
             ImmutableMap.of("otel.exporter.otlp.protocol", "foo"));
     assertThatThrownBy(
             () ->
@@ -63,7 +63,7 @@ class SpanExporterConfigurationTest {
   @Test
   void configureOtlpTimeout() {
     ConfigProperties config =
-        DefaultConfigProperties.createForTest(
+        DefaultConfigProperties.createFromMap(
             Collections.singletonMap("otel.exporter.otlp.timeout", "10"));
     try (SpanExporter exporter =
         SpanExporterConfiguration.configureExporter(

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
@@ -29,7 +29,7 @@ public class TracerProviderConfigurationTest {
   @Test
   void configuration() {
     ConfigProperties config =
-        DefaultConfigProperties.createForTest(ImmutableMap.of("test.option", "true"));
+        DefaultConfigProperties.createFromMap(ImmutableMap.of("test.option", "true"));
     Sampler sampler =
         TracerProviderConfiguration.configureSampler("testSampler", config, spiHelper);
 
@@ -42,7 +42,7 @@ public class TracerProviderConfigurationTest {
   @Test
   void emptyClassLoader() {
     ConfigProperties config =
-        DefaultConfigProperties.createForTest(ImmutableMap.of("test.option", "true"));
+        DefaultConfigProperties.createFromMap(ImmutableMap.of("test.option", "true"));
     assertThatThrownBy(
             () ->
                 TracerProviderConfiguration.configureSampler(
@@ -57,7 +57,7 @@ public class TracerProviderConfigurationTest {
             () ->
                 TracerProviderConfiguration.configureSampler(
                     "catSampler",
-                    DefaultConfigProperties.createForTest(Collections.emptyMap()),
+                    DefaultConfigProperties.createFromMap(Collections.emptyMap()),
                     spiHelper))
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("catSampler");
@@ -68,7 +68,7 @@ public class TracerProviderConfigurationTest {
     assertThat(
             TracerProviderConfiguration.configureSampler(
                 "parentbased_jaeger_remote",
-                DefaultConfigProperties.createForTest(Collections.emptyMap()),
+                DefaultConfigProperties.createFromMap(Collections.emptyMap()),
                 spiHelper))
         .satisfies(
             sampler -> {

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordExporterFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordExporterFactory.java
@@ -97,9 +97,7 @@ final class LogRecordExporterFactory
       properties.put("otel.exporter.otlp.logs.client.certificate", otlp.getClientCertificate());
     }
 
-    // TODO(jack-berg): add method for creating from map
     ConfigProperties configProperties = DefaultConfigProperties.createFromMap(properties);
-
     return FileConfigUtil.assertNotNull(
         logRecordExporterSpiManager(configProperties, spiHelper).getByName("otlp"),
         "otlp exporter");

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordExporterFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordExporterFactory.java
@@ -98,7 +98,7 @@ final class LogRecordExporterFactory
     }
 
     // TODO(jack-berg): add method for creating from map
-    ConfigProperties configProperties = DefaultConfigProperties.createForTest(properties);
+    ConfigProperties configProperties = DefaultConfigProperties.createFromMap(properties);
 
     return FileConfigUtil.assertNotNull(
         logRecordExporterSpiManager(configProperties, spiHelper).getByName("otlp"),

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricExporterFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricExporterFactory.java
@@ -117,7 +117,6 @@ final class MetricExporterFactory
           "otel.exporter.otlp.metrics.temporality.preference", model.getTemporalityPreference());
     }
 
-    // TODO(jack-berg): add method for creating from map
     ConfigProperties configProperties = DefaultConfigProperties.createFromMap(properties);
     return FileConfigUtil.assertNotNull(
         metricExporterSpiManager(configProperties, spiHelper).getByName("otlp"), "otlp exporter");

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricExporterFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricExporterFactory.java
@@ -118,7 +118,7 @@ final class MetricExporterFactory
     }
 
     // TODO(jack-berg): add method for creating from map
-    ConfigProperties configProperties = DefaultConfigProperties.createForTest(properties);
+    ConfigProperties configProperties = DefaultConfigProperties.createFromMap(properties);
     return FileConfigUtil.assertNotNull(
         metricExporterSpiManager(configProperties, spiHelper).getByName("otlp"), "otlp exporter");
   }
@@ -126,7 +126,7 @@ final class MetricExporterFactory
   private static MetricExporter createConsoleExporter(SpiHelper spiHelper) {
     return FileConfigUtil.assertNotNull(
         metricExporterSpiManager(
-                DefaultConfigProperties.createForTest(Collections.emptyMap()), spiHelper)
+                DefaultConfigProperties.createFromMap(Collections.emptyMap()), spiHelper)
             .getByName("logging"),
         "logging exporter");
   }

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricReaderFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricReaderFactory.java
@@ -91,7 +91,7 @@ final class MetricReaderFactory
         }
 
         // TODO(jack-berg): add method for creating from map
-        ConfigProperties configProperties = DefaultConfigProperties.createForTest(properties);
+        ConfigProperties configProperties = DefaultConfigProperties.createFromMap(properties);
 
         return FileConfigUtil.addAndReturn(
             closeables,

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricReaderFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricReaderFactory.java
@@ -90,9 +90,7 @@ final class MetricReaderFactory
               "otel.exporter.prometheus.port", String.valueOf(prometheusModel.getPort()));
         }
 
-        // TODO(jack-berg): add method for creating from map
         ConfigProperties configProperties = DefaultConfigProperties.createFromMap(properties);
-
         return FileConfigUtil.addAndReturn(
             closeables,
             FileConfigUtil.assertNotNull(

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/PropagatorsFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/PropagatorsFactory.java
@@ -52,7 +52,7 @@ final class PropagatorsFactory implements Factory<List<String>, ContextPropagato
             ConfigurablePropagatorProvider.class,
             ConfigurablePropagatorProvider::getName,
             ConfigurablePropagatorProvider::getPropagator,
-            DefaultConfigProperties.createForTest(Collections.emptyMap()));
+            DefaultConfigProperties.createFromMap(Collections.emptyMap()));
     Set<TextMapPropagator> propagators = new LinkedHashSet<>();
     for (String propagator : model) {
       propagators.add(getPropagator(propagator, spiPropagatorsManager));

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SamplerFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SamplerFactory.java
@@ -106,11 +106,9 @@ final class SamplerFactory
               .map(entry -> entry.getKey() + "=" + entry.getValue())
               .collect(joining(","));
 
-      // TODO(jack-berg): add method for creating from map
       ConfigProperties configProperties =
           DefaultConfigProperties.createFromMap(
               Collections.singletonMap("otel.traces.sampler.arg", otelTraceSamplerArg));
-
       return FileConfigUtil.addAndReturn(
           closeables,
           FileConfigUtil.assertNotNull(

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SamplerFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SamplerFactory.java
@@ -108,7 +108,7 @@ final class SamplerFactory
 
       // TODO(jack-berg): add method for creating from map
       ConfigProperties configProperties =
-          DefaultConfigProperties.createForTest(
+          DefaultConfigProperties.createFromMap(
               Collections.singletonMap("otel.traces.sampler.arg", otelTraceSamplerArg));
 
       return FileConfigUtil.addAndReturn(

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanExporterFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanExporterFactory.java
@@ -107,9 +107,7 @@ final class SpanExporterFactory
       properties.put("otel.exporter.otlp.traces.client.certificate", model.getClientCertificate());
     }
 
-    // TODO(jack-berg): add method for creating from map
     ConfigProperties configProperties = DefaultConfigProperties.createFromMap(properties);
-
     return FileConfigUtil.assertNotNull(
         spanExporterSpiManager(configProperties, spiHelper).getByName("otlp"), "otlp exporter");
   }
@@ -134,9 +132,7 @@ final class SpanExporterFactory
       properties.put("otel.exporter.zipkin.timeout", Integer.toString(model.getTimeout()));
     }
 
-    // TODO(jack-berg): add method for creating from map
     ConfigProperties configProperties = DefaultConfigProperties.createFromMap(properties);
-
     return FileConfigUtil.assertNotNull(
         spanExporterSpiManager(configProperties, spiHelper).getByName("zipkin"), "zipkin exporter");
   }

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanExporterFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanExporterFactory.java
@@ -108,7 +108,7 @@ final class SpanExporterFactory
     }
 
     // TODO(jack-berg): add method for creating from map
-    ConfigProperties configProperties = DefaultConfigProperties.createForTest(properties);
+    ConfigProperties configProperties = DefaultConfigProperties.createFromMap(properties);
 
     return FileConfigUtil.assertNotNull(
         spanExporterSpiManager(configProperties, spiHelper).getByName("otlp"), "otlp exporter");
@@ -117,7 +117,7 @@ final class SpanExporterFactory
   private static SpanExporter createConsoleExporter(SpiHelper spiHelper) {
     return FileConfigUtil.assertNotNull(
         spanExporterSpiManager(
-                DefaultConfigProperties.createForTest(Collections.emptyMap()), spiHelper)
+                DefaultConfigProperties.createFromMap(Collections.emptyMap()), spiHelper)
             .getByName("logging"),
         "logging exporter");
   }
@@ -135,7 +135,7 @@ final class SpanExporterFactory
     }
 
     // TODO(jack-berg): add method for creating from map
-    ConfigProperties configProperties = DefaultConfigProperties.createForTest(properties);
+    ConfigProperties configProperties = DefaultConfigProperties.createFromMap(properties);
 
     return FileConfigUtil.assertNotNull(
         spanExporterSpiManager(configProperties, spiHelper).getByName("zipkin"), "zipkin exporter");


### PR DESCRIPTION
`DefaultConfigProperties.createForTest` produces a `DefaultConfigProperties` which ignores system properties and environment variables. Originally, this was only used in tests, hence the name. But file configuration creates various exporters by translating the configuration model to an equivalent `ConfigProperties` and invoking the SPIs to configure. 

This PR renames `createForTest` to `createFromMap` to reflect its valid use outside tests.