### PR TITLE
Fix opentracing header name issue

### DIFF
--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/OtTracePropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/OtTracePropagator.java
@@ -20,6 +20,7 @@ import io.opentelemetry.context.propagation.TextMapSetter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Locale;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -108,14 +109,16 @@ public final class OtTracePropagator implements TextMapPropagator {
     if (carrier != null) {
       BaggageBuilder baggageBuilder = Baggage.builder();
       for (String key : getter.keys(carrier)) {
-        if (!key.startsWith(PREFIX_BAGGAGE_HEADER)) {
+        String lowercaseKey = key.toLowerCase(Locale.ROOT);
+        if (!lowercaseKey.startsWith(PREFIX_BAGGAGE_HEADER)) {
           continue;
         }
         String value = getter.get(carrier, key);
         if (value == null) {
           continue;
         }
-        baggageBuilder.put(key.replace(OtTracePropagator.PREFIX_BAGGAGE_HEADER, ""), value);
+        String baggageKey = lowercaseKey.replace(OtTracePropagator.PREFIX_BAGGAGE_HEADER, "");
+        baggageBuilder.put(baggageKey, value);
       }
       Baggage baggage = baggageBuilder.build();
       if (!baggage.isEmpty()) {

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/OtTracePropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/OtTracePropagator.java
@@ -117,7 +117,8 @@ public final class OtTracePropagator implements TextMapPropagator {
         if (value == null) {
           continue;
         }
-        String baggageKey = lowercaseKey.replace(OtTracePropagator.PREFIX_BAGGAGE_HEADER, "");
+        String baggageKey =
+            lowercaseKey.substring(OtTracePropagator.PREFIX_BAGGAGE_HEADER.length());
         baggageBuilder.put(baggageKey, value);
       }
       Baggage baggage = baggageBuilder.build();

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/OtTracePropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/OtTracePropagatorTest.java
@@ -328,9 +328,8 @@ class OtTracePropagatorTest {
 
   @Test
   void extract_Baggage_CapitalizedHeaders() {
-    String capitalizedBaggageHeader = capitalizeFirstLetter(
-        OtTracePropagator.PREFIX_BAGGAGE_HEADER + "some-key",
-        "-");
+    String capitalizedBaggageHeader =
+        capitalizeFirstLetter(OtTracePropagator.PREFIX_BAGGAGE_HEADER + "some-key", "-");
     Map<String, String> carrier = new LinkedHashMap<>();
     carrier.put(OtTracePropagator.TRACE_ID_HEADER, TRACE_ID);
     carrier.put(OtTracePropagator.SPAN_ID_HEADER, SPAN_ID);

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/OtTracePropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/OtTracePropagatorTest.java
@@ -20,6 +20,7 @@ import io.opentelemetry.context.propagation.TextMapSetter;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
@@ -53,6 +54,18 @@ class OtTracePropagatorTest {
 
   private static Context withSpanContext(SpanContext spanContext, Context context) {
     return context.with(Span.wrap(spanContext));
+  }
+
+  private static String capitalizeFirstLetter(String input, String delimiter) {
+    String[] words = input.split(delimiter);
+
+    for (int i = 0; i < words.length; i++) {
+      String firstLetter = words[i].substring(0, 1).toUpperCase(Locale.ROOT);
+      String restOfWord = words[i].substring(1).toLowerCase(Locale.ROOT);
+      words[i] = firstLetter + restOfWord;
+    }
+
+    return String.join(delimiter, words);
   }
 
   @Test
@@ -310,6 +323,23 @@ class OtTracePropagatorTest {
     Context context = propagator.extract(Context.current(), carrier, getter);
 
     Baggage expectedBaggage = Baggage.builder().put("foo", "bar").put("key", "value").build();
+    assertThat(Baggage.fromContext(context)).isEqualTo(expectedBaggage);
+  }
+
+  @Test
+  void extract_Baggage_CapitalizedHeaders() {
+    String capitalizedBaggageHeader = capitalizeFirstLetter(
+        OtTracePropagator.PREFIX_BAGGAGE_HEADER + "some-key",
+        "-");
+    Map<String, String> carrier = new LinkedHashMap<>();
+    carrier.put(OtTracePropagator.TRACE_ID_HEADER, TRACE_ID);
+    carrier.put(OtTracePropagator.SPAN_ID_HEADER, SPAN_ID);
+    carrier.put(OtTracePropagator.SAMPLED_HEADER, Common.TRUE_INT);
+    carrier.put(capitalizedBaggageHeader, "value");
+
+    Context context = propagator.extract(Context.current(), carrier, getter);
+
+    Baggage expectedBaggage = Baggage.builder().put("some-key", "value").build();
     assertThat(Baggage.fromContext(context)).isEqualTo(expectedBaggage);
   }
 


### PR DESCRIPTION
Fixes an issue in opentracing baggage propagation.

There is no guarantee that `TextMapGetter`s  will send headers(`.keys()`) as lowercase strings. Some of the `TextMapGetter`s like `undertow:1.7` send the headers as they receive them(e.g. `Ot-Baggage-Key`) but ensure case insensitivity of headers by allowing `get()` to be called regardless of the header name case. This behaviour breaks the `OtTracePropagator` because it expects lowercase literal `ot-baggage-` to be present in header name.

This PR fixes that issue.