### PR TITLE
Demonstrate span linking composite propagator

### DIFF
--- a/extensions/trace-propagators/build.gradle.kts
+++ b/extensions/trace-propagators/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
 
   compileOnly(project(":sdk-extensions:autoconfigure-spi"))
 
+  testImplementation(project(":sdk:testing"))
+
   testImplementation("io.jaegertracing:jaeger-client")
   testImplementation("com.google.guava:guava")
 }

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/SpanLinkingMultiTextMapPropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/SpanLinkingMultiTextMapPropagator.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.extension.trace.propagation;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.context.propagation.TextMapSetter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+public class SpanLinkingMultiTextMapPropagator implements TextMapPropagator {
+
+  public static final ContextKey<Collection<SpanContext>> SPAN_LINKS =
+      ContextKey.named("opentelemetry-propagators-span-links");
+
+  private final List<TextMapPropagator> textMapPropagators;
+  private final List<String> allFields;
+
+  SpanLinkingMultiTextMapPropagator(List<TextMapPropagator> textMapPropagators) {
+    this.textMapPropagators = textMapPropagators;
+    this.allFields = Collections.unmodifiableList(getAllFields(this.textMapPropagators));
+  }
+
+  @Override
+  public Collection<String> fields() {
+    return allFields;
+  }
+
+  private static List<String> getAllFields(List<TextMapPropagator> textPropagators) {
+    Set<String> fields = new LinkedHashSet<>();
+    for (TextMapPropagator textPropagator : textPropagators) {
+      fields.addAll(textPropagator.fields());
+    }
+
+    return new ArrayList<>(fields);
+  }
+
+  @Override
+  public <C> void inject(Context context, @Nullable C carrier, TextMapSetter<C> setter) {
+    if (context == null || setter == null) {
+      return;
+    }
+    for (TextMapPropagator textPropagator : textMapPropagators) {
+      textPropagator.inject(context, carrier, setter);
+    }
+  }
+
+  @Override
+  public <C> Context extract(Context context, @Nullable C carrier, TextMapGetter<C> getter) {
+    if (context == null) {
+      return Context.root();
+    }
+    if (getter == null) {
+      return context;
+    }
+
+    SpanContext parentSpanContext = null;
+    List<SpanContext> spanLinks = null;
+
+    for (TextMapPropagator textPropagator : textMapPropagators) {
+      SpanContext result =
+          Span.fromContext(textPropagator.extract(Context.root(), carrier, getter))
+              .getSpanContext();
+      if (result.isValid()) {
+        if (parentSpanContext == null) {
+          parentSpanContext = result;
+        } else {
+          if (spanLinks == null) {
+            spanLinks = new ArrayList<>();
+          }
+          spanLinks.add(result);
+        }
+      }
+    }
+
+    if (spanLinks != null) {
+      context = context.with(SPAN_LINKS, Collections.unmodifiableList(spanLinks));
+    }
+    if (parentSpanContext != null) {
+      context = Span.wrap(parentSpanContext).storeInContext(context);
+    }
+
+    return context;
+  }
+}

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/SpanLinkingMultiTextMapPropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/SpanLinkingMultiTextMapPropagatorTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.extension.trace.propagation;
+
+import static io.opentelemetry.extension.trace.propagation.SpanLinkingMultiTextMapPropagator.SPAN_LINKS;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.context.propagation.TextMapSetter;
+import io.opentelemetry.sdk.trace.IdGenerator;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+class SpanLinkingMultiTextMapPropagatorTest {
+
+  private static final TextMapGetter<Map<String, String>> MAP_GETTER =
+      new TextMapGetter<Map<String, String>>() {
+        @Override
+        public Iterable<String> keys(Map<String, String> carrier) {
+          return carrier.keySet();
+        }
+
+        @Nullable
+        @Override
+        public String get(@Nullable Map<String, String> carrier, String key) {
+          return carrier.get(key);
+        }
+      };
+
+  @Test
+  void test() {
+    String field1 = "field1";
+    String field2 = "field2";
+    String field3 = "field3";
+    TestPropagator propagator1 = new TestPropagator(field1);
+    TestPropagator propagator2 = new TestPropagator(field2);
+    TestPropagator propagator3 = new TestPropagator(field3);
+    SpanContext spanContext1 =
+        SpanContext.create(
+            IdGenerator.random().generateTraceId(),
+            IdGenerator.random().generateSpanId(),
+            TraceFlags.getDefault(),
+            TraceState.getDefault());
+    SpanContext spanContext2 =
+        SpanContext.create(
+            IdGenerator.random().generateTraceId(),
+            IdGenerator.random().generateSpanId(),
+            TraceFlags.getDefault(),
+            TraceState.getDefault());
+    SpanContext spanContext3 =
+        SpanContext.create(
+            IdGenerator.random().generateTraceId(),
+            IdGenerator.random().generateSpanId(),
+            TraceFlags.getDefault(),
+            TraceState.getDefault());
+    Map<String, String> carrier =
+        ImmutableMap.of(
+            field1,
+            encodeTraceParent(spanContext1),
+            field2,
+            encodeTraceParent(spanContext2),
+            field3,
+            encodeTraceParent(spanContext3));
+
+    TextMapPropagator propagator1Priority =
+        new SpanLinkingMultiTextMapPropagator(Arrays.asList(propagator1, propagator2, propagator3));
+    TextMapPropagator propagator2Priority =
+        new SpanLinkingMultiTextMapPropagator(Arrays.asList(propagator2, propagator1, propagator3));
+
+    // Extract context with propagator1Priority, which prioritizes span context from field1. The
+    // contexts in field2 and field3 should end up as links.
+    Context result = propagator1Priority.extract(Context.root(), carrier, MAP_GETTER);
+    assertThat(Span.fromContext(result).getSpanContext()).isEqualTo(spanContext1);
+    assertThat(result.get(SPAN_LINKS)).isEqualTo(Arrays.asList(spanContext2, spanContext3));
+
+    // Extract context with propagator2Priority, which prioritizes span context from field2. The
+    // contexts in field1 and field3 should end up as links.
+    result = propagator2Priority.extract(Context.root(), carrier, MAP_GETTER);
+    assertThat(Span.fromContext(result).getSpanContext()).isEqualTo(spanContext2);
+    assertThat(result.get(SPAN_LINKS)).isEqualTo(Arrays.asList(spanContext1, spanContext3));
+  }
+
+  private static class TestPropagator implements TextMapPropagator {
+
+    private final String traceParentField;
+
+    private TestPropagator(String traceParentField) {
+      this.traceParentField = traceParentField;
+    }
+
+    @Override
+    public Collection<String> fields() {
+      return Collections.singletonList(traceParentField);
+    }
+
+    @Override
+    public <C> void inject(Context context, @Nullable C carrier, TextMapSetter<C> setter) {}
+
+    @Override
+    public <C> Context extract(Context context, @Nullable C carrier, TextMapGetter<C> getter) {
+      String traceParent = getter.get(carrier, traceParentField);
+      if (traceParent == null) {
+        return context;
+      }
+      return context.with(Span.wrap(decodeTraceParent(traceParent)));
+    }
+  }
+
+  private static String encodeTraceParent(SpanContext spanContext) {
+    return spanContext.getTraceId() + "|" + spanContext.getSpanId();
+  }
+
+  private static SpanContext decodeTraceParent(String traceParent) {
+    String[] parts = traceParent.split("\\|");
+    if (parts.length != 2) {
+      return SpanContext.getInvalid();
+    }
+    return SpanContext.create(parts[0], parts[1], TraceFlags.getDefault(), TraceState.getDefault());
+  }
+}


### PR DESCRIPTION
cc @tylerbenson / @jsuereth 

This branch shows an alternative to the default composite text map propagator. Where the composite text map propagator sets the parent to be the span context extracted from the last registered propagator, this assigns the parent to be the span context extracted from the first registered propagator. Additionally, for each additional valid span context extracted from subsequent propagators, it populates the context with a key so that the caller can access those spans and create links while starting the span.