### PR TITLE
Add addAllAttributes() to ReadWriteLogRecord.

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-logs.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-logs.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.logs.ReadWriteLogRecord  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.logs.ReadWriteLogRecord setAllAttributes(io.opentelemetry.api.common.Attributes)

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
@@ -24,6 +24,8 @@ public interface ReadWriteLogRecord {
    */
   <T> ReadWriteLogRecord setAttribute(AttributeKey<T> key, T value);
 
+  // TODO: add additional setters
+
   /**
    * Sets attributes to the {@link ReadWriteLogRecord}. If the {@link ReadWriteLogRecord} previously
    * contained a mapping for any of the keys, the old values are replaced by the specified values.

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.logs;
 
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 
 /**
@@ -23,7 +24,15 @@ public interface ReadWriteLogRecord {
    */
   <T> ReadWriteLogRecord setAttribute(AttributeKey<T> key, T value);
 
-  // TODO: add additional setters
+  @SuppressWarnings("unchecked")
+  default ReadWriteLogRecord setAllAttributes(Attributes attributes) {
+    if (attributes == null || attributes.isEmpty()) {
+      return this;
+    }
+    attributes.forEach(
+        (attributeKey, value) -> this.setAttribute((AttributeKey<Object>) attributeKey, value));
+    return this;
+  }
 
   /** Return an immutable {@link LogRecordData} instance representing this log record. */
   LogRecordData toLogRecordData();

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
@@ -24,6 +24,14 @@ public interface ReadWriteLogRecord {
    */
   <T> ReadWriteLogRecord setAttribute(AttributeKey<T> key, T value);
 
+  /**
+   * Sets attributes to the {@link ReadWriteLogRecord}. If the {@link ReadWriteLogRecord} previously
+   * contained a mapping for any of the keys, the old values are replaced by the specified values.
+   *
+   * @param attributes the attributes
+   * @return this.
+   * @since 1.31.0
+   */
   @SuppressWarnings("unchecked")
   default ReadWriteLogRecord setAllAttributes(Attributes attributes) {
     if (attributes == null || attributes.isEmpty()) {

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/ReadWriteLogRecordTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/ReadWriteLogRecordTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.logs;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.internal.AttributesMap;
+import io.opentelemetry.sdk.logs.data.Body;
+import io.opentelemetry.sdk.resources.Resource;
+import org.junit.jupiter.api.Test;
+
+class ReadWriteLogRecordTest {
+
+  @Test
+  void addAllAttributes() {
+    Body body = Body.string("bod");
+    AttributesMap initialAttributes = AttributesMap.create(100, 200);
+    initialAttributes.put(stringKey("foo"), "aaiosjfjioasdiojfjioasojifja");
+    initialAttributes.put(stringKey("untouched"), "yes");
+    Attributes newAttributes = Attributes.of(stringKey("foo"), "bar", stringKey("bar"), "buzz");
+    LogLimits limits = LogLimits.getDefault();
+    Resource resource = Resource.empty();
+    InstrumentationScopeInfo scope = InstrumentationScopeInfo.create("test");
+    SpanContext spanContext = SpanContext.getInvalid();
+
+    SdkReadWriteLogRecord logRecord =
+        SdkReadWriteLogRecord.create(
+            limits,
+            resource,
+            scope,
+            0L,
+            0L,
+            spanContext,
+            Severity.DEBUG,
+            "buggin",
+            body,
+            initialAttributes);
+
+    logRecord.setAllAttributes(newAttributes);
+
+    Attributes result = logRecord.toLogRecordData().getAttributes();
+    assertThat(result.get(stringKey("foo"))).isEqualTo("bar");
+    assertThat(result.get(stringKey("bar"))).isEqualTo("buzz");
+    assertThat(result.get(stringKey("untouched"))).isEqualTo("yes");
+  }
+}

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/ReadWriteLogRecordTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/ReadWriteLogRecordTest.java
@@ -21,28 +21,8 @@ class ReadWriteLogRecordTest {
 
   @Test
   void addAllAttributes() {
-    Body body = Body.string("bod");
-    AttributesMap initialAttributes = AttributesMap.create(100, 200);
-    initialAttributes.put(stringKey("foo"), "aaiosjfjioasdiojfjioasojifja");
-    initialAttributes.put(stringKey("untouched"), "yes");
     Attributes newAttributes = Attributes.of(stringKey("foo"), "bar", stringKey("bar"), "buzz");
-    LogLimits limits = LogLimits.getDefault();
-    Resource resource = Resource.empty();
-    InstrumentationScopeInfo scope = InstrumentationScopeInfo.create("test");
-    SpanContext spanContext = SpanContext.getInvalid();
-
-    SdkReadWriteLogRecord logRecord =
-        SdkReadWriteLogRecord.create(
-            limits,
-            resource,
-            scope,
-            0L,
-            0L,
-            spanContext,
-            Severity.DEBUG,
-            "buggin",
-            body,
-            initialAttributes);
+    SdkReadWriteLogRecord logRecord = buildLogRecord();
 
     logRecord.setAllAttributes(newAttributes);
 
@@ -50,5 +30,44 @@ class ReadWriteLogRecordTest {
     assertThat(result.get(stringKey("foo"))).isEqualTo("bar");
     assertThat(result.get(stringKey("bar"))).isEqualTo("buzz");
     assertThat(result.get(stringKey("untouched"))).isEqualTo("yes");
+  }
+
+  @Test
+  void addAllHandlesNull() {
+    SdkReadWriteLogRecord logRecord = buildLogRecord();
+    Attributes originalAttributes = logRecord.toLogRecordData().getAttributes();
+    ReadWriteLogRecord result = logRecord.setAllAttributes(null);
+    assertThat(result.toLogRecordData().getAttributes()).isEqualTo(originalAttributes);
+  }
+
+  @Test
+  void allHandlesEmpty() {
+    SdkReadWriteLogRecord logRecord = buildLogRecord();
+    Attributes originalAttributes = logRecord.toLogRecordData().getAttributes();
+    ReadWriteLogRecord result = logRecord.setAllAttributes(Attributes.empty());
+    assertThat(result.toLogRecordData().getAttributes()).isEqualTo(originalAttributes);
+  }
+
+  SdkReadWriteLogRecord buildLogRecord() {
+    Body body = Body.string("bod");
+    AttributesMap initialAttributes = AttributesMap.create(100, 200);
+    initialAttributes.put(stringKey("foo"), "aaiosjfjioasdiojfjioasojifja");
+    initialAttributes.put(stringKey("untouched"), "yes");
+    LogLimits limits = LogLimits.getDefault();
+    Resource resource = Resource.empty();
+    InstrumentationScopeInfo scope = InstrumentationScopeInfo.create("test");
+    SpanContext spanContext = SpanContext.getInvalid();
+
+    return SdkReadWriteLogRecord.create(
+        limits,
+        resource,
+        scope,
+        0L,
+        0L,
+        spanContext,
+        Severity.DEBUG,
+        "buggin",
+        body,
+        initialAttributes);
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleUpDownCounterTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkDoubleUpDownCounterTest.java
@@ -254,4 +254,18 @@ class SdkDoubleUpDownCounterTest {
                                             .hasValue(20_000)
                                             .hasAttributes(attributeEntry(keys[3], values[3])))));
   }
+
+  @Test
+  void testToString() {
+    String expected =
+        "SdkDoubleUpDownCounter{descriptor=InstrumentDescriptor{name=testUpDownCounter, description=description, unit=ms, type=UP_DOWN_COUNTER, valueType=DOUBLE, advice=Advice{explicitBucketBoundaries=null, attributes=null}}}";
+    DoubleUpDownCounter counter =
+        sdkMeter
+            .upDownCounterBuilder("testUpDownCounter")
+            .ofDoubles()
+            .setDescription("description")
+            .setUnit("ms")
+            .build();
+    assertThat(counter).hasToString(expected);
+  }
 }


### PR DESCRIPTION
This addition of `addAllAttributes()` matches exactly what is in the `Span` interface (signal type interface parity).

In Android, we expect to need to add a common set of "global" attributes to every event in a standard way.  This helps to facilitate that more cleanly than other approaches.