### PR TITLE
Unify `queueSize` metric description and attribute

### DIFF
--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessor.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessor.java
@@ -45,7 +45,7 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
   private static final String WORKER_THREAD_NAME =
       BatchLogRecordProcessor.class.getSimpleName() + "_WorkerThread";
   private static final AttributeKey<String> LOG_RECORD_PROCESSOR_TYPE_LABEL =
-      AttributeKey.stringKey("logRecordProcessorType");
+      AttributeKey.stringKey("processorType");
   private static final AttributeKey<Boolean> LOG_RECORD_PROCESSOR_DROPPED_LABEL =
       AttributeKey.booleanKey("dropped");
   private static final String LOG_RECORD_PROCESSOR_TYPE_VALUE =
@@ -172,7 +172,7 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
       meter
           .gaugeBuilder("queueSize")
           .ofLongs()
-          .setDescription("The number of logs queued")
+          .setDescription("The number of items queued")
           .setUnit("1")
           .buildWithCallback(
               result ->

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -48,7 +48,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
   private static final String WORKER_THREAD_NAME =
       BatchSpanProcessor.class.getSimpleName() + "_WorkerThread";
   private static final AttributeKey<String> SPAN_PROCESSOR_TYPE_LABEL =
-      AttributeKey.stringKey("spanProcessorType");
+      AttributeKey.stringKey("processorType");
   private static final AttributeKey<Boolean> SPAN_PROCESSOR_DROPPED_LABEL =
       AttributeKey.booleanKey("dropped");
   private static final String SPAN_PROCESSOR_TYPE_VALUE = BatchSpanProcessor.class.getSimpleName();
@@ -189,7 +189,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
       meter
           .gaugeBuilder("queueSize")
           .ofLongs()
-          .setDescription("The number of spans queued")
+          .setDescription("The number of items queued")
           .setUnit("1")
           .buildWithCallback(
               result ->


### PR DESCRIPTION
Fixes #4834 

Also references #4382 and #5066

The Java SDK, when auto-configured, will emit 2 metrics with the same metric name (`queueSize`) but a different description. Combined with the very popular Prometheus exporter in the OpenTelemetry Collector, this leads to an error and 1 of the 2 metrics being dropped. The metric is emitted as part of the Batch*Processors for traces and logs.

This PR uses the same description for both metrics and updates an attribute key to be common across both. The Attribute name could be seen as a larger change outside the scope of this PR, and I'm happy to remove it.  In my opinion, when I look at how this metric could be used, I see a benefit with using a common name of `processorType` for the attribute key.

I also understand there may be a larger issue at the specification level to help resolve this, but this issue has existed for well over a year. It can be resolved with this PR while waiting for the specification to be clearer on handling these use cases.